### PR TITLE
fix: Change client.cli to use the same `ai.backend.cli.main:main` as its CommandGroup

### DIFF
--- a/changes/650.fix.md
+++ b/changes/650.fix.md
@@ -1,0 +1,1 @@
+Change `client.cli` to use `ai.backend.cli.main:main` as its root CommandGroup.

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -2,7 +2,6 @@ from . import admin  # noqa  # type: ignore
 from . import config  # noqa  # type: ignore
 from . import dotfile  # noqa  # type: ignore
 from . import extensions  # noqa  # type: ignore
-from . import main  # noqa  # type: ignore
 from . import server_log  # noqa  # type: ignore
 from . import session  # noqa  # type: ignore
 from . import session_template  # noqa  # type: ignore

--- a/src/ai/backend/client/cli/admin/__init__.py
+++ b/src/ai/backend/client/cli/admin/__init__.py
@@ -1,4 +1,4 @@
-from ..main import main
+from ai.backend.cli.main import main
 
 
 @main.group()

--- a/src/ai/backend/client/cli/admin/session.py
+++ b/src/ai/backend/client/cli/admin/session.py
@@ -6,13 +6,13 @@ from typing import Any, Dict, List
 
 import click
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 from ai.backend.client.output.fields import session_fields, session_fields_v5
 from ai.backend.client.output.types import FieldSpec
 from ai.backend.client.session import Session
 
 from ..extensions import pass_ctx_obj
-from ..main import main
 from ..pretty import print_fail
 from ..session import session as user_session
 from ..types import CLIContext

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -7,6 +7,7 @@ from typing import Dict, List, MutableMapping, Optional, Sequence, Union
 import aiohttp
 import click
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..compat import asyncio_run, asyncio_run_forever
@@ -14,7 +15,6 @@ from ..config import DEFAULT_CHUNK_SIZE
 from ..request import Request
 from ..session import AsyncSession
 from ..versioning import get_naming
-from .main import main
 from .pretty import print_error, print_fail, print_info, print_warn
 
 

--- a/src/ai/backend/client/cli/config.py
+++ b/src/ai/backend/client/cli/config.py
@@ -5,13 +5,13 @@ import warnings
 
 import click
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from .. import __version__
 from ..config import get_config, local_state_path
 from ..exceptions import BackendClientError
 from ..session import Session
-from .main import main
 from .pretty import print_done, print_error, print_fail, print_warn
 
 

--- a/src/ai/backend/client/cli/dotfile.py
+++ b/src/ai/backend/client/cli/dotfile.py
@@ -3,10 +3,10 @@ import sys
 import click
 from tabulate import tabulate
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..session import Session
-from .main import main
 from .pretty import print_error, print_info, print_warn
 
 

--- a/src/ai/backend/client/cli/logs.py
+++ b/src/ai/backend/client/cli/logs.py
@@ -2,11 +2,11 @@ import sys
 
 import click
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..compat import asyncio_run
 from ..session import AsyncSession
-from .main import main
 from .pretty import print_error
 
 

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -9,10 +9,11 @@ import aiohttp
 import click
 from aiohttp import web
 
+from ai.backend.cli.main import main
+
 from ..exceptions import BackendAPIError, BackendClientError
 from ..request import Request
 from ..session import AsyncSession
-from .main import main
 from .pretty import print_error, print_fail, print_info
 
 

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -16,13 +16,13 @@ import tabulate as tabulate_mod
 from humanize import naturalsize
 from tabulate import tabulate
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..compat import asyncio_run, current_loop
 from ..config import local_cache_path
 from ..exceptions import BackendError
 from ..session import AsyncSession
-from .main import main
 from .params import CommaSeparatedListType, RangeExprOptionType
 from .pretty import (
     format_info,

--- a/src/ai/backend/client/cli/server_log.py
+++ b/src/ai/backend/client/cli/server_log.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 import click
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..session import Session
-from .main import main
 from .pretty import print_error
 
 

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -18,6 +18,7 @@ from dateutil.tz import tzutc
 from humanize import naturalsize
 from tabulate import tabulate
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..compat import asyncio_run
@@ -28,7 +29,6 @@ from ..output.types import FieldSpec
 from ..session import AsyncSession, Session
 from ..types import Undefined, undefined
 from . import events
-from .main import main
 from .params import CommaSeparatedListType
 from .pretty import print_done, print_error, print_fail, print_info, print_wait, print_warn
 from .run import format_stats, prepare_env_arg, prepare_mount_arg, prepare_resource_arg

--- a/src/ai/backend/client/cli/session_template.py
+++ b/src/ai/backend/client/cli/session_template.py
@@ -3,10 +3,10 @@ import sys
 import click
 from tabulate import tabulate
 
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 
 from ..session import Session
-from .main import main
 from .pretty import print_error, print_info, print_warn
 
 

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -9,13 +9,13 @@ from tabulate import tabulate
 from tqdm import tqdm
 
 from ai.backend.cli.interaction import ask_yn
+from ai.backend.cli.main import main
 from ai.backend.cli.types import ExitCode
 from ai.backend.client.config import DEFAULT_CHUNK_SIZE, APIConfig
 from ai.backend.client.session import Session
 
 from ..compat import asyncio_run
 from ..session import AsyncSession
-from .main import main
 from .params import ByteSizeParamCheckType, ByteSizeParamType, CommaSeparatedKVListParamType
 from .pretty import print_done, print_error, print_fail, print_info, print_wait, print_warn
 


### PR DESCRIPTION
In this PR, `ai.backend.client.cli` is changed to use `CommandGroup`(**ai.backend.cli.main:main**, **cli.main** in short) rather than its own from **ai.backend.client.cli.main:main**(**client.main** in short). It seems that the previous one(**client.main:main**) has been used until we merged into a monorepo. However, since we are maintaining in a monorepo style, it is required to integrated one of two `cli`s into the other one. It seems reasonable to keep **cli.main:main** since it should be the main root of **cli**, and `ai.backend.client.cli` subpackage should remain as a part of it.

Before | After
------ | -----
<img width="604" alt="image" src="https://user-images.githubusercontent.com/14137676/184312758-a6bc719c-bc65-409d-94a2-92a25157753a.png"> | <img width="610" alt="image" src="https://user-images.githubusercontent.com/14137676/184312845-7edfb56e-d40e-43e3-bca3-46475f6487c0.png">

