### PR TITLE
feat: execute keypair bootstrap script for batch compute session

### DIFF
--- a/changes/437.feature
+++ b/changes/437.feature
@@ -1,1 +1,1 @@
-Execute keypair bootstrap script for batch compute session.
+Execute the keypair bootstrap script for batch compute session as well (previously it was only executed for interactive sessions)

--- a/changes/437.feature
+++ b/changes/437.feature
@@ -1,0 +1,1 @@
+Execute keypair bootstrap script for batch compute session.

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -506,8 +506,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
         owner_uuid, group_id, resource_policy = await _query_userinfo(request, params, conn)
 
         # Use keypair bootstrap_script if it is not delivered as a parameter
-        # (only for INTERACTIVE sessions).
-        if params['session_type'] == SessionTypes.INTERACTIVE and not params['bootstrap_script']:
+        if not params['bootstrap_script']:
             script, _ = await query_bootstrap_script(conn, owner_access_key)
             params['bootstrap_script'] = script
 


### PR DESCRIPTION
Execute keypair bootstrap script for batch compute session as well. I don't see any reason to skip the bootstrap script for batch session.