### PR TITLE
fix: modify sed command format

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -684,7 +684,7 @@ mkdir -p "$VAR_BASE_PATH"
 sed_inplace "s/port = 8120/port = ${ETCD_PORT}/" ./agent.toml
 sed_inplace "s/port = 6001/port = ${AGENT_RPC_PORT}/" ./agent.toml
 sed_inplace "s/port = 6009/port = ${AGENT_WATCHER_PORT}/" ./agent.toml
-sed_inplace "s/var-base-path = .*$/var-base-path = \"${VAR_BASE_PATH}\"/" ./agent.toml
+sed_inplace 's@var-base-path = .*$@var-base-path = "'"${VAR_BASE_PATH}"'"@' ./agent.toml
 
 # configure storage-proxy
 cp configs/storage-proxy/sample.toml ./storage-proxy.toml


### PR DESCRIPTION
![MicrosoftTeams-image](https://user-images.githubusercontent.com/65989401/179695915-a6465e95-3a7f-416b-b6be-6f389a3acdef.png)
sed-related errors in the "copy default configuration files to manager / agent root" process when running install-dev.sh after patching. (Error in both mac and linux)
A parsing error occurred while executing the sed command, and the parsing was modified. 

