### PR TITLE
ci: Relabeling should trigger the default workflow to apply `skip:ci` semantics

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,6 +1,9 @@
 name: default
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
 
 jobs:
   lint:


### PR DESCRIPTION
Like the previously modified #659, the default workflow detects when the label is changed and operates again.
Otherwise, skip:ci will not be recognized when labeling after pr is created.