### PR TITLE
feat: add config to support SSO vendors

### DIFF
--- a/changes/652.feature.md
+++ b/changes/652.feature.md
@@ -1,0 +1,1 @@
+Add a new config `service.single_sign_on_vendors` to selectively expose SSO services to login page.

--- a/changes/652.feature.md
+++ b/changes/652.feature.md
@@ -1,1 +1,1 @@
-Add a new config `service.single_sign_on_vendors` to selectively expose SSO services to login page.
+Add a new API router (`/func/saml`) and a config `service.single_sign_on_vendors` to integrate SSO login, especially SAML 2.0 in this case. Also, the redirect responses (30X) are now transparently delivered to the downstream without raising `BackendAPIError`.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -37,6 +37,8 @@ allow_signup_without_confirmation = false
 webui_debug = false
 # Enable masking user information
 mask_user_info = false
+# Comma-separeated list of available SSO vendors: "saml"
+# single_sign_on_vendors = "saml"
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -348,6 +348,7 @@ class Request:
                 data=self._pack_content(),
                 timeout=timeout_config,
                 headers=self.headers,
+                allow_redirects=False,
             )
 
         return FetchContextManager(self.session, _rqst_ctx_builder, **kwargs)
@@ -580,7 +581,7 @@ class FetchContextManager:
                 self._rqst_ctx = self.rqst_ctx_builder()
                 assert self._rqst_ctx is not None
                 raw_resp = await self._rqst_ctx.__aenter__()
-                if self.check_status and raw_resp.status // 100 != 2:
+                if self.check_status and raw_resp.status // 100 not in [2, 3]:
                     msg = await raw_resp.text()
                     await raw_resp.__aexit__(None, None, None)
                     raise BackendAPIError(raw_resp.status, raw_resp.reason or "", msg)

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -45,6 +45,8 @@ config_iv = t.Dict(
                 t.Key("allow_signup_without_confirmation", default=False): t.ToBool,
                 t.Key("webui_debug", default=False): t.ToBool,
                 t.Key("mask_user_info", default=False): t.ToBool,
+                t.Key("single_sign_on_vendors", default=None): t.Null
+                | tx.StringList(empty_str_as_empty_list=True),
             }
         ).allow_extra("*"),
         t.Key("resources"): t.Dict(

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -533,6 +533,7 @@ async def server_main(
     cors.add(app.router.add_route("GET", "/func/{path:hanati/user}", anon_web_plugin_handler))
     cors.add(app.router.add_route("GET", "/func/{path:cloud/.*$}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:cloud/.*$}", anon_web_plugin_handler))
+    cors.add(app.router.add_route("POST", "/func/{path:saml/.*$}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:auth/signup}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:auth/signout}", web_handler))
     cors.add(app.router.add_route("GET", "/func/{path:stream/kernel/_/events}", web_handler))

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -15,6 +15,7 @@ connectionMode = "SESSION"
 {% toml_field "debug" config["service"]["webui_debug"] %}
 {% toml_field "debug" config["service"]["webui_debug"] %}
 {% toml_field "maskUserInfo" config["service"]["mask_user_info"] %}
+{% toml_strlist_field "singleSignOnVendors" config["service"]["single_sign_on_vendors"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
- New API router: `/func/saml`.
- New config: `service.single_sign_on_vendors` which translates to `general.singleSignOnVendors` in Web-UI.
  - This field is a comma-separated list of strings.
- The redirect responses (30X) are now transparently delivered to the downstream without raising `BackendAPIError`.

### Related PRs
- https://github.com/lablup/backend.ai-webui/pull/1413