### PR TITLE
add g++ package at install-dev.sh on Ubuntu

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -260,7 +260,7 @@ install_script_deps() {
   case $DISTRO in
   Debian)
     $sudo apt-get update
-    $sudo apt-get install -y git jq gcc make
+    $sudo apt-get install -y git jq gcc make g++
     ;;
   RedHat)
     $sudo yum clean expire-cache  # next yum invocation will update package metadata cache


### PR DESCRIPTION
add g++ package at install-dev.sh on Ubuntu
New backend.ai version[21.03] needs g++ package on Ubuntu

This repository is a meta repository where we only keep compatible version
dependencies to individual components of Backend.AI.

Please head to appropriate Backend.AI sub-projects (e.g., manager, agent, kernels) to
contribute your code unless you really have contribution here.

close https://github.com/lablup/backend.ai/issues/401