### PR TITLE
misc: do not create subshell in executing `py` and `backend.ai` scripts

### DIFF
--- a/backend.ai
+++ b/backend.ai
@@ -1,2 +1,2 @@
 #! /bin/bash
-./py -m ai.backend.cli "$@"
+exec ./py -m ai.backend.cli "$@"

--- a/changes/819.misc
+++ b/changes/819.misc
@@ -1,0 +1,1 @@
+Do not create a subshell in executing the `py` and `backend.ai` scripts.

--- a/py
+++ b/py
@@ -15,4 +15,4 @@ PYTHONPATH="${PYTHONPATH}"
 for plugin_dir in $(ls -d plugins/*/ 2>/dev/null); do
   PYTHONPATH="${plugin_dir}/src:${PYTHONPATH}"
 done
-PYTHONPATH="src:${PYTHONPATH}" python "$@"
+PYTHONPATH="src:${PYTHONPATH}" exec python "$@"


### PR DESCRIPTION
When I launch the servers (manager, agent, storage-proxy, webserver) with the `systemd` services, I was unable to terminate the server processes via `systemctl stop` command. This is because the `py` and `backend.ai` spawn a child subshell to execute the python server modules, so the scripts, not the server modules, are the ones that receive the termination signal. Eventually, the script processes are terminated after `TimeoutStopSec`, but the python server processes have been kept alive by changing the parent process to the `init`.

To avoid this kind of inconvenience, I prefixed the `exec` command in `py` and `backend.ai` scripts.