### PR TITLE
Fix missing tar-unpack before downloading single file from container

### DIFF
--- a/changes/778.fix.md
+++ b/changes/778.fix.md
@@ -1,0 +1,1 @@
+Unpack tar file before downloading Docker session's selected file.

--- a/changes/778.fix.md
+++ b/changes/778.fix.md
@@ -1,1 +1,1 @@
-Unpack tar file before downloading Docker session's selected file.
+Fix missing unpacking of the tar file before downloading a single file from a session container

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1917,6 +1917,9 @@ class AbstractAgent(
     async def download_file(self, kernel_id: KernelId, filepath: str):
         return await self.kernel_registry[kernel_id].download_file(filepath)
 
+    async def download_single(self, kernel_id: KernelId, filepath: str):
+        return await self.kernel_registry[kernel_id].download_single(filepath)
+
     async def list_files(self, kernel_id: KernelId, path: str):
         return await self.kernel_registry[kernel_id].list_files(path)
 

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -7,7 +7,6 @@ import os
 import re
 import shutil
 import subprocess
-import tarfile
 import textwrap
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Final, FrozenSet, Mapping, Optional, Sequence, Tuple
@@ -247,10 +246,9 @@ class DockerKernel(AbstractKernel):
                     if fsize > 1048576:
                         raise ValueError("too large file")
                     tarobj.fileobj.seek(0)
-                    tar = tarfile.open(mode="r", fileobj=tarobj.fileobj)
-                    extarobj = tar.extractfile(tar.getnames()[0])
-                    if extarobj:
-                        tarbytes = extarobj.read()
+                    inner_file = tarobj.extractfile(tarobj.getnames()[0])
+                    if inner_file:
+                        tarbytes = inner_file.read()
                     else:
                         log.warning("Could not found the file: {0}", abspath)
                         raise FileNotFoundError(f"Could not found the file: {abspath}")

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -247,20 +247,13 @@ class DockerKernel(AbstractKernel):
                     if fsize > 1048576:
                         raise ValueError("too large file")
                     tarobj.fileobj.seek(0)
-
-                    def extract_tarfile(tarobj, abspath) -> bytes:
-                        tar = tarfile.open(fileobj=tarobj.fileobj)
-                        extarobj = tar.extractfile(tar.getnames()[0])
-                        if extarobj:
-                            tarbytes = extarobj.read()
-                        else:
-                            log.warning("Could not found the file: {0}", abspath)
-                            raise FileNotFoundError(f"Could not found the file: {abspath}")
-                        tar.close()
-                        return tarbytes
-
-                    loop = current_loop()
-                    tarbytes = await loop.run_in_executor(None, extract_tarfile, tarobj, abspath)
+                    tar = tarfile.open(mode="r", fileobj=tarobj.fileobj)
+                    extarobj = tar.extractfile(tar.getnames()[0])
+                    if extarobj:
+                        tarbytes = extarobj.read()
+                    else:
+                        log.warning("Could not found the file: {0}", abspath)
+                        raise FileNotFoundError(f"Could not found the file: {abspath}")
             except DockerError:
                 log.warning("Could not found the file: {0}", abspath)
                 raise FileNotFoundError(f"Could not found the file: {abspath}")

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -245,6 +245,28 @@ class DockerKernel(AbstractKernel):
                     fsize = tarobj.fileobj.tell()
                     if fsize > 1048576:
                         raise ValueError("too large file")
+                    tarbytes = tarobj.fileobj.getvalue()
+            except DockerError:
+                log.warning("Could not found the file: {0}", abspath)
+                raise FileNotFoundError(f"Could not found the file: {abspath}")
+        return tarbytes
+
+    async def download_single(self, filepath: str):
+        container_id = self.data["container_id"]
+        async with closing_async(Docker()) as docker:
+            container = docker.containers.container(container_id)
+            home_path = PurePosixPath("/home/work")
+            try:
+                abspath = home_path / filepath
+                abspath.relative_to(home_path)
+            except ValueError:
+                raise PermissionError("You cannot download files outside /home/work")
+            try:
+                with await container.get_archive(str(abspath)) as tarobj:
+                    tarobj.fileobj.seek(0, 2)
+                    fsize = tarobj.fileobj.tell()
+                    if fsize > 1048576:
+                        raise ValueError("too large file")
                     tarobj.fileobj.seek(0)
                     inner_file = tarobj.extractfile(tarobj.getnames()[0])
                     if inner_file:

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -247,14 +247,20 @@ class DockerKernel(AbstractKernel):
                     if fsize > 1048576:
                         raise ValueError("too large file")
                     tarobj.fileobj.seek(0)
-                    tar = tarfile.open(fileobj=tarobj.fileobj)
-                    tarobj = tar.extractfile(tar.getnames()[0])
-                    if tarobj:
-                        tarbytes = tarobj.read()
-                    else:
-                        log.warning("Could not found the file: {0}", abspath)
-                        raise FileNotFoundError(f"Could not found the file: {abspath}")
-                    tar.close()
+
+                    def extract_tarfile(tarobj, abspath) -> bytes:
+                        tar = tarfile.open(fileobj=tarobj.fileobj)
+                        extarobj = tar.extractfile(tar.getnames()[0])
+                        if extarobj:
+                            tarbytes = extarobj.read()
+                        else:
+                            log.warning("Could not found the file: {0}", abspath)
+                            raise FileNotFoundError(f"Could not found the file: {abspath}")
+                        tar.close()
+                        return tarbytes
+
+                    loop = current_loop()
+                    tarbytes = await loop.run_in_executor(None, extract_tarfile, tarobj, abspath)
             except DockerError:
                 log.warning("Could not found the file: {0}", abspath)
                 raise FileNotFoundError(f"Could not found the file: {abspath}")

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -297,6 +297,10 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
+    async def download_single(self, filepath):
+        raise NotImplementedError
+
+    @abstractmethod
     async def list_files(self, path: str):
         raise NotImplementedError
 

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -262,7 +262,7 @@ class KubernetesKernel(AbstractKernel):
 
     async def download_single(self, filepath: str):
         # TODO: Implement download single file operations with pure Kubernetes API
-        log.error("Committing in Kubernetes is not supported yet.")
+        log.error("download_single() in the k8s backend is not supported yet.")
         raise NotImplementedError
 
     async def list_files(self, container_path: str):

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -260,6 +260,11 @@ class KubernetesKernel(AbstractKernel):
 
         return None
 
+    async def download_single(self, filepath: str):
+        # TODO: Implement download single file operations with pure Kubernetes API
+        log.error("Committing in Kubernetes is not supported yet.")
+        raise NotImplementedError
+
     async def list_files(self, container_path: str):
         # TODO: Implement file operations with pure Kubernetes API
         await kube_config.load_kube_config()

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -610,6 +610,12 @@ class AgentRPCServer(aobject):
 
     @rpc_function
     @collect_error
+    async def download_single(self, kernel_id: str, filepath: str):
+        log.info("rpc::download_single(k:{0}, fn:{1})", kernel_id, filepath)
+        return await self.agent.download_single(KernelId(UUID(kernel_id)), filepath)
+
+    @rpc_function
+    @collect_error
     async def list_files(self, kernel_id: str, path: str):
         log.info("rpc::list_files(k:{0}, fn:{1})", kernel_id, path)
         return await self.agent.list_files(KernelId(UUID(kernel_id)), path)

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -2298,7 +2298,7 @@ async def download_single(request: web.Request, params: Any) -> web.Response:
     )
     try:
         await root_ctx.registry.increment_session_usage(session_name, owner_access_key)
-        result = await root_ctx.registry.download_file(session_name, owner_access_key, file)
+        result = await root_ctx.registry.download_single(session_name, owner_access_key, file)
     except asyncio.CancelledError:
         raise
     except BackendError:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -357,6 +357,7 @@ class AgentRegistry:
             "shutdown_service": KernelExecutionFailed,
             "upload_file": KernelExecutionFailed,
             "download_file": KernelExecutionFailed,
+            "download_single": KernelExecutionFailed,
             "list_files": KernelExecutionFailed,
             "get_logs_from_agent": KernelExecutionFailed,
             "refresh_session": KernelExecutionFailed,
@@ -2411,6 +2412,23 @@ class AgentRegistry:
                 keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.download_file(str(kernel["id"]), filepath)
+
+    async def download_single(
+        self,
+        session_name_or_id: Union[str, SessionId],
+        access_key: AccessKey,
+        filepath: str,
+    ) -> bytes:
+        kernel = await self.get_session(session_name_or_id, access_key)
+        async with self.handle_kernel_exception("download_single", kernel["id"], access_key):
+            async with RPCContext(
+                kernel["agent"],
+                kernel["agent_addr"],
+                invoke_timeout=None,
+                order_key=kernel["id"],
+                keepalive_timeout=self.rpc_keepalive_timeout,
+            ) as rpc:
+                return await rpc.call.download_single(str(kernel["id"]), filepath)
 
     async def list_files(
         self,


### PR DESCRIPTION
Unpack tar file before downloading the Docker session's selected file If you want to select Docker session's file, It'll be downloaded after packing to tar archive.

So, I unpacked tar archived the selected Docker session file, and then processed to download it.

close https://github.com/lablup/backend.ai/issues/774

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
