### PR TITLE
docs: Add guide for documentation build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# backend.ai Documentation
+# Backend.AI Documentation
 
-Build guide for Backend.AI Documentation
+Developer guide for Backend.AI documentation
 
 
 ## Setting up the build environment for docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,185 @@ Build guide for Backend.AI Documentation
 
 ## Setup build environment
 
+> 📌 NOTE: You may need a sudo access for a certain command.
+
+### clone docs in `lablup/backend.ai` project
+Download `lablup/backend.ai` project using `git clone` and rename it as `meta`.
+
+```console
+$ cd ~
+$ git clone https://github.com/lablup/backend.ai meta
+```
+Change current working directory to `docs` directory in meta directory, which you downloaded just now.
+
+```console
+$ cd ~/meta/docs
+```
+
+### pyenv and pyenv-virtualenv installation
+
+#### MacOS version
+
+Install [pyenv](https://github.com/pyenv/pyenv) using brew.
+
+```console
+$ brew install pyenv
+```
+
+Set `PYENV_ROOT`, add `pyenv` to `PATH` and execute shell run command file (`.zshrc` or `.bashrc` or etc.).   
+For now, we will use `.zshrc` as an example.
+
+```console
+$ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+$ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+$ eval '"(pyenv init --path)"' >> ~/.zshrc
+$ source ~/.zshrc
+```
+
+Install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) using brew.   
+This is the actual command to create the environment using pyenv.
+
+```console
+$ brew install pyenv-virtualenv
+```
+
+Add `pyenv-virtualenv` to `PATH` and execute shell run command file (`.zshrc` or `.bashrc` or etc.).
+
+```console
+$ eval "$(pyenv virtualenv-init -)"
+```
+
+#### Linux (Ubuntu) version
+
+Install [pyenv](https://github.com/pyenv/pyenv) using `git clone`.   
+
+```console
+$ git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+```
+
+SET `PYENV_ROOT`, add `pyenv` to `PATH` and add `pyenv-virtualenv` to `PATH`.
+Execute shell run command file (`.zshrc` or `.bashrc` or etc.).
+
+```console
+$ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+$ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+$ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init --path)"\nfi' >> ~/.bashrc
+$ source ~/.bashrc
+```
+
+Restart the shell to enable pyenv
+
+```console
+$ exec $SHELL
+```
+
+Install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) using `git clone`.   
+
+```console
+$ git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
+```
+
+Add `pyenv virtualenv-init` to `$SHELL` to enable auto-activate of virtualenvs.
+
+```console
+$ echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+```
+
+Restart the shell to enable pyenv-virtualenv
+
+```console
+$ exec $SHELL
+```
+
+### install certain version of pyenv
+
+There's no specific restriction about the version of python3 for building documentation of Backend.AI, but
+we recommend you to install the version higher than Python 3.8.
+
+> e.g. Install pyenv version: `3.9.6`
+
+```console
+$ pyenv install 3.9.6
+```
+
+### 
+
+### pyenv activate
+
+> 📌 NOTE: You need to create pyenv first, and then activate/deactivate it.
+
+Create a pyenv with version and a genuine name.
+For now, we can use `bai-doc`.
+
+```console
+$ pyenv virtualenv 3.9.6 bai-doc
+```
+
+Add current directory to automatically activate pyenv.
+
+```console
+$ cd ~/meta/docs
+$ pyenv local bai-doc
+```
+
+### sphinx installation
+
+Install [sphinx](https://www.sphinx-doc.org/en/master/) using [pip](https://pypi.org/project/pip/)
+
+```console
+$ pip install sphinx
+```
+
+### sphinx-intl installation
+
+Install [sphinx-intl](https://github.com/sphinx-doc/sphinx-intl) using pip.
+
+```console
+$ pip install sphinx-intl
+```ß
+
 ## Build documents
+> 📌 NOTE: Please make sure pyenv installation completed and the activation has been enabled before building documents, and current working directory need to be root directory of `docs`.
 
-## Translation
+### Make Default html files
+```console
+$ make html
+```
+### Translation
 
-## Build PDF document
+#### Make pot(Portable Object Template) files
+```console
+$ make gettext
+```
+
+#### Make po(Portable Object) files using sphinx-intl
+> For now, we use Korean language as an example for translation.
+
+```console
+$ sphinx-intl update -p _build/locale/ -l ko_KR
+```
+
+#### Make html files with translated version
+
+```console
+$ make -e SPHINXOPTS="-D language='ko'" html
+```
+
+## 🚧 Build PDF document (WIP) 🚧
+ Help wanted!   
+Looking for people to help with a short guide for building PDF document based on html files derived from sphinx.
+
+## Advanced Setting
+
+### Managing the hierachy of toctree(Table of Contents) of documentation
+
+When documentation of each file gets too big to contain all things in one topic,   
+It should be branched with proper sub-topics.   
+The hierarchy of toctree has been managed through `index.rst`.   
+Please note that contents in `index.rst` must contain the actual directory tree, unless it will not contain documentation you expected.   
+
+For More Information, Please check out [`index.rst`](https://github.com/lablup/backend.ai/blob/main/docs/index.rst) file.
+
 
 ## References for newcomers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,19 @@
 
 Build guide for Backend.AI Documentation
 
-## Setup build environment
+
+## Setting up the build environment for docs
 
 > 📌 NOTE: You may need a sudo access for a certain command.
 
 ### clone docs in `lablup/backend.ai` project
-Download `lablup/backend.ai` project using `git clone` and rename it as `meta`.
+Download `lablup/backend.ai` project using `git clone` and rename the clone directory as `meta`.
 
 ```console
 $ cd ~
 $ git clone https://github.com/lablup/backend.ai meta
 ```
-Change current working directory to `docs` directory in meta directory, which you downloaded just now.
+Change the current working directory to `meta/docs`.
 
 ```console
 $ cd ~/meta/docs
@@ -22,13 +23,13 @@ $ cd ~/meta/docs
 ### pyenv and pyenv-virtualenv installation
 
 #### pyenv installation
-Please refer to the [README](https://github.com/pyenv/pyenv#installation) file in the official repository of [pyenv](https://github.com/pyenv/pyenv) and install it.
+Please refer to the [README](https://github.com/pyenv/pyenv#installation) of the official [pyenv](https://github.com/pyenv/pyenv) repository and install it.
 
 #### pyenv-virtualenv installation (optional)
-`pyenv-virtualenv` is a `pyenv` plugin. It's not mandatory to build the backend.ai documentation, but highly recommended.   
-To install it, please refer to the [README](https://github.com/pyenv/pyenv-virtualenv#installation) file in the official repository of [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv).
+`pyenv-virtualenv` is a `pyenv` plugin.  It is not mandatory to build the Backend.AI docs but highly recommended.   
+To install it, please refer to the [README](https://github.com/pyenv/pyenv-virtualenv#installation) of the official [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) repository.
 
-### sphinx installation
+### Sphinx installation
 
 Install [sphinx](https://www.sphinx-doc.org/en/master/) using [pip](https://pypi.org/project/pip/)
 
@@ -42,41 +43,46 @@ Install [sphinx-intl](https://github.com/sphinx-doc/sphinx-intl) using pip.
 
 ```console
 $ pip install sphinx-intl
-```ß
+```
 
-## Build documents
+
+## Building HTML document
+
 > 📌 NOTE: Please make sure pyenv installation completed and the activation has been enabled before building documents, and current working directory need to be root directory of `docs`.
 
-### Make Default html files
+### Make the html version
 ```console
 $ make html
 ```
 ### Translation
 
-#### Make pot(Portable Object Template) files
+#### Generate/update pot (Portable Object Template) files
 ```console
 $ make gettext
 ```
 
-#### Make po(Portable Object) files using sphinx-intl
+#### Build po (Portable Object) files using sphinx-intl
 
-> For now, we use Korean language as an example for translation.
+> In this guide, we use Korean as the target translation language.
 
 ```console
 $ sphinx-intl update -p _build/locale/ -l ko_KR
 ```
 
-#### Make html files with translated version
+#### Build HTML files with translated version
 
 ```console
 $ make -e SPHINXOPTS="-D language='ko'" html
 ```
 
-## 🚧 Build PDF document (WIP) 🚧
- Help wanted!   
-Looking for people to help with a short guide for building PDF document based on html files derived from sphinx.
+## 🚧 Building PDF document (WIP) 🚧
 
-## Advanced Setting
+> Help wanted!   
+
+We are looking for people to help with a short guide for building PDF document based on html files derived from sphinx.
+
+
+## Advanced Settings
 
 ### Managing the hierachy of toctree(Table of Contents) of documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# backend.ai Documentation
+
+Build guide for Backend.AI Documentation
+
+## Setup build environment
+
+## Build documents
+
+## Translation
+
+## Build PDF document
+
+## References for newcomers
+
+http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,109 +21,12 @@ $ cd ~/meta/docs
 
 ### pyenv and pyenv-virtualenv installation
 
-#### MacOS version
+#### pyenv installation
+Please refer to the [README](https://github.com/pyenv/pyenv#installation) file in the official repository of [pyenv](https://github.com/pyenv/pyenv) and install it.
 
-Install [pyenv](https://github.com/pyenv/pyenv) using brew.
-
-```console
-$ brew install pyenv
-```
-
-Set `PYENV_ROOT`, add `pyenv` to `PATH` and execute shell run command file (`.zshrc` or `.bashrc` or etc.).   
-For now, we will use `.zshrc` as an example.
-
-```console
-$ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-$ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-$ eval '"(pyenv init --path)"' >> ~/.zshrc
-$ source ~/.zshrc
-```
-
-Install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) using brew.   
-This is the actual command to create the environment using pyenv.
-
-```console
-$ brew install pyenv-virtualenv
-```
-
-Add `pyenv-virtualenv` to `PATH` and execute shell run command file (`.zshrc` or `.bashrc` or etc.).
-
-```console
-$ eval "$(pyenv virtualenv-init -)"
-```
-
-#### Linux (Ubuntu) version
-
-Install [pyenv](https://github.com/pyenv/pyenv) using `git clone`.   
-
-```console
-$ git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-```
-
-SET `PYENV_ROOT`, add `pyenv` to `PATH` and add `pyenv-virtualenv` to `PATH`.
-Execute shell run command file (`.zshrc` or `.bashrc` or etc.).
-
-```console
-$ echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-$ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-$ echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init --path)"\nfi' >> ~/.bashrc
-$ source ~/.bashrc
-```
-
-Restart the shell to enable pyenv
-
-```console
-$ exec $SHELL
-```
-
-Install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) using `git clone`.   
-
-```console
-$ git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
-```
-
-Add `pyenv virtualenv-init` to `$SHELL` to enable auto-activate of virtualenvs.
-
-```console
-$ echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
-```
-
-Restart the shell to enable pyenv-virtualenv
-
-```console
-$ exec $SHELL
-```
-
-### install certain version of pyenv
-
-There's no specific restriction about the version of python3 for building documentation of Backend.AI, but
-we recommend you to install the version higher than Python 3.8.
-
-> e.g. Install pyenv version: `3.9.6`
-
-```console
-$ pyenv install 3.9.6
-```
-
-### 
-
-### pyenv activate
-
-> 📌 NOTE: You need to create pyenv first, and then activate/deactivate it.
-
-Create a pyenv with version and a genuine name.
-For now, we can use `bai-doc`.
-
-```console
-$ pyenv virtualenv 3.9.6 bai-doc
-```
-
-Add current directory to automatically activate pyenv.
-
-```console
-$ cd ~/meta/docs
-$ pyenv local bai-doc
-```
+#### pyenv-virtualenv installation (optional)
+`pyenv-virtualenv` is a `pyenv` plugin. It's not mandatory to build the backend.ai documentation, but highly recommended.   
+To install it, please refer to the [README](https://github.com/pyenv/pyenv-virtualenv#installation) file in the official repository of [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv).
 
 ### sphinx installation
 
@@ -156,6 +59,7 @@ $ make gettext
 ```
 
 #### Make po(Portable Object) files using sphinx-intl
+
 > For now, we use Korean language as an example for translation.
 
 ```console

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+import sphinx_rtd_theme
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
@@ -34,6 +35,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
+	'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,7 +71,9 @@ release = '20.03'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'ko_KR'
+locale_dirs = ['locales/']
+gettext_compact = True
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+
 import sphinx_rtd_theme
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
@@ -35,7 +36,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
-	'sphinx_rtd_theme',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Table of Contents
 
    install/guides
    install/supplementary
+   install/configure-autoscaling
 
 .. _migration:
 


### PR DESCRIPTION
This PR resolves a basic guide for building documentation of this project.
Please note that this guide is a quick-fix, which means it can be deprecated when automated documentation (at least API) is enabled.