### PR TITLE
feat: impl abusing report and agent local_config API

### DIFF
--- a/changes/737.feature.md
+++ b/changes/737.feature.md
@@ -1,1 +1,1 @@
-impl graphql resolver querying agent local_config
+impl abusing report and agent local_config API

--- a/changes/737.feature.md
+++ b/changes/737.feature.md
@@ -1,0 +1,1 @@
+impl graphql resolver querying agent local_config

--- a/changes/737.feature.md
+++ b/changes/737.feature.md
@@ -1,1 +1,1 @@
-impl abusing report and agent local_config API
+Introduce abusing container status and agent local_config API

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -560,9 +560,11 @@ class AgentRPCServer(aobject):
     @rpc_function
     @collect_error
     async def get_local_config(self) -> Mapping[str, Any]:
+        agent_config: Mapping[str, Any] = self.local_config["agent"]
+        report_path: Path | None = agent_config.get("abuse-report-path")
         return {
             "agent": {
-                "abuse-report-path": str(self.local_config["agent"].get("abuse-report-path", "")),
+                "abuse-report-path": str(report_path) if report_path is not None else "",
             },
             "watcher": self.local_config["watcher"],
         }

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import importlib
+import json
 import logging
 import logging.config
 import os
@@ -575,6 +576,19 @@ class AgentRPCServer(aobject):
             },
             "watcher": self.local_config["watcher"],
         }
+
+    @rpc_function
+    @collect_error
+    async def get_abusing_report(
+        self,
+        kernel_id,  # type: str
+    ):
+        if (abuse_path := self.local_config["agent"].get("abuse-report-path")) is not None:
+            report_path = Path(abuse_path, f"report.{kernel_id}.json")
+            if report_path.is_file():
+                with open(report_path) as file:
+                    return json.load(file)
+        return
 
     @rpc_function
     @collect_error

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -559,8 +559,6 @@ class AgentRPCServer(aobject):
     @rpc_function
     @collect_error
     async def get_local_config(self):
-        log.debug("rpc::get_local_config()")
-
         def get_or_empty(val):
             if val is None:
                 return ""

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -586,7 +586,7 @@ class AgentRPCServer(aobject):
         if (abuse_path := self.local_config["agent"].get("abuse-report-path")) is not None:
             report_path = Path(abuse_path, f"report.{kernel_id}.json")
             if report_path.is_file():
-                with open(report_path) as file:
+                with open(report_path, "r") as file:
                     return json.load(file)
         return
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -558,6 +558,28 @@ class AgentRPCServer(aobject):
 
     @rpc_function
     @collect_error
+    async def get_local_config(self):
+        log.debug("rpc::get_local_config()")
+
+        def get_or_empty(val):
+            if val is None:
+                return ""
+            return str(val)
+
+        return {
+            "agent": {
+                "abuse-report-path": get_or_empty(
+                    self.local_config["agent"].get("abuse-report-path")
+                ),
+                "image-commit-path": get_or_empty(
+                    self.local_config["agent"].get("image-commit-path")
+                ),
+            },
+            "watcher": self.local_config["watcher"],
+        }
+
+    @rpc_function
+    @collect_error
     async def shutdown_service(
         self,
         kernel_id,  # type: str

--- a/src/ai/backend/client/cli/admin/agent.py
+++ b/src/ai/backend/client/cli/admin/agent.py
@@ -38,6 +38,7 @@ def info(ctx: CLIContext, agent_id: str) -> None:
         agent_fields["occupied_slots"],
         agent_fields["hardware_metadata"],
         agent_fields["live_stat"],
+        agent_fields["local_config"],
     ]
     with Session() as session:
         try:

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -975,6 +975,26 @@ def commit(session_id):
             sys.exit(ExitCode.FAILURE)
 
 
