### PR TITLE
feature: Improve logging in tests

### DIFF
--- a/changes/630.feature.md
+++ b/changes/630.feature.md
@@ -1,0 +1,1 @@
+Add `common.logging.LocalLogger` to improve logging outputs in test cases, which does not use the relay handler to send log records to another (parent) process but just the standard Python logging subsystem

--- a/src/ai/backend/common/logging.py
+++ b/src/ai/backend/common/logging.py
@@ -58,7 +58,7 @@ logging_config_iv = t.Dict(
         t.Key("console", default=None): t.Null
         | t.Dict(
             {
-                t.Key("colored", default=True): t.Bool,
+                t.Key("colored", default=None): t.Null | t.Bool,
                 t.Key("format", default="verbose"): logformat_iv,
             }
         ).allow_extra("*"),
@@ -238,7 +238,10 @@ def setup_console_log_handler(config: Mapping[str, Any]) -> logging.Handler:
     }
     drv_config = config["console"]
     console_formatter: logging.Formatter
-    if drv_config["colored"]:
+    colored = drv_config["colored"]
+    if colored is None:
+        colored = sys.stderr.isatty()
+    if colored:
         console_formatter = coloredlogs.ColoredFormatter(
             log_formats[drv_config["format"]],
             datefmt="%Y-%m-%d %H:%M:%S.%f",  # coloredlogs has intrinsic support for msec

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import json
 import subprocess
 import time
@@ -9,6 +10,8 @@ import pytest
 
 from ai.backend.common.types import HostPortPair
 from ai.backend.testutils.pants import get_parallel_slot
+
+log = logging.getLogger(__name__)
 
 
 def wait_health_check(container_id):
@@ -34,6 +37,7 @@ def wait_health_check(container_id):
 def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
     etcd_allocated_port = 12379 + get_parallel_slot() * 10
+    log.info("spawning etcd container on port %d", etcd_allocated_port)
     proc = subprocess.run(
         [
             "docker",
@@ -77,7 +81,7 @@ def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
 def redis_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
     redis_allocated_port = 36379 + get_parallel_slot() * 10
-    print("spawning redis container on port", redis_allocated_port)
+    log.info("spawning redis container on port %d", redis_allocated_port)
     proc = subprocess.run(
         [
             "docker",
@@ -114,6 +118,7 @@ def redis_container() -> Iterator[tuple[str, HostPortPair]]:
 def postgres_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
     postgres_allocated_port = 15432 + get_parallel_slot() * 10
+    log.info("spawning postgres container on port %d", postgres_allocated_port)
     proc = subprocess.run(
         [
             "docker",

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 import json
+import logging
 import subprocess
 import time
 from typing import Iterator

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -26,6 +26,16 @@ def logging_config():
     config = {
         "drivers": ["console"],
         "console": {"colored": None, "format": "verbose"},
+        "level": "DEBUG",
+        "pkg-ns": {
+            "": "INFO",
+            "ai.backend": "DEBUG",
+            "tests": "DEBUG",
+            "alembic": "INFO",
+            "aiotools": "INFO",
+            "aiohttp": "INFO",
+            "sqlalchemy": "WARNING",
+        },
     }
     logger = LocalLogger(config)
     with logger:

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from ai.backend.common import config
 from ai.backend.common import validators as tx
+from ai.backend.common.logging import LocalLogger
 from ai.backend.common.types import EtcdRedisConfig, HostPortPair
 from ai.backend.testutils.bootstrap import etcd_container, redis_container  # noqa: F401
 from ai.backend.testutils.pants import get_parallel_slot
@@ -81,7 +82,9 @@ def local_config(test_id, etcd_container, redis_container):  # noqa: F811
         _override_if_exists(fs_local_config["etcd"], cfg["etcd"], "password")
     except config.ConfigurationError:
         pass
-    yield cfg
+    logger = LocalLogger(cfg["logging"])
+    with logger:
+        yield cfg
     shutil.rmtree(ipc_base_path)
 
 

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -34,6 +34,7 @@ from dateutil.tz import tzutc
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.config import ConfigurationError, etcd_config_iv, redis_config_iv
+from ai.backend.common.logging import LocalLogger
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.types import HostPortPair
 from ai.backend.manager.api.context import RootContext
@@ -181,7 +182,9 @@ def local_config(
         _override_if_exists(fs_local_config["db"], cfg["db"], "password")
     except ConfigurationError:
         pass
-    yield cfg
+    logger = LocalLogger(cfg["logging"])
+    with logger:
+        yield cfg
     try:
         shutil.rmtree(ipc_base_path)
     except IOError:

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -113,6 +113,16 @@ def logging_config():
     config = {
         "drivers": ["console"],
         "console": {"colored": None, "format": "verbose"},
+        "level": "DEBUG",
+        "pkg-ns": {
+            "": "INFO",
+            "ai.backend": "DEBUG",
+            "tests": "DEBUG",
+            "alembic": "INFO",
+            "aiotools": "INFO",
+            "aiohttp": "INFO",
+            "sqlalchemy": "WARNING",
+        },
     }
     logger = LocalLogger(config)
     with logger:


### PR DESCRIPTION
This PR is cherry-picked from #627 to split the feature addition as a standalone PR.

It adds `common.logging.LocalLogger` which supports `console` and `file` logging backends with the
Python's standard logging mechanism instead of relaying log records to the parent process.  Also it
adds the `logging_config` session-level test fixture called by the `local_config` fixtures in the
manager and agent test suites, so that any test case that directly/indirectly involves logging to
display pretty and proper log outputs.

There is a minor update of allowing `None` for the `colored` config parameter of the console log
handler to auto-detect whether stderr is a tty or not, to decide colored outputs.