### PR TITLE
fix: invalid previous tag added on changelog

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -173,6 +173,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Fetch remote tags
+      run: git fetch origin 'refs/tags/*:refs/tags/*'
     - name: Apply cache for Pants
       uses: actions/cache@v3
       id: cache

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -49,7 +49,7 @@ def main():
                 % (changelog_url, tag)
             )
             content += (
-                "\n\n### Full Commitlog\n\nCheck out [the full commit logs](%s) between release (%s) and (%s).\n"
+                "\n\n### Full Commit Logs\n\nCheck out [the full commit logs](%s) between release (%s) and (%s).\n"
                 % (commitlog_url, prev_tag, tag)
             )
             if not args.draft:


### PR DESCRIPTION
This PR fixes release changelog containing invalid (or empty) previous tag due to `action/checkout` action fetching only current tag info.