### PR TITLE
feature: Auto-generate and auto-commit news fragment from PR title

### DIFF
--- a/.github/workflows/label-matcher.json
+++ b/.github/workflows/label-matcher.json
@@ -1,0 +1,272 @@
+[
+  {
+    "id": 1797645205,
+    "node_id": "MDU6TGFiZWwxNzk3NjQ1MjA1",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/agent",
+    "name": "agent",
+    "color": "7c61cf",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 4329308633,
+    "node_id": "LA_kwDOBC4ECs8AAAABAgwB2Q",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/app-proxy",
+    "name": "app-proxy",
+    "color": "c8bbf2",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1491889106,
+    "node_id": "MDU6TGFiZWwxNDkxODg5MTA2",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/blocker",
+    "name": "blocker",
+    "color": "ff2222",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 456025123,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMjM=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/bug",
+    "name": "bug",
+    "color": "D93F0B",
+    "default": true,
+    "description": ""
+  },
+  {
+    "id": 1797650185,
+    "node_id": "MDU6TGFiZWwxNzk3NjUwMTg1",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/cli",
+    "name": "cli",
+    "color": "e4dbff",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1797645388,
+    "node_id": "MDU6TGFiZWwxNzk3NjQ1Mzg4",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/client",
+    "name": "client",
+    "color": "c8bbf2",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1797645434,
+    "node_id": "MDU6TGFiZWwxNzk3NjQ1NDM0",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/common",
+    "name": "common",
+    "color": "7c61cf",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1797650245,
+    "node_id": "MDU6TGFiZWwxNzk3NjUwMjQ1",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/console",
+    "name": "console",
+    "color": "e4dbff",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1615664730,
+    "node_id": "MDU6TGFiZWwxNjE1NjY0NzMw",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/docs",
+    "name": "docs",
+    "color": "c4f1ff",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 456025124,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMjQ=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/duplicate",
+    "name": "duplicate",
+    "color": "cccccc",
+    "default": true,
+    "description": null
+  },
+  {
+    "id": 4514085828,
+    "node_id": "LA_kwDOBC4ECs8AAAABDQ97xA",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/enhance",
+    "name": "enhance",
+    "color": "1d76db",
+    "default": false,
+    "description": "Optimization, performance improvements, and other enhnacements that do not add user-visible features"
+  },
+  {
+    "id": 1746506134,
+    "node_id": "MDU6TGFiZWwxNzQ2NTA2MTM0",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/enterprise",
+    "name": "enterprise",
+    "color": "445566",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 3660564174,
+    "node_id": "LA_kwDOBC4ECs7aL8bO",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/epic",
+    "name": "epic",
+    "color": "FBCA04",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 456025126,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMjY=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/feature",
+    "name": "feature",
+    "color": "1d76db",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 2266209106,
+    "node_id": "MDU6TGFiZWwyMjY2MjA5MTA2",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/good%20first%20issue",
+    "name": "good first issue",
+    "color": "fbca04",
+    "default": true,
+    "description": ""
+  },
+  {
+    "id": 4616305696,
+    "node_id": "LA_kwDOBC4ECs8AAAABEyc8IA",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/hacktoberfest-accepted",
+    "name": "hacktoberfest-accepted",
+    "color": "1d76db",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 456025128,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMjg=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/help%20wanted",
+    "name": "help wanted",
+    "color": "fef2c0",
+    "default": true,
+    "description": null
+  },
+  {
+    "id": 2320352723,
+    "node_id": "MDU6TGFiZWwyMzIwMzUyNzIz",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/i18n",
+    "name": "i18n",
+    "color": "fbca04",
+    "default": false,
+    "description": "i18n / L10N related issues"
+  },
+  {
+    "id": 538432807,
+    "node_id": "MDU6TGFiZWw1Mzg0MzI4MDc=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/infrastructure",
+    "name": "infrastructure",
+    "color": "bbeebb",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1830268528,
+    "node_id": "MDU6TGFiZWwxODMwMjY4NTI4",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/installer",
+    "name": "installer",
+    "color": "b59cff",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 456025130,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMzA=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/invalid",
+    "name": "invalid",
+    "color": "e6e6e6",
+    "default": true,
+    "description": null
+  },
+  {
+    "id": 1484728156,
+    "node_id": "MDU6TGFiZWwxNDg0NzI4MTU2",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/maintenance",
+    "name": "maintenance",
+    "color": "006b75",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 1797645161,
+    "node_id": "MDU6TGFiZWwxNzk3NjQ1MTYx",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/manager",
+    "name": "manager",
+    "color": "7c61cf",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 3680651990,
+    "node_id": "LA_kwDOBC4ECs7bYkrW",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/minor",
+    "name": "minor",
+    "color": "90BA3F",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 4234178013,
+    "node_id": "LA_kwDOBC4ECs78YG3d",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/on-hold",
+    "name": "on-hold",
+    "color": "FEF2C0",
+    "default": false,
+    "description": "Temporarily suspended for further work"
+  },
+  {
+    "id": 456025131,
+    "node_id": "MDU6TGFiZWw0NTYwMjUxMzE=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/question",
+    "name": "question",
+    "color": "cc317c",
+    "default": true,
+    "description": null
+  },
+  {
+    "id": 2307787525,
+    "node_id": "MDU6TGFiZWwyMzA3Nzg3NTI1",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/refactor",
+    "name": "refactor",
+    "color": "0052CC",
+    "default": false,
+    "description": "Code-level changes for better maintainability and readability"
+  },
+  {
+    "id": 4450478030,
+    "node_id": "LA_kwDOBC4ECs8AAAABCUTnzg",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/require:db-migration",
+    "name": "require:db-migration",
+    "color": "64A8DA",
+    "default": false,
+    "description": "Automatically set when alembic migrations are added or updated"
+  },
+  {
+    "id": 538431308,
+    "node_id": "MDU6TGFiZWw1Mzg0MzEzMDg=",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/security",
+    "name": "security",
+    "color": "bbeebb",
+    "default": false,
+    "description": ""
+  },
+  {
+    "id": 4360599055,
+    "node_id": "LA_kwDOBC4ECs8AAAABA-l2Dw",
+    "url": "https://api.github.com/repos/lablup/backend.ai/labels/skip:changelog",
+    "name": "skip:changelog",
+    "color": "C2E0C6",
+    "default": false,
+    "description": "Make the action workflow to skip towncrier check"
+  }
+]

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -43,7 +43,6 @@ jobs:
       env:
         CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
       working-directory: scripts/
