### PR TITLE
fix: Serialization failures when returning kernel creation results

### DIFF
--- a/changes/849.fix.md
+++ b/changes/849.fix.md
@@ -1,0 +1,1 @@
+Fix serialization failures when returning kernel creation results with additional accelerator device information

--- a/python.lock
+++ b/python.lock
@@ -68,6 +68,7 @@
 //     "setproctitle~=1.2.2",
 //     "tabulate~=0.8.9",
 //     "tblib~=1.7",
+//     "temporenc~=0.1.0",
 //     "tenacity>=8.0",
 //     "tomli~=2.0.1",
 //     "tomlkit~=0.11.1",
@@ -574,23 +575,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "868a71704262834065ca7113d80b1f679609e2df77d837747e3d92150dd5a39b",
-              "url": "https://files.pythonhosted.org/packages/43/21/f390eec6d1559433a2fdf5f1532ddd4caf8316655d2453e7233ac4f30263/asyncpg-0.26.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "9654085f2b22f66952124de13a8071b54453ff972c25c59b5ce1173a4283ffd9",
+              "url": "https://files.pythonhosted.org/packages/6c/06/3a35225d0cb2b630faddbe5c97dcc85e6f3c72873428374795b9bee08fda/asyncpg-0.27.0-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e5bd99ee7a00e87df97b804f178f31086e88c8106aca9703b1d7be5078999e68",
-              "url": "https://files.pythonhosted.org/packages/00/2c/77e110cdcb0ed5b0cc60697454d9102284489d796b0e051565f4ea78c58c/asyncpg-0.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "720986d9a4705dd8a40fdf172036f5ae787225036a7eb46e704c45aa8f62c054",
+              "url": "https://files.pythonhosted.org/packages/04/78/06b4979eb2b553a450fe38008353f5cba152a66de83c64b1639046e9ca0e/asyncpg-0.27.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "2ed3880b3aec8bda90548218fe0914d251d641f798382eda39a17abfc4910af0",
-              "url": "https://files.pythonhosted.org/packages/92/6f/3a84d4525de4f6ccd4b87e2300fb121801721014e53855468c009e6a6ec9/asyncpg-0.26.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "a7a94c03386bb95456b12c66026b3a87d1b965f0f1e5733c36e7229f8f137747",
+              "url": "https://files.pythonhosted.org/packages/15/83/055b9aadaf23e8d4276e85208cf73c38b25ff931706e83c3a032ea84dc4c/asyncpg-0.27.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "77e684a24fee17ba3e487ca982d0259ed17bae1af68006f4cf284b23ba20ea2c",
-              "url": "https://files.pythonhosted.org/packages/e4/57/0a4c4d3f2307b12f633b28c370669d6115a1780416310ec536f01ace09ad/asyncpg-0.26.0.tar.gz"
+              "hash": "bfc3980b4ba6f97138b04f0d32e8af21d6c9fa1f8e6e140c07d15690a0a99279",
+              "url": "https://files.pythonhosted.org/packages/82/06/10eabd23fe4f6297726747964121cbfe6a9c9969dd1d5596302fd83a171b/asyncpg-0.27.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7a6206210c869ebd3f4eb9e89bea132aefb56ff3d1b7dd7e26b102b17e27bbb1",
+              "url": "https://files.pythonhosted.org/packages/df/7d/a6b3aa9c80791ec7daa358856bd7c9690eddfbde68408c13d2d8f3e9a3af/asyncpg-0.27.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fca608d199ffed4903dce1bcd97ad0fe8260f405c1c225bdf0002709132171c2",
+              "url": "https://files.pythonhosted.org/packages/e6/c9/7a361daeeec3ab9b63347a5629895099317003b1db9949536339848aea35/asyncpg-0.27.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20b596d8d074f6f695c13ffb8646d0b6bb1ab570ba7b0cfd349b921ff03cfc1e",
+              "url": "https://files.pythonhosted.org/packages/f3/66/b9efec66d97008fd0276382fdcb9ebd47e8c66484d4ae2feef67e7d482a9/asyncpg-0.27.0-cp310-cp310-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "asyncpg",
@@ -598,21 +614,19 @@
             "Cython<0.30.0,>=0.29.24; extra == \"dev\"",
             "Sphinx~=4.1.2; extra == \"dev\"",
             "Sphinx~=4.1.2; extra == \"docs\"",
-            "flake8~=3.9.2; extra == \"dev\"",
-            "flake8~=3.9.2; extra == \"test\"",
-            "pycodestyle~=2.7.0; extra == \"dev\"",
-            "pycodestyle~=2.7.0; extra == \"test\"",
+            "flake8~=5.0.4; extra == \"dev\"",
+            "flake8~=5.0.4; extra == \"test\"",
             "pytest>=6.0; extra == \"dev\"",
             "sphinx-rtd-theme~=0.5.2; extra == \"dev\"",
             "sphinx-rtd-theme~=0.5.2; extra == \"docs\"",
             "sphinxcontrib-asyncio~=0.3.0; extra == \"dev\"",
             "sphinxcontrib-asyncio~=0.3.0; extra == \"docs\"",
             "typing-extensions>=3.7.4.3; python_version < \"3.8\"",
-            "uvloop>=0.15.3; (platform_system != \"Windows\" and python_version >= \"3.7\") and extra == \"dev\"",
-            "uvloop>=0.15.3; (platform_system != \"Windows\" and python_version >= \"3.7\") and extra == \"test\""
+            "uvloop>=0.15.3; platform_system != \"Windows\" and extra == \"dev\"",
+            "uvloop>=0.15.3; platform_system != \"Windows\" and extra == \"test\""
           ],
