### PR TITLE
feat(web): Add `[service].static_path` option

### DIFF
--- a/changes/599.feature.md
+++ b/changes/599.feature.md
@@ -1,0 +1,1 @@
+Add the `static_path` option to `webserver.conf` for site-specific customization and refactor internal configuration handling and request handlers of the webserver

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -4,12 +4,12 @@ port = 8080
 wsproxy.url = ""
 
 # If you need ssl-enabled server, fill these configurations.
-#ssl-enabled = true
-#ssl-cert = 
-#ssl-privkey =
+#ssl_enabled = true
+#ssl_cert =
+#ssl_privkey =
 
 # Set or enable it when using nginx proxy
-#force-endpoint-protocol = "https"
+#force_endpoint_protocol = "https"
 
 # "webui" mode is for serving "backend.ai-webui" PWA,
 # where non-existent URLs are fall-back to "index.html"
@@ -101,7 +101,7 @@ login_allowed_fail_count = 10
 #auto_logout = false
 
 # Add a manually configured license information shown in the UI.
-#[license]
+[license]
 #edition = "Open Source"
 #valid_since = ""
 #valid_until = ""

--- a/src/ai/backend/web/auth.py
+++ b/src/ai/backend/web/auth.py
@@ -1,5 +1,5 @@
-import copy
 import json
+from typing import Optional
 
 from aiohttp import web
 from aiohttp_session import get_session
@@ -12,12 +12,12 @@ from . import user_agent
 
 async def get_api_session(
     request: web.Request,
-    api_endpoint: str = None,
+    override_api_endpoint: Optional[str] = None,
 ) -> APISession:
     config = request.app["config"]