-      # TODO: pass issue number linked to the pull request as a parameter
       run: |
         git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
         git merge refs/remotes/origin/${CURRENT_BRANCH}

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -16,6 +16,7 @@ jobs:
           changes
           scripts
           packages
+          .github
     - name: Get current branch name
       id: branch-name
       uses: tj-actions/branch-names@v5.5

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -6,10 +6,13 @@ on:
 
 jobs:
   towncrier:
+    if: |
+      toJson(github.event.pull_request.labels.*.name) != '[]'
+        && toJson(github.event.pull_request.labels.*.name) != ''
+        && !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
     strategy:
       matrix:
-        labels: ${{ github.event.pull_request.labels.*.name }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') }}
+        label: ${{ github.event.pull_request.labels.*.name }}
     runs-on: ubuntu-latest
     env:
       BASE_BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -37,14 +37,11 @@ jobs:
         python -m pip install -U towncrier~=21.9
     - name: Create or Update news fragment
       env:
-        CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         CONTENT: ${{ steps.pr-fragment.outputs.content }}
         FRAGMENT: ${{ steps.pr-fragment.outputs.fragment }}
       working-directory: .
       run: |
-        git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
-        git merge refs/remotes/origin/${CURRENT_BRANCH}
         python scripts/update-news-fragment.py -n "$PR_NUMBER" --content "$CONTENT" -f "$FRAGMENT"
     - name: Get Changed Files
       id: changed-files
@@ -68,9 +65,6 @@ jobs:
     - name: Check existence of news fragment
       env:
         BASE_BRANCH: ${{ github.base_ref }}
-        CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
       run: |
-        git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
-        git merge refs/remotes/origin/${CURRENT_BRANCH}
         git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
         python -m towncrier.check --compare-with=origin/${BASE_BRANCH}

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -38,11 +38,13 @@ jobs:
         python -m pip install -U towncrier~=21.9
     - name: Create or Update news fragment
       env:
+        BASE_BRANCH: ${{ github.base_ref }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         CONTENT: ${{ steps.pr-fragment.outputs.content }}
         FRAGMENT: ${{ steps.pr-fragment.outputs.fragment }}
       working-directory: .
       run: |
+        git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
         python scripts/update-news-fragment.py -n "$PR_NUMBER" --content "$CONTENT" -f "$FRAGMENT"
     - name: Get Changed Files
       id: changed-files

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -2,22 +2,12 @@ name: timeline-check
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [labeled, unlabeled, opened, synchronize, reopened, edited]
 
 jobs:
   towncrier:
-    if: |
-      toJson(github.event.pull_request.labels.*.name) != '[]'
-        && toJson(github.event.pull_request.labels.*.name) != ''
-        && !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
-    strategy:
-      matrix:
-        label: ${{ github.event.pull_request.labels.*.name }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
-    env:
-      BASE_BRANCH: ${{ github.base_ref }}
-      PR_TITLE: $ {{ github.event.pull_request.title }}
-      PR_LABEL: ${{ matrix.label }}
     steps:
     - name: Sparse-checkout
       uses: lablup/sparse-checkout@v1
@@ -29,6 +19,13 @@ jobs:
     - name: Get current branch name
       id: branch-name
       uses: tj-actions/branch-names@v5.5
+    - name: Get title and fragment from Pull Request
+      id: pr-fragment
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        echo "::set-output name=content::${PR_TITLE##*:}"
+        echo "::set-output name=fragment::${PR_TITLE%:*}"
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -38,34 +35,42 @@ jobs:
       run: |
         python -m pip install -U pip setuptools
         python -m pip install -U towncrier~=21.9
-    - name: Check existence of news fragment
-      run: |
-        git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
-        python -m towncrier.check --compare-with=origin/${BASE_BRANCH}
-    - name: Update existing news fragment
+    - name: Create or Update news fragment
       env:
         CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
-      working-directory: scripts/
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        CONTENT: ${{ steps.pr-fragment.outputs.content }}
+        FRAGMENT: ${{ steps.pr-fragment.outputs.fragment }}
+      working-directory: .
       run: |
         git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
         git merge refs/remotes/origin/${CURRENT_BRANCH}
-        python update-news-fragment.py --content "$PR_NAME" -f "$PR_LABEL"
+        python scripts/update-news-fragment.py -n "$PR_NUMBER" --content "$CONTENT" -f "$FRAGMENT"
     - name: Get Changed Files
       id: changed-files
       uses: tj-actions/changed-files@v31
       with:
         files: |
           changes/**
+    - name: Set Label
+      if: ${{ steps.changed-files.outputs.any_changed }}
+      uses: christianvuerings/add-labels@v1
+      with:
+        labels: ${{ steps.pr-fragment.outputs.fragment }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Auto commit and push changes
       id: auto-commit-push
-      if: ${{ steps.changed-files.outputs.changes_detected }}
+      if: ${{ steps.changed-files.outputs.any_changed }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: update $PR_LABEL news fragment
-    - name: Debug change log
+        commit_message: update "${{ steps.pr-fragment.outputs.fragment }}" news fragment
+    - name: Check existence of news fragment
+      env:
+        BASE_BRANCH: ${{ github.base_ref }}
+        CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
       run: |
-        if ${{ steps.auto-commit-push.outputs.changes_detected }}; then
-          echo "update $PR_LABEL news fragment"
-        else
-          echo "no changes detected"
-        fi
+        git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
+        git merge refs/remotes/origin/${CURRENT_BRANCH}
+        git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
+        python -m towncrier.check --compare-with=origin/${BASE_BRANCH}

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -6,8 +6,15 @@ on:
 
 jobs:
   towncrier:
+    strategy:
+      matrix:
+        labels: ${{ github.event.pull_request.labels.*.name }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') }}
     runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.base_ref }}
+      PR_TITLE: $ {{ github.event.pull_request.title }}
+      PR_LABEL: ${{ matrix.label }}
     steps:
     - name: Sparse-checkout
       uses: lablup/sparse-checkout@v1
@@ -16,6 +23,9 @@ jobs:
           changes
           scripts
           packages
+    - name: Get current branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5.5
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -29,5 +39,31 @@ jobs:
       run: |
         git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
         python -m towncrier.check --compare-with=origin/${BASE_BRANCH}
+    - name: Update existing news fragment
       env:
-        BASE_BRANCH: ${{ github.base_ref }}
+        CURRENT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
+      working-directory: scripts/
+      # TODO: pass issue number linked to the pull request as a parameter
+      run: |
+        git fetch --no-tags origin +refs/heads/${CURRENT_BRANCH}:refs/remotes/origin/${CURRENT_BRANCH}
+        git merge refs/remotes/origin/${CURRENT_BRANCH}
+        python update-news-fragment.py --content "$PR_NAME" -f "$PR_LABEL"
+    - name: Get Changed Files
+      id: changed-files
+      uses: tj-actions/changed-files@v31
+      with:
+        files: |
+          changes/**
+    - name: Auto commit and push changes
+      id: auto-commit-push
+      if: ${{ steps.changed-files.outputs.changes_detected }}
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: update $PR_LABEL news fragment
+    - name: Debug change log
+      run: |
+        if ${{ steps.auto-commit-push.outputs.changes_detected }}; then
+          echo "update $PR_LABEL news fragment"
+        else
+          echo "no changes detected"
+        fi

--- a/changes/742.misc.md
+++ b/changes/742.misc.md
@@ -1,0 +1,1 @@
+Auto-generate and Auto-commit news fragment from PR title

--- a/changes/742.misc.md
+++ b/changes/742.misc.md
@@ -1,1 +1,0 @@
-Auto-generate and Auto-commit news fragment from PR title

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -18,7 +18,7 @@ def get_config():
 
 
 def get_repository_labels():
-    directory = os.path.abspath("./github/workflows")
+    directory = os.path.abspath("./.github/workflows")
     config_path = Path(os.path.join(directory, "label-matcher.json"))
     with open(config_path, encoding='utf-8') as json_f:
         labels = [x["name"] for x in json.loads(json_f.read())]

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -67,7 +67,7 @@ def main():
 
     files = [basename for basename in files if len(basename.split(".")) == 3]
     if not files:
-        basename = '.'.join([str(0), args.fragment, 'md'])
+        basename = '.'.join([str(args.number if args.number else 0), args.fragment, 'md'])
         output_path = Path(os.path.join(fragment_dir, basename))
         output_path.write_text(args.content)
         print(f'\n### {args.fragment.title()}\n * {args.content} ({basename})', file=sys.stderr)
@@ -76,16 +76,12 @@ def main():
 
     for basename in files:
         parts = basename.split(".")
-        if parts[1] == args.fragment:
-            _basename = basename
-            message = f'Successfully updated the "{parts[1].title()}" news fragment found by towncrier.\n'
-        else:
-            _basename = '.'.join([str(args.number if args.number else 0), args.fragment, 'md'])
-            message = f'Successfully created the "{parts[1].title()}" news fragment found by towncrier.\n'
-        output_path = Path(os.path.join(fragment_dir, _basename))
+        if parts[1] != args.fragment:
+            continue
+        output_path = Path(os.path.join(fragment_dir, basename))
         output_path.write_text(args.content)
-        print(f'\n### {parts[1].title()}\n * {args.content} ({_basename})', file=sys.stderr)
-        print(message, file=sys.stderr)
+        print(f'\n### {parts[1].title()}\n * {args.content} ({basename})', file=sys.stderr)
+        print(f'Successfully updated the "{parts[1].title()}" news fragment found by towncrier.\n', file=sys.stderr)
     sys.exit(0)
 
 

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -1,0 +1,66 @@
+import os
+import re
+import sys
+import argparse
+import tomli as tomllib
+from pathlib import Path
+
+
+def get_config():
+    directory = os.path.abspath("./")
+    config_path = Path(os.path.join(directory, "pyproject.toml"))
+
+    with open(config_path, "rb") as conf:
+        config_toml = tomllib.load(conf)
+    config = config_toml["tool"]["towncrier"]
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--content', default='',
+        help='Enter the contents for the news fragment to modify.'
+    )
+    parser.add_argument(
+        '-f', '--fragment', type=str, default='',
+        help='Enter the fragment types for the new fragment you want to modify.'
+    )
+
+    args = parser.parse_args()
+    if not args.content:
+        print("::error ::No contents given from args.")
+        sys.exit(1)
+    if not args.fragment:
+        print("::error ::No fragment types given from args.")
+        sys.exit(1)
+
+    config = get_config()
+    fragment_dir = config.get("directory")
+    try:
+        files = os.listdir(fragment_dir)
+    except FileNotFoundError as e:
+        raise Exception()
+
+    files = [basename for basename in files if len(basename.split(".")) == 3]
+    if not files:
+        # FIX: integer value to issue number linked to pull request
+        basename = '.'.join([str(0), args.fragment, 'md'])
+        output_path = Path(os.path.join(fragment_dir, basename))
+        output_path.write_text(args.content)
+        print(f'\n### {args.fragment.title()}\n * {args.content} ({basename})', file=sys.stderr)
+        print(f'Successfully created the "{args.fragment.title()}" news fragment found by towncrier.\n', file=sys.stderr)
+
+        sys.exit(0)
+
+    for basename in files:
+        parts = basename.split(".")
+        if parts[1] != args.fragment:
+            continue
+        output_path = Path(os.path.join(fragment_dir, basename))
+        output_path.write_text(args.content)
+        print(f'\n### {parts[1].title()}\n * {args.content} ({basename})', file=sys.stderr)
+        print(f'Successfully updated the "{parts[1].title()}" news fragment found by towncrier.\n', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -19,6 +19,10 @@ def get_config():
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        '-n', '--number', type=int, default=0,
+        help='Enter the number of the news fragment you want to create.'
+    )
+    parser.add_argument(
         '--content', default='',
         help='Enter the contents for the news fragment to modify.'
     )
@@ -58,12 +62,18 @@ def main():
 
     for basename in files:
         parts = basename.split(".")
-        if parts[1] != args.fragment:
-            continue
-        output_path = Path(os.path.join(fragment_dir, basename))
+        if parts[1] == args.fragment:
+            _basename = basename
+            message = f'Successfully updated the "{parts[1].title()}" news fragment found by towncrier.\n'
+        else:
+            _basename = '.'.join([str(args.number if args.number else 0), args.fragment, 'md'])
+            message = f'Successfully created the "{parts[1].title()}" news fragment found by towncrier.\n'
+        output_path = Path(os.path.join(fragment_dir, _basename))
         output_path.write_text(args.content)
-        print(f'\n### {parts[1].title()}\n * {args.content} ({basename})', file=sys.stderr)
-        print(f'Successfully updated the "{parts[1].title()}" news fragment found by towncrier.\n', file=sys.stderr)
+        print(f'\n### {parts[1].title()}\n * {args.content} ({_basename})', file=sys.stderr)
+        print(message, file=sys.stderr)
+    sys.exit(0)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import json
 import argparse
 import tomli as tomllib
 from pathlib import Path
@@ -14,6 +15,14 @@ def get_config():
         config_toml = tomllib.load(conf)
     config = config_toml["tool"]["towncrier"]
     return config
+
+
+def get_repository_labels():
+    directory = os.path.abspath("./github/workflows")
+    config_path = Path(os.path.join(directory, "label-matcher.json"))
+    with open(config_path, encoding='utf-8') as json_f:
+        labels = [x["name"] for x in json.loads(json_f.read())]
+    return labels
 
 
 def main():
@@ -37,6 +46,11 @@ def main():
         sys.exit(1)
     if not args.fragment:
         print("::error ::No fragment types given from args.")
+        sys.exit(1)
+
+    repository_labels = get_repository_labels()
+    if args.fragment not in repository_labels:
+        print(f'Invalid {args.fragment} tag.\nUnable to create/update the news fragment.\n', file=sys.stderr)
         sys.exit(1)
 
     config = get_config()

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -44,7 +44,6 @@ def main():
 
     files = [basename for basename in files if len(basename.split(".")) == 3]
     if not files:
-        # FIX: integer value to issue number linked to pull request
         basename = '.'.join([str(0), args.fragment, 'md'])
         output_path = Path(os.path.join(fragment_dir, basename))
         output_path.write_text(args.content)

--- a/scripts/update-news-fragment.py
+++ b/scripts/update-news-fragment.py
@@ -36,6 +36,11 @@ def main():
         sys.exit(1)
 
     config = get_config()
+    towncrier_types = [t["directory"] for t in config["type"]]
+    if args.fragment not in towncrier_types:
+        print(f'Towncrier does not support {args.fragment} tag.\n Unable to create/update the news fragment.\n', file=sys.stderr)
+        sys.exit(1)
+
     fragment_dir = config.get("directory")
     try:
         files = os.listdir(fragment_dir)
@@ -49,7 +54,6 @@ def main():
         output_path.write_text(args.content)
         print(f'\n### {args.fragment.title()}\n * {args.content} ({basename})', file=sys.stderr)
         print(f'Successfully created the "{args.fragment.title()}" news fragment found by towncrier.\n', file=sys.stderr)
-
         sys.exit(0)
 
     for basename in files:


### PR DESCRIPTION
issue #742 

#### Description
- Add the python script `scripts/update-news-fragment.py` to handle the news fragments.
  - Check existence of the news fragment from the matching labels 
  - Create the news fragment by first assigned label when it does not exist.
  - Updates the news fragment by using the changed PR title
- Update `timeline-check.yml` action workflow to generate auto-commit, auto-push the news fragments

#### Question
- I didn't find a clear approach to retrieve the content of the previous PR title, so updated the news fragment for all cases when the PR title changes. 