### PR TITLE
fix: Raise explicit error if multiple entries found when deleting a vfolder

### DIFF
--- a/changes/492.fix.md
+++ b/changes/492.fix.md
@@ -1,1 +1,1 @@
-Do not delete a virtual folder if there are other folders with the same name (in other folder hosts), rather than blindly and dangerously deleting the first-queried one.
+Do not delete a virtual folder if there are other folders with the same name (in other folder hosts) and handle by new relevant exception, `TooManyVFoldersFound`, rather than blindly and dangerously deleting the first-queried one.

--- a/changes/492.fix.md
+++ b/changes/492.fix.md
@@ -1,0 +1,1 @@
+Raise an error on deleting vfolder by its name if there is the same name of vfolder in multiple accessible storage hosts.

--- a/changes/492.fix.md
+++ b/changes/492.fix.md
@@ -1,1 +1,1 @@
-Raise an error on deleting vfolder by its name if there is the same name of vfolder in multiple accessible storage hosts.
+Do not delete a virtual folder if there are other folders with the same name (in other folder hosts), rather than blindly and dangerously deleting the first-queried one.

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -256,9 +256,9 @@ class VFolderCreationFailed(BackendError, web.HTTPBadRequest):
     error_title = 'Virtual folder creation has failed.'
 
 
-class VFolderDeletionFailed(BackendError, web.HTTPBadRequest):
-    error_type = 'https://api.backend.ai/probs/vfolder-deletion-failed'
-    error_title = 'Virtual folder deletion has failed.'
+class TooManyVFoldersFound(BackendError, web.HTTPNotFound):
+    error_type = 'https://api.backend.ai/probs/too-many-vfolders'
+    error_title = 'Thare are two or more matching vfolders.'
 
 
 class VFolderNotFound(ObjectNotFound):

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -257,7 +257,7 @@ class VFolderCreationFailed(BackendError, web.HTTPBadRequest):
 
 
 class VFolderDeletionFailed(BackendError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/vfolder-deletion-failed"
+    error_type = 'https://api.backend.ai/probs/vfolder-deletion-failed'
     error_title = 'Virtual folder deletion has failed.'
 
 

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -258,7 +258,7 @@ class VFolderCreationFailed(BackendError, web.HTTPBadRequest):
 
 class TooManyVFoldersFound(BackendError, web.HTTPNotFound):
     error_type = 'https://api.backend.ai/probs/too-many-vfolders'
-    error_title = 'Thare are two or more matching vfolders.'
+    error_title = 'There are two or more matching vfolders.'
 
 
 class VFolderNotFound(ObjectNotFound):

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -255,6 +255,7 @@ class VFolderCreationFailed(BackendError, web.HTTPBadRequest):
     error_type  = 'https://api.backend.ai/probs/vfolder-creation-failed'
     error_title = 'Virtual folder creation has failed.'
 
+
 class VFolderDeletionFailed(BackendError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/vfolder-deletion-failed"
     error_title = 'Virtual folder deletion has failed.'

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -255,6 +255,10 @@ class VFolderCreationFailed(BackendError, web.HTTPBadRequest):
     error_type  = 'https://api.backend.ai/probs/vfolder-creation-failed'
     error_title = 'Virtual folder creation has failed.'
 
+class VFolderDeletionFailed(BackendError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/vfolder-deletion-failed"
+    error_title = 'Virtual folder deletion has failed.'
+
 
 class VFolderNotFound(ObjectNotFound):
     object_name = 'virtual folder'

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -54,7 +54,7 @@ from ..models import (
 )
 from .auth import admin_required, auth_required, superadmin_required
 from .exceptions import (
-    VFolderCreationFailed, VFolderDeletionFailed, VFolderNotFound, VFolderAlreadyExists,
+    VFolderCreationFailed, TooManyVFoldersFound, VFolderNotFound, VFolderAlreadyExists,
     GenericForbidden, ObjectNotFound, InvalidAPIParameters, ServerMisconfiguredError,
     BackendAgentError, InternalServerError, GroupNotFound,
 )
@@ -1622,16 +1622,16 @@ async def delete(request: web.Request) -> web.Response:
         #                 'that is not owned by myself.')
         #         break
         # FIXME: For now, multiple entries on delete vfolder will raise an error. Will be fixed in 22.06
-        # query_accesible_vfolders returns list
-        entry = entries[0]
         if len(entries) > 1:
             log.error('VFOLDER.DELETE(folder name:{}, hosts:{}', folder_name, [entry['host'] for entry in entries])
-            raise VFolderDeletionFailed(
+            raise TooManyVFoldersFound(
                 extra_msg="Multiple folders with the same name.",
                 extra_data=None,
             )
         elif len(entries) == 0:
             raise InvalidAPIParameters('No such vfolder.')
+        # query_accesible_vfolders returns list
+        entry = entries[0]
         # Folder owner OR user who have DELETE permission can delete folder.
         if (
             not entry['is_owner']

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1608,7 +1608,7 @@ async def delete(request: web.Request) -> web.Response:
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,
-            extra_vf_conds=(vfolders.c.name == folder_name)
+            extra_vf_conds=(vfolders.c.name == folder_name),
         )
         # for entry in entries:
         #     if entry['name'] == folder_name:
@@ -1627,7 +1627,7 @@ async def delete(request: web.Request) -> web.Response:
         if len(entries) > 1:
             log.error('VFOLDER.DELETE(folder name:{}, hosts:{}', folder_name, [entry['host'] for entry in entries])
             raise VFolderDeletionFailed(
-                extra_msg=f"Found same name of vfolder to delete on multiple storage hosts.",
+                extra_msg="Found same name of vfolder to delete on multiple storage hosts.",
                 extra_data=None,
             )
         elif len(entries) == 0:

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1632,9 +1632,6 @@ async def delete(request: web.Request) -> web.Response:
             )
         elif len(entries) == 0:
             raise InvalidAPIParameters('No such vfolder.')
-        else:
-            pass
-
         # Folder owner OR user who have DELETE permission can delete folder.
         if (
             not entry['is_owner']


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
## Description
> ⚠️ NOTE: This PR is solving a critical issue which is related to data manipulation reported from several environments. Following @achimnol's suggestion, **It need to be applied not only for current upstream but also from 21.03.**

This PR resolves to prevent manager from deleting unexpected vfolder on deletion requests by raising error when there's the same name of vfolder in multiple accessible storage hosts.


## Screenshots
<img width="720" alt="Screen Shot 2022-06-23 at 11 54 01 PM" src="https://user-images.githubusercontent.com/46954439/175329219-8eaa2c22-5445-49d0-8133-6a0044cf032f.png">
<img width="1416" alt="Screen Shot 2022-06-24 at 12 46 54 AM" src="https://user-images.githubusercontent.com/46954439/175349088-093dfedc-315b-4406-9c74-80a16d0be17f.png">

