### PR TITLE
setup: Add `--ipc-base-path` option to install-dev.sh

### DIFF
--- a/changes/841.misc.md
+++ b/changes/841.misc.md
@@ -1,0 +1,1 @@
+Add `--ipc-base-path` option to `install-dev.sh` to ease setting up multiple development environments in a single node

--- a/configs/agent/halfstack.toml
+++ b/configs/agent/halfstack.toml
@@ -13,6 +13,7 @@ agent-sock-port = 6007
 scaling-group = "default"
 pid-file = "./agent.pid"
 event-loop = "uvloop"
+# ipc-base-path = "/tmp/backend.ai/ipc"
 var-base-path = "./var/lib/backend.ai"
 # allow-compute-plugins = []
 # block-compute-plugins = []

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -21,7 +21,7 @@ service-addr = { host = "0.0.0.0", port = 8081 }
 ssl-enabled = false
 #ssl-cert = "/etc/backend.ai/ssl/apiserver-fullchain.pem"   # env: BACKNED_SSL_CERT
 #ssl-privkey = "/etc/backend.ai/ssl/apiserver-privkey.pem"  # env: BACKNED_SSL_KEY
-
+# ipc-base-path = "/tmp/backend.ai/ipc"
 heartbeat-timeout = 10.0
 #id = ""
 pid-file = "./manager.pid"             # env: BACKEND_PID_FILE

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -67,6 +67,12 @@ heartbeat-timeout = 30.0
 # If set to an empty string, it does NOT create the PID file.
 # pid-file = "./manager.pid"             # env: BACKEND_PID_FILE
 
+# The base directory to put domain sockets for IPC.
+# Normally you don't have to change it.
+# NOTE: If Docker is installed via Snap (https://snapcraft.io/docker),
+#       you must change this to a directory under your *home* directory.
+# ipc-base-path = "/tmp/backend.ai/ipc"
+
 # The list of black-listed manager plugins.
 disabled-plugins = []
 

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -113,6 +113,10 @@ usage() {
   echo "  ${LWHITE}--ipc-base-path PATH${NC}"
   echo "    The base path for IPC sockets and shared temporary files."
   echo "    (default: /tmp/backend.ai/ipc)"
+  echo ""
+  echo "  ${LWHITE}--var-base-path PATH${NC}"
+  echo "    The base path for shared data files."
+  echo "    (default: ./var/lib/backend.ai)"
 }
 
 show_error() {
@@ -203,7 +207,6 @@ if [ ! -f "${ROOT_PATH}/BUILD_ROOT" ]; then
   echo "Please \`cd\` there and run \`./scripts/install-dev.sh <args>\`"
   exit 1
 fi
-VAR_BASE_PATH=$(relpath "${ROOT_PATH}/var/lib/backend.ai")
 PLUGIN_PATH=$(relpath "${ROOT_PATH}/plugins")
 HALFSTACK_VOLUME_PATH=$(relpath "${ROOT_PATH}/volumes")
 PANTS_VERSION=$(cat pants.toml | $bpython -c 'import sys,re;m=re.search("pants_version = \"([^\"]+)\"", sys.stdin.read());print(m.group(1) if m else sys.exit(1))')
@@ -230,6 +233,7 @@ WSPROXY_PORT="5050"
 AGENT_RPC_PORT="6011"
 AGENT_WATCHER_PORT="6019"
 IPC_BASE_PATH="/tmp/backend.ai/ipc"
+VAR_BASE_PATH=$(relpath "${ROOT_PATH}/var/lib/backend.ai")
 VFOLDER_REL_PATH="vfroot/local"
 LOCAL_STORAGE_PROXY="local"
 # MUST be one of the real storage volumes
@@ -263,6 +267,8 @@ while [ $# -gt 0 ]; do
     --agent-watcher-port=*) AGENT_WATCHER_PORT="${1#*=}" ;;
     --ipc-base-path)        IPC_BASE_PATH=$2; shift ;;
     --ipc-base-path=*)      IPC_BASE_PATH="${1#*=}" ;;
+    --var-base-path)        VAR_BASE_PATH=$2; shift ;;
+    --var-base-path=*)      VAR_BASE_PATH="${1#*=}" ;;
     --codespaces-on-create) CODESPACES_ON_CREATE=1 ;;
     --codespaces-post-create) CODESPACES_POST_CREATE=1 ;;
     *)
