### PR TITLE
feat: Support image commit feature flag for webui

### DIFF
--- a/changes/660.feature.md
+++ b/changes/660.feature.md
@@ -1,0 +1,1 @@
+Add a config `service.enable_container_commit` to provide container commit of corresponding session which has been executing inside docker in agent server by saving based on image-commit-path in agent configuration file.

--- a/changes/660.feature.md
+++ b/changes/660.feature.md
@@ -1,1 +1,1 @@
-Add a config `service.enable_container_commit` to provide container commit of corresponding session which has been executing inside docker in agent server by saving based on image-commit-path in agent configuration file.
+webserver: Include the feature flag `service.enable_container_commit` in `/config.toml` which allows users to commit their running session containers and save as images inside the configured path in the corresponding agent host

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -39,6 +39,8 @@ webui_debug = false
 mask_user_info = false
 # Comma-separeated list of available SSO vendors: "saml"
 # single_sign_on_vendors = "saml"
+# Enable container commit
+# enable_container_commit = false
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -16,6 +16,7 @@ connectionMode = "SESSION"
 {% toml_field "debug" config["service"]["webui_debug"] %}
 {% toml_field "maskUserInfo" config["service"]["mask_user_info"] %}
 {% toml_strlist_field "singleSignOnVendors" config["service"]["single_sign_on_vendors"] %}
+{% toml_field "enableContainerCommit" config["service"]["enable_container_commit"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
### Description
This PR adds variable `enable_container_commit` in webserver configuration file for supporting container image commit operation on static build webui inside webserver.
Also, this feature is available from `22.09` and later versions.

Related PR: 
   - #601
   - [backend.ai-webui#1412](https://github.com/lablup/backend.ai-webui/pull/1412)
