### PR TITLE
fix: update ssh command which spawns outdated `backend.ai` commands

### DIFF
--- a/changes/761.fix.md
+++ b/changes/761.fix.md
@@ -1,0 +1,1 @@
+update ssh command which spawns outdated `backend.ai` commands.

--- a/src/ai/backend/client/cli/ssh.py
+++ b/src/ai/backend/client/cli/ssh.py
@@ -19,7 +19,7 @@ def container_ssh_ctx(session_ref: str, port: int) -> Iterator[Path]:
     key_path = Path(f"~/.ssh/id_{random_id}").expanduser()
     try:
         subprocess.run(
-            ["backend.ai", "session", "download", session_ref, key_filename],
+            ["./backend.ai", "session", "download", session_ref, key_filename],
             shell=False,
             check=True,
             stdout=subprocess.PIPE,
@@ -34,7 +34,7 @@ def container_ssh_ctx(session_ref: str, port: int) -> Iterator[Path]:
     # proxy_proc is a background process
     proxy_proc = subprocess.Popen(
         [
-            "backend.ai",
+            "./backend.ai",
             "app",
             session_ref,
             "sshd",


### PR DESCRIPTION
Update cli commands use outdated `backend.ai` commands
