### PR TITLE
fix: typo on session commit status API response

### DIFF
--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1341,7 +1341,7 @@ async def get_commit_status(request: web.Request, params: Mapping[str, Any]) -> 
     except BackendError:
         log.exception("GET_COMMIT_STATUS: exception")
         raise
-    resp = {"stats": status_info["status"], "kernel": status_info["kernel"]}
+    resp = {"status": status_info["status"], "kernel": status_info["kernel"]}
     return web.json_response(resp, status=200)
 
 


### PR DESCRIPTION
resolve https://github.com/lablup/backend.ai/issues/795

This will help resolve the confusion of getting a "stats" key with a value that represents status. Thank you.