### PR TITLE
fix: add timeout to `prepare()`'s `PersistentTaskGroup`

### DIFF
--- a/changes/514.fix
+++ b/changes/514.fix
@@ -1,2 +1,1 @@
 Fix `prepare()` not running when `start_session()` call hangs without raising Exception
-

--- a/changes/514.fix
+++ b/changes/514.fix
@@ -1,0 +1,2 @@
+Fix `prepare()` not running when `start_session()` call hangs without raising Exception
+

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -784,7 +784,7 @@ class SchedulerDispatcher(aobject):
                 log.debug("prepare(): preparing {} session(s)", len(scheduled_sessions))
                 async with (
                     async_timeout.timeout(delay=50.0),
-                    aiotools.TaskGroup() as tg
+                    aiotools.PersistentTaskGroup() as tg
                 ):
                     for scheduled_session in scheduled_sessions:
                         await self.registry.event_producer.produce_event(

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -805,7 +805,7 @@ class SchedulerDispatcher(aobject):
                 raise asyncio.CancelledError()
             raise
         except asyncio.TimeoutError:
-            log.warn('timeout while executing start_session()')
+            log.warn('prepare(): timeout while executing start_session()', source)
 
     async def start_session(
         self,

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -805,7 +805,7 @@ class SchedulerDispatcher(aobject):
                 raise asyncio.CancelledError()
             raise
         except asyncio.TimeoutError:
-            log.warn('prepare(): timeout while executing start_session()', source)
+            log.warn('prepare(): timeout while executing start_session()')
 
     async def start_session(
         self,

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import aiotools
+import async_timeout
 import sqlalchemy as sa
 from dateutil.tz import tzutc
 from sqlalchemy.engine.row import Row
@@ -781,7 +782,10 @@ class SchedulerDispatcher(aobject):
 
                 scheduled_sessions = await execute_with_retry(_mark_session_preparing)
                 log.debug("prepare(): preparing {} session(s)", len(scheduled_sessions))
-                async with aiotools.TaskGroup() as tg:
+                async with (
+                    async_timeout.timeout(delay=50.0),
+                    aiotools.TaskGroup() as tg
+                ):
                     for scheduled_session in scheduled_sessions:
                         await self.registry.event_producer.produce_event(
                             SessionPreparingEvent(
@@ -800,6 +804,8 @@ class SchedulerDispatcher(aobject):
                          "maybe another prepare() call is still running")
                 raise asyncio.CancelledError()
             raise
+        except asyncio.TimeoutError:
+            log.warn('timeout while executing start_session()')
 
     async def start_session(
         self,

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -784,7 +784,7 @@ class SchedulerDispatcher(aobject):
                 log.debug("prepare(): preparing {} session(s)", len(scheduled_sessions))
                 async with (
                     async_timeout.timeout(delay=50.0),
-                    aiotools.PersistentTaskGroup() as tg
+                    aiotools.PersistentTaskGroup() as tg,
                 ):
                     for scheduled_session in scheduled_sessions:
                         await self.registry.event_producer.produce_event(


### PR DESCRIPTION
This PR resolves `prepare()` hanging infinitely when individual session's `start_session()` task inside `TaskGroup` hangs.    
This PR also changes `TaskGroup` to `PersistentTaskGroup`, as every `start_session()` call needs execution result.