### PR TITLE
ci: Workaround potential pants bug when running some commands in parallel

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -29,7 +29,9 @@ jobs:
         mkdir .tmp
         ./pants --no-verify-config version
     - name: Check BUILD files
-      run: ./pants tailor --check update-build-files --check # '::' # to add in 2.13+
+      run: |
+        ./pants tailor --check
+        ./pants update-build-files --check  # '::' # to add in 2.13+
     - name: Lint
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then

--- a/changes/546.misc.md
+++ b/changes/546.misc.md
@@ -1,0 +1,1 @@
+Workaround a pants bug when checking BUILD files in CI


### PR DESCRIPTION
After merging #545, this began to happen in both local setups and GitHub Actions.
