### PR TITLE
fix: skip measuring the stat for an agent registry item if it has not yet assigned container ID to prevent the occasional unhandled `UnboundLocalError`

### DIFF
--- a/changes/478.fix
+++ b/changes/478.fix
@@ -1,0 +1,1 @@
+Skip measuring the stat for an agent registry item if it has not yet assigned container ID to prevent the occasional unhandled `UnboundLocalError`.

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -366,7 +366,7 @@ class StatContext:
                     cid = info['container_id']
                 except KeyError:
                     log.warning('collect_container_stat(): no container for kernel {}', kid)
-                    continue
+                else:
                 kernel_id_map[ContainerId(cid)] = kid
             unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
             for unused_kernel_id in unused_kernel_ids:

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -367,7 +367,7 @@ class StatContext:
                 except KeyError:
                     log.warning('collect_container_stat(): no container for kernel {}', kid)
                 else:
-                kernel_id_map[ContainerId(cid)] = kid
+                    kernel_id_map[ContainerId(cid)] = kid
             unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
             for unused_kernel_id in unused_kernel_ids:
                 log.debug('removing kernel_metric for {}', unused_kernel_id)

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -366,6 +366,7 @@ class StatContext:
                     cid = info['container_id']
                 except KeyError:
                     log.warning('collect_container_stat(): no container for kernel {}', kid)
+                    continue
                 kernel_id_map[ContainerId(cid)] = kid
             unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
             for unused_kernel_id in unused_kernel_ids:


### PR DESCRIPTION
Sometimes, the `UnboundLocalError` is raised due to the missing container ID in one of the agent registry items. To avoid this unhandled exception, this PR skips adding, or referencing, the container ID from the `kernel_id_map`.

<img width="975" alt="image" src="https://user-images.githubusercontent.com/7539358/174092260-740dc7c5-1aba-4ec8-899e-f2103f925542.png">

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
