### PR TITLE
fix(install-dev): A typo in sed expression while installing backend.ai-webui

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -512,7 +512,7 @@ install_editable_webui() {
     local site_name=$(basename $(pwd))
     # The debug mode here is only for 'hard-core' debugging scenarios -- it changes lots of behaviors.
     # (e.g., separate debugging of Electron's renderer and main threads)
-    sed_inplace "s@debug = true@debug = false" config.toml
+    sed_inplace "s@debug = true@debug = false@" config.toml
     # The webserver endpoint to use in the session mode.
     sed_inplace "s@#apiEndpoint =@apiEndpoint = "'"'"http://127.0.0.1:${WEBSERVER_PORT}"'"@' config.toml
     sed_inplace "s@#apiEndpointText =@apiEndpointText = "'"'"${site_name}"'"' config.toml


### PR DESCRIPTION
fix: set the backend.ai-webui bug on install-dev.sh

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
