### PR TITLE
setup: Replace toml with tomli

### DIFF
--- a/changes/445.fix.md
+++ b/changes/445.fix.md
@@ -1,0 +1,1 @@
+Replace `toml` with `tomli` which is chosen as the stdlib base implementation in Python 3.11

--- a/python.lock
+++ b/python.lock
@@ -66,7 +66,7 @@
 //     "tabulate~=0.8.9",
 //     "tblib~=1.7",
 //     "tenacity>=8.0",
-//     "toml>=0.10.2; python_version <= \"3.11\"",
+//     "tomli~=2.0.1",
 //     "tomlkit~=0.8.0",
 //     "tqdm>=4.61",
 //     "trafaret~=2.1",
@@ -80,7 +80,6 @@
 //     "types-setuptools",
 //     "types-six",
 //     "types-tabulate",
-//     "types-toml",
 //     "typing_extensions~=4.1.1",
 //     "uvloop>=0.16",
 //     "yarl>=1.7",
@@ -1921,49 +1920,69 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c1ba333b4024c17c7591f0f372e2daa3c31db495a9b2af3cf664aef3c14354f7",
-              "url": "https://files.pythonhosted.org/packages/26/71/5fbd40e87fabaf6f60c2fa8934d93ec1df542b7f978a080ce99f6734934d/msgpack-1.0.3-cp310-cp310-win_amd64.whl"
+              "hash": "4dea20515f660aa6b7e964433b1808d098dcfcabbebeaaad240d11f909298075",
+              "url": "https://files.pythonhosted.org/packages/ef/3f/f20ed47d3a356a556edbd8f9d0515a5a111ffde1e24213a64da948d823a2/msgpack-1.0.4-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36a64a10b16c2ab31dcd5f32d9787ed41fe68ab23dd66957ca2826c7f10d0b85",
-              "url": "https://files.pythonhosted.org/packages/06/e5/da31b9be6bed416c29906e0f9eff66af3e08f0b6e11caa7858d649e8ca1f/msgpack-1.0.3-cp310-cp310-win32.whl"
+              "hash": "f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f",
+              "url": "https://files.pythonhosted.org/packages/22/44/0829b19ac243211d1d2bd759999aa92196c546518b0be91de9cacc98122a/msgpack-1.0.4.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c58cdec1cb5fcea8c2f1771d7b5fec79307d056874f746690bd2bdd609ab147",
-              "url": "https://files.pythonhosted.org/packages/1b/18/61b7462849c31fafd7c7d05a2ae896d495a1c1bf7f25788a4a8af9439153/msgpack-1.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "aca0f1644d6b5a73eb3e74d4d64d5d8c6c3d577e753a04c9e9c87d07692c58db",
+              "url": "https://files.pythonhosted.org/packages/29/e3/c596dbeac35a2e14282d95b71851de8fac2ff4ad6cb7e87b1eea04396985/msgpack-1.0.4-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "96acc674bb9c9be63fa8b6dabc3248fdc575c4adc005c440ad02f87ca7edd079",
-              "url": "https://files.pythonhosted.org/packages/4f/e9/837b5c2209d41ddaf99cc7247598191d6f9f776c017b95abb5ada761ef93/msgpack-1.0.3-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "eb514ad14edf07a1dbe63761fd30f89ae79b42625731e1ccf5e1f1092950eaa6",
+              "url": "https://files.pythonhosted.org/packages/4e/77/7a9ec1887d62c16dd2d9d21bf8184af535d1371d75751415871f70f373f1/msgpack-1.0.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e",
-              "url": "https://files.pythonhosted.org/packages/61/3c/2206f39880d38ca7ad8ac1b28d2d5ca81632d163b2d68ef90e46409ca057/msgpack-1.0.3.tar.gz"
+              "hash": "49565b0e3d7896d9ea71d9095df15b7f75a035c49be733051c34762ca95bbf7e",
+              "url": "https://files.pythonhosted.org/packages/6c/99/decc145948ac7ecb97ae58eed39e827a289bb8d1e4b471bff158af3bd9a2/msgpack-1.0.4-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2f97c0f35b3b096a330bb4a1a9247d0bd7e1f3a2eba7ab69795501504b1c2c39",
-              "url": "https://files.pythonhosted.org/packages/a5/36/3734c798885a93c6e8fe4422184ad089c6e2e44c18d2b18f09cc029c02b8/msgpack-1.0.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "c23080fdeec4716aede32b4e0ef7e213c7b1093eede9ee010949f2a418ced6ba",
+              "url": "https://files.pythonhosted.org/packages/70/74/6cfcf4c52e5d69fa2e5e0fc66005db28f1ae613271cfd1c0b4b7ab309553/msgpack-1.0.4-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2c3ca57c96c8e69c1a0d2926a6acf2d9a522b41dc4253a8945c4c6cd4981a4e3",
-              "url": "https://files.pythonhosted.org/packages/b9/f4/4d2ee26409739c1a4b1dc3b8e4c50dedd9d5054d1ab5fec9830c42ebb3b6/msgpack-1.0.3-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "0dfe3947db5fb9ce52aaea6ca28112a170db9eae75adf9339a1aec434dc954ef",
+              "url": "https://files.pythonhosted.org/packages/76/19/c84285eacc20a7161962a7a15944364a8310dd7840c3aa57d87c7bb4f6c2/msgpack-1.0.4-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b0a792c091bac433dfe0a70ac17fc2087d4595ab835b47b89defc8bbabcf5c73",
-              "url": "https://files.pythonhosted.org/packages/bd/c5/e69b0e5f216191b09261957a75a78078aa2bc90a7138e5186eb641e45d9f/msgpack-1.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4ab251d229d10498e9a2f3b1e68ef64cb393394ec477e3370c457f9430ce9250",
+              "url": "https://files.pythonhosted.org/packages/83/69/2f442b38fbba1cedc88bfce381b67d78b59145471a3c9581ec9417a8625b/msgpack-1.0.4-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "112b0f93202d7c0fef0b7810d465fde23c746a2d482e1e2de2aafd2ce1492c88",
+              "url": "https://files.pythonhosted.org/packages/91/d2/c6aa033ca5ffd635561d53535af20ac1565b0ea3c1506d12f9a8fdad79af/msgpack-1.0.4-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "002b5c72b6cd9b4bafd790f364b8480e859b4712e91f43014fe01e4f957b8467",
+              "url": "https://files.pythonhosted.org/packages/bb/99/f4d7081da13af22efb547f305ea563f41d43dbaa1637136bbfd6ee9b2b36/msgpack-1.0.4-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "35bc0faa494b0f1d851fd29129b2575b2e26d41d177caacd4206d81502d4c6a6",
+              "url": "https://files.pythonhosted.org/packages/dc/16/a8b2de141c4fc536627560b9d3139a6f73bdb2cb5d32ec08a0d875b1210a/msgpack-1.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4733359808c56d5d7756628736061c432ded018e7a1dff2d35a02439043321aa",
+              "url": "https://files.pythonhosted.org/packages/ea/18/ef2e84d4ac07262b6ce2ff52cf4f6c97d95b4702a1acbc0da34fdc7701d9/msgpack-1.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "msgpack",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.0.3"
+          "version": "1.0.4"
         },
         {
           "artifacts": [
@@ -2739,13 +2758,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "84316970995a7adb907a56754d2b92d88fc2d252963dc5ac34c88f0f1a22c25d",
-              "url": "https://files.pythonhosted.org/packages/c3/d8/46f3c0dadb5499031282b43d9c280a3c3d70107b6b0217122a92476fb5b0/redis-4.3.1-py3-none-any.whl"
+              "hash": "f57f8df5d238a8ecf92f499b6b21467bfee6c13d89953c27edf1e2bc673622e7",
+              "url": "https://files.pythonhosted.org/packages/39/a6/022ed2fb6d4526c60e7b7e8830e6d5797cd2711719aa4392f99eda787706/redis-4.3.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "94b617b4cd296e94991146f66fc5559756fbefe9493604f0312e4d3298ac63e9",
-              "url": "https://files.pythonhosted.org/packages/56/78/c8c819080f6fbdd72e314756e1cb259199814b64d821dd396810dedce247/redis-4.3.1.tar.gz"
+              "hash": "2f7a57cf4af15cd543c4394bcbe2b9148db2606a37edba755368836e3a1d053e",
+              "url": "https://files.pythonhosted.org/packages/09/37/d58ce17fed05620b3ebfe6dff2b94367347b2fd01491b1a38bd4e74d9eeb/redis-4.3.3.tar.gz"
             }
           ],
           "project_name": "redis",
