### PR TITLE
setup: Introduce our own PyPI to workaround upstream issues

### DIFF
--- a/changes/545.misc.md
+++ b/changes/545.misc.md
@@ -1,0 +1,1 @@
+Introduce https://dist.backend.ai/pypi/simple to serve custom prebuilt wheels and workaround upstream issues in a timely manner

--- a/pants.toml
+++ b/pants.toml
@@ -36,6 +36,9 @@ enable_resolves = true
 interpreter_constraints = ["CPython==3.10.5"]
 lockfile_generator = "pex"
 
+[python-repos]
+indexes.add = ["https://dist.backend.ai/pypi/simple/"]
+
 [python.resolves]
 python-default = "python.lock"
 python-kernel = "python-kernel.lock"
@@ -45,12 +48,12 @@ python-kernel = "python-kernel.lock"
 
 # Temporarily reverted due to pantsbuild/pants#15990
 [pex-cli]
-version = "v2.1.94"
+version = "v2.1.98"
 known_versions = [
-    "v2.1.94|macos_arm64|775c22b97e057d595a8b334fab89f5a07ac9c552a36912504f62577f53a2d2d2|3802178",
-    "v2.1.94|macos_x86_64|775c22b97e057d595a8b334fab89f5a07ac9c552a36912504f62577f53a2d2d2|3802178",
-    "v2.1.94|linux_arm64|775c22b97e057d595a8b334fab89f5a07ac9c552a36912504f62577f53a2d2d2|3802178",
-    "v2.1.94|linux_x86_64|775c22b97e057d595a8b334fab89f5a07ac9c552a36912504f62577f53a2d2d2|3802178",
+    "v2.1.98|macos_arm64|b3db597492c3d1250036749bec8330a0e8786ec7a4bd6f0c9f8ff1675c90c0b4|3811372",
+    "v2.1.98|macos_x86_64|b3db597492c3d1250036749bec8330a0e8786ec7a4bd6f0c9f8ff1675c90c0b4|3811372",
+    "v2.1.98|linux_arm64|b3db597492c3d1250036749bec8330a0e8786ec7a4bd6f0c9f8ff1675c90c0b4|3811372",
+    "v2.1.98|linux_x86_64|b3db597492c3d1250036749bec8330a0e8786ec7a4bd6f0c9f8ff1675c90c0b4|3811372",
 ]
 # When trying a new pex version, you could find out the hash and size-in-bytes as follows:
 # $ curl -s -L https://github.com/pantsbuild/pex/releases/download/v2.1.94/pex | tee >(wc -c) >(shasum -a 256) >/dev/null

--- a/python.lock
+++ b/python.lock
@@ -1580,8 +1580,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d0d481ff55ea6cc49dab2c8276597bd4f1a84a8745fedb4bc23e12e9fb9d0e45",
-              "url": "https://files.pythonhosted.org/packages/b3/96/333410b506da8e6bb2935a452199b07b0541ddb855b52f6604f7bf581e11/grpcio-1.47.0-cp310-cp310-win_amd64.whl"
+              "hash": "c6345a0b8188ff915bf33cce6e445d9fd3738faa32640ca6267bd1344249ef6f",
+              "url": "https://raw.githubusercontent.com/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.47.0-cp310-cp310-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1622,6 +1622,11 @@
               "algorithm": "sha256",
               "hash": "e9723784cf264697024778dcf4b7542c851fe14b14681d6268fb984a53f76df1",
               "url": "https://files.pythonhosted.org/packages/ad/97/f5c1f0b99c2185056eba061a713266e3810f349664e487995b6b06f72bab/grpcio-1.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d0d481ff55ea6cc49dab2c8276597bd4f1a84a8745fedb4bc23e12e9fb9d0e45",
+              "url": "https://files.pythonhosted.org/packages/b3/96/333410b506da8e6bb2935a452199b07b0541ddb855b52f6604f7bf581e11/grpcio-1.47.0-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
@@ -3195,13 +3200,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
+              "hash": "0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
+              "url": "https://files.pythonhosted.org/packages/a4/53/bfc6409447ca024558b8b19d055de94c813c3e32c0296c48a0873a161cf5/setuptools-63.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450",
+              "url": "https://files.pythonhosted.org/packages/0a/ba/52611dc8278828eb9ec339e6914a0f865f9e2af967214905927835dfac0a/setuptools-63.2.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -3249,7 +3254,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "63.2"
         },
         {
           "artifacts": [
@@ -4064,7 +4069,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.94",
+  "pex_version": "2.1.98",
   "prefer_older_binary": false,
   "requirements": [
     "Jinja2~=3.0.1",
@@ -4152,6 +4157,7 @@
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",
+  "target_systems": [],
   "transitive": true,
   "use_pep517": null
 }


### PR DESCRIPTION
For infinite stream of questions about installing grpcio on M1 Mac and until this problem is ultimately fixed by Google, we decided to have our own PyPI distribution service: https://dist.backend.ai/pypi/simple/

**WARNING:** The exact list of packages served there may change over time depending on our needs, so we advise the general audience *not* to rely on this package index.

Special thanks to @jsirois for quickly patching pantsbuild/pex#1849!