-    if api_endpoint is not None:
-        config = copy.deepcopy(config)
-        config["api"]["endpoint"] = api_endpoint
+    api_endpoint = config["api"]["endpoint"][0]
+    if override_api_endpoint is not None:
+        api_endpoint = override_api_endpoint
     session = await get_session(request)
     if not session.get("authenticated", False):
         raise web.HTTPUnauthorized(
@@ -51,31 +51,31 @@ async def get_api_session(
             content_type="application/problem+json",
         )
     ak, sk = token["access_key"], token["secret_key"]
-    config = APIConfig(
+    api_config = APIConfig(
         domain=config["api"]["domain"],
-        endpoint=config["api"]["endpoint"],
+        endpoint=api_endpoint,
         access_key=ak,
         secret_key=sk,
         user_agent=user_agent,
-        skip_sslcert_validation=not config["api"].get("ssl-verify", True),
+        skip_sslcert_validation=not config["api"]["ssl_verify"],
     )
-    return APISession(config=config, proxy_mode=True)
+    return APISession(config=api_config, proxy_mode=True)
 
 
 async def get_anonymous_session(
     request: web.Request,
-    api_endpoint: str = None,
+    override_api_endpoint: Optional[str] = None,
 ) -> APISession:
     config = request.app["config"]
-    if api_endpoint is not None:
-        config = copy.deepcopy(config)
-        config["api"]["endpoint"] = api_endpoint
-    config = APIConfig(
+    api_endpoint = config["api"]["endpoint"][0]
+    if override_api_endpoint is not None:
+        api_endpoint = override_api_endpoint
+    api_config = APIConfig(
         domain=config["api"]["domain"],
-        endpoint=config["api"]["endpoint"],
+        endpoint=api_endpoint,
         access_key="",
         secret_key="",
         user_agent=user_agent,
-        skip_sslcert_validation=not config["api"].get("ssl-verify", True),
+        skip_sslcert_validation=not config["api"]["ssl_verify"],
     )
-    return APISession(config=config, proxy_mode=True)
+    return APISession(config=api_config, proxy_mode=True)

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -8,6 +8,12 @@ from ai.backend.common import validators as tx
 
 default_static_path = Path(pkg_resources.resource_filename("ai.backend.web", "static")).resolve()
 
+license_defs = {
+    "edition": "Open Source",
+    "valid_since": "",
+    "valid_until": "",
+}
+
 config_iv = t.Dict(
     {
         t.Key("service"): t.Dict(
@@ -101,11 +107,15 @@ config_iv = t.Dict(
                 t.Key("auto_logout", default=False): t.ToBool,
             }
         ).allow_extra("*"),
-        t.Key("license"): t.Dict(
+        t.Key("license", default=license_defs): t.Dict(
             {
-                t.Key("edition", default="Open Source"): t.String,
-                t.Key("valid_since", default=""): t.String(allow_blank=True),
-                t.Key("valid_until", default=""): t.String(allow_blank=True),
+                t.Key("edition", default=license_defs["edition"]): t.String,
+                t.Key("valid_since", default=license_defs["valid_since"]): t.String(
+                    allow_blank=True
+                ),
+                t.Key("valid_until", default=license_defs["valid_until"]): t.String(
+                    allow_blank=True
+                ),
             }
         ).allow_extra("*"),
     }

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -60,12 +60,13 @@ config_iv = t.Dict(
         ).allow_extra("*"),
         t.Key("environments"): t.Dict(
             {
-                t.Key("allowlist", default=""): tx.StringList(empty_str_as_empty_list=True),
+                t.Key("allowlist", default=None): t.Null
+                | tx.StringList(empty_str_as_empty_list=True),
             }
         ).allow_extra("*"),
         t.Key("plugin"): t.Dict(
             {
-                t.Key("page", default=False): t.ToBool | t.String(allow_blank=True),
+                t.Key("page", default=None): t.Null | t.String(allow_blank=True),
             }
         ).allow_extra("*"),
         t.Key("pipeline"): t.Dict(
@@ -78,7 +79,8 @@ config_iv = t.Dict(
                 t.Key("brand"): t.String,
                 t.Key("default_environment", default=None): t.Null | t.String,
                 t.Key("default_import_environment", default=None): t.Null | t.String,
-                t.Key("menu_blocklist", default=""): tx.StringList(empty_str_as_empty_list=True),
+                t.Key("menu_blocklist", default=None): t.Null
+                | tx.StringList(empty_str_as_empty_list=True),
             }
         ).allow_extra("*"),
         t.Key("api"): t.Dict(

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import pkg_resources
+import trafaret as t
+import yarl
+
+from ai.backend.common import validators as tx
+
+default_static_path = Path(pkg_resources.resource_filename("ai.backend.web", "static")).resolve()
+
+config_iv = t.Dict(
+    {
+        t.Key("service"): t.Dict(
+            {
+                t.Key("ip", default="0.0.0.0"): tx.IPAddress,
+                t.Key("port"): t.ToInt[1:65535],
+                t.Key("wsproxy"): t.Dict(
+                    {
+                        t.Key("url", default=""): t.String(allow_blank=True),
+                    }
+                ),
+                tx.AliasedKey(["ssl_enabled", "ssl-enabled"], default=False): t.ToBool,
+                tx.AliasedKey(["ssl_cert", "ssl-cert"], default=None): t.Null
+                | tx.Path(type="file"),
+                tx.AliasedKey(["ssl_privkey", "ssl-privkey"], default=None): t.Null
+                | tx.Path(type="file"),
+                t.Key("static_path", default=default_static_path): tx.Path(type="dir"),
+                tx.AliasedKey(
+                    ["force_endpoint_protocol", "force-endpoint-protocol"],
+                    default=None,
+                ): t.Null
+                | t.Enum("https", "http"),
+                t.Key("mode"): t.Enum("webui", "static"),
+                t.Key("enable_signup", default=False): t.ToBool,
+                t.Key("allow_anonymous_change_password", default=False): t.ToBool,
+                t.Key("allow_project_resource_monitor", default=False): t.ToBool,
+                t.Key("allow_change_signin_mode", default=False): t.ToBool,
+                t.Key("allow_manual_image_name_for_session", default=False): t.ToBool,
+                t.Key("allow_signup_without_confirmation", default=False): t.ToBool,
+                t.Key("webui_debug", default=False): t.ToBool,
+                t.Key("mask_user_info", default=False): t.ToBool,
+            }
+        ).allow_extra("*"),
+        t.Key("resources"): t.Dict(
+            {
+                t.Key("open_port_to_public", default=False): t.ToBool,
+                t.Key("max_cpu_cores_per_container", default=64): t.ToInt,
+                t.Key("max_memory_per_container", default=64): t.ToInt,
+                t.Key("max_cuda_devices_per_container", default=16): t.ToInt,
+                t.Key("max_cuda_shares_per_container", default=16): t.ToFloat,
+                t.Key("max_shm_per_container", default=2): t.ToInt,
+                t.Key("max_file_upload_size", default=4294967296): t.ToInt,
+            }
+        ).allow_extra("*"),
+        t.Key("environments"): t.Dict(
+            {
+                t.Key("allowlist", default=""): tx.StringList(empty_str_as_empty_list=True),
+            }
+        ).allow_extra("*"),
+        t.Key("plugin"): t.Dict(
+            {
+                t.Key("page", default=False): t.ToBool | t.String(allow_blank=True),
+            }
+        ).allow_extra("*"),
+        t.Key("pipeline"): t.Dict(
+            {
+                t.Key("endpoint", default=None): t.Null | tx.URL,
+            }
+        ).allow_extra("*"),
+        t.Key("ui"): t.Dict(
+            {
+                t.Key("brand"): t.String,
+                t.Key("default_environment", default=None): t.Null | t.String,
+                t.Key("default_import_environment", default=None): t.Null | t.String,
+                t.Key("menu_blocklist", default=""): tx.StringList(empty_str_as_empty_list=True),
+            }
+        ).allow_extra("*"),
+        t.Key("api"): t.Dict(
+            {
+                t.Key("domain"): t.String,
+                t.Key("endpoint"): tx.DelimiterSeperatedList[yarl.URL](tx.URL, min_length=1),
+                t.Key("text"): t.String,
+                tx.AliasedKey(["ssl_verify", "ssl-verify"], default=True): t.ToBool,
+                t.Key("auth_token_name", default="sToken"): t.String,
+            }
+        ).allow_extra("*"),
+        t.Key("session"): t.Dict(
+            {
+                t.Key("redis"): t.Dict(
+                    {
+                        t.Key("host", default="localhost"): t.String,
+                        t.Key("port", default=6379): t.ToInt[1:65535],
+                        t.Key("db", default=0): t.ToInt,
+                        t.Key("password", default=None): t.Null | t.String,
+                    }
+                ),
+                t.Key("max_age", default=604800): t.ToInt,  # seconds (default: 1 week)
+                t.Key("flush_on_startup", default=False): t.ToBool,
+                t.Key("login_block_time", default=1200): t.ToInt,  # seconds (default: 20 min)
+                t.Key("login_allowed_fail_count", default=10): t.ToInt,
+                t.Key("auto_logout", default=False): t.ToBool,
+            }
+        ).allow_extra("*"),
+        t.Key("license"): t.Dict(
+            {
+                t.Key("edition", default="Open Source"): t.String,
+                t.Key("valid_since", default=""): t.String(allow_blank=True),
+                t.Key("valid_until", default=""): t.String(allow_blank=True),
+            }
+        ).allow_extra("*"),
+    }
+).allow_extra("*")

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -127,11 +127,11 @@ class WebSocketProxy:
             await self.up_conn.close()
 
 
-async def decrypt_payload(request):
+async def decrypt_payload(request: web.Request) -> str:
     config = request.app["config"]
-    scheme = config["service"].get("force-endpoint-protocol")
+    scheme = config["service"]["force-endpoint-protocol"]
     if not request.content:
-        return request
+        return ""
     if scheme is None:
         scheme = request.scheme
     api_endpoint = f"{scheme}://{request.host}"

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -128,10 +128,10 @@ class WebSocketProxy:
 
 
 async def decrypt_payload(request: web.Request) -> str:
-    config = request.app["config"]
-    scheme = config["service"]["force-endpoint-protocol"]
     if not request.content:
         return ""
+    config = request.app["config"]
+    scheme = config["service"]["force-endpoint-protocol"]
     if scheme is None:
         scheme = request.scheme
     api_endpoint = f"{scheme}://{request.host}"

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -131,7 +131,7 @@ async def decrypt_payload(request: web.Request) -> str:
     if not request.content:
         return ""
     config = request.app["config"]
-    scheme = config["service"]["force-endpoint-protocol"]
+    scheme = config["service"]["force_endpoint_protocol"]
     if scheme is None:
         scheme = request.scheme
     api_endpoint = f"{scheme}://{request.host}"
@@ -166,9 +166,10 @@ async def web_handler(request, *, is_anonymous=False) -> web.StreamResponse:
             request_headers = extra_config_headers.check(request.headers)
             request_api_version = request_headers.get("X-BackendAI-Version", None)
             secure_context = request_headers.get("X-BackendAI-Encoded", None)
+            decrypted_payload_length = 0
             if secure_context:
                 payload = await decrypt_payload(request)
-                payload_length = len(payload)
+                decrypted_payload_length = len(payload)
             else:
                 payload = request.content
             # Send X-Forwarded-For header for token authentication with the client IP.
@@ -196,7 +197,7 @@ async def web_handler(request, *, is_anonymous=False) -> web.StreamResponse:
             if "Content-Length" in request.headers and not secure_context:
                 api_rqst.headers["Content-Length"] = request.headers["Content-Length"]
             if "Content-Length" in request.headers and secure_context:
-                api_rqst.headers["Content-Length"] = str(payload_length)
+                api_rqst.headers["Content-Length"] = str(decrypted_payload_length)
             for hdr in HTTP_HEADERS_TO_FORWARD:
                 if request.headers.get(hdr) is not None:
                     api_rqst.headers[hdr] = request.headers[hdr]
@@ -342,13 +343,13 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
     # Choose a specific Manager endpoint for persistent web app connection.
     api_endpoint = None
     should_save_session = False
-    _endpoints = request.app["config"]["api"]["endpoint"].split(",")
-    _endpoints = [e.strip() for e in _endpoints]
+    configured_endpoints = request.app["config"]["api"]["endpoint"]
     if session.get("api_endpoints", {}).get(app):
-        if session["api_endpoints"][app] in _endpoints:
+        stringified_endpoints = [str(e) for e in configured_endpoints]
+        if session["api_endpoints"][app] in stringified_endpoints:
             api_endpoint = session["api_endpoints"][app]
     if api_endpoint is None:
-        api_endpoint = random.choice(_endpoints)
+        api_endpoint = random.choice(configured_endpoints)
         if "api_endpoints" not in session:
             session["api_endpoints"] = {}
         session["api_endpoints"][app] = api_endpoint
@@ -361,12 +362,11 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
     try:
         async with api_session:
             request_api_version = request.headers.get("X-BackendAI-Version", None)
-            params = request.query if request.query else None
             api_rqst = Request(
                 request.method,
                 path,
                 request.content,
-                params=params,
+                params=request.query,
                 content_type=request.content_type,
                 override_api_version=request_api_version,
             )

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -352,7 +352,7 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
         api_endpoint = random.choice(configured_endpoints)
         if "api_endpoints" not in session:
             session["api_endpoints"] = {}
-        session["api_endpoints"][app] = api_endpoint
+        session["api_endpoints"][app] = str(api_endpoint)
         should_save_session = True
 
     if is_anonymous:

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -392,7 +392,7 @@ async def login_handler(request: web.Request) -> web.Response:
     try:
         anon_api_config = APIConfig(
             domain=config["api"]["domain"],
-            endpoint=config["api"]["endpoint"],
+            endpoint=config["api"]["endpoint"][0],
             access_key="",
             secret_key="",  # anonymous session
             user_agent=user_agent,
@@ -499,7 +499,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
     try:
         anon_api_config = APIConfig(
             domain=config["api"]["domain"],
-            endpoint=config["api"]["endpoint"],
+            endpoint=config["api"]["endpoint"][0],
             access_key="",
             secret_key="",  # anonymous session
             user_agent=user_agent,

--- a/src/ai/backend/web/template.py
+++ b/src/ai/backend/web/template.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from jinja2 import lexer, nodes
+from jinja2.ext import Extension
+from jinja2.parser import Parser
+
+
+class TOMLField(Extension):
+
+    tags = {"toml_field"}
+
+    def parse(self, parser: Parser) -> nodes.Node | List[nodes.Node]:
+        tag_name = list(self.tags)[0]
+        lineno = parser.stream.expect(f"name:{tag_name}").lineno
+        field_name: lexer.Token = parser.stream.expect(lexer.TOKEN_STRING)
+        field_value: nodes.Expr = parser.parse_expression()
+        return nodes.Output(
+            [
+                nodes.CondExpr(
+                    nodes.Test(field_value, "none", [], [], None, None),
+                    # TOML does not have "null" syntax so let's comment out the field.
+                    nodes.TemplateData(f"# {field_name.value} ="),
+                    nodes.Concat(
+                        [
+                            nodes.TemplateData(f"{field_name.value} = "),
+                            self._transform(field_value),
+                        ]
+                    ),
+                ),
+            ],
+            lineno=lineno,
+        )
+
+    def _transform(self, field_value: nodes.Expr) -> nodes.Expr:
+        field_value = nodes.Filter(field_value, "tojson", [], [], None, None)
+        field_value = nodes.Filter(field_value, "safe", [], [], None, None)
+        return field_value
+
+
+class TOMLStringListField(TOMLField):
+
+    tags = {"toml_strlist_field"}
+
+    def _transform(self, field_value: nodes.Expr) -> nodes.Expr:
+        field_value = nodes.Filter(field_value, "join", [nodes.Const(",")], [], None, None)
+        field_value = nodes.Filter(field_value, "tojson", [], [], None, None)
+        field_value = nodes.Filter(field_value, "safe", [], [], None, None)
+        return field_value

--- a/src/ai/backend/web/template.py
+++ b/src/ai/backend/web/template.py
@@ -1,7 +1,7 @@
 import json
-from typing import Any, List
+from typing import Any, List, Optional
 
-from jinja2 import lexer, nodes
+from jinja2 import nodes
 from jinja2.ext import Extension
 from jinja2.parser import Parser
 
@@ -13,27 +13,36 @@ class TOMLField(Extension):
     def parse(self, parser: Parser) -> nodes.Node | List[nodes.Node]:
         tag_name = list(self.tags)[0]
         lineno = parser.stream.expect(f"name:{tag_name}").lineno
-        field_name: lexer.Token = parser.stream.expect(lexer.TOKEN_STRING)
+        field_name: nodes.Expr = parser.parse_expression()
         field_value: nodes.Expr = parser.parse_expression()
         return nodes.Output(
             [
                 nodes.CondExpr(
                     nodes.Test(field_value, "none", [], [], None, None),
                     # TOML does not have "null" syntax so let's comment out the field.
-                    nodes.TemplateData(f"# {field_name.value} ="),
                     nodes.Concat(
                         [
-                            nodes.TemplateData(f"{field_name.value} = "),
-                            self._transform(field_value),
-                        ]
+                            nodes.TemplateData("# "),
+                            field_name,
+                            nodes.TemplateData(" = "),
+                        ],
+                        lineno=lineno,
+                    ),
+                    nodes.Concat(
+                        [
+                            field_name,
+                            nodes.TemplateData(" = "),
+                            self._transform(field_value, lineno=lineno),
+                        ],
+                        lineno=lineno,
                     ),
                 ),
             ],
             lineno=lineno,
         )
 
-    def _transform(self, field_value: nodes.Expr) -> nodes.Expr:
-        field_value = nodes.Filter(field_value, "toml_scalar", [], [], None, None)
+    def _transform(self, field_value: nodes.Expr, lineno: Optional[int] = None) -> nodes.Expr:
+        field_value = nodes.Filter(field_value, "toml_scalar", [], [], None, None, lineno=lineno)
         return field_value
 
 
@@ -41,9 +50,11 @@ class TOMLStringListField(TOMLField):
 
     tags = {"toml_strlist_field"}
 
-    def _transform(self, field_value: nodes.Expr) -> nodes.Expr:
-        field_value = nodes.Filter(field_value, "join", [nodes.Const(",")], [], None, None)
-        field_value = nodes.Filter(field_value, "toml_scalar", [], [], None, None)
+    def _transform(self, field_value: nodes.Expr, lineno: Optional[int] = None) -> nodes.Expr:
+        field_value = nodes.Filter(
+            field_value, "join", [nodes.Const(",")], [], None, None, lineno=lineno
+        )
+        field_value = nodes.Filter(field_value, "toml_scalar", [], [], None, None, lineno=lineno)
         return field_value
 
 

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -25,13 +25,17 @@ maxShmPerContainer = {{ config["resources"]["max_shm_per_container"] | tojson }}
 maxFileUploadSize = {{ config["resources"]["max_file_upload_size"] | tojson }}
 
 [environments]
+{% if config["environments"]["allowlist"] -%}{# This list should not be present if not used #}
 allowlist = {{ config["environments"]["allowlist"] | join(",") | tojson }}
+{%- endif %}
 
 [menu]
+{% if config["ui"]["menu_blocklist"] -%}{# This list should not be present if not used #}
 blocklist = {{ config["ui"]["menu_blocklist"] | join(",") | tojson }}
+{%- endif %}
 
 [plugin]
-{% if config["plugin"]["page"] -%}
+{% if config["plugin"]["page"] -%}{# This list should not be present if not used #}
 page = {{ config["plugin"]["page"] | join(",") | tojson }}
 {%- endif %}
 

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -1,0 +1,47 @@
+[general]
+apiEndpoint = {{ endpoint_url | tojson }}
+apiEndpointText = {{ config["api"]["text"] | tojson }}
+defaultSessionEnvironment = {{ config["ui"]["default_environment"] | tojson }}
+defaultImportEnvironment = {{ config["ui"]["default_import_environment"] | tojson }}
+siteDescription = {{ config["ui"]["brand"] | tojson }}
+connectionMode = "SESSION"
+signupSupport = {{ config["service"]["enable_signup"] | tojson }}
+allowChangeSigninMode = {{ config["service"]["allow_change_signin_mode"] | tojson }}
+allowAnonymousChangePassword = {{ config["service"]["allow_anonymous_change_password"] | tojson }}
+allowProjectResourceMonitor = {{ config["service"]["allow_project_resource_monitor"] | tojson }}
+allowManualImageNameForSession = {{ config["service"]["allow_manual_image_name_for_session"] | tojson }}
+allowSignupWithoutConfirmation = {{ config["service"]["allow_signup_without_confirmation"] | tojson }}
+autoLogout = {{ config["session"]["auto_logout"] | tojson }}
+debug = {{ config["service"]["webui_debug"] | tojson }}
+maskUserInfo = {{ config["service"]["mask_user_info"] | tojson }}
+
+[resources]
+openPortToPublic = {{ config["resources"]["open_port_to_public"] | tojson }}
+maxCPUCoresPerContainer = {{ config["resources"]["max_cpu_cores_per_container"] | tojson }}
+maxMemoryPerContainer = {{ config["resources"]["max_memory_per_container"] | tojson }}
+maxCUDADevicesPerContainer = {{ config["resources"]["max_cuda_devices_per_container"] | tojson }}
+maxCUDASharesPerContainer = {{ config["resources"]["max_cuda_shares_per_container"] | tojson }}
+maxShmPerContainer = {{ config["resources"]["max_shm_per_container"] | tojson }}
+maxFileUploadSize = {{ config["resources"]["max_file_upload_size"] | tojson }}
+
+[environments]
+allowlist = {{ config["environments"]["allowlist"] | join(",") | tojson }}
+
+[menu]
+blocklist = {{ config["ui"]["menu_blocklist"] | join(",") | tojson }}
+
+[plugin]
+{% if config["plugin"]["page"] -%}
+page = {{ config["plugin"]["page"] | join(",") | tojson }}
+{%- endif %}
+
+[wsproxy]
+proxyURL = {{ config["service"]["wsproxy"]["url"] | tojson }}
+#proxyBaseURL =
+#proxyListenIP =
+
+[license]
+edition = {{ config["license"]["edition"] | tojson }}
+validSince = {{ config["license"]["valid_since"] | tojson }}
+validUntil = {{ config["license"]["valid_until"] | tojson }}
+

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -1,51 +1,46 @@
 [general]
-apiEndpoint = {{ endpoint_url | tojson }}
-apiEndpointText = {{ config["api"]["text"] | tojson }}
-defaultSessionEnvironment = {{ config["ui"]["default_environment"] | tojson }}
-defaultImportEnvironment = {{ config["ui"]["default_import_environment"] | tojson }}
-siteDescription = {{ config["ui"]["brand"] | tojson }}
+{% toml_field "apiEndpoint" endpoint_url %}
+{% toml_field "apiEndpointText" config["api"]["text"] %}
+{% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
+{% toml_field "defaultImportEnvironment" config["ui"]["default_import_environment"] %}
+{% toml_field "siteDescription" config["ui"]["brand"] %}
 connectionMode = "SESSION"
-signupSupport = {{ config["service"]["enable_signup"] | tojson }}
-allowChangeSigninMode = {{ config["service"]["allow_change_signin_mode"] | tojson }}
-allowAnonymousChangePassword = {{ config["service"]["allow_anonymous_change_password"] | tojson }}
-allowProjectResourceMonitor = {{ config["service"]["allow_project_resource_monitor"] | tojson }}
-allowManualImageNameForSession = {{ config["service"]["allow_manual_image_name_for_session"] | tojson }}
-allowSignupWithoutConfirmation = {{ config["service"]["allow_signup_without_confirmation"] | tojson }}
-autoLogout = {{ config["session"]["auto_logout"] | tojson }}
-debug = {{ config["service"]["webui_debug"] | tojson }}
-maskUserInfo = {{ config["service"]["mask_user_info"] | tojson }}
+{% toml_field "signupSupport" config["service"]["enable_signup"] %}
+{% toml_field "allowChangeSigninMode" config["service"]["allow_change_signin_mode"] %}
+{% toml_field "allowAnonymousChangePassword" config["service"]["allow_anonymous_change_password"] %}
+{% toml_field "allowProjectResourceMonitor" config["service"]["allow_project_resource_monitor"] %}
+{% toml_field "allowManualImageNameForSession" config["service"]["allow_manual_image_name_for_session"] %}
+{% toml_field "allowSignupWithoutConfirmation" config["service"]["allow_signup_without_confirmation"] %}
+{% toml_field "autoLogout" config["session"]["auto_logout"] %}
+{% toml_field "debug" config["service"]["webui_debug"] %}
+{% toml_field "debug" config["service"]["webui_debug"] %}
+{% toml_field "maskUserInfo" config["service"]["mask_user_info"] %}
 
 [resources]
-openPortToPublic = {{ config["resources"]["open_port_to_public"] | tojson }}
-maxCPUCoresPerContainer = {{ config["resources"]["max_cpu_cores_per_container"] | tojson }}
-maxMemoryPerContainer = {{ config["resources"]["max_memory_per_container"] | tojson }}
-maxCUDADevicesPerContainer = {{ config["resources"]["max_cuda_devices_per_container"] | tojson }}
-maxCUDASharesPerContainer = {{ config["resources"]["max_cuda_shares_per_container"] | tojson }}
-maxShmPerContainer = {{ config["resources"]["max_shm_per_container"] | tojson }}
-maxFileUploadSize = {{ config["resources"]["max_file_upload_size"] | tojson }}
+{% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}
+{% toml_field "maxCPUCoresPerContainer" config["resources"]["max_cpu_cores_per_container"] %}
+{% toml_field "maxMemoryPerContainer" config["resources"]["max_memory_per_container"] %}
+{% toml_field "maxCUDADevicesPerContainer" config["resources"]["max_cuda_devices_per_container"] %}
+{% toml_field "maxCUDASharesPerContainer" config["resources"]["max_cuda_shares_per_container"] %}
+{% toml_field "maxShmPerContainer" config["resources"]["max_shm_per_container"] %}
+{% toml_field "maxFileUploadSize" config["resources"]["max_file_upload_size"] %}
 
 [environments]
-{% if config["environments"]["allowlist"] -%}{# This list should not be present if not used #}
-allowlist = {{ config["environments"]["allowlist"] | join(",") | tojson }}
-{%- endif %}
+{% toml_strlist_field "allowlist" config["environments"]["allowlist"] %}
 
 [menu]
-{% if config["ui"]["menu_blocklist"] -%}{# This list should not be present if not used #}
-blocklist = {{ config["ui"]["menu_blocklist"] | join(",") | tojson }}
-{%- endif %}
+{% toml_strlist_field "blocklist" config["ui"]["menu_blocklist"] %}
 
 [plugin]
-{% if config["plugin"]["page"] -%}{# This list should not be present if not used #}
-page = {{ config["plugin"]["page"] | join(",") | tojson }}
-{%- endif %}
+{% toml_strlist_field "page" config["plugin"]["page"] %}
 
 [wsproxy]
-proxyURL = {{ config["service"]["wsproxy"]["url"] | tojson }}
-#proxyBaseURL =
-#proxyListenIP =
+{% toml_field "proxyURL" config["service"]["wsproxy"]["url"] %}
+# proxyBaseURL =
+# proxyListenIP =
 
 [license]
-edition = {{ config["license"]["edition"] | tojson }}
-validSince = {{ config["license"]["valid_since"] | tojson }}
-validUntil = {{ config["license"]["valid_until"] | tojson }}
+{% toml_field "edition" config["license"]["edition"] %}
+{% toml_field "validSince" config["license"]["valid_since"] %}
+{% toml_field "validUntil" config["license"]["valid_until"] %}
 

--- a/src/ai/backend/web/templates/config_ini.toml.j2
+++ b/src/ai/backend/web/templates/config_ini.toml.j2
@@ -1,0 +1,11 @@
+[general]
+apiEndpoint = {{ endpoint_url | tojson }}
+apiEndpointText = {{ config["api"]["text"] | tojson }}
+defaultSessionEnvironment = {{ config["ui"]["default_environment"] | tojson }}
+siteDescription = {{ config["ui"]["brand"] | tojson }}
+connectionMode = "SESSION"
+
+[wsproxy]
+proxyURL = {{ config["service"]["wsproxy"]["url"] | tojson }}
+proxyBaseURL =
+proxyListenIP =

--- a/src/ai/backend/web/templates/config_ini.toml.j2
+++ b/src/ai/backend/web/templates/config_ini.toml.j2
@@ -1,11 +1,11 @@
 [general]
-apiEndpoint = {{ endpoint_url | tojson }}
-apiEndpointText = {{ config["api"]["text"] | tojson }}
-defaultSessionEnvironment = {{ config["ui"]["default_environment"] | tojson }}
-siteDescription = {{ config["ui"]["brand"] | tojson }}
+{% toml_field "apiEndpoint" endpoint_url %}
+{% toml_field "apiEndpointText" config["api"]["text"] %}
+{% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
+{% toml_field "siteDescription" config["ui"]["brand"] %}
 connectionMode = "SESSION"
 
 [wsproxy]
-proxyURL = {{ config["service"]["wsproxy"]["url"] | tojson }}
-proxyBaseURL =
-proxyListenIP =
+{% toml_field "proxyURL" config["service"]["wsproxy"]["url"] %}
+# proxyBaseURL =
+# proxyListenIP =

--- a/tests/common/test_validators.py
+++ b/tests/common/test_validators.py
@@ -191,7 +191,21 @@ def test_binary_size_commutative_with_null():
 
 
 def test_delimiter_list():
+    iv = tx.DelimiterSeperatedList(t.String(allow_blank=True), delimiter=":")
+    assert iv.check("") == [""]
+    assert iv.check(":") == ["", ""]
+    iv = tx.DelimiterSeperatedList(
+        t.String(allow_blank=True),
+        delimiter=":",
+        empty_str_as_empty_list=True,
+    )
+    assert iv.check("") == []
+    assert iv.check(":") == ["", ""]
     iv = tx.DelimiterSeperatedList(t.String, delimiter=":")
+    with pytest.raises(t.DataError):
+        iv.check("")
+    with pytest.raises(t.DataError):
+        iv.check(":")
     assert iv.check("aaa:bbb:ccc") == ["aaa", "bbb", "ccc"]
     assert iv.check("xxx") == ["xxx"]
     iv = tx.DelimiterSeperatedList(tx.HostPortPair, delimiter=",")
@@ -202,13 +216,24 @@ def test_delimiter_list():
 
 
 def test_string_list():
-    iv = tx.StringList(delimiter=":")
+    iv = tx.StringList(delimiter=":", allow_blank=True)
     assert iv.check("aaa:bbb:ccc") == ["aaa", "bbb", "ccc"]
     assert iv.check(":bbb") == ["", "bbb"]
     assert iv.check("aaa:") == ["aaa", ""]
     assert iv.check("xxx") == ["xxx"]
     assert iv.check("") == [""]
     assert iv.check(123) == ["123"]
+    iv = tx.StringList(delimiter=":", allow_blank=False)
+    with pytest.raises(t.DataError):
+        iv.check("")
+    with pytest.raises(t.DataError):
+        iv.check(":bbb")
+    iv = tx.StringList(delimiter=":", allow_blank=True, min_length=2)
+    with pytest.raises(t.DataError):
+        iv.check("")
+    with pytest.raises(t.DataError):
+        iv.check("a")
+    assert iv.check("a:b") == ["a", "b"]
 
 
 def test_enum():

--- a/tests/webserver/test_auth.py
+++ b/tests/webserver/test_auth.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yarl
 from aiohttp import web
 
 from ai.backend.web.auth import get_anonymous_session, get_api_session
@@ -17,7 +18,11 @@ async def test_get_api_session(mocker):
     mock_request = DummyRequest(
         {
             "config": {
-                "api": {"domain": "default", "endpoint": "https://api.backend.ai"},
+                "api": {
+                    "domain": "default",
+                    "endpoint": [yarl.URL("https://api.backend.ai")],
+                    "ssl_verify": False,
+                },
             }
         }
     )
@@ -65,7 +70,11 @@ async def test_get_api_session_with_specific_api_endpoint(mocker):
     mock_request = DummyRequest(
         {
             "config": {
-                "api": {"domain": "default", "endpoint": "https://api.backend.ai"},
+                "api": {
+                    "domain": "default",
+                    "endpoint": [yarl.URL("https://api.backend.ai")],
+                    "ssl_verify": False,
+                },
             }
         }
     )
@@ -88,7 +97,11 @@ async def test_get_anonymous_session(mocker):
     mock_request = DummyRequest(
         {
             "config": {
-                "api": {"domain": "default", "endpoint": "https://api.backend.ai"},
+                "api": {
+                    "domain": "default",
+                    "endpoint": [yarl.URL("https://api.backend.ai")],
+                    "ssl_verify": False,
+                },
             }
         }
     )
@@ -109,7 +122,11 @@ async def test_get_anonymous_session_with_specific_api_endpoint(mocker):
     mock_request = DummyRequest(
         {
             "config": {
-                "api": {"domain": "default", "endpoint": "https://api.backend.ai"},
+                "api": {
+                    "domain": "default",
+                    "endpoint": [yarl.URL("https://api.backend.ai")],
+                    "ssl_verify": False,
+                },
             }
         }
     )


### PR DESCRIPTION
Resolves #590.

This PR also contains various improvements over configuration handling
of the web server and internal refactorings to improve the code quality.

**`common.validators`:**
* fix: Use the generic types correctly with `DelimiterSeperatedList`
* feat: Add `allow_blank`, `empty_str_as_empty_list` options to
  `DelimiterSeperatedList`
* This PR keeps backward-compatibility of `tx.DelimiterSeperatedList`!

**`web.server` and `web.config` (new):**
* fix: Correct type annotation and return value usage of
  `decrypt_payload()`
* refactor: Use trafaret to parse, validate, and convert the
  configuration values from webserver.conf
  - Now it requires all sections must be present in webserver.conf
    even when they omit all of their belonging keys.
* refactor: Use Jinja2's `tojson` and `join` filters to format
  structurely parsed configuration values via trafaret when rendering
  `/config.toml` and `/config.ini` routes
* refactor: Split out `confing_ini_handler()` and
  `config_toml_handler()` from `console_handler()` with explicit routing
* refactor: Reduce the region covered by the `try` block to catch
  Backend.AI API errors to avoid "possibly unbound local variable" error
  in `login_handler()`
* refactor: Rename `header_handler()` to `apply_cache_headers()` for
  brevity and clarity
* refactor: Use consistent snake_case for configuration key names
  and keep backward-compatibility by using `tx.AliasedKey` with
  additional kebab-case key names.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->