### PR TITLE
ci: Manually upgrade pex version to avoid platform-flapping issue

### DIFF
--- a/changes/498.misc.md
+++ b/changes/498.misc.md
@@ -1,0 +1,1 @@
+Manually upgrade pex version to 2.1.93 to avoid alternating platform tags in lockfiles depending on at which architecture the lockfiles are generated

--- a/pants.toml
+++ b/pants.toml
@@ -43,6 +43,15 @@ python-kernel = "python-kernel.lock"
 # [setup-py-generation]
 # first_party_depenency_version_scheme = "exact"
 
+[pex-cli]
+version = "v2.1.93"
+known_versions = [
+    "v2.1.93|macos_arm64|80fc6b94f5db253a71061974cb8d8ce520932aef44d989e9057917cc33a30fd6|3802280",
+    "v2.1.93|macos_x86_64|80fc6b94f5db253a71061974cb8d8ce520932aef44d989e9057917cc33a30fd6|3802280",
+    "v2.1.93|linux_arm64|80fc6b94f5db253a71061974cb8d8ce520932aef44d989e9057917cc33a30fd6|3802280",
+    "v2.1.93|linux_x86_64|80fc6b94f5db253a71061974cb8d8ce520932aef44d989e9057917cc33a30fd6|3802280",
+]
+
 [flake8]
 version = "flake8>=4.0"
 extra_requirements.add = [

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.12.0rc2"
+pants_version = "2.12.0rc3"
 pythonpath = ["%(buildroot)s/tools/pants-plugins"]
 local_execution_root_dir="%(buildroot)s/.tmp"
 backend_packages = [

--- a/python-kernel.lock
+++ b/python-kernel.lock
@@ -554,15 +554,11 @@
           "version": "0.16"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "async_timeout~=3.0",

--- a/python.lock
+++ b/python.lock
@@ -3146,38 +3146,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57ea67a9206eab2abe130e4fdae0662f10cca3dc72ba27553f70a7d613588571",
-              "url": "https://files.pythonhosted.org/packages/3d/19/877d024f2e6fd0da38c11480b8d6f1a37d430015749dac0fab165edcc78c/SQLAlchemy-1.4.38-cp310-cp310-win_amd64.whl"
+              "hash": "50e7569637e2e02253295527ff34666706dbb2bc5f6c61a5a7f44b9610c9bb09",
+              "url": "https://files.pythonhosted.org/packages/04/e9/4b313778b1f16d1eea96a1e657f04011ca9d51c28c42c070e7718e7c1892/SQLAlchemy-1.4.39-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "82701a4cbb14affc6c1ae62dcebdaff65611b7c7f96f9d0e92a34a8be112a8fa",
-              "url": "https://files.pythonhosted.org/packages/79/7f/edd5b5776f4e53ef6edda18daa5d491587fac3af721d6203f3b26c6c98f1/SQLAlchemy-1.4.38-cp310-cp310-win32.whl"
+              "hash": "8194896038753b46b08a0b0ae89a5d80c897fb601dd51e243ed5720f1f155d27",
+              "url": "https://files.pythonhosted.org/packages/1f/93/e5211e989324793487efb45405343d81b554886e278234066e20f77d434d/SQLAlchemy-1.4.39.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "6edadd6a0a722c22558e1d1f5360d3e85fa938bc69d9049d29968a643de6dd34",
-              "url": "https://files.pythonhosted.org/packages/98/a7/10d04747aab7af0adf4d85c9acee2224afd850a1905a44a4cb39c2637b72/SQLAlchemy-1.4.38-cp310-cp310-macosx_10_15_universal2.whl"
+              "hash": "26146c59576dfe9c546c9f45397a7c7c4a90c25679492ff610a7500afc7d03a6",
+              "url": "https://files.pythonhosted.org/packages/3c/78/1caf5af666e20468cb34961db31da6881520d931c9b61fa316fda4c21395/SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "93ae1d2ef42fbf0f0b3d44b35225bda123310df4b33c9bf662e7b50a68c48a98",
-              "url": "https://files.pythonhosted.org/packages/be/06/8c75ad5b5d2f0935304dbdbd0cdf54761f73f6bc4d18cd092b49ed7520d5/SQLAlchemy-1.4.38.tar.gz"
+              "hash": "ede13a472caa85a13abe5095e71676af985d7690eaa8461aeac5c74f6600b6c0",
+              "url": "https://files.pythonhosted.org/packages/44/c3/82386d127ff87aa5751ff35052d057ffe0d8d0ca674349f5006b86fe0296/SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf05b312bf0165f92fa0eb09e7661c26f2f06c7a89694ecb79fa15a933deb768",
-              "url": "https://files.pythonhosted.org/packages/c6/f1/1b3394834e10e90d46062990a1344c7fd6f1bf68b023bce551f7861ca096/SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "1745987ada1890b0e7978abdb22c133eca2e89ab98dc17939042240063e1ef21",
+              "url": "https://files.pythonhosted.org/packages/9d/e7/1b6a6c46445605ee86663e12bfb741f5adf985a30f9e96a6a2130bb34065/SQLAlchemy-1.4.39-cp310-cp310-macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42810e560b57e981ed0a947b65a4936b398b4fca97e5b56e10a9c5a151568de2",
-              "url": "https://files.pythonhosted.org/packages/d8/c7/20d7eff8cc446d1d062e4cc84cd026a0856c620b61389d122d4148d23946/SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "7f13644b15665f7322f9e0635129e0ef2098409484df67fcd225d954c5861559",
+              "url": "https://files.pythonhosted.org/packages/d8/1c/0f698cae8f02e1b67b987ab2b5522f4b00cc5c9db180748ea090cfba0b49/SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b8cd779ef29718f3d2c558042ccc45c03006c599dd722fb760faca641a2f32ac",
-              "url": "https://files.pythonhosted.org/packages/dc/d2/168947db642dc8a4eb98e2a40efa0b86bb0965f7df089488f6cb2e72967b/SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "91d2b89bb0c302f89e753bea008936acfa4e18c156fb264fe41eb6bbb2bbcdeb",
+              "url": "https://files.pythonhosted.org/packages/fe/8e/399663bac6946b52d7206d96c82d6350d8f31d536a781ceff4f1082a016b/SQLAlchemy-1.4.39-cp310-cp310-win32.whl"
             }
           ],
           "project_name": "sqlalchemy",