-          "requires_python": ">=3.6.0",
-          "version": "0.26"
+          "requires_python": ">=3.7.0",
+          "version": "0.27"
         },
         {
           "artifacts": [
@@ -1061,58 +1075,58 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294",
-              "url": "https://files.pythonhosted.org/packages/da/81/330bf2ac32feb234096bfdebaae53888e95de8af01b88b6f477156569401/cryptography-38.0.1-cp36-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "25c1d1f19729fb09d42e06b4bf9895212292cb27bb50229f5aa64d039ab29146",
+              "url": "https://files.pythonhosted.org/packages/bf/96/bad32526aedc42309ef0eb5193a2802971dec3d088a49988d7fa326d7214/cryptography-38.0.3-cp36-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
-              "url": "https://files.pythonhosted.org/packages/1c/e5/1deb15c5c38bf0826c85e480cc05402553427663db9ae45e63ee3b06ba4d/cryptography-38.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd",
+              "url": "https://files.pythonhosted.org/packages/13/dd/a9608b7aebe5d2dc0c98a4b2090a6b815628efa46cc1c046b89d8cd25f4c/cryptography-38.0.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
-              "url": "https://files.pythonhosted.org/packages/4b/25/c995d4269baceab3288c89f74cb08788a973f8f293758934387ebacdef08/cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl"
+              "hash": "bbf203f1a814007ce24bd4d51362991d5cb90ba0c177a9c08825f2cc304d871f",
+              "url": "https://files.pythonhosted.org/packages/1e/da/7fcb7ac1caf8f7bb3f8099bf0075595ea681ab7c8fb82cfd2bd148cb3100/cryptography-38.0.3-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7",
-              "url": "https://files.pythonhosted.org/packages/6d/0c/5e67831007ba6cd7e52c4095f053cf45c357739b0a7c46a45ddd50049019/cryptography-38.0.1.tar.gz"
+              "hash": "728f2694fa743a996d7784a6194da430f197d5c58e2f4e278612b359f455e4a2",
+              "url": "https://files.pythonhosted.org/packages/37/19/234484df6fc7bdf4cf81cd4a89f600fce9f8f7a4bc1b307d7abbcd382b64/cryptography-38.0.3-cp36-abi3-manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd",
-              "url": "https://files.pythonhosted.org/packages/97/ff/d93aa93fe9052b1ab235eead370165387ff5057f961dd2798175243d47e4/cryptography-38.0.1-cp36-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "5419a127426084933076132d317911e3c6eb77568a1ce23c3ac1e12d111e61e0",
+              "url": "https://files.pythonhosted.org/packages/57/68/5fe4461ce8c0611eb09452e613512e1ddf62afcafc1ef4003d26345b3efe/cryptography-38.0.3-cp36-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0",
-              "url": "https://files.pythonhosted.org/packages/9b/4e/d7454551c3c7b327510e35d88db35c300484225ba47be861e28f0b520b33/cryptography-38.0.1-cp36-abi3-manylinux_2_24_x86_64.whl"
+              "hash": "9b24bcff7853ed18a63cfb0c2b008936a9554af24af2fb146e16d8e1aed75748",
+              "url": "https://files.pythonhosted.org/packages/6a/a6/45d1b0bea677172e3d50e02566fa6c9df813306765e6bc71ca551b3d1432/cryptography-38.0.3-cp36-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407",
-              "url": "https://files.pythonhosted.org/packages/a3/bc/37f2744e2a3c77c964ac1cf7dd651d289020d3b476603c3c18e50d5f2371/cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "dfb4f4dd568de1b6af9f4cda334adf7d72cf5bc052516e1b2608b683375dd95c",
+              "url": "https://files.pythonhosted.org/packages/6f/bd/c0459289c3ede4102ff65b6dda437c5b23833c360f0cf2b89a1c4a24f764/cryptography-38.0.3-cp36-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
-              "url": "https://files.pythonhosted.org/packages/c2/f5/5ca3e00f8131b2d6d70cd5fc54079c7e5c3a2c28f863bd3980bf4d6b970f/cryptography-38.0.1-cp36-abi3-macosx_10_10_universal2.whl"
+              "hash": "b1b52c9e5f8aa2b802d48bd693190341fae201ea51c7a167d69fc48b60e8a959",
+              "url": "https://files.pythonhosted.org/packages/bd/b4/2f8532124bda7470af31b6d9322b5bbb74e3bde94030f9b3a88450f12c8e/cryptography-38.0.3-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a",
-              "url": "https://files.pythonhosted.org/packages/c9/e7/9c7b7e8caef887a319e6492a30559c5136e305aae5885a8193c3a4e1dec6/cryptography-38.0.1-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "554bec92ee7d1e9d10ded2f7e92a5d70c1f74ba9524947c0ba0c850c7b011828",
+              "url": "https://files.pythonhosted.org/packages/c1/39/ff2c4dbddf50d79118a14eaba170ad80b65127201a566c359f76ffa34625/cryptography-38.0.3-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6",
-              "url": "https://files.pythonhosted.org/packages/d2/42/2b5be637a08a0d83057bbce4c2cd904271a6b2fb46b6cd4abcb6f2df222c/cryptography-38.0.1-cp36-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "ed7b00096790213e09eb11c97cc6e2b757f15f3d2f85833cd2d3ec3fe37c1722",
+              "url": "https://files.pythonhosted.org/packages/da/d0/af5cb66a892ec8a39d3089801fd8333fef5c335c33277591ef956ee1eba9/cryptography-38.0.3-cp36-abi3-macosx_10_10_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153",
-              "url": "https://files.pythonhosted.org/packages/d4/94/a3e3c06b318453a5943e6dfc84102248d27629d5ba037b3056ae3dae98af/cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+              "hash": "984fe150f350a3c91e84de405fe49e688aa6092b3525f407a18b9646f6612320",
+              "url": "https://files.pythonhosted.org/packages/fe/44/e5f4e5040491130f58d3ffbc3d21e917cced3e13faa126530109c18dee2e/cryptography-38.0.3-cp36-abi3-macosx_10_10_universal2.whl"
             }
           ],
           "project_name": "cryptography",
