### PR TITLE
setup: Allow installation of package wheels on compatible Python versions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,4 +51,5 @@ installer:
 - any: [
     'scripts/install-dev.sh',
     'scripts/delete-dev.sh',
+    'tools/pants-plugins/**/*',
   ]

--- a/changes/727.fix.md
+++ b/changes/727.fix.md
@@ -1,0 +1,1 @@
+Allow installation of packaged wheels on compatible Python versions (e.g., any of 3.10.x)

--- a/tools/pants-plugins/setupgen/register.py
+++ b/tools/pants-plugins/setupgen/register.py
@@ -4,6 +4,8 @@ import re
 from pathlib import Path
 
 from pants.backend.python.goals.setup_py import SetupKwargs, SetupKwargsRequest
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Target
@@ -27,7 +29,10 @@ license_classifier_map = {
 
 
 @rule
-async def setup_kwargs_plugin(request: CustomSetupKwargsRequest) -> SetupKwargs:
+async def setup_kwargs_plugin(
+    request: CustomSetupKwargsRequest,
+    python_setup: PythonSetup,
+) -> SetupKwargs:
     kwargs = request.explicit_kwargs.copy()
 
     # Single-source the version from VERSION.
@@ -122,6 +127,12 @@ async def setup_kwargs_plugin(request: CustomSetupKwargsRequest) -> SetupKwargs:
             f"{sorted(conflicting_hardcoded_kwargs)}",
         )
     kwargs.update(hardcoded_kwargs)
+
+    # Override the interpreter compatibility range
+    interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
+    python_requires = next(str(ic.specifier) for ic in interpreter_constraints)
+    if m := re.search(r"=(\d+\.\d+)", python_requires):
+        kwargs["python_requires"] = f"~={m.group(1)}.0"
 
     return SetupKwargs(kwargs, address=request.target.address)
 

--- a/tools/pants-plugins/setupgen/register.py
+++ b/tools/pants-plugins/setupgen/register.py
@@ -131,7 +131,7 @@ async def setup_kwargs_plugin(
     # Override the interpreter compatibility range
     interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
     python_requires = next(str(ic.specifier) for ic in interpreter_constraints)
-    if m := re.search(r"=(?P<major>\d+)\.(?P<minor>\d+)", python_requires):
+    if m := re.search(r"==(?P<major>\d+)\.(?P<minor>\d+)", python_requires):
         major = int(m.group("major"))
         minor = int(m.group("minor"))
         kwargs["python_requires"] = f">={major}.{minor},<{major}.{minor + 1}"

--- a/tools/pants-plugins/setupgen/register.py
+++ b/tools/pants-plugins/setupgen/register.py
@@ -131,8 +131,10 @@ async def setup_kwargs_plugin(
     # Override the interpreter compatibility range
     interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
     python_requires = next(str(ic.specifier) for ic in interpreter_constraints)
-    if m := re.search(r"=(\d+\.\d+)", python_requires):
-        kwargs["python_requires"] = f"~={m.group(1)}.0"
+    if m := re.search(r"=(?P<major>\d+)\.(?P<minor>\d+)", python_requires):
+        major = int(m.group("major"))
+        minor = int(m.group("minor"))
+        kwargs["python_requires"] = f">={major}.{minor},<{major}.{minor + 1}"
 
     return SetupKwargs(kwargs, address=request.target.address)
 


### PR DESCRIPTION
When the main interpreter constraint in `pants.toml` says "==3.10.7", this PR will generate `.tar.gz`, `.whl` distributions with ">=3.10,<3.11" to allow installation on compatible Python versions, while keeping the exact Python versions in CI scripts and the build toolchain.
