### PR TITLE
Fix ResourceSlotColumn to check None type early

### DIFF
--- a/changes/856.fix.md
+++ b/changes/856.fix.md
@@ -1,0 +1,1 @@
+Fix `ResourceSlotColumn` to check None type early.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -174,18 +174,24 @@ class ResourceSlotColumn(TypeDecorator):
     impl = JSONB
     cache_ok = True
 
-    def process_bind_param(self, value: Union[Mapping, ResourceSlot], dialect):
-        if isinstance(value, Mapping) and not isinstance(value, ResourceSlot):
-            return value
-        return value.to_json() if value is not None else None
+    def process_bind_param(
+        self, value: Union[Mapping, ResourceSlot, None], dialect
+    ) -> Optional[Mapping]:
+        if value is None:
+            return None
+        if isinstance(value, ResourceSlot):
+            return value.to_json()
+        return value
 
-    def process_result_value(self, raw_value: Dict[str, str], dialect):
+    def process_result_value(self, raw_value: Dict[str, str], dialect) -> ResourceSlot:
+        if raw_value is None:
+            return ResourceSlot()
         # legacy handling
         interim_value: Dict[str, Any] = raw_value
         mem = raw_value.get("mem")
         if isinstance(mem, str) and not mem.isdigit():
             interim_value["mem"] = BinarySize.from_str(mem)
-        return ResourceSlot.from_json(interim_value) if raw_value is not None else None
+        return ResourceSlot.from_json(interim_value)
 
     def copy(self):
         return ResourceSlotColumn()


### PR DESCRIPTION
ResourceSlotColumn column type can get `None` value in `process_bind_param` and `process_result_value` methods.
Let those methods check `None` early and return.