### PR TITLE
fix(xfs): error in getting vfolder inode usage

### DIFF
--- a/changes/789.fix
+++ b/changes/789.fix
@@ -1,0 +1,1 @@
+Error in getting vfolder inode usage by converting the human-readable string of `inode_size` to `inode_count` number.

--- a/src/ai/backend/storage/xfs/__init__.py
+++ b/src/ai/backend/storage/xfs/__init__.py
@@ -250,6 +250,7 @@ class XfsVolume(BaseVolume):
             raise ExecutionError("unexpected format for xfs_quota report")
         proj_name, used_size, _, _, _, _, inode_used, _, _, _, _ = report.split()
         used_bytes = int(BinarySize.finite_from_str(used_size))
+        inode_count = int(BinarySize.finite_from_str(inode_used))
         if not str(vfid).startswith(proj_name):
             raise ExecutionError("vfid and project name does not match")
-        return VFolderUsage(file_count=int(inode_used), used_bytes=used_bytes)
+        return VFolderUsage(file_count=inode_count, used_bytes=used_bytes)


### PR DESCRIPTION
For a virtual folder which is created on XFS with quota support, the call to `get_uasge` is failing since the `inode_size` is a humanized string (e.g.: `1.6k`) while `VFolderUsage` requires integers for both of its parameters:

```shell
ERROR Error handling request
Traceback (most recent call last):
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/ai/backend/storage/api/manager.py", line 42, in token_auth_middleware
    return await handler(request)
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/ai/backend/storage/api/manager.py", line 363, in get_vfolder_usage
    usage = await volume.get_usage(params["vfid"])
  File "/home/bai/.pyenv/versions/bai-22.09-storage-proxy/lib/python3.10/site-packages/ai/backend/storage/xfs/__init__.py", line 260, in get_usage
    return VFolderUsage(file_count=int(inode_used), used_bytes=used_bytes)
ValueError: invalid literal for int() with base 10: '1.6k'
```

This PR fixes this by converting the humanized string `inode_size` to `inode_count` number.