@@ -705,7 +711,7 @@ configure_backendai() {
   sed_inplace "s/port = 8120/port = ${ETCD_PORT}/" ./manager.toml
   sed_inplace "s/port = 8100/port = ${POSTGRES_PORT}/" ./manager.toml
   sed_inplace "s/port = 8081/port = ${MANAGER_PORT}/" ./manager.toml
-  sed_inplace "s@ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
+  sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
   cp configs/manager/halfstack.alembic.ini ./alembic.ini
   sed_inplace "s/localhost:8100/localhost:${POSTGRES_PORT}/" ./alembic.ini
   ./backend.ai mgr etcd put config/redis/addr "127.0.0.1:${REDIS_PORT}"
@@ -720,7 +726,8 @@ configure_backendai() {
   sed_inplace "s/port = 8120/port = ${ETCD_PORT}/" ./agent.toml
   sed_inplace "s/port = 6001/port = ${AGENT_RPC_PORT}/" ./agent.toml
   sed_inplace "s/port = 6009/port = ${AGENT_WATCHER_PORT}/" ./agent.toml
-  sed_inplace "s@ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
+  sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
+  sed_inplace "s@\(# \)\{0,1\}var-base-path = .*@var-base-path = "'"'"${VAR_BASE_PATH}"'"'"@" ./manager.toml
   if [ $ENABLE_CUDA -eq 1 ]; then
     sed_inplace "s/# allow-compute-plugins =.*/allow-compute-plugins = [\"ai.backend.accelerator.cuda_open\"]/" ./agent.toml
   elif [ $ENABLE_CUDA_MOCK -eq 1 ]; then
@@ -728,7 +735,6 @@ configure_backendai() {
   else
     sed_inplace "s/# allow-compute-plugins =.*/allow-compute-plugins = []/" ./agent.toml
   fi
-  sed_inplace 's@var-base-path = .*$@var-base-path = "'"${VAR_BASE_PATH}"'"@' ./agent.toml
 
   # configure storage-proxy
   cp configs/storage-proxy/sample.toml ./storage-proxy.toml

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -726,8 +726,8 @@ configure_backendai() {
   sed_inplace "s/port = 8120/port = ${ETCD_PORT}/" ./agent.toml
   sed_inplace "s/port = 6001/port = ${AGENT_RPC_PORT}/" ./agent.toml
   sed_inplace "s/port = 6009/port = ${AGENT_WATCHER_PORT}/" ./agent.toml
-  sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
-  sed_inplace "s@\(# \)\{0,1\}var-base-path = .*@var-base-path = "'"'"${VAR_BASE_PATH}"'"'"@" ./manager.toml
+  sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./agent.toml
+  sed_inplace "s@\(# \)\{0,1\}var-base-path = .*@var-base-path = "'"'"${VAR_BASE_PATH}"'"'"@" ./agent.toml
   if [ $ENABLE_CUDA -eq 1 ]; then
     sed_inplace "s/# allow-compute-plugins =.*/allow-compute-plugins = [\"ai.backend.accelerator.cuda_open\"]/" ./agent.toml
   elif [ $ENABLE_CUDA_MOCK -eq 1 ]; then

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -153,7 +153,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   if [ $(id -u) = "0" ]; then
     docker_sudo=''
   else
-    docker_sudo='sudo'
+    docker_sudo='sudo -E'
   fi
 else
   docker_sudo=''
@@ -161,7 +161,7 @@ fi
 if [ $(id -u) = "0" ]; then
   sudo=''
 else
-  sudo='sudo'
+  sudo='sudo -E'
 fi
 
 # Detect distribution

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -229,7 +229,7 @@ manager_local_config_iv = (
             ),
             t.Key("manager"): t.Dict(
                 {
-                    t.Key("ipc-base-path", default="/tmp/backend.ai/manager/ipc"): tx.Path(
+                    t.Key("ipc-base-path", default="/tmp/backend.ai/ipc"): tx.Path(
                         type="dir", auto_create=True
                     ),
                     t.Key("num-proc", default=_max_cpu_count): t.Int[1:_max_cpu_count],


### PR DESCRIPTION
When installing two or more agents/dev-setups in a single node, we need to be able to customize `ipc-base-path` of the manager and agent.

This PR also changes the manager's default `ipc-base-path` from `/tmp/backend.ai/manager/ipc` to `/tmp/backend.ai/ipc` for consistency.  As long as the manager instances are gracefully restarted upon updates, there should be no problems as the only content in the manager's IPC directory is the unix socket for relaying log records.

refs #496 -- Note that this PR does not implement the full requirements of #496 but only 
covers the update of `install-dev.sh` while assuming that the Docker daemon is separated.

It's a follow-up to lablup/backend.ai-agent#347.