### PR TITLE
fix: Incorrectly spelled word in ImageNotFound exception message

### DIFF
--- a/changes/615.fix.md
+++ b/changes/615.fix.md
@@ -1,0 +1,1 @@
+correct misspelled word in ImageNotFound exception message.

--- a/changes/615.fix.md
+++ b/changes/615.fix.md
@@ -1,1 +1,1 @@
-correct misspelled word in ImageNotFound exception message.
+Correct misspelled word in ImageNotFound exception message.

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -326,7 +326,7 @@ class ImageRow(Base):
                     return row
             except UnknownImageReference:
                 continue
-        raise ImageNotFound("Unkown image references: " + ", ".join(searched_refs))
+        raise ImageNotFound("Unknown image references: " + ", ".join(searched_refs))
 
     @classmethod
     async def list(cls, session: AsyncSession, load_aliases=False) -> List[ImageRow]:


### PR DESCRIPTION
fix: incorrectly spelled word in ImageNotFound exception message.

Change & Correct word from 'Unkown' to 'Unknown'.

fix issue #614 