### PR TITLE
ci: SBOM report manual trigger workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - uses: CycloneDX/gh-python-generate-sbom@v1
+    - uses: CycloneDX/gh-python-generate-sbom@v1.0.1
     - name: Upload SBOM report
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,6 +1,6 @@
 name: SBOM report
 
-on: [pull_request]
+on: [workflow_dispatch]
 
 jobs:
   sbom:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,7 +1,6 @@
 name: SBOM report
 
-on:
-  workflow_dispatch:
+on: [pull_request]
 
 jobs:
   sbom:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,42 @@
+name: SBOM report
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sbom:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Apply cache for Pants
+      uses: actions/cache@v3
+      id: cache
+      with:
+        # pants-specific cache
+        path: |
+          ~/.cache/pants/setup
+          ~/.cache/pants/lmdb_store
+          ~/.cache/pants/named_caches
+        key: ${{ runner.os }}-${{ hashFiles('pants*.toml', '**/*.lock') }}-
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
+        cache: pip
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - uses: CycloneDX/gh-python-generate-sbom@v1
+    - name: Upload SBOM report
+      uses: actions/upload-artifact@v3
+      with:
+        name: SBOM report
+        path: ./bom.xml


### PR DESCRIPTION
There are actions that are officially provided by CycloneDX, so we used the workflow.
In the case of the v1 version or v1.0.0 version specified in the readme, it is not compatible with the latest CycloneDX, so v1.0.1 version was applied.

https://github.com/CycloneDX/gh-python-generate-sbom/tree/v1.0.1
close #739 