### PR TITLE
fix: agent startup error due to `UnboundLocalError` in dumping the last registry

### DIFF
--- a/changes/452.fix
+++ b/changes/452.fix
@@ -1,0 +1,1 @@
+Agent startup error due to `UnboundLocalError` of `now` variable in dumping the last registry.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1803,7 +1803,8 @@ class AbstractAgent(aobject, Generic[KernelObjectType, KernelCreationContextType
         return await self.kernel_registry[kernel_id].list_files(path)
 
     async def save_last_registry(self, force=False) -> None:
-        if (not force) and (now := time.monotonic() <= self.last_registry_written_time + 60):
+        now = time.monotonic()
+        if (not force) and (now <= self.last_registry_written_time + 60):
             return  # don't save too frequently
         try:
             ipc_base_path = self.local_config["agent"]["ipc-base-path"]


### PR DESCRIPTION
This is a follow-up of https://github.com/lablup/backend.ai/pull/450.
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
