### PR TITLE
feat: Support installation on openSUSE

### DIFF
--- a/changes/474.feature.md
+++ b/changes/474.feature.md
@@ -1,1 +1,1 @@
-Support for openSUSE Tumbleweed installation
+Support for openSUSE (Leap and Tumbleweed) installation

--- a/changes/474.feature.md
+++ b/changes/474.feature.md
@@ -1,0 +1,1 @@
+Support for openSUSE Tumbleweed installation

--- a/scripts/check-docker.py
+++ b/scripts/check-docker.py
@@ -1,8 +1,8 @@
 import functools
+import json
 import re
 import subprocess
 import sys
-import os
 from pathlib import Path
 from urllib.parse import quote
 
@@ -90,6 +90,8 @@ def main():
     try:
         proc = run(['docker', 'compose', 'version'], capture_output=True, check=True)
     except subprocess.CalledProcessError as e:
+        fail_with_compose_install_request()
+    else:
         m = re.search(r'\d+\.\d+\.\d+', proc.stdout.decode())
         if m is None:
             log("Failed to retrieve the docker-compose version!")

--- a/scripts/check-docker.py
+++ b/scripts/check-docker.py
@@ -72,41 +72,6 @@ def fail_with_compose_install_request():
     sys.exit(1)
 
 
-# Whatever is guessed above can be overridden in /usr/lib/os-release by derivatives
-def get_os_release():
-    distinfo = {}
-    os_release = os.environ.get('LSB_OS_RELEASE', '/usr/lib/os-release')
-    if os.path.exists(os_release):
-        try:
-            with open(os_release) as os_release_file:
-                for line in os_release_file:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    # Skip invalid lines
-                    if not '=' in line:
-                        continue
-                    var, arg = line.split('=', 1)
-                    if arg.startswith('"') and arg.endswith('"'):
-                        arg = arg[1:-1]
-                    if arg: # Ignore empty arguments
-                        # Concert os-release to lsb-release-style
-                        if var == 'VERSION_ID':
-                            # It'll ignore point-releases
-                            distinfo['RELEASE'] = arg.strip()
-                        elif var == 'VERSION_CODENAME':
-                            distinfo['CODENAME'] = arg.strip()
-                        elif var == 'ID':
-                            # ID=debian
-                            distinfo['ID'] = arg.strip().title()
-                        elif var == 'PRETTY_NAME':
-                            distinfo['DESCRIPTION'] = arg.strip()
-        except IOError as msg:
-            print('Unable to open ' + os_release + ':', str(msg), file=sys.stderr)
-            exit(1)
-
-    return distinfo
-
 def main():
     requests_unixsocket.monkeypatch()
 
@@ -122,34 +87,18 @@ def main():
         else:
             fail_with_system_docker_install_request()
 
-    if sys.platform.startswith('linux') and 'suse' in get_os_release()['ID'].lower():
-        try:
-            proc = run(['docker-compose', 'version'], capture_output=True, check=True)
-        except subprocess.CalledProcessError as e:
-            fail_with_compose_install_request()
+    try:
+        proc = run(['docker', 'compose', 'version'], capture_output=True, check=True)
+    except subprocess.CalledProcessError as e:
+        m = re.search(r'\d+\.\d+\.\d+', proc.stdout.decode())
+        if m is None:
+            log("Failed to retrieve the docker-compose version!")
+            sys.exit(1)
         else:
-            m = re.search(r'\d+\.\d+\.\d+', proc.stdout.decode())
-            if m is None:
-                log("Failed to retrieve the docker-compose version!")
-                sys.exit(1)
-            else:
-                compose_version = m.group(0)
-                log(f"Detected docker-compose installation ({compose_version})")
-                if parse_version(compose_version) < (2, 0, 0):
-                    fail_with_compose_install_request()
-    else:
-        try:
-            proc = run(['docker', 'compose', 'version'], capture_output=True, check=True)
-        except subprocess.CalledProcessError as e:
-            m = re.search(r'\d+\.\d+\.\d+', proc.stdout.decode())
-            if m is None:
-                log("Failed to retrieve the docker-compose version!")
-                sys.exit(1)
-            else:
-                compose_version = m.group(0)
-                log(f"Detected docker-compose installation ({compose_version})")
-                if parse_version(compose_version) < (2, 0, 0):
-                    fail_with_compose_install_request()
+            compose_version = m.group(0)
+            log(f"Detected docker-compose installation ({compose_version})")
+            if parse_version(compose_version) < (2, 0, 0):
+                fail_with_compose_install_request()
 
     # Now we can proceed with the given docker & docker-compose installation.
 

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -577,16 +577,8 @@ sed_inplace "s/8110:6379/${REDIS_PORT}:6379/" "docker-compose.halfstack.current.
 sed_inplace "s/8120:2379/${ETCD_PORT}:2379/" "docker-compose.halfstack.current.yml"
 mkdir -p "${HALFSTACK_VOLUME_PATH}/postgres-data"
 mkdir -p "${HALFSTACK_VOLUME_PATH}/etcd-data"
