### PR TITLE
fix(install-dev): Publicly open the manager's service-addr

### DIFF
--- a/changes/470.misc.md
+++ b/changes/470.misc.md
@@ -1,0 +1,1 @@
+Publicly open the service IP address of the manager for when installed as development setup on a virtual machine

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -15,7 +15,7 @@ password = "develove"
 
 [manager]
 num-proc = 4
-service-addr = { host = "127.0.0.1", port = 8081 }
+service-addr = { host = "0.0.0.0", port = 8081 }
 #user = "nobody"
 #group = "nobody"
 ssl-enabled = false


### PR DESCRIPTION
* When installed on a VM, it should be accessible from the VM host.