### PR TITLE
feat: Add `GET_ACTUAL_RESOURCE_ALLOC_TIME` API

### DIFF
--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -662,6 +662,26 @@ def logs(session_id):
             sys.exit(1)
 
 
+@session.command('resource-allocation-time')
+@click.argument('session_id', metavar='SESSID')
+def resource_allocation_time(session_id):
+    '''
+    Shows the resource allocation time (PREPARING ~ TERMINATED) of a compute session.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    '''
+    with Session() as session:
+        print_wait('Retrieving resource allocation time...')
+        kernel = session.ComputeSession(session_id)
+        try:
+            result = kernel.get_actual_resource_alloc_time().get('result')
+            print_info(f'result: {result}')
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
 @session.command()
 @click.argument('session_id', metavar='SESSID')
 @click.argument('new_id', metavar='NEWID')

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -647,6 +647,22 @@ class ComputeSession(BaseFunction):
             return await resp.json()
 
     @api_function
+    async def get_actual_resource_alloc_time(self):
+        """
+        Retrieves the actual resource allocation time (PREPARING ~ TERMINATED) of the compute session.
+        """
+        params = {}
+        if self.owner_access_key:
+            params['owner_access_key'] = self.owner_access_key
+        prefix = get_naming(api_session.get().api_version, 'path')
+        rqst = Request(
+            'GET', f'/{prefix}/{self.name}/resource_allocation_time/actual',
+            params=params,
+        )
+        async with rqst.fetch() as resp:
+            return await resp.json()
+
+    @api_function
     async def execute(self, run_id: str = None,
                       code: str = None,
                       mode: str = 'query',

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -2103,6 +2103,36 @@ async def get_container_logs(request: web.Request, params: Any) -> web.Response:
 @auth_required
 @check_api_params(
     t.Dict({
+        t.Key('owner_access_key', default=None): t.Null | t.String,
+    }))
+async def get_actual_resource_alloc_time(request: web.Request, params: Any) -> web.Response:
+    root_ctx: RootContext = request.app['_root.context']
+    session_name: str = request.match_info['session_name']
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
+    log.info('GET_ACTUAL_RESOURCE_ALLOC_TIME (ak:{}/{}, s:{}',
+             requester_access_key, owner_access_key, session_name)
+    async with root_ctx.db.begin_readonly() as conn:
+        compute_session = await root_ctx.registry.get_session(
+            session_name, owner_access_key,
+            allow_stale=True,
+            db_connection=conn,
+        )
+        status_history = compute_session['status_history'] or {}
+    if (preparing := status_history.get(KernelStatus.PREPARING.name)) is None:
+        resp = {'result': {'seconds': 0, 'microseconds': 0}}
+    elif (terminated := status_history.get(KernelStatus.TERMINATED.name)) is None:
+        alloc_time = datetime.now(tzutc()) - isoparse(preparing)    # datetime.timedelta
+        resp = {'result': {'seconds': alloc_time.seconds, 'microseconds': alloc_time.microseconds}}
+    else:
+        alloc_time = isoparse(terminated) - isoparse(preparing)
+        resp = {'result': {'seconds': alloc_time.seconds, 'microseconds': alloc_time.microseconds}}
+    return web.json_response(resp, status=200)
+
+
+@server_status_required(READ_ALLOWED)
+@auth_required
+@check_api_params(
+    t.Dict({
         tx.AliasedKey(['session_name', 'sessionName', 'task_id', 'taskId']) >> 'kernel_id': tx.UUID,
     }))
 async def get_task_logs(request: web.Request, params: Any) -> web.StreamResponse:
@@ -2274,4 +2304,5 @@ def create_app(default_cors_options: CORSOptions) -> Tuple[web.Application, Iter
     cors.add(app.router.add_route('GET',  '/{session_name}/download_single', download_single))
     cors.add(app.router.add_route('GET',  '/{session_name}/files', list_files))
     cors.add(app.router.add_route('POST', '/{session_name}/start-service', start_service))
+    cors.add(app.router.add_route('GET',  '/{session_name}/resource_allocation_time/actual', get_actual_resource_alloc_time))
     return app, []


### PR DESCRIPTION
This PR resolves lablup/backend.ai#469.

**WARNING: This PR is based on previous PR lablup/backend.ai#480, which has to be merged before this.**

In this PR, both an endpoint and an api function are added to compute actual resource allocation time of session. Suppose we already have timestamps for each session status, thanks to lablup/backend.ai#480, we can easily get an elapsed time from `PREPARING` to `TERMINATED`.

<img width="665" alt="스크린샷 2022-06-20 오후 3 43 35" src="https://user-images.githubusercontent.com/14137676/174543124-9620265f-2a06-4f87-a157-e36d658c14e4.png">