-case $DISTRO in
-  SUSE)
-    $docker_sudo docker-compose -f "docker-compose.halfstack.current.yml" up -d
-    $docker_sudo docker-compose -f "docker-compose.halfstack.current.yml" ps   # You should see three containers here.
-    ;;
-  *)
-    $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" up -d
-    $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" ps   # You should see three containers here.
-    ;;
-esac
+$docker_sudo docker compose -f "docker-compose.halfstack.current.yml" up -d
+$docker_sudo docker compose -f "docker-compose.halfstack.current.yml" ps   # You should see three containers here.
 
 check_snappy() {
   pip download python-snappy
@@ -684,14 +676,7 @@ show_info "Setting up virtual folder..."
 mkdir -p "${ROOT_PATH}/${VFOLDER_REL_PATH}"
 ./backend.ai mgr etcd put-json volumes "./dev.etcd.volumes.json"
 mkdir -p scratches
-case $DISTRO in
-  SUSE)
-    POSTGRES_CONTAINER_ID=$($docker_sudo docker-compose -f "docker-compose.halfstack.current.yml" ps | grep "[-_]backendai-half-db[-_]1" | awk '{print $1}')
-    ;;
-  *)
-    POSTGRES_CONTAINER_ID=$($docker_sudo docker compose -f "docker-compose.halfstack.current.yml" ps | grep "[-_]backendai-half-db[-_]1" | awk '{print $1}')
-    ;;
-esac
+POSTGRES_CONTAINER_ID=$($docker_sudo docker compose -f "docker-compose.halfstack.current.yml" ps | grep "[-_]backendai-half-db[-_]1" | awk '{print $1}')
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update domains set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update groups set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
 $docker_sudo docker exec -it $POSTGRES_CONTAINER_ID psql postgres://postgres:develove@localhost:5432/backend database -c "update keypair_resource_policies set allowed_vfolder_hosts = '{${LOCAL_STORAGE_PROXY}:${LOCAL_STORAGE_VOLUME}}';"
@@ -799,23 +784,9 @@ echo " "
 echo "${GREEN}Development environment is now ready.${NC}"
 show_note "How to run docker-compose:"
 if [ ! -z "$docker_sudo" ]; then
-  case $DISTRO in
-    SUSE)
-      echo "    > ${WHITE}${docker_sudo} docker-compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
-      ;;
-    *)
-      echo "    > ${WHITE}${docker_sudo} docker compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
-      ;;
-  esac
+  echo "    > ${WHITE}${docker_sudo} docker compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
 else
-  case $DISTRO in
-    SUSE)
-      echo "    > ${WHITE}docker-compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
-      ;;
-    *)
-      echo "    > ${WHITE}docker compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
-      ;;
-  esac
+  echo "    > ${WHITE}docker compose -f docker-compose.halfstack.current.yml up -d ...${NC}"
 fi
 show_note "How to reset this setup:"
 echo "    > ${WHITE}$(dirname $0)/delete-dev.sh${NC}"


### PR DESCRIPTION
Feat: Support for openSUSE Tumbleweed installation
Only the openSUSE Tumbleweed supports docker-compose v2.2, so only this
distribution is supported.
The lastest openSUSE Leap v15.4's docker-compose version is 1.25.
Also, The lastest SLES 15 SP3's docker-compose version is 1.25.
As a result, It only supported "openSUSE Tumbleweed", rolling release version.
close https://github.com/lablup/backend.ai/issues/404

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
