### PR TITLE
ci: label trigger timeline-check action

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -1,6 +1,8 @@
 name: timeline-check
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
 
 jobs:
   towncrier:


### PR DESCRIPTION
It is stated in the official github document that on: pull_request works for reopened, opened, and synchronize by default.
In addition to the corresponding action, when the label is changed, the action is activated.

`Note: More than one activity type triggers this event. For information about each activity type, see "[Webhook events and payloads](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)." By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. To trigger workflows by different activity types, use the types keyword. For more information, see "[Workflow syntax for GitHub Actions](https://docs.github.com/en/articles/workflow-syntax-for-github-actions#onevent_nametypes)."`

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