@@ -1140,7 +1154,7 @@
             "twine>=1.12.0; extra == \"docstest\""
           ],
           "requires_python": ">=3.6",
-          "version": "38.0.1"
+          "version": "38.0.3"
         },
         {
           "artifacts": [
@@ -1208,6 +1222,26 @@
           ],
           "requires_python": ">=3.10",
           "version": "0.1.13"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41",
+              "url": "https://files.pythonhosted.org/packages/de/4c/2854d9e3dcce78108126aa3634186a64ddbfd06d4d69af74954665529e52/exceptiongroup-1.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad",
+              "url": "https://files.pythonhosted.org/packages/4f/7e/eca80dbb5c10ec12ffb50884f52ecbff653cb5f443b0529244a748f114da/exceptiongroup-1.0.0.tar.gz"
+            }
+          ],
+          "project_name": "exceptiongroup",
+          "requires_dists": [
+            "pytest>=6; extra == \"test\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "1"
         },
         {
           "artifacts": [
@@ -1312,13 +1346,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "99510e664155f1a3c0396a076b5deb6367c52ea04d280152c85ac7f51f50eb42",
-              "url": "https://files.pythonhosted.org/packages/98/dc/ab7e2156ec6a33c66d85986178abc7944f40804d7558cd544ccb114af6a9/google_auth-2.13.0-py2.py3-none-any.whl"
+              "hash": "1ad5b0e6eba5f69645971abb3d2c197537d5914070a8c6d30299dfdb07c5c700",
+              "url": "https://files.pythonhosted.org/packages/6a/da/e02110f71cb3fc3134bd1984ed9a531557bdf32c8c34ed1d6a2ec33f88a6/google_auth-2.14.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9352dd6394093169157e6971526bab9a2799244d68a94a4a609f0dd751ef6f5e",
-              "url": "https://files.pythonhosted.org/packages/93/cd/e9136c12110ec50ddab676c6cb35f913566120c503730820905f64a11230/google-auth-2.13.0.tar.gz"
+              "hash": "cf24817855d874ede2efd071aa22125445f555de1685b739a9782fcf408c2a3d",
+              "url": "https://files.pythonhosted.org/packages/e5/f9/47e309e4df306111d94ae8879c5677fa41f92f4e1fe4a33141086057dcff/google-auth-2.14.0.tar.gz"
             }
           ],
           "project_name": "google-auth",
