### PR TITLE
fix to install default packages on AWS Ubuntu & CentOS

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -260,11 +260,11 @@ install_script_deps() {
   case $DISTRO in
   Debian)
     $sudo apt-get update
-    $sudo apt-get install -y git jq
+    $sudo apt-get install -y git jq gcc make
     ;;
   RedHat)
     $sudo yum clean expire-cache  # next yum invocation will update package metadata cache
-    $sudo yum install -y git jq
+    $sudo yum install -y git jq gcc make
     ;;
   Darwin)
     if ! type "brew" >/dev/null 2>&1; then
@@ -285,7 +285,7 @@ install_pybuild_deps() {
     $sudo apt-get install -y libssl-dev libreadline-dev libgdbm-dev zlib1g-dev libbz2-dev libsqlite3-dev libffi-dev liblzma-dev
     ;;
   RedHat)
-    $sudo yum install -y openssl-devel readline-devel gdbm-devel zlib-devel bzip2-devel libsqlite-devel libffi-devel lzma-devel
+    $sudo yum install -y openssl-devel readline-devel gdbm-devel zlib-devel bzip2-devel libsqlite-devel libffi-devel lzma-devel xz-devel
     ;;
   Darwin)
     brew install openssl


### PR DESCRIPTION
fix to install default packages at install-dev.sh  on AWS Ubuntu & CentOS
 - Ubuntu: `gcc`, `make`
 - CentOS: `gcc`, `make`, `xz-devel`

close #366

It's the auto-installer's base package issue on the AWS Ubuntu  & CentOS instance.

This repository is a meta repository where we only keep compatible version
dependencies to individual components of Backend.AI.

Please head to appropriate Backend.AI sub-projects (e.g., manager, agent, kernels) to
contribute your code unless you really have contribution here.
