### PR TITLE
feat(scripts): Improve pre-push hook and use updatable hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
+[*.sh]
+indent_style = space
+indent_size = 2
+
 [*.{py,md}]
 max_line_length = 100
 indent_style = space

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -409,10 +409,10 @@ install_git_hooks() {
       :
     else
       echo "" >> .git/hooks/pre-commit
-      cat scripts/pre-commit.sh >> .git/hooks/pre-commit
+      cat scripts/pre-commit >> .git/hooks/pre-commit
     fi
   else
-    cp scripts/pre-commit.sh .git/hooks/pre-commit
+    cp scripts/pre-commit .git/hooks/pre-commit
     chmod +x .git/hooks/pre-commit
   fi
   local magic_str="monorepo standard pre-push hook"
@@ -422,10 +422,10 @@ install_git_hooks() {
       :
     else
       echo "" >> .git/hooks/pre-push
-      cat scripts/pre-push.sh >> .git/hooks/pre-push
+      cat scripts/pre-push >> .git/hooks/pre-push
     fi
   else
-    cp scripts/pre-push.sh .git/hooks/pre-push
+    cp scripts/pre-push .git/hooks/pre-push
     chmod +x .git/hooks/pre-push
   fi
 }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,3 @@
+# backend.ai monorepo standard pre-push hook
+BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
+${BASE_PATH}/scripts/pre-commit.sh "$@"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,5 +1,6 @@
 # backend.ai monorepo standard pre-commit hook
-BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
+BASE_PATH=$(pwd)
+cd "${BASE_PATH}"
 if [ -f "$BASE_PATH/pants-local" ]; then
   PANTS="$BASE_PATH/pants-local"
 else

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,6 +1,5 @@
-# backend.ai monorepo standard pre-commit hook
+# implementation: backend.ai monorepo standard pre-commit hook
 BASE_PATH=$(pwd)
-cd "${BASE_PATH}"
 if [ -f "$BASE_PATH/pants-local" ]; then
   PANTS="$BASE_PATH/pants-local"
 else

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,3 @@
+# backend.ai monorepo standard pre-push hook
+BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
+${BASE_PATH}/scripts/pre-push.sh "$@"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -19,10 +19,13 @@ if [ "$1" != "origin" ]; then
     ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
     git remote add "$ORIGIN" "$1"
     git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
+    cleanup_remote() {
+        git remote remove "$ORIGIN"
+    }
+    trap cleanup_remote EXIT
 else
     ORIGIN="origin"
 fi
 echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
 "$PANTS" tailor --check update-build-files --check
 "$PANTS" lint check --changed-since="${ORIGIN}/${BASE_BRANCH}"
-git remote remove "$ORIGIN"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -17,12 +17,12 @@ fi
 if [ "$1" != "origin" ]; then
     # extract the owner name of the target repo
     ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
-    git remote add "$ORIGIN" "$1"
-    git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
     cleanup_remote() {
         git remote remove "$ORIGIN"
     }
     trap cleanup_remote EXIT
+    git remote add "$ORIGIN" "$1"
+    git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
 else
     ORIGIN="origin"
 fi

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -15,16 +15,16 @@ else
   BASE_BRANCH="main"
 fi
 if [ "$1" != "origin" ]; then
-    # extract the owner name of the target repo
-    ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
-    cleanup_remote() {
-        git remote remove "$ORIGIN"
-    }
-    trap cleanup_remote EXIT
-    git remote add "$ORIGIN" "$1"
-    git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
+  # extract the owner name of the target repo
+  ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
+  cleanup_remote() {
+    git remote remove "$ORIGIN"
+  }
+  trap cleanup_remote EXIT
+  git remote add "$ORIGIN" "$1"
+  git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
 else
-    ORIGIN="origin"
+  ORIGIN="origin"
 fi
 echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
 "$PANTS" tailor --check update-build-files --check

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,6 +1,5 @@
-# backend.ai monorepo standard pre-push hook
+# implementation: backend.ai monorepo standard pre-push hook
 BASE_PATH=$(pwd)
-cd "${BASE_PATH}"
 if [ -f "$BASE_PATH/pants-local" ]; then
   PANTS="$BASE_PATH/pants-local"
 else


### PR DESCRIPTION
- scripts/pre-commit, scripts/pre-push will be added to actual hooks
  while scripts/pre-commit.sh, scripts/pre-push.sh will remain as
  updatable (versioned) implementation of them.
- Use a temporarily added git remote to resolve the "bad revision"
  error when using `--changed-since` against a branch in a fork repo.

After this PR is merged, please update your git hooks as follows,
so that hooks could be versioned without manual updates:

**`.git/hooks/pre-commit`**:
```bash
# backend.ai monorepo standard pre-commit hook
BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
${BASE_PATH}/scripts/pre-commit.sh "$@"
```

**`.git/hooks/pre-push`**:
```bash
# backend.ai monorepo standard pre-push hook
BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
${BASE_PATH}/scripts/pre-push.sh "$@"
```