### PR TITLE
setup: Bump python version from 3.10.5 to 3.10.7

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.5"
+        python-version: "3.10.7"
         cache: pip
     - name: Bootstrap Pants
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,10 +38,14 @@ jobs:
           key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10.7"
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
       run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.5"
+        python-version: "3.10.7"
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.5"
+        python-version: "3.10.7"
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -131,7 +131,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.5"
+        python-version: "3.10.7"
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -184,7 +184,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.5"
+        python-version: "3.10.7"
         cache: pip
     - name: Bootstrap Pants
       run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,10 +20,14 @@ jobs:
           ~/.cache/pants/lmdb_store
           ~/.cache/pants/named_caches
         key: ${{ runner.os }}-${{ hashFiles('pants*.toml', '**/*.lock') }}-
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10.7"
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -70,10 +74,14 @@ jobs:
           ~/.cache/pants/lmdb_store
           ~/.cache/pants/named_caches
         key: ${{ runner.os }}-${{ hashFiles('pants*.toml', '**/*.lock') }}-
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10.7"
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -128,10 +136,14 @@ jobs:
           key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10.7"
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
       run: |
@@ -181,10 +193,14 @@ jobs:
           key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10.7"
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
       run: |

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -17,9 +17,10 @@ jobs:
           scripts
           packages
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        check-latest: true
     - name: Install dependencies
       run: |
         python -m pip install -U pip setuptools

--- a/changes/719.misc.md
+++ b/changes/719.misc.md
@@ -1,0 +1,1 @@
+Bump base Python version from 3.10.5 to 3.10.7 to reflect Python coroutine bugfix.

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -275,7 +275,7 @@ just like VSCode (see `the official reference <https://www.npmjs.com/package/coc
      "coc.preferences.formatOnType": true,
      "coc.preferences.formatOnSaveFiletypes": ["python"],
      "coc.preferences.willSaveHandlerTimeout": 5000,
-     "python.pythonPath": "dist/export/python/virtualenvs/python-default/3.10.5/bin/python",
+     "python.pythonPath": "dist/export/python/virtualenvs/python-default/3.10.7/bin/python",
      "python.formatting.provider": "black",
      "python.formatting.blackPath": "dist/export/python/virtualenvs/tools/black/bin/black",
      "python.sortImports.path": "dist/export/python/virtualenvs/tools/isort/bin/isort",

--- a/pants.toml
+++ b/pants.toml
@@ -43,7 +43,7 @@ enable_resolves = true
 # * Let other developers do:
 #   - Run `./pants export ::` again
 #   - Update their local IDE/editor's interpreter path configurations
-interpreter_constraints = ["CPython==3.10.5"]
+interpreter_constraints = ["CPython==3.10.7"]
 lockfile_generator = "pex"
 tailor_pex_binary_targets = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ ignore_missing_imports = true
 mypy_path = "stubs:src"
 namespace_packages = true
 explicit_package_bases = true
-python_executable = "dist/export/python/virtualenvs/python-default/3.10.5/bin/python"
+python_executable = "dist/export/python/virtualenvs/python-default/3.10.7/bin/python"
 
 [tool.black]
 line-length = 100

--- a/python-kernel.lock
+++ b/python-kernel.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 2,
 //   "valid_for_interpreter_constraints": [
-//     "CPython==3.10.5"
+//     "CPython==3.10.7"
 //   ],
 //   "generated_with_requirements": [
 //     "async_timeout~=3.0",
@@ -567,7 +567,7 @@
     "uvloop~=0.16"
   ],
   "requires_python": [
-    "==3.10.5"
+    "==3.10.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/python.lock
+++ b/python.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 2,
 //   "valid_for_interpreter_constraints": [
-//     "CPython==3.10.5"
+//     "CPython==3.10.7"
 //   ],
 //   "generated_with_requirements": [
 //     "Jinja2~=3.1.2",
@@ -4058,7 +4058,7 @@
     "zipstream-new~=1.1.8"
   ],
   "requires_python": [
-    "==3.10.5"
+    "==3.10.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/tools/flake8.lock
+++ b/tools/flake8.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 2,
 //   "valid_for_interpreter_constraints": [
-//     "CPython==3.10.5"
+//     "CPython==3.10.7"
 //   ],
 //   "generated_with_requirements": [
 //     "flake8>=4.0.1",
@@ -176,7 +176,7 @@
     "setuptools>=60.0"
   ],
   "requires_python": [
-    "==3.10.5"
+    "==3.10.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/tools/pytest.lock
+++ b/tools/pytest.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 2,
 //   "valid_for_interpreter_constraints": [
-//     "CPython==3.10.5"
+//     "CPython==3.10.7"
 //   ],
 //   "generated_with_requirements": [
 //     "aioresponses>=0.7.3",
@@ -848,7 +848,7 @@
     "pytest>=7.1.2"
   ],
   "requires_python": [
-    "==3.10.5"
+    "==3.10.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",


### PR DESCRIPTION
* Bump the base Python version from 3.10.5 to 3.10.7 to reflect the bug fix of mis-truncated stack chain when an exception is thrown into coroutines (e.g., cancellation).
  - refs python/cpython#93592
* Let GitHub action workflows take the Python version from `pants.toml` (the first match found)
  - Now it is sufficient to modify `pants.toml` only when you upgrade Python.
  - If the designated Python version is not available in [actions/python-versions](https://github.com/actions/python-versions), you may need to create an issue in [actions/setup-python](https://github.com/actions/setup-python/issues?q=is%3Aissue+author%3Aachimnol+is%3Aclosed) or wait a couple of days.
* NOTE: Developers should install Python 3.10.7 by their own (e.g., using pyenv) as Pants itself does not auto-install Python runtimes.