### PR TITLE
feat: Preserve the given value `reason` on forced kernel termination with a fallback

### DIFF
--- a/changes/681.feature.md
+++ b/changes/681.feature.md
@@ -1,0 +1,1 @@
+Enable support for providing a custom `reason` message on forced kernel termination

--- a/changes/681.feature.md
+++ b/changes/681.feature.md
@@ -1,1 +1,1 @@
-Enable support for providing a custom `reason` message on forced kernel termination
+Preserve the given `reason` value even when a kernel is force-terminated with a fallback to `force-terminated`

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     Literal,
     Mapping,
+    Optional,
     Sequence,
     Set,
     Tuple,
@@ -405,7 +406,7 @@ class AgentRPCServer(aobject):
     async def destroy_kernel(
         self,
         kernel_id: str,
-        reason: str = None,
+        reason: Optional[str] = None,
         suppress_events: bool = False,
     ):
         loop = asyncio.get_running_loop()

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1825,7 +1825,7 @@ class AgentRegistry:
         session_getter: SessionGetter,
         *,
         forced: bool = False,
-        reason: str = "user-requested",
+        reason: Optional[str] = None,
     ) -> Mapping[str, Any]:
         """
         Destroy session kernels. Do not destroy
@@ -1837,8 +1837,8 @@ class AgentRegistry:
         """
         async with self.db.begin_readonly() as conn:
             session = await session_getter(db_connection=conn)
-        if forced:
-            reason = "force-terminated"
+        if not reason:
+            reason = "force-terminated" if forced else "user-requested"
         hook_result = await self.hook_plugin_ctx.dispatch(
             "PRE_DESTROY_SESSION",
             (session["session_id"], session["session_name"], session["access_key"]),


### PR DESCRIPTION
This PR resolves lablup/backend.ai#680.

The `reason` message is restricted to `force-terminated` when forcing a termination. However, there is a necessity on providing a detailed `reason` message to describe the circumstance why the kernel has terminated.

In this PR, I changed the default value of the parameter `reason` to `None` and let it be `user-requested` or `force-terminated` only in case a caller does not pass the `reason` argument. This change provides support for custom `reason` messages, even with the condition `forced=True`, while it still maintains compatibility with the old version.