### PR TITLE
fix: comment out script for new storage host `netapp`

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -655,6 +655,7 @@ sed_inplace "s/^\[volume\./# \[volume\./" ./storage-proxy.toml
 sed_inplace "s/^backend =/# backend =/" ./storage-proxy.toml
 sed_inplace "s/^path =/# path =/" ./storage-proxy.toml
 sed_inplace "s/^purity/# purity/" ./storage-proxy.toml
+sed_inplace "s/^netapp/# netapp/" ./storage-proxy.toml
 # add "volume1" vfs volume
 echo "\n[volume.volume1]\nbackend = \"vfs\"\npath = \"${INSTALL_PATH}/${VFOLDER_REL_PATH}\"" >> ./storage-proxy.toml
 


### PR DESCRIPTION
### Description
---
This PR resolves the current error during process execution in [backend.ai-storage-proxy](https://github.com/lablup/backend.ai-storage-proxy) caused by [the new storage host (NetApp)](https://www.netapp.com/) added from 21.09.

### Before
---
![Screen Shot 2022-01-03 at 6 08 53 PM](https://user-images.githubusercontent.com/46954439/147914322-bc72a3d9-3454-42ba-bfa9-f0bed7b173a3.png)

### After
---
![Screen Shot 2022-01-03 at 6 10 11 PM](https://user-images.githubusercontent.com/46954439/147914555-d7d52eb3-0563-45e3-a069-36cf0aac6cc9.png)

