### PR TITLE
feat(install-dev): Add check for `-f` flag compatibility of docker compose v2 in user/root privileges

### DIFF
--- a/changes/602.fix.md
+++ b/changes/602.fix.md
@@ -1,1 +1,1 @@
-fix: Checking docker compose plugin v2 -f flag on both user and root(sudo) mode
+install-dev: Add compatibility checks for `-f` option of the `docker compose` (v2) commands in the user home directory and system-wide directory

--- a/changes/602.fix.md
+++ b/changes/602.fix.md
@@ -1,0 +1,1 @@
+fix: Checking docker compose plugin v2 -f flag on both user and root(sudo) mode

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -544,6 +544,17 @@ $bpython scripts/check-docker.py
 if [ $? -ne 0 ]; then
   exit 1
 fi
+# checking docker compose v2 -f flag
+if $(docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
+  show_error "As a user permission, Docker compose v2 is not installed."
+  show_info "Please, Check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on ${HOME}/.docker/cli-plugins "
+  exit 1
+fi
+if $(sudo docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
+  show_error "As a root permission, Docker compose v2 is not installed."
+  show_info "Please, Check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on /usr/local/lib/docker/cli-plugins "
+  exit 1
+fi
 if [ "$DISTRO" = "Darwin" ]; then
   echo "validating Docker Desktop mount permissions..."
   docker pull alpine:3.8 > /dev/null

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -546,13 +546,13 @@ if [ $? -ne 0 ]; then
 fi
 # checking docker compose v2 -f flag
 if $(docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
-  show_error "As a user permission, Docker compose v2 is not installed."
-  show_info "Please, Check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on ${HOME}/.docker/cli-plugins "
+  show_error "When run as a user, 'docker compose' seems not to be a compatible version (v2)."
+  show_info "Please check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on ${HOME}/.docker/cli-plugins"
   exit 1
 fi
 if $(sudo docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
-  show_error "As a root permission, Docker compose v2 is not installed."
-  show_info "Please, Check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on /usr/local/lib/docker/cli-plugins "
+  show_error "When run as the root, 'docker compose' seems not to be a compatible version (v2)"
+  show_info "Please check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on /usr/local/lib/docker/cli-plugins"
   exit 1
 fi
 if [ "$DISTRO" = "Darwin" ]; then


### PR DESCRIPTION
Add check for the compatibility of `-f` flag of the `docker compose` command in user/root privileges.

close https://github.com/lablup/backend.ai/issues/596
