### PR TITLE
fix(logging): Do null-check of the 'level' value even if the key exists

### DIFF
--- a/changes/540.fix.md
+++ b/changes/540.fix.md
@@ -1,0 +1,1 @@
+Re-add null-check of the `'level'` key of the log record removed in #538

--- a/src/ai/backend/common/logging.py
+++ b/src/ai/backend/common/logging.py
@@ -196,7 +196,10 @@ class CustomJsonFormatter(JsonFormatter):
             # this doesn't use record.created, so it is slightly off
             now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
             log_record['timestamp'] = now
-        log_record['level'] = log_record.get('level', record.levelname).upper()
+        if loglevel := log_record.get('level'):
+            log_record['level'] = loglevel.upper()
+        else:
+            log_record['level'] = record.levelname.upper()
 
 
 class pretty:


### PR DESCRIPTION
In #538, we found that some (?) log messages have `None` value in the `'level'` key.
