### PR TITLE
fix: libsnappy-devel -> snappy-devel for RHEL/CentOS

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -456,7 +456,7 @@ check_snappy() {
   local pkgfile=$(ls | grep snappy)
   if [[ $pkgfile =~ .*\.tar.gz ]]; then
     # source build is required!
-    install_system_pkg "libsnappy-dev" "libsnappy-devel" "snappy"
+    install_system_pkg "libsnappy-dev" "snappy-devel" "snappy"
   fi
   rm -f $pkgfile
 }


### PR DESCRIPTION
Installation with `install-dev.sh` in CentOS breaks due to missing package `libsnappy-devel`.