### PR TITLE
fix: typo on session commit status API response

### DIFF
--- a/changes/821.fix.md
+++ b/changes/821.fix.md
@@ -1,0 +1,1 @@
+Fix a typo on response message to describe the status when calling GET session commit API

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1341,7 +1341,7 @@ async def get_commit_status(request: web.Request, params: Mapping[str, Any]) -> 
     except BackendError:
         log.exception("GET_COMMIT_STATUS: exception")
         raise
-    resp = {"stats": status_info["status"], "kernel": status_info["kernel"]}
+    resp = {"status": status_info["status"], "kernel": status_info["kernel"]}
     return web.json_response(resp, status=200)
 
 


### PR DESCRIPTION
### Describe a Bug
* macOS (Apple Silicon)
* Backend.AI version: 22.09.2
* Response of GET /session/{session_name}/commit API has typo
* Issue described in [here](https://github.com/lablup/backend.ai/issues/795)

### Change
* Change response message: `stats` -> `status`
* This will help resolve the confusion of getting a "stats" key with a value that represents status.

#### Before a change

![image](https://user-images.githubusercontent.com/43671025/197318050-0a993cdf-eeb5-42e1-a9b6-c6cab00dc21c.png)

#### After a change

<img width="598" alt="Screen Shot 2022-10-22 at 12 48 13 PM" src="https://user-images.githubusercontent.com/43671025/197318057-f9943bd3-2f3d-4826-b42f-3fe343a0a865.png">
