### PR TITLE
feat(install-dev): Warn and exit if user is not on the build root.

### DIFF
--- a/changes/524.feature.md
+++ b/changes/524.feature.md
@@ -1,0 +1,1 @@
+install-dev: Ensure that the user is on the build root directory (the repository's topmost directory).

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -180,6 +180,12 @@ else
 fi
 
 ROOT_PATH="$(pwd)"
+if [ ! -f "${ROOT_PATH}/BUILD_ROOT" ]; then
+  show_error "BUILD_ROOT is not found!"
+  echo "You are not on the root directory of the repository checkout."
+  echo "Please \`cd\` there and run \`./scripts/install-dev.sh <args>\`"
+  exit 1
+fi
 PLUGIN_PATH="${ROOT_PATH}/plugins"
 HALFSTACK_VOLUME_PATH="${ROOT_PATH}/volumes"
 PANTS_VERSION=$(cat pants.toml | $bpython -c 'import sys,re;m=re.search("pants_version = \"([^\"]+)\"", sys.stdin.read());print(m.group(1) if m else sys.exit(1))')


### PR DESCRIPTION
Sometimes it is confusing that we should run `install-dev.sh` from the build root instead of the inside of `scripts` directory.