@@ -1337,7 +1371,7 @@
             "six>=1.9.0"
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "2.13"
+          "version": "2.14"
         },
         {
           "artifacts": [
@@ -1435,46 +1469,49 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "60839ab4ea7de6139a3be35b77e22e0398c270020050458b3d25db4c7c394df5",
-              "url": "https://files.pythonhosted.org/packages/5b/9f/ab2bb73975df5d234b5cc5283597cc773487f471f24f6646335660d36a12/greenlet-1.1.3.post0-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "1cfeae4dda32eb5c64df05d347c4496abfa57ad16a90082798a2bba143c6c854",
+              "url": "https://files.pythonhosted.org/packages/cb/3a/bb0efd3cd2ad01fe14b0115c4287418d90d8620e2d4aa6c1567e3ba2d122/greenlet-2.0.0-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a812df7282a8fc717eafd487fccc5ba40ea83bb5b13eb3c90c446d88dbdfd2be",
-              "url": "https://files.pythonhosted.org/packages/3c/19/ae42cfb96a20e3b5bc0ebb1a9ce42940de1b522414396bad1d5d1abfa93a/greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "a245898ec5e9ca0bc87a63e4e222cc633dc4d1f1a0769c34a625ad67edb9f9de",
+              "url": "https://files.pythonhosted.org/packages/1c/af/2e58e43c1ca24b5cb286a3b17ede6512d23f7a0c83c81d88bed8c0f87a60/greenlet-2.0.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83a7a6560df073ec9de2b7cb685b199dfd12519bc0020c62db9d1bb522f989fa",
-              "url": "https://files.pythonhosted.org/packages/77/77/206360c55000e29c1509899df7b2edb9e9a1fa01bb013bdaebd0a9837252/greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3dc294afebf2acfd029373dbf3d01d36fd8d6888a03f5a006e2d690f66b153d9",
+              "url": "https://files.pythonhosted.org/packages/20/f8/8d331619f4cbc7d74458613686b4deaf78d7975f98f421e77ea237cc1916/greenlet-2.0.0-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f6661b58412879a2aa099abb26d3c93e91dedaba55a6394d1fb1512a77e85de9",
-              "url": "https://files.pythonhosted.org/packages/7c/c9/a4d77c0d9395a48560154470bbd79f14960ad4b6a16a10233881ca384d2d/greenlet-1.1.3.post0-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "6c66f0da8049ee3c126b762768179820d4c0ae0ca46ae489039e4da2fae39a52",
+              "url": "https://files.pythonhosted.org/packages/23/6f/f72865c589d0c79f03b51520a4cdd65647de0513e9ad107a5731df89c235/greenlet-2.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "17a69967561269b691747e7f436d75a4def47e5efcbc3c573180fc828e176d80",
-              "url": "https://files.pythonhosted.org/packages/af/3f/8c27cce2330959125cc707fa1c835d415dc45c1f566b2f8504cc3a6d266e/greenlet-1.1.3.post0-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "adcf45221f253b3a681c99da46fa6ac33596fa94c2f30c54368f7ee1c4563a39",
+              "url": "https://files.pythonhosted.org/packages/25/00/a8dbe88bfc98d6ff31d75107691c17470280d272020714a24d282de78e76/greenlet-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2c6e942ca9835c0b97814d14f78da453241837419e0d26f7403058e8db3e38f8",
-              "url": "https://files.pythonhosted.org/packages/bf/a9/374f33142e3b6058f1403f15289f0b4ffd3fc067982c16fef5489a7f2e39/greenlet-1.1.3.post0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "f7edbd2957f72aea357241fe42ffc712a8e9b8c2c42f24e2ef5d97b255f66172",
+              "url": "https://files.pythonhosted.org/packages/a0/18/e70f2694a8dfdde0cba93926bc37c4a09ce0a5e603f659e766bbe1ff0b7a/greenlet-2.0.0-cp310-cp310-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f5e09dc5c6e1796969fd4b775ea1417d70e49a5df29aaa8e5d10675d9e11872c",
-              "url": "https://files.pythonhosted.org/packages/ea/37/e54ce453b298e890f59dba3db32461579328a07d5b65e3eabf80f971c099/greenlet-1.1.3.post0.tar.gz"
+              "hash": "79687c48e7f564be40c46b3afea6d141b8d66ffc2bc6147e026d491c6827954a",
+              "url": "https://files.pythonhosted.org/packages/d0/38/f8882b1758e64ba61687e0c2b73dfe6214a680c97d35c093fd251da258bc/greenlet-2.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "greenlet",
           "requires_dists": [
-            "Sphinx; extra == \"docs\""
+            "Sphinx; extra == \"docs\"",
+            "docutils<0.18; python_version < \"3\" and extra == \"docs\"",
+            "faulthandler; (python_version == \"2.7\" and platform_python_implementation == \"CPython\") and extra == \"test\"",
+            "objgraph; extra == \"test\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.1.3.post0"
+          "version": "2"
         },
         {
           "artifacts": [
@@ -1605,8 +1642,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8777703e8e1d54bcc1e30294104f626d66b30a8e32ee8c79d3587ff92f9c87fc",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-linux_x86_64.whl"
+              "hash": "5b4bdda35b40105b4ee3c87c72393496bec5e7f333befdcdd623511bf2684307",
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1620,13 +1657,13 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "951e212c2e5e7328246f241d17d94e5eaef81c639a7d48164f451694ff99b157",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "8777703e8e1d54bcc1e30294104f626d66b30a8e32ee8c79d3587ff92f9c87fc",
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-linux_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b4bdda35b40105b4ee3c87c72393496bec5e7f333befdcdd623511bf2684307",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-macosx_12_0_arm64.whl"
+              "hash": "951e212c2e5e7328246f241d17d94e5eaef81c639a7d48164f451694ff99b157",
+              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/hiredis/hiredis-1.1.0-cp310-cp310-macosx_10_15_x86_64.whl"
             }
           ],
           "project_name": "hiredis",
@@ -2586,13 +2623,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
-              "url": "https://files.pythonhosted.org/packages/e3/b9/3541bbcb412a9fd56593005ff32183825634ef795a1c01ceb6dee86e7259/pytest-7.1.3-py3-none-any.whl"
+              "hash": "892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
+              "url": "https://files.pythonhosted.org/packages/67/68/a5eb36c3a8540594b6035e6cdae40c1ef1b6a2bfacbecc3d1a544583c078/pytest-7.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39",
-              "url": "https://files.pythonhosted.org/packages/a4/a7/8c63a4966935b0d0b039fd67ebf2e1ae00f1af02ceb912d838814d772a9a/pytest-7.1.3.tar.gz"
+              "hash": "c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59",
+              "url": "https://files.pythonhosted.org/packages/0b/21/055f39bf8861580b43f845f9e8270c7786fe629b2f8562ff09007132e2e7/pytest-7.2.0.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -2600,6 +2637,7 @@
             "argcomplete; extra == \"testing\"",
             "attrs>=19.2.0",
             "colorama; sys_platform == \"win32\"",
+            "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
             "hypothesis>=3.56; extra == \"testing\"",
             "importlib-metadata>=0.12; python_version < \"3.8\"",
             "iniconfig",
@@ -2607,14 +2645,13 @@
             "nose; extra == \"testing\"",
             "packaging",
             "pluggy<2.0,>=0.12",
-            "py>=1.8.2",
             "pygments>=2.7.2; extra == \"testing\"",
             "requests; extra == \"testing\"",
-            "tomli>=1.0.0",
+            "tomli>=1.0.0; python_version < \"3.11\"",
             "xmlschema; extra == \"testing\""
           ],
           "requires_python": ">=3.7",
-          "version": "7.1.3"
+          "version": "7.2"
         },
         {
           "artifacts": [
@@ -3329,19 +3366,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7",
-              "url": "https://files.pythonhosted.org/packages/df/b6/310fe14933403413f7352be0c8e75b7ed23db2170d769ed69e40f40130a3/tomlkit-0.11.5-py3-none-any.whl"
+              "hash": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
+              "url": "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c",
-              "url": "https://files.pythonhosted.org/packages/0c/2b/7823f215c6aec294f5ab5ff2f529aca1d85e8bec2208ae7ea89ca1413620/tomlkit-0.11.5.tar.gz"
+              "hash": "71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73",
+              "url": "https://files.pythonhosted.org/packages/ff/04/58b4c11430ed4b7b8f1723a5e4f20929d59361e9b17f0872d69681fd8ffd/tomlkit-0.11.6.tar.gz"
             }
           ],
           "project_name": "tomlkit",
           "requires_dists": [],
