### PR TITLE
setup: Update required software versions

### DIFF
--- a/changes/475.fix.md
+++ b/changes/475.fix.md
@@ -1,0 +1,5 @@
+Update PostgreSQL, Redis and etcd versions
+ * PostgreSQL: 13.1 -> 13.7 (old versions)12.3 -> 12.11
+ * Redis: 6.2.6 -> 6.2.7
+ * etcd: 3.5.1 -> 3.5.4 (old versions) 3.4.14 -> 3.4.18
+

--- a/docker-compose.halfstack-2009.yml
+++ b/docker-compose.halfstack-2009.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:12.3-alpine
+    image: postgres:12.11-alpine
     restart: unless-stopped
     command: postgres -c 'max_connections=256'
     networks:

--- a/docker-compose.halfstack-2103.yml
+++ b/docker-compose.halfstack-2103.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.1-alpine
+    image: postgres:13.7-alpine
     restart: unless-stopped
     command: postgres -c 'max_connections=256'
     networks:
@@ -22,7 +22,7 @@ services:
       retries: 10
 
   backendai-half-redis:
-    image: redis:6.0.9-alpine
+    image: redis:6.2.7-alpine
     restart: unless-stopped
     networks:
       - half
@@ -35,7 +35,7 @@ services:
       retries: 10
 
   backendai-half-etcd:
-    image: quay.io/coreos/etcd:v3.4.14
+    image: quay.io/coreos/etcd:v3.4.18
     restart: unless-stopped
     volumes:
       - "./tmp/backend.ai-halfstack/${DATADIR_PREFIX:-.}/etcd-data:/etcd-data:rw"

--- a/docker-compose.halfstack-2109.yml
+++ b/docker-compose.halfstack-2109.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.4-alpine
+    image: postgres:13.7-alpine
     restart: unless-stopped
     command: postgres -c 'max_connections=256'
     networks:
@@ -22,7 +22,7 @@ services:
       retries: 10
 
   backendai-half-redis:
-    image: redis:6.2.6-alpine
+    image: redis:6.2.7-alpine
     restart: unless-stopped
     networks:
       - half
@@ -35,7 +35,7 @@ services:
       retries: 10
 
   backendai-half-etcd:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     restart: unless-stopped
     volumes:
       - "./tmp/backend.ai-halfstack/${DATADIR_PREFIX:-.}/etcd-data:/etcd-data:rw"

--- a/docker-compose.halfstack-2203.yml
+++ b/docker-compose.halfstack-2203.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.6-alpine
+    image: postgres:13.7-alpine
     restart: unless-stopped
     command: postgres -c 'max_connections=256'
     networks:

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.4-alpine
+    image: postgres:13.7-alpine
     command: postgres -c 'max_connections=256'
     networks:
       - half
@@ -32,7 +32,7 @@ services:
 
   # Initial master is node01.
   backendai-half-redis-node01:
-    image: redis:6.2.6-alpine
+    image: redis:6.2.7-alpine
     command: >
       redis-server
       --requirepass ${REDIS_PASSWORD:-develove}
@@ -56,7 +56,7 @@ services:
     cpu_count: 1
 
   backendai-half-redis-node02:
-    image: redis:6.2.6-alpine
+    image: redis:6.2.7-alpine
     command: >
       redis-server
       --requirepass ${REDIS_PASSWORD:-develove}
@@ -73,7 +73,7 @@ services:
       context: .
       dockerfile: redis-sentinel.dockerfile
       cache_from:
-        - redis:6.2.6-alpine
+        - redis:6.2.7-alpine
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
     networks:
@@ -81,7 +81,7 @@ services:
     cpu_count: 1
 
   backendai-half-redis-node03:
-    image: redis:6.2.6-alpine
+    image: redis:6.2.7-alpine
     command: >
       redis-server
       --requirepass ${REDIS_PASSWORD:-develove}
@@ -98,7 +98,7 @@ services:
       context: .
       dockerfile: redis-sentinel.dockerfile
       cache_from:
-        - redis:6.2.6-alpine
+        - redis:6.2.7-alpine
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
     networks:
@@ -106,7 +106,7 @@ services:
     cpu_count: 1
 
   backendai-half-etcd-proxy:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     depends_on:
       - "backendai-half-etcd-node01"
       - "backendai-half-etcd-node02"
@@ -124,7 +124,7 @@ services:
       --listen-addr=0.0.0.0:2379"
 
   backendai-half-etcd-node01:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd01-data:/etcd-data:rw"
     networks:
@@ -148,7 +148,7 @@ services:
       --initial-cluster-state $${STATE}"
 
   backendai-half-etcd-node02:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd02-data:/etcd-data:rw"
     networks:
@@ -172,7 +172,7 @@ services:
       --initial-cluster-state $${STATE}"
 
   backendai-half-etcd-node03:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd03-data:/etcd-data:rw"
     networks:

--- a/docker-compose.halfstack-prod.yml
+++ b/docker-compose.halfstack-prod.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.4-alpine
+    image: postgres:13.7-alpine
     restart: unless-stopped
     command: postgres -c 'max_connections=256'
     networks:
@@ -19,7 +19,7 @@ services:
     mem_limit: "2g"
 
   backendai-half-redis:
-    image: redis:6.2.6-alpine
+    image: redis:6.2.7-alpine
     restart: unless-stopped
     networks:
       - half
@@ -30,7 +30,7 @@ services:
     mem_limit: "2g"
 
   backendai-half-etcd:
-    image: quay.io/coreos/etcd:v3.5.1
+    image: quay.io/coreos/etcd:v3.5.4
     restart: unless-stopped
     volumes:
       - "./data/etcd:/etcd-data:rw"


### PR DESCRIPTION
This PR updates PostgreSQL, Redis and etcd package versions to apply bugfixes on the packages.

 * PostgreSQL: 13.1 → 13.7 (old versions)12.3 → 12.11
 * Redis: 6.2.6 → 6.2.7 (old versions) 6.0.9 → 6.2.7
 * etcd: 3.5.1 → 3.5.4 (old versions) 3.4.14 → 3.4.18
