### PR TITLE
setup: change the value of num-proc to 1 of manager.toml

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -606,6 +606,7 @@ show_info "Copy default configuration files to manager / agent root..."
 cd "${INSTALL_PATH}/manager"
 pyenv local "venv-${ENV_ID}-manager"
 cp config/halfstack.toml ./manager.toml
+sed_inplace "s/num-proc = .*/num-proc = 1/" ./manager.toml
 sed_inplace "s/port = 8120/port = ${ETCD_PORT}/" ./manager.toml
 sed_inplace "s/port = 8100/port = ${POSTGRES_PORT}/" ./manager.toml
 sed_inplace "s/port = 8081/port = ${MANAGER_PORT}/" ./manager.toml


### PR DESCRIPTION
When a user tries to install in a low-end PC or a VM which have cores less than 4, `num-proc = 4` causes an installation error.