### PR TITLE
feat(install-dev): Enhance the pre-push hook

### DIFF
--- a/changes/519.misc.md
+++ b/changes/519.misc.md
@@ -1,0 +1,1 @@
+Improve the latency of git pre push hook with better defaults and auto-detection of release branches

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -202,6 +202,9 @@ Switching between branches
 When each branch has different external package requirements, you should run ``./pants export ::``
 before running codes after ``git switch``-ing between such branches.
 
+Sometimes, you may experience bogus "glob" warning from pants because it sees a stale cache.
+In that case, run ``killall -r pantsd`` and it will be fine.
+
 Running entrypoints
 -------------------
 

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -380,7 +380,7 @@ If Pants behaves strangely, you could simply reset all its runtime-generated fil
 
 .. code-block:: console
 
-   $ killall pantsd
+   $ killall -r pantsd
    $ rm -r .tmp .pants.d ~/.cache/pants
 
 After this, re-running any Pants command will automatically reinitialize itself and

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -426,6 +426,8 @@ bootstrap_pants() {
     else
       echo "Chosen Python $_PYENV_PYVER (from pyenv) as the local Pants interpreter"
     fi
+    # In most cases, we won't need to modify the source code of pants.
+    echo "ENABLE_PANTSD=true" > "$ROOT_PATH/.pants.env"
     echo "PY=\$(pyenv prefix $_PYENV_PYVER)/bin/python" >> "$ROOT_PATH/.pants.env"
     if [ -d tools/pants-src ]; then
       rm -rf tools/pants-src

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,11 +1,18 @@
 # backend.ai monorepo standard pre-push hook
-BASEPATH=$(cd "$(dirname "$0")"/../.. && pwd)
-if [ -f "$BASEPATH/pants-local" ]; then
-    PANTS=$BASEPATH/pants-local
+BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
+if [ -f "$BASE_PATH/pants-local" ]; then
+    PANTS=$BASE_PATH/pants-local
 else
-    PANTS=$BASEPATH/pants
+    PANTS=$BASE_PATH/pants
 fi
-set -ex
-$PANTS fmt ::
-$PANTS lint check --changed-since=$(git merge-base main HEAD)
-$PANTS tailor --check
+CURRENT_COMMIT=$(git rev-parse --short HEAD)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ -n $(echo "$CURRENT_BRANCH" | sed -n '/^[0-9]\+\.[0-9]\+$/p') ]; then
+  # if we are on a release branch, use it as the base branch.
+  BASE_BRANCH="$CURRENT_BRANCH"
+else
+  BASE_BRANCH="main"
+fi
+echo "Performing formatting and lint checks on $1/$BASE_BRANCH..HEAD@$CURRENT_COMMIT"
+"$PANTS" tailor --check update-build-files --check
+"$PANTS" fmt lint check --changed-since=$1/$BASE_BRANCH

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -15,4 +15,4 @@ else
 fi
 echo "Performing formatting and lint checks on $1/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT}"
 "$PANTS" tailor --check update-build-files --check
-"$PANTS" fmt lint check --changed-since="$1/${BASE_BRANCH}..HEAD"
+"$PANTS" fmt lint check --changed-since="$1/${BASE_BRANCH}"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,18 +1,18 @@
 # backend.ai monorepo standard pre-push hook
 BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
 if [ -f "$BASE_PATH/pants-local" ]; then
-    PANTS=$BASE_PATH/pants-local
+  PANTS="$BASE_PATH/pants-local"
 else
-    PANTS=$BASE_PATH/pants
+  PANTS="$BASE_PATH/pants"
 fi
 CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ -n $(echo "$CURRENT_BRANCH" | sed -n '/^[0-9]\+\.[0-9]\+$/p') ]; then
-  # if we are on a release branch, use it as the base branch.
+if [ -n "$(echo "$CURRENT_BRANCH" | sed -n '/^[0-9]\+\.[0-9]\+$/p')" ]; then
+  # if we are on the release branch, use it as the base branch.
   BASE_BRANCH="$CURRENT_BRANCH"
 else
   BASE_BRANCH="main"
 fi
-echo "Performing formatting and lint checks on $1/$BASE_BRANCH..HEAD@$CURRENT_COMMIT"
+echo "Performing formatting and lint checks on $1/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT}"
 "$PANTS" tailor --check update-build-files --check
-"$PANTS" fmt lint check --changed-since=$1/$BASE_BRANCH
+"$PANTS" fmt lint check --changed-since="$1/${BASE_BRANCH}..HEAD"


### PR DESCRIPTION
A follow-up to #518

* Enable pantsd by default when installed via sources (linux-aarch64).
  This will reduce the latency of pants execution from the second run.
* If you are on a release branch, use it as the base branch to check
  the changed files.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
