### PR TITLE
Fix/typo in install dev.sh

### DIFF
--- a/docker-compose.halfstack-2109.yml
+++ b/docker-compose.halfstack-2109.yml
@@ -35,7 +35,7 @@ services:
       retries: 10
 
   backendai-half-etcd:
-    image: quay.io/coreos/etcd:v3.4.15
+    image: quay.io/coreos/etcd:v3.5.0
     restart: unless-stopped
     volumes:
       - "./tmp/backend.ai-halfstack/${DATADIR_PREFIX:-.}/etcd-data:/etcd-data:rw"

--- a/docs/locales/ko_KR/LC_MESSAGES/common-api.po
+++ b/docs/locales/ko_KR/LC_MESSAGES/common-api.po
@@ -160,7 +160,7 @@ msgstr ""
 
 #: ../../common-api/auth.rst:66
 msgid "Common Structure of API Responses"
-msgstr ""
+msgstr "API 응답들의 흔한 구조"
 
 #: ../../common-api/auth.rst:74
 msgid "Status code"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -669,7 +669,7 @@ cd "${INSTALL_PATH}/manager"
 python -m ai.backend.manager.cli etcd put-json volumes "./dev.etcd.volumes.json"
 cd "${INSTALL_PATH}/agent"
 mkdir -p scratches
-POSTGRES_CONTAINER_ID=$(sudo docker ps | grep "${ENV_ID}_backendai-half-db-1" | awk '{print $1}')
+POSTGRES_CONTAINER_ID=$(sudo docker ps | grep "${ENV_ID}-backendai-half-db-1" | awk '{print $1}')
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update domains set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update groups set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update keypair_resource_policies set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -669,7 +669,7 @@ cd "${INSTALL_PATH}/manager"
 python -m ai.backend.manager.cli etcd put-json volumes "./dev.etcd.volumes.json"
 cd "${INSTALL_PATH}/agent"
 mkdir -p scratches
-POSTGRES_CONTAINER_ID=$(sudo docker ps | grep "${ENV_ID}_backendai-half-db_1" | awk '{print $1}')
+POSTGRES_CONTAINER_ID=$(sudo docker ps | grep "${ENV_ID}_backendai-half-db-1" | awk '{print $1}')
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update domains set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update groups set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update keypair_resource_policies set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"


### PR DESCRIPTION
During the installation process, the following message appeared because POSTGRES_CONTAINER_ID is ''.
`Error: No such container: psql`
<img width="633" alt="Screen Shot 2021-11-01 at 5 46 19 PM" src="https://user-images.githubusercontent.com/68562176/139645777-a361fd77-d82d-45f6-9ccb-a138733dc2f9.png">

In Docker container list, Name is "backendai-half-db-1" but there's a typo with "backendai-half-db_1" in install-dev.sh.
<img width="1259" alt="Screen Shot 2021-11-01 at 5 50 52 PM" src="https://user-images.githubusercontent.com/68562176/139646280-4c7ca67f-548e-47a7-8ca6-717f67441835.png">

<img width="954" alt="Screen Shot 2021-11-01 at 5 56 32 PM" src="https://user-images.githubusercontent.com/68562176/139647011-bd8be9ea-1007-462e-afaf-8e4320d9969a.png">


