### PR TITLE
feat: Let GraphQL queries filter ComputeSession by id

### DIFF
--- a/changes/772.feature.md
+++ b/changes/772.feature.md
@@ -1,0 +1,1 @@
+Expose `ComputeSession.id` to query filter to enable GraphQL queries filter items by list of id.

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -991,6 +991,7 @@ class ComputeSession(graphene.ObjectType):
         return [(await con.resolve_abusing_report(info, self.access_key)) for con in containers]
 
     _queryfilter_fieldspec = {
+        "id": ("kernels_id", None),
         "type": ("kernels_session_type", lambda s: SessionTypes[s]),
         "name": ("kernels_session_name", None),
         "image": ("kernels_image", None),


### PR DESCRIPTION
This PR enables GraphQL queries to filter `ComputeSession` items by `id`. It is necessary for fetching multiple `ComputeSession` items by a list of their `id`.

Related PRs
- https://github.com/lablup/backend.ai-batch-workflow/pull/139
