### PR TITLE
fix: Change `ExitCode` into `IntEnum` to remove unintended console output upon errorneous exits

### DIFF
--- a/changes/845.fix.md
+++ b/changes/845.fix.md
@@ -1,0 +1,1 @@
+Modify to receive `enum.IntEnum` as an argument so that `sys.exit()` does not output a message.

--- a/changes/845.fix.md
+++ b/changes/845.fix.md
@@ -1,1 +1,1 @@
-Modify to receive `enum.IntEnum` as an argument so that `sys.exit()` does not output a message.
+Modify `ExitCode` to take `enum.IntEnum` as an argument so that `sys.exit()` does not output a message.

--- a/src/ai/backend/cli/types.py
+++ b/src/ai/backend/cli/types.py
@@ -9,7 +9,7 @@ class CliContextInfo:
     info: Dict = attr.field()
 
 
-class ExitCode(enum.Enum):
+class ExitCode(enum.IntEnum):
     OK = 0
     FAILURE = 1
     TIMEOUT = 2


### PR DESCRIPTION
close #844 
When sys.exit() receives a non-Int value as an argument, it is judged as a message and printed.
So, I modified the argument to receive enum.IntEnum.
refs. https://docs.python.org/3/library/sys.html#sys.exit
