### PR TITLE
fix: Add detection logic of HT sibling core count

### DIFF
--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -31,7 +31,7 @@ class libnuma:
             return 1
 
     @staticmethod
-    def htcpu_info():
+    async def htcpu_info():
         file_path = os.path.join("/sys/devices/system/cpu/cpu0/topology/thread_siblings_list")
         cpu_count = os.cpu_count()
         num_htSiblings = 0

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -4,6 +4,7 @@ import sys
 
 import aiohttp
 import aiotools
+import psutil
 
 _numa_supported = False
 
@@ -32,20 +33,17 @@ class libnuma:
 
     @staticmethod
     async def htcpu_info():
-        file_path = os.path.join("/sys/devices/system/cpu/cpu0/topology/thread_siblings_list")
-        cpu_count = os.cpu_count()
         num_htSiblings = 0
         try:
-            with open(file_path) as siblings:
-                htSiblings = len(siblings.read().split(','))
-                if htSiblings > 0:
-                    num_htSiblings = cpu_count // htSiblings
-                    return({'isActive': True, 'num_htcpu': num_htSiblings})
-                else:
-                    return({'isActive': False, 'num_htcpu': 0})
-        except (IOError, OSError) as e:
+            htSiblings = psutil.cpu_count(logical=False)
+            if htSiblings > 0:
+                num_htSiblings = psutil.cpu_count() // htSiblings
+                return({'isActive': True, 'num_htcpu': num_htSiblings})
+            else:
+                return({'isActive': False, 'num_htcpu': 0})
+        except OSError as e:
             raise Exception(
-                "{}\nCould not read thread siblings list".format(e))
+                "{}\nCould not read thread siblings".format(e))
 
     @staticmethod
     @aiotools.lru_cache(maxsize=1)


### PR DESCRIPTION
This PR refers to: lablup/backend.ai-internal#51
Current implementation does not concider hyperthreaded cores. Hwtool reports the number of physical cores only and license server activate physical cores without hyperthreaded cores. However, license server detect a higher total number of cores if hyperthread is activated and this raises an invalidation error.
With this PR we can detect hyperthreading. Make Activator check for hyperthreaded cores in order to remove them from the cores license has to activate. 