### PR TITLE
docs: Update outdated README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Backend.AI
 ==========
 
-[![PyPI release version](https://badge.fury.io/py/backend.ai.svg)](https://pypi.org/project/backend.ai/)
-![Supported Python versions](https://img.shields.io/pypi/pyversions/backend.ai.svg)
+[![PyPI version](https://badge.fury.io/py/backend.ai-manager.svg)](https://badge.fury.io/py/backend.ai-manager)
+![Supported Python versions](https://img.shields.io/pypi/pyversions/backend.ai-manager.svg)
 [![Gitter](https://badges.gitter.im/lablup/backend.ai.svg)](https://gitter.im/lablup/backend.ai)
 
 Backend.AI is a streamlined, container-based computing cluster orchestrator


### PR DESCRIPTION
Fix https://github.com/lablup/backend.ai/issues/793

Hello @kyujin-cho, how are you?
README badges are still pointing to the abandoned `backend.ai` pypi package after migration.
In contrast, `backend.ai-manager` is updated as noted by the issue. This will help to keep up with the latest changes to the mono-repo. I look forward to contributing more to your repo. Thank you.

Best regards,
won