### PR TITLE
ci: automatic db migration labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+require:db-migration:
+- any: ['src/ai/backend/manager/alembic/versions/*.py']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,24 @@
+
+
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Added auto labeling ci for efficient pr management
If there is a change in the migration file that is created when the db schema is changed, create a require:db-migration tag
It is thought that auto labeling will be possible by checking the change of manager, agent, etc. composed of monorepo using this workflow.

In the future, I think it would be nice to be able to import the label assigned to the issue linked to Development.