### PR TITLE
fix(testutils): Apply healthcheck to etcd container fixture too

### DIFF
--- a/changes/460.fix.md
+++ b/changes/460.fix.md
@@ -1,0 +1,1 @@
+Apply health check to the test fixture for creating an etcd container


### PR DESCRIPTION
Occasionally running pytest on `tests/common/test_distributed.py` (observed twice) and `tests/agent/docker/agent.py` (observed once).
The root cause is unknown yet, but try to avoid potential races upon the etcd container fixture.