### PR TITLE
fix: agent startup error due to unbound local error in dumping the last registry

### DIFF
--- a/changes/450.fix
+++ b/changes/450.fix
@@ -1,0 +1,1 @@
+Always dump kernel registry information to a file upon agent termination.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1803,7 +1803,8 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
         return await self.kernel_registry[kernel_id].list_files(path)
 
     async def save_last_registry(self, force=False) -> None:
-        if (not force) and (now := time.monotonic() <= self.last_registry_written_time + 60):
+        now = time.monotonic()
+        if (not force) and (now <= self.last_registry_written_time + 60):
             return  # don't save too frequently
         try:
             ipc_base_path = self.local_config["agent"]["ipc-base-path"]

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -893,7 +893,7 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
             while True:
                 ev = await self.container_lifecycle_queue.get()
                 if isinstance(ev, Sentinel):
-                    await self.save_last_registry()
+                    await self.save_last_registry(force=True)
                     return
                 # attr currently does not support customizing getstate/setstate dunder methods
                 # until the next release.
@@ -1802,8 +1802,8 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
     async def list_files(self, kernel_id: KernelId, path: str):
         return await self.kernel_registry[kernel_id].list_files(path)
 
-    async def save_last_registry(self) -> None:
-        if now := time.monotonic() <= self.last_registry_written_time + 60:
+    async def save_last_registry(self, force=False) -> None:
+        if (not force) and (now := time.monotonic() <= self.last_registry_written_time + 60):
             return  # don't save too frequently
         try:
             ipc_base_path = self.local_config["agent"]["ipc-base-path"]

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -365,7 +365,7 @@ class StatContext:
                 try:
                     cid = info['container_id']
                 except KeyError:
-                    log.warning('collect_container_stat(): no container for kernel {}}', kid)
+                    log.warning('collect_container_stat(): no container for kernel {}', kid)
                 kernel_id_map[ContainerId(cid)] = kid
             unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
             for unused_kernel_id in unused_kernel_ids:


### PR DESCRIPTION
- fix: always dump kernel registry information upon agent termination
- Add news fragment
- fix: typo
- fix: UnboundLocalError in starting the agent server

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
