### PR TITLE
feat: return one result value using SQL union query in `query_accessible_vfolders`.

### DIFF
--- a/changes/656.feature.md
+++ b/changes/656.feature.md
@@ -1,0 +1,1 @@
+To support vfolder pagination, the result of `query_accessible_vfolders` is returned as a single table using SQL union query.


### PR DESCRIPTION
- migrate from https://github.com/lablup/backend.ai-manager/pull/573 to mono-repo  

  > To successfully support the pagination query, the vfolder list is united into one.
Previously, `query_accessible_vfolders()` was implemented with Python's list concat, but now only one query containing all vfolder lists is returned.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
