### PR TITLE
installer: Fix up grpcio install issue on M1 and Python 3.10

### DIFF
--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -150,6 +150,7 @@ if [ $REMOVE_SOURCE -eq 1 ]; then
   $sudo rm -rf "${INSTALL_PATH}/backend.ai"
   $sudo rm -rf "${INSTALL_PATH}/vfolder"
   $sudo rm -rf "${INSTALL_PATH}/accel-cuda"
+  $sudo rm -rf "${INSTALL_PATH}/tester"
   $sudo rm -rf "${INSTALL_PATH}/wheelhouse"
   echo "Please remove ${INSTALL_PATH} by yourself."
 else

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -125,6 +125,7 @@ if [ $REMOVE_VENVS -eq 1 ]; then
   pyenv uninstall -f "venv-${ENV_ID}-webserver"
   pyenv uninstall -f "venv-${ENV_ID}-storage-proxy"
   pyenv uninstall -f "venv-${ENV_ID}-tester"
+  pyenv uninstall -f "tmp-grpcio-build"
 else
   echo "Skipped removal of Python virtual environments."
 fi
@@ -149,6 +150,7 @@ if [ $REMOVE_SOURCE -eq 1 ]; then
   $sudo rm -rf "${INSTALL_PATH}/backend.ai"
   $sudo rm -rf "${INSTALL_PATH}/vfolder"
   $sudo rm -rf "${INSTALL_PATH}/accel-cuda"
+  $sudo rm -rf "${INSTALL_PATH}/wheelhouse"
   echo "Please remove ${INSTALL_PATH} by yourself."
 else
   echo "Skipped removal of cloned source files."

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -593,6 +593,9 @@ if [ "$DISTRO" = "Darwin" -a "$(uname -p)" = "arm" ]; then
     export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
     export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
     echo "Set grpcio wheel build variables."
+  else
+    unset GRPC_PYTHON_BUILD_SYSTEM_OPENSSL
+    unset GRPC_PYTHON_BUILD_SYSTEM_ZLIB
   fi
   pip install -U -q pip setuptools wheel
   # ref: https://github.com/grpc/grpc/issues/28387

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -558,6 +558,8 @@ if [ "$DISTRO" = "Darwin" -a "$(uname -p)" = "arm" ]; then
   pip wheel -w ./wheelhouse --no-binary :all: grpcio grpcio-tools
   pyenv shell --unset
   pyenv uninstall -f tmp-grpcio-build
+  echo "List of prebuilt wheels:"
+  ls -l ./wheelhouse
   # Currently there are not many packages that provides prebuilt binaries for M1 Macs.
   # Let's configure necessary env-vars to build them locally via bdist_wheel.
   echo "Configuring additional build flags for local wheel builds for macOS on Apple Silicon ..."


### PR DESCRIPTION
- install-dev: Fix up grpcio wheel build for Python 3.10 and Apple Silicon (upstream: grpc/grpc#28387)
- fix: Explicitly clear GRPC build flags in Python 3.10
- fix: Reorder db init and image rescan because now 22.03+ uses the pgsql database for storing image metadata.
- fix: Explicitly set the architecture when making an initial alias of "python" image