@@ -3214,7 +3214,7 @@
             "typing-extensions!=3.10.0.1; extra == \"aiosqlite\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.4.38"
+          "version": "1.4.39"
         },
         {
           "artifacts": [
@@ -3437,19 +3437,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ccbcc5e72084c015e2405cb629d769116f7c10f918e3f02d409a94d0167ffaae",
-              "url": "https://files.pythonhosted.org/packages/1f/6d/9b705d4ca63577884381c5446f2f16ec8e8362186d9c26bc13de2a30ba03/types_cachetools-5.2.0-py3-none-any.whl"
+              "hash": "b496b7e364ba050c4eaadcc6582f2c9fbb04f8ee7141eb3b311a8589dbd4506a",
+              "url": "https://files.pythonhosted.org/packages/3c/5f/2456d574ade7917f699933852986f2792ba9b49aa646aee3ecebc5665b20/types_cachetools-5.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f8ae68aa6502c5c93bbf6ae51ca60fefa9f6a5896846baf7981067809977a61a",
-              "url": "https://files.pythonhosted.org/packages/89/eb/396ce3d75169c570986dd6998aa122c65294ae63307372c3e80a4759d128/types-cachetools-5.2.0.tar.gz"
+              "hash": "069cfc825697cd51445c1feabbe4edc1fae2b2315870e7a9a179a7c4a5851bee",
+              "url": "https://files.pythonhosted.org/packages/d4/a6/dfd0bdcb01347fb610531355946eb78b2b2ee94f05076f4723bc1ca841eb/types-cachetools-5.2.1.tar.gz"
             }
           ],
           "project_name": "types-cachetools",
           "requires_dists": [],
           "requires_python": null,
