### PR TITLE
Change python default version(3.9.10) & description

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -51,7 +51,7 @@ usage() {
   echo ""
   echo "  ${LWHITE}--python-version VERSION${NC}"
   echo "                       Set the Python version to install via pyenv"
-  echo "                       (default: 3.9.5)"
+  echo "                       (default: 3.9.10)"
   echo ""
   echo "  ${LWHITE}--install-path PATH${NC}  Set the target directory"
   echo "                       (default: ./backend.ai-dev)"
@@ -177,7 +177,7 @@ fi
 
 ROOT_PATH=$(pwd)
 ENV_ID=""
-PYTHON_VERSION="3.9.9"
+PYTHON_VERSION="3.9.10"
 SERVER_BRANCH="main"
 CLIENT_BRANCH="main"
 INSTALL_PATH="./backend.ai-dev"


### PR DESCRIPTION
on install-dev.sh, option describe that python default version is `3.9.5`
However, on the file, already set ` PYTHON_VERSION="3.9.9"`

change python install version: `3.9.9` to `3.9.10`
change python default version description: `3.9.5` to `3.9.10`

close https://github.com/lablup/backend.ai/issues/356

This repository is a meta repository where we only keep compatible version
dependencies to individual components of Backend.AI.

Please head to appropriate Backend.AI sub-projects (e.g., manager, agent, kernels) to
contribute your code unless you really have contribution here.
