### PR TITLE
feat: Do not return AgentSummary if hide-agents is true

### DIFF
--- a/changes/699.feature.md
+++ b/changes/699.feature.md
@@ -1,1 +1,1 @@
-hide-agent configuration blocks API from returning agent summary data.
+Show agent summary information to user only if `manager.hide-agents` config is set to `true`.

--- a/changes/699.feature.md
+++ b/changes/699.feature.md
@@ -1,0 +1,1 @@
+hide-agent configuration blocks API from returning agent summary data.

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -439,6 +439,9 @@ class AgentSummary(graphene.ObjectType):
         scaling_group: str = None,
         access_key: str,
     ) -> Sequence[Agent | None]:
+        if graph_ctx.local_config["manager"]["hide-agents"]:
+            return []
+
         query = (
             sa.select([agents])
             .select_from(agents)
@@ -473,6 +476,9 @@ class AgentSummary(graphene.ObjectType):
         raw_status: str = None,
         filter: str = None,
     ) -> int:
+        if graph_ctx.local_config["manager"]["hide-agents"]:
+            return 0
+
         query = sa.select([sa.func.count()]).select_from(agents)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group
@@ -501,6 +507,9 @@ class AgentSummary(graphene.ObjectType):
         filter: str = None,
         order: str = None,
     ) -> Sequence[Agent]:
+        if graph_ctx.local_config["manager"]["hide-agents"]:
+            return []
+
         query = sa.select([agents]).select_from(agents).limit(limit).offset(offset)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -439,9 +439,6 @@ class AgentSummary(graphene.ObjectType):
         scaling_group: str = None,
         access_key: str,
     ) -> Sequence[Agent | None]:
-        if graph_ctx.local_config["manager"]["hide-agents"]:
-            return []
-
         query = (
             sa.select([agents])
             .select_from(agents)
@@ -476,9 +473,6 @@ class AgentSummary(graphene.ObjectType):
         raw_status: str = None,
         filter: str = None,
     ) -> int:
-        if graph_ctx.local_config["manager"]["hide-agents"]:
-            return 0
-
         query = sa.select([sa.func.count()]).select_from(agents)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group
@@ -507,9 +501,6 @@ class AgentSummary(graphene.ObjectType):
         filter: str = None,
         order: str = None,
     ) -> Sequence[Agent]:
-        if graph_ctx.local_config["manager"]["hide-agents"]:
-            return []
-
         query = sa.select([agents]).select_from(agents).limit(limit).offset(offset)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -558,6 +558,9 @@ class Queries(graphene.ObjectType):
         scaling_group: str | None = None,
     ) -> AgentSummary:
         ctx: GraphQueryContext = info.context
+        if ctx.local_config["manager"]["hide-agents"]:
+            raise ObjectNotFound(object_name="agent")
+
         loader = ctx.dataloader_manager.get_loader(
             ctx,
             "Agent",
@@ -583,8 +586,12 @@ class Queries(graphene.ObjectType):
         scaling_group: str | None = None,
         status: str | None = None,
     ) -> AgentSummaryList:
+        ctx: GraphQueryContext = info.context
+        if ctx.local_config["manager"]["hide-agents"]:
+            raise ObjectNotFound(object_name="agent")
+
         total_count = await AgentSummary.load_count(
-            info.context,
+            ctx,
             access_key=access_key,
             scaling_group=scaling_group,
             domain_name=domain_name,
@@ -592,7 +599,7 @@ class Queries(graphene.ObjectType):
             filter=filter,
         )
         agent_list = await AgentSummary.load_slice(
-            info.context,
+            ctx,
             limit,
             offset,
             access_key=access_key,


### PR DESCRIPTION
do not return AgentSummary and AgentSummaryList gql objects if `hide-agents` is true.

Follow-up of #645.
Resolves #640.