### PR TITLE
ci: Let workflows recognize skip:ci, skip:changelog labels

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
 
 
   typecheck:
-    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
       if: always()  # We want the log even on failures.
 
   test:
-    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
+    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -53,6 +54,7 @@ jobs:
 
 
   typecheck:
+    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -99,6 +101,7 @@ jobs:
       if: always()  # We want the log even on failures.
 
   test:
+    if: !contains(github.event.pull_request.labels.*.name, 'skip:ci')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   towncrier:
-    if: !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') }}
     runs-on: ubuntu-latest
     steps:
     - name: Sparse-checkout

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   towncrier:
+    if: !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
     runs-on: ubuntu-latest
     steps:
     - name: Sparse-checkout


### PR DESCRIPTION
Let's use `skip:ci`, `skip:changelog` labels to mark skipping specific workflows for PRs.