### PR TITLE
fix: logical errors in calculating monthly stats

### DIFF
--- a/changes/840.fix.md
+++ b/changes/840.fix.md
@@ -1,0 +1,1 @@
+Modify `get_time_binned_monthly_stats` logic so that number of sessions and resource usage is calculated appropriately during all session execution times.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -585,11 +585,9 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
         rows = result.fetchall()
 
     # Build time-series of time-binned stats.
-    rowcount = len(rows)
     now_ts = now.timestamp()
     start_date_ts = start_date.timestamp()
     ts = start_date_ts
-    idx = 0
     tseries = []
     # Iterate over each time window.
     while ts < now_ts:
@@ -601,28 +599,28 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
         io_read_bytes = 0
         io_write_bytes = 0
         disk_used = 0
-        idx = 0
         # Accumulate stats for containers overlapping with this time window.
-        while idx < rowcount and ts + time_window > rows[idx].created_at.timestamp():
-            # Accumulate stats for overlapping containers in this time window.
-            if ts < rows[idx].terminated_at.timestamp():
-                row = rows[idx]
-                num_sessions += 1
-                cpu_allocated += int(row.occupied_slots.get("cpu", 0))
-                mem_allocated += int(row.occupied_slots.get("mem", 0))
-                if "cuda.devices" in row.occupied_slots:
-                    gpu_allocated += int(row.occupied_slots["cuda.devices"])
-                if "cuda.shares" in row.occupied_slots:
-                    gpu_allocated += Decimal(row.occupied_slots["cuda.shares"])
-                raw_stat = await redis_helper.execute(
-                    root_ctx.redis_stat, lambda r: r.get(str(row["id"]))
-                )
-                if raw_stat:
-                    last_stat = msgpack.unpackb(raw_stat)
-                    io_read_bytes += int(nmget(last_stat, "io_read.current", 0))
-                    io_write_bytes += int(nmget(last_stat, "io_write.current", 0))
-                    disk_used += int(nmget(last_stat, "io_scratch_size/stats.max", 0, "/"))
-            idx += 1
+        for row in rows:
+            if (
+                ts + time_window <= row.created_at.timestamp()
+                or ts >= row.terminated_at.timestamp()
+            ):
+                continue
+            num_sessions += 1
+            cpu_allocated += int(row.occupied_slots.get("cpu", 0))
+            mem_allocated += int(row.occupied_slots.get("mem", 0))
+            if "cuda.devices" in row.occupied_slots:
+                gpu_allocated += int(row.occupied_slots["cuda.devices"])
+            if "cuda.shares" in row.occupied_slots:
+                gpu_allocated += Decimal(row.occupied_slots["cuda.shares"])
+            raw_stat = await redis_helper.execute(
+                root_ctx.redis_stat, lambda r: r.get(str(row["id"]))
+            )
+            if raw_stat:
+                last_stat = msgpack.unpackb(raw_stat)
+                io_read_bytes += int(nmget(last_stat, "io_read.current", 0))
+                io_write_bytes += int(nmget(last_stat, "io_write.current", 0))
+                disk_used += int(nmget(last_stat, "io_scratch_size/stats.max", 0, "/"))
         stat = {
             "date": ts,
             "num_sessions": {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
this resolves #839 
Modify calculating monthly stats logic so that number of sessions and resource usage is calculated appropriately during all session execution times.