### PR TITLE
fix(test): Add missing `export` keyword to `BACKENDAI_TEST_CLIENT_ENV` environment variable

### DIFF
--- a/changes/463.fix.md
+++ b/changes/463.fix.md
@@ -1,0 +1,1 @@
+Add `export` keyword to set `BACKENDAI_TEST_CLIENT_ENV` as an environment variable.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -628,8 +628,8 @@ sed_inplace "s/https:\/\/api.backend.ai/http:\/\/127.0.0.1:${MANAGER_PORT}/" ./w
 sed_inplace "s/ssl-verify = true/ssl-verify = false/" ./webserver.conf
 sed_inplace "s/redis.port = 6379/redis.port = ${REDIS_PORT}/" ./webserver.conf
 
-echo "BACKENDAI_TEST_CLIENT_ENV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )/env-local-admin-api.sh" > ./env-tester-admin.sh
-echo "BACKENDAI_TEST_CLIENT_ENV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )/env-local-user-api.sh" > ./env-tester-user.sh
+echo "export BACKENDAI_TEST_CLIENT_ENV=${PWD}/env-local-admin-api.sh" > ./env-tester-admin.sh
+echo "export BACKENDAI_TEST_CLIENT_ENV=${PWD}/env-local-user-api.sh" > ./env-tester-user.sh
 
 # DB schema
 show_info "Setting up databases..."


### PR DESCRIPTION
Refs:
- https://github.com/lablup/backend.ai/pull/442

There were some problems in previous PR;
1. `export` keyword was missing. Therefore, `BACKENDAI_TEST_CLIENT_ENV` was declared as bash variable rather than environment variable, which is not accessible from python runtime.
2. `$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )` means the path of the current script file, which is `/scripts`. However the actual scripts, `env-local-admin-api.sh` and `env-local-user-api.sh`, locate in root of the project. Therefore, it is changed to `${PWD}` which should be the root.

Sorry for the mistake.