@@ -2761,7 +2780,7 @@
             "typing-extensions; python_version < \"3.8\""
           ],
           "requires_python": ">=3.6",
-          "version": "4.3.1"
+          "version": "4.3.3"
         },
         {
           "artifacts": [
@@ -3032,38 +3051,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "64d796e9af522162f7f2bf7a3c5531a0a550764c426782797bbeed809d0646c5",
-              "url": "https://files.pythonhosted.org/packages/46/be/1fe89630d6bcd239c702117a5c7be7f1403137b8dd5fb451533995d73b58/SQLAlchemy-1.4.36-cp310-cp310-win_amd64.whl"
+              "hash": "7a44683cf97744a405103ef8fdd31199e9d7fc41b4a67e9044523b29541662b0",
+              "url": "https://files.pythonhosted.org/packages/5b/50/f611e2a374e9b408019ffa8c69f243fdece6e8e03a381b7dd362e4758701/SQLAlchemy-1.4.37-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d07fe2de0325d06e7e73281e9a9b5e259fbd7cbfbe398a0433cbb0082ad8fa7",
-              "url": "https://files.pythonhosted.org/packages/3e/2c/fcb7508e5e40c42eb00516c7c1a936afae7af95b2de0e4680a60924fff7f/SQLAlchemy-1.4.36-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "7ee34c85cbda7779d66abac392c306ec78c13f5c73a1f01b8b767916d4895d23",
+              "url": "https://files.pythonhosted.org/packages/29/14/d62efb904935f7876728272a705863ffe310d8cf3c2c54c2c495376d12bc/SQLAlchemy-1.4.37-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f0394a3acfb8925db178f7728adb38c027ed7e303665b225906bfa8099dc1ce8",
-              "url": "https://files.pythonhosted.org/packages/82/39/cab0562a7e580004b513856bf73af789a8b9aa810b3e2bb25b9ab74f720f/SQLAlchemy-1.4.36-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "78363f400fbda80f866e8e91d37d36fe6313ff847ded08674e272873c1377ea5",
+              "url": "https://files.pythonhosted.org/packages/7d/17/50a2cf230101515517d188d46742fd8eb05a139176d3324fca59b63a47ec/SQLAlchemy-1.4.37-cp310-cp310-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09c606d8238feae2f360b8742ffbe67741937eb0a05b57f536948d198a3def96",
-              "url": "https://files.pythonhosted.org/packages/9c/6b/81d2d3e3020f9105570a7e8730815134223802f13d1fd122ee5c813cf1d2/SQLAlchemy-1.4.36-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "2aac2a685feb9882d09f457f4e5586c885d578af4e97a2b759e91e8c457cbce5",
+              "url": "https://files.pythonhosted.org/packages/81/13/45ef5db732bd80944d72c7f7a79e72e0d4d3c68db475eca5744be71d983d/SQLAlchemy-1.4.37-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "be094460930087e50fd08297db9d7aadaed8408ad896baf758e9190c335632da",
-              "url": "https://files.pythonhosted.org/packages/b5/b1/3ea004b6e6a30f5098c20bfb3153343acabf5a6e0f1a77e1ab941165f3db/SQLAlchemy-1.4.36-cp310-cp310-win32.whl"
+              "hash": "3688f92c62db6c5df268e2264891078f17ecb91e3141b400f2e28d0f75796dea",
+              "url": "https://files.pythonhosted.org/packages/8c/6b/dd25a730940556f4a0130968f29040e4aa6478285a33ac041d1b0817d398/SQLAlchemy-1.4.37.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "5041474dcab7973baa91ec1f3112049a9dd4652898d6a95a6a895ff5c58beb6b",
-              "url": "https://files.pythonhosted.org/packages/d4/c8/1496a0fb6b853eeb2fbd82f0cdd3b5c1ca0a7d46146dc91ce3b65a1616bf/SQLAlchemy-1.4.36-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8b38e088659b30c2ca0af63e5d139fad1779a7925d75075a08717a21c406c0f6",
+              "url": "https://files.pythonhosted.org/packages/ea/61/b164b4fcf4a2161692fa8903c79cebc5a7c711c3701493f72292efb32e6a/SQLAlchemy-1.4.37-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "64678ac321d64a45901ef2e24725ec5e783f1f4a588305e196431447e7ace243",
-              "url": "https://files.pythonhosted.org/packages/fb/b0/53e540c9fad14ac2da8a15ae95d707b167f64f62d85d4f506b0335dfd66d/SQLAlchemy-1.4.36.tar.gz"
+              "hash": "6629c79967a6c92e33fad811599adf9bc5cee6e504a1027bbf9cc1b6fb2d276d",
+              "url": "https://files.pythonhosted.org/packages/f3/60/622337c2cc2ace7997c9434ea3aef8d68cc068901cdbcdf95619248504da/SQLAlchemy-1.4.37-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "sqlalchemy",
@@ -3086,7 +3105,7 @@
             "mysql-connector-python; extra == \"mysql_connector\"",
             "mysqlclient<2,>=1.4.0; python_version < \"3\" and extra == \"mysql\"",
             "mysqlclient>=1.4.0; python_version >= \"3\" and extra == \"mysql\"",
-            "pg8000>=1.16.6; extra == \"postgresql_pg8000\"",
+            "pg8000!=1.29.0,>=1.16.6; extra == \"postgresql_pg8000\"",
             "psycopg2-binary; extra == \"postgresql_psycopg2binary\"",
             "psycopg2>=2.7; extra == \"postgresql\"",
             "psycopg2cffi; extra == \"postgresql_psycopg2cffi\"",
@@ -3100,7 +3119,7 @@
             "typing-extensions!=3.10.0.1; extra == \"aiosqlite\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.4.36"
+          "version": "1.4.37"
         },
         {
           "artifacts": [
@@ -3192,24 +3211,6 @@
           "requires_dists": [],
           "requires_python": ">=2.6",
           "version": "3.1.10"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-              "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
-              "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz"
-            }
-          ],
-          "project_name": "toml",
-          "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.6",
-          "version": "0.10.2"
         },
         {
           "artifacts": [
@@ -3433,19 +3434,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7b273a34f32af9910cf9405728c9d2ad3afc4be63e4048091a1a73d76681fe67",
-              "url": "https://files.pythonhosted.org/packages/c6/e0/6e3e8e3af769206cb4f3f9e90e9e72e9df3bf921602d63ac117dcd7f1c30/types_PyYAML-6.0.7-py3-none-any.whl"
+              "hash": "56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff",
+              "url": "https://files.pythonhosted.org/packages/cf/1e/e8a2e127dac81fa53d181f15c6ca5ea3f472e8e531055a6b2bcb25be8a9d/types_PyYAML-6.0.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "59480cf44595d836aaae050f35e3c39f197f3a833679ef3978d97aa9f2fb7def",
-              "url": "https://files.pythonhosted.org/packages/42/6d/3d9bcc1ca2634492fa92bd311d2e1fede17ce9377e54bf11560ccf5305ca/types-PyYAML-6.0.7.tar.gz"
+              "hash": "d9495d377bb4f9c5387ac278776403eb3b4bb376851025d913eea4c22b4c6438",
+              "url": "https://files.pythonhosted.org/packages/1d/b5/bb2c2541056b26c419ed9ce8635e483257562433026a7174bddd078f665c/types-PyYAML-6.0.8.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
           "requires_python": null,
-          "version": "6.0.7"
+          "version": "6.0.8"
         },
         {
           "artifacts": [
@@ -3500,24 +3501,6 @@
           "requires_dists": [],
           "requires_python": null,
           "version": "0.8.9"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "05a8da4bfde2f1ee60e90c7071c063b461f74c63a9c3c1099470c08d6fa58615",
-              "url": "https://files.pythonhosted.org/packages/77/02/8bb35dc27ea84f9ac5f4bf70a51ae5626734843ac73a117fd88888551069/types_toml-0.10.7-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a567fe2614b177d537ad99a661adc9bfc8c55a46f95e66370a4ed2dd171335f9",
-              "url": "https://files.pythonhosted.org/packages/c5/da/a5fb5c4eb663a1cd2d0c8ef619c42d51e6b8f55e155341e7b39b8c6c67b4/types-toml-0.10.7.tar.gz"
-            }
-          ],
-          "project_name": "types-toml",
-          "requires_dists": [],
-          "requires_python": null,
-          "version": "0.10.7"
         },
         {
           "artifacts": [
@@ -3825,7 +3808,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.84",
+  "pex_version": "2.1.90",
   "prefer_older_binary": false,
   "requirements": [
     "Jinja2~=3.0.1",
@@ -3885,7 +3868,7 @@
     "tabulate~=0.8.9",
     "tblib~=1.7",
     "tenacity>=8.0",
-    "toml>=0.10.2; python_version <= \"3.11\"",
+    "tomli~=2.0.1",
     "tomlkit~=0.8.0",
     "tqdm>=4.61",
     "trafaret~=2.1",
@@ -3899,7 +3882,6 @@
     "types-setuptools",
     "types-six",
     "types-tabulate",
-    "types-toml",
     "typing_extensions~=4.1.1",
     "uvloop>=0.16",
     "yarl>=1.7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ setproctitle~=1.2.2
 tabulate~=0.8.9
 tblib~=1.7
 tenacity>=8.0
-toml>=0.10.2 ; python_version<='3.11'
+tomli~=2.0.1
 tomlkit~=0.8.0
 tqdm>=4.61
 trafaret~=2.1
@@ -73,7 +73,6 @@ types-python-dateutil
 types-setuptools
 types-six
 types-tabulate
-types-toml
 
 backend.ai-krunner-alpine~=3.3
 backend.ai-krunner-static-gnu~=2.0

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -10,8 +10,7 @@ from typing import (
     cast,
 )
 
-import toml
-from toml.decoder import InlineTableDict
+import tomli
 import trafaret as t
 
 from . import validators as tx
@@ -88,8 +87,7 @@ def read_from_file(toml_path: Optional[Union[Path, str]], daemon_name: str) -> T
     else:
         discovered_path = Path(toml_path)
     try:
-        config = cast(Dict[str, Any], toml.loads(discovered_path.read_text()))
-        config = _sanitize_inline_dicts(config)
+        config = cast(Dict[str, Any], tomli.loads(discovered_path.read_text()))
     except IOError:
         raise ConfigurationError({
             'read_from_file()': f"Could not read config from: {discovered_path}",
@@ -106,8 +104,7 @@ async def read_from_etcd(etcd_config: Mapping[str, Any],
     if raw_value is None:
         return None
     config: Dict[str, Any]
-    config = cast(Dict[str, Any], toml.loads(raw_value))
-    config = _sanitize_inline_dicts(config)
+    config = cast(Dict[str, Any], tomli.loads(raw_value))
     return config
 
 
@@ -142,22 +139,6 @@ def merge(table: Mapping[str, Any], updates: Mapping[str, Any]) -> Mapping[str, 
             orig = result.get(k, {})
             assert isinstance(orig, Mapping)
             result[k] = merge(orig, v)
-        else:
-            result[k] = v
-    return result
-
-
-def _sanitize_inline_dicts(table: Dict[str, Any] | InlineTableDict) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
-    # Due to the way of toml.decoder to use Python class hierarchy to annotate
-    # inline or non-inline tables of TOML, we need to skip type checking here.
-    for k, v in table.items():  # type: ignore
-        if isinstance(v, InlineTableDict):
-            # Since this function always returns a copied dict,
-            # this automatically converts InlineTableDict to dict.
-            result[k] = _sanitize_inline_dicts(cast(Dict[str, Any], v))
-        elif isinstance(v, Dict):
-            result[k] = _sanitize_inline_dicts(v)
         else:
             result[k] = v
     return result

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -28,7 +28,7 @@ import aioredis
 import click
 import jinja2
 from setproctitle import setproctitle
-import toml
+import tomli
 import uvloop
 import yarl
 
@@ -630,7 +630,7 @@ async def server_main(
               default=False,
               help='Use more verbose logging.')
 def main(config_path: str, debug: bool) -> None:
-    config = toml.loads(Path(config_path).read_text(encoding='utf-8'))
+    config = tomli.loads(Path(config_path).read_text(encoding='utf-8'))
     config['debug'] = debug
     if config['debug']:
         debugFlag = 'DEBUG'

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,9 +1,8 @@
 import pickle
 
-import toml
-from toml.decoder import InlineTableDict
+import tomli
 
-from ai.backend.common.config import override_key, merge, _sanitize_inline_dicts
+from ai.backend.common.config import override_key, merge
 
 
 def test_override_key():
@@ -62,21 +61,10 @@ def test_sanitize_inline_dicts():
     b = { x = 1, y = { t = 2, u = 2 } }
     '''
 
-    result = toml.loads(sample)
+    result = tomli.loads(sample)
     assert isinstance(result['section']['a'], dict)
-    assert isinstance(result['section']['a'], InlineTableDict)
     assert isinstance(result['section']['b'], dict)
-    assert isinstance(result['section']['b'], InlineTableDict)
     assert isinstance(result['section']['b']['y'], dict)
-    assert isinstance(result['section']['b']['y'], InlineTableDict)
-
-    result = _sanitize_inline_dicts(result)
-    assert isinstance(result['section']['a'], dict)
-    assert not isinstance(result['section']['a'], InlineTableDict)
-    assert isinstance(result['section']['b'], dict)
-    assert not isinstance(result['section']['b'], InlineTableDict)
-    assert isinstance(result['section']['b']['y'], dict)
-    assert not isinstance(result['section']['b']['y'], InlineTableDict)
 
     # Also ensure the result is picklable.
     data = pickle.dumps(result)


### PR DESCRIPTION
- `tomli` is chosen as the official stdlib `tomllib` in Python 3.11.
  So let's use it for maximum compatibility.

  ref) https://peps.python.org/pep-0680/