### PR TITLE
feat: Generalize an interface for watchdog timer on DistributedLock

### DIFF
--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -131,7 +131,9 @@ class FileLock(AbstractDistributedLock):
             fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
             self._locked = False
             if self._debug:
-                log.debug(f"{self.__class__.__name__} implicitly released by watchdog: {self._path}")
+                log.debug(
+                    f"{self.__class__.__name__} implicitly released by watchdog: {self._path}"
+                )
 
     @property
     def is_locked(self) -> bool:

--- a/src/ai/backend/manager/pglock.py
+++ b/src/ai/backend/manager/pglock.py
@@ -27,3 +27,6 @@ class PgAdvisoryLock(AbstractDistributedLock):
             return await self._lock_ctx.__aexit__(*exc_info)
         finally:
             self._lock_ctx = None
+
+    async def _watchdog_timer(self, ttl: float) -> None:
+        pass


### PR DESCRIPTION
In this PR, watchdog-related properties are added to `AbstractDistributedLock`.
- `enqueue_watchdog_task()` and `dequeue_watchdog_task()` are for abstraction; these methods provide capsulization of actual task handling process.
- `_watchdog_timer()` is an abstract method; each class inherits `AbstractDistributedLock` can define its own specified lock-related logics in this method, and this will be used as an actual handler when watchdog timer rings.