### PR TITLE
fix: install grpcio on Apple M1 & python version notation

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -51,7 +51,7 @@ usage() {
   echo ""
   echo "  ${LWHITE}--python-version VERSION${NC}"
   echo "                       Set the Python version to install via pyenv"
-  echo "                       (default: 3.9.10)"
+  echo "                       (default: 3.10.2)"
   echo ""
   echo "  ${LWHITE}--install-path PATH${NC}  Set the target directory"
   echo "                       (default: ./backend.ai-dev)"
@@ -542,7 +542,7 @@ if [ "$DISTRO" = "Darwin" -a "$(uname -p)" = "arm" ]; then
   show_info "Prebuild grpcio wheels for Apple Silicon..."
   pyenv virtualenv "${PYTHON_VERSION}" tmp-grpcio-build
   pyenv shell tmp-grpcio-build
-  if [ $(python -c 'import sys; print(1 if sys.version_info >= (3, 10) else 0)') -eq 0 ]; then
+  if [ $(python -c 'import sys; print(1 if sys.version_info >= (3, 10) else 0)') -eq 1 ]; then
     # ref: https://github.com/grpc/grpc/issues/25082
     export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
     export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1


### PR DESCRIPTION
1. fix to install grpcio on Apple M1 platform
read the link https://github.com/grpc/grpc/issues/25082
Some environment variables need to be set for build on apple M1 platform.
```
export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
```

However, I found that the script doesn't set some environment variables on Apple M1.
So, I fix shell script code.

2. fix the python version notation on shell script
`3.9.10` to `3.10.2`

This repository is a meta repository where we only keep compatible version
dependencies to individual components of Backend.AI.

Please head to appropriate Backend.AI sub-projects (e.g., manager, agent, kernels) to
contribute your code unless you really have contribution here.