-          "version": "5.2"
+          "version": "5.2.1"
         },
         {
           "artifacts": [
@@ -3529,37 +3529,37 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff",
-              "url": "https://files.pythonhosted.org/packages/cf/1e/e8a2e127dac81fa53d181f15c6ca5ea3f472e8e531055a6b2bcb25be8a9d/types_PyYAML-6.0.8-py3-none-any.whl"
+              "hash": "b738e9ef120da0af8c235ba49d3b72510f56ef9bcc308fc8e7357100ff122284",
+              "url": "https://files.pythonhosted.org/packages/c0/9c/b3c5f249a5f9c6a94ed046b55b378752fb5d1e6312a87622ed44e3f9896e/types_PyYAML-6.0.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d9495d377bb4f9c5387ac278776403eb3b4bb376851025d913eea4c22b4c6438",
-              "url": "https://files.pythonhosted.org/packages/1d/b5/bb2c2541056b26c419ed9ce8635e483257562433026a7174bddd078f665c/types-PyYAML-6.0.8.tar.gz"
+              "hash": "33ae75c84b8f61fddf0c63e9c7e557db9db1694ad3c2ee8628ec5efebb5a5e9b",
+              "url": "https://files.pythonhosted.org/packages/2b/0d/882d0771996897df176521a93c2ce9d9b0da66d0f9c2bc441b9872a91297/types-PyYAML-6.0.9.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
           "requires_python": null,
-          "version": "6.0.8"
+          "version": "6.0.9"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9c7cdaf0d55113e24ac17103bde2d434472abf1dbf444238e989fe4e798ffa26",
-              "url": "https://files.pythonhosted.org/packages/58/68/dda470233bc56db72b51fb20de9ead5faa138595debbc861256ec20740b6/types_setuptools-57.4.17-py3-none-any.whl"
+              "hash": "9660b8774b12cd61b448e2fd87a667c02e7ec13ce9f15171f1d49a4654c4df6a",
+              "url": "https://files.pythonhosted.org/packages/14/45/b8368a8c2d1dc4fa47eb4db980966e23edecbda16fab7a38186b076bbd4d/types_setuptools-57.4.18-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9d556fcaf6808a1cead4aaa41e5c07a61f0152a875811e1239738eba4e0b7b16",
-              "url": "https://files.pythonhosted.org/packages/ba/97/1e6f2106412d038b2ca4b18bd652a15a50096c6829345d9d0076ad9555a5/types-setuptools-57.4.17.tar.gz"
+              "hash": "8ee03d823fe7fda0bd35faeae33d35cb5c25b497263e6a58b34c4cfd05f40bcf",
+              "url": "https://files.pythonhosted.org/packages/13/5e/3d46cd143913bd51dde973cd23b1d412de9662b08a3b8c213f26b265e6f1/types-setuptools-57.4.18.tar.gz"
             }
           ],
           "project_name": "types-setuptools",
           "requires_dists": [],
           "requires_python": null,
-          "version": "57.4.17"
+          "version": "57.4.18"
         },
         {
           "artifacts": [
@@ -3583,19 +3583,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "67fb3bba17e594413fa6521dbd342c3ca40520ab66084714232af0c14ac62ddb",
-              "url": "https://files.pythonhosted.org/packages/63/98/0926e5098d5ef2424c38ee4ce358d3196be2f21c257ce94e37f3c2955f2b/types_tabulate-0.8.10-py3-none-any.whl"
+              "hash": "af811268241e8fb87b63c052c87d1e329898a93191309d5d42111372232b2e0e",
+              "url": "https://files.pythonhosted.org/packages/d7/79/4a0608d40e0ee84461639040d124455197f73ca865e36ac685900d2be8d4/types_tabulate-0.8.11-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0667539fc66330a25daa6b4e52d494b783628a9fed54a3ff315076dcd15a1ecd",
-              "url": "https://files.pythonhosted.org/packages/95/7a/5a2b1d3c01cc21dceb9ae5910419fb2abc2bab4cd6624fd48b72ee664a62/types-tabulate-0.8.10.tar.gz"
+              "hash": "17a5fa3b5ca453815778fc9865e8ecd0118b07b2b9faff3e2b06fe448174dd5e",
+              "url": "https://files.pythonhosted.org/packages/3a/ea/2914c9be43eecae6ddb0f10ae4b51e2f14a711d69393a6e8c8a33ac1b7c7/types-tabulate-0.8.11.tar.gz"
             }
           ],
           "project_name": "types-tabulate",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.8.10"
