### PR TITLE
ci: Make the pre-push branch check consistent in Mac/Linux

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -7,7 +7,7 @@ else
 fi
 CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ -n "$(echo "$CURRENT_BRANCH" | sed -n '/^[0-9]\+\.[0-9]\+$/p')" ]; then
+if [ -n "$(echo "$CURRENT_BRANCH" | sed -n '/[[:digit:]]\{1,\}\.[[:digit:]]\{1,\}/p')" ]; then
   # if we are on the release branch, use it as the base branch.
   BASE_BRANCH="$CURRENT_BRANCH"
 else


### PR DESCRIPTION
- macOS and BSD versions of `sed` uses the POSIX standard more strictly.
  `\+` in regular expression is a GNU extension so we need to write it
  as `\{1,\}` for maximum POSIX compatibility.
  Also let's use the basic regex digit character class syntax.

ref: https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification