### PR TITLE
fix: skip resolving fields from dead agent

### DIFF
--- a/changes/775.fix.md
+++ b/changes/775.fix.md
@@ -1,0 +1,1 @@
+skip resolving fields from dead agent.

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -156,7 +156,10 @@ sizebytes_output_formatter = SizeBytesOutputFormatter()
 
 class AgentStatFormatter(OutputFormatter):
     def format_console(self, value: Any, field: FieldSpec) -> str:
-        raw_stats = json.loads(value)
+        try:
+            raw_stats = json.loads(value)
+        except TypeError:
+            return ""
 
         value_formatters = {
             "bytes": lambda m: "{} / {}".format(

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -597,7 +597,8 @@ class ModifyAgent(graphene.Mutation):
         set_if_set(props, data, "schedulable")
         set_if_set(props, data, "scaling_group")
         # TODO: Need to skip the following RPC call if the agent is not alive, or timeout.
-        await graph_ctx.registry.update_scaling_group(id, data["scaling_group"])
+        if (scaling_group := data.get("scaling_group")) is not None:
+            await graph_ctx.registry.update_scaling_group(id, scaling_group)
 
         update_query = sa.update(agents).values(data).where(agents.c.id == id)
         return await simple_db_mutate(cls, graph_ctx, update_query)

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -191,11 +191,15 @@ class Agent(graphene.ObjectType):
     async def resolve_hardware_metadata(
         self,
         info: graphene.ResolveInfo,
-    ) -> Mapping[str, HardwareMetadata]:
+    ) -> Mapping[str, HardwareMetadata] | None:
+        if self.status != AgentStatus.ALIVE:
+            return None
         graph_ctx: GraphQueryContext = info.context
         return await graph_ctx.registry.gather_agent_hwinfo(self.id)
 
-    async def resolve_local_config(self, info: graphene.ResolveInfo) -> Mapping[str, Any]:
+    async def resolve_local_config(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
+        if self.status != AgentStatus.ALIVE:
+            return None
         graph_ctx: GraphQueryContext = info.context
         return await graph_ctx.registry.get_agent_local_config(self.id, self.addr)
 


### PR DESCRIPTION
Managers try to resolve Agent's fields, whose status is not `ALIVE`.
Return `None` value before managers fetch RPC call to dead agents.