### PR TITLE
refactor: modify a missing change of an enum value on Backend.AI Manager cli

### DIFF
--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -16,6 +16,7 @@ from redis.asyncio import Redis
 from redis.asyncio.client import Pipeline
 from setproctitle import setproctitle
 
+from ai.backend.cli.types import ExitCode
 from ai.backend.common import redis_helper as redis_helper
 from ai.backend.common.cli import LazyGroup
 from ai.backend.common.logging import BraceStyleAdapter
@@ -107,7 +108,7 @@ def dbshell(cli_ctx: CLIContext, container_name, psql_help, psql_args):
                 "Please set the container name explicitly.",
                 err=True,
             )
-            sys.exit(1)
+            sys.exit(ExitCode.FAILURE)
         container_name = candidate_container_names.decode().splitlines()[0].strip()
     elif container_name == "-":
         # Use the host-provided psql command

--- a/src/ai/backend/manager/cli/etcd.py
+++ b/src/ai/backend/manager/cli/etcd.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, AsyncIterator
 
 import click
 
+from ai.backend.cli.types import ExitCode
 from ai.backend.common.cli import EnumChoice, MinMaxRange
 from ai.backend.common.config import redis_config_iv
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
@@ -194,7 +195,7 @@ def get(cli_ctx: CLIContext, key, prefix, scope) -> None:
                 else:
                     val = await etcd.get(key, scope=scope)
                     if val is None:
-                        sys.exit(1)
+                        sys.exit(ExitCode.FAILURE)
                     print(val)
             except Exception:
                 log.exception("An error occurred.")


### PR DESCRIPTION
Following the #486 As mentioned in the issue and #559 , #655  Merged PRs,
I found a missing item about changing numeric exit code to enum value on Backend.AI Manager cli.

So, I also change some missing item about changing numeric exitcode to enum value.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
