### PR TITLE
feat: support advertise URL for WSProxoy v2

### DIFF
--- a/changes/582.feature
+++ b/changes/582.feature
@@ -1,1 +1,1 @@
-Support version 2 WSProxy when the coordinator's user-accessible URL is different from the manager-accessible URL (usually when the user is separated from the Backend.AI service by NAT).
+Support wsproxy v2 when the coordinator's user-accessible URL is different from the manager-accessible URL (usually when the user is separated from the Backend.AI service by NAT)

--- a/changes/582.feature
+++ b/changes/582.feature
@@ -1,0 +1,1 @@
+Support version 2 WSProxy when the coordinator's user-accessible URL is different from the manager-accessible URL (usually when the user is separated from the Backend.AI service by NAT).

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -33,7 +33,7 @@ class WSProxyVersionQueryParams:
 @aiotools.lru_cache(expire_after=30)  # expire after 30 seconds
 async def query_wsproxy_status(
     wsproxy_addr: str,
-) -> str:
+) -> dict[str, Any]:
     async with aiohttp.ClientSession() as session:
         async with session.get(wsproxy_addr + "/status") as resp:
             return await resp.json()

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -31,13 +31,12 @@ class WSProxyVersionQueryParams:
 
 
 @aiotools.lru_cache(expire_after=30)  # expire after 30 seconds
-async def query_wsproxy_version(
+async def query_wsproxy_status(
     wsproxy_addr: str,
 ) -> str:
     async with aiohttp.ClientSession() as session:
         async with session.get(wsproxy_addr + "/status") as resp:
-            version_json = await resp.json()
-            return version_json["api_version"]
+            return await resp.json()
 
 
 @auth_required
@@ -91,7 +90,8 @@ async def get_wsproxy_version(request: web.Request, params: Any) -> web.Response
                 if not wsproxy_addr:
                     wsproxy_version = "v1"
                 else:
-                    wsproxy_version = await query_wsproxy_version(wsproxy_addr)
+                    wsproxy_status = await query_wsproxy_status(wsproxy_addr)
+                    wsproxy_version = wsproxy_status["api_version"]
                 return web.json_response(
                     {
                         "wsproxy_version": wsproxy_version,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1247,8 +1247,8 @@ async def start_service(request: web.Request, params: Mapping[str, Any]) -> web.
     if not wsproxy_addr:
         raise ServiceUnavailable("No coordinator configured for this resource group")
     wsproxy_status = await query_wsproxy_status(wsproxy_addr)
-    if wsproxy_status.get("advertise_address"):
-        wsproxy_advertise_addr = wsproxy_status["advertise_address"]
+    if advertise_addr := wsproxy_status.get("advertise_address"):
+        wsproxy_advertise_addr = advertise_addr
     else:
         wsproxy_advertise_addr = wsproxy_addr
 


### PR DESCRIPTION
Return WSProxy advertise URL, if exists, by querying the value from the coordinator in starting an app service. Since the coordinator's `status` handler now returns the advertise address, the `query_wsproxy_version` method is renamed to `query_wsproxy_status`.

This PR resolves https://github.com/lablup/backend.ai/issues/581.