-          "requires_python": "<4.0,>=3.6",
-          "version": "0.11.5"
+          "requires_python": ">=3.6",
+          "version": "0.11.6"
         },
         {
           "artifacts": [
@@ -3529,19 +3566,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "29228db9f82df4f1b7febee06bbfb601677882e98a3da98132e31c6874163e15",
-              "url": "https://files.pythonhosted.org/packages/1d/14/1b89f3003c0718c0a48626699837947783cb670d023bc85a6a92261ee695/types_PyYAML-6.0.12-py3-none-any.whl"
+              "hash": "aaf5e51444c13bd34104695a89ad9c48412599a4f615d65a60e649109714f608",
+              "url": "https://files.pythonhosted.org/packages/c5/e2/263bb5d8ad3e3027e92a7cd2cca64942163416cd7d8bbd6810c924b673dd/types_PyYAML-6.0.12.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f6f350418125872f3f0409d96a62a5a5ceb45231af5cc07ee0034ec48a3c82fa",
-              "url": "https://files.pythonhosted.org/packages/d3/47/e1941cf017d2dbf4411f6c8a3932f72eb900572ced7d0ac5d5bab1145357/types-PyYAML-6.0.12.tar.gz"
+              "hash": "70ccaafcf3fb404d57bffc1529fdd86a13e8b4f2cf9fc3ee81a6408ce0ad59d2",
+              "url": "https://files.pythonhosted.org/packages/38/e5/49cea32633e9425589f913a9fecb47ab3fe363bf1d3c431961842b454b74/types-PyYAML-6.0.12.1.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
           "requires_python": null,
-          "version": "6.0.12"
+          "version": "6.0.12.1"
         },
         {
           "artifacts": [
@@ -3992,6 +4029,7 @@
     "setproctitle~=1.2.2",
     "tabulate~=0.8.9",
     "tblib~=1.7",
+    "temporenc~=0.1.0",
     "tenacity>=8.0",
     "tomli~=2.0.1",
     "tomlkit~=0.11.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ rich~=12.2
 SQLAlchemy[postgresql_asyncpg]~=1.4.40
 setproctitle~=1.2.2
 tabulate~=0.8.9
+temporenc~=0.1.0
 tblib~=1.7
 tenacity>=8.0
 tomli~=2.0.1

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -45,7 +45,7 @@ from typing import (
 from uuid import UUID
 
 import aiotools
-import attr
+import attrs
 import pkg_resources
 import snappy
 import zmq
@@ -93,7 +93,6 @@ from ai.backend.common.types import (
     ClusterInfo,
     ContainerId,
     DeviceId,
-    DeviceModelInfo,
     DeviceName,
     HardwareMetadata,
     ImageRegistry,
@@ -488,14 +487,14 @@ KernelCreationContextType = TypeVar(
 )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attrs.define(auto_attribs=True, slots=True)
 class RestartTracker:
     request_lock: asyncio.Lock
     destroy_event: asyncio.Event
     done_event: asyncio.Event
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attrs.define(auto_attribs=True, slots=True)
 class ComputerContext:
     instance: AbstractComputePlugin
     devices: Collection[AbstractComputeDevice]
@@ -946,7 +945,7 @@ class AbstractAgent(
                 if isinstance(ev, Sentinel):
                     await self.save_last_registry(force=True)
                     return
-                # attr currently does not support customizing getstate/setstate dunder methods
+                # attrs currently does not support customizing getstate/setstate dunder methods
                 # until the next release.
                 if self.local_config["debug"]["log-events"]:
                     log.info(f"lifecycle event: {ev!r}")
@@ -1502,18 +1501,11 @@ class AbstractAgent(
         await ctx.process_mounts(resource_spec.mounts)
 
         # Get attached devices information (including model_name).
-        serialized_attached_devices = {}
+        attached_devices = {}
         for dev_name, device_alloc in resource_spec.allocations.items():
             computer_set = self.computers[dev_name]
             devices = await computer_set.instance.get_attached_devices(device_alloc)
-            serialized_attached_devices[dev_name] = [
-                DeviceModelInfo(
-                    device_id=str(device_info["device_id"]),
-                    model_name=device_info["model_name"],
-                    data=device_info["data"],
-                )
-                for device_info in devices
-            ]
+            attached_devices[dev_name] = devices
 
         exposed_ports = [2000, 2001]
         service_ports = []
@@ -1590,7 +1582,7 @@ class AbstractAgent(
 
         if self.local_config["debug"]["log-kernel-config"]:
             log.info(
-                "kernel starting with resource spec: \n{0}", pretty(attr.asdict(resource_spec))
+                "kernel starting with resource spec: \n{0}", pretty(attrs.asdict(resource_spec))
             )
         kernel_obj: KernelObjectType = await ctx.spawn(
             resource_spec,
@@ -1671,8 +1663,8 @@ class AbstractAgent(
             "stdout_port": kernel_obj["stdout_port"],  # legacy
             "service_ports": service_ports,
             "container_id": kernel_obj["container_id"],
-            "resource_spec": resource_spec.to_json_serializable_dict(),
-            "attached_devices": serialized_attached_devices,
+            "resource_spec": attrs.asdict(resource_spec),
+            "attached_devices": attached_devices,
         }
 
     @abstractmethod

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -93,6 +93,7 @@ from ai.backend.common.types import (
     ClusterInfo,
     ContainerId,
     DeviceId,
+    DeviceModelInfo,
     DeviceName,
     HardwareMetadata,
     ImageRegistry,
@@ -1501,11 +1502,18 @@ class AbstractAgent(
         await ctx.process_mounts(resource_spec.mounts)
 
         # Get attached devices information (including model_name).
-        attached_devices = {}
+        serialized_attached_devices = {}
         for dev_name, device_alloc in resource_spec.allocations.items():
             computer_set = self.computers[dev_name]
             devices = await computer_set.instance.get_attached_devices(device_alloc)
-            attached_devices[dev_name] = devices
+            serialized_attached_devices[dev_name] = [
+                DeviceModelInfo(
+                    device_id=str(device_info["device_id"]),
+                    model_name=device_info["model_name"],
+                    data=device_info["data"],
+                )
+                for device_info in devices
+            ]
 
         exposed_ports = [2000, 2001]
         service_ports = []
@@ -1664,7 +1672,7 @@ class AbstractAgent(
             "service_ports": service_ports,
             "container_id": kernel_obj["container_id"],
             "resource_spec": resource_spec.to_json_serializable_dict(),
-            "attached_devices": attached_devices,
+            "attached_devices": serialized_attached_devices,
         }
 
     @abstractmethod

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -30,7 +30,7 @@ from typing import (
 )
 
 import aiodocker
-import attr
+import attrs
 
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.plugin import AbstractPlugin, BasePluginContext
@@ -80,7 +80,7 @@ class AllocationStrategy(enum.Enum):
     EVENLY = 1
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attrs.define(auto_attribs=True, slots=True)
 class KernelResourceSpec:
     """
     This struct-like object stores the kernel resource allocation information
@@ -104,7 +104,7 @@ class KernelResourceSpec:
     scratch_disk_size: int
     """The size of scratch disk. (not implemented yet)"""
 
-    mounts: List["Mount"] = attr.Factory(list)
+    mounts: List["Mount"] = attrs.Factory(list)
     """The mounted vfolder list."""
 
     def freeze(self) -> None:
@@ -208,7 +208,7 @@ class KernelResourceSpec:
         return cls.read_from_string(text)
 
     def to_json_serializable_dict(self) -> Mapping[str, Any]:
-        o = attr.asdict(self)
+        o = attrs.asdict(self)
         for slot_name, alloc in o["slots"].items():
             if known_slot_types.get(slot_name, "count") == "bytes":
                 o["slots"] = f"{BinarySize(alloc):s}"
@@ -235,7 +235,7 @@ class KernelResourceSpec:
         return json.dumps(self.to_json_serializable_dict())
 
 
-@attr.s(auto_attribs=True)
+@attrs.define(auto_attribs=True)
 class AbstractComputeDevice:
     device_id: DeviceId
     hw_location: str  # either PCI bus ID or arbitrary string
@@ -413,7 +413,7 @@ class ComputePluginContext(BasePluginContext[AbstractComputePlugin]):
         self.plugins[plugin.key] = plugin
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attrs.define(auto_attribs=True, slots=True)
 class Mount:
     type: MountTypes
     source: Optional[Path]
@@ -444,7 +444,7 @@ class Mount:
         return cls(type, source, target, perm, None)
 
 
-@attr.s(auto_attribs=True)
+@attrs.define(auto_attribs=True)
 class DeviceSlotInfo:
     slot_type: SlotTypes
     slot_name: SlotName

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -214,14 +214,20 @@ class KernelResourceSpec:
                 o["slots"] = f"{BinarySize(alloc):s}"
             else:
                 o["slots"] = str(alloc)
+        serialized_allocations = {}
         for dev_name, dev_alloc in o["allocations"].items():
+            serialized_dev_alloc = {}
             for slot_name, per_device_alloc in dev_alloc.items():
+                serialized_per_device_alloc = {}
                 for dev_id, alloc in per_device_alloc.items():
                     if known_slot_types.get(slot_name, "count") == "bytes":
-                        alloc = f"{BinarySize(alloc):s}"
+                        serialized_alloc = f"{BinarySize(alloc):s}"
                     else:
-                        alloc = str(alloc)
-                    o["allocations"][dev_name][slot_name][dev_id] = alloc
+                        serialized_alloc = str(alloc)
+                    serialized_per_device_alloc[str(dev_id)] = serialized_alloc
+                serialized_dev_alloc[str(slot_name)] = serialized_per_device_alloc
+            serialized_allocations[str(dev_name)] = serialized_dev_alloc
+        o["allocations"] = serialized_allocations
         o["mounts"] = list(map(str, self.mounts))
         return o
 

--- a/src/ai/backend/common/msgpack.py
+++ b/src/ai/backend/common/msgpack.py
@@ -2,16 +2,54 @@
 Wrapper of msgpack-python with good defaults.
 """
 
+import datetime
+import enum
+import pickle
+import uuid
+from decimal import Decimal
 from typing import Any
 
 import msgpack as _msgpack
+import temporenc
+
+__all__ = ("packb", "unpackb")
+
+
+class ExtTypes(enum.IntEnum):
+    # We can define up to 255 extension type identifiers.
+    UUID = 1
+    DATETIME = 16
+    DECIMAL = 32
+    BINARY_SIZE = 33
+
+
+def _default(obj: object) -> _msgpack.ExtType:
+    match obj:
+        case uuid.UUID():
+            return _msgpack.ExtType(ExtTypes.UUID, obj.bytes)
+        case datetime.datetime():
+            return _msgpack.ExtType(ExtTypes.DATETIME, temporenc.packb(obj))
+        case Decimal():
+            return _msgpack.ExtType(ExtTypes.DECIMAL, pickle.dumps(obj, protocol=5))
+    raise TypeError("Unknown type: %r" % (obj,))
+
+
+def _ext_hook(code: int, data: bytes) -> Any:
+    match code:
+        case ExtTypes.UUID:
+            return uuid.UUID(bytes=data)
+        case ExtTypes.DATETIME:
+            return temporenc.unpackb(data).datetime()
+        case ExtTypes.DECIMAL:
+            return pickle.loads(data)
+    return _msgpack.ExtType(code, data)
 
 
 def packb(data: Any, **kwargs) -> bytes:
     opts = {"use_bin_type": True, **kwargs}
-    return _msgpack.packb(data, **opts)
+    return _msgpack.packb(data, default=_default, **opts)
 
 
 def unpackb(packed: bytes, **kwargs) -> Any:
     opts = {"raw": False, "use_list": False, **kwargs}
-    return _msgpack.unpackb(packed, **opts)
+    return _msgpack.unpackb(packed, ext_hook=_ext_hook, **opts)

--- a/src/ai/backend/common/msgpack.py
+++ b/src/ai/backend/common/msgpack.py
@@ -4,34 +4,51 @@ Wrapper of msgpack-python with good defaults.
 
 import datetime
 import enum
+import os
 import pickle
 import uuid
 from decimal import Decimal
+from pathlib import PosixPath, PurePosixPath
 from typing import Any
 
 import msgpack as _msgpack
 import temporenc
 
+from .types import BinarySize
+
 __all__ = ("packb", "unpackb")
 
 
 class ExtTypes(enum.IntEnum):
-    # We can define up to 255 extension type identifiers.
+    # We can define up to 128 extension type identifiers.
     UUID = 1
-    DATETIME = 16
-    DECIMAL = 32
-    BINARY_SIZE = 33
+    DATETIME = 2
+    DECIMAL = 3
+    POSIX_PATH = 4
+    PURE_POSIX_PATH = 5
+    ENUM = 6
+    BACKENDAI_BINARY_SIZE = 16
 
 
-def _default(obj: object) -> _msgpack.ExtType:
+def _default(obj: object) -> Any:
     match obj:
+        case tuple():
+            return list(obj)
         case uuid.UUID():
             return _msgpack.ExtType(ExtTypes.UUID, obj.bytes)
         case datetime.datetime():
             return _msgpack.ExtType(ExtTypes.DATETIME, temporenc.packb(obj))
+        case BinarySize():
+            return _msgpack.ExtType(ExtTypes.BACKENDAI_BINARY_SIZE, pickle.dumps(obj, protocol=5))
         case Decimal():
             return _msgpack.ExtType(ExtTypes.DECIMAL, pickle.dumps(obj, protocol=5))
-    raise TypeError("Unknown type: %r" % (obj,))
+        case PosixPath():
+            return _msgpack.ExtType(ExtTypes.POSIX_PATH, os.fsencode(obj))
+        case PurePosixPath():
+            return _msgpack.ExtType(ExtTypes.PURE_POSIX_PATH, os.fsencode(obj))
+        case enum.Enum():
+            return _msgpack.ExtType(ExtTypes.ENUM, pickle.dumps(obj, protocol=5))
+    raise TypeError(f"Unknown type: {obj!r} ({type(obj)})")
 
 
 def _ext_hook(code: int, data: bytes) -> Any:
@@ -42,14 +59,31 @@ def _ext_hook(code: int, data: bytes) -> Any:
             return temporenc.unpackb(data).datetime()
         case ExtTypes.DECIMAL:
             return pickle.loads(data)
+        case ExtTypes.POSIX_PATH:
+            return PosixPath(os.fsdecode(data))
+        case ExtTypes.PURE_POSIX_PATH:
+            return PurePosixPath(os.fsdecode(data))
+        case ExtTypes.ENUM:
+            return pickle.loads(data)
+        case ExtTypes.BACKENDAI_BINARY_SIZE:
+            return pickle.loads(data)
     return _msgpack.ExtType(code, data)
 
 
 def packb(data: Any, **kwargs) -> bytes:
-    opts = {"use_bin_type": True, **kwargs}
+    opts = {
+        "use_bin_type": True,  # bytes -> bin type (default for Python 3)
+        "strict_types": True,  # do not serialize subclasses using superclasses
+        **kwargs,
+    }
     return _msgpack.packb(data, default=_default, **opts)
 
 
 def unpackb(packed: bytes, **kwargs) -> Any:
-    opts = {"raw": False, "use_list": False, **kwargs}
+    opts = {
+        "raw": False,  # assume str as UTF-8 (default for Python 3)
+        "strict_map_key": False,  # allow using UUID as map keys
+        "use_list": False,  # array -> tuple
+        **kwargs,
+    }
     return _msgpack.unpackb(packed, ext_hook=_ext_hook, **opts)

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -825,7 +825,7 @@ class ClusterSSHKeyPair(TypedDict):
 
 
 class DeviceModelInfo(TypedDict):
-    device_id: DeviceId
+    device_id: DeviceId | str
     model_name: str
     data: Mapping[str, Any]
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1366,9 +1366,12 @@ class AgentRegistry:
             for slot_name, allocation_by_device in alloc_map.items():
                 total_allocs: List[Decimal] = []
                 for allocation in allocation_by_device.values():
-                    if BinarySize.suffix_map.get(allocation[-1].lower()) is not None:
+                    if (
+                        isinstance(allocation, BinarySize)
+                        and BinarySize.suffix_map.get(allocation[-1].lower()) is not None
+                    ):
                         total_allocs.append(Decimal(BinarySize.from_str(allocation)))
-                    else:
+                    else:  # maybe Decimal("Infinity"), etc.
                         total_allocs.append(Decimal(allocation))
                 slots[slot_name] = str(sum(total_allocs))
         return slots

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1367,7 +1367,7 @@ class AgentRegistry:
                 total_allocs: List[Decimal] = []
                 for allocation in allocation_by_device.values():
                     if (
-                        isinstance(allocation, BinarySize)
+                        isinstance(allocation, (BinarySize, str))
                         and BinarySize.suffix_map.get(allocation[-1].lower()) is not None
                     ):
                         total_allocs.append(Decimal(BinarySize.from_str(allocation)))

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -62,22 +62,22 @@ def test_msgpack_datetime():
     unpacked = msgpack.unpackb(packed)
     t = unpacked["timestamp"]
     assert isinstance(t, datetime)
-    assert t.tzinfo is not None
-    tzname = t.tzname()
-    assert tzname is not None
-    assert tzname.startswith("UTC")  # should be always UTC
+    if t.tzinfo is not None:
+        tzname = t.tzname()
+        assert tzname is not None
+        assert tzname.startswith("UTC")  # should be always UTC
     assert t == now
 
-    now = datetime.now(gettz("KST"))
+    now = datetime.now(gettz("Asia/Seoul"))
     data = {"timestamp": now}
     packed = msgpack.packb(data)
     unpacked = msgpack.unpackb(packed)
     t = unpacked["timestamp"]
     assert isinstance(t, datetime)
-    assert t.tzinfo is not None
-    tzname = t.tzname()
-    assert tzname is not None
-    assert tzname.startswith("UTC")  # should be always UTC
+    if t.tzinfo is not None:
+        tzname = t.tzname()
+        assert tzname is not None
+        assert tzname.startswith("UTC")  # should be always UTC
     assert t == now
 
 

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -1,4 +1,11 @@
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from dateutil.tz import tzutc
+
 from ai.backend.common import msgpack
+from ai.backend.common.types import BinarySize
 
 
 def test_msgpack_with_unicode():
@@ -27,3 +34,48 @@ def test_msgpack_kwargs():
     assert isinstance(unpacked["mem"], list)
     assert isinstance(unpacked["cuda_mem"], list)
     assert isinstance(unpacked["cuda_util"], list)
+
+
+def test_msgpack_uuid():
+    device_id = uuid.uuid4()
+    data = {"device_id": device_id}
+    packed = msgpack.packb(data)
+    unpacked = msgpack.unpackb(packed)
+    assert isinstance(unpacked["device_id"], uuid.UUID)
+    assert unpacked["device_id"] == device_id
+
+
+def test_msgpack_datetime():
+    now = datetime.now(tzutc())
+    data = {"timestamp": now}
+    packed = msgpack.packb(data)
+    unpacked = msgpack.unpackb(packed)
+    assert isinstance(unpacked["timestamp"], datetime)
+    assert unpacked["timestamp"] == now
+
+
+def test_msgpack_decimal():
+    value = Decimal(
+        "1209705197565610203801239512319273475.2350976162030923750923750961028963490861246890575"
+    )
+    data = {"value": value}
+    packed = msgpack.packb(data)
+    unpacked = msgpack.unpackb(packed)
+    assert isinstance(unpacked["value"], Decimal)
+    assert unpacked["value"] == value
+
+
+def test_msgpack_binarysize():
+    size = BinarySize.from_str("64T")
+    data = {"size": size}
+    packed = msgpack.packb(data)
+    unpacked = msgpack.unpackb(packed)
+    assert isinstance(unpacked["size"], int)
+    assert unpacked["size"] == size
+
+    size = BinarySize.from_str("Infinity")
+    data = {"size": size}
+    packed = msgpack.packb(data)
+    unpacked = msgpack.unpackb(packed)
+    assert isinstance(unpacked["size"], Decimal)
+    assert unpacked["size"] == Decimal("Infinity")


### PR DESCRIPTION
Taken from https://github.com/lablup/backend.ai/pull/491/commits/39ab5756717af673570ba81002a41df2b41948ce (part of #491)

This PR improves it further by introducing [msgpack extended types](https://github.com/msgpack/msgpack-python#extended-types), allowing seamless serialization of UUIDs, enums, datetimes, Path, etc.