### PR TITLE
hotfix: Update corresponding location of `grpcio`-related packages

### DIFF
--- a/python.lock
+++ b/python.lock
@@ -1581,7 +1581,7 @@
             {
               "algorithm": "sha256",
               "hash": "c6345a0b8188ff915bf33cce6e445d9fd3738faa32640ca6267bd1344249ef6f",
-              "url": "https://raw.githubusercontent.com/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.47.0-cp310-cp310-macosx_12_0_arm64.whl"
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.47.0-cp310-cp310-macosx_12_0_arm64.whl#sha256=c6345a0b8188ff915bf33cce6e445d9fd3738faa32640ca6267bd1344249ef6f"
             },
             {
               "algorithm": "sha256",
@@ -1663,8 +1663,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "dd5d330230038374e64fc652fc4c1b25d457a8b67b9069bfce83a17ab675650b",
-              "url": "https://files.pythonhosted.org/packages/37/53/e751a848b31cebfff50680a42c304d3c001f46b2b475580e616c88b93881/grpcio_tools-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl"
+              "hash": "8526e7a66a03407e1ca9d83f10dce376471dd7f46af5b093f9024ca9b6e251a6",
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio_tools-1.47.0-cp310-cp310-macosx_12_0_arm64.whl#sha256=8526e7a66a03407e1ca9d83f10dce376471dd7f46af5b093f9024ca9b6e251a6"
             },
             {
               "algorithm": "sha256",

--- a/python.lock
+++ b/python.lock
@@ -1581,7 +1581,7 @@
             {
               "algorithm": "sha256",
               "hash": "c6345a0b8188ff915bf33cce6e445d9fd3738faa32640ca6267bd1344249ef6f",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.47.0-cp310-cp310-macosx_12_0_arm64.whl#sha256=c6345a0b8188ff915bf33cce6e445d9fd3738faa32640ca6267bd1344249ef6f"
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.47.0-cp310-cp310-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1664,7 +1664,7 @@
             {
               "algorithm": "sha256",
               "hash": "8526e7a66a03407e1ca9d83f10dce376471dd7f46af5b093f9024ca9b6e251a6",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio_tools-1.47.0-cp310-cp310-macosx_12_0_arm64.whl#sha256=8526e7a66a03407e1ca9d83f10dce376471dd7f46af5b093f9024ca9b6e251a6"
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio_tools-1.47.0-cp310-cp310-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",


### PR DESCRIPTION
Since there is an issue about installing `grpcio` on ARM64 macOS, we are currently using our own wheel repository. However, after the wheel location has changed due to git-lfs, it is not updated on our repository, which is actually using the wheel file.
In this PR, I changed the `url` of `grpcio`-related packages **manually** and tested the install process.
You may compare the location from both [backend.ai-oven](https://github.com/lablup/backend.ai-oven/blob/8dcc73e1f99dccdce36d3b70562afbf2244d92b3/pypi/package/index.html) and [backend.ai](https://github.com/lablup/backend.ai/blob/f05b4362c490390c5f32029893b53e4d64115ff6/python.lock#L1584).