### PR TITLE
feat: Add commit history between releases

### DIFF
--- a/changes/721.feature.md
+++ b/changes/721.feature.md
@@ -1,0 +1,1 @@
+Add commit history link between releases in release notes(`CHANGELOG_RELEASE.md`) by updating `scripts/extract-release-changelog.py`

--- a/changes/721.feature.md
+++ b/changes/721.feature.md
@@ -1,1 +1,1 @@
-Add commit history link between releases in release notes(`CHANGELOG_RELEASE.md`) by updating `scripts/extract-release-changelog.py`
+Add commit history link between releases in release notes(`CHANGELOG_RELEASE.md`).

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -14,6 +14,13 @@ def get_tag():
     revision = p.stdout.decode().strip()
     return revision
 
+def get_prev_tag():
+    rev = subprocess.run(['git', 'rev-list', '--tags', '--skip=0', '--max-count=1'], capture_output=True)
+    rev = rev.stdout.decode().strip()
+
+    tag = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', f'{rev}'], capture_output=True)
+    tag = tag.stdout.decode().strip()
+    return tag
 
 def main():
     parser = argparse.ArgumentParser()
@@ -23,8 +30,11 @@ def main():
     )
     args = parser.parse_args()
 
-    tag = get_tag()
-    url = f"https://github.com/lablup/backend.ai/blob/{tag}/CHANGELOG.md"
+    prev_tag, tag = get_prev_tag(), get_tag()
+    url = {
+        "commit_log": f"https://github.com/lablup/backend.ai/compare/{prev_tag}...{tag}",
+        "change_log": f"https://github.com/lablup/backend.ai/blob/{tag}/CHANGELOG.md"
+    }
     print(f"Making release notes for {tag} ...", file=sys.stderr)
 
     input_path = Path('./CHANGELOG.md')
@@ -37,7 +47,11 @@ def main():
             content = m.group(1).strip()
             content += (
                 "\n\n### Full Changelog\n\nCheck out [the full changelog](%s) until this release (%s).\n"
-                % (url, tag)
+                % (url["change_log"], tag)
+            )
+            content += (
+                "\n\n### Full Commitlog\n\nCheck out [the full commit logs](%s) between release (%s) and (%s).\n"
+                % (url["commit_log"], prev_tag, tag)
             )
             if not args.draft:
                 output_path.write_text(content)

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -31,10 +31,9 @@ def main():
     args = parser.parse_args()
 
     prev_tag, tag = get_prev_tag(), get_tag()
-    url = {
-        "commit_log": f"https://github.com/lablup/backend.ai/compare/{prev_tag}...{tag}",
-        "change_log": f"https://github.com/lablup/backend.ai/blob/{tag}/CHANGELOG.md"
-    }
+    commitlog_url = f"https://github.com/lablup/backend.ai/compare/{prev_tag}...{tag}"
+    changelog_url = f"https://github.com/lablup/backend.ai/blob/{tag}/CHANGELOG.md"
+
     print(f"Making release notes for {tag} ...", file=sys.stderr)
 
     input_path = Path('./CHANGELOG.md')
@@ -47,11 +46,11 @@ def main():
             content = m.group(1).strip()
             content += (
                 "\n\n### Full Changelog\n\nCheck out [the full changelog](%s) until this release (%s).\n"
-                % (url["change_log"], tag)
+                % (changelog_url, tag)
             )
             content += (
                 "\n\n### Full Commitlog\n\nCheck out [the full commit logs](%s) between release (%s) and (%s).\n"
-                % (url["commit_log"], prev_tag, tag)
+                % (commitlog_url, prev_tag, tag)
             )
             if not args.draft:
                 output_path.write_text(content)

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -15,11 +15,11 @@ def get_tag():
     return revision
 
 def get_prev_tag():
-    rev = subprocess.run(['git', 'rev-list', '--tags', '--skip=0', '--max-count=1'], capture_output=True)
-    rev = rev.stdout.decode().strip()
+    p = subprocess.run(['git', 'rev-list', '--tags', '--skip=0', '--max-count=1'], capture_output=True)
+    rev = p.stdout.decode().strip()
 
-    tag = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', f'{rev}'], capture_output=True)
-    tag = tag.stdout.decode().strip()
+    p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', f'{rev}'], capture_output=True)
+    tag = p.stdout.decode().strip()
     return tag
 
 def main():


### PR DESCRIPTION
issue #691 

- Add commit history link between releases in release notes(`CHANGELOG_RELEASE.md`) by updating `scripts/extract-release-changelog.py`