### PR TITLE
fix: webserver plugin string is broken

### DIFF
--- a/changes/850.fix.md
+++ b/changes/850.fix.md
@@ -1,0 +1,1 @@
+Fix string parser option to prevent tokenizing WebUI plugin string into characters.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -71,7 +71,7 @@ config_iv = t.Dict(
         ).allow_extra("*"),
         t.Key("plugin"): t.Dict(
             {
-                t.Key("page", default=None): t.Null | t.String(allow_blank=True),
+                t.Key("page", default=None): t.Null | tx.StringList(empty_str_as_empty_list=True),
             }
         ).allow_extra("*"),
         t.Key("pipeline"): t.Dict(


### PR DESCRIPTION
This PR fixes string parser option to prevent tokenizing WebUI plugin string into characters.

Example:
```ini
[plugin]
page = 't,e,s,t,-,p,l,u,g,i,n,,"
```