### PR TITLE
fix: debug syntax err in install script

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -777,8 +777,8 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 # Update tester env script
 cd "${INSTALL_PATH}/tester"
 VENV_PATH="$(pyenv root)/versions/venv-${ENV_ID}-client"
-sed_inplace "s/export BACKENDAI_TEST_CLIENT_VENV=/home/user/.pyenv/versions/venv-dev-client/export BACKENDAI_TEST_CLIENT_VENV=${VENV_PATH}" ./env-tester.sh
-sed_inplace "s/export BACKENDAI_TEST_CLIENT_ENV=/home/user/bai-dev/client-py/my-backend-session.sh/export BACKENDAI_TEST_CLIENT_ENV=${INSTALL_PATH}/client-py/${CLIENT_ADMIN_CONF_FOR_API}" ./env-tester.sh
+sed_inplace "s@export BACKENDAI_TEST_CLIENT_VENV=\/home\/user\/.pyenv\/versions\/venv-dev-client@export BACKENDAI_TEST_CLIENT_VENV=${VENV_PATH}@" ./env-tester.sh
+sed_inplace "s@export BACKENDAI_TEST_CLIENT_ENV=\/home\/user\/bai-dev\/client-py\/my-backend-session.sh@export BACKENDAI_TEST_CLIENT_ENV=${INSTALL_PATH}\/client-py\/${CLIENT_ADMIN_CONF_FOR_API}@" ./env-tester.sh
 cd "${INSTALL_PATH}/client-py"
 
 show_info "Pre-pulling frequently used kernel images..."

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -777,8 +777,8 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 # Update tester env script
 cd "${INSTALL_PATH}/tester"
 VENV_PATH="$(pyenv root)/versions/venv-${ENV_ID}-client"
-sed_inplace "s@export BACKENDAI_TEST_CLIENT_VENV=\/home\/user\/.pyenv\/versions\/venv-dev-client@export BACKENDAI_TEST_CLIENT_VENV=${VENV_PATH}@" ./env-tester.sh
-sed_inplace "s@export BACKENDAI_TEST_CLIENT_ENV=\/home\/user\/bai-dev\/client-py\/my-backend-session.sh@export BACKENDAI_TEST_CLIENT_ENV=${INSTALL_PATH}\/client-py\/${CLIENT_ADMIN_CONF_FOR_API}@" ./env-tester.sh
+sed_inplace "s@export BACKENDAI_TEST_CLIENT_VENV=/home/user/.pyenv/versions/venv-dev-client@export BACKENDAI_TEST_CLIENT_VENV=${VENV_PATH}@" ./env-tester.sh
+sed_inplace "s@export BACKENDAI_TEST_CLIENT_ENV=/home/user/bai-dev/client-py/my-backend-session.sh@export BACKENDAI_TEST_CLIENT_ENV=${INSTALL_PATH}/client-py/${CLIENT_ADMIN_CONF_FOR_API}@" ./env-tester.sh
 cd "${INSTALL_PATH}/client-py"
 
 show_info "Pre-pulling frequently used kernel images..."

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -627,7 +627,7 @@ pip install -U -e ../client-py -r requirements/dev.txt
 cd "${INSTALL_PATH}/tester"
 pyenv local "venv-${ENV_ID}-tester"
 pip install -U -q pip setuptools wheel
-pip install -U -e ../client-py -r requirements/dev.txt
+pip install -U -r requirements/dev.txt
 
 # Copy default configurations
 show_info "Copy default configuration files to manager / agent root..."


### PR DESCRIPTION
fix syntax error in install script, sed inlace statement

the fixed script can install development environment.

<img width="793" alt="image" src="https://user-images.githubusercontent.com/44239739/149879092-126b297e-7d92-4d12-a134-5a499309d729.png">

