### PR TITLE
ci: add auto-labeled items

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,17 @@
 require:db-migration:
 - any: ['src/ai/backend/manager/alembic/versions/*.py']
+
+storage-proxy:
+- any: ['src/ai/backend/storage/**/*.py']
+
+agent:
+- any: ['src/ai/backend/agent/**/*.py']
+
+manager:
+- any: ['src/ai/backend/manager/**/*.py']
+
+common:
+- any: ['src/ai/backend/common/**/*.py']
+
+installer:
+- any: ['scripts/install-dev.sh']


### PR DESCRIPTION
It detects changes in storage, agent, manager, common, and install-dev and auto-labels tags for each item.
I think it will be useful for situations where labeling is omitted, or for prs of people who do not have permission in the current repo.