### PR TITLE
feat: add `app_download_url` webserver config to control the app download url

### DIFF
--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -45,6 +45,8 @@ mask_user_info = false
 # enable_container_commit = false
 # Hide agent information for users.
 # hide_agents = true
+# URL to download the webui electron app. If blank, https://github.com/lablup/backend.ai-webui/releases/download will be used.
+# app_download_url = ""
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -50,6 +50,7 @@ config_iv = t.Dict(
                 | tx.StringList(empty_str_as_empty_list=True),
                 t.Key("enable_container_commit", default=False): t.ToBool,
                 t.Key("hide_agents", default=True): t.ToBool,
+                t.Key("app_download_url", default=""): t.String(allow_blank=True),
             }
         ).allow_extra("*"),
         t.Key("resources"): t.Dict(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -19,6 +19,7 @@ connectionMode = "SESSION"
 {% toml_strlist_field "singleSignOnVendors" config["service"]["single_sign_on_vendors"] %}
 {% toml_field "enableContainerCommit" config["service"]["enable_container_commit"] %}
 {% toml_field "hideAgents" config["service"]["hide_agents"] %}
+{% toml_field "appDownloadUrl" config["service"]["app_download_url"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
Add `app_download_url`, an option to set the WebUI desktop app download URL. A scenario is possible in which the user can receive the WebUI desktop application even in an offline environment by setting this option to a specific address on the corporate network.

related PR: https://github.com/lablup/backend.ai-webui/pull/1503