### PR TITLE
git ignore kernel scratches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ ENV/
 
 # Release artifacts
 /CHANGELOG_RELEASE.md
+
+# Kernel scratches
+/scratches/

--- a/changes/497.fix.md
+++ b/changes/497.fix.md
@@ -1,1 +1,0 @@
-Let git ignore `/scratches` directory kernels use.

--- a/changes/497.fix.md
+++ b/changes/497.fix.md
@@ -1,0 +1,1 @@
+Let git ignore `/scratches` directory kernels use.

--- a/changes/497.misc.md
+++ b/changes/497.misc.md
@@ -1,0 +1,1 @@
+Let git ignore `/scratches` directory that kernels use.


### PR DESCRIPTION
let git ignore `/scratches` directory which is created for kernels.
git keeps tracking the directory like below

<img width="640" alt="image" src="https://user-images.githubusercontent.com/44239739/175884765-e885b717-8d91-4ba5-9559-a2bad5d44d1d.png">
