### PR TITLE
fix: Add a subvolume syscall exception for btrfs (#454)

### DIFF
--- a/changes/473.fix.md
+++ b/changes/473.fix.md
@@ -1,0 +1,1 @@
+Fix Python os.statvfs syscall to btrfs subvolume(eg. /var/lib/docker/btrfs ) permission error. add exception handling for btrfs subvolume syscall before os.statvfs syscall

--- a/changes/473.fix.md
+++ b/changes/473.fix.md
@@ -1,1 +1,1 @@
-Fix Python os.statvfs syscall to btrfs subvolume(eg. /var/lib/docker/btrfs ) permission error. add exception handling for btrfs subvolume syscall before os.statvfs syscall
+Let it ignore a permission error when calling Python `os.statvfs()` on a btrfs subvolume (e.g., `/var/lib/docker/btrfs`) as the intention of the call is to retrieve filesystem-level disk usage rather than subvolume statistics

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -371,6 +371,8 @@ class MemoryPlugin(AbstractComputePlugin):
             per_disk_stat = {}
             for disk_info in psutil.disk_partitions():
                 if disk_info.fstype not in pruned_disk_types:
+                    if '/var/lib/docker/btrfs' == disk_info.mountpoint:
+                        continue
                     dstat = os.statvfs(disk_info.mountpoint)
                     disk_usage = Decimal(dstat.f_frsize * (dstat.f_blocks - dstat.f_bavail))
                     disk_capacity = Decimal(dstat.f_frsize * dstat.f_blocks)


### PR DESCRIPTION
add a btrfs subvolumn system call exception

Python os.statvfs syscall to btrfs subvolume(eg. /var/lib/docker/btrfs ) failed with permission error,
adding exception handling before os.statvfs syscall

close https://github.com/lablup/backend.ai/issues/454

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
