### PR TITLE
feat: Add `status_history` to the result of `get_container_stats_for_period()`

### DIFF
--- a/changes/653.feature.md
+++ b/changes/653.feature.md
@@ -1,0 +1,1 @@
+Add `status_history` to the query field of `get_container_stats_for_period` to know when the status of the session within a given period has changed.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -429,6 +429,7 @@ async def get_container_stats_for_period(
             "terminated_at": str(row["terminated_at"]),
             "status": row["status"].name,
             "status_changed": str(row["status_changed"]),
+            "status_history": row["status_history"] or {},
         }
         if group_id not in objs_per_group:
             objs_per_group[group_id] = {

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -322,6 +322,7 @@ async def get_container_stats_for_period(
                     kernels.c.status,
                     kernels.c.status_changed,
                     kernels.c.last_stat,
+                    kernels.c.status_history,
                     kernels.c.created_at,
                     kernels.c.terminated_at,
                     groups.c.name,


### PR DESCRIPTION
I added `status_history` to the query field of `get_container_stats_for_period`. This is to check when resources are allocated by adding `scheduled_at` (one of the session history) to the Usage Logs page of the control panel.

**Related issue:**
- https://github.com/lablup/backend.ai-control-panel/issues/299
- https://github.com/lablup/backend.ai/issues/469