### PR TITLE
fix: Update pants python resolve constraints

### DIFF
--- a/changes/869.fix.md
+++ b/changes/869.fix.md
@@ -1,0 +1,1 @@
+Update pants python resolve constraints.

--- a/pants.toml
+++ b/pants.toml
@@ -44,7 +44,7 @@ enable_resolves = true
 #   - Update their local IDE/editor's interpreter path configurations
 interpreter_constraints = ["CPython==3.10.8"]
 tailor_pex_binary_targets = false
-resolves_to_interpreter_constraints = "{'python-default': ['>=3.10.8'], 'python-kernel': ['==3.9.*'], 'pants-plugins': ['>=3.9,<3.10']}"
+resolves_to_interpreter_constraints = "{'python-default': ['==3.10.8'], 'python-kernel': ['==3.9.*'], 'pants-plugins': ['>=3.9,<3.10']}"
 
 [python-bootstrap]
 search_path = ["<PYENV>", "<PATH>"]

--- a/pants.toml
+++ b/pants.toml
@@ -44,7 +44,7 @@ enable_resolves = true
 #   - Update their local IDE/editor's interpreter path configurations
 interpreter_constraints = ["CPython==3.10.8"]
 tailor_pex_binary_targets = false
-resolves_to_interpreter_constraints = "{'python-kernel': ['==3.9.*'], 'pants-plugins': ['>=3.7,<3.10']}"
+resolves_to_interpreter_constraints = "{'python-default': ['>=3.10.8'], 'python-kernel': ['==3.9.*'], 'pants-plugins': ['>=3.9,<3.10']}"
 
 [python-bootstrap]
 search_path = ["<PYENV>", "<PATH>"]


### PR DESCRIPTION
Update pants python resolve constaints.
Since pants version 2.14, pantsbuild-pants has no artifact for `cp38-cp38-macosx_12_0_arm64`.

<img width="1548" alt="image" src="https://user-images.githubusercontent.com/44239739/201295227-06a54c67-93a3-4d4c-aa14-5be010656cc9.png">

---
```
ProcessExecutionFailure: Process 'Building 1 requirement for requirements.pex from the tools/pants-plugins.lock resolve: pantsbuild.pants<2.15,>=2.14.0a0' failed with exit code 1.
stdout:

stderr:
Failed to resolve compatible artifacts from lock tools/pants-plugins.lock for 1 target:
1. /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8:
    Failed to resolve all requirements for cp38-cp38-macosx_12_0_arm64 interpreter at /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/bin/python3.8 from tools/pants-plugins.lock:

Configured with:
    build: True
    use_wheel: True

Dependency on pantsbuild-pants not satisfied, 1 incompatible candidate found:
1.) pantsbuild-pants 2.14 (via: pantsbuild.pants<2.15,>=2.14.0a0) does not have any compatible artifacts:
    https://files.pythonhosted.org/packages/71/bc/6662a9cc8cff3e2d4a116d33859c98c3295f45e93189096ca84b6f554a45/pantsbuild.pants-2.14.0-cp39-cp39-manylinux2014_x86_64.whl
    https://files.pythonhosted.org/packages/4e/fe/f46438d974b4d19b32728f3823f63ae05397ee7da064d9c2284272f351bc/pantsbuild.pants-2.14.0-cp38-cp38-manylinux2014_x86_64.whl
    https://files.pythonhosted.org/packages/65/4b/959230b5a72b177c1ef2c9dc6bdb7214fb429b39d694c7c85363bde4814f/pantsbuild.pants-2.14.0-cp37-cp37m-manylinux2014_x86_64.whl
    https://files.pythonhosted.org/packages/68/48/b8df6c443d06187663b27d4e88c8ef8b1ba2916e225c78ab1b4b032c7072/pantsbuild.pants-2.14.0-cp39-cp39-macosx_10_16_x86_64.whl
    https://files.pythonhosted.org/packages/68/71/50d1567ce077b3dc8acf0d9a11e8878ece1d031f3bd432412da558381cd7/pantsbuild.pants-2.14.0-cp38-cp38-macosx_11_0_x86_64.whl
    https://files.pythonhosted.org/packages/80/f9/f485c7a71d2adc937620c0d61fc4818da5ac92b968f6ea5dbffe280f29b7/pantsbuild.pants-2.14.0-cp39-cp39-macosx_11_0_arm64.whl
    https://files.pythonhosted.org/packages/92/6c/bd8b17ff1df4931ea0358c2475307f22259461df8f96a92db85ab8809c9c/pantsbuild.pants-2.14.0-cp37-cp37m-macosx_10_16_x86_64.whl
    https://files.pythonhosted.org/packages/9b/e9/c00b331432f789bfb8c10b5489f19245edaf8ba9c5140cc5584530fded5c/pantsbuild.pants-2.14.0-cp39-cp39-macosx_10_15_x86_64.whl
    https://files.pythonhosted.org/packages/b6/f0/c3bb663441bf2dc30846690396a858c021a1fb02a4fa4c85af0f66cc041e/pantsbuild.pants-2.14.0-cp37-cp37m-macosx_10_15_x86_64.whl
    https://files.pythonhosted.org/packages/db/2d/3319dc26b7d372bbc3ddd096222613b36ba7fc428c4ba14ee012c0e700b9/pantsbuild.pants-2.14.0-cp38-cp38-macosx_10_15_x86_64.whl
```