### PR TITLE
fix: Ignore plugins-not-found message

### DIFF
--- a/changes/465.fix.md
+++ b/changes/465.fix.md
@@ -1,0 +1,1 @@
+Ignore error messages caused in case of plugin-not-found to keep any test case from being interfered.

--- a/py
+++ b/py
@@ -12,7 +12,7 @@ fi
 LOCKSET=${LOCKSET:-python-default/$PYTHON_VERSION}
 source dist/export/python/virtualenvs/$LOCKSET/bin/activate
 PYTHONPATH="${PYTHONPATH}"
-for plugin_dir in $(ls -d plugins/*/); do
+for plugin_dir in $(ls -d plugins/*/ 2>/dev/null); do
   PYTHONPATH="${plugin_dir}/src:${PYTHONPATH}"
 done
 PYTHONPATH="src:${PYTHONPATH}" python "$@"

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -13,8 +13,7 @@ def test_add_user(run: ClientRunnerFunc):
     # Check if test account exists
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
-        loaded = json.loads(decoded)
+        loaded = json.loads(p.before.decode())
         user_list = loaded.get('items')
 
     test_user1 = get_user_from_list(user_list, 'testaccount1')


### PR DESCRIPTION
Refs:
- lablup/backend.ai#464

Changed it to ignore messages from `ls -d plugins/*/` when there is no plugin.