### PR TITLE
fix: save kernel registry when KernelStartedEvent and KernelTerminatedEvent

### DIFF
--- a/changes/441.fix
+++ b/changes/441.fix
@@ -1,0 +1,1 @@
+Dump kernel registry information to a file upon `KernelStartedEvent` or `KernelTerminatedEvent`. Saving at container start event did not ensure the existence of kernel object's `runner` attribute, which may cause `AttributeError` in restarting the Agent server.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -3,6 +3,10 @@
 # Set "echo -e" as default
 shopt -s xpg_echo
 
+# For CentOS 7 or older versions of Linux only
+# - To make old gcc to allow declaring a vairiable inside a for loop.
+# PANTS_PYTHON_NATIVE_CODE_CPP_FLAGS="-std=gnu99"
+
 RED="\033[0;91m"
 GREEN="\033[0;92m"
 YELLOW="\033[0;93m"

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -890,7 +890,6 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
         async with aiotools.PersistentTaskGroup(
             exception_handler=lifecycle_task_exception_handler,
         ) as tg:
-            ipc_base_path = self.local_config['agent']['ipc-base-path']
             while True:
                 ev = await self.container_lifecycle_queue.get()
                 if isinstance(ev, Sentinel):

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -632,6 +632,8 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
                             await t
                         except asyncio.CancelledError:
                             continue
+        if isinstance(event, KernelStartedEvent) or isinstance(event, KernelTerminatedEvent):
+            await self.save_last_registry()
         await self.event_producer.produce_event(event, source=self.local_config['agent']['id'])
 
     async def produce_error_event(
@@ -891,13 +893,8 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
             ipc_base_path = self.local_config['agent']['ipc-base-path']
             while True:
                 ev = await self.container_lifecycle_queue.get()
-                now = time.monotonic()
-                if now > self.last_registry_written_time + 60 or isinstance(ev, Sentinel):
-                    self.last_registry_written_time = now
-                    with open(ipc_base_path / f'last_registry.{self.local_instance_id}.dat', 'wb') as f:
-                        pickle.dump(self.kernel_registry, f)
-                    log.debug(f'saved last_registry.{self.local_instance_id}.dat')
                 if isinstance(ev, Sentinel):
+                    await self.save_last_registry()
                     return
                 # attr currently does not support customizing getstate/setstate dunder methods
                 # until the next release.
@@ -1805,3 +1802,16 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
 
     async def list_files(self, kernel_id: KernelId, path: str):
         return await self.kernel_registry[kernel_id].list_files(path)
+
+    async def save_last_registry(self) -> None:
+        if now := time.monotonic() <= self.last_registry_written_time + 60:
+            return  # don't save too frequently
+        try:
+            ipc_base_path = self.local_config["agent"]["ipc-base-path"]
+            last_registry_file = f"last_registry.{self.local_instance_id}.dat"
+            with open(ipc_base_path / last_registry_file, "wb") as f:
+                pickle.dump(self.kernel_registry, f)
+            self.last_registry_written_time = now
+            log.debug("saved {}", last_registry_file)
+        except Exception as e:
+            log.exception("unable to save {}", last_registry_file, exc_info=e)

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -171,7 +171,6 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         self.stats_enabled = False
         self._tasks = set()
         self.environ = environ
-        self.runner = None
 
     async def init(self) -> None:
         log.debug('kernel.init(k:{0}, api-ver:{1}, client-features:{2}): '

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -171,6 +171,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         self.stats_enabled = False
         self._tasks = set()
         self.environ = environ
+        self.runner = None
 
     async def init(self) -> None:
         log.debug('kernel.init(k:{0}, api-ver:{1}, client-features:{2}): '

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -362,7 +362,10 @@ class StatContext:
         async with self._lock:
             kernel_id_map: Dict[ContainerId, KernelId] = {}
             for kid, info in self.agent.kernel_registry.items():
-                cid = info['container_id']
+                try:
+                    cid = info['container_id']
+                except KeyError:
+                    log.warning('collect_container_stat(): no container for kernel {}}', kid)
                 kernel_id_map[ContainerId(cid)] = kid
             unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
             for unused_kernel_id in unused_kernel_ids:


### PR DESCRIPTION
Dump kernel registry information to a file upon `KernelStartedEvent` or `KernelTerminatedEvent`. Saving at container start event did not ensure the existence of kernel object's `runner` attribute, which may cause `AttributeError` in restarting the Agent server.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
