### PR TITLE
fix: Get field_name from ResolveInfo in gql middleware

### DIFF
--- a/changes/882.fix.md
+++ b/changes/882.fix.md
@@ -1,0 +1,1 @@
+Get mutation name from ResolveInfo.field_name in gql mutation middleware.

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1412,7 +1412,7 @@ class GQLMutationPrivilegeCheckMiddleware:
     def resolve(self, next, root, info: graphene.ResolveInfo, **args) -> Any:
         graph_ctx: GraphQueryContext = info.context
         if info.operation.operation == "mutation" and len(info.path) == 1:
-            mutation_cls = getattr(Mutations, info.path[0]).type
+            mutation_cls = getattr(Mutations, info.field_name).type
             # default is allow nobody.
             allowed_roles = getattr(mutation_cls, "allowed_roles", [])
             if graph_ctx.user["role"] not in allowed_roles:


### PR DESCRIPTION
resolves: #879 

Get mutation name from `ResolveInfo.field_name` rather from `ResolveInfo.path[0]`, and this enable to use alias.
https://github.com/graphql-python/graphql-core/blob/main/src/graphql/type/definition.py#L613-L635
`ResolveInfo` has `field_name.