### PR TITLE
add: support webserver option for session enqueue

### DIFF
--- a/changes/732.feature.md
+++ b/changes/732.feature.md
@@ -1,0 +1,1 @@
+Add webserver option to support session enqueue feature, introduced from lablup/backend.ai-webui#1162

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -33,6 +33,8 @@ allow_change_signin_mode = false
 allow_manual_image_name_for_session = false
 # Allow users can sign up without confirmation such as token or email confirmation.
 allow_signup_without_confirmation = false
+# Allow users enqueue the compute session
+always_enqueue_compute_session = false
 # Debug mode for Web-UI (not Webserver's debug flag)
 webui_debug = false
 # Enable masking user information

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -43,6 +43,7 @@ config_iv = t.Dict(
                 t.Key("allow_change_signin_mode", default=False): t.ToBool,
                 t.Key("allow_manual_image_name_for_session", default=False): t.ToBool,
                 t.Key("allow_signup_without_confirmation", default=False): t.ToBool,
+                t.Key("always_enqueue_compute_session", default=False): t.ToBool,
                 t.Key("webui_debug", default=False): t.ToBool,
                 t.Key("mask_user_info", default=False): t.ToBool,
                 t.Key("single_sign_on_vendors", default=None): t.Null

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -11,6 +11,7 @@ connectionMode = "SESSION"
 {% toml_field "allowProjectResourceMonitor" config["service"]["allow_project_resource_monitor"] %}
 {% toml_field "allowManualImageNameForSession" config["service"]["allow_manual_image_name_for_session"] %}
 {% toml_field "allowSignupWithoutConfirmation" config["service"]["allow_signup_without_confirmation"] %}
+{% toml_field "alwaysEnqueueComputeSession" config["service"]["always_enqueue_compute_session"] %}
 {% toml_field "autoLogout" config["session"]["auto_logout"] %}
 {% toml_field "debug" config["service"]["webui_debug"] %}
 {% toml_field "debug" config["service"]["webui_debug"] %}


### PR DESCRIPTION
This change adds webserver option to support session enqueue feature, introduced from https://github.com/lablup/backend.ai-webui/pull/1162 


A user cannot create a compute session when there is no available resource in the Agent hosts. In the absence of the resources, the session launcher dialog disables the CREATE button.

Some users / groups find this inconvenient since they have to wait until other users destroy their compute sessions to create their own. They rather wanted to create a PENDING session immediately and then get the RUNNING session automatically just after the resources are available. Therefore, queueing the session creation request feature added in backend.ai-webui, and it is configurable via `config.toml` as a global service option. 

This PR adds the `alwaysEnqueueComputeSession` option under `general` section of webserver-side `config.toml` too.
