### PR TITLE
feat: Bump the client's target API version to v6.20220615

### DIFF
--- a/changes/533.feature.md
+++ b/changes/533.feature.md
@@ -1,0 +1,1 @@
+client: Bump the compatible manager API version range to v6.20220615

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -1,10 +1,10 @@
-from . import admin  # noqa
-from . import config  # noqa
-from . import dotfile  # noqa
-from . import extensions  # noqa
-from . import main  # noqa
-from . import server_log  # noqa
-from . import session  # noqa
-from . import session_template  # noqa
-from . import vfolder  # noqa
-from . import app, logs, proxy, run  # noqa
+from . import admin  # noqa  # type: ignore
+from . import config  # noqa  # type: ignore
+from . import dotfile  # noqa  # type: ignore
+from . import extensions  # noqa  # type: ignore
+from . import main  # noqa  # type: ignore
+from . import server_log  # noqa  # type: ignore
+from . import session  # noqa  # type: ignore
+from . import session_template  # noqa  # type: ignore
+from . import vfolder  # noqa  # type: ignore
+from . import app, logs, proxy, run  # noqa  # type: ignore

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -38,7 +38,7 @@ class Undefined(enum.Enum):
 _config = None
 _undefined = Undefined.token
 
-API_VERSION = (6, '20220315')
+API_VERSION = (6, '20220615')
 MIN_API_VERSION = (5, '20191215')
 
 DEFAULT_CHUNK_SIZE = 16 * (2**20)  # 16 MiB


### PR DESCRIPTION
* This change was intended to be included in #493, but the encryption
  logic is completely triggered by the client and optional, so let's
  first silence the version compatibility warning in the CLI.
