### PR TITLE
fix: `DockerKernel` object has no attribute `runner`

### DIFF
--- a/changes/534.fix.md
+++ b/changes/534.fix.md
@@ -1,0 +1,1 @@
+Fix agent crashing with `AttributeError: 'DockerKernel' object has no attribute 'runner'` error.

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -68,10 +68,12 @@ class DockerKernel(AbstractKernel):
             client_features=client_features)
 
     async def get_completions(self, text: str, opts: Mapping[str, Any]):
+        assert self.runner is not None
         result = await self.runner.feed_and_get_completion(text, opts)
         return {'status': 'finished', 'completions': result}
 
     async def check_status(self):
+        assert self.runner is not None
         result = await self.runner.feed_and_get_status()
         return result
 
@@ -83,10 +85,12 @@ class DockerKernel(AbstractKernel):
         return {'logs': ''.join(logs)}
 
     async def interrupt_kernel(self):
+        assert self.runner is not None
         await self.runner.feed_interrupt()
         return {'status': 'finished'}
 
     async def start_service(self, service: str, opts: Mapping[str, Any]):
+        assert self.runner is not None
         if self.data.get('block_service_ports', False):
             return {
                 'status': 'failed',
@@ -107,9 +111,11 @@ class DockerKernel(AbstractKernel):
         return result
 
     async def shutdown_service(self, service: str):
+        assert self.runner is not None
         await self.runner.feed_shutdown_service(service)
 
     async def get_service_apps(self):
+        assert self.runner is not None
         result = await self.runner.feed_service_apps()
         return result
 

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -150,7 +150,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
 
     _tasks: Set[asyncio.Task]
 
-    runner: 'AbstractCodeRunner'
+    runner: Optional[AbstractCodeRunner]
 
     def __init__(
         self, kernel_id: KernelId, image: ImageRef, version: int, *,
@@ -173,6 +173,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         self.stats_enabled = False
         self._tasks = set()
         self.environ = environ
+        self.runner = None
 
     async def init(self) -> None:
         log.debug('kernel.init(k:{0}, api-ver:{1}, client-features:{2}): '
@@ -277,6 +278,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
     ) -> NextResult:
         myself = asyncio.current_task()
         assert myself is not None
+        assert self.runner is not None
         self._tasks.add(myself)
         try:
             await self.runner.attach_output_queue(run_id)

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -141,10 +141,12 @@ class KubernetesKernel(AbstractKernel):
         return True
 
     async def get_completions(self, text: str, opts: Mapping[str, Any]):
+        assert self.runner is not None
         result = await self.runner.feed_and_get_completion(text, opts)
         return {'status': 'finished', 'completions': result}
 
     async def check_status(self):
+        assert self.runner is not None
         result = await self.runner.feed_and_get_status()
         return result
 
@@ -156,10 +158,12 @@ class KubernetesKernel(AbstractKernel):
         return {'logs': result.data.decode('utf-8')}
 
     async def interrupt_kernel(self):
+        assert self.runner is not None
         await self.runner.feed_interrupt()
         return {'status': 'finished'}
 
     async def start_service(self, service: str, opts: Mapping[str, Any]):
+        assert self.runner is not None
         if self.data.get('block_service_ports', False):
             return {
                 'status': 'failed',
@@ -180,9 +184,11 @@ class KubernetesKernel(AbstractKernel):
         return result
 
     async def shutdown_service(self, service: str):
+        assert self.runner is not None
         await self.runner.feed_shutdown_service(service)
 
     async def get_service_apps(self):
+        assert self.runner is not None
         result = await self.runner.feed_service_apps()
         return result
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR fixes agent creation failing due to agent referencing unset `AbstractKernel.runner` object.
