### PR TITLE
change docker-compose ver link for multi-platform support

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -358,11 +358,11 @@ install_docker_compose() {
   show_info "Install docker-compose"
   case $DISTRO in
   Debian)
-    $sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    $sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s | tr '[:upper:]' '[:lower:]' | sed -e 's/_.*//')-$(uname -m)" -o /usr/local/bin/docker-compose
     $sudo chmod +x /usr/local/bin/docker-compose
     ;;
   RedHat)
-    $sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    $sudo curl -L "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-$(uname -s | tr '[:upper:]' '[:lower:]' | sed -e 's/_.*//')-$(uname -m)" -o /usr/local/bin/docker-compose
     $sudo chmod +x /usr/local/bin/docker-compose
     ;;
   Darwin)


### PR DESCRIPTION
change docker-compose version download link on install-dev.sh for multi-platform support.
Until docker-compose 1.29.2 ver, It supported only x86_64 platform.
However, Docker-compose 2.0.0 and above version, can support multi-platform.
such as aarch64, armv6, armv7, s390x.

As a result, change the docker-compose download link from `1.29.2` to `2.2.3`.

close https://github.com/lablup/backend.ai/issues/375

This repository is a meta repository where we only keep compatible version
dependencies to individual components of Backend.AI.

Please head to appropriate Backend.AI sub-projects (e.g., manager, agent, kernels) to
contribute your code unless you really have contribution here.
