### PR TITLE
fix: Type correction on renaming file api

### DIFF
--- a/changes/488.fix.md
+++ b/changes/488.fix.md
@@ -1,0 +1,1 @@
+Add default value for `is_dir` parameter at rename_file function described in storage-proxy API

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -31,7 +31,7 @@ import yarl
 from .base import (
     Item, PaginatedList,
 )
-from ..api.exceptions import VFolderOperationFailed
+from ..api.exceptions import InvalidAPIParameters, VFolderOperationFailed
 from ..exceptions import InvalidArgument
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
@@ -165,7 +165,7 @@ class StorageSessionManager:
                 try:
                     error_data = await client_resp.json()
                     raise VFolderOperationFailed(
-                        extra_msg=error_data.pop("msg"),
+                        extra_msg= error_data.pop("msg", None),
                         extra_data=error_data,
                     )
                 except aiohttp.ClientResponseError:
@@ -173,7 +173,10 @@ class StorageSessionManager:
                     raise VFolderOperationFailed(
                         extra_msg=f"Storage proxy responded with "
                                   f"{client_resp.status} {client_resp.reason}",
+                        extra_data=None,
                     )
+                except VFolderOperationFailed as e:
+                    raise InvalidAPIParameters(e.extra_msg, e.extra_data)
             yield proxy_info.client_api_url, client_resp
 
 

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -144,7 +144,6 @@ class StorageSessionManager:
         vfolder_host_or_proxy_name: str,
         method: str,
         request_relpath: str,
-        /,
         *args,
         **kwargs,
     ) -> AsyncIterator[Tuple[yarl.URL, aiohttp.ClientResponse]]:
@@ -165,7 +164,7 @@ class StorageSessionManager:
                 try:
                     error_data = await client_resp.json()
                     raise VFolderOperationFailed(
-                        extra_msg= error_data.pop("msg", None),
+                        extra_msg=error_data.pop("msg", None),
                         extra_data=error_data,
                     )
                 except aiohttp.ClientResponseError:

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -485,7 +485,7 @@ async def rename_file(request: web.Request) -> web.Response:
                 t.Key("vfid"): tx.UUID(),
                 t.Key("relpath"): tx.PurePath(relative_only=True),
                 t.Key("new_name"): t.String(),
-                t.Key("is_dir"): t.ToBool(),  # ignored since 22.03
+                t.Key("is_dir",default=False): t.ToBool,  # ignored since 22.03
             },
         ),
     ) as params:

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -485,7 +485,7 @@ async def rename_file(request: web.Request) -> web.Response:
                 t.Key("vfid"): tx.UUID(),
                 t.Key("relpath"): tx.PurePath(relative_only=True),
                 t.Key("new_name"): t.String(),
-                t.Key("is_dir",default=False): t.ToBool,  # ignored since 22.03
+                t.Key("is_dir", default=False): t.ToBool,  # ignored since 22.03
             },
         ),
     ) as params:


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
## Description
This PR resolves two things; setting the default value for `is_dir` parameter in the rename_file function, and providing more precise message in exception handling when virtual folder operation errors occurred on the same function.
I confirmed this issue during E2E testing for #443.

## Screenshot(s)
<img width="1412" alt="Screen Shot 2022-06-23 at 12 16 18 PM" src="https://user-images.githubusercontent.com/46954439/175205475-5c9add4d-4ac0-4e8f-b341-9cd6e7f2337d.png">
<img width="1412" alt="Screen Shot 2022-06-23 at 12 17 53 PM" src="https://user-images.githubusercontent.com/46954439/175205497-af79be25-6fd0-4887-bc2d-d1f75222ed04.png">
