### PR TITLE
fix: checking enable-cuda & enable-cuda-mock, modify cp cuda-mock.toml

### DIFF
--- a/changes/578.fix.md
+++ b/changes/578.fix.md
@@ -1,1 +1,1 @@
-fix: checking "--enable-cuda" & "--enable-cuda-mock", modify cp cuda-mock.toml file
+install-dev.sh: Fix "AND" operator when checking `--enable-cuda` &amp; `--enable-cuda-mock` and modify the default-installed `cuda-mock.toml` file

--- a/changes/578.fix.md
+++ b/changes/578.fix.md
@@ -1,0 +1,1 @@
+fix: checking "--enable-cuda" & "--enable-cuda-mock", modify cp cuda-mock.toml file

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -562,7 +562,7 @@ if [ "$DISTRO" = "Darwin" ]; then
   echo "${REWRITELN}validating Docker Desktop mount permissions: ok"
 fi
 
-if [ $ENABLE_CUDA -eq 1 ] & [ $ENABLE_CUDA_MOCK -eq 1 ]; then
+if [ $ENABLE_CUDA -eq 1 ] && [ $ENABLE_CUDA_MOCK -eq 1 ]; then
   show_error "You can't use both CUDA and CUDA mock plugins at once!"
   show_error "Please remove --enable-cuda or --enable-cuda-mock flag to continue."
   exit -1
@@ -660,7 +660,7 @@ check_snappy
 $PANTS export '::'
 
 if [ $ENABLE_CUDA_MOCK -eq 1 ]; then
-  cp "configs/accelerator/cuda-mock-enterprise.toml" cuda-mock.toml
+  cp "configs/accelerator/cuda-mock.toml" cuda-mock.toml
 fi
 
 # configure manager


### PR DESCRIPTION
fix: checking enable-cuda & enable-cuda-mock, modify cp cuda-mock.toml file

1. Clearly checking "--enable-cuda" and "--enable-cuda-mock" in the install-dev.sh
2. modify to copy cuda-mock.toml file

fix #577

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
