### PR TITLE
ci: Fix sync-labels option error

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: jsoref/labeler@fix-labeler
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: jsoref/labeler@fix-labeler
+    - uses: jsoref/labeler@v0-5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The sync-labels option of the labeler, which syncs the current label according to this change, is not working properly.

It was an issue raised 2 months ago, but it is an issue that is not being dealt with and left unattended.
https://github.com/actions/labeler/issues/404

A branch with a bug-fixed version exists and changes to that version
https://github.com/actions/labeler/pull/405