### PR TITLE
feat: Optimize the launch speed of CLI and daemons in the dev mode

### DIFF
--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -15,6 +15,7 @@ from ipaddress import ip_network
 from pathlib import Path
 from pprint import pformat, pprint
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Callable,
@@ -57,7 +58,6 @@ from ai.backend.common.types import (
 from ai.backend.common.utils import current_loop
 
 from . import __version__ as VERSION
-from .agent import AbstractAgent
 from .config import (
     agent_etcd_config_iv,
     agent_local_config_iv,
@@ -68,6 +68,9 @@ from .exception import ResourceError
 from .monitor import AgentErrorPluginContext, AgentStatsPluginContext
 from .types import AgentBackend, LifecycleEvent, VolumeInfo
 from .utils import get_subnet_ip
+
+if TYPE_CHECKING:
+    from .agent import AbstractAgent
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.server"))
 

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -20,11 +20,8 @@ from ai.backend.common import redis_helper as redis_helper
 from ai.backend.common.cli import LazyGroup
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.validators import TimeDuration
-from ai.backend.manager.models import kernels
-from ai.backend.manager.models.utils import connect_database
 
 from ..config import load as load_config
-from ..models.keypair import generate_keypair as _gen_keypair
 from .context import CLIContext, init_logger, redis_ctx
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
@@ -145,6 +142,8 @@ def generate_keypair(cli_ctx: CLIContext):
     """
     Generate a random keypair and print it out to stdout.
     """
+    from ..models.keypair import generate_keypair as _gen_keypair
+
     log.info("generating keypair...")
     ak, sk = _gen_keypair()
     print(f"Access Key: {ak} ({len(ak)} bytes)")
@@ -176,6 +175,9 @@ def clear_history(cli_ctx: CLIContext, retention, vacuum_full) -> None:
     Delete old records from the kernels table and
     invoke the PostgreSQL's vaccuum operation to clear up the actual disk space.
     """
+    from ai.backend.manager.models import kernels
+    from ai.backend.manager.models.utils import connect_database
+
     local_config = cli_ctx.local_config
     with cli_ctx.logger:
         today = datetime.now()

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -194,8 +194,8 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import HostPortPair, SlotName, SlotTypes, current_resource_slots
 
 from ..manager.defs import INTRINSIC_SLOTS
+from .api import ManagerStatus
 from .api.exceptions import ServerMisconfiguredError
-from .api.manager import ManagerStatus
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -44,6 +44,7 @@ from ai.backend.common.plugin.monitor import INCREMENT
 from ai.backend.common.utils import env_info
 
 from . import __version__
+from .api import ManagerStatus
 from .api.context import RootContext
 from .api.exceptions import (
     BackendError,
@@ -53,20 +54,12 @@ from .api.exceptions import (
     MethodNotAllowed,
     URLNotFound,
 )
-from .api.manager import ManagerStatus
 from .api.types import AppCreator, CleanupContext, WebMiddleware, WebRequestHandler
 from .config import LocalConfig, SharedConfig
 from .config import load as load_config
 from .config import volume_config_iv
 from .defs import REDIS_IMAGE_DB, REDIS_LIVE_DB, REDIS_STAT_DB, REDIS_STREAM_DB, REDIS_STREAM_LOCK
 from .exceptions import InvalidArgument
-from .idle import init_idle_checkers
-from .models.storage import StorageSessionManager
-from .models.utils import connect_database
-from .plugin.monitor import ManagerErrorPluginContext, ManagerStatsPluginContext
-from .plugin.webapp import WebappPluginContext
-from .registry import AgentRegistry
-from .scheduler.dispatcher import SchedulerDispatcher
 from .types import DistributedLockFactory
 
 VALID_VERSIONS: Final = frozenset(
@@ -259,6 +252,8 @@ async def shared_config_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def webapp_plugin_ctx(root_app: web.Application) -> AsyncIterator[None]:
+    from .plugin.webapp import WebappPluginContext
+
     root_ctx: RootContext = root_app["_root.context"]
     plugin_ctx = WebappPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     await plugin_ctx.init()
@@ -327,6 +322,8 @@ async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .models.utils import connect_database
+
     async with connect_database(root_ctx.local_config) as db:
         root_ctx.db = db
         yield
@@ -358,6 +355,8 @@ async def event_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def idle_checker_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .idle import init_idle_checkers
+
     root_ctx.idle_checker_host = await init_idle_checkers(
         root_ctx.db,
         root_ctx.shared_config,
@@ -372,6 +371,8 @@ async def idle_checker_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def storage_manager_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .models.storage import StorageSessionManager
+
     raw_vol_config = await root_ctx.shared_config.etcd.get_prefix("volumes")
     config = volume_config_iv.check(raw_vol_config)
     root_ctx.storage_manager = StorageSessionManager(config)
@@ -397,6 +398,8 @@ async def hook_plugin_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def agent_registry_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .registry import AgentRegistry
+
     root_ctx.registry = AgentRegistry(
         root_ctx.shared_config,
         root_ctx.db,
@@ -415,6 +418,8 @@ async def agent_registry_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def sched_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .scheduler.dispatcher import SchedulerDispatcher
+
     sched_dispatcher = await SchedulerDispatcher.new(
         root_ctx.local_config,
         root_ctx.shared_config,
@@ -429,6 +434,8 @@ async def sched_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @actxmgr
 async def monitoring_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    from .plugin.monitor import ManagerErrorPluginContext, ManagerStatsPluginContext
+
     ectx = ManagerErrorPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     sctx = ManagerStatsPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     init_success = False

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -1,10 +1,11 @@
 import ast
+import collections
 import configparser
 import itertools
 import logging
 from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterable, Iterator, Optional
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,34 @@ def scan_entrypoint_from_package_metadata(group_name: str) -> Iterator[EntryPoin
     yield from entry_points().select(group=group_name)
 
 
+_default_glob_excluded_patterns = [
+    "ai/backend/webui",
+    "ai/backend/web/static",
+    "ai/backend/runner",
+    "ai/backend/kernel",
+]
+
+
+def _glob(base_path: Path, filename: str, excluded_patterns: Iterable[str]) -> Iterator[Path]:
+    q: collections.deque[Path] = collections.deque()
+    q.append(base_path)
+    while q:
+        search_path = q.pop()
+        assert search_path.is_dir()
+        for item in search_path.iterdir():
+            if item.is_dir():
+                if search_path.name == "__pycache__":
+                    continue
+                if search_path.name.startswith("."):
+                    continue
+                if any(search_path.match(pattern) for pattern in excluded_patterns):
+                    continue
+                q.append(item)
+            else:
+                if item.name == filename:
+                    yield item
+
+
 def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     entrypoints = {}
     # Scan self-exported entrypoints when executed via pex.
@@ -70,7 +99,7 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     log.debug(
         "scan_entrypoint_from_buildscript(%r): Namespace path: %s", group_name, ai_backend_ns_path
     )
-    for buildscript_path in ai_backend_ns_path.glob("**/BUILD"):
+    for buildscript_path in _glob(ai_backend_ns_path, "BUILD", _default_glob_excluded_patterns):
         for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
             entrypoints[entrypoint.name] = entrypoint
     # Override with the entrypoints found in the current source directories,
@@ -81,7 +110,7 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     else:
         src_path = build_root / "src"
         log.debug("scan_entrypoint_from_buildscript(%r): current src: %s", group_name, src_path)
-        for buildscript_path in src_path.glob("**/BUILD"):
+        for buildscript_path in _glob(src_path, "BUILD", _default_glob_excluded_patterns):
             for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
                 entrypoints[entrypoint.name] = entrypoint
     yield from entrypoints.values()
@@ -101,11 +130,11 @@ def scan_entrypoint_from_plugin_checkouts(group_name: str) -> Iterator[EntryPoin
             plugins_path,
         )
         # For cases when plugins use Pants
-        for buildscript_path in plugins_path.glob("**/BUILD"):
+        for buildscript_path in _glob(plugins_path, "BUILD", _default_glob_excluded_patterns):
             for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
                 entrypoints[entrypoint.name] = entrypoint
         # For cases when plugins use standard setup.cfg
-        for setup_cfg_path in plugins_path.glob("**/setup.cfg"):
+        for setup_cfg_path in _glob(plugins_path, "BUILD", _default_glob_excluded_patterns):
             for entrypoint in extract_entrypoints_from_setup_cfg(group_name, setup_cfg_path):
                 if entrypoint.name not in entrypoints:
                     entrypoints[entrypoint.name] = entrypoint


### PR DESCRIPTION
- Skip `ai/backend/webui` and `ai/backend/web/static` directories
  when scanning entrypoints
- Defer imports in `manager.server` and `agent.server` modules
  to reduce the startup time via profiling
- Mark some imports for `TYPE_CHECKING` as well