+          "version": "0.8.11"
         },
         {
           "artifacts": [
@@ -3895,15 +3895,11 @@
           "version": "1.1.8"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "Jinja2~=3.0.1",

--- a/tools/flake8.lock
+++ b/tools/flake8.lock
@@ -183,15 +183,11 @@
           "version": "62.6"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "flake8-commas>=2.1",

--- a/tools/isort.lock
+++ b/tools/isort.lock
@@ -66,15 +66,11 @@
           "version": "5.10.1"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "isort[colors,pyproject]<6.0,>=5.9.3"

--- a/tools/mypy.lock
+++ b/tools/mypy.lock
@@ -131,15 +131,11 @@
           "version": "4.2"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "mypy>=0.950"

--- a/tools/pytest.lock
+++ b/tools/pytest.lock
@@ -796,13 +796,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231",
-              "url": "https://files.pythonhosted.org/packages/11/40/8fcb3c0f72e11dc44e1102b2adf5f160b8a00e84d915798c60aabcd9257a/pytest_mock-3.7.0-py3-none-any.whl"
+              "hash": "d989f11ca4a84479e288b0cd1e6769d6ad0d3d7743dcc75e460d1416a5f2135a",
+              "url": "https://files.pythonhosted.org/packages/c3/ab/76e3a40f0faea13806d0ac8e69b3903cfb7d76e49905a259c0465470963f/pytest_mock-3.8.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534",
-              "url": "https://files.pythonhosted.org/packages/96/e1/fb53b62056e6840a36d9a4beb4e42726155594c567b574103435a7131c60/pytest-mock-3.7.0.tar.gz"
+              "hash": "2c6d756d5d3bf98e2e80797a959ca7f81f479e7d1f5f571611b0fdd6d1745240",
+              "url": "https://files.pythonhosted.org/packages/78/c2/ff2327e36c93d950db089e308a38334717d3378c55afc8d95d1d23ade9c1/pytest-mock-3.8.1.tar.gz"
             }
           ],
           "project_name": "pytest-mock",
@@ -813,7 +813,7 @@
             "tox; extra == \"dev\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.7"
+          "version": "3.8.1"
         },
         {
           "artifacts": [
@@ -926,15 +926,11 @@
           "version": "1.7.2"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "aioresponses>=0.7.3",

--- a/tools/towncrier.lock
+++ b/tools/towncrier.lock
@@ -81,13 +81,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec",
-              "url": "https://files.pythonhosted.org/packages/ab/b5/1bd220dd470b0b912fc31499e0d9c652007a60caf137995867ccc4b98cb6/importlib_metadata-4.11.4-py3-none-any.whl"
+              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
+              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700",
-              "url": "https://files.pythonhosted.org/packages/35/a8/f2bd0d488c2bf932b4dda0fb91cbb687c0b1132b33130d1cfad4e2b4b963/importlib_metadata-4.11.4.tar.gz"
+              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
+              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -101,7 +101,7 @@
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
             "pytest-flake8; extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
@@ -112,7 +112,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.11.4"
+          "version": "4.12"
         },
         {
           "artifacts": [
@@ -519,15 +519,11 @@
           "version": "3.8"
         }
       ],
-      "platform_tag": [
-        "cp310",
-        "cp310",
-        "manylinux_2_31_aarch64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.93",
   "prefer_older_binary": false,
   "requirements": [
     "towncrier>=21.9"


### PR DESCRIPTION
When generating lockfiles in different architectures (x86-64/arm64), an extra platform tag (which is not used actually) becomes alternating.  To avoid this issue, we could upgrade pex to 2.1.93.  Also upgrade Pants from 2.12.0rc2 to 2.12.0rc3.

You don't have to do anything special.  For source-based pants users, you need to manually checkout the new release tag, but there is no "release_2.12.0rc3" tag yet.  As there is no significant functional differences between rc2 and rc3, you may just stay as-is.

refs pantsbuild/pex#1685
refs https://github.com/pantsbuild/pants/blob/2.12.x/src/python/pants/notes/2.12.x.md