### PR TITLE
hotfix: kernel stat not pushed to redis db

### DIFF
--- a/changes/661.fix.md
+++ b/changes/661.fix.md
@@ -1,0 +1,1 @@
+Fix kernel stats not being updated to database

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -440,17 +440,16 @@ class StatContext:
                             self.kernel_metrics[kernel_id][metric_key].update(measure)
 
         async def _pipe_builder(r: Redis):
-            async with r.pipeline() as pipe:
-                for kernel_id in updated_kernel_ids:
-                    metrics = self.kernel_metrics[kernel_id]
-                    serializable_metrics = {
-                        key: obj.to_serializable_dict() for key, obj in metrics.items()
-                    }
-                    if self.agent.local_config["debug"]["log-stats"]:
-                        log.debug("kernel_updates: {0}: {1}", kernel_id, serializable_metrics)
-                    serialized_metrics = msgpack.packb(serializable_metrics)
-
-                    await pipe.set(str(kernel_id), serialized_metrics)
-                    return pipe
+            pipe = r.pipeline(transaction=False)
+            for kernel_id in updated_kernel_ids:
+                metrics = self.kernel_metrics[kernel_id]
+                serializable_metrics = {
+                    key: obj.to_serializable_dict() for key, obj in metrics.items()
+                }
+                if self.agent.local_config["debug"]["log-stats"]:
+                    log.debug("kernel_updates: {0}: {1}", kernel_id, serializable_metrics)
+                serialized_metrics = msgpack.packb(serializable_metrics)
+                pipe.set(str(kernel_id), serialized_metrics)
+            return pipe
 
         await redis_helper.execute(self.agent.redis_stat_pool, _pipe_builder)

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -26,6 +26,7 @@ from typing import (
 
 import attr
 from redis.asyncio import Redis
+from redis.asyncio.client import Pipeline
 
 from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.identity import is_containerized
@@ -439,7 +440,7 @@ class StatContext:
                         else:
                             self.kernel_metrics[kernel_id][metric_key].update(measure)
 
-        async def _pipe_builder(r: Redis):
+        async def _pipe_builder(r: Redis) -> Pipeline:
             pipe = r.pipeline(transaction=False)
             for kernel_id in updated_kernel_ids:
                 metrics = self.kernel_metrics[kernel_id]


### PR DESCRIPTION
This PR fixes kernel stat (`REDIS_LIVE_DB.<kernel_id>`) not being updated to redis.
