### PR TITLE
feat: Support encrypted requests in the client SDK

### DIFF
--- a/changes/493.feature.md
+++ b/changes/493.feature.md
@@ -1,0 +1,1 @@
+Add support for optional payload encryption in the client SDK and CLI as a follow-up to #484

--- a/src/ai/backend/client/auth.py
+++ b/src/ai/backend/client/auth.py
@@ -1,10 +1,14 @@
+import base64
 import enum
 import hashlib
 import hmac
+import secrets
 from datetime import datetime
 from typing import Mapping, Tuple
 
 import attrs
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad, unpad
 from yarl import URL
 
 __all__ = (
@@ -12,6 +16,11 @@ __all__ = (
     "AuthTokenTypes",
     "generate_signature",
 )
+
+
+_iv_dict = [
+    bytes([char]) for char in b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+]
 
 
 class AuthTokenTypes(enum.Enum):
@@ -67,3 +76,20 @@ def generate_signature(
         ),
     }
     return headers, signature
+
+
+def encrypt_payload(endpoint: str, body: bytes) -> bytes:
+    iv = b"".join(secrets.choice(_iv_dict) for _ in range(16))
+    encoded_endpoint = base64.b64encode(endpoint.encode("utf-8"))
+    key = (encoded_endpoint + iv + iv)[:32]
+    crypt = AES.new(key, AES.MODE_CBC, iv)
+    result = base64.b64encode(crypt.encrypt(pad(body, 16)))
+    return iv + b":" + result
+
+
+def decrypt_payload(endpoint: str, payload: bytes) -> bytes:
+    iv, real_payload = payload.split(b":")
+    key = (base64.b64encode(endpoint.encode("ascii")) + iv + iv)[:32]
+    crypt = AES.new(key, AES.MODE_CBC, iv)
+    b64p = base64.b64decode(real_payload)
+    return unpad(crypt.decrypt(bytes(b64p)), 16)

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -122,6 +122,14 @@ class WebSocketProxy:
             await self.up_conn.close()
 
 
+def _decrypt_payload(endpoint: str, payload: bytes) -> bytes:
+    iv, real_payload = payload.split(b":")
+    key = (base64.b64encode(endpoint.encode("ascii")) + iv + iv)[:32]
+    crypt = AES.new(key, AES.MODE_CBC, iv)
+    b64p = base64.b64decode(real_payload)
+    return unpad(crypt.decrypt(bytes(b64p)), 16)
+
+
 @web.middleware
 async def decrypt_payload(request: web.Request, handler) -> web.StreamResponse:
     request_headers = extra_config_headers.check(request.headers)
@@ -135,14 +143,8 @@ async def decrypt_payload(request: web.Request, handler) -> web.StreamResponse:
         if scheme is None:
             scheme = request.scheme
         api_endpoint = f"{scheme}://{request.host}"
-        payload = await request.text()
-        initial_vector, real_payload = payload.split(":")
-        key = (base64.b64encode(api_endpoint.encode("ascii")).decode() + initial_vector * 2)[0:32]
-        crypt = AES.new(
-            bytes(key, encoding="utf8"), AES.MODE_CBC, bytes(initial_vector, encoding="utf8")
-        )
-        b64p = base64.b64decode(real_payload)
-        request["payload"] = unpad(crypt.decrypt(bytes(b64p)), 16)
+        payload = await request.read()
+        request["payload"] = _decrypt_payload(api_endpoint, payload)
     else:
         # For all other requests without explicit encryption,
         # let the handler decide how to read the body.

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from dateutil.tz import tzutc
 
-from ai.backend.client.auth import generate_signature
+from ai.backend.client.auth import decrypt_payload, encrypt_payload, generate_signature
 
 
 def test_generate_signature(defconfig):
@@ -22,3 +22,13 @@ def test_generate_signature(defconfig):
     assert kwargs["hash_type"].upper() in headers["Authorization"]
     assert kwargs["access_key"] in headers["Authorization"]
     assert signature in headers["Authorization"]
+
+
+def test_encrypt():
+    endpoint = "https://example.com"
+    orig = b"hello world"
+    enc = encrypt_payload(endpoint, orig)
+    print(repr(orig), repr(enc))
+    dec = decrypt_payload(endpoint, enc)
+    assert orig != enc
+    assert orig == dec


### PR DESCRIPTION
This is a follow-up of #484.
Let's automatically encrypt the payloads for user authentication and password change requests if the manager/webserver API endpoint uses the plain HTTP.