### PR TITLE
feat: Support installation on openSUSE

### DIFF
--- a/changes/485.feature.md
+++ b/changes/485.feature.md
@@ -1,0 +1,1 @@
+ Support for openSUSE release versions (both Leap and Tumbleweed) installation

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -161,6 +161,8 @@ elif [ -f /etc/redhat-release -o "$DISTRO" == "RedHat" -o "$DISTRO" == "CentOS" 
   DISTRO="RedHat"
 elif [ -f /etc/system-release -o "$DISTRO" == "Amazon" ]; then
   DISTRO="RedHat"
+elif [ -f /usr/lib/os-release -o "$DISTRO" == "SUSE" ]; then
+  DISTRO="SUSE"
 else
   show_error "Sorry, your host OS distribution is not supported by this script."
   show_info "Please send us a pull request or file an issue to support your environment!"
@@ -261,6 +263,10 @@ install_script_deps() {
     $sudo yum clean expire-cache  # next yum invocation will update package metadata cache
     $sudo yum install -y git jq gcc make gcc-c++
     ;;
+  SUSE)
+    $sudo zypper update
+    $sudo zypper install -y git jq gcc make gcc-c++
+    ;;
   Darwin)
     if ! type "brew" >/dev/null 2>&1; then
       show_error "brew is not available!"
@@ -281,6 +287,10 @@ install_pybuild_deps() {
     ;;
   RedHat)
     $sudo yum install -y openssl-devel readline-devel gdbm-devel zlib-devel bzip2-devel sqlite-devel libffi-devel xz-devel
+    ;;
+  SUSE)
+    $sudo zypper update
+    $sudo zypper install -y openssl-devel readline-devel gdbm-devel zlib-devel libbz2-devel sqlite3-devel libffi-devel xz-devel
     ;;
   Darwin)
     brew install openssl
@@ -306,6 +316,9 @@ install_git_lfs() {
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | $sudo bash
     $sudo yum install -y git-lfs
     ;;
+  SUSE)
+    $sudo zypper install -y git-lfs
+    ;;
   Darwin)
     brew install git-lfs
     ;;
@@ -321,6 +334,9 @@ install_system_pkg() {
     ;;
   RedHat)
     $sudo yum install -y $2
+    ;;
+  SUSE)
+    $sudo zypper install -y $2
     ;;
   Darwin)
     brew install $3


### PR DESCRIPTION
Feat: Support for openSUSE installation
Support for openSUSE installation release versions.
example) openSUSE Leap 15.3 & openSUSE Tumbleweed

After installing docker compose as a plugin (Install the plugin manually, following the link https://docs.docker.com/compose/install/compose-plugin/ ), I checked that script can installed on  openSUSE Tumbleweed and Leap 15.3, Fedora Core 35.

close #404

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
