### PR TITLE
fix: unable to purge user when there is no related keyapir

### DIFF
--- a/changes/725.fix
+++ b/changes/725.fix
@@ -1,0 +1,1 @@
+Let admins can purge a user account even if there is no related kaypair.


### PR DESCRIPTION
Set concurrency used in purging a user only when there is a related keypair.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
