### PR TITLE
fix: Skip non-running sessions when checking commit status

### DIFF
--- a/changes/667.fix.md
+++ b/changes/667.fix.md
@@ -1,0 +1,1 @@
+Skip non-running sessions, returning null, when checking the commit status because the agent(s) won't have any information about the kernels

--- a/changes/667.fix.md
+++ b/changes/667.fix.md
@@ -1,1 +1,1 @@
-Skip non-running sessions, returning null, when checking the commit status because the agent(s) won't have any information about the kernels
+Skip non-running sessions for commit status checks by returning null in the `commit_status` GraphQL query field because the agent(s) won't have any information about the non-running kernels

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -963,6 +963,8 @@ class ComputeSession(graphene.ObjectType):
 
     async def resolve_commit_status(self, info: graphene.ResolveInfo) -> Optional[str]:
         graph_ctx: GraphQueryContext = info.context
+        if self.status != "RUNNING":
+            return None
         commit_status = await graph_ctx.registry.get_commit_status(self.id, self.access_key)
         return commit_status["status"]
 


### PR DESCRIPTION
- Currently this triggers "Session Not Found" error in
  `AgentRegistry.get_commit_status()`'s call to
  `AgentRegistry.get_session()`.
- Terminated sessions will not be present in the agents.