### PR TITLE
fix: Update deprecated `etcd` apis with `image` apis

### DIFF
--- a/changes/509.fix.md
+++ b/changes/509.fix.md
@@ -1,0 +1,1 @@
+Update deprecated manager APIs, such as `etcd alias` and `etcd rescan-images`.

--- a/docs/client/dev/testing.rst
+++ b/docs/client/dev/testing.rst
@@ -40,7 +40,7 @@ Prerequisite
 Please refer the README of the manager and agent repositories to set up them.
 To avoid an indefinite waiting time for pulling Docker images:
 
-* (manager) ``python -m ai.backend.manager.cli etcd rescan-images``
+* (manager) ``python -m ai.backend.manager.cli image rescan``
 
 * (agent) ``docker pull``
 

--- a/docs/locales/ko/LC_MESSAGES/client/dev/testing.po
+++ b/docs/locales/ko/LC_MESSAGES/client/dev/testing.po
@@ -79,7 +79,7 @@ msgid ""
 msgstr ""
 
 #: ../../client/dev/testing.rst:43 7c8dd221394042c0bd080363b7cfce48
-msgid "(manager) ``python -m ai.backend.manager.cli etcd rescan-images``"
+msgid "(manager) ``python -m ai.backend.manager.cli image rescan``"
 msgstr ""
 
 #: ../../client/dev/testing.rst:45 3df55cd371254d379a190c6fead3d0a6

--- a/docs/locales/ko/LC_MESSAGES/migration/docker-hub-to-backendai-cr.po
+++ b/docs/locales/ko/LC_MESSAGES/migration/docker-hub-to-backendai-cr.po
@@ -91,7 +91,7 @@ msgstr ""
 #: 1b9e1c630e544377b9081d4416a3e555
 msgid ""
 "If you have configured image aliases, you need to udpate them manually as "
-"well, using the ``backend.ai mgr etcd alias`` command. This does not affect "
+"well, using the ``backend.ai mgr image alias`` command. This does not affect "
 "existing sessions running with old aliases."
 msgstr ""
 

--- a/docs/migration/docker-hub-to-backendai-cr.rst
+++ b/docs/migration/docker-hub-to-backendai-cr.rst
@@ -32,7 +32,7 @@ This registry migration does not affect existing running sessions, though the Do
 
       $ sudo systemctl stop backendai-manager  # stop the manager daemon (may differ by setup)
       $ backend.ai mgr etcd put-json '' registry-config.json
-      $ backend.ai mgr etcd rescan-images cr.backend.ai
+      $ backend.ai mgr image rescan cr.backend.ai
       $ sudo systemctl start backendai-manager  # start the manager daemon (may differ by setup)
 
    * The agents will automatically pull the images since the image references are changed even when the new images are actually same to the existing ones.
@@ -44,7 +44,7 @@ This registry migration does not affect existing running sessions, though the Do
 
      For example, ``lablup/python:3.6-ubuntu18.04`` is now referred as ``cr.backend.ai/stable/python:3.6-ubuntu18.04``.
 
-   * If you have configured image aliases, you need to udpate them manually as well, using the ``backend.ai mgr etcd alias`` command.
+   * If you have configured image aliases, you need to udpate them manually as well, using the ``backend.ai mgr image alias`` command.
      This does not affect existing sessions running with old aliases.
 
 4. Update the allowed docker registries policy for each domain using the ``backend.ai mgr dbshell`` command. Remove "index.docker.io" from the existing values and replace "..." below with your own domain names and additional registries.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -649,11 +649,11 @@ fi
 
 # Scan the container image registry
 show_info "Scanning the image registry..."
-./backend.ai mgr etcd rescan-images cr.backend.ai
+./backend.ai mgr image rescan cr.backend.ai
 if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
-  ./backend.ai mgr etcd alias python "cr.backend.ai/multiarch/python:3.9-ubuntu20.04" aarch64
+  ./backend.ai mgr image alias python "cr.backend.ai/multiarch/python:3.9-ubuntu20.04" aarch64
 else
-  ./backend.ai mgr etcd alias python "cr.backend.ai/stable/python:3.9-ubuntu20.04" x86_64
+  ./backend.ai mgr image alias python "cr.backend.ai/stable/python:3.9-ubuntu20.04" x86_64
 fi
 
 # Virtual folder setup

--- a/src/ai/backend/manager/README.md
+++ b/src/ai/backend/manager/README.md
@@ -117,7 +117,7 @@ Set up the public Docker registry:
 ```console
 $ backend.ai mgr etcd put config/docker/registry/index.docker.io "https://registry-1.docker.io"
 $ backend.ai mgr etcd put config/docker/registry/index.docker.io/username "lablup"
-$ backend.ai mgr etcd rescan-images index.docker.io
+$ backend.ai mgr image rescan index.docker.io
 ```
 
 Set up the vfolder paths:


### PR DESCRIPTION
During the installation process of `backend.ai`, I found some warning messages that we are currently using deprecated apis, such as:

<img width="570" alt="스크린샷 2022-07-04 오전 9 25 49" src="https://user-images.githubusercontent.com/14137676/177063481-993b12d3-b420-463a-bfff-6b21ccb8f366.png">
<img width="567" alt="스크린샷 2022-07-04 오전 9 29 56" src="https://user-images.githubusercontent.com/14137676/177063488-62c4b8ce-f95e-4ab3-a4b7-e4775207ef8a.png">

`backend.ai etcd alias` -> `backend.ai image alias`
`backend.ai mgr etcd rescan-images` -> `backend.ai mgr image rescan`

Therefore, I changed the code to use new APIs rather than the old ones. This is not an urgent fix but required for consistency on maintenance.
