### PR TITLE
fix: Refine `install-dev.sh` and the `./py` wrapper

### DIFF
--- a/changes/438.fix
+++ b/changes/438.fix
@@ -1,1 +1,1 @@
-Refine `install-dev.sh` and `./pants` script to better detect and use an existing CPython available in the host
+Refine `scripts/install-dev.sh`, `./py`, and `./pants-local` scripts to better detect and use an existing CPython available in the host

--- a/changes/438.fix
+++ b/changes/438.fix
@@ -1,0 +1,1 @@
+modify install and pants executing scripts for detail handling.

--- a/changes/438.fix
+++ b/changes/438.fix
@@ -1,1 +1,1 @@
-modify install and pants executing scripts for detail handling.
+Refine `install-dev.sh` and `./pants` script to better detect and use an existing CPython available in the host

--- a/py
+++ b/py
@@ -4,7 +4,7 @@ if [ ! -d dist/export/python/virtualenvs/python-default ]; then
   >&2 echo "Please run './pants export ::' first and try again."
   exit 1
 fi
-PYTHON_VERSION=$(cat pants.toml | python -c 'import sys,re;m=re.search("CPython==([^\"]+)", sys.stdin.read());print(m.group(1) if m else sys.exit(1))')
+PYTHON_VERSION=$(cat pants.toml | python3 -c 'import sys,re;m=re.search("CPython==([^\"]+)", sys.stdin.read());print(m.group(1) if m else sys.exit(1))')
 if [ $? -ne 0 ]; then
   >&2 echo "Could not read the target CPython interpreter version from pants.toml"
   exit 1

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -166,10 +166,10 @@ else
   show_info "Please send us a pull request or file an issue to support your environment!"
   exit 1
 fi
-if [ $(has_python "python") -eq 1 ]; then
-  bpython=$(which "python")
-elif [ $(has_python "python3") -eq 1 ]; then
+if [ $(has_python "python3") -eq 1 ]; then
   bpython=$(which "python3")
+elif [ $(has_python "python") -eq 1 ]; then
+  bpython=$(which "python")
 elif [ $(has_python "python2") -eq 1 ]; then
   bpython=$(which "python2")
 else
@@ -444,7 +444,7 @@ echo "${LGREEN}Backend.AI one-line installer for developers${NC}"
 # Check prerequisites
 show_info "Checking prerequisites and script dependencies..."
 install_script_deps
-$bpython -m pip --disable-pip-version-check install -q requests requests_unixsocket
+$bpython -m pip --disable-pip-version-check install -q requests requests-unixsocket
 $bpython scripts/check-docker.py
 if [ $? -ne 0 ]; then
   exit 1
@@ -521,7 +521,9 @@ show_info "Using the current working-copy directory as the installation path..."
 mkdir -p ./wheelhouse
 if [ "$DISTRO" = "Darwin" -a "$(uname -p)" = "arm" ]; then
   show_info "Prebuild grpcio wheels for Apple Silicon..."
-  pyenv virtualenv "${PYTHON_VERSION}" tmp-grpcio-build
+  if [ -z "$(pyenv virtualenvs | grep "tmp-grpcio-build")" ]; then
+    pyenv virtualenv "${PYTHON_VERSION}" tmp-grpcio-build
+  fi
   pyenv shell tmp-grpcio-build
   if [ $(python -c 'import sys; print(1 if sys.version_info >= (3, 10) else 0)') -eq 0 ]; then
     # ref: https://github.com/grpc/grpc/issues/25082

--- a/tools/pants-local
+++ b/tools/pants-local
@@ -14,6 +14,8 @@ fi
 if [ -z "$PY" ]; then
   echo "The Python version for source-built Pants is not configured in ./.pants.env"
   exit 1
+else
+  export PY=$PY
 fi
 PANTS_SOURCE="${PANTS_SOURCE:-$(pwd)/tools/pants-src}"
 


### PR DESCRIPTION
modify install and pants executing scripts for detail handling such as exporting `PY` env and check whether a temporary env exists