### PR TITLE
fix: Correct CPU arch detection in `install-dev.sh`

### DIFF
--- a/changes/505.fix.md
+++ b/changes/505.fix.md
@@ -1,1 +1,1 @@
-fix to check machine arch clearly on docker image pulling.
+Use `uname -m` instead of `uname -p` for better compatibility with many Linux variants and macOS when configuring the image registry and pulling the base Python image

--- a/changes/505.fix.md
+++ b/changes/505.fix.md
@@ -1,0 +1,1 @@
+fix to check machine arch clearly on docker image pulling.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -641,7 +641,7 @@ show_info "Setting up databases..."
 show_info "Configuring the Lablup's official image registry..."
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai "https://cr.backend.ai"
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/type "harbor2"
-if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
+if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community,multiarch"
 else
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community"
@@ -650,7 +650,7 @@ fi
 # Scan the container image registry
 show_info "Scanning the image registry..."
 ./backend.ai mgr etcd rescan-images cr.backend.ai
-if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
+if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
   ./backend.ai mgr etcd alias python "cr.backend.ai/multiarch/python:3.9-ubuntu20.04" aarch64
 else
   ./backend.ai mgr etcd alias python "cr.backend.ai/stable/python:3.9-ubuntu20.04" x86_64
@@ -728,7 +728,7 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 
 show_info "Pre-pulling frequently used kernel images..."
 echo "NOTE: Other images will be downloaded from the docker registry when requested.\n"
-if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
+if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
   $docker_sudo docker pull "cr.backend.ai/multiarch/python:3.9-ubuntu20.04"
 else
   $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -641,7 +641,7 @@ show_info "Setting up databases..."
 show_info "Configuring the Lablup's official image registry..."
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai "https://cr.backend.ai"
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/type "harbor2"
-if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community,multiarch"
 else
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community"
@@ -650,7 +650,7 @@ fi
 # Scan the container image registry
 show_info "Scanning the image registry..."
 ./backend.ai mgr etcd rescan-images cr.backend.ai
-if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
   ./backend.ai mgr etcd alias python "cr.backend.ai/multiarch/python:3.9-ubuntu20.04" aarch64
 else
   ./backend.ai mgr etcd alias python "cr.backend.ai/stable/python:3.9-ubuntu20.04" x86_64
@@ -728,7 +728,7 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 
 show_info "Pre-pulling frequently used kernel images..."
 echo "NOTE: Other images will be downloaded from the docker registry when requested.\n"
-if ["$(uname -m)" = "arm64"]||["$(uname -m)" = "aarch64"]; then
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
   $docker_sudo docker pull "cr.backend.ai/multiarch/python:3.9-ubuntu20.04"
 else
   $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -729,7 +729,7 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 show_info "Pre-pulling frequently used kernel images..."
 echo "NOTE: Other images will be downloaded from the docker registry when requested.\n"
 if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
-  $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"
+  $docker_sudo docker pull "cr.backend.ai/multiarch/python:3.9-ubuntu20.04"
 else
   $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"
   if [ $DOWNLOAD_BIG_IMAGES -eq 1 ]; then

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -641,7 +641,7 @@ show_info "Setting up databases..."
 show_info "Configuring the Lablup's official image registry..."
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai "https://cr.backend.ai"
 ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/type "harbor2"
-if [ "$(uname -p)" = "arm" ]; then
+if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community,multiarch"
 else
   ./backend.ai mgr etcd put config/docker/registry/cr.backend.ai/project "stable,community"
@@ -650,7 +650,7 @@ fi
 # Scan the container image registry
 show_info "Scanning the image registry..."
 ./backend.ai mgr etcd rescan-images cr.backend.ai
-if [ "$(uname -p)" = "arm" ]; then
+if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
   ./backend.ai mgr etcd alias python "cr.backend.ai/multiarch/python:3.9-ubuntu20.04" aarch64
 else
   ./backend.ai mgr etcd alias python "cr.backend.ai/stable/python:3.9-ubuntu20.04" x86_64
@@ -728,7 +728,7 @@ chmod +x "${CLIENT_USER_CONF_FOR_SESSION}"
 
 show_info "Pre-pulling frequently used kernel images..."
 echo "NOTE: Other images will be downloaded from the docker registry when requested.\n"
-if [ "$(uname -p)" = "arm" ]; then
+if ["$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
   $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"
 else
   $docker_sudo docker pull "cr.backend.ai/stable/python:3.9-ubuntu20.04"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
fix to check machine arch clearly
make sure to check machine architecture clearly to query the Docker registry.

Sometimes, some Linux VM's `$(uname -p)` result is 'Unknown'. So, changed `$(uname -p)`  to `$(uname -m)` and clearly shows `arm64` and `aarch64` on docker image pulling.