### PR TITLE
fix: Insufficient privilege error of the `run` cmd run as a user

### DIFF
--- a/changes/639.fix.md
+++ b/changes/639.fix.md
@@ -1,0 +1,1 @@
+Fix a spurious insufficient privilege error when running `backend.ai run` command as a normal user due to a mishandling of the default value of `--assign-agent` CLI option

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -570,11 +570,9 @@ def run(
 
     if preopen is None:
         preopen = []  # noqa
-    if assign_agent is None:
-        assign_agent = []  # noqa
 
     preopen_ports = preopen
-    assigned_agent_list = assign_agent
+    assigned_agent_list = assign_agent  # should be None if not specified
     for env_vmap, build_vmap, exec_vmap in vmaps_product:
         interpolated_envs = tuple((k, vt.substitute(env_vmap)) for k, vt in env_templates.items())
         if build:


### PR DESCRIPTION
- In `backend.ai run` CLI command, the unspecified value of
  `--assign-agent` option has been transformed as an empty list.
- In the server-side, this triggers the privilege check as the manager
  treats an empty list as a valid list.
- Let the client CLI preserve the default `None` value when passing it
  to the functional API wrappers and the manager.
