### PR TITLE
fix: Request failure when freezing manager

### DIFF
--- a/changes/889.fix.md
+++ b/changes/889.fix.md
@@ -1,0 +1,1 @@
+Fix request failure that cannot freeze manager using CLI command 

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -146,7 +146,7 @@ async def fetch_manager_status(request: web.Request) -> web.Response:
 @check_api_params(
     t.Dict(
         {
-            t.Key("status"): tx.Enum(ManagerStatus, use_name=True),
+            t.Key("status"): tx.Enum(ManagerStatus),
             t.Key("force_kill", default=False): t.ToBool,
         }
     )
@@ -159,7 +159,6 @@ async def update_manager_status(request: web.Request, params: Any) -> web.Respon
         params["force_kill"],
     )
     try:
-        params = await request.json()
         status = params["status"]
         force_kill = params["force_kill"]
     except json.JSONDecodeError:


### PR DESCRIPTION
This PR support that manager could be freezed.

resolve #888 
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
