### PR TITLE
fix: Missing dependencies for ai.backend.web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,18 +5,17 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
-build/
-develop-eggs/
-dist/
+/build/
+/dist/
 downloads/
+develop-eggs/
 eggs/
 .eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
+/lib/
+/lib64/
+/parts/
+/sdist/
+/var/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -32,7 +31,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-htmlcov/
+/htmlcov/
 .tox/
 .coverage
 .coverage.*
@@ -61,9 +60,6 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-
-# PyBuilder
-target/
 
 # IPython Notebook
 .ipynb_checkpoints

--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ python_requirements(
     module_mapping={
         "aiodataloader-ng": ["aiodataloader"],
         "attrs": ["attr", "attrs"],
+        "aiohttp-session": ["aiohttp_session"],
         "python-dateutil": ["dateutil"],
         "python-json-logger": ["pythonjsonlogger"],
         "python-snappy": ["snappy"],

--- a/changes/459.fix.md
+++ b/changes/459.fix.md
@@ -1,0 +1,1 @@
+Correct missing dependencies due to different package-import names and indirect module references in the webserver

--- a/src/ai/backend/web/BUILD
+++ b/src/ai/backend/web/BUILD
@@ -4,6 +4,7 @@ python_sources(
     dependencies=[
         "src/ai/backend/client:lib",
         ":resources",
+        "//:reqs#coloredlogs",  # indirectly referred by logging config string
     ],
 )
 


### PR DESCRIPTION
There are some dependencies that require manual definition and import-pkg name mapping.