+@session.command()
+@click.argument("session_id", metavar="SESSID")
+def abuse_history(session_id):
+    """
+    Get abusing reports of session's sibling kernels.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    """
+
+    with Session() as session:
+        try:
+            session = session.ComputeSession(session_id)
+            report = session.get_abusing_report()
+            print(dict(report))
+        except Exception as e:
+            print_error(e)
+            sys.exit(ExitCode.FAILURE)
+
+
 def _ssh_cmd(docs: str = None):
     @click.argument("session_ref", type=str, metavar="SESSION_REF")
     @click.option(

--- a/src/ai/backend/client/func/agent.py
+++ b/src/ai/backend/client/func/agent.py
@@ -35,6 +35,7 @@ _default_detail_fields = (
     agent_fields["mem_cur_bytes"],
     agent_fields["available_slots"],
     agent_fields["occupied_slots"],
+    agent_fields["local_config"],
 )
 
 

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -55,6 +55,7 @@ _default_list_fields = (
     session_fields["status_info"],
     session_fields["status_changed"],
     session_fields["result"],
+    session_fields["abusing_reports"],
 )
 
 

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -961,6 +961,23 @@ class ComputeSession(BaseFunction):
         async with api_rqst.fetch() as resp:
             return await resp.json()
 
+    @api_function
+    async def get_abusing_report(self):
+        """
+        Retrieves abusing reports of session's sibling kernels.
+        """
+        params = {}
+        if self.owner_access_key:
+            params["owner_access_key"] = self.owner_access_key
+        prefix = get_naming(api_session.get().api_version, "path")
+        rqst = Request(
+            "GET",
+            f"/{prefix}/{self.name}/abusing-report",
+            params=params,
+        )
+        async with rqst.fetch() as resp:
+            return await resp.json()
+
     # only supported in AsyncAPISession
     def listen_events(self, scope: Literal["*", "session", "kernel"] = "*") -> SSEContextManager:
         """

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -58,6 +58,7 @@ agent_fields = FieldSet(
         FieldSpec(
             "compute_containers", subfields=container_fields, formatter=ContainerListFormatter()
         ),
+        FieldSpec("local_config", formatter=nested_dict_formatter),
         # legacy fields
         FieldSpec("cpu_cur_pct", "CPU Usage (%)"),
         FieldSpec("mem_cur_bytes", "Used Memory (MiB)", formatter=mibytes_output_formatter),

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -205,6 +205,7 @@ session_fields = FieldSet(
             "dependencies { name id }",
             formatter=DependencyListFormatter(),
         ),
+        FieldSpec("containers", formatter=nested_dict_formatter),
         FieldSpec("abusing_report", formatter=nested_dict_formatter),
     ]
 )

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -205,7 +205,7 @@ session_fields = FieldSet(
             "dependencies { name id }",
             formatter=DependencyListFormatter(),
         ),
-        FieldSpec("abusing_report", formatter=nested_dict_formatter),
+        FieldSpec("abusing_reports"),
     ]
 )
 

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -205,6 +205,7 @@ session_fields = FieldSet(
             "dependencies { name id }",
             formatter=DependencyListFormatter(),
         ),
+        FieldSpec("abusing_report", formatter=nested_dict_formatter),
     ]
 )
 

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -205,7 +205,6 @@ session_fields = FieldSet(
             "dependencies { name id }",
             formatter=DependencyListFormatter(),
         ),
-        FieldSpec("containers", formatter=nested_dict_formatter),
         FieldSpec("abusing_report", formatter=nested_dict_formatter),
     ]
 )

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1360,9 +1360,6 @@ async def get_abusing_report(request: web.Request, params: Mapping[str, Any]) ->
     session_name: str = request.match_info["session_name"]
     requester_access_key, owner_access_key = await get_access_key_scopes(request)
 
-    myself = asyncio.current_task()
-    assert myself is not None
-
     log.info(
         "GET_ABUSING_REPORT (ak:{}/{}, s:{})", requester_access_key, owner_access_key, session_name
     )

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -197,7 +197,7 @@ class Agent(graphene.ObjectType):
 
     async def resolve_local_config(self, info: graphene.ResolveInfo) -> Mapping[str, Any]:
         graph_ctx: GraphQueryContext = info.context
-        return await graph_ctx.registry.get_local_config(self.id, self.addr)
+        return await graph_ctx.registry.get_agent_local_config(self.id, self.addr)
 
     _queryfilter_fieldspec = {
         "id": ("id", None),

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -105,6 +105,7 @@ class Agent(graphene.ObjectType):
     version = graphene.String()
     compute_plugins = graphene.JSONString()
     hardware_metadata = graphene.JSONString()
+    local_config = graphene.JSONString()
 
     # Legacy fields
     mem_slots = graphene.Int()
@@ -193,6 +194,10 @@ class Agent(graphene.ObjectType):
     ) -> Mapping[str, HardwareMetadata]:
         graph_ctx: GraphQueryContext = info.context
         return await graph_ctx.registry.gather_agent_hwinfo(self.id)
+
+    async def resolve_local_config(self, info: graphene.ResolveInfo) -> Mapping[str, Any]:
+        graph_ctx: GraphQueryContext = info.context
+        return await graph_ctx.registry.get_local_config(self.id, self.addr)
 
     _queryfilter_fieldspec = {
         "id": ("id", None),

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -594,6 +594,7 @@ class ComputeContainer(graphene.ObjectType):
     created_at = GQLDateTime()
     terminated_at = GQLDateTime()
     starts_at = GQLDateTime()
+    abusing_report = graphene.JSONString()
 
     # resources
     agent = graphene.String()
@@ -661,6 +662,12 @@ class ComputeContainer(graphene.ObjectType):
 
     async def resolve_last_stat(self, info: graphene.ResolveInfo) -> Optional[Mapping[str, Any]]:
         return await self.resolve_live_stat(info)
+
+    async def resolve_abusing_report(
+        self, info: graphene.ResolveInfo
+    ) -> Optional[Mapping[str, Any]]:
+        graph_ctx: GraphQueryContext = info.context
+        return await graph_ctx.registry.get_abusing_report(self.id)
 
     _queryfilter_fieldspec = {
         "image": ("image", None),

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3046,7 +3046,7 @@ class AgentRegistry:
                 resp: Mapping[str, Any] = await rpc.call.commit(str(kernel["id"]), email, filename)
         return resp
 
-    async def get_local_config(
+    async def get_agent_local_config(
         self,
         agent_id: AgentId,
         agent_addr: str,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3066,11 +3066,11 @@ class AgentRegistry:
         if access_key is not None:
             kernel = await self.get_session(session_name_or_id, access_key)
         else:
-            query = sa.select([kernels.c.agent, kernels.c.agent_addr]).where(
+            query = sa.select([kernels.c.id, kernels.c.agent, kernels.c.agent_addr]).where(
                 kernels.c.id == session_name_or_id
             )
             async with self.db.begin_readonly() as conn:
-                kernel = await conn.scalar(query)
+                kernel = (await conn.execute(query)).first()
         async with RPCContext(
             kernel["agent"],
             kernel["agent_addr"],

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3061,16 +3061,9 @@ class AgentRegistry:
     async def get_abusing_report(
         self,
         session_name_or_id: Union[str, SessionId],
-        access_key: AccessKey | None = None,
+        access_key: AccessKey,
     ) -> Optional[Mapping[str, str]]:
-        if access_key is not None:
-            kernel = await self.get_session(session_name_or_id, access_key)
-        else:
-            query = sa.select([kernels.c.id, kernels.c.agent, kernels.c.agent_addr]).where(
-                kernels.c.id == session_name_or_id
-            )
-            async with self.db.begin_readonly() as conn:
-                kernel = (await conn.execute(query)).first()
+        kernel = await self.get_session(session_name_or_id, access_key)
         async with RPCContext(
             kernel["agent"],
             kernel["agent_addr"],

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3046,6 +3046,18 @@ class AgentRegistry:
                 resp: Mapping[str, Any] = await rpc.call.commit(str(kernel["id"]), email, filename)
         return resp
 
+    async def get_local_config(
+        self,
+        agent_id: AgentId,
+        agent_addr: str,
+    ) -> Mapping[str, str]:
+        async with RPCContext(
+            agent_id,
+            agent_addr,
+            invoke_timeout=None,
+        ) as rpc:
+            return await rpc.call.get_local_config()
+
 
 async def check_scaling_group(
     conn: SAConnection,


### PR DESCRIPTION
Implement kernel's abusing report API.
Add CLI command and add ComputeContainer graph field `abusing_report`.
example image)
abusing report is saved as following.
<img width="608" alt="image" src="https://user-images.githubusercontent.com/44239739/192078265-58eb64f1-04de-45d3-80e2-e62d166b1d0c.png">

The report shows as following.
<img width="948" alt="image" src="https://user-images.githubusercontent.com/44239739/192078214-16a8ac6e-911e-4b8f-ae41-6cf8abe52b63.png">

---
Since there are many unserializable items in agent's local_config that RPC function cannot parse, let agents return only a few items of local_config

<img width="685" alt="image" src="https://user-images.githubusercontent.com/44239739/191697073-1286bce2-37a1-4532-9317-e52683372ff3.png">
