### PR TITLE
setup: Upgrade pants from 2.13.0rc0 to 2.13.1rc2

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.13.0rc0"
+pants_version = "2.13.1rc2"
 pythonpath = ["%(buildroot)s/tools/pants-plugins"]
 local_execution_root_dir="%(buildroot)s/.tmp"
 backend_packages = [


### PR DESCRIPTION
refs https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.13.x.md

There is nothing to do for most developers as Pants will automatically re-bootstrap itself, _except_ when you're on Linux aarch64 setups. In that case, you need to manually do:
```console
$ cd tools/pants-src
$ git fetch --tags
$ git checkout release_2.13.1rc2
$ cd ../..
$ ./pants-local version
```