### PR TITLE
fix: extra vfolder access restriction not applied

### DIFF
--- a/changes/766.fix.md
+++ b/changes/766.fix.md
@@ -1,0 +1,1 @@
+Fix extra vFolder access condition not applied when querying vFolder

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -294,6 +294,10 @@ async def query_accessible_vfolders(
             _query = _query.where(extra_vf_conds)
         if extra_vf_user_conds is not None:
             _query = _query.where(extra_vf_user_conds)
+        if extra_vfperm_conds is not None:
+            _query = _query.where(extra_vfperm_conds)
+        if extra_vf_group_conds is not None:
+            _query = _query.where(extra_vf_group_conds)
         result = await conn.execute(_query)
         for row in result:
             row_keys = row.keys()


### PR DESCRIPTION
This PR fixes extra vFolder access condition not applied when querying vFolder by using `query_accessible_vfolders()`.