### PR TITLE
refactor: Fix a missing change of numeric exitcode to an enum value

### DIFF
--- a/src/ai/backend/cli/extensions.py
+++ b/src/ai/backend/cli/extensions.py
@@ -5,6 +5,8 @@ import sys
 import click
 from click.exceptions import Abort, ClickException
 
+from .types import ExitCode
+
 
 class InterruptAwareCommandMixin(click.BaseCommand):
     """
@@ -45,7 +47,7 @@ class InterruptAwareCommandMixin(click.BaseCommand):
             else:
                 print("Aborted!", end="", file=sys.stderr)
                 sys.stderr.flush()
-                sys.exit(1)
+                sys.exit(ExitCode.FAILURE)
         except ClickException as e:
             e.show()
             sys.exit(e.exit_code)


### PR DESCRIPTION
Following the #486 As mentioned in the issue and #559  Merged PR,
I found a missing item about changing numeric exit code to enum value.

As a result, I modify missing item about changing numeric exitcode to enum value.
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
