### PR TITLE
ci: Improve test coverage and add the missing client-sdk test suite

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-coverage:
     if: ${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || (!contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == true) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-coverage:
     if: ${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || (!contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == true) }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -66,8 +66,7 @@ jobs:
 
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    runs-on:
-      labels: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:
@@ -122,8 +121,7 @@ jobs:
 
   test:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    runs-on:
-      labels: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-latest-8-cores
+      labels: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
       with:
@@ -115,7 +115,7 @@ jobs:
   test:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-latest-8-cores
+      labels: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -62,7 +62,8 @@ jobs:
 
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-20.04-8core
     steps:
     - uses: actions/checkout@v3
       with:
@@ -113,7 +114,8 @@ jobs:
 
   test:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-20.04-8core
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-latest-4-cores
+      labels: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-20.04-8core
+      labels: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:
@@ -115,7 +115,7 @@ jobs:
   test:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-20.04-8core
+      labels: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-latest-4-cores
     steps:
     - uses: actions/checkout@v3
       with:

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -9,4 +9,4 @@ search_path = ["<PATH>"]
 log = true
 
 [pytest]
-args = ["-vv", "--no-header"]
+args = ["-vv", "--no-header", "--suppress-no-test-exit-code"]

--- a/pants.toml
+++ b/pants.toml
@@ -97,7 +97,7 @@ extra_requirements.add = [
     "pytest-mock>=3.8.2",
     "aioresponses>=0.7.3",
 ]
-args = ["-v", "--suppress-no-test-exit-code", "-m", "'not integration'"]
+args = ["-v", "--suppress-no-test-exit-code"]
 lockfile = "tools/pytest.lock"
 execution_slot_var = "BACKEND_TEST_EXEC_SLOT"
 

--- a/pants.toml
+++ b/pants.toml
@@ -92,11 +92,12 @@ version = "pytest>=7.1.2"
 extra_requirements.add = [
     "pytest-asyncio>=0.19",
     "pytest-aiohttp>=1.0.4",
+    "pytest-custom_exit_code>=0.3.0",
     "pytest-dependency>=0.5.1",
     "pytest-mock>=3.8.2",
     "aioresponses>=0.7.3",
 ]
-args = ["-v", "-m", "'not integration'"]
+args = ["-v", "--suppress-no-test-exit-code", "-m", "'not integration'"]
 lockfile = "tools/pytest.lock"
 execution_slot_var = "BACKEND_TEST_EXEC_SLOT"
 

--- a/src/ai/backend/cli/loader.py
+++ b/src/ai/backend/cli/loader.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click  # noqa: E402
 
 from ai.backend.plugin.entrypoint import scan_entrypoints
@@ -5,9 +7,12 @@ from ai.backend.plugin.entrypoint import scan_entrypoints
 from .main import main  # noqa: E402
 
 
-def load_entry_points() -> click.Group:
+def load_entry_points(
+    allowlist: Optional[set[str]] = None,
+    blocklist: Optional[set[str]] = None,
+) -> click.Group:
     entry_prefix = "backendai_cli_v10"
-    for entrypoint in scan_entrypoints(entry_prefix):
+    for entrypoint in scan_entrypoints(entry_prefix, allowlist=allowlist, blocklist=blocklist):
         if entrypoint.name == "_":
             cmd_group: click.Group = entrypoint.load()
             for name, cmd in cmd_group.commands.items():

--- a/src/ai/backend/cli/types.py
+++ b/src/ai/backend/cli/types.py
@@ -11,6 +11,7 @@ class CliContextInfo:
 
 class ExitCode(enum.IntEnum):
     OK = 0
-    FAILURE = 1
-    TIMEOUT = 2
-    INVALID_ARGUMENT = 3
+    FAILURE = 1  # generic failure
+    INVALID_USAGE = 2  # wraps Click's UsageError
+    OPERATION_TIMEOUT = 3  # timeout during operation
+    INVALID_ARGUMENT = 4  # invalid argument while it's not UsageError

--- a/src/ai/backend/client/cli/BUILD
+++ b/src/ai/backend/client/cli/BUILD
@@ -1,1 +1,1 @@
-python_sources()
+python_sources(name="src")

--- a/src/ai/backend/client/cli/admin/BUILD
+++ b/src/ai/backend/client/cli/admin/BUILD
@@ -1,1 +1,1 @@
-python_sources()
+python_sources(name="src")

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -1363,7 +1363,7 @@ def _watch_cmd(docs: Optional[str] = None):
                 async with timeout(max_wait):
                     await _run_events()
             except asyncio.TimeoutError:
-                sys.exit(ExitCode.TIMEOUT)
+                sys.exit(ExitCode.OPERATION_TIMEOUT)
 
         try:
             if max_wait > 0:

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -386,7 +386,7 @@ class APIConfig:
         return self._announcement_handler
 
 
-def get_config():
+def get_config() -> APIConfig:
     """
     Returns the configuration for the current process.
     If there is no explicitly set :class:`APIConfig` instance,
@@ -399,7 +399,7 @@ def get_config():
     return _config
 
 
-def set_config(conf: APIConfig):
+def set_config(conf: Optional[APIConfig]) -> None:
     """
     Sets the configuration used throughout the current process.
     """

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -218,7 +218,7 @@ class VFolder(BaseFunction):
                                         # Retry.
                                         raise ResponseFailed
                                 size = int(raw_resp.headers["Content-Length"])
-                                if_range = raw_resp.headers["Last-Modified"]
+                                if_range = raw_resp.headers.get("Last-Modified")
                                 q: janus.Queue[bytes] = janus.Queue(MAX_INFLIGHT_CHUNKS)
                                 try:
                                     with tqdm(

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -87,7 +87,7 @@ def get_docker_connector() -> tuple[yarl.URL, aiohttp.BaseConnector]:
                 search_paths = [Path(docker_host.path.replace("/", "\\"))]
                 connector_cls = aiohttp.NamedPipeConnector
             case _ as unknown_scheme:
-                raise RuntimeError("Unsupported connection scheme", unknown_scheme)
+                raise RuntimeError("unsupported connection scheme", unknown_scheme)
     else:
         match sys.platform:
             case "linux" | "darwin":
@@ -102,8 +102,8 @@ def get_docker_connector() -> tuple[yarl.URL, aiohttp.BaseConnector]:
                     Path(r"\\.\pipe\docker_engine"),
                 ]
                 connector_cls = aiohttp.NamedPipeConnector
-            case _ as unsupported_platform:
-                raise RuntimeError("Unsupported platform", unsupported_platform)
+            case _ as platform_name:
+                raise RuntimeError("unsupported platform", platform_name)
     for p in search_paths:
         if p.exists() and (p.is_socket() or p.is_fifo()):
             decoded_path = os.fsdecode(p)

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -77,3 +77,82 @@ class MockableZMQAsyncSock:
 
     async def recv_multipart(self):
         pass
+
+
+class AsyncContextMock(mock.Mock):
+    """
+    Provides a mock that can be used:
+
+        async with mock():
+          ...
+
+    Example:
+
+        # In the test code:
+        mock_obj = unittest.mock.Mock()
+        mock_obj.fetch.return_value = AsyncContextMock(
+            status=200,
+            json=mock.AsyncMock(return_value={'hello': 'world'})
+        )
+        mocker.patch('mypkg.mymod.MyClass', return_value=mock_obj)
+
+        # In the tested code:
+        obj = mpkg.mymod.MyClass()
+        async with obj.fetch() as resp:
+            # resp.status is 200
+            result = await resp.json()
+            # result is {'hello': 'world'}
+    """
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class AsyncContextMagicMock(mock.MagicMock):
+    """
+    Provides a magic mock that can be used:
+
+        async with mock():
+          ...
+    """
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class AsyncContextCoroutineMock(AsyncMock):
+    """
+    Provides a mock that can be used:
+
+        async with (await mock(...)):
+          ...
+
+    Example:
+
+        # In the test code:
+        mock_obj = unittest.mock.AsyncMock()
+        mock_obj.fetch.return_value = AsyncContextMock(
+            status=200,
+            json=mock.AsyncMock(return_value={'hello': 'world'})
+        )
+        mocker.patch('mypkg.mymod.MyClass', return_value=mock_obj)
+
+        # In the tested code:
+        obj = mpkg.mymod.MyClass()
+        async with (await obj.fetch()) as resp:
+            # resp.status is 200
+            result = await resp.json()
+            # result is {'hello': 'world'}
+    """
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/tests/client/BUILD
+++ b/tests/client/BUILD
@@ -1,0 +1,2 @@
+python_test_utils(name="testutils")
+python_tests(name="tests")

--- a/tests/client/cli/BUILD
+++ b/tests/client/cli/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/client/cli/BUILD
+++ b/tests/client/cli/BUILD
@@ -1,7 +1,6 @@
 python_tests(
     name="tests",
     dependencies=[
-        "src/ai/backend/client:src",
         "src/ai/backend/client/cli:src",
     ],
 )

--- a/tests/client/cli/BUILD
+++ b/tests/client/cli/BUILD
@@ -1,1 +1,7 @@
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    dependencies=[
+        "src/ai/backend/client:src",
+        "src/ai/backend/client/cli:src",
+    ],
+)

--- a/tests/client/cli/test_cli_commands.py
+++ b/tests/client/cli/test_cli_commands.py
@@ -1,5 +1,5 @@
-import sys
 import re
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -13,29 +13,28 @@ def runner():
     return CliRunner()
 
 
-@pytest.mark.parametrize('help_arg', ['-h', '--help'])
+@pytest.mark.parametrize("help_arg", ["-h", "--help"])
 def test_print_help(runner, help_arg):
     result = runner.invoke(main, [help_arg])
     assert result.exit_code == 0
-    assert re.match(r'Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]', result.output)
+    assert re.match(r"Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]", result.output)
 
 
 def test_print_help_for_unknown_command(runner):
-    result = runner.invoke(main, ['x-non-existent-command'])
+    result = runner.invoke(main, ["x-non-existent-command"])
     assert result.exit_code == 2
-    assert re.match(r'Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]', result.output)
+    assert re.match(r"Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]", result.output)
 
 
-def test_config(runner, monkeypatch, example_keypair,
-                unused_tcp_port_factory):
+def test_config(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
-    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    api_url = "http://127.0.0.1:{}".format(api_port)
     set_config(None)
-    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
-    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
-    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
+    monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
+    monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
     config = get_config()
-    result = runner.invoke(main, ['config'])
+    result = runner.invoke(main, ["config"])
     assert result.exit_code == 0
     assert str(config.endpoint) in result.output
     assert config.version in result.output
@@ -45,37 +44,36 @@ def test_config(runner, monkeypatch, example_keypair,
 
 
 def test_config_unset(runner, monkeypatch):
-    monkeypatch.delenv('BACKEND_ACCESS_KEY', raising=False)
-    monkeypatch.delenv('BACKEND_SECRET_KEY', raising=False)
-    monkeypatch.delenv('BACKEND_ENDPOINT', raising=False)
+    monkeypatch.delenv("BACKEND_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("BACKEND_SECRET_KEY", raising=False)
+    monkeypatch.delenv("BACKEND_ENDPOINT", raising=False)
     # now this works as "anonymous" session config.
-    result = runner.invoke(main, ['config'])
+    result = runner.invoke(main, ["config"])
     assert result.exit_code == 0
 
 
 def test_compiler_shortcut(mocker):
-    mocker.patch.object(sys, 'argv', ['lcc', '-h'])
+    mocker.patch.object(sys, "argv", ["lcc", "-h"])
     try:
         main()
     except SystemExit:
         pass
-    assert sys.argv == ['lcc', '-h']
+    assert sys.argv == ["lcc", "-h"]
 
-    mocker.patch.object(sys, 'argv', ['lpython', '-h'])
+    mocker.patch.object(sys, "argv", ["lpython", "-h"])
     try:
         main()
     except SystemExit:
         pass
-    assert sys.argv == ['lpython', '-h']
+    assert sys.argv == ["lpython", "-h"]
 
 
-def test_run_file_or_code_required(runner, monkeypatch, example_keypair,
-                                   unused_tcp_port_factory):
+def test_run_file_or_code_required(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
-    api_url = 'http://127.0.0.1:{}'.format(api_port)
-    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
-    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
-    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
-    result = runner.invoke(main, ['run', 'python'])
+    api_url = "http://127.0.0.1:{}".format(api_port)
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
+    monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
+    monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
+    result = runner.invoke(main, ["run", "python"])
     assert result.exit_code == 1
-    assert 'provide the command-line code snippet' in result.output
+    assert "provide the command-line code snippet" in result.output

--- a/tests/client/cli/test_cli_commands.py
+++ b/tests/client/cli/test_cli_commands.py
@@ -1,10 +1,10 @@
 import re
-import sys
 
 import pytest
 from click.testing import CliRunner
 
-from ai.backend.client.cli.main import main
+from ai.backend.cli.loader import load_entry_points
+from ai.backend.cli.types import ExitCode
 from ai.backend.client.config import get_config, set_config
 
 
@@ -13,20 +13,25 @@ def runner():
     return CliRunner()
 
 
+@pytest.fixture(scope="module")
+def cli_entrypoint():
+    return load_entry_points(allowlist={"ai.backend.client.cli"})
+
+
 @pytest.mark.parametrize("help_arg", ["-h", "--help"])
-def test_print_help(runner, help_arg):
-    result = runner.invoke(main, [help_arg])
-    assert result.exit_code == 0
+def test_print_help(runner, cli_entrypoint, help_arg):
+    result = runner.invoke(cli_entrypoint, [help_arg])
+    assert result.exit_code == ExitCode.OK
     assert re.match(r"Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]", result.output)
 
 
-def test_print_help_for_unknown_command(runner):
-    result = runner.invoke(main, ["x-non-existent-command"])
-    assert result.exit_code == 2
+def test_print_help_for_unknown_command(runner, cli_entrypoint):
+    result = runner.invoke(cli_entrypoint, ["x-non-existent-command"])
+    assert result.exit_code == ExitCode.INVALID_USAGE
     assert re.match(r"Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]", result.output)
 
 
-def test_config(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
+def test_config(runner, cli_entrypoint, monkeypatch, example_keypair, unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
     api_url = "http://127.0.0.1:{}".format(api_port)
     set_config(None)
@@ -34,8 +39,8 @@ def test_config(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
     monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
     monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
     config = get_config()
-    result = runner.invoke(main, ["config"])
-    assert result.exit_code == 0
+    result = runner.invoke(cli_entrypoint, ["config"])
+    assert result.exit_code == ExitCode.OK
     assert str(config.endpoint) in result.output
     assert config.version in result.output
     assert config.access_key in result.output
@@ -43,37 +48,39 @@ def test_config(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
     assert config.hash_type in result.output
 
 
-def test_config_unset(runner, monkeypatch):
+def test_config_unset(runner, cli_entrypoint, monkeypatch):
     monkeypatch.delenv("BACKEND_ACCESS_KEY", raising=False)
     monkeypatch.delenv("BACKEND_SECRET_KEY", raising=False)
     monkeypatch.delenv("BACKEND_ENDPOINT", raising=False)
     # now this works as "anonymous" session config.
-    result = runner.invoke(main, ["config"])
-    assert result.exit_code == 0
+    result = runner.invoke(cli_entrypoint, ["config"])
+    assert result.exit_code == ExitCode.OK
 
 
-def test_compiler_shortcut(mocker):
-    mocker.patch.object(sys, "argv", ["lcc", "-h"])
-    try:
-        main()
-    except SystemExit:
-        pass
-    assert sys.argv == ["lcc", "-h"]
+# def test_compiler_shortcut(mocker):
+#     mocker.patch.object(sys, "argv", ["lcc", "-h"])
+#     try:
+#         main()
+#     except SystemExit:
+#         pass
+#     assert sys.argv == ["lcc", "-h"]
+#
+#     mocker.patch.object(sys, "argv", ["lpython", "-h"])
+#     try:
+#         main()
+#     except SystemExit:
+#         pass
+#     assert sys.argv == ["lpython", "-h"]
 
-    mocker.patch.object(sys, "argv", ["lpython", "-h"])
-    try:
-        main()
-    except SystemExit:
-        pass
-    assert sys.argv == ["lpython", "-h"]
 
-
-def test_run_file_or_code_required(runner, monkeypatch, example_keypair, unused_tcp_port_factory):
+def test_run_file_or_code_required(
+    runner, cli_entrypoint, monkeypatch, example_keypair, unused_tcp_port_factory
+):
     api_port = unused_tcp_port_factory()
     api_url = "http://127.0.0.1:{}".format(api_port)
     monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
     monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
     monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
-    result = runner.invoke(main, ["run", "python"])
-    assert result.exit_code == 1
+    result = runner.invoke(cli_entrypoint, ["run", "python"])
+    assert result.exit_code == ExitCode.INVALID_ARGUMENT
     assert "provide the command-line code snippet" in result.output

--- a/tests/client/cli/test_cli_commands.py
+++ b/tests/client/cli/test_cli_commands.py
@@ -1,0 +1,81 @@
+import sys
+import re
+
+import pytest
+from click.testing import CliRunner
+
+from ai.backend.client.cli.main import main
+from ai.backend.client.config import get_config, set_config
+
+
+@pytest.fixture(scope="module")
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize('help_arg', ['-h', '--help'])
+def test_print_help(runner, help_arg):
+    result = runner.invoke(main, [help_arg])
+    assert result.exit_code == 0
+    assert re.match(r'Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]', result.output)
+
+
+def test_print_help_for_unknown_command(runner):
+    result = runner.invoke(main, ['x-non-existent-command'])
+    assert result.exit_code == 2
+    assert re.match(r'Usage: ([.\w]+) \[OPTIONS\] COMMAND \[ARGS\]', result.output)
+
+
+def test_config(runner, monkeypatch, example_keypair,
+                unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    set_config(None)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    config = get_config()
+    result = runner.invoke(main, ['config'])
+    assert result.exit_code == 0
+    assert str(config.endpoint) in result.output
+    assert config.version in result.output
+    assert config.access_key in result.output
+    assert config.secret_key[:6] in result.output
+    assert config.hash_type in result.output
+
+
+def test_config_unset(runner, monkeypatch):
+    monkeypatch.delenv('BACKEND_ACCESS_KEY', raising=False)
+    monkeypatch.delenv('BACKEND_SECRET_KEY', raising=False)
+    monkeypatch.delenv('BACKEND_ENDPOINT', raising=False)
+    # now this works as "anonymous" session config.
+    result = runner.invoke(main, ['config'])
+    assert result.exit_code == 0
+
+
+def test_compiler_shortcut(mocker):
+    mocker.patch.object(sys, 'argv', ['lcc', '-h'])
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert sys.argv == ['lcc', '-h']
+
+    mocker.patch.object(sys, 'argv', ['lpython', '-h'])
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert sys.argv == ['lpython', '-h']
+
+
+def test_run_file_or_code_required(runner, monkeypatch, example_keypair,
+                                   unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    result = runner.invoke(main, ['run', 'python'])
+    assert result.exit_code == 1
+    assert 'provide the command-line code snippet' in result.output

--- a/tests/client/cli/test_cli_proxy.py
+++ b/tests/client/cli/test_cli_proxy.py
@@ -1,6 +1,6 @@
 import aiohttp
-from aiohttp import web
 import pytest
+from aiohttp import web
 
 from ai.backend.client import config
 from ai.backend.client.cli.proxy import create_proxy_app
@@ -28,15 +28,15 @@ async def api_app_fixture(unused_tcp_port_factory):
 
     async def echo_web(request):
         body = await request.read()
-        resp = web.Response(status=200, reason='Good', body=body)
-        resp.headers['Content-Type'] = request.content_type
+        resp = web.Response(status=200, reason="Good", body=body)
+        resp.headers["Content-Type"] = request.content_type
         return resp
 
-    app.router.add_route('GET', r'/stream/echo', echo_ws)
-    app.router.add_route('POST', r'/echo', echo_web)
+    app.router.add_route("GET", r"/stream/echo", echo_ws)
+    app.router.add_route("POST", r"/echo", echo_web)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '127.0.0.1', api_port)
+    site = web.TCPSite(runner, "127.0.0.1", api_port)
     await site.start()
     try:
         yield app, recv_queue, api_port
@@ -50,7 +50,7 @@ async def proxy_app_fixture(unused_tcp_port_factory):
     runner = web.AppRunner(app)
     proxy_port = unused_tcp_port_factory()
     await runner.setup()
-    site = web.TCPSite(runner, '127.0.0.1', proxy_port)
+    site = web.TCPSite(runner, "127.0.0.1", proxy_port)
     await site.start()
     try:
         yield app, proxy_port
@@ -63,27 +63,27 @@ async def proxy_app_fixture(unused_tcp_port_factory):
 )
 @pytest.mark.asyncio
 async def test_proxy_web(
-    monkeypatch, example_keypair,
+    monkeypatch,
+    example_keypair,
     api_app_fixture,
     proxy_app_fixture,
 ):
     api_app, recv_queue, api_port = api_app_fixture
-    api_url = 'http://127.0.0.1:{}'.format(api_port)
-    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
-    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
-    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
-    monkeypatch.setattr(config, '_config', config.APIConfig())
+    api_url = "http://127.0.0.1:{}".format(api_port)
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
+    monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
+    monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
+    monkeypatch.setattr(config, "_config", config.APIConfig())
     proxy_app, proxy_port = proxy_app_fixture
     proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
     async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
-        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+        proxy_url = "http://127.0.0.1:{}".format(proxy_port)
         data = {"test": 1234}
-        async with proxy_client.request('POST', proxy_url + '/echo',
-                                        json=data) as resp:
+        async with proxy_client.request("POST", proxy_url + "/echo", json=data) as resp:
             assert resp.status == 200
-            assert resp.reason == 'Good'
+            assert resp.reason == "Good"
             ret = await resp.json()
-            assert ret['test'] == 1234
+            assert ret["test"] == 1234
 
 
 @pytest.mark.xfail(
@@ -91,26 +91,26 @@ async def test_proxy_web(
 )
 @pytest.mark.asyncio
 async def test_proxy_web_502(
-    monkeypatch, example_keypair,
+    monkeypatch,
+    example_keypair,
     proxy_app_fixture,
     unused_tcp_port_factory,
 ):
     api_port = unused_tcp_port_factory()
-    api_url = 'http://127.0.0.1:{}'.format(api_port)
-    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
-    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
-    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
-    monkeypatch.setattr(config, '_config', config.APIConfig())
+    api_url = "http://127.0.0.1:{}".format(api_port)
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
+    monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
+    monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
+    monkeypatch.setattr(config, "_config", config.APIConfig())
     # Skip creation of api_app; let the proxy use a non-existent server.
     proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
     async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
         proxy_app, proxy_port = proxy_app_fixture
-        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+        proxy_url = "http://127.0.0.1:{}".format(proxy_port)
         data = {"test": 1234}
-        async with proxy_client.request('POST', proxy_url + '/echo',
-                                        json=data) as resp:
+        async with proxy_client.request("POST", proxy_url + "/echo", json=data) as resp:
             assert resp.status == 502
-            assert resp.reason == 'Bad Gateway'
+            assert resp.reason == "Bad Gateway"
 
 
 @pytest.mark.xfail(
@@ -118,27 +118,28 @@ async def test_proxy_web_502(
 )
 @pytest.mark.asyncio
 async def test_proxy_websocket(
-    monkeypatch, example_keypair,
+    monkeypatch,
+    example_keypair,
     api_app_fixture,
     proxy_app_fixture,
 ):
     api_app, recv_queue, api_port = api_app_fixture
-    api_url = 'http://127.0.0.1:{}'.format(api_port)
-    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
-    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
-    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
-    monkeypatch.setattr(config, '_config', config.APIConfig())
+    api_url = "http://127.0.0.1:{}".format(api_port)
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", example_keypair[0])
+    monkeypatch.setenv("BACKEND_SECRET_KEY", example_keypair[1])
+    monkeypatch.setenv("BACKEND_ENDPOINT", api_url)
+    monkeypatch.setattr(config, "_config", config.APIConfig())
     proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
     async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
         proxy_app, proxy_port = proxy_app_fixture
-        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
-        ws = await proxy_client.ws_connect(proxy_url + '/stream/echo')
-        await ws.send_str('test')
-        assert await ws.receive_str() == 'test'
-        await ws.send_bytes(b'\x00\x00')
-        assert await ws.receive_bytes() == b'\x00\x00'
+        proxy_url = "http://127.0.0.1:{}".format(proxy_port)
+        ws = await proxy_client.ws_connect(proxy_url + "/stream/echo")
+        await ws.send_str("test")
+        assert await ws.receive_str() == "test"
+        await ws.send_bytes(b"\x00\x00")
+        assert await ws.receive_bytes() == b"\x00\x00"
         assert recv_queue[0].type == aiohttp.WSMsgType.TEXT
-        assert recv_queue[0].data == 'test'
+        assert recv_queue[0].data == "test"
         assert recv_queue[1].type == aiohttp.WSMsgType.BINARY
-        assert recv_queue[1].data == b'\x00\x00'
+        assert recv_queue[1].data == b"\x00\x00"
         await ws.close()

--- a/tests/client/cli/test_cli_proxy.py
+++ b/tests/client/cli/test_cli_proxy.py
@@ -1,0 +1,144 @@
+import aiohttp
+from aiohttp import web
+import pytest
+
+from ai.backend.client import config
+from ai.backend.client.cli.proxy import create_proxy_app
+
+
+@pytest.fixture
+async def api_app_fixture(unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    app = web.Application()
+    recv_queue = []
+
+    async def echo_ws(request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                recv_queue.append(msg)
+                await ws.send_str(msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                recv_queue.append(msg)
+                await ws.send_bytes(msg.data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                recv_queue.append(msg)
+        return ws
+
+    async def echo_web(request):
+        body = await request.read()
+        resp = web.Response(status=200, reason='Good', body=body)
+        resp.headers['Content-Type'] = request.content_type
+        return resp
+
+    app.router.add_route('GET', r'/stream/echo', echo_ws)
+    app.router.add_route('POST', r'/echo', echo_web)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', api_port)
+    await site.start()
+    try:
+        yield app, recv_queue, api_port
+    finally:
+        await runner.cleanup()
+
+
+@pytest.fixture
+async def proxy_app_fixture(unused_tcp_port_factory):
+    app = create_proxy_app()
+    runner = web.AppRunner(app)
+    proxy_port = unused_tcp_port_factory()
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', proxy_port)
+    await site.start()
+    try:
+        yield app, proxy_port
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.xfail(
+    reason="pytest-dev/pytest-asyncio#153 should be resolved to make this test working",
+)
+@pytest.mark.asyncio
+async def test_proxy_web(
+    monkeypatch, example_keypair,
+    api_app_fixture,
+    proxy_app_fixture,
+):
+    api_app, recv_queue, api_port = api_app_fixture
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    proxy_app, proxy_port = proxy_app_fixture
+    proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
+    async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
+        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+        data = {"test": 1234}
+        async with proxy_client.request('POST', proxy_url + '/echo',
+                                        json=data) as resp:
+            assert resp.status == 200
+            assert resp.reason == 'Good'
+            ret = await resp.json()
+            assert ret['test'] == 1234
+
+
+@pytest.mark.xfail(
+    reason="pytest-dev/pytest-asyncio#153 should be resolved to make this test working",
+)
+@pytest.mark.asyncio
+async def test_proxy_web_502(
+    monkeypatch, example_keypair,
+    proxy_app_fixture,
+    unused_tcp_port_factory,
+):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    # Skip creation of api_app; let the proxy use a non-existent server.
+    proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
+    async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
+        proxy_app, proxy_port = proxy_app_fixture
+        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+        data = {"test": 1234}
+        async with proxy_client.request('POST', proxy_url + '/echo',
+                                        json=data) as resp:
+            assert resp.status == 502
+            assert resp.reason == 'Bad Gateway'
+
+
+@pytest.mark.xfail(
+    reason="pytest-dev/pytest-asyncio#153 should be resolved to make this test working",
+)
+@pytest.mark.asyncio
+async def test_proxy_websocket(
+    monkeypatch, example_keypair,
+    api_app_fixture,
+    proxy_app_fixture,
+):
+    api_app, recv_queue, api_port = api_app_fixture
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    proxy_timeout = aiohttp.ClientTimeout(connect=1.0)
+    async with aiohttp.ClientSession(timeout=proxy_timeout) as proxy_client:
+        proxy_app, proxy_port = proxy_app_fixture
+        proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+        ws = await proxy_client.ws_connect(proxy_url + '/stream/echo')
+        await ws.send_str('test')
+        assert await ws.receive_str() == 'test'
+        await ws.send_bytes(b'\x00\x00')
+        assert await ws.receive_bytes() == b'\x00\x00'
+        assert recv_queue[0].type == aiohttp.WSMsgType.TEXT
+        assert recv_queue[0].data == 'test'
+        assert recv_queue[1].type == aiohttp.WSMsgType.BINARY
+        assert recv_queue[1].data == b'\x00\x00'
+        await ws.close()

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+from ai.backend.client.config import APIConfig, set_config
+
+
+@pytest.fixture(autouse=True)
+def defconfig():
+    endpoint = os.environ.get('BACKEND_TEST_ENDPOINT', 'http://127.0.0.1:8081')
+    access_key = os.environ.get('BACKEND_TEST_ADMIN_ACCESS_KEY',
+                                'AKIAIOSFODNN7EXAMPLE')
+    secret_key = os.environ.get('BACKEND_TEST_ADMIN_SECRET_KEY',
+                                'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
+    c = APIConfig(endpoint=endpoint, access_key=access_key, secret_key=secret_key)
+    set_config(c)
+    return c
+
+
+@pytest.fixture
+def userconfig():
+    endpoint = os.environ.get('BACKEND_TEST_ENDPOINT', 'http://127.0.0.1:8081')
+    access_key = os.environ.get('BACKEND_TEST_USER_ACCESS_KEY',
+                                'AKIANABBDUSEREXAMPLE')
+    secret_key = os.environ.get('BACKEND_TEST_USER_SECRET_KEY',
+                                'C8qnIo29EZvXkPK_MXcuAakYTy4NYrxwmCEyNPlf')
+    c = APIConfig(endpoint=endpoint, access_key=access_key, secret_key=secret_key)
+    set_config(c)
+    return c
+
+
+@pytest.fixture
+def example_keypair(defconfig):
+    return (defconfig.access_key, defconfig.secret_key)
+
+
+@pytest.fixture
+def user_keypair(userconfig):
+    return (userconfig.access_key, userconfig.secret_key)
+
+
+@pytest.fixture
+def dummy_endpoint(defconfig):
+    return str(defconfig.endpoint) + '/'

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -7,11 +7,11 @@ from ai.backend.client.config import APIConfig, set_config
 
 @pytest.fixture(autouse=True)
 def defconfig():
-    endpoint = os.environ.get('BACKEND_TEST_ENDPOINT', 'http://127.0.0.1:8081')
-    access_key = os.environ.get('BACKEND_TEST_ADMIN_ACCESS_KEY',
-                                'AKIAIOSFODNN7EXAMPLE')
-    secret_key = os.environ.get('BACKEND_TEST_ADMIN_SECRET_KEY',
-                                'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
+    endpoint = os.environ.get("BACKEND_TEST_ENDPOINT", "http://127.0.0.1:8081")
+    access_key = os.environ.get("BACKEND_TEST_ADMIN_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
+    secret_key = os.environ.get(
+        "BACKEND_TEST_ADMIN_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    )
     c = APIConfig(endpoint=endpoint, access_key=access_key, secret_key=secret_key)
     set_config(c)
     return c
@@ -19,11 +19,11 @@ def defconfig():
 
 @pytest.fixture
 def userconfig():
-    endpoint = os.environ.get('BACKEND_TEST_ENDPOINT', 'http://127.0.0.1:8081')
-    access_key = os.environ.get('BACKEND_TEST_USER_ACCESS_KEY',
-                                'AKIANABBDUSEREXAMPLE')
-    secret_key = os.environ.get('BACKEND_TEST_USER_SECRET_KEY',
-                                'C8qnIo29EZvXkPK_MXcuAakYTy4NYrxwmCEyNPlf')
+    endpoint = os.environ.get("BACKEND_TEST_ENDPOINT", "http://127.0.0.1:8081")
+    access_key = os.environ.get("BACKEND_TEST_USER_ACCESS_KEY", "AKIANABBDUSEREXAMPLE")
+    secret_key = os.environ.get(
+        "BACKEND_TEST_USER_SECRET_KEY", "C8qnIo29EZvXkPK_MXcuAakYTy4NYrxwmCEyNPlf"
+    )
     c = APIConfig(endpoint=endpoint, access_key=access_key, secret_key=secret_key)
     set_config(c)
     return c
@@ -41,4 +41,4 @@ def user_keypair(userconfig):
 
 @pytest.fixture
 def dummy_endpoint(defconfig):
-    return str(defconfig.endpoint) + '/'
+    return str(defconfig.endpoint) + "/"

--- a/tests/client/integration/BUILD
+++ b/tests/client/integration/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/client/integration/test_agent.py
+++ b/tests/client/integration/test_agent.py
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 async def test_list_agent():
     with Session() as sess:
         result = sess.Agent.list_with_limit(1, 0)
-        assert len(result['items']) == 1
+        assert len(result["items"]) == 1

--- a/tests/client/integration/test_agent.py
+++ b/tests/client/integration/test_agent.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ai.backend.client.session import Session
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_agent():
+    with Session() as sess:
+        result = sess.Agent.list_with_limit(1, 0)
+        assert len(result['items']) == 1

--- a/tests/client/integration/test_auth.py
+++ b/tests/client/integration/test_auth.py
@@ -1,0 +1,76 @@
+import pytest
+
+import uuid
+
+from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.request import Request
+from ai.backend.client.exceptions import BackendAPIError
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+def test_auth():
+    random_msg = uuid.uuid4().hex
+    with Session():
+        request = Request('GET', '/auth')
+        request.set_json({
+            'echo': random_msg,
+        })
+        with request.fetch() as resp:
+            assert resp.status == 200
+            data = resp.json()
+            assert data['authorized'] == 'yes'
+            assert data['echo'] == random_msg
+
+
+def test_auth_missing_signature(monkeypatch):
+    random_msg = uuid.uuid4().hex
+    with Session():
+        rqst = Request('GET', '/auth')
+        rqst.set_json({'echo': random_msg})
+        # let it bypass actual signing
+        from ai.backend.client import request
+        noop_sign = lambda *args, **kwargs: ({}, None)
+        monkeypatch.setattr(request, 'generate_signature', noop_sign)
+        with pytest.raises(BackendAPIError) as e:
+            with rqst.fetch():
+                pass
+        assert e.value.status == 401
+
+
+def test_auth_malformed():
+    with Session():
+        request = Request('GET', '/auth')
+        request.set_content(
+            b'<this is not json>',
+            content_type='application/json',
+        )
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 400
+
+
+def test_auth_missing_body():
+    with Session():
+        request = Request('GET', '/auth')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 400
+
+
+@pytest.mark.asyncio
+async def test_async_auth():
+    random_msg = uuid.uuid4().hex
+    async with AsyncSession():
+        request = Request('GET', '/auth')
+        request.set_json({
+            'echo': random_msg,
+        })
+        async with request.fetch() as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data['authorized'] == 'yes'
+            assert data['echo'] == random_msg

--- a/tests/client/integration/test_auth.py
+++ b/tests/client/integration/test_auth.py
@@ -1,10 +1,10 @@
-import pytest
-
 import uuid
 
-from ai.backend.client.session import Session, AsyncSession
-from ai.backend.client.request import Request
+import pytest
+
 from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.request import Request
+from ai.backend.client.session import AsyncSession, Session
 
 # module-level marker
 pytestmark = pytest.mark.integration
@@ -13,26 +13,29 @@ pytestmark = pytest.mark.integration
 def test_auth():
     random_msg = uuid.uuid4().hex
     with Session():
-        request = Request('GET', '/auth')
-        request.set_json({
-            'echo': random_msg,
-        })
+        request = Request("GET", "/auth")
+        request.set_json(
+            {
+                "echo": random_msg,
+            }
+        )
         with request.fetch() as resp:
             assert resp.status == 200
             data = resp.json()
-            assert data['authorized'] == 'yes'
-            assert data['echo'] == random_msg
+            assert data["authorized"] == "yes"
+            assert data["echo"] == random_msg
 
 
 def test_auth_missing_signature(monkeypatch):
     random_msg = uuid.uuid4().hex
     with Session():
-        rqst = Request('GET', '/auth')
-        rqst.set_json({'echo': random_msg})
+        rqst = Request("GET", "/auth")
+        rqst.set_json({"echo": random_msg})
         # let it bypass actual signing
         from ai.backend.client import request
+
         noop_sign = lambda *args, **kwargs: ({}, None)
-        monkeypatch.setattr(request, 'generate_signature', noop_sign)
+        monkeypatch.setattr(request, "generate_signature", noop_sign)
         with pytest.raises(BackendAPIError) as e:
             with rqst.fetch():
                 pass
@@ -41,10 +44,10 @@ def test_auth_missing_signature(monkeypatch):
 
 def test_auth_malformed():
     with Session():
-        request = Request('GET', '/auth')
+        request = Request("GET", "/auth")
         request.set_content(
-            b'<this is not json>',
-            content_type='application/json',
+            b"<this is not json>",
+            content_type="application/json",
         )
         with pytest.raises(BackendAPIError) as e:
             with request.fetch():
@@ -54,7 +57,7 @@ def test_auth_malformed():
 
 def test_auth_missing_body():
     with Session():
-        request = Request('GET', '/auth')
+        request = Request("GET", "/auth")
         with pytest.raises(BackendAPIError) as e:
             with request.fetch():
                 pass
@@ -65,12 +68,14 @@ def test_auth_missing_body():
 async def test_async_auth():
     random_msg = uuid.uuid4().hex
     async with AsyncSession():
-        request = Request('GET', '/auth')
-        request.set_json({
-            'echo': random_msg,
-        })
+        request = Request("GET", "/auth")
+        request.set_json(
+            {
+                "echo": random_msg,
+            }
+        )
         async with request.fetch() as resp:
             assert resp.status == 200
             data = await resp.json()
-            assert data['authorized'] == 'yes'
-            assert data['echo'] == random_msg
+            assert data["authorized"] == "yes"
+            assert data["echo"] == random_msg

--- a/tests/client/integration/test_image.py
+++ b/tests/client/integration/test_image.py
@@ -1,0 +1,64 @@
+import pytest
+
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.session import Session
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_images_by_admin():
+    with Session() as sess:
+        images = sess.Image.list()
+        image = images[0]
+    assert len(images) > 0
+    assert 'name' in image
+    assert 'tag' in image
+    assert 'hash' in image
+
+
+@pytest.mark.asyncio
+async def test_list_images_by_user(userconfig):
+    with Session() as sess:
+        images = sess.Image.list()
+        image = images[0]
+    assert len(images) > 0
+    assert 'name' in image
+    assert 'tag' in image
+    assert 'hash' in image
+
+# This is invasive...
+# async def test_rescan_images():
+#     pass
+
+
+@pytest.mark.asyncio
+async def test_alias_dealias_image_by_admin():
+    with Session() as sess:
+        def get_test_image_info():
+            items = sess.Image.list(
+                fields=('name', 'registry', 'tag', 'aliases'))
+            for item in items:
+                if 'lua' in item['name'] and '5.1-alpine3.8' in item['tag']:
+                    return item
+
+        img_info = get_test_image_info()
+        test_alias = 'testalias-b9f1ce136f584ca892d5fef3e78dd11d'
+        test_target = img_info['registry'] + '/' + img_info['name'] + ':' + \
+            img_info['tag']
+        sess.Image.aliasImage(test_alias, test_target)
+        assert get_test_image_info()['aliases'] == [test_alias]
+
+        sess.Image.dealiasImage(test_alias)
+        assert len(get_test_image_info()['aliases']) == 0
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_mutate_alias_dealias(userconfig):
+    with Session() as sess:
+        test_alias = 'testalias-b9f1ce136f584ca892d5fef3e78dd11d'
+        with pytest.raises(BackendAPIError):
+            sess.Image.aliasImage(test_alias, 'lua:5.1-alpine3.8')
+        with pytest.raises(BackendAPIError):
+            sess.Image.dealiasImage(test_alias)

--- a/tests/client/integration/test_image.py
+++ b/tests/client/integration/test_image.py
@@ -13,9 +13,9 @@ async def test_list_images_by_admin():
         images = sess.Image.list()
         image = images[0]
     assert len(images) > 0
-    assert 'name' in image
-    assert 'tag' in image
-    assert 'hash' in image
+    assert "name" in image
+    assert "tag" in image
+    assert "hash" in image
 
 
 @pytest.mark.asyncio
@@ -24,9 +24,10 @@ async def test_list_images_by_user(userconfig):
         images = sess.Image.list()
         image = images[0]
     assert len(images) > 0
-    assert 'name' in image
-    assert 'tag' in image
-    assert 'hash' in image
+    assert "name" in image
+    assert "tag" in image
+    assert "hash" in image
+
 
 # This is invasive...
 # async def test_rescan_images():
@@ -36,29 +37,28 @@ async def test_list_images_by_user(userconfig):
 @pytest.mark.asyncio
 async def test_alias_dealias_image_by_admin():
     with Session() as sess:
+
         def get_test_image_info():
-            items = sess.Image.list(
-                fields=('name', 'registry', 'tag', 'aliases'))
+            items = sess.Image.list(fields=("name", "registry", "tag", "aliases"))
             for item in items:
-                if 'lua' in item['name'] and '5.1-alpine3.8' in item['tag']:
+                if "lua" in item["name"] and "5.1-alpine3.8" in item["tag"]:
                     return item
 
         img_info = get_test_image_info()
-        test_alias = 'testalias-b9f1ce136f584ca892d5fef3e78dd11d'
-        test_target = img_info['registry'] + '/' + img_info['name'] + ':' + \
-            img_info['tag']
+        test_alias = "testalias-b9f1ce136f584ca892d5fef3e78dd11d"
+        test_target = img_info["registry"] + "/" + img_info["name"] + ":" + img_info["tag"]
         sess.Image.aliasImage(test_alias, test_target)
-        assert get_test_image_info()['aliases'] == [test_alias]
+        assert get_test_image_info()["aliases"] == [test_alias]
 
         sess.Image.dealiasImage(test_alias)
-        assert len(get_test_image_info()['aliases']) == 0
+        assert len(get_test_image_info()["aliases"]) == 0
 
 
 @pytest.mark.asyncio
 async def test_user_cannot_mutate_alias_dealias(userconfig):
     with Session() as sess:
-        test_alias = 'testalias-b9f1ce136f584ca892d5fef3e78dd11d'
+        test_alias = "testalias-b9f1ce136f584ca892d5fef3e78dd11d"
         with pytest.raises(BackendAPIError):
-            sess.Image.aliasImage(test_alias, 'lua:5.1-alpine3.8')
+            sess.Image.aliasImage(test_alias, "lua:5.1-alpine3.8")
         with pytest.raises(BackendAPIError):
             sess.Image.dealiasImage(test_alias)

--- a/tests/client/integration/test_kernel.py
+++ b/tests/client/integration/test_kernel.py
@@ -1,0 +1,226 @@
+import secrets
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+import pytest
+
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.session import Session
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+def aggregate_console(c):
+    return {
+        'stdout': ''.join(item[1] for item in c if item[0] == 'stdout'),
+        'stderr': ''.join(item[1] for item in c if item[0] == 'stderr'),
+        'html': ''.join(item[1] for item in c if item[0] == 'html'),
+        'media': list(item[1] for item in c if item[0] == 'media'),
+    }
+
+
+def exec_loop(kernel, mode, code, opts=None, user_inputs=None):
+    # The server may return continuation if kernel preparation
+    # takes a little longer time (a few seconds).
+    console = []
+    num_queries = 0
+    run_id = secrets.token_hex(8)
+    if user_inputs is None:
+        user_inputs = []
+    while True:
+        result = kernel.execute(
+            run_id,
+            code=code if num_queries == 0 or mode == 'input' else '',
+            mode=mode,
+            opts=opts)
+        num_queries += 1
+        console.extend(result['console'])
+        if result['status'] == 'finished':
+            break
+        elif result['status'] == 'waiting-input':
+            mode = 'input'
+            code = user_inputs.pop(0)
+            opts = None
+        else:
+            mode = 'continue'
+            code = ''
+            opts = None
+    return aggregate_console(console), num_queries
+
+
+@pytest.yield_fixture
+def py3_kernel():
+    with Session() as sess:
+        kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04')
+        yield kernel
+        kernel.destroy()
+
+
+def test_hello():
+    with Session() as sess:
+        result = sess.Kernel.hello()
+    assert 'version' in result
+
+
+def test_kernel_lifecycles():
+    with Session() as sess:
+        kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04')
+        kernel_id = kernel.kernel_id
+        info = kernel.get_info()
+        # the tag may be different depending on alias/metadata config.
+        lang = info['lang']
+        assert lang.startswith('index.docker.io/lablup/python:')
+        assert info['numQueriesExecuted'] == 1
+        info = kernel.get_info()
+        assert info['numQueriesExecuted'] == 2
+        kernel.destroy()
+        # kernel destruction is no longer synchronous!
+        time.sleep(2.0)
+        with pytest.raises(BackendAPIError) as e:
+            info = sess.Kernel(kernel_id).get_info()
+        assert e.value.status == 404
+
+
+def test_kernel_execution_query_mode(py3_kernel):
+    code = 'print("hello world"); x = 1 / 0'
+    console, n = exec_loop(py3_kernel, 'query', code, None)
+    assert 'hello world' in console['stdout']
+    assert 'ZeroDivisionError' in console['stderr']
+    assert len(console['media']) == 0
+    info = py3_kernel.get_info()
+    assert info['numQueriesExecuted'] == n + 1
+
+
+def test_kernel_execution_query_mode_user_input(py3_kernel):
+    name = secrets.token_hex(8)
+    code = 'name = input("your name? "); print(f"hello, {name}!")'
+    console, n = exec_loop(py3_kernel, 'query', code, None, user_inputs=[name])
+    assert 'your name?' in console['stdout']
+    assert 'hello, {}!'.format(name) in console['stdout']
+
+
+def test_kernel_get_or_create_reuse():
+    with Session() as sess:
+        try:
+            # Sessions with same token and same language must be reused.
+            t = secrets.token_hex(6)
+            kernel1 = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
+                                                client_token=t)
+            kernel2 = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
+                                                client_token=t)
+            assert kernel1.kernel_id == kernel2.kernel_id
+        finally:
+            kernel1.destroy()
+
+
+def test_kernel_execution_batch_mode(py3_kernel):
+    with tempfile.NamedTemporaryFile('w', suffix='.py', dir=Path.cwd()) as f:
+        f.write('print("hello world")\nx = 1 / 0\n')
+        f.flush()
+        f.seek(0)
+        py3_kernel.upload([f.name])
+    console, _ = exec_loop(py3_kernel, 'batch', '', {
+        'build': '',
+        'exec': 'python {}'.format(Path(f.name).name),
+    })
+    assert 'hello world' in console['stdout']
+    assert 'ZeroDivisionError' in console['stderr']
+    assert len(console['media']) == 0
+
+
+def test_kernel_execution_batch_mode_user_input(py3_kernel):
+    name = secrets.token_hex(8)
+    with tempfile.NamedTemporaryFile('w', suffix='.py', dir=Path.cwd()) as f:
+        f.write('name = input("your name? "); print(f"hello, {name}!")')
+        f.flush()
+        f.seek(0)
+        py3_kernel.upload([f.name])
+    console, _ = exec_loop(py3_kernel, 'batch', '', {
+        'build': '',
+        'exec': 'python {}'.format(Path(f.name).name),
+    }, user_inputs=[name])
+    assert 'your name?' in console['stdout']
+    assert 'hello, {}!'.format(name) in console['stdout']
+
+
+def test_kernel_execution_with_vfolder_mounts():
+    with Session() as sess:
+        vfname = 'vftest-' + secrets.token_hex(4)
+        sess.VFolder.create(vfname)
+        vfolder = sess.VFolder(vfname)
+        try:
+            with tempfile.NamedTemporaryFile('w', suffix='.py',
+                                             dir=Path.cwd()) as f:
+                f.write('print("hello world")\nx = 1 / 0\n')
+                f.flush()
+                f.seek(0)
+                vfolder.upload([f.name])
+            kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
+                                               mounts=[vfname])
+            try:
+                console, n = exec_loop(kernel, 'batch', '', {
+                    'build': '',
+                    'exec': 'python {}/{}'.format(vfname, Path(f.name).name),
+                })
+                assert 'hello world' in console['stdout']
+                assert 'ZeroDivisionError' in console['stderr']
+                assert len(console['media']) == 0
+            finally:
+                kernel.destroy()
+        finally:
+            vfolder.delete()
+
+
+def test_kernel_restart(py3_kernel):
+    num_queries = 1  # first query is done by py3_kernel fixture (creation)
+    first_code = textwrap.dedent('''
+    a = "first"
+    with open("test.txt", "w") as f:
+        f.write("helloo?")
+    print(a)
+    ''').strip()
+    second_code_name_error = textwrap.dedent('''
+    print(a)
+    ''').strip()
+    second_code_file_check = textwrap.dedent('''
+    with open("test.txt", "r") as f:
+        print(f.read())
+    ''').strip()
+    console, n = exec_loop(py3_kernel, 'query', first_code)
+    num_queries += n
+    assert 'first' in console['stdout']
+    assert console['stderr'] == ''
+    assert len(console['media']) == 0
+    py3_kernel.restart()
+    num_queries += 1
+    console, n = exec_loop(py3_kernel, 'query', second_code_name_error)
+    num_queries += n
+    assert 'NameError' in console['stderr']
+    assert len(console['media']) == 0
+    console, n = exec_loop(py3_kernel, 'query', second_code_file_check)
+    num_queries += n
+    assert 'helloo?' in console['stdout']
+    assert console['stderr'] == ''
+    assert len(console['media']) == 0
+    info = py3_kernel.get_info()
+    # FIXME: this varies between 2~4
+    assert info['numQueriesExecuted'] == num_queries
+
+
+def test_admin_api(py3_kernel):
+    sess = py3_kernel.session
+    q = '''
+    query($ak: String!) {
+        compute_sessions(access_key: $ak, status: "RUNNING") {
+            lang
+        }
+    }'''
+    resp = sess.Admin.query(q, {
+        'ak': sess.config.access_key,
+    })
+    assert 'compute_sessions' in resp
+    assert len(resp['compute_sessions']) >= 1
+    lang = resp['compute_sessions'][0]['lang']
+    assert lang.startswith('index.docker.io/lablup/python:')

--- a/tests/client/integration/test_kernel.py
+++ b/tests/client/integration/test_kernel.py
@@ -3,6 +3,7 @@ import tempfile
 import textwrap
 import time
 from pathlib import Path
+
 import pytest
 
 from ai.backend.client.exceptions import BackendAPIError
@@ -14,10 +15,10 @@ pytestmark = pytest.mark.integration
 
 def aggregate_console(c):
     return {
-        'stdout': ''.join(item[1] for item in c if item[0] == 'stdout'),
-        'stderr': ''.join(item[1] for item in c if item[0] == 'stderr'),
-        'html': ''.join(item[1] for item in c if item[0] == 'html'),
-        'media': list(item[1] for item in c if item[0] == 'media'),
+        "stdout": "".join(item[1] for item in c if item[0] == "stdout"),
+        "stderr": "".join(item[1] for item in c if item[0] == "stderr"),
+        "html": "".join(item[1] for item in c if item[0] == "html"),
+        "media": list(item[1] for item in c if item[0] == "media"),
     }
 
 
@@ -31,21 +32,19 @@ def exec_loop(kernel, mode, code, opts=None, user_inputs=None):
         user_inputs = []
     while True:
         result = kernel.execute(
-            run_id,
-            code=code if num_queries == 0 or mode == 'input' else '',
-            mode=mode,
-            opts=opts)
+            run_id, code=code if num_queries == 0 or mode == "input" else "", mode=mode, opts=opts
+        )
         num_queries += 1
-        console.extend(result['console'])
-        if result['status'] == 'finished':
+        console.extend(result["console"])
+        if result["status"] == "finished":
             break
-        elif result['status'] == 'waiting-input':
-            mode = 'input'
+        elif result["status"] == "waiting-input":
+            mode = "input"
             code = user_inputs.pop(0)
             opts = None
         else:
-            mode = 'continue'
-            code = ''
+            mode = "continue"
+            code = ""
             opts = None
     return aggregate_console(console), num_queries
 
@@ -53,7 +52,7 @@ def exec_loop(kernel, mode, code, opts=None, user_inputs=None):
 @pytest.yield_fixture
 def py3_kernel():
     with Session() as sess:
-        kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04')
+        kernel = sess.Kernel.get_or_create("python:3.6-ubuntu18.04")
         yield kernel
         kernel.destroy()
 
@@ -61,20 +60,20 @@ def py3_kernel():
 def test_hello():
     with Session() as sess:
         result = sess.Kernel.hello()
-    assert 'version' in result
+    assert "version" in result
 
 
 def test_kernel_lifecycles():
     with Session() as sess:
-        kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04')
+        kernel = sess.Kernel.get_or_create("python:3.6-ubuntu18.04")
         kernel_id = kernel.kernel_id
         info = kernel.get_info()
         # the tag may be different depending on alias/metadata config.
-        lang = info['lang']
-        assert lang.startswith('index.docker.io/lablup/python:')
-        assert info['numQueriesExecuted'] == 1
+        lang = info["lang"]
+        assert lang.startswith("index.docker.io/lablup/python:")
+        assert info["numQueriesExecuted"] == 1
         info = kernel.get_info()
-        assert info['numQueriesExecuted'] == 2
+        assert info["numQueriesExecuted"] == 2
         kernel.destroy()
         # kernel destruction is no longer synchronous!
         time.sleep(2.0)
@@ -85,20 +84,20 @@ def test_kernel_lifecycles():
 
 def test_kernel_execution_query_mode(py3_kernel):
     code = 'print("hello world"); x = 1 / 0'
-    console, n = exec_loop(py3_kernel, 'query', code, None)
-    assert 'hello world' in console['stdout']
-    assert 'ZeroDivisionError' in console['stderr']
-    assert len(console['media']) == 0
+    console, n = exec_loop(py3_kernel, "query", code, None)
+    assert "hello world" in console["stdout"]
+    assert "ZeroDivisionError" in console["stderr"]
+    assert len(console["media"]) == 0
     info = py3_kernel.get_info()
-    assert info['numQueriesExecuted'] == n + 1
+    assert info["numQueriesExecuted"] == n + 1
 
 
 def test_kernel_execution_query_mode_user_input(py3_kernel):
     name = secrets.token_hex(8)
     code = 'name = input("your name? "); print(f"hello, {name}!")'
-    console, n = exec_loop(py3_kernel, 'query', code, None, user_inputs=[name])
-    assert 'your name?' in console['stdout']
-    assert 'hello, {}!'.format(name) in console['stdout']
+    console, n = exec_loop(py3_kernel, "query", code, None, user_inputs=[name])
+    assert "your name?" in console["stdout"]
+    assert "hello, {}!".format(name) in console["stdout"]
 
 
 def test_kernel_get_or_create_reuse():
@@ -106,67 +105,79 @@ def test_kernel_get_or_create_reuse():
         try:
             # Sessions with same token and same language must be reused.
             t = secrets.token_hex(6)
-            kernel1 = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
-                                                client_token=t)
-            kernel2 = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
-                                                client_token=t)
+            kernel1 = sess.Kernel.get_or_create("python:3.6-ubuntu18.04", client_token=t)
+            kernel2 = sess.Kernel.get_or_create("python:3.6-ubuntu18.04", client_token=t)
             assert kernel1.kernel_id == kernel2.kernel_id
         finally:
             kernel1.destroy()
 
 
 def test_kernel_execution_batch_mode(py3_kernel):
-    with tempfile.NamedTemporaryFile('w', suffix='.py', dir=Path.cwd()) as f:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", dir=Path.cwd()) as f:
         f.write('print("hello world")\nx = 1 / 0\n')
         f.flush()
         f.seek(0)
         py3_kernel.upload([f.name])
-    console, _ = exec_loop(py3_kernel, 'batch', '', {
-        'build': '',
-        'exec': 'python {}'.format(Path(f.name).name),
-    })
-    assert 'hello world' in console['stdout']
-    assert 'ZeroDivisionError' in console['stderr']
-    assert len(console['media']) == 0
+    console, _ = exec_loop(
+        py3_kernel,
+        "batch",
+        "",
+        {
+            "build": "",
+            "exec": "python {}".format(Path(f.name).name),
+        },
+    )
+    assert "hello world" in console["stdout"]
+    assert "ZeroDivisionError" in console["stderr"]
+    assert len(console["media"]) == 0
 
 
 def test_kernel_execution_batch_mode_user_input(py3_kernel):
     name = secrets.token_hex(8)
-    with tempfile.NamedTemporaryFile('w', suffix='.py', dir=Path.cwd()) as f:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", dir=Path.cwd()) as f:
         f.write('name = input("your name? "); print(f"hello, {name}!")')
         f.flush()
         f.seek(0)
         py3_kernel.upload([f.name])
-    console, _ = exec_loop(py3_kernel, 'batch', '', {
-        'build': '',
-        'exec': 'python {}'.format(Path(f.name).name),
-    }, user_inputs=[name])
-    assert 'your name?' in console['stdout']
-    assert 'hello, {}!'.format(name) in console['stdout']
+    console, _ = exec_loop(
+        py3_kernel,
+        "batch",
+        "",
+        {
+            "build": "",
+            "exec": "python {}".format(Path(f.name).name),
+        },
+        user_inputs=[name],
+    )
+    assert "your name?" in console["stdout"]
+    assert "hello, {}!".format(name) in console["stdout"]
 
 
 def test_kernel_execution_with_vfolder_mounts():
     with Session() as sess:
-        vfname = 'vftest-' + secrets.token_hex(4)
+        vfname = "vftest-" + secrets.token_hex(4)
         sess.VFolder.create(vfname)
         vfolder = sess.VFolder(vfname)
         try:
-            with tempfile.NamedTemporaryFile('w', suffix='.py',
-                                             dir=Path.cwd()) as f:
+            with tempfile.NamedTemporaryFile("w", suffix=".py", dir=Path.cwd()) as f:
                 f.write('print("hello world")\nx = 1 / 0\n')
                 f.flush()
                 f.seek(0)
                 vfolder.upload([f.name])
-            kernel = sess.Kernel.get_or_create('python:3.6-ubuntu18.04',
-                                               mounts=[vfname])
+            kernel = sess.Kernel.get_or_create("python:3.6-ubuntu18.04", mounts=[vfname])
             try:
-                console, n = exec_loop(kernel, 'batch', '', {
-                    'build': '',
-                    'exec': 'python {}/{}'.format(vfname, Path(f.name).name),
-                })
-                assert 'hello world' in console['stdout']
-                assert 'ZeroDivisionError' in console['stderr']
-                assert len(console['media']) == 0
+                console, n = exec_loop(
+                    kernel,
+                    "batch",
+                    "",
+                    {
+                        "build": "",
+                        "exec": "python {}/{}".format(vfname, Path(f.name).name),
+                    },
+                )
+                assert "hello world" in console["stdout"]
+                assert "ZeroDivisionError" in console["stderr"]
+                assert len(console["media"]) == 0
             finally:
                 kernel.destroy()
         finally:
@@ -175,52 +186,61 @@ def test_kernel_execution_with_vfolder_mounts():
 
 def test_kernel_restart(py3_kernel):
     num_queries = 1  # first query is done by py3_kernel fixture (creation)
-    first_code = textwrap.dedent('''
+    first_code = textwrap.dedent(
+        """
     a = "first"
     with open("test.txt", "w") as f:
         f.write("helloo?")
     print(a)
-    ''').strip()
-    second_code_name_error = textwrap.dedent('''
+    """
+    ).strip()
+    second_code_name_error = textwrap.dedent(
+        """
     print(a)
-    ''').strip()
-    second_code_file_check = textwrap.dedent('''
+    """
+    ).strip()
+    second_code_file_check = textwrap.dedent(
+        """
     with open("test.txt", "r") as f:
         print(f.read())
-    ''').strip()
-    console, n = exec_loop(py3_kernel, 'query', first_code)
+    """
+    ).strip()
+    console, n = exec_loop(py3_kernel, "query", first_code)
     num_queries += n
-    assert 'first' in console['stdout']
-    assert console['stderr'] == ''
-    assert len(console['media']) == 0
+    assert "first" in console["stdout"]
+    assert console["stderr"] == ""
+    assert len(console["media"]) == 0
     py3_kernel.restart()
     num_queries += 1
-    console, n = exec_loop(py3_kernel, 'query', second_code_name_error)
+    console, n = exec_loop(py3_kernel, "query", second_code_name_error)
     num_queries += n
-    assert 'NameError' in console['stderr']
-    assert len(console['media']) == 0
-    console, n = exec_loop(py3_kernel, 'query', second_code_file_check)
+    assert "NameError" in console["stderr"]
+    assert len(console["media"]) == 0
+    console, n = exec_loop(py3_kernel, "query", second_code_file_check)
     num_queries += n
-    assert 'helloo?' in console['stdout']
-    assert console['stderr'] == ''
-    assert len(console['media']) == 0
+    assert "helloo?" in console["stdout"]
+    assert console["stderr"] == ""
+    assert len(console["media"]) == 0
     info = py3_kernel.get_info()
     # FIXME: this varies between 2~4
-    assert info['numQueriesExecuted'] == num_queries
+    assert info["numQueriesExecuted"] == num_queries
 
 
 def test_admin_api(py3_kernel):
     sess = py3_kernel.session
-    q = '''
+    q = """
     query($ak: String!) {
         compute_sessions(access_key: $ak, status: "RUNNING") {
             lang
         }
-    }'''
-    resp = sess.Admin.query(q, {
-        'ak': sess.config.access_key,
-    })
-    assert 'compute_sessions' in resp
-    assert len(resp['compute_sessions']) >= 1
-    lang = resp['compute_sessions'][0]['lang']
-    assert lang.startswith('index.docker.io/lablup/python:')
+    }"""
+    resp = sess.Admin.query(
+        q,
+        {
+            "ak": sess.config.access_key,
+        },
+    )
+    assert "compute_sessions" in resp
+    assert len(resp["compute_sessions"]) >= 1
+    lang = resp["compute_sessions"][0]["lang"]
+    assert lang.startswith("index.docker.io/lablup/python:")

--- a/tests/client/integration/test_keypair.py
+++ b/tests/client/integration/test_keypair.py
@@ -1,0 +1,71 @@
+import pytest
+
+import uuid
+
+from ai.backend.client.config import get_config
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.session import Session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_keypair_manipulation_operations():
+    email = 'testion' + uuid.uuid4().hex + '@test.mars'
+    access_key = None
+    with Session() as sess:
+        try:
+            # Create keypair
+            result = sess.KeyPair.create(user_id=email, is_active=True,
+                                         is_admin=False,
+                                         resource_policy='default',
+                                         rate_limit=1)
+            access_key = result['keypair']['access_key']
+            keypairs = sess.KeyPair.list(user_id=email)
+            assert len(keypairs) == 1
+            assert keypairs[0]['access_key'] == access_key
+            assert keypairs[0]['is_active']
+            assert not keypairs[0]['is_admin']
+
+            # Update keypair
+            sess.KeyPair.update(access_key, is_active=False)
+            keypairs = sess.KeyPair.list(user_id=email)
+            assert not keypairs[0]['is_active']
+
+            # Activate keypair
+            sess.KeyPair.activate(access_key)
+            keypairs = sess.KeyPair.list(user_id=email)
+            assert keypairs[0]['is_active']
+
+            # Deactivate keypair
+            sess.KeyPair.deactivate(access_key)
+            keypairs = sess.KeyPair.list(user_id=email)
+            assert not keypairs[0]['is_active']
+
+            # Delete Keypair
+            sess.KeyPair.delete(access_key)
+            keypairs = sess.KeyPair.list(user_id=email)
+            assert len(keypairs) == 0
+        except Exception:
+            if access_key:
+                sess.KeyPair.delete(access_key)
+            raise
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_create_keypair(userconfig):
+    email = 'testion' + uuid.uuid4().hex + '@test.mars'
+    with Session() as sess:
+        with pytest.raises(BackendAPIError):
+            sess.KeyPair.create(user_id=email, is_active=True,
+                                is_admin=False, resource_policy='default',
+                                rate_limit=1)
+
+
+@pytest.mark.asyncio
+async def test_keypair_info():
+    current_config = get_config()
+    with Session() as sess:
+        result = sess.KeyPair(current_config.access_key).info()
+    assert result['access_key'] == current_config.access_key
+    assert result['secret_key'] == current_config.secret_key

--- a/tests/client/integration/test_keypair.py
+++ b/tests/client/integration/test_keypair.py
@@ -1,6 +1,6 @@
-import pytest
-
 import uuid
+
+import pytest
 
 from ai.backend.client.config import get_config
 from ai.backend.client.exceptions import BackendAPIError
@@ -11,36 +11,39 @@ pytestmark = pytest.mark.integration
 
 @pytest.mark.asyncio
 async def test_keypair_manipulation_operations():
-    email = 'testion' + uuid.uuid4().hex + '@test.mars'
+    email = "testion" + uuid.uuid4().hex + "@test.mars"
     access_key = None
     with Session() as sess:
         try:
             # Create keypair
-            result = sess.KeyPair.create(user_id=email, is_active=True,
-                                         is_admin=False,
-                                         resource_policy='default',
-                                         rate_limit=1)
-            access_key = result['keypair']['access_key']
+            result = sess.KeyPair.create(
+                user_id=email,
+                is_active=True,
+                is_admin=False,
+                resource_policy="default",
+                rate_limit=1,
+            )
+            access_key = result["keypair"]["access_key"]
             keypairs = sess.KeyPair.list(user_id=email)
             assert len(keypairs) == 1
-            assert keypairs[0]['access_key'] == access_key
-            assert keypairs[0]['is_active']
-            assert not keypairs[0]['is_admin']
+            assert keypairs[0]["access_key"] == access_key
+            assert keypairs[0]["is_active"]
+            assert not keypairs[0]["is_admin"]
 
             # Update keypair
             sess.KeyPair.update(access_key, is_active=False)
             keypairs = sess.KeyPair.list(user_id=email)
-            assert not keypairs[0]['is_active']
+            assert not keypairs[0]["is_active"]
 
             # Activate keypair
             sess.KeyPair.activate(access_key)
             keypairs = sess.KeyPair.list(user_id=email)
-            assert keypairs[0]['is_active']
+            assert keypairs[0]["is_active"]
 
             # Deactivate keypair
             sess.KeyPair.deactivate(access_key)
             keypairs = sess.KeyPair.list(user_id=email)
-            assert not keypairs[0]['is_active']
+            assert not keypairs[0]["is_active"]
 
             # Delete Keypair
             sess.KeyPair.delete(access_key)
@@ -54,12 +57,16 @@ async def test_keypair_manipulation_operations():
 
 @pytest.mark.asyncio
 async def test_user_cannot_create_keypair(userconfig):
-    email = 'testion' + uuid.uuid4().hex + '@test.mars'
+    email = "testion" + uuid.uuid4().hex + "@test.mars"
     with Session() as sess:
         with pytest.raises(BackendAPIError):
-            sess.KeyPair.create(user_id=email, is_active=True,
-                                is_admin=False, resource_policy='default',
-                                rate_limit=1)
+            sess.KeyPair.create(
+                user_id=email,
+                is_active=True,
+                is_admin=False,
+                resource_policy="default",
+                rate_limit=1,
+            )
 
 
 @pytest.mark.asyncio
@@ -67,5 +74,5 @@ async def test_keypair_info():
     current_config = get_config()
     with Session() as sess:
         result = sess.KeyPair(current_config.access_key).info()
-    assert result['access_key'] == current_config.access_key
-    assert result['secret_key'] == current_config.secret_key
+    assert result["access_key"] == current_config.access_key
+    assert result["secret_key"] == current_config.secret_key

--- a/tests/client/integration/test_load.py
+++ b/tests/client/integration/test_load.py
@@ -47,7 +47,7 @@ def run_create_kernel(_idx):
     try:
         k = ComputeSession.get_or_create("python3")
         ret = k.kernel_id
-    except:
+    except Exception:
         log.exception("run_create_kernel")
         ret = None
     finally:

--- a/tests/client/integration/test_load.py
+++ b/tests/client/integration/test_load.py
@@ -1,14 +1,14 @@
-'''
+"""
 A standalone script to generate some loads to the public API server.
 It assumes that you have already configured the access key and secret key
 as environment variables.
-'''
+"""
 
 import logging
 import multiprocessing
 import secrets
-from statistics import mean, median, stdev
 import time
+from statistics import mean, median, stdev
 
 import pytest
 
@@ -17,33 +17,38 @@ from ai.backend.client.func.session import ComputeSession
 # module-level marker
 pytestmark = pytest.mark.integration
 
-log = logging.getLogger('ai.backend.client.test.load')
+log = logging.getLogger("ai.backend.client.test.load")
 
-sample_code = '''
+sample_code = """
 import os
 print('ls:', os.listdir('.'))
 with open('test.txt', 'w') as f:
     f.write('hello world')
-'''
+"""
 
-sample_code_julia = '''
+sample_code_julia = """
 println("wow")
-'''
+"""
 
 
 def print_stat(msg, times_taken):
-    print('{}: mean {:.2f} secs, median {:.2f} secs, stdev {:.2f}'.format(
-        msg, mean(times_taken), median(times_taken), stdev(times_taken),
-    ))
+    print(
+        "{}: mean {:.2f} secs, median {:.2f} secs, stdev {:.2f}".format(
+            msg,
+            mean(times_taken),
+            median(times_taken),
+            stdev(times_taken),
+        )
+    )
 
 
 def run_create_kernel(_idx):
     begin = time.monotonic()
     try:
-        k = ComputeSession.get_or_create('python3')
+        k = ComputeSession.get_or_create("python3")
         ret = k.kernel_id
     except:
-        log.exception('run_create_kernel')
+        log.exception("run_create_kernel")
         ret = None
     finally:
         end = time.monotonic()
@@ -67,7 +72,7 @@ def create_kernels(concurrency, parallel=False):
             times_taken.append(t)
             kernel_ids.append(kid)
 
-    print_stat('create_kernel', times_taken)
+    print_stat("create_kernel", times_taken)
     return kernel_ids
 
 
@@ -78,10 +83,10 @@ def run_execute_code(kid):
         run_id = secrets.token_hex(8)
         while True:
             result = ComputeSession(kid).execute(run_id, sample_code)
-            console.extend(result['console'])
-            if result['status'] == 'finished':
+            console.extend(result["console"])
+            if result["status"] == "finished":
                 break
-        stdout = ''.join(rec[1] for rec in console if rec[0] == 'stdout')
+        stdout = "".join(rec[1] for rec in console if rec[0] == "stdout")
         end = time.monotonic()
         print(stdout)
         return end - begin
@@ -103,7 +108,7 @@ def execute_codes(kernel_ids, parallel=False):
             if t is not None:
                 times_taken.append(t)
 
-    print_stat('execute_code', times_taken)
+    print_stat("execute_code", times_taken)
 
 
 def run_restart_kernel(kid):
@@ -131,7 +136,7 @@ def restart_kernels(kernel_ids, parallel=False):
             if t is not None:
                 times_taken.append(t)
 
-    print_stat('restart_kernel', times_taken)
+    print_stat("restart_kernel", times_taken)
 
 
 def run_destroy_kernel(kid):
@@ -158,17 +163,20 @@ def destroy_kernels(kernel_ids, parallel=False):
             if t is not None:
                 times_taken.append(t)
 
-    print_stat('destroy_kernel', times_taken)
+    print_stat("destroy_kernel", times_taken)
 
 
-@pytest.mark.parametrize('concurrency,parallel,restart', [
-    (5, False, False),
-    (5, True,  False),
-    (5, False, True),
-    (5, True,  True),
-])
+@pytest.mark.parametrize(
+    "concurrency,parallel,restart",
+    [
+        (5, False, False),
+        (5, True, False),
+        (5, False, True),
+        (5, True, True),
+    ],
+)
 def test_high_load_requests(capsys, defconfig, concurrency, parallel, restart):
-    '''
+    """
     Tests creation and use of multiple concurrent kernels in various ways.
 
     NOTE: This test may fail if your system has too less cores compared to the
@@ -183,11 +191,11 @@ def test_high_load_requests(capsys, defconfig, concurrency, parallel, restart):
     Running this tests with different parameters without no delays between
     parameter sets would cause "503 Service Unavailable" errors as it will
     quickly saturate the resource limit of the developer's PC.
-    '''
+    """
 
     # Show stdout for timing statistics
     with capsys.disabled():
-        print('waiting for previous asynchronous kernel destruction for 5 secs...')
+        print("waiting for previous asynchronous kernel destruction for 5 secs...")
         time.sleep(5)
         kids = create_kernels(concurrency, parallel)
         execute_codes(kids, parallel)

--- a/tests/client/integration/test_load.py
+++ b/tests/client/integration/test_load.py
@@ -1,0 +1,197 @@
+'''
+A standalone script to generate some loads to the public API server.
+It assumes that you have already configured the access key and secret key
+as environment variables.
+'''
+
+import logging
+import multiprocessing
+import secrets
+from statistics import mean, median, stdev
+import time
+
+import pytest
+
+from ai.backend.client.func.session import ComputeSession
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+log = logging.getLogger('ai.backend.client.test.load')
+
+sample_code = '''
+import os
+print('ls:', os.listdir('.'))
+with open('test.txt', 'w') as f:
+    f.write('hello world')
+'''
+
+sample_code_julia = '''
+println("wow")
+'''
+
+
+def print_stat(msg, times_taken):
+    print('{}: mean {:.2f} secs, median {:.2f} secs, stdev {:.2f}'.format(
+        msg, mean(times_taken), median(times_taken), stdev(times_taken),
+    ))
+
+
+def run_create_kernel(_idx):
+    begin = time.monotonic()
+    try:
+        k = ComputeSession.get_or_create('python3')
+        ret = k.kernel_id
+    except:
+        log.exception('run_create_kernel')
+        ret = None
+    finally:
+        end = time.monotonic()
+    t = end - begin
+    return t, ret
+
+
+def create_kernels(concurrency, parallel=False):
+    kernel_ids = []
+    times_taken = []
+
+    if parallel:
+        pool = multiprocessing.Pool(concurrency)
+        results = pool.map(run_create_kernel, range(concurrency))
+        for t, kid in results:
+            times_taken.append(t)
+            kernel_ids.append(kid)
+    else:
+        for _idx in range(concurrency):
+            t, kid = run_create_kernel(_idx)
+            times_taken.append(t)
+            kernel_ids.append(kid)
+
+    print_stat('create_kernel', times_taken)
+    return kernel_ids
+
+
+def run_execute_code(kid):
+    if kid is not None:
+        begin = time.monotonic()
+        console = []
+        run_id = secrets.token_hex(8)
+        while True:
+            result = ComputeSession(kid).execute(run_id, sample_code)
+            console.extend(result['console'])
+            if result['status'] == 'finished':
+                break
+        stdout = ''.join(rec[1] for rec in console if rec[0] == 'stdout')
+        end = time.monotonic()
+        print(stdout)
+        return end - begin
+    return None
+
+
+def execute_codes(kernel_ids, parallel=False):
+    times_taken = []
+
+    if parallel:
+        pool = multiprocessing.Pool(len(kernel_ids))
+        results = pool.map(run_execute_code, kernel_ids)
+        for t in results:
+            if t is not None:
+                times_taken.append(t)
+    else:
+        for kid in kernel_ids:
+            t = run_execute_code(kid)
+            if t is not None:
+                times_taken.append(t)
+
+    print_stat('execute_code', times_taken)
+
+
+def run_restart_kernel(kid):
+    # 2nd params is currently ignored.
+    if kid is not None:
+        begin = time.monotonic()
+        ComputeSession(kid).restart()
+        end = time.monotonic()
+        return end - begin
+    return None
+
+
+def restart_kernels(kernel_ids, parallel=False):
+    times_taken = []
+
+    if parallel:
+        pool = multiprocessing.Pool(len(kernel_ids))
+        results = pool.map(run_restart_kernel, kernel_ids)
+        for t in results:
+            if t is not None:
+                times_taken.append(t)
+    else:
+        for kid in kernel_ids:
+            t = run_restart_kernel(kid)
+            if t is not None:
+                times_taken.append(t)
+
+    print_stat('restart_kernel', times_taken)
+
+
+def run_destroy_kernel(kid):
+    if kid is not None:
+        begin = time.monotonic()
+        ComputeSession(kid).destroy()
+        end = time.monotonic()
+        return end - begin
+    return None
+
+
+def destroy_kernels(kernel_ids, parallel=False):
+    times_taken = []
+
+    if parallel:
+        pool = multiprocessing.Pool(len(kernel_ids))
+        results = pool.map(run_destroy_kernel, kernel_ids)
+        for t in results:
+            if t is not None:
+                times_taken.append(t)
+    else:
+        for kid in kernel_ids:
+            t = run_destroy_kernel(kid)
+            if t is not None:
+                times_taken.append(t)
+
+    print_stat('destroy_kernel', times_taken)
+
+
+@pytest.mark.parametrize('concurrency,parallel,restart', [
+    (5, False, False),
+    (5, True,  False),
+    (5, False, True),
+    (5, True,  True),
+])
+def test_high_load_requests(capsys, defconfig, concurrency, parallel, restart):
+    '''
+    Tests creation and use of multiple concurrent kernels in various ways.
+
+    NOTE: This test may fail if your system has too less cores compared to the
+    given concurrency.  The exact number of cores required is determined by the
+    Python3 kernel's resource requirements (CPU slots).
+
+    NOTE: This test may occasionally fail if it takes too long time to destroy
+    Docker containers in the manager because the resources occupation is
+    restored after container destruction but the destroy API returns after
+    stopping containers but before they are actually destroyed.
+    We have inserted some small delay to work-around this.
+    Running this tests with different parameters without no delays between
+    parameter sets would cause "503 Service Unavailable" errors as it will
+    quickly saturate the resource limit of the developer's PC.
+    '''
+
+    # Show stdout for timing statistics
+    with capsys.disabled():
+        print('waiting for previous asynchronous kernel destruction for 5 secs...')
+        time.sleep(5)
+        kids = create_kernels(concurrency, parallel)
+        execute_codes(kids, parallel)
+        if restart:
+            restart_kernels(kids, parallel)
+            execute_codes(kids, parallel)
+        destroy_kernels(kids, parallel)

--- a/tests/client/integration/test_manager.py
+++ b/tests/client/integration/test_manager.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ai.backend.client.session import Session
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_get_manager_status():
+    with Session() as sess:
+        resp = sess.Manager.status()
+    assert resp['status'] == 'running'
+    assert 'active_sessions' in resp

--- a/tests/client/integration/test_manager.py
+++ b/tests/client/integration/test_manager.py
@@ -10,5 +10,5 @@ pytestmark = pytest.mark.integration
 async def test_get_manager_status():
     with Session() as sess:
         resp = sess.Manager.status()
-    assert resp['status'] == 'running'
-    assert 'active_sessions' in resp
+    assert resp["status"] == "running"
+    assert "active_sessions" in resp

--- a/tests/client/integration/test_request.py
+++ b/tests/client/integration/test_request.py
@@ -2,26 +2,26 @@ import pytest
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.request import Request
-from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.session import AsyncSession, Session
 
 pytestmark = pytest.mark.integration
 
 
 def test_connection():
     with Session():
-        request = Request('GET', '/')
+        request = Request("GET", "/")
         with request.fetch() as resp:
-            assert 'version' in resp.json()
+            assert "version" in resp.json()
 
 
 def test_not_found():
     with Session():
-        request = Request('GET', '/invalid-url-wow')
+        request = Request("GET", "/invalid-url-wow")
         with pytest.raises(BackendAPIError) as e:
             with request.fetch():
                 pass
         assert e.value.status == 404
-        request = Request('GET', '/auth/uh-oh')
+        request = Request("GET", "/auth/uh-oh")
         with pytest.raises(BackendAPIError) as e:
             with request.fetch():
                 pass
@@ -31,6 +31,6 @@ def test_not_found():
 @pytest.mark.asyncio
 async def test_async_connection():
     async with AsyncSession():
-        request = Request('GET', '/')
+        request = Request("GET", "/")
         async with request.fetch() as resp:
-            assert 'version' in await resp.json()
+            assert "version" in await resp.json()

--- a/tests/client/integration/test_request.py
+++ b/tests/client/integration/test_request.py
@@ -1,0 +1,36 @@
+import pytest
+
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.request import Request
+from ai.backend.client.session import Session, AsyncSession
+
+pytestmark = pytest.mark.integration
+
+
+def test_connection():
+    with Session():
+        request = Request('GET', '/')
+        with request.fetch() as resp:
+            assert 'version' in resp.json()
+
+
+def test_not_found():
+    with Session():
+        request = Request('GET', '/invalid-url-wow')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 404
+        request = Request('GET', '/auth/uh-oh')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 404
+
+
+@pytest.mark.asyncio
+async def test_async_connection():
+    async with AsyncSession():
+        request = Request('GET', '/')
+        async with request.fetch() as resp:
+            assert 'version' in await resp.json()

--- a/tests/client/integration/test_resource_policy.py
+++ b/tests/client/integration/test_resource_policy.py
@@ -1,0 +1,81 @@
+import uuid
+
+import pytest
+
+from ai.backend.client.config import get_config
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.session import Session
+
+# module-level marker
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_manipulate_resource_policy(self):
+    access_key = get_config().access_key
+    rpname = 'testrp-' + uuid.uuid4().hex
+    with Session() as sess:
+        try:
+            rp = sess.ResourcePolicy(access_key)
+            assert rp.info(rpname) is None
+            rps = sess.ResourcePolicy.list()
+            original_count = len(rps)
+
+            # Create resource policy
+            sess.ResourcePolicy.create(
+                name=rpname, default_for_unspecified='LIMITED',
+                total_resource_slots='{}', max_concurrent_sessions=1,
+                max_containers_per_session=1, max_vfolder_count=1,
+                max_vfolder_size=1, idle_timeout=1,
+                allowed_vfolder_hosts=['local'],
+            )
+            rps = sess.ResourcePolicy.list()
+            assert len(rps) == original_count + 1
+            info = rp.info(rpname)
+            assert info['name'] == rpname
+            assert info['total_resource_slots'] == '{}'
+            assert info['max_concurrent_sessions'] == 1
+            assert info['max_vfolder_count'] == 1
+            assert info['max_vfolder_size'] == 1
+            assert info['idle_timeout'] == 1
+
+            # Update resource policy
+            sess.ResourcePolicy.update(
+                name=rpname, default_for_unspecified='LIMITED',
+                total_resource_slots='{"cpu": "count"}',
+                max_concurrent_sessions=2,
+                max_containers_per_session=2, max_vfolder_count=2,
+                max_vfolder_size=2, idle_timeout=2,
+                allowed_vfolder_hosts=['local'],
+            )
+            rps = sess.ResourcePolicy.list()
+            assert len(rps) == original_count + 1
+            info = rp.info(rpname)
+            assert info['name'] == rpname
+            assert info['total_resource_slots'] == '{"cpu": "count"}'
+            assert info['max_concurrent_sessions'] == 2
+            assert info['max_vfolder_count'] == 2
+            assert info['max_vfolder_size'] == 2
+            assert info['idle_timeout'] == 2
+
+            # Delete ResourcePolicy
+            sess.ResourcePolicy.delete(rpname)
+            rps = sess.ResourcePolicy.list()
+            assert len(rps) == original_count
+        except Exception:
+            sess.ResourcePolicy.delete(rpname)
+            raise
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_create_resource_policy(self, userconfig):
+    rpname = 'testrp-' + uuid.uuid4().hex
+    with Session() as sess:
+        with pytest.raises(BackendAPIError):
+            sess.ResourcePolicy.create(
+                name=rpname, default_for_unspecified='LIMITED',
+                total_resource_slots='{}', max_concurrent_sessions=1,
+                max_containers_per_session=1, max_vfolder_count=1,
+                max_vfolder_size=1, idle_timeout=1,
+                allowed_vfolder_hosts=['local'],
+            )

--- a/tests/client/integration/test_resource_policy.py
+++ b/tests/client/integration/test_resource_policy.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.integration
 @pytest.mark.asyncio
 async def test_manipulate_resource_policy(self):
     access_key = get_config().access_key
-    rpname = 'testrp-' + uuid.uuid4().hex
+    rpname = "testrp-" + uuid.uuid4().hex
     with Session() as sess:
         try:
             rp = sess.ResourcePolicy(access_key)
@@ -23,40 +23,47 @@ async def test_manipulate_resource_policy(self):
 
             # Create resource policy
             sess.ResourcePolicy.create(
-                name=rpname, default_for_unspecified='LIMITED',
-                total_resource_slots='{}', max_concurrent_sessions=1,
-                max_containers_per_session=1, max_vfolder_count=1,
-                max_vfolder_size=1, idle_timeout=1,
-                allowed_vfolder_hosts=['local'],
+                name=rpname,
+                default_for_unspecified="LIMITED",
+                total_resource_slots="{}",
+                max_concurrent_sessions=1,
+                max_containers_per_session=1,
+                max_vfolder_count=1,
+                max_vfolder_size=1,
+                idle_timeout=1,
+                allowed_vfolder_hosts=["local"],
             )
             rps = sess.ResourcePolicy.list()
             assert len(rps) == original_count + 1
             info = rp.info(rpname)
-            assert info['name'] == rpname
-            assert info['total_resource_slots'] == '{}'
-            assert info['max_concurrent_sessions'] == 1
-            assert info['max_vfolder_count'] == 1
-            assert info['max_vfolder_size'] == 1
-            assert info['idle_timeout'] == 1
+            assert info["name"] == rpname
+            assert info["total_resource_slots"] == "{}"
+            assert info["max_concurrent_sessions"] == 1
+            assert info["max_vfolder_count"] == 1
+            assert info["max_vfolder_size"] == 1
+            assert info["idle_timeout"] == 1
 
             # Update resource policy
             sess.ResourcePolicy.update(
-                name=rpname, default_for_unspecified='LIMITED',
+                name=rpname,
+                default_for_unspecified="LIMITED",
                 total_resource_slots='{"cpu": "count"}',
                 max_concurrent_sessions=2,
-                max_containers_per_session=2, max_vfolder_count=2,
-                max_vfolder_size=2, idle_timeout=2,
-                allowed_vfolder_hosts=['local'],
+                max_containers_per_session=2,
+                max_vfolder_count=2,
+                max_vfolder_size=2,
+                idle_timeout=2,
+                allowed_vfolder_hosts=["local"],
             )
             rps = sess.ResourcePolicy.list()
             assert len(rps) == original_count + 1
             info = rp.info(rpname)
-            assert info['name'] == rpname
-            assert info['total_resource_slots'] == '{"cpu": "count"}'
-            assert info['max_concurrent_sessions'] == 2
-            assert info['max_vfolder_count'] == 2
-            assert info['max_vfolder_size'] == 2
-            assert info['idle_timeout'] == 2
+            assert info["name"] == rpname
+            assert info["total_resource_slots"] == '{"cpu": "count"}'
+            assert info["max_concurrent_sessions"] == 2
+            assert info["max_vfolder_count"] == 2
+            assert info["max_vfolder_size"] == 2
+            assert info["idle_timeout"] == 2
 
             # Delete ResourcePolicy
             sess.ResourcePolicy.delete(rpname)
@@ -69,13 +76,17 @@ async def test_manipulate_resource_policy(self):
 
 @pytest.mark.asyncio
 async def test_user_cannot_create_resource_policy(self, userconfig):
-    rpname = 'testrp-' + uuid.uuid4().hex
+    rpname = "testrp-" + uuid.uuid4().hex
     with Session() as sess:
         with pytest.raises(BackendAPIError):
             sess.ResourcePolicy.create(
-                name=rpname, default_for_unspecified='LIMITED',
-                total_resource_slots='{}', max_concurrent_sessions=1,
-                max_containers_per_session=1, max_vfolder_count=1,
-                max_vfolder_size=1, idle_timeout=1,
-                allowed_vfolder_hosts=['local'],
+                name=rpname,
+                default_for_unspecified="LIMITED",
+                total_resource_slots="{}",
+                max_concurrent_sessions=1,
+                max_containers_per_session=1,
+                max_vfolder_count=1,
+                max_vfolder_size=1,
+                idle_timeout=1,
+                allowed_vfolder_hosts=["local"],
             )

--- a/tests/client/output/BUILD
+++ b/tests/client/output/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/client/output/test_types.py
+++ b/tests/client/output/test_types.py
@@ -35,21 +35,36 @@ def test_fieldspec_init():
     assert f.humanized_name == "Key Foo"
     assert not f.subfields  # not initialized in this case
 
-    f = FieldSpec("key_foo", subfields=FieldSet([
-        FieldSpec("bar"),
-        FieldSpec("baz", alt_name="bbb"),
-    ]))
+    f = FieldSpec(
+        "key_foo",
+        subfields=FieldSet(
+            [
+                FieldSpec("bar"),
+                FieldSpec("baz", alt_name="bbb"),
+            ]
+        ),
+    )
     assert f.field_ref == "key_foo { bar baz }"
     assert f.field_name == "key_foo"
     assert f.humanized_name == "Key Foo"
     assert f.subfields["bar"].field_ref == "bar"
     assert f.subfields["bbb"].field_ref == "baz"
 
-    f = FieldSpec("key_foo", subfields=FieldSet([
-        FieldSpec("bar", subfields=FieldSet([
-            FieldSpec("kaz"),
-        ])),
-    ]))
+    f = FieldSpec(
+        "key_foo",
+        subfields=FieldSet(
+            [
+                FieldSpec(
+                    "bar",
+                    subfields=FieldSet(
+                        [
+                            FieldSpec("kaz"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    )
     assert f.field_ref == "key_foo { bar { kaz } }"
     assert f.field_name == "key_foo"
     assert f.humanized_name == "Key Foo"

--- a/tests/client/output/test_types.py
+++ b/tests/client/output/test_types.py
@@ -1,0 +1,56 @@
+from ai.backend.client.output.types import FieldSet, FieldSpec
+
+
+def test_fieldspec_init():
+    f = FieldSpec("key_foo")
+    assert f.field_ref == "key_foo"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Key Foo"
+    assert f.alt_name == "key_foo"
+    assert not f.subfields
+
+    f = FieldSpec("key_foo", "Foo")
+    assert f.field_ref == "key_foo"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Foo"
+    assert f.alt_name == "key_foo"
+    assert not f.subfields
+
+    fs = FieldSet([f])
+    assert fs["key_foo"] == f
+
+    f = FieldSpec("key_foo", "Foo", alt_name="key_fuu")
+    assert f.field_ref == "key_foo"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Foo"
+    assert f.alt_name == "key_fuu"
+    assert not f.subfields
+
+    fs = FieldSet([f])
+    assert fs["key_fuu"] == f
+
+    f = FieldSpec("key_foo { bar }")
+    assert f.field_ref == "key_foo { bar }"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Key Foo"
+    assert not f.subfields  # not initialized in this case
+
+    f = FieldSpec("key_foo", subfields=FieldSet([
+        FieldSpec("bar"),
+        FieldSpec("baz", alt_name="bbb"),
+    ]))
+    assert f.field_ref == "key_foo { bar baz }"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Key Foo"
+    assert f.subfields["bar"].field_ref == "bar"
+    assert f.subfields["bbb"].field_ref == "baz"
+
+    f = FieldSpec("key_foo", subfields=FieldSet([
+        FieldSpec("bar", subfields=FieldSet([
+            FieldSpec("kaz"),
+        ])),
+    ]))
+    assert f.field_ref == "key_foo { bar { kaz } }"
+    assert f.field_name == "key_foo"
+    assert f.humanized_name == "Key Foo"
+    assert f.subfields["bar"].field_ref == "bar { kaz }"

--- a/tests/client/test_asyncio_kernel.py
+++ b/tests/client/test_asyncio_kernel.py
@@ -1,26 +1,25 @@
 import secrets
-from unittest import mock
 import uuid
+from unittest import mock
 
 import pytest
 
 from ai.backend.client.session import AsyncSession
-from ai.backend.client.versioning import get_naming
 from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
-
+from ai.backend.client.versioning import get_naming
 
 simulated_api_versions = [
-    (4, '20190615'),
-    (5, '20191215'),
-    (6, '20200815'),
+    (4, "20190615"),
+    (5, "20191215"),
+    (6, "20200815"),
 ]
 
 
-@pytest.fixture(scope='module', autouse=True, params=simulated_api_versions)
+@pytest.fixture(scope="module", autouse=True, params=simulated_api_versions)
 def api_version(request):
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = request.param
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield request.param
 
 
@@ -31,18 +30,16 @@ async def test_create_kernel_url(mocker):
         status=201,
         json=AsyncMock(
             return_value={
-                'sessionId': str(uuid.uuid4()),
-                'created': True,
+                "sessionId": str(uuid.uuid4()),
+                "created": True,
             },
         ),
     )
-    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
-                                return_value=mock_req_obj)
+    mock_req_cls = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     async with AsyncSession() as session:
-        await session.ComputeSession.get_or_create('python:3.6-ubuntu18.04')
-        prefix = get_naming(session.api_version, 'path')
-        mock_req_cls.assert_called_once_with(
-            'POST', f'/{prefix}')
+        await session.ComputeSession.get_or_create("python:3.6-ubuntu18.04")
+        prefix = get_naming(session.api_version, "path")
+        mock_req_cls.assert_called_once_with("POST", f"/{prefix}")
         mock_req_obj.fetch.assert_called_once_with()
         mock_req_obj.fetch.return_value.json.assert_awaited_once_with()
 
@@ -52,13 +49,11 @@ async def test_destroy_kernel_url(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
     session_name = secrets.token_hex(12)
-    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
-                                return_value=mock_req_obj)
+    mock_req_cls = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     async with AsyncSession() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         await session.ComputeSession(session_name).destroy()
-        mock_req_cls.assert_called_once_with(
-            'DELETE', f'/{prefix}/{session_name}', params={})
+        mock_req_cls.assert_called_once_with("DELETE", f"/{prefix}/{session_name}", params={})
 
 
 @pytest.mark.asyncio
@@ -66,13 +61,11 @@ async def test_restart_kernel_url(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
     session_name = secrets.token_hex(12)
-    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
-                                return_value=mock_req_obj)
+    mock_req_cls = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     async with AsyncSession() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         await session.ComputeSession(session_name).restart()
-        mock_req_cls.assert_called_once_with(
-            'PATCH', f'/{prefix}/{session_name}', params={})
+        mock_req_cls.assert_called_once_with("PATCH", f"/{prefix}/{session_name}", params={})
 
 
 @pytest.mark.asyncio
@@ -80,32 +73,25 @@ async def test_get_kernel_info_url(mocker):
     return_value = {}
     mock_json_coro = AsyncMock(return_value=return_value)
     mock_req_obj = mock.Mock()
-    mock_req_obj.fetch.return_value = AsyncContextMock(
-        status=200, json=mock_json_coro)
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200, json=mock_json_coro)
     session_name = secrets.token_hex(12)
-    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
-                                return_value=mock_req_obj)
+    mock_req_cls = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     async with AsyncSession() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         await session.ComputeSession(session_name).get_info()
-        mock_req_cls.assert_called_once_with(
-            'GET', f'/{prefix}/{session_name}', params={})
+        mock_req_cls.assert_called_once_with("GET", f"/{prefix}/{session_name}", params={})
 
 
 @pytest.mark.asyncio
 async def test_execute_code_url(mocker):
-    return_value = {'result': 'hi'}
+    return_value = {"result": "hi"}
     mock_json_coro = AsyncMock(return_value=return_value)
     mock_req_obj = mock.Mock()
-    mock_req_obj.fetch.return_value = AsyncContextMock(
-        status=200, json=mock_json_coro)
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200, json=mock_json_coro)
     session_name = secrets.token_hex(12)
     run_id = secrets.token_hex(8)
-    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
-                                return_value=mock_req_obj)
+    mock_req_cls = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     async with AsyncSession() as session:
-        prefix = get_naming(session.api_version, 'path')
-        await session.ComputeSession(session_name).execute(run_id, 'hello')
-        mock_req_cls.assert_called_once_with(
-            'POST', f'/{prefix}/{session_name}',
-            params={})
+        prefix = get_naming(session.api_version, "path")
+        await session.ComputeSession(session_name).execute(run_id, "hello")
+        mock_req_cls.assert_called_once_with("POST", f"/{prefix}/{session_name}", params={})

--- a/tests/client/test_asyncio_kernel.py
+++ b/tests/client/test_asyncio_kernel.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 
 from ai.backend.client.session import AsyncSession
-from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
 from ai.backend.client.versioning import get_naming
+from ai.backend.testutils.mock import AsyncContextMock, AsyncMock
 
 simulated_api_versions = [
     (4, "20190615"),

--- a/tests/client/test_asyncio_kernel.py
+++ b/tests/client/test_asyncio_kernel.py
@@ -1,0 +1,111 @@
+import secrets
+from unittest import mock
+import uuid
+
+import pytest
+
+from ai.backend.client.session import AsyncSession
+from ai.backend.client.versioning import get_naming
+from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
+
+
+simulated_api_versions = [
+    (4, '20190615'),
+    (5, '20191215'),
+    (6, '20200815'),
+]
+
+
+@pytest.fixture(scope='module', autouse=True, params=simulated_api_versions)
+def api_version(request):
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = request.param
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield request.param
+
+
+@pytest.mark.asyncio
+async def test_create_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=201,
+        json=AsyncMock(
+            return_value={
+                'sessionId': str(uuid.uuid4()),
+                'created': True,
+            },
+        ),
+    )
+    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
+                                return_value=mock_req_obj)
+    async with AsyncSession() as session:
+        await session.ComputeSession.get_or_create('python:3.6-ubuntu18.04')
+        prefix = get_naming(session.api_version, 'path')
+        mock_req_cls.assert_called_once_with(
+            'POST', f'/{prefix}')
+        mock_req_obj.fetch.assert_called_once_with()
+        mock_req_obj.fetch.return_value.json.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_destroy_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    session_name = secrets.token_hex(12)
+    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
+                                return_value=mock_req_obj)
+    async with AsyncSession() as session:
+        prefix = get_naming(session.api_version, 'path')
+        await session.ComputeSession(session_name).destroy()
+        mock_req_cls.assert_called_once_with(
+            'DELETE', f'/{prefix}/{session_name}', params={})
+
+
+@pytest.mark.asyncio
+async def test_restart_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    session_name = secrets.token_hex(12)
+    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
+                                return_value=mock_req_obj)
+    async with AsyncSession() as session:
+        prefix = get_naming(session.api_version, 'path')
+        await session.ComputeSession(session_name).restart()
+        mock_req_cls.assert_called_once_with(
+            'PATCH', f'/{prefix}/{session_name}', params={})
+
+
+@pytest.mark.asyncio
+async def test_get_kernel_info_url(mocker):
+    return_value = {}
+    mock_json_coro = AsyncMock(return_value=return_value)
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=200, json=mock_json_coro)
+    session_name = secrets.token_hex(12)
+    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
+                                return_value=mock_req_obj)
+    async with AsyncSession() as session:
+        prefix = get_naming(session.api_version, 'path')
+        await session.ComputeSession(session_name).get_info()
+        mock_req_cls.assert_called_once_with(
+            'GET', f'/{prefix}/{session_name}', params={})
+
+
+@pytest.mark.asyncio
+async def test_execute_code_url(mocker):
+    return_value = {'result': 'hi'}
+    mock_json_coro = AsyncMock(return_value=return_value)
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=200, json=mock_json_coro)
+    session_name = secrets.token_hex(12)
+    run_id = secrets.token_hex(8)
+    mock_req_cls = mocker.patch('ai.backend.client.func.session.Request',
+                                return_value=mock_req_obj)
+    async with AsyncSession() as session:
+        prefix = get_naming(session.api_version, 'path')
+        await session.ComputeSession(session_name).execute(run_id, 'hello')
+        mock_req_cls.assert_called_once_with(
+            'POST', f'/{prefix}/{session_name}',
+            params={})

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -7,18 +7,18 @@ from ai.backend.client.auth import generate_signature
 
 def test_generate_signature(defconfig):
     kwargs = dict(
-        method='GET',
+        method="GET",
         version=defconfig.version,
         endpoint=defconfig.endpoint,
         date=datetime.now(tzutc()),
-        rel_url='/path/to/api/',
-        content_type='plain/text',
+        rel_url="/path/to/api/",
+        content_type="plain/text",
         access_key=defconfig.access_key,
         secret_key=defconfig.secret_key,
-        hash_type='md5',
+        hash_type="md5",
     )
     headers, signature = generate_signature(**kwargs)
 
-    assert kwargs['hash_type'].upper() in headers['Authorization']
-    assert kwargs['access_key'] in headers['Authorization']
-    assert signature in headers['Authorization']
+    assert kwargs["hash_type"].upper() in headers["Authorization"]
+    assert kwargs["access_key"] in headers["Authorization"]
+    assert signature in headers["Authorization"]

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from dateutil.tz import tzutc
+
+from ai.backend.client.auth import generate_signature
+
+
+def test_generate_signature(defconfig):
+    kwargs = dict(
+        method='GET',
+        version=defconfig.version,
+        endpoint=defconfig.endpoint,
+        date=datetime.now(tzutc()),
+        rel_url='/path/to/api/',
+        content_type='plain/text',
+        access_key=defconfig.access_key,
+        secret_key=defconfig.secret_key,
+        hash_type='md5',
+    )
+    headers, signature = generate_signature(**kwargs)
+
+    assert kwargs['hash_type'].upper() in headers['Authorization']
+    assert kwargs['access_key'] in headers['Authorization']
+    assert signature in headers['Authorization']

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -6,7 +6,7 @@ import pytest
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.func.base import BaseFunction, api_function
 from ai.backend.client.session import AsyncSession, Session
-from ai.backend.client.test_utils import AsyncMock
+from ai.backend.testutils.mock import AsyncMock
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -1,0 +1,99 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from ai.backend.client.config import API_VERSION
+from ai.backend.client.func.base import BaseFunction, api_function
+from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.test_utils import AsyncMock
+
+
+@pytest.fixture(scope='module', autouse=True)
+def api_version():
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = API_VERSION
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield
+
+
+class DummyFunction:
+
+    session = None
+
+    @api_function
+    @classmethod
+    async def get_or_create(cls):
+        await asyncio.sleep(0)
+        return 'created'
+
+    @api_function
+    async def calculate(self):
+        await asyncio.sleep(0)
+        return 'done'
+
+
+def test_api_function_metaclass():
+    # Here, we repeat intentionally the same stuffs
+    # to check if our metaclass works across multiple
+    # re-definition and re-instantiation scenarios.
+
+    with Session() as session:
+        Dummy = type('DummyFunction', (BaseFunction, ), {
+            **DummyFunction.__dict__,
+            'session': session,
+        })
+
+        assert Dummy.session is session
+        assert Dummy().session is session
+
+        assert Dummy.get_or_create() == 'created'
+        assert Dummy().calculate() == 'done'
+        assert Dummy.get_or_create() == 'created'
+        assert Dummy().calculate() == 'done'
+
+    with Session() as session:
+        Dummy = type('DummyFunction', (BaseFunction, ), {
+            **DummyFunction.__dict__,
+            'session': session,
+        })
+
+        assert Dummy.session is session
+        assert Dummy().session is session
+
+        assert Dummy.get_or_create() == 'created'
+        assert Dummy().calculate() == 'done'
+        assert Dummy.get_or_create() == 'created'
+        assert Dummy().calculate() == 'done'
+
+
+@pytest.mark.asyncio
+async def test_api_function_metaclass_async():
+
+    async with AsyncSession() as session:
+        Dummy = type('DummyFunction', (BaseFunction, ), {
+            **DummyFunction.__dict__,
+            'session': session,
+        })
+
+        assert Dummy.session is session
+        assert Dummy().session is session
+
+        assert await Dummy.get_or_create() == 'created'
+        assert await Dummy().calculate() == 'done'
+        assert await Dummy.get_or_create() == 'created'
+        assert await Dummy().calculate() == 'done'
+
+    async with AsyncSession() as session:
+        Dummy = type('DummyFunction', (BaseFunction, ), {
+            **DummyFunction.__dict__,
+            'session': session,
+        })
+
+        assert Dummy.session is session
+        assert Dummy().session is session
+
+        assert await Dummy.get_or_create() == 'created'
+        assert await Dummy().calculate() == 'done'
+        assert await Dummy.get_or_create() == 'created'
+        assert await Dummy().calculate() == 'done'

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -5,15 +5,15 @@ import pytest
 
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.func.base import BaseFunction, api_function
-from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.session import AsyncSession, Session
 from ai.backend.client.test_utils import AsyncMock
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def api_version():
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = API_VERSION
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield
 
 
@@ -25,12 +25,12 @@ class DummyFunction:
     @classmethod
     async def get_or_create(cls):
         await asyncio.sleep(0)
-        return 'created'
+        return "created"
 
     @api_function
     async def calculate(self):
         await asyncio.sleep(0)
-        return 'done'
+        return "done"
 
 
 def test_api_function_metaclass():
@@ -39,61 +39,77 @@ def test_api_function_metaclass():
     # re-definition and re-instantiation scenarios.
 
     with Session() as session:
-        Dummy = type('DummyFunction', (BaseFunction, ), {
-            **DummyFunction.__dict__,
-            'session': session,
-        })
+        Dummy = type(
+            "DummyFunction",
+            (BaseFunction,),
+            {
+                **DummyFunction.__dict__,
+                "session": session,
+            },
+        )
 
         assert Dummy.session is session
         assert Dummy().session is session
 
-        assert Dummy.get_or_create() == 'created'
-        assert Dummy().calculate() == 'done'
-        assert Dummy.get_or_create() == 'created'
-        assert Dummy().calculate() == 'done'
+        assert Dummy.get_or_create() == "created"
+        assert Dummy().calculate() == "done"
+        assert Dummy.get_or_create() == "created"
+        assert Dummy().calculate() == "done"
 
     with Session() as session:
-        Dummy = type('DummyFunction', (BaseFunction, ), {
-            **DummyFunction.__dict__,
-            'session': session,
-        })
+        Dummy = type(
+            "DummyFunction",
+            (BaseFunction,),
+            {
+                **DummyFunction.__dict__,
+                "session": session,
+            },
+        )
 
         assert Dummy.session is session
         assert Dummy().session is session
 
-        assert Dummy.get_or_create() == 'created'
-        assert Dummy().calculate() == 'done'
-        assert Dummy.get_or_create() == 'created'
-        assert Dummy().calculate() == 'done'
+        assert Dummy.get_or_create() == "created"
+        assert Dummy().calculate() == "done"
+        assert Dummy.get_or_create() == "created"
+        assert Dummy().calculate() == "done"
 
 
 @pytest.mark.asyncio
 async def test_api_function_metaclass_async():
 
     async with AsyncSession() as session:
-        Dummy = type('DummyFunction', (BaseFunction, ), {
-            **DummyFunction.__dict__,
-            'session': session,
-        })
+        Dummy = type(
+            "DummyFunction",
+            (BaseFunction,),
+            {
+                **DummyFunction.__dict__,
+                "session": session,
+            },
+        )
 
         assert Dummy.session is session
         assert Dummy().session is session
 
-        assert await Dummy.get_or_create() == 'created'
-        assert await Dummy().calculate() == 'done'
-        assert await Dummy.get_or_create() == 'created'
-        assert await Dummy().calculate() == 'done'
+        assert await Dummy.get_or_create() == "created"
+        assert await Dummy().calculate() == "done"
+        assert await Dummy.get_or_create() == "created"
+        assert await Dummy().calculate() == "done"
 
     async with AsyncSession() as session:
-        Dummy = type('DummyFunction', (BaseFunction, ), {
-            **DummyFunction.__dict__,
-            'session': session,
-        })
+        Dummy = type(
+            "DummyFunction",
+            (BaseFunction,),
+            {
+                **DummyFunction.__dict__,
+                "session": session,
+            },
+        )
 
         assert Dummy.session is session
         assert Dummy().session is session
 
-        assert await Dummy.get_or_create() == 'created'
-        assert await Dummy().calculate() == 'done'
-        assert await Dummy.get_or_create() == 'created'
-        assert await Dummy().calculate() == 'done'
+        assert await Dummy.get_or_create() == "created"
+        assert await Dummy().calculate() == "done"
+        assert await Dummy.get_or_create() == "created"
+        assert await Dummy().calculate() == "done"

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -4,75 +4,73 @@ from unittest import mock
 import pytest
 from yarl import URL
 
-from ai.backend.client.config import (
-    get_env, bool_env, APIConfig, get_config, set_config,
-)
+from ai.backend.client.config import APIConfig, bool_env, get_config, get_env, set_config
 
 
 @pytest.fixture
 def cfg_params():
     return {
-        'endpoint': 'http://127.0.0.1:8081',
-        'version': 'vtest',
-        'user_agent': 'Backed.AI Client Test',
-        'access_key': 'AKIAIOSFODNN7EXAMPLE',
-        'secret_key': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-        'hash_type': 'md5',
-        'vfolder_mounts': ['abc', 'def'],
+        "endpoint": "http://127.0.0.1:8081",
+        "version": "vtest",
+        "user_agent": "Backed.AI Client Test",
+        "access_key": "AKIAIOSFODNN7EXAMPLE",
+        "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "hash_type": "md5",
+        "vfolder_mounts": ["abc", "def"],
     }
 
 
 def test_get_env():
     with pytest.raises(KeyError):
-        get_env('TESTKEY')
+        get_env("TESTKEY")
     with pytest.raises(KeyError):
-        with mock.patch.dict(os.environ, {'TESTKEY': 'testkey'}):
-            get_env('TESTKEY')
-    with mock.patch.dict(os.environ, {'BACKEND_TESTKEY': 'testkey'}):
-        r = get_env('TESTKEY')
-        assert r == 'testkey'
-    with mock.patch.dict(os.environ, {'SORNA_TESTKEY': 'testkey'}):
-        r = get_env('TESTKEY')
-        assert r == 'testkey'
+        with mock.patch.dict(os.environ, {"TESTKEY": "testkey"}):
+            get_env("TESTKEY")
+    with mock.patch.dict(os.environ, {"BACKEND_TESTKEY": "testkey"}):
+        r = get_env("TESTKEY")
+        assert r == "testkey"
+    with mock.patch.dict(os.environ, {"SORNA_TESTKEY": "testkey"}):
+        r = get_env("TESTKEY")
+        assert r == "testkey"
 
 
 def test_bool_env():
-    assert bool_env('y')
-    assert bool_env('Y')
-    assert bool_env('yes')
-    assert bool_env('YES')
-    assert bool_env('t')
-    assert bool_env('T')
-    assert bool_env('true')
-    assert bool_env('TRUE')
-    assert bool_env('1')
+    assert bool_env("y")
+    assert bool_env("Y")
+    assert bool_env("yes")
+    assert bool_env("YES")
+    assert bool_env("t")
+    assert bool_env("T")
+    assert bool_env("true")
+    assert bool_env("TRUE")
+    assert bool_env("1")
 
-    assert not bool_env('n')
-    assert not bool_env('N')
-    assert not bool_env('no')
-    assert not bool_env('NO')
-    assert not bool_env('f')
-    assert not bool_env('F')
-    assert not bool_env('false')
-    assert not bool_env('FALSE')
-    assert not bool_env('0')
+    assert not bool_env("n")
+    assert not bool_env("N")
+    assert not bool_env("no")
+    assert not bool_env("NO")
+    assert not bool_env("f")
+    assert not bool_env("F")
+    assert not bool_env("false")
+    assert not bool_env("FALSE")
+    assert not bool_env("0")
 
     with pytest.raises(ValueError):
-        bool_env('other')
+        bool_env("other")
 
 
 def test_api_config_initialization(cfg_params):
     params = cfg_params
     cfg = APIConfig(**params)
 
-    assert str(cfg.endpoint) == params['endpoint']
-    assert str(cfg.endpoint) == params['endpoint']
-    assert cfg.user_agent == params['user_agent']
-    assert cfg.access_key == params['access_key']
-    assert cfg.secret_key == params['secret_key']
-    assert cfg.version == params['version']
-    assert cfg.hash_type == params['hash_type']
-    assert set(cfg.vfolder_mounts) == set(params['vfolder_mounts'])
+    assert str(cfg.endpoint) == params["endpoint"]
+    assert str(cfg.endpoint) == params["endpoint"]
+    assert cfg.user_agent == params["user_agent"]
+    assert cfg.access_key == params["access_key"]
+    assert cfg.secret_key == params["secret_key"]
+    assert cfg.version == params["version"]
+    assert cfg.hash_type == params["hash_type"]
+    assert set(cfg.vfolder_mounts) == set(params["vfolder_mounts"])
 
     assert isinstance(cfg.endpoint, URL)
     assert isinstance(cfg.version, str)
@@ -84,35 +82,38 @@ def test_api_config_initialization(cfg_params):
 
 
 def test_validation():
-    mandatory_args = {'access_key': 'a', 'secret_key': 's'}
+    mandatory_args = {"access_key": "a", "secret_key": "s"}
     with pytest.raises(ValueError):
-        APIConfig(endpoint='/mylocalpath', **mandatory_args)
-    cfg = APIConfig(vfolder_mounts=['abc'], **mandatory_args)
-    assert cfg.vfolder_mounts == ['abc']
-    cfg = APIConfig(vfolder_mounts='', **mandatory_args)
+        APIConfig(endpoint="/mylocalpath", **mandatory_args)
+    cfg = APIConfig(vfolder_mounts=["abc"], **mandatory_args)
+    assert cfg.vfolder_mounts == ["abc"]
+    cfg = APIConfig(vfolder_mounts="", **mandatory_args)
     assert cfg.vfolder_mounts == []
-    cfg = APIConfig(vfolder_mounts=['abc', 'def'], **mandatory_args)
-    assert set(cfg.vfolder_mounts) == set(['abc', 'def'])
+    cfg = APIConfig(vfolder_mounts=["abc", "def"], **mandatory_args)
+    assert set(cfg.vfolder_mounts) == set(["abc", "def"])
 
 
 def test_set_and_get_config(mocker, cfg_params):
     # Mocking the global variable ``_config``.
     # The value of a global variable will affect other test cases.
-    mocker.patch('ai.backend.client.config._config', None)
+    mocker.patch("ai.backend.client.config._config", None)
     cfg = APIConfig(**cfg_params)
     set_config(cfg)
     assert get_config() == cfg
 
 
 def test_get_config_return_default_config_when_config_is_none(mocker, cfg_params):
-    mocker.patch('ai.backend.client.config._config', None)
-    mocker.patch('os.environ', {
-        'BACKEND_ACCESS_KEY': cfg_params['access_key'],
-        'BACKEND_SECRET_KEY': cfg_params['secret_key'],
-    })
+    mocker.patch("ai.backend.client.config._config", None)
+    mocker.patch(
+        "os.environ",
+        {
+            "BACKEND_ACCESS_KEY": cfg_params["access_key"],
+            "BACKEND_SECRET_KEY": cfg_params["secret_key"],
+        },
+    )
 
     cfg = get_config()
-    assert str(cfg.endpoint) == APIConfig.DEFAULTS['endpoint']
-    assert cfg.version == APIConfig.DEFAULTS['version']
-    assert cfg.access_key == cfg_params['access_key']
-    assert cfg.secret_key == cfg_params['secret_key']
+    assert str(cfg.endpoint) == APIConfig.DEFAULTS["endpoint"]
+    assert cfg.version == APIConfig.DEFAULTS["version"]
+    assert cfg.access_key == cfg_params["access_key"]
+    assert cfg.secret_key == cfg_params["secret_key"]

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -1,0 +1,118 @@
+import os
+from unittest import mock
+
+import pytest
+from yarl import URL
+
+from ai.backend.client.config import (
+    get_env, bool_env, APIConfig, get_config, set_config,
+)
+
+
+@pytest.fixture
+def cfg_params():
+    return {
+        'endpoint': 'http://127.0.0.1:8081',
+        'version': 'vtest',
+        'user_agent': 'Backed.AI Client Test',
+        'access_key': 'AKIAIOSFODNN7EXAMPLE',
+        'secret_key': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        'hash_type': 'md5',
+        'vfolder_mounts': ['abc', 'def'],
+    }
+
+
+def test_get_env():
+    with pytest.raises(KeyError):
+        get_env('TESTKEY')
+    with pytest.raises(KeyError):
+        with mock.patch.dict(os.environ, {'TESTKEY': 'testkey'}):
+            get_env('TESTKEY')
+    with mock.patch.dict(os.environ, {'BACKEND_TESTKEY': 'testkey'}):
+        r = get_env('TESTKEY')
+        assert r == 'testkey'
+    with mock.patch.dict(os.environ, {'SORNA_TESTKEY': 'testkey'}):
+        r = get_env('TESTKEY')
+        assert r == 'testkey'
+
+
+def test_bool_env():
+    assert bool_env('y')
+    assert bool_env('Y')
+    assert bool_env('yes')
+    assert bool_env('YES')
+    assert bool_env('t')
+    assert bool_env('T')
+    assert bool_env('true')
+    assert bool_env('TRUE')
+    assert bool_env('1')
+
+    assert not bool_env('n')
+    assert not bool_env('N')
+    assert not bool_env('no')
+    assert not bool_env('NO')
+    assert not bool_env('f')
+    assert not bool_env('F')
+    assert not bool_env('false')
+    assert not bool_env('FALSE')
+    assert not bool_env('0')
+
+    with pytest.raises(ValueError):
+        bool_env('other')
+
+
+def test_api_config_initialization(cfg_params):
+    params = cfg_params
+    cfg = APIConfig(**params)
+
+    assert str(cfg.endpoint) == params['endpoint']
+    assert str(cfg.endpoint) == params['endpoint']
+    assert cfg.user_agent == params['user_agent']
+    assert cfg.access_key == params['access_key']
+    assert cfg.secret_key == params['secret_key']
+    assert cfg.version == params['version']
+    assert cfg.hash_type == params['hash_type']
+    assert set(cfg.vfolder_mounts) == set(params['vfolder_mounts'])
+
+    assert isinstance(cfg.endpoint, URL)
+    assert isinstance(cfg.version, str)
+    assert isinstance(cfg.user_agent, str)
+    assert isinstance(cfg.access_key, str)
+    assert isinstance(cfg.secret_key, str)
+    assert isinstance(cfg.hash_type, str)
+    assert isinstance(cfg.vfolder_mounts, list)
+
+
+def test_validation():
+    mandatory_args = {'access_key': 'a', 'secret_key': 's'}
+    with pytest.raises(ValueError):
+        APIConfig(endpoint='/mylocalpath', **mandatory_args)
+    cfg = APIConfig(vfolder_mounts=['abc'], **mandatory_args)
+    assert cfg.vfolder_mounts == ['abc']
+    cfg = APIConfig(vfolder_mounts='', **mandatory_args)
+    assert cfg.vfolder_mounts == []
+    cfg = APIConfig(vfolder_mounts=['abc', 'def'], **mandatory_args)
+    assert set(cfg.vfolder_mounts) == set(['abc', 'def'])
+
+
+def test_set_and_get_config(mocker, cfg_params):
+    # Mocking the global variable ``_config``.
+    # The value of a global variable will affect other test cases.
+    mocker.patch('ai.backend.client.config._config', None)
+    cfg = APIConfig(**cfg_params)
+    set_config(cfg)
+    assert get_config() == cfg
+
+
+def test_get_config_return_default_config_when_config_is_none(mocker, cfg_params):
+    mocker.patch('ai.backend.client.config._config', None)
+    mocker.patch('os.environ', {
+        'BACKEND_ACCESS_KEY': cfg_params['access_key'],
+        'BACKEND_SECRET_KEY': cfg_params['secret_key'],
+    })
+
+    cfg = get_config()
+    assert str(cfg.endpoint) == APIConfig.DEFAULTS['endpoint']
+    assert cfg.version == APIConfig.DEFAULTS['version']
+    assert cfg.access_key == cfg_params['access_key']
+    assert cfg.secret_key == cfg_params['secret_key']

--- a/tests/client/test_kernel.py
+++ b/tests/client/test_kernel.py
@@ -1,27 +1,26 @@
 import secrets
-from unittest import mock
 import uuid
+from unittest import mock
 
 import pytest
 
 from ai.backend.client.config import APIConfig
-from ai.backend.client.session import api_session, Session
-from ai.backend.client.versioning import get_naming
+from ai.backend.client.session import Session, api_session
 from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
-
+from ai.backend.client.versioning import get_naming
 
 simulated_api_versions = [
-    (4, '20190615'),
-    (5, '20191215'),
-    (6, '20200815'),
+    (4, "20190615"),
+    (5, "20191215"),
+    (6, "20200815"),
 ]
 
 
-@pytest.fixture(scope='module', autouse=True, params=simulated_api_versions)
+@pytest.fixture(scope="module", autouse=True, params=simulated_api_versions)
 def api_version(request):
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = request.param
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield request.param
 
 
@@ -31,34 +30,33 @@ def test_create_with_config(mocker, api_version):
         status=201,
         json=AsyncMock(
             return_value={
-                'sessionId': str(uuid.uuid4()),
-                'created': True,
+                "sessionId": str(uuid.uuid4()),
+                "created": True,
             },
         ),
     )
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     myconfig = APIConfig(
-        endpoint='https://localhost:9999',
-        access_key='1234',
-        secret_key='asdf',
-        user_agent='BAIClientTest',
-        version=f'v{api_version[0]}.{api_version[1]}',
+        endpoint="https://localhost:9999",
+        access_key="1234",
+        secret_key="asdf",
+        user_agent="BAIClientTest",
+        version=f"v{api_version[0]}.{api_version[1]}",
     )
     with Session(config=myconfig) as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         if api_version[0] == 4:
-            assert prefix == 'kernel'
+            assert prefix == "kernel"
         else:
-            assert prefix == 'session'
+            assert prefix == "session"
         assert session.config is myconfig
-        session.ComputeSession.get_or_create('python')
-        mock_req.assert_called_once_with('POST', f'/{prefix}')
+        session.ComputeSession.get_or_create("python")
+        mock_req.assert_called_once_with("POST", f"/{prefix}")
         current_api_session = api_session.get()
-        assert str(current_api_session.config.endpoint) == 'https://localhost:9999'
-        assert current_api_session.config.user_agent == 'BAIClientTest'
-        assert current_api_session.config.access_key == '1234'
-        assert current_api_session.config.secret_key == 'asdf'
+        assert str(current_api_session.config.endpoint) == "https://localhost:9999"
+        assert current_api_session.config.user_agent == "BAIClientTest"
+        assert current_api_session.config.access_key == "1234"
+        assert current_api_session.config.secret_key == "asdf"
 
 
 def test_create_kernel_url(mocker):
@@ -67,17 +65,16 @@ def test_create_kernel_url(mocker):
         status=201,
         json=AsyncMock(
             return_value={
-                'sessionId': str(uuid.uuid4()),
-                'created': True,
+                "sessionId": str(uuid.uuid4()),
+                "created": True,
             },
         ),
     )
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     with Session() as session:
-        prefix = get_naming(session.api_version, 'path')
-        session.ComputeSession.get_or_create('python:3.6-ubuntu18.04')
-        mock_req.assert_called_once_with('POST', f'/{prefix}')
+        prefix = get_naming(session.api_version, "path")
+        session.ComputeSession.get_or_create("python:3.6-ubuntu18.04")
+        mock_req.assert_called_once_with("POST", f"/{prefix}")
         mock_req_obj.fetch.assert_called_once_with()
         mock_req_obj.fetch.return_value.json.assert_called_once_with()
 
@@ -85,32 +82,26 @@ def test_create_kernel_url(mocker):
 def test_destroy_kernel_url(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     with Session() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         session_name = secrets.token_hex(12)
         cs = session.ComputeSession(session_name)
         cs.destroy()
-        mock_req.assert_called_once_with(
-            'DELETE', f'/{prefix}/{session_name}',
-            params={})
+        mock_req.assert_called_once_with("DELETE", f"/{prefix}/{session_name}", params={})
         mock_req_obj.fetch.assert_called_once_with()
 
 
 def test_restart_kernel_url(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     with Session() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         session_name = secrets.token_hex(12)
         cs = session.ComputeSession(session_name)
         cs.restart()
-        mock_req.assert_called_once_with(
-            'PATCH', f'/{prefix}/{session_name}',
-            params={})
+        mock_req.assert_called_once_with("PATCH", f"/{prefix}/{session_name}", params={})
         mock_req_obj.fetch.assert_called_once_with()
 
 
@@ -118,38 +109,33 @@ def test_get_kernel_info_url(mocker):
     return_value = {}
     mock_json_coro = AsyncMock(return_value=return_value)
     mock_req_obj = mock.Mock()
-    mock_req_obj.fetch.return_value = AsyncContextMock(
-        status=200, json=mock_json_coro)
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200, json=mock_json_coro)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     with Session() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         session_name = secrets.token_hex(12)
         cs = session.ComputeSession(session_name)
         cs.get_info()
-        mock_req.assert_called_once_with(
-            'GET', f'/{prefix}/{session_name}',
-            params={})
+        mock_req.assert_called_once_with("GET", f"/{prefix}/{session_name}", params={})
         mock_req_obj.fetch.assert_called_once_with()
         mock_req_obj.fetch.return_value.json.assert_called_once_with()
 
 
 def test_execute_code_url(mocker):
-    return_value = {'result': 'hi'}
+    return_value = {"result": "hi"}
     mock_json_coro = AsyncMock(return_value=return_value)
     mock_req_obj = mock.Mock()
-    mock_req_obj.fetch.return_value = AsyncContextMock(
-        status=200, json=mock_json_coro)
-    mock_req = mocker.patch('ai.backend.client.func.session.Request',
-                            return_value=mock_req_obj)
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200, json=mock_json_coro)
+    mock_req = mocker.patch("ai.backend.client.func.session.Request", return_value=mock_req_obj)
     with Session() as session:
-        prefix = get_naming(session.api_version, 'path')
+        prefix = get_naming(session.api_version, "path")
         session_name = secrets.token_hex(12)
         cs = session.ComputeSession(session_name)
         run_id = secrets.token_hex(8)
-        cs.execute(run_id, 'hello')
+        cs.execute(run_id, "hello")
         mock_req.assert_called_once_with(
-            'POST', f'/{prefix}/{session_name}',
+            "POST",
+            f"/{prefix}/{session_name}",
             params={},
         )
         mock_req_obj.fetch.assert_called_once_with()

--- a/tests/client/test_kernel.py
+++ b/tests/client/test_kernel.py
@@ -6,8 +6,8 @@ import pytest
 
 from ai.backend.client.config import APIConfig
 from ai.backend.client.session import Session, api_session
-from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
 from ai.backend.client.versioning import get_naming
+from ai.backend.testutils.mock import AsyncContextMock, AsyncMock
 
 simulated_api_versions = [
     (4, "20190615"),

--- a/tests/client/test_kernel.py
+++ b/tests/client/test_kernel.py
@@ -1,0 +1,156 @@
+import secrets
+from unittest import mock
+import uuid
+
+import pytest
+
+from ai.backend.client.config import APIConfig
+from ai.backend.client.session import api_session, Session
+from ai.backend.client.versioning import get_naming
+from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
+
+
+simulated_api_versions = [
+    (4, '20190615'),
+    (5, '20191215'),
+    (6, '20200815'),
+]
+
+
+@pytest.fixture(scope='module', autouse=True, params=simulated_api_versions)
+def api_version(request):
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = request.param
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield request.param
+
+
+def test_create_with_config(mocker, api_version):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=201,
+        json=AsyncMock(
+            return_value={
+                'sessionId': str(uuid.uuid4()),
+                'created': True,
+            },
+        ),
+    )
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    myconfig = APIConfig(
+        endpoint='https://localhost:9999',
+        access_key='1234',
+        secret_key='asdf',
+        user_agent='BAIClientTest',
+        version=f'v{api_version[0]}.{api_version[1]}',
+    )
+    with Session(config=myconfig) as session:
+        prefix = get_naming(session.api_version, 'path')
+        if api_version[0] == 4:
+            assert prefix == 'kernel'
+        else:
+            assert prefix == 'session'
+        assert session.config is myconfig
+        session.ComputeSession.get_or_create('python')
+        mock_req.assert_called_once_with('POST', f'/{prefix}')
+        current_api_session = api_session.get()
+        assert str(current_api_session.config.endpoint) == 'https://localhost:9999'
+        assert current_api_session.config.user_agent == 'BAIClientTest'
+        assert current_api_session.config.access_key == '1234'
+        assert current_api_session.config.secret_key == 'asdf'
+
+
+def test_create_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=201,
+        json=AsyncMock(
+            return_value={
+                'sessionId': str(uuid.uuid4()),
+                'created': True,
+            },
+        ),
+    )
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    with Session() as session:
+        prefix = get_naming(session.api_version, 'path')
+        session.ComputeSession.get_or_create('python:3.6-ubuntu18.04')
+        mock_req.assert_called_once_with('POST', f'/{prefix}')
+        mock_req_obj.fetch.assert_called_once_with()
+        mock_req_obj.fetch.return_value.json.assert_called_once_with()
+
+
+def test_destroy_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    with Session() as session:
+        prefix = get_naming(session.api_version, 'path')
+        session_name = secrets.token_hex(12)
+        cs = session.ComputeSession(session_name)
+        cs.destroy()
+        mock_req.assert_called_once_with(
+            'DELETE', f'/{prefix}/{session_name}',
+            params={})
+        mock_req_obj.fetch.assert_called_once_with()
+
+
+def test_restart_kernel_url(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    with Session() as session:
+        prefix = get_naming(session.api_version, 'path')
+        session_name = secrets.token_hex(12)
+        cs = session.ComputeSession(session_name)
+        cs.restart()
+        mock_req.assert_called_once_with(
+            'PATCH', f'/{prefix}/{session_name}',
+            params={})
+        mock_req_obj.fetch.assert_called_once_with()
+
+
+def test_get_kernel_info_url(mocker):
+    return_value = {}
+    mock_json_coro = AsyncMock(return_value=return_value)
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=200, json=mock_json_coro)
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    with Session() as session:
+        prefix = get_naming(session.api_version, 'path')
+        session_name = secrets.token_hex(12)
+        cs = session.ComputeSession(session_name)
+        cs.get_info()
+        mock_req.assert_called_once_with(
+            'GET', f'/{prefix}/{session_name}',
+            params={})
+        mock_req_obj.fetch.assert_called_once_with()
+        mock_req_obj.fetch.return_value.json.assert_called_once_with()
+
+
+def test_execute_code_url(mocker):
+    return_value = {'result': 'hi'}
+    mock_json_coro = AsyncMock(return_value=return_value)
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(
+        status=200, json=mock_json_coro)
+    mock_req = mocker.patch('ai.backend.client.func.session.Request',
+                            return_value=mock_req_obj)
+    with Session() as session:
+        prefix = get_naming(session.api_version, 'path')
+        session_name = secrets.token_hex(12)
+        cs = session.ComputeSession(session_name)
+        run_id = secrets.token_hex(8)
+        cs.execute(run_id, 'hello')
+        mock_req.assert_called_once_with(
+            'POST', f'/{prefix}/{session_name}',
+            params={},
+        )
+        mock_req_obj.fetch.assert_called_once_with()
+        mock_req_obj.fetch.return_value.json.assert_called_once_with()

--- a/tests/client/test_manager.py
+++ b/tests/client/test_manager.py
@@ -4,7 +4,7 @@ import pytest
 
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.session import Session
-from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
+from ai.backend.testutils.mock import AsyncContextMock, AsyncMock
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/client/test_manager.py
+++ b/tests/client/test_manager.py
@@ -1,0 +1,60 @@
+from unittest import mock
+
+import pytest
+
+from ai.backend.client.config import API_VERSION
+from ai.backend.client.session import Session
+from ai.backend.client.test_utils import AsyncMock, AsyncContextMock
+
+
+@pytest.fixture(scope='module', autouse=True)
+def api_version():
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = API_VERSION
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield
+
+
+def test_status(mocker):
+    return_value = {'status': 'running', 'active_sessions': 3}
+    mock_json_coro = AsyncMock(return_value=return_value)
+    mock_req_obj = mocker.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200,
+                                                       json=mock_json_coro)
+    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+
+    with Session() as session:
+        resp = session.Manager.status()
+        mock_req_obj.fetch.assert_called_once_with()
+        assert resp['status'] == return_value['status']
+        assert resp['active_sessions'] == return_value['active_sessions']
+
+
+def test_freeze(mocker):
+    mock_req_obj = mocker.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+
+    with Session() as session:
+        session.Manager.freeze()
+        mock_req_obj.fetch.assert_called_once_with()
+
+
+def test_freeze_opt_force_kill(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+
+    with Session() as session:
+        session.Manager.freeze(force_kill=True)
+        mock_req_obj.fetch.assert_called_once_with()
+
+
+def test_unfreeze(mocker):
+    mock_req_obj = mock.Mock()
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
+    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+
+    with Session() as session:
+        session.Manager.unfreeze()
+        mock_req_obj.fetch.assert_called_once_with()

--- a/tests/client/test_manager.py
+++ b/tests/client/test_manager.py
@@ -4,36 +4,35 @@ import pytest
 
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.session import Session
-from ai.backend.client.test_utils import AsyncMock, AsyncContextMock
+from ai.backend.client.test_utils import AsyncContextMock, AsyncMock
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def api_version():
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = API_VERSION
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield
 
 
 def test_status(mocker):
-    return_value = {'status': 'running', 'active_sessions': 3}
+    return_value = {"status": "running", "active_sessions": 3}
     mock_json_coro = AsyncMock(return_value=return_value)
     mock_req_obj = mocker.Mock()
-    mock_req_obj.fetch.return_value = AsyncContextMock(status=200,
-                                                       json=mock_json_coro)
-    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+    mock_req_obj.fetch.return_value = AsyncContextMock(status=200, json=mock_json_coro)
+    mocker.patch("ai.backend.client.func.manager.Request", return_value=mock_req_obj)
 
     with Session() as session:
         resp = session.Manager.status()
         mock_req_obj.fetch.assert_called_once_with()
-        assert resp['status'] == return_value['status']
-        assert resp['active_sessions'] == return_value['active_sessions']
+        assert resp["status"] == return_value["status"]
+        assert resp["active_sessions"] == return_value["active_sessions"]
 
 
 def test_freeze(mocker):
     mock_req_obj = mocker.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
-    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+    mocker.patch("ai.backend.client.func.manager.Request", return_value=mock_req_obj)
 
     with Session() as session:
         session.Manager.freeze()
@@ -43,7 +42,7 @@ def test_freeze(mocker):
 def test_freeze_opt_force_kill(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
-    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+    mocker.patch("ai.backend.client.func.manager.Request", return_value=mock_req_obj)
 
     with Session() as session:
         session.Manager.freeze(force_kill=True)
@@ -53,7 +52,7 @@ def test_freeze_opt_force_kill(mocker):
 def test_unfreeze(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = AsyncContextMock(status=204)
-    mocker.patch('ai.backend.client.func.manager.Request', return_value=mock_req_obj)
+    mocker.patch("ai.backend.client.func.manager.Request", return_value=mock_req_obj)
 
     with Session() as session:
         session.Manager.unfreeze()

--- a/tests/client/test_pretty.py
+++ b/tests/client/test_pretty.py
@@ -1,9 +1,8 @@
-from ai.backend.client.cli.pretty import (
-    bold, italic, underline, inverse,
-    print_pretty, PrintStatus,
-)
-from click import unstyle
 import time
+
+from click import unstyle
+
+from ai.backend.client.cli.pretty import PrintStatus, bold, inverse, italic, print_pretty, underline
 
 
 def test_pretty_output():
@@ -12,28 +11,27 @@ def test_pretty_output():
 
     pprint = print_pretty
 
-    print('normal print')
-    pprint('wow ' + bold('wow') + ' wow!')
-    print('just ' + underline('print') + ' ' + italic('grrrrrgh') + '... wooah!')
-    pprint(inverse('wow') + '!!', status=PrintStatus.WARNING)
-    pprint('some long loading.... zzzzzzzzzzzzz', status=PrintStatus.WAITING)
+    print("normal print")
+    pprint("wow " + bold("wow") + " wow!")
+    print("just " + underline("print") + " " + italic("grrrrrgh") + "... wooah!")
+    pprint(inverse("wow") + "!!", status=PrintStatus.WARNING)
+    pprint("some long loading.... zzzzzzzzzzzzz", status=PrintStatus.WAITING)
     time.sleep(0.3)
-    pprint('doing something...', status=PrintStatus.WAITING)
+    pprint("doing something...", status=PrintStatus.WAITING)
     time.sleep(0.3)
-    pprint('done!', status=PrintStatus.DONE)
-    pprint('doing ' + bold('something') + '...',
-           status=PrintStatus.WAITING)
+    pprint("done!", status=PrintStatus.DONE)
+    pprint("doing " + bold("something") + "...", status=PrintStatus.WAITING)
     time.sleep(0.5)
-    pprint('doing more...', status=PrintStatus.WAITING)
+    pprint("doing more...", status=PrintStatus.WAITING)
     time.sleep(0.3)
-    pprint('failed!', status=PrintStatus.FAILED)
-    print('normal print')
+    pprint("failed!", status=PrintStatus.FAILED)
+    print("normal print")
 
 
 def test_unstyle():
-    print(unstyle(underline('non-underline')))
-    print(unstyle(italic('non-italic')))
+    print(unstyle(underline("non-underline")))
+    print(unstyle(italic("non-italic")))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_pretty_output()

--- a/tests/client/test_pretty.py
+++ b/tests/client/test_pretty.py
@@ -1,0 +1,39 @@
+from ai.backend.client.cli.pretty import (
+    bold, italic, underline, inverse,
+    print_pretty, PrintStatus,
+)
+from click import unstyle
+import time
+
+
+def test_pretty_output():
+    # Currently this is a graphical test -- you should show the output
+    # using "-s" option in pytest and check it manually with your eyes.
+
+    pprint = print_pretty
+
+    print('normal print')
+    pprint('wow ' + bold('wow') + ' wow!')
+    print('just ' + underline('print') + ' ' + italic('grrrrrgh') + '... wooah!')
+    pprint(inverse('wow') + '!!', status=PrintStatus.WARNING)
+    pprint('some long loading.... zzzzzzzzzzzzz', status=PrintStatus.WAITING)
+    time.sleep(0.3)
+    pprint('doing something...', status=PrintStatus.WAITING)
+    time.sleep(0.3)
+    pprint('done!', status=PrintStatus.DONE)
+    pprint('doing ' + bold('something') + '...',
+           status=PrintStatus.WAITING)
+    time.sleep(0.5)
+    pprint('doing more...', status=PrintStatus.WAITING)
+    time.sleep(0.3)
+    pprint('failed!', status=PrintStatus.FAILED)
+    print('normal print')
+
+
+def test_unstyle():
+    print(unstyle(underline('non-underline')))
+    print(unstyle(italic('non-italic')))
+
+
+if __name__ == '__main__':
+    test_pretty_output()

--- a/tests/client/test_request.py
+++ b/tests/client/test_request.py
@@ -4,21 +4,21 @@ import json
 from unittest import mock
 
 import aiohttp
-from aioresponses import aioresponses
 import pytest
+from aioresponses import aioresponses
 
-from ai.backend.client.config import get_config, API_VERSION
-from ai.backend.client.exceptions import BackendClientError, BackendAPIError
-from ai.backend.client.request import Request, Response, AttachedFile
-from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.config import API_VERSION, get_config
+from ai.backend.client.exceptions import BackendAPIError, BackendClientError
+from ai.backend.client.request import AttachedFile, Request, Response
+from ai.backend.client.session import AsyncSession, Session
 from ai.backend.client.test_utils import AsyncMock
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def api_version():
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = API_VERSION
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield
 
 
@@ -31,90 +31,90 @@ def session(defconfig):
 @pytest.fixture
 def mock_request_params(session):
     yield {
-        'method': 'GET',
-        'path': '/function/item/',
-        'params': {'app': '999'},
-        'content': b'{"test1": 1}',
-        'content_type': 'application/json',
+        "method": "GET",
+        "path": "/function/item/",
+        "params": {"app": "999"},
+        "content": b'{"test1": 1}',
+        "content_type": "application/json",
     }
 
 
 def test_request_initialization(mock_request_params):
     rqst = Request(**mock_request_params)
 
-    assert rqst.method == mock_request_params['method']
-    assert rqst.params == mock_request_params['params']
-    assert rqst.path == mock_request_params['path'].lstrip('/')
-    assert rqst.content == mock_request_params['content']
-    assert 'X-BackendAI-Version' in rqst.headers
+    assert rqst.method == mock_request_params["method"]
+    assert rqst.params == mock_request_params["params"]
+    assert rqst.path == mock_request_params["path"].lstrip("/")
+    assert rqst.content == mock_request_params["content"]
+    assert "X-BackendAI-Version" in rqst.headers
 
 
 def test_request_set_content_none(mock_request_params):
     mock_request_params = mock_request_params.copy()
-    mock_request_params['content'] = None
+    mock_request_params["content"] = None
     rqst = Request(**mock_request_params)
-    assert rqst.content == b''
+    assert rqst.content == b""
     assert rqst._pack_content() is rqst.content
 
 
 def test_request_set_content(mock_request_params):
     rqst = Request(**mock_request_params)
-    assert rqst.content == mock_request_params['content']
-    assert rqst.content_type == 'application/json'
+    assert rqst.content == mock_request_params["content"]
+    assert rqst.content_type == "application/json"
     assert rqst._pack_content() is rqst.content
 
-    mock_request_params['content'] = 'hello'
-    mock_request_params['content_type'] = None
+    mock_request_params["content"] = "hello"
+    mock_request_params["content_type"] = None
     rqst = Request(**mock_request_params)
-    assert rqst.content == b'hello'
-    assert rqst.content_type == 'text/plain'
+    assert rqst.content == b"hello"
+    assert rqst.content_type == "text/plain"
     assert rqst._pack_content() is rqst.content
 
-    mock_request_params['content'] = b'\x00\x01\xfe\xff'
-    mock_request_params['content_type'] = None
+    mock_request_params["content"] = b"\x00\x01\xfe\xff"
+    mock_request_params["content_type"] = None
     rqst = Request(**mock_request_params)
-    assert rqst.content == b'\x00\x01\xfe\xff'
-    assert rqst.content_type == 'application/octet-stream'
+    assert rqst.content == b"\x00\x01\xfe\xff"
+    assert rqst.content_type == "application/octet-stream"
     assert rqst._pack_content() is rqst.content
 
 
 def test_request_attach_files(mock_request_params):
     files = [
-        AttachedFile('test1.txt', io.BytesIO(), 'application/octet-stream'),
-        AttachedFile('test2.txt', io.BytesIO(), 'application/octet-stream'),
+        AttachedFile("test1.txt", io.BytesIO(), "application/octet-stream"),
+        AttachedFile("test2.txt", io.BytesIO(), "application/octet-stream"),
     ]
 
-    mock_request_params['content'] = b'something'
+    mock_request_params["content"] = b"something"
     rqst = Request(**mock_request_params)
     with pytest.raises(AssertionError):
         rqst.attach_files(files)
 
-    mock_request_params['content'] = b''
+    mock_request_params["content"] = b""
     rqst = Request(**mock_request_params)
     rqst.attach_files(files)
 
-    assert rqst.content_type == 'multipart/form-data'
-    assert rqst.content == b''
+    assert rqst.content_type == "multipart/form-data"
+    assert rqst.content == b""
     packed_content = rqst._pack_content()
     assert packed_content.is_multipart
 
 
 def test_build_correct_url(mock_request_params):
     config = get_config()
-    canonical_url = str(config.endpoint).rstrip('/') + '/function?app=999'
+    canonical_url = str(config.endpoint).rstrip("/") + "/function?app=999"
 
-    mock_request_params['path'] = '/function'
+    mock_request_params["path"] = "/function"
     rqst = Request(**mock_request_params)
     assert str(rqst._build_url()) == canonical_url
 
-    mock_request_params['path'] = 'function'
+    mock_request_params["path"] = "function"
     rqst = Request(**mock_request_params)
     assert str(rqst._build_url()) == canonical_url
 
 
 @pytest.mark.asyncio
 async def test_fetch_invalid_method(mock_request_params):
-    mock_request_params['method'] = 'STRANGE'
+    mock_request_params["method"] = "STRANGE"
     rqst = Request(**mock_request_params)
 
     with pytest.raises(AssertionError):
@@ -125,34 +125,39 @@ async def test_fetch_invalid_method(mock_request_params):
 @pytest.mark.asyncio
 async def test_fetch(dummy_endpoint):
     with aioresponses() as m, Session():
-        body = b'hello world'
+        body = b"hello world"
         m.post(
-            dummy_endpoint + 'function', status=200, body=body,
-            headers={'Content-Type': 'text/plain; charset=utf-8',
-                     'Content-Length': str(len(body))},
+            dummy_endpoint + "function",
+            status=200,
+            body=body,
+            headers={"Content-Type": "text/plain; charset=utf-8", "Content-Length": str(len(body))},
         )
-        rqst = Request('POST', 'function')
+        rqst = Request("POST", "function")
         async with rqst.fetch() as resp:
             assert isinstance(resp, Response)
             assert resp.status == 200
-            assert resp.content_type == 'text/plain'
+            assert resp.content_type == "text/plain"
             assert await resp.text() == body.decode()
             assert resp.content_length == len(body)
 
     with aioresponses() as m, Session():
         body = b'{"a": 1234, "b": null}'
         m.post(
-            dummy_endpoint + 'function', status=200, body=body,
-            headers={'Content-Type': 'application/json; charset=utf-8',
-                     'Content-Length': str(len(body))},
+            dummy_endpoint + "function",
+            status=200,
+            body=body,
+            headers={
+                "Content-Type": "application/json; charset=utf-8",
+                "Content-Length": str(len(body)),
+            },
         )
-        rqst = Request('POST', 'function')
+        rqst = Request("POST", "function")
         async with rqst.fetch() as resp:
             assert isinstance(resp, Response)
             assert resp.status == 200
-            assert resp.content_type == 'application/json'
+            assert resp.content_type == "application/json"
             assert await resp.text() == body.decode()
-            assert await resp.json() == {'a': 1234, 'b': None}
+            assert await resp.json() == {"a": 1234, "b": None}
             assert resp.content_length == len(body)
 
 
@@ -160,18 +165,19 @@ async def test_fetch(dummy_endpoint):
 async def test_streaming_fetch(dummy_endpoint):
     # Read content by chunks.
     with aioresponses() as m, Session():
-        body = b'hello world'
+        body = b"hello world"
         m.post(
-            dummy_endpoint + 'function', status=200, body=body,
-            headers={'Content-Type': 'text/plain; charset=utf-8',
-                     'Content-Length': str(len(body))},
+            dummy_endpoint + "function",
+            status=200,
+            body=body,
+            headers={"Content-Type": "text/plain; charset=utf-8", "Content-Length": str(len(body))},
         )
-        rqst = Request('POST', 'function')
+        rqst = Request("POST", "function")
         async with rqst.fetch() as resp:
             assert resp.status == 200
-            assert resp.content_type == 'text/plain'
-            assert await resp.read(3) == b'hel'
-            assert await resp.read(2) == b'lo'
+            assert resp.content_type == "text/plain"
+            assert await resp.read(3) == b"hel"
+            assert await resp.read(2) == b"lo"
             await resp.read()
             with pytest.raises(AssertionError):
                 assert await resp.text()
@@ -180,29 +186,34 @@ async def test_streaming_fetch(dummy_endpoint):
 @pytest.mark.asyncio
 async def test_invalid_requests(dummy_endpoint):
     with aioresponses() as m, Session():
-        body = json.dumps({
-            'type': 'https://api.backend.ai/probs/kernel-not-found',
-            'title': 'Kernel Not Found',
-        }).encode('utf8')
+        body = json.dumps(
+            {
+                "type": "https://api.backend.ai/probs/kernel-not-found",
+                "title": "Kernel Not Found",
+            }
+        ).encode("utf8")
         m.post(
-            dummy_endpoint, status=404, body=body,
-            headers={'Content-Type': 'application/problem+json; charset=utf-8',
-                     'Content-Length': str(len(body))},
+            dummy_endpoint,
+            status=404,
+            body=body,
+            headers={
+                "Content-Type": "application/problem+json; charset=utf-8",
+                "Content-Length": str(len(body)),
+            },
         )
-        rqst = Request('POST', '/')
+        rqst = Request("POST", "/")
         with pytest.raises(BackendAPIError) as e:
             async with rqst.fetch():
                 pass
             assert e.status == 404
-            assert e.data['type'] == \
-                'https://api.backend.ai/probs/kernel-not-found'
-            assert e.data['title'] == 'Kernel Not Found'
+            assert e.data["type"] == "https://api.backend.ai/probs/kernel-not-found"
+            assert e.data["title"] == "Kernel Not Found"
 
 
 @pytest.mark.asyncio
 async def test_fetch_invalid_method_async():
     async with AsyncSession():
-        rqst = Request('STRANGE', '/')
+        rqst = Request("STRANGE", "/")
         with pytest.raises(AssertionError):
             async with rqst.fetch():
                 pass
@@ -212,9 +223,8 @@ async def test_fetch_invalid_method_async():
 async def test_fetch_client_error_async(dummy_endpoint):
     with aioresponses() as m:
         async with AsyncSession():
-            m.post(dummy_endpoint,
-                   exception=aiohttp.ClientConnectionError())
-            rqst = Request('POST', '/')
+            m.post(dummy_endpoint, exception=aiohttp.ClientConnectionError())
+            rqst = Request("POST", "/")
             with pytest.raises(BackendClientError):
                 async with rqst.fetch():
                     pass
@@ -226,9 +236,8 @@ async def test_fetch_cancellation_async(dummy_endpoint):
     # It seems that aiohttp swallows asyncio.CancelledError
     with aioresponses() as m:
         async with AsyncSession():
-            m.post(dummy_endpoint,
-                   exception=asyncio.CancelledError())
-            rqst = Request('POST', '/')
+            m.post(dummy_endpoint, exception=asyncio.CancelledError())
+            rqst = Request("POST", "/")
             with pytest.raises(asyncio.CancelledError):
                 async with rqst.fetch():
                     pass
@@ -238,9 +247,8 @@ async def test_fetch_cancellation_async(dummy_endpoint):
 async def test_fetch_timeout_async(dummy_endpoint):
     with aioresponses() as m:
         async with AsyncSession():
-            m.post(dummy_endpoint,
-                   exception=asyncio.TimeoutError())
-            rqst = Request('POST', '/')
+            m.post(dummy_endpoint, exception=asyncio.TimeoutError())
+            rqst = Request("POST", "/")
             with pytest.raises(asyncio.TimeoutError):
                 async with rqst.fetch():
                     pass
@@ -251,12 +259,13 @@ async def test_response_async(defconfig, dummy_endpoint):
     body = b'{"test": 5678}'
     with aioresponses() as m:
         m.post(
-            dummy_endpoint + 'function', status=200, body=body,
-            headers={'Content-Type': 'application/json',
-                     'Content-Length': str(len(body))},
+            dummy_endpoint + "function",
+            status=200,
+            body=body,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
         )
         async with AsyncSession(config=defconfig):
-            rqst = Request('POST', '/function')
+            rqst = Request("POST", "/function")
             async with rqst.fetch() as resp:
                 assert await resp.text() == '{"test": 5678}'
-                assert await resp.json() == {'test': 5678}
+                assert await resp.json() == {"test": 5678}

--- a/tests/client/test_request.py
+++ b/tests/client/test_request.py
@@ -1,0 +1,262 @@
+import asyncio
+import io
+import json
+from unittest import mock
+
+import aiohttp
+from aioresponses import aioresponses
+import pytest
+
+from ai.backend.client.config import get_config, API_VERSION
+from ai.backend.client.exceptions import BackendClientError, BackendAPIError
+from ai.backend.client.request import Request, Response, AttachedFile
+from ai.backend.client.session import Session, AsyncSession
+from ai.backend.client.test_utils import AsyncMock
+
+
+@pytest.fixture(scope='module', autouse=True)
+def api_version():
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = API_VERSION
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield
+
+
+@pytest.fixture
+def session(defconfig):
+    with Session(config=defconfig) as session:
+        yield session
+
+
+@pytest.fixture
+def mock_request_params(session):
+    yield {
+        'method': 'GET',
+        'path': '/function/item/',
+        'params': {'app': '999'},
+        'content': b'{"test1": 1}',
+        'content_type': 'application/json',
+    }
+
+
+def test_request_initialization(mock_request_params):
+    rqst = Request(**mock_request_params)
+
+    assert rqst.method == mock_request_params['method']
+    assert rqst.params == mock_request_params['params']
+    assert rqst.path == mock_request_params['path'].lstrip('/')
+    assert rqst.content == mock_request_params['content']
+    assert 'X-BackendAI-Version' in rqst.headers
+
+
+def test_request_set_content_none(mock_request_params):
+    mock_request_params = mock_request_params.copy()
+    mock_request_params['content'] = None
+    rqst = Request(**mock_request_params)
+    assert rqst.content == b''
+    assert rqst._pack_content() is rqst.content
+
+
+def test_request_set_content(mock_request_params):
+    rqst = Request(**mock_request_params)
+    assert rqst.content == mock_request_params['content']
+    assert rqst.content_type == 'application/json'
+    assert rqst._pack_content() is rqst.content
+
+    mock_request_params['content'] = 'hello'
+    mock_request_params['content_type'] = None
+    rqst = Request(**mock_request_params)
+    assert rqst.content == b'hello'
+    assert rqst.content_type == 'text/plain'
+    assert rqst._pack_content() is rqst.content
+
+    mock_request_params['content'] = b'\x00\x01\xfe\xff'
+    mock_request_params['content_type'] = None
+    rqst = Request(**mock_request_params)
+    assert rqst.content == b'\x00\x01\xfe\xff'
+    assert rqst.content_type == 'application/octet-stream'
+    assert rqst._pack_content() is rqst.content
+
+
+def test_request_attach_files(mock_request_params):
+    files = [
+        AttachedFile('test1.txt', io.BytesIO(), 'application/octet-stream'),
+        AttachedFile('test2.txt', io.BytesIO(), 'application/octet-stream'),
+    ]
+
+    mock_request_params['content'] = b'something'
+    rqst = Request(**mock_request_params)
+    with pytest.raises(AssertionError):
+        rqst.attach_files(files)
+
+    mock_request_params['content'] = b''
+    rqst = Request(**mock_request_params)
+    rqst.attach_files(files)
+
+    assert rqst.content_type == 'multipart/form-data'
+    assert rqst.content == b''
+    packed_content = rqst._pack_content()
+    assert packed_content.is_multipart
+
+
+def test_build_correct_url(mock_request_params):
+    config = get_config()
+    canonical_url = str(config.endpoint).rstrip('/') + '/function?app=999'
+
+    mock_request_params['path'] = '/function'
+    rqst = Request(**mock_request_params)
+    assert str(rqst._build_url()) == canonical_url
+
+    mock_request_params['path'] = 'function'
+    rqst = Request(**mock_request_params)
+    assert str(rqst._build_url()) == canonical_url
+
+
+@pytest.mark.asyncio
+async def test_fetch_invalid_method(mock_request_params):
+    mock_request_params['method'] = 'STRANGE'
+    rqst = Request(**mock_request_params)
+
+    with pytest.raises(AssertionError):
+        async with rqst.fetch():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_fetch(dummy_endpoint):
+    with aioresponses() as m, Session():
+        body = b'hello world'
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'text/plain; charset=utf-8',
+                     'Content-Length': str(len(body))},
+        )
+        rqst = Request('POST', 'function')
+        async with rqst.fetch() as resp:
+            assert isinstance(resp, Response)
+            assert resp.status == 200
+            assert resp.content_type == 'text/plain'
+            assert await resp.text() == body.decode()
+            assert resp.content_length == len(body)
+
+    with aioresponses() as m, Session():
+        body = b'{"a": 1234, "b": null}'
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'application/json; charset=utf-8',
+                     'Content-Length': str(len(body))},
+        )
+        rqst = Request('POST', 'function')
+        async with rqst.fetch() as resp:
+            assert isinstance(resp, Response)
+            assert resp.status == 200
+            assert resp.content_type == 'application/json'
+            assert await resp.text() == body.decode()
+            assert await resp.json() == {'a': 1234, 'b': None}
+            assert resp.content_length == len(body)
+
+
+@pytest.mark.asyncio
+async def test_streaming_fetch(dummy_endpoint):
+    # Read content by chunks.
+    with aioresponses() as m, Session():
+        body = b'hello world'
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'text/plain; charset=utf-8',
+                     'Content-Length': str(len(body))},
+        )
+        rqst = Request('POST', 'function')
+        async with rqst.fetch() as resp:
+            assert resp.status == 200
+            assert resp.content_type == 'text/plain'
+            assert await resp.read(3) == b'hel'
+            assert await resp.read(2) == b'lo'
+            await resp.read()
+            with pytest.raises(AssertionError):
+                assert await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_invalid_requests(dummy_endpoint):
+    with aioresponses() as m, Session():
+        body = json.dumps({
+            'type': 'https://api.backend.ai/probs/kernel-not-found',
+            'title': 'Kernel Not Found',
+        }).encode('utf8')
+        m.post(
+            dummy_endpoint, status=404, body=body,
+            headers={'Content-Type': 'application/problem+json; charset=utf-8',
+                     'Content-Length': str(len(body))},
+        )
+        rqst = Request('POST', '/')
+        with pytest.raises(BackendAPIError) as e:
+            async with rqst.fetch():
+                pass
+            assert e.status == 404
+            assert e.data['type'] == \
+                'https://api.backend.ai/probs/kernel-not-found'
+            assert e.data['title'] == 'Kernel Not Found'
+
+
+@pytest.mark.asyncio
+async def test_fetch_invalid_method_async():
+    async with AsyncSession():
+        rqst = Request('STRANGE', '/')
+        with pytest.raises(AssertionError):
+            async with rqst.fetch():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_client_error_async(dummy_endpoint):
+    with aioresponses() as m:
+        async with AsyncSession():
+            m.post(dummy_endpoint,
+                   exception=aiohttp.ClientConnectionError())
+            rqst = Request('POST', '/')
+            with pytest.raises(BackendClientError):
+                async with rqst.fetch():
+                    pass
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_fetch_cancellation_async(dummy_endpoint):
+    # It seems that aiohttp swallows asyncio.CancelledError
+    with aioresponses() as m:
+        async with AsyncSession():
+            m.post(dummy_endpoint,
+                   exception=asyncio.CancelledError())
+            rqst = Request('POST', '/')
+            with pytest.raises(asyncio.CancelledError):
+                async with rqst.fetch():
+                    pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeout_async(dummy_endpoint):
+    with aioresponses() as m:
+        async with AsyncSession():
+            m.post(dummy_endpoint,
+                   exception=asyncio.TimeoutError())
+            rqst = Request('POST', '/')
+            with pytest.raises(asyncio.TimeoutError):
+                async with rqst.fetch():
+                    pass
+
+
+@pytest.mark.asyncio
+async def test_response_async(defconfig, dummy_endpoint):
+    body = b'{"test": 5678}'
+    with aioresponses() as m:
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'application/json',
+                     'Content-Length': str(len(body))},
+        )
+        async with AsyncSession(config=defconfig):
+            rqst = Request('POST', '/function')
+            async with rqst.fetch() as resp:
+                assert await resp.text() == '{"test": 5678}'
+                assert await resp.json() == {'test': 5678}

--- a/tests/client/test_request.py
+++ b/tests/client/test_request.py
@@ -11,7 +11,7 @@ from ai.backend.client.config import API_VERSION, get_config
 from ai.backend.client.exceptions import BackendAPIError, BackendClientError
 from ai.backend.client.request import AttachedFile, Request, Response
 from ai.backend.client.session import AsyncSession, Session
-from ai.backend.client.test_utils import AsyncMock
+from ai.backend.testutils.mock import AsyncMock
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/client/test_vfolder.py
+++ b/tests/client/test_vfolder.py
@@ -5,7 +5,7 @@ from aioresponses import aioresponses
 
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.session import Session
-from ai.backend.client.test_utils import AsyncMock
+from ai.backend.testutils.mock import AsyncMock
 
 
 def build_url(config, path: str):

--- a/tests/client/test_vfolder.py
+++ b/tests/client/test_vfolder.py
@@ -9,44 +9,42 @@ from ai.backend.client.test_utils import AsyncMock
 
 
 def build_url(config, path: str):
-    base_url = config.endpoint.path.rstrip('/')
-    query_path = path.lstrip('/') if len(path) > 0 else ''
-    path = '{0}/{1}'.format(base_url, query_path)
+    base_url = config.endpoint.path.rstrip("/")
+    query_path = path.lstrip("/") if len(path) > 0 else ""
+    path = "{0}/{1}".format(base_url, query_path)
     canonical_url = config.endpoint.with_path(path)
     return canonical_url
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def api_version():
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = API_VERSION
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield
 
 
 def test_create_vfolder():
     with Session() as session, aioresponses() as m:
         payload = {
-            'id': 'fake-vfolder-id',
-            'name': 'fake-vfolder-name',
-            'host': 'local',
+            "id": "fake-vfolder-id",
+            "name": "fake-vfolder-name",
+            "host": "local",
         }
-        m.post(build_url(session.config, '/folders'), status=201,
-               payload=payload)
-        resp = session.VFolder.create('fake-vfolder-name')
+        m.post(build_url(session.config, "/folders"), status=201, payload=payload)
+        resp = session.VFolder.create("fake-vfolder-name")
         assert resp == payload
 
 
 def test_create_vfolder_in_other_host():
     with Session() as session, aioresponses() as m:
         payload = {
-            'id': 'fake-vfolder-id',
-            'name': 'fake-vfolder-name',
-            'host': 'fake-vfolder-host',
+            "id": "fake-vfolder-id",
+            "name": "fake-vfolder-name",
+            "host": "fake-vfolder-host",
         }
-        m.post(build_url(session.config, '/folders'), status=201,
-               payload=payload)
-        resp = session.VFolder.create('fake-vfolder-name', 'fake-vfolder-host')
+        m.post(build_url(session.config, "/folders"), status=201, payload=payload)
+        resp = session.VFolder.create("fake-vfolder-name", "fake-vfolder-host")
         assert resp == payload
 
 
@@ -54,67 +52,70 @@ def test_list_vfolders():
     with Session() as session, aioresponses() as m:
         payload = [
             {
-                'name': 'fake-vfolder1',
-                'id': 'fake-vfolder1-id',
-                'host': 'fake-vfolder1-host',
-                'is_owner': True,
-                'permissions': 'wd',
+                "name": "fake-vfolder1",
+                "id": "fake-vfolder1-id",
+                "host": "fake-vfolder1-host",
+                "is_owner": True,
+                "permissions": "wd",
             },
             {
-                'name': 'fake-vfolder2',
-                'id': 'fake-vfolder2-id',
-                'host': 'fake-vfolder2-host',
-                'is_owner': True,
-                'permissions': 'wd',
+                "name": "fake-vfolder2",
+                "id": "fake-vfolder2-id",
+                "host": "fake-vfolder2-host",
+                "is_owner": True,
+                "permissions": "wd",
             },
         ]
-        m.get(build_url(session.config, '/folders'), status=200,
-              payload=payload)
+        m.get(build_url(session.config, "/folders"), status=200, payload=payload)
         resp = session.VFolder.list()
         assert resp == payload
 
 
 def test_delete_vfolder():
     with Session() as session, aioresponses() as m:
-        vfolder_name = 'fake-vfolder-name'
-        m.delete(build_url(session.config, '/folders/{}'.format(vfolder_name)),
-                 status=204)
+        vfolder_name = "fake-vfolder-name"
+        m.delete(build_url(session.config, "/folders/{}".format(vfolder_name)), status=204)
         resp = session.VFolder(vfolder_name).delete()
         assert resp == {}
 
 
 def test_vfolder_get_info():
     with Session() as session, aioresponses() as m:
-        vfolder_name = 'fake-vfolder-name'
+        vfolder_name = "fake-vfolder-name"
         payload = {
-            'name': vfolder_name,
-            'id': 'fake-vfolder-id',
-            'host': 'fake-vfolder-host',
-            'numFiles': 5,
-            'created': '2018-06-02 09:04:15.585917+00:00',
-            'is_owner': True,
-            'permission': 'wd',
+            "name": vfolder_name,
+            "id": "fake-vfolder-id",
+            "host": "fake-vfolder-host",
+            "numFiles": 5,
+            "created": "2018-06-02 09:04:15.585917+00:00",
+            "is_owner": True,
+            "permission": "wd",
         }
-        m.get(build_url(session.config, '/folders/{}'.format(vfolder_name)),
-              status=200, payload=payload)
+        m.get(
+            build_url(session.config, "/folders/{}".format(vfolder_name)),
+            status=200,
+            payload=payload,
+        )
         resp = session.VFolder(vfolder_name).info()
         assert resp == payload
 
 
 def test_vfolder_delete_files():
     with Session() as session, aioresponses() as m:
-        vfolder_name = 'fake-vfolder-name'
-        files = ['fake-file1', 'fake-file2']
-        m.delete(build_url(session.config,
-                           '/folders/{}/delete-files'.format(vfolder_name)),
-                 status=200, payload={})
+        vfolder_name = "fake-vfolder-name"
+        files = ["fake-file1", "fake-file2"]
+        m.delete(
+            build_url(session.config, "/folders/{}/delete-files".format(vfolder_name)),
+            status=200,
+            payload={},
+        )
         resp = session.VFolder(vfolder_name).delete_files(files)
-        assert resp == '{}'
+        assert resp == "{}"
 
 
 def test_vfolder_list_files():
     with Session() as session, aioresponses() as m:
-        vfolder_name = 'fake-vfolder-name'
+        vfolder_name = "fake-vfolder-name"
         payload = {
             "files": [
                 {
@@ -136,39 +137,42 @@ def test_vfolder_list_files():
             ],
             "folder_path": "/mnt/local/1f6bd27fde1248cabfb50306ea83fc0a",
         }
-        m.get(build_url(session.config,
-                        '/folders/{}/files'.format(vfolder_name)),
-              status=200, payload=payload)
-        resp = session.VFolder(vfolder_name).list_files('.')
+        m.get(
+            build_url(session.config, "/folders/{}/files".format(vfolder_name)),
+            status=200,
+            payload=payload,
+        )
+        resp = session.VFolder(vfolder_name).list_files(".")
         assert resp == payload
 
 
 def test_vfolder_invite():
     with Session() as session, aioresponses() as m:
-        vfolder_name = 'fake-vfolder-name'
-        user_ids = ['user1@lablup.com', 'user2@lablup.com']
-        payload = {'invited_ids': user_ids}
-        m.post(build_url(session.config,
-                         '/folders/{}/invite'.format(vfolder_name)),
-               status=201, payload=payload)
-        resp = session.VFolder(vfolder_name).invite('rw', user_ids)
+        vfolder_name = "fake-vfolder-name"
+        user_ids = ["user1@lablup.com", "user2@lablup.com"]
+        payload = {"invited_ids": user_ids}
+        m.post(
+            build_url(session.config, "/folders/{}/invite".format(vfolder_name)),
+            status=201,
+            payload=payload,
+        )
+        resp = session.VFolder(vfolder_name).invite("rw", user_ids)
         assert resp == payload
 
 
 def test_vfolder_invitations():
     with Session() as session, aioresponses() as m:
         payload = {
-            'invitations': [
+            "invitations": [
                 {
-                    'id': 'fake-invitation-id',
-                    'inviter': 'inviter@lablup.com',
-                    'perm': 'ro',
-                    'vfolder_id': 'fake-vfolder-id',
+                    "id": "fake-invitation-id",
+                    "inviter": "inviter@lablup.com",
+                    "perm": "ro",
+                    "vfolder_id": "fake-vfolder-id",
                 },
             ],
         }
-        m.get(build_url(session.config, '/folders/invitations/list'),
-              status=200, payload=payload)
+        m.get(build_url(session.config, "/folders/invitations/list"), status=200, payload=payload)
         resp = session.VFolder.invitations()
         assert resp == payload
 
@@ -176,35 +180,39 @@ def test_vfolder_invitations():
 def test_vfolder_accept_invitation():
     with Session() as session, aioresponses() as m:
         payload = {
-            'msg': ('User invitee@lablup.com now can access'
-                    ' vfolder fake-vfolder-id'),
+            "msg": ("User invitee@lablup.com now can access" " vfolder fake-vfolder-id"),
         }
-        m.post(build_url(session.config, '/folders/invitations/accept'),
-               status=200, payload=payload)
-        resp = session.VFolder.accept_invitation('inv-id')
+        m.post(
+            build_url(session.config, "/folders/invitations/accept"), status=200, payload=payload
+        )
+        resp = session.VFolder.accept_invitation("inv-id")
         assert resp == payload
 
 
 def test_vfolder_delete_invitation():
     with Session() as session, aioresponses() as m:
-        payload = {'msg': 'Vfolder invitation is deleted: fake-inv-id.'}
-        m.delete(build_url(session.config, '/folders/invitations/delete'),
-                 status=200, payload=payload)
-        resp = session.VFolder.delete_invitation('inv-id')
+        payload = {"msg": "Vfolder invitation is deleted: fake-inv-id."}
+        m.delete(
+            build_url(session.config, "/folders/invitations/delete"), status=200, payload=payload
+        )
+        resp = session.VFolder.delete_invitation("inv-id")
         assert resp == payload
 
 
 def test_vfolder_clone():
     with Session() as session, aioresponses() as m:
-        source_vfolder_name = 'fake-source-vfolder-name'
-        target_vfolder_name = 'fake-target-vfolder-name'
+        source_vfolder_name = "fake-source-vfolder-name"
+        target_vfolder_name = "fake-target-vfolder-name"
         payload = {
-            'target_name': target_vfolder_name,
-            'target_host': 'local',
-            'permission': 'rw',
-            'usage_mode': 'general',
+            "target_name": target_vfolder_name,
+            "target_host": "local",
+            "permission": "rw",
+            "usage_mode": "general",
         }
-        m.post(build_url(session.config, '/folders/{}/clone'.format(source_vfolder_name)),
-               status=201, payload=payload)
+        m.post(
+            build_url(session.config, "/folders/{}/clone".format(source_vfolder_name)),
+            status=201,
+            payload=payload,
+        )
         resp = session.VFolder(source_vfolder_name).clone(target_vfolder_name)
         assert resp == payload

--- a/tests/client/test_vfolder.py
+++ b/tests/client/test_vfolder.py
@@ -1,0 +1,210 @@
+from unittest import mock
+
+import pytest
+from aioresponses import aioresponses
+
+from ai.backend.client.config import API_VERSION
+from ai.backend.client.session import Session
+from ai.backend.client.test_utils import AsyncMock
+
+
+def build_url(config, path: str):
+    base_url = config.endpoint.path.rstrip('/')
+    query_path = path.lstrip('/') if len(path) > 0 else ''
+    path = '{0}/{1}'.format(base_url, query_path)
+    canonical_url = config.endpoint.with_path(path)
+    return canonical_url
+
+
+@pytest.fixture(scope='module', autouse=True)
+def api_version():
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = API_VERSION
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield
+
+
+def test_create_vfolder():
+    with Session() as session, aioresponses() as m:
+        payload = {
+            'id': 'fake-vfolder-id',
+            'name': 'fake-vfolder-name',
+            'host': 'local',
+        }
+        m.post(build_url(session.config, '/folders'), status=201,
+               payload=payload)
+        resp = session.VFolder.create('fake-vfolder-name')
+        assert resp == payload
+
+
+def test_create_vfolder_in_other_host():
+    with Session() as session, aioresponses() as m:
+        payload = {
+            'id': 'fake-vfolder-id',
+            'name': 'fake-vfolder-name',
+            'host': 'fake-vfolder-host',
+        }
+        m.post(build_url(session.config, '/folders'), status=201,
+               payload=payload)
+        resp = session.VFolder.create('fake-vfolder-name', 'fake-vfolder-host')
+        assert resp == payload
+
+
+def test_list_vfolders():
+    with Session() as session, aioresponses() as m:
+        payload = [
+            {
+                'name': 'fake-vfolder1',
+                'id': 'fake-vfolder1-id',
+                'host': 'fake-vfolder1-host',
+                'is_owner': True,
+                'permissions': 'wd',
+            },
+            {
+                'name': 'fake-vfolder2',
+                'id': 'fake-vfolder2-id',
+                'host': 'fake-vfolder2-host',
+                'is_owner': True,
+                'permissions': 'wd',
+            },
+        ]
+        m.get(build_url(session.config, '/folders'), status=200,
+              payload=payload)
+        resp = session.VFolder.list()
+        assert resp == payload
+
+
+def test_delete_vfolder():
+    with Session() as session, aioresponses() as m:
+        vfolder_name = 'fake-vfolder-name'
+        m.delete(build_url(session.config, '/folders/{}'.format(vfolder_name)),
+                 status=204)
+        resp = session.VFolder(vfolder_name).delete()
+        assert resp == {}
+
+
+def test_vfolder_get_info():
+    with Session() as session, aioresponses() as m:
+        vfolder_name = 'fake-vfolder-name'
+        payload = {
+            'name': vfolder_name,
+            'id': 'fake-vfolder-id',
+            'host': 'fake-vfolder-host',
+            'numFiles': 5,
+            'created': '2018-06-02 09:04:15.585917+00:00',
+            'is_owner': True,
+            'permission': 'wd',
+        }
+        m.get(build_url(session.config, '/folders/{}'.format(vfolder_name)),
+              status=200, payload=payload)
+        resp = session.VFolder(vfolder_name).info()
+        assert resp == payload
+
+
+def test_vfolder_delete_files():
+    with Session() as session, aioresponses() as m:
+        vfolder_name = 'fake-vfolder-name'
+        files = ['fake-file1', 'fake-file2']
+        m.delete(build_url(session.config,
+                           '/folders/{}/delete-files'.format(vfolder_name)),
+                 status=200, payload={})
+        resp = session.VFolder(vfolder_name).delete_files(files)
+        assert resp == '{}'
+
+
+def test_vfolder_list_files():
+    with Session() as session, aioresponses() as m:
+        vfolder_name = 'fake-vfolder-name'
+        payload = {
+            "files": [
+                {
+                    "mode": "-rw-r--r--",
+                    "size": 4751244,
+                    "ctime": 1528277299.2744732,
+                    "mtime": 1528277299.2744732,
+                    "atime": 1528277300.7658687,
+                    "filename": "bigtxt.txt",
+                },
+                {
+                    "mode": "-rw-r--r--",
+                    "size": 200000,
+                    "ctime": 1528333257.6576185,
+                    "mtime": 1528288069.625786,
+                    "atime": 1528332829.692922,
+                    "filename": "200000",
+                },
+            ],
+            "folder_path": "/mnt/local/1f6bd27fde1248cabfb50306ea83fc0a",
+        }
+        m.get(build_url(session.config,
+                        '/folders/{}/files'.format(vfolder_name)),
+              status=200, payload=payload)
+        resp = session.VFolder(vfolder_name).list_files('.')
+        assert resp == payload
+
+
+def test_vfolder_invite():
+    with Session() as session, aioresponses() as m:
+        vfolder_name = 'fake-vfolder-name'
+        user_ids = ['user1@lablup.com', 'user2@lablup.com']
+        payload = {'invited_ids': user_ids}
+        m.post(build_url(session.config,
+                         '/folders/{}/invite'.format(vfolder_name)),
+               status=201, payload=payload)
+        resp = session.VFolder(vfolder_name).invite('rw', user_ids)
+        assert resp == payload
+
+
+def test_vfolder_invitations():
+    with Session() as session, aioresponses() as m:
+        payload = {
+            'invitations': [
+                {
+                    'id': 'fake-invitation-id',
+                    'inviter': 'inviter@lablup.com',
+                    'perm': 'ro',
+                    'vfolder_id': 'fake-vfolder-id',
+                },
+            ],
+        }
+        m.get(build_url(session.config, '/folders/invitations/list'),
+              status=200, payload=payload)
+        resp = session.VFolder.invitations()
+        assert resp == payload
+
+
+def test_vfolder_accept_invitation():
+    with Session() as session, aioresponses() as m:
+        payload = {
+            'msg': ('User invitee@lablup.com now can access'
+                    ' vfolder fake-vfolder-id'),
+        }
+        m.post(build_url(session.config, '/folders/invitations/accept'),
+               status=200, payload=payload)
+        resp = session.VFolder.accept_invitation('inv-id')
+        assert resp == payload
+
+
+def test_vfolder_delete_invitation():
+    with Session() as session, aioresponses() as m:
+        payload = {'msg': 'Vfolder invitation is deleted: fake-inv-id.'}
+        m.delete(build_url(session.config, '/folders/invitations/delete'),
+                 status=200, payload=payload)
+        resp = session.VFolder.delete_invitation('inv-id')
+        assert resp == payload
+
+
+def test_vfolder_clone():
+    with Session() as session, aioresponses() as m:
+        source_vfolder_name = 'fake-source-vfolder-name'
+        target_vfolder_name = 'fake-target-vfolder-name'
+        payload = {
+            'target_name': target_vfolder_name,
+            'target_host': 'local',
+            'permission': 'rw',
+            'usage_mode': 'general',
+        }
+        m.post(build_url(session.config, '/folders/{}/clone'.format(source_vfolder_name)),
+               status=201, payload=payload)
+        resp = session.VFolder(source_vfolder_name).clone(target_vfolder_name)
+        assert resp == payload

--- a/tests/client/test_vfolder_tus.py
+++ b/tests/client/test_vfolder_tus.py
@@ -1,31 +1,30 @@
+import secrets
 from pathlib import Path
 from unittest import mock
 
-import secrets
 import pytest
 from aioresponses import aioresponses
+from aiotusclient import client
 
 from ai.backend.client.config import API_VERSION
-from ai.backend.client.session import AsyncSession
 from ai.backend.client.request import Request, Response
+from ai.backend.client.session import AsyncSession
 from ai.backend.client.test_utils import AsyncMock
-
-from aiotusclient import client
 
 
 def build_url(config, path: str):
-    base_url = config.endpoint.path.rstrip('/')
-    query_path = path.lstrip('/') if len(path) > 0 else ''
-    path = '{0}/{1}'.format(base_url, query_path)
+    base_url = config.endpoint.path.rstrip("/")
+    query_path = path.lstrip("/") if len(path) > 0 else ""
+    path = "{0}/{1}".format(base_url, query_path)
     canonical_url = config.endpoint.with_path(path)
     return canonical_url
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def api_version():
     mock_nego_func = AsyncMock()
     mock_nego_func.return_value = API_VERSION
-    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+    with mock.patch("ai.backend.client.session._negotiate_api_version", mock_nego_func):
         yield
 
 
@@ -34,41 +33,48 @@ async def test_upload_jwt_generation(tmp_path):
     with aioresponses() as m:
 
         async with AsyncSession() as session:
-            mock_file = tmp_path / 'example.bin'
+            mock_file = tmp_path / "example.bin"
             mock_file.write_bytes(secrets.token_bytes(32))
 
-            vfolder_name = 'fake-vfolder-name'
+            vfolder_name = "fake-vfolder-name"
 
-            file_size = '1024'
-            payload = {'token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9. \
+            file_size = "1024"
+            payload = {
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9. \
             eyJwYXRoIjoiaHR0cDoxMjcuMC4wLjEvZm9sZGVycy9mYWtlLXZmb2xkZXItbmFtZS9yZXF1ZXN0LXVwbG9hZCIsInNpemUiOjEwMjR9.\
-            5IXk0xdrr6aPzVjud4cdfcXWch7Bq-m7SlFhnUv8XL8'}
+            5IXk0xdrr6aPzVjud4cdfcXWch7Bq-m7SlFhnUv8XL8"
+            }
 
-            m.post(build_url(session.config, '/folders/{}/request-upload'.format(vfolder_name)),
-                   payload=payload, status=200)
+            m.post(
+                build_url(session.config, "/folders/{}/request-upload".format(vfolder_name)),
+                payload=payload,
+                status=200,
+            )
 
-            rqst = Request('POST', '/folders/{}/request-upload'.format(vfolder_name))
-            rqst.set_json({
-                'path': "{}".format(str(Path(mock_file))),
-                'size': str(file_size),
-            })
+            rqst = Request("POST", "/folders/{}/request-upload".format(vfolder_name))
+            rqst.set_json(
+                {
+                    "path": "{}".format(str(Path(mock_file))),
+                    "size": str(file_size),
+                }
+            )
 
             async with rqst.fetch() as resp:
                 res = await resp.json()
                 assert isinstance(resp, Response)
                 assert resp.status == 200
-                assert resp.content_type == 'application/json'
+                assert resp.content_type == "application/json"
                 assert res == payload
-                assert 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' in res['token']
+                assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" in res["token"]
 
 
 @pytest.mark.asyncio
 async def test_tus_upload(tmp_path: Path):
 
-    basedir = tmp_path / 'example.bin'
+    basedir = tmp_path / "example.bin"
     mock_file = basedir
     mock_file.write_bytes(secrets.token_bytes(1024))
-    vfolder_name = 'fake-vfolder-name'
+    vfolder_name = "fake-vfolder-name"
     with aioresponses() as m:
 
         tus_client = client.TusClient()
@@ -79,36 +85,45 @@ async def test_tus_upload(tmp_path: Path):
             eyJwYXRoIjoiaHR0cDoxMjcuMC4wLjEvZm9sZGVycy9mYWtlLXZmb2xkZXItbmFtZS9yZXF1ZXN0LXVwbG9hZCIsInNpemUiOjEwMjR9.\
                 5IXk0xdrr6aPzVjud4cdfcXWch7Bq-m7SlFhnUv8XL8"
 
-        storage_proxy_payload = {'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers':
-        'Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type',
-        'Access-Control-Expose-Headers':
-        'Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type',
-        'Access-Control-Allow-Methods': '*',
-        'Cache-Control': 'no-store',
-        'Tus-Resumable': '1.0.0',
-        'Upload-Offset': '1024',
-        'Upload-Length': '1024',
-        'Content-Length': '0',
-        'Content-Type': 'application/octet-stream',
-        'Date': 'Thu, 10 Sep 2020 05:52:12 GMT',
-        'Server': 'Python/3.8 aiohttp/3.6.2'}
+        storage_proxy_payload = {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type",
+            "Access-Control-Expose-Headers": "Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type",
+            "Access-Control-Allow-Methods": "*",
+            "Cache-Control": "no-store",
+            "Tus-Resumable": "1.0.0",
+            "Upload-Offset": "1024",
+            "Upload-Length": "1024",
+            "Content-Length": "0",
+            "Content-Type": "application/octet-stream",
+            "Date": "Thu, 10 Sep 2020 05:52:12 GMT",
+            "Server": "Python/3.8 aiohttp/3.6.2",
+        }
 
-        upload_url = 'http://127.0.0.1:6021/upload?token={}'.format(token)
-        m.head('http://127.0.0.1:6021/folders/{}/upload?token={}'.format(vfolder_name, token),
-               status=200)
-        m.patch('http://127.0.0.1:6021/upload?token={}'.format(token),
-                payload=storage_proxy_payload, status=204,
-                headers={'upload-offset': '1024',
-                         'Content-Type': 'application/offset+octet-stream',
-                         'Tus-Resumable': '1.0.0'})
+        upload_url = "http://127.0.0.1:6021/upload?token={}".format(token)
+        m.head(
+            "http://127.0.0.1:6021/folders/{}/upload?token={}".format(vfolder_name, token),
+            status=200,
+        )
+        m.patch(
+            "http://127.0.0.1:6021/upload?token={}".format(token),
+            payload=storage_proxy_payload,
+            status=204,
+            headers={
+                "upload-offset": "1024",
+                "Content-Type": "application/offset+octet-stream",
+                "Tus-Resumable": "1.0.0",
+            },
+        )
 
         uploader = tus_client.async_uploader(
             file_stream=input_file,
             url=upload_url,
             upload_checksum=False,
             chunk_size=1024,
-            retries=1, retry_delay=1)
+            retries=1,
+            retry_delay=1,
+        )
 
         res = await uploader.upload()
         if res is None:
@@ -122,36 +137,45 @@ async def test_vfolder_download(mocker):
     mock_reader = AsyncMock()
     mock_reader.next = AsyncMock()
     mock_reader.next.return_value = None
-    mock_file = 'fake-file1'
+    mock_file = "fake-file1"
     with aioresponses() as m:
 
         async with AsyncSession() as session:
-            vfolder_name = 'fake-vfolder-name'
+            vfolder_name = "fake-vfolder-name"
             # client to manager
             # manager to storage-proxy
-            storage_path = str(build_url(session.config, '/download'.replace('8081', '6021')))
+            storage_path = str(build_url(session.config, "/download".replace("8081", "6021")))
 
-            payload = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.\
+            payload = {
+                "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.\
             eyJvcCI6ImRvd25sb2FkIiwidm9sdW1lIjoidm9sdW1lMSIsInZmaWQiOiI4ZGFlNjk5Mi1kMjIzLTQwM2MtYTUyZC1iYWRlNGYwMGFhMzIiLCJyZWxwYXRoIjoic2V0dXAuY2ZnIiwiZXhwIjoxNjAwMTM0MzI5fQ.\
-            -cirX1fTBVqDAuW6IPzwpHjtopnSdio_BeuD2DACsbQ', 'url': storage_path}
+            -cirX1fTBVqDAuW6IPzwpHjtopnSdio_BeuD2DACsbQ",
+                "url": storage_path,
+            }
 
             # 1. Client to Manager throught Request
-            m.post(build_url(session.config, "/folders/{}/request-download".format(
-                             vfolder_name)),
-                             payload=payload,
-                             status=200,
-                             headers={'User-Agent': 'Backend.AI Client for Python 20.09.0a1.dev0',
-                                      'X-BackendAI-Domain': 'default',
-                                      'X-BackendAI-Version': 'v6.20200815',
-                                      'Date': '2020-09-14T01:45:29.117351+00:00',
-                                      'Content-Type': 'application/json',
-                                      'Authorization': 'BackendAI signMethod=HMAC-SHA256,\
+            m.post(
+                build_url(session.config, "/folders/{}/request-download".format(vfolder_name)),
+                payload=payload,
+                status=200,
+                headers={
+                    "User-Agent": "Backend.AI Client for Python 20.09.0a1.dev0",
+                    "X-BackendAI-Domain": "default",
+                    "X-BackendAI-Version": "v6.20200815",
+                    "Date": "2020-09-14T01:45:29.117351+00:00",
+                    "Content-Type": "application/json",
+                    "Authorization": "BackendAI signMethod=HMAC-SHA256,\
                                        credential=AKIAIOSFODNN7EXAMPLE:\
                                        623674bb421ff0c96a9fe78a4a8c6a\
-                                       45fc5c0a370257800310cd9c7826819b3c'})
+                                       45fc5c0a370257800310cd9c7826819b3c",
+                },
+            )
 
             # 2. Client to Manager through TusClient. Upload url
-            m.get(storage_path + "?token={}".format(payload['token']),
-                  headers={'Content-Length': '527'}, status=200)
+            m.get(
+                storage_path + "?token={}".format(payload["token"]),
+                headers={"Content-Length": "527"},
+                status=200,
+            )
             await session.VFolder(vfolder_name).download([mock_file])
             assert Path("fake-file1").exists() == 1

--- a/tests/client/test_vfolder_tus.py
+++ b/tests/client/test_vfolder_tus.py
@@ -1,5 +1,6 @@
 import secrets
 from pathlib import Path
+from time import time
 from unittest import mock
 
 import pytest
@@ -138,6 +139,8 @@ async def test_vfolder_download(mocker):
     mock_reader.next = AsyncMock()
     mock_reader.next.return_value = None
     mock_file = "fake-file1"
+
+    today_timestamp = time()
     with aioresponses() as m:
 
         async with AsyncSession() as session:
@@ -174,7 +177,10 @@ async def test_vfolder_download(mocker):
             # 2. Client to Manager through TusClient. Upload url
             m.get(
                 storage_path + "?token={}".format(payload["token"]),
-                headers={"Content-Length": "527"},
+                headers={
+                    "Content-Length": "527",
+                    "Last-Modified": str(today_timestamp),
+                },
                 status=200,
             )
             await session.VFolder(vfolder_name).download([mock_file])

--- a/tests/client/test_vfolder_tus.py
+++ b/tests/client/test_vfolder_tus.py
@@ -9,7 +9,7 @@ from aiotusclient import client
 from ai.backend.client.config import API_VERSION
 from ai.backend.client.request import Request, Response
 from ai.backend.client.session import AsyncSession
-from ai.backend.client.test_utils import AsyncMock
+from ai.backend.testutils.mock import AsyncMock
 
 
 def build_url(config, path: str):

--- a/tests/client/test_vfolder_tus.py
+++ b/tests/client/test_vfolder_tus.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+from unittest import mock
+
+import secrets
+import pytest
+from aioresponses import aioresponses
+
+from ai.backend.client.config import API_VERSION
+from ai.backend.client.session import AsyncSession
+from ai.backend.client.request import Request, Response
+from ai.backend.client.test_utils import AsyncMock
+
+from aiotusclient import client
+
+
+def build_url(config, path: str):
+    base_url = config.endpoint.path.rstrip('/')
+    query_path = path.lstrip('/') if len(path) > 0 else ''
+    path = '{0}/{1}'.format(base_url, query_path)
+    canonical_url = config.endpoint.with_path(path)
+    return canonical_url
+
+
+@pytest.fixture(scope='module', autouse=True)
+def api_version():
+    mock_nego_func = AsyncMock()
+    mock_nego_func.return_value = API_VERSION
+    with mock.patch('ai.backend.client.session._negotiate_api_version', mock_nego_func):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_upload_jwt_generation(tmp_path):
+    with aioresponses() as m:
+
+        async with AsyncSession() as session:
+            mock_file = tmp_path / 'example.bin'
+            mock_file.write_bytes(secrets.token_bytes(32))
+
+            vfolder_name = 'fake-vfolder-name'
+
+            file_size = '1024'
+            payload = {'token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9. \
+            eyJwYXRoIjoiaHR0cDoxMjcuMC4wLjEvZm9sZGVycy9mYWtlLXZmb2xkZXItbmFtZS9yZXF1ZXN0LXVwbG9hZCIsInNpemUiOjEwMjR9.\
+            5IXk0xdrr6aPzVjud4cdfcXWch7Bq-m7SlFhnUv8XL8'}
+
+            m.post(build_url(session.config, '/folders/{}/request-upload'.format(vfolder_name)),
+                   payload=payload, status=200)
+
+            rqst = Request('POST', '/folders/{}/request-upload'.format(vfolder_name))
+            rqst.set_json({
+                'path': "{}".format(str(Path(mock_file))),
+                'size': str(file_size),
+            })
+
+            async with rqst.fetch() as resp:
+                res = await resp.json()
+                assert isinstance(resp, Response)
+                assert resp.status == 200
+                assert resp.content_type == 'application/json'
+                assert res == payload
+                assert 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' in res['token']
+
+
+@pytest.mark.asyncio
+async def test_tus_upload(tmp_path: Path):
+
+    basedir = tmp_path / 'example.bin'
+    mock_file = basedir
+    mock_file.write_bytes(secrets.token_bytes(1024))
+    vfolder_name = 'fake-vfolder-name'
+    with aioresponses() as m:
+
+        tus_client = client.TusClient()
+        input_file = open(basedir, "rb")
+        print(f"Uploading {basedir} ...")
+        # TODO: refactor out the progress bar
+        token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9pwd.\
+            eyJwYXRoIjoiaHR0cDoxMjcuMC4wLjEvZm9sZGVycy9mYWtlLXZmb2xkZXItbmFtZS9yZXF1ZXN0LXVwbG9hZCIsInNpemUiOjEwMjR9.\
+                5IXk0xdrr6aPzVjud4cdfcXWch7Bq-m7SlFhnUv8XL8"
+
+        storage_proxy_payload = {'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers':
+        'Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type',
+        'Access-Control-Expose-Headers':
+        'Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Content-Type',
+        'Access-Control-Allow-Methods': '*',
+        'Cache-Control': 'no-store',
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': '1024',
+        'Upload-Length': '1024',
+        'Content-Length': '0',
+        'Content-Type': 'application/octet-stream',
+        'Date': 'Thu, 10 Sep 2020 05:52:12 GMT',
+        'Server': 'Python/3.8 aiohttp/3.6.2'}
+
+        upload_url = 'http://127.0.0.1:6021/upload?token={}'.format(token)
+        m.head('http://127.0.0.1:6021/folders/{}/upload?token={}'.format(vfolder_name, token),
+               status=200)
+        m.patch('http://127.0.0.1:6021/upload?token={}'.format(token),
+                payload=storage_proxy_payload, status=204,
+                headers={'upload-offset': '1024',
+                         'Content-Type': 'application/offset+octet-stream',
+                         'Tus-Resumable': '1.0.0'})
+
+        uploader = tus_client.async_uploader(
+            file_stream=input_file,
+            url=upload_url,
+            upload_checksum=False,
+            chunk_size=1024,
+            retries=1, retry_delay=1)
+
+        res = await uploader.upload()
+        if res is None:
+            assert True
+        else:
+            assert False
+
+
+@pytest.mark.asyncio
+async def test_vfolder_download(mocker):
+    mock_reader = AsyncMock()
+    mock_reader.next = AsyncMock()
+    mock_reader.next.return_value = None
+    mock_file = 'fake-file1'
+    with aioresponses() as m:
+
+        async with AsyncSession() as session:
+            vfolder_name = 'fake-vfolder-name'
+            # client to manager
+            # manager to storage-proxy
+            storage_path = str(build_url(session.config, '/download'.replace('8081', '6021')))
+
+            payload = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.\
+            eyJvcCI6ImRvd25sb2FkIiwidm9sdW1lIjoidm9sdW1lMSIsInZmaWQiOiI4ZGFlNjk5Mi1kMjIzLTQwM2MtYTUyZC1iYWRlNGYwMGFhMzIiLCJyZWxwYXRoIjoic2V0dXAuY2ZnIiwiZXhwIjoxNjAwMTM0MzI5fQ.\
+            -cirX1fTBVqDAuW6IPzwpHjtopnSdio_BeuD2DACsbQ', 'url': storage_path}
+
+            # 1. Client to Manager throught Request
+            m.post(build_url(session.config, "/folders/{}/request-download".format(
+                             vfolder_name)),
+                             payload=payload,
+                             status=200,
+                             headers={'User-Agent': 'Backend.AI Client for Python 20.09.0a1.dev0',
+                                      'X-BackendAI-Domain': 'default',
+                                      'X-BackendAI-Version': 'v6.20200815',
+                                      'Date': '2020-09-14T01:45:29.117351+00:00',
+                                      'Content-Type': 'application/json',
+                                      'Authorization': 'BackendAI signMethod=HMAC-SHA256,\
+                                       credential=AKIAIOSFODNN7EXAMPLE:\
+                                       623674bb421ff0c96a9fe78a4a8c6a\
+                                       45fc5c0a370257800310cd9c7826819b3c'})
+
+            # 2. Client to Manager through TusClient. Upload url
+            m.get(storage_path + "?token={}".format(payload['token']),
+                  headers={'Content-Length': '527'}, status=200)
+            await session.VFolder(vfolder_name).download([mock_file])
+            assert Path("fake-file1").exists() == 1

--- a/tools/pytest.lock
+++ b/tools/pytest.lock
@@ -13,6 +13,7 @@
 //     "pytest-aiohttp>=1.0.4",
 //     "pytest-asyncio>=0.19",
 //     "pytest-cov!=2.12.1,<3.1,>=2.12",
+//     "pytest-custom_exit_code>=0.3.0",
 //     "pytest-dependency>=0.5.1",
 //     "pytest-mock>=3.8.2",
 //     "pytest-xdist<3,>=2.5",
@@ -315,13 +316,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a",
-              "url": "https://files.pythonhosted.org/packages/66/c7/564f6fb7412070356a31b03d53ee3c8f2d3695c2babe261a5cc1b75cf1a3/exceptiongroup-1.0.1-py3-none-any.whl"
+              "hash": "542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
+              "url": "https://files.pythonhosted.org/packages/ce/2e/9a327cc0d2d674ee2d570ee30119755af772094edba86d721dda94404d1a/exceptiongroup-1.0.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2",
-              "url": "https://files.pythonhosted.org/packages/13/55/43ff6658a50a7f722d2f904810b42514c23a5d649d8a5d890cdc16b617de/exceptiongroup-1.0.1.tar.gz"
+              "hash": "bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec",
+              "url": "https://files.pythonhosted.org/packages/fa/e1/4f89a2608978a78876a76e69e82fa1fc5ce3fb346297eed2a51dd3df2dcf/exceptiongroup-1.0.4.tar.gz"
             }
           ],
           "project_name": "exceptiongroup",
@@ -329,7 +330,7 @@
             "pytest>=6; extra == \"test\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.0.1"
+          "version": "1.0.4"
         },
         {
           "artifacts": [
@@ -688,13 +689,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2c85a835df33fda40fe3973b451e0c194ca11bc2c007eabff90bb3d156fc172b",
-              "url": "https://files.pythonhosted.org/packages/f1/26/c94ee7873982c5ddde3e62e7b04ee8d6800f843f0729676255e414acee94/pytest_asyncio-0.20.1-py3-none-any.whl"
+              "hash": "07e0abf9e6e6b95894a39f688a4a875d63c2128f76c02d03d16ccbc35bcc0f8a",
+              "url": "https://files.pythonhosted.org/packages/65/57/fb0d22ee0d9cd8d8b277cdf4fd7efa3e245c9577d2c2d54c6c2c18b535a2/pytest_asyncio-0.20.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "626699de2a747611f3eeb64168b3575f70439b06c3d0206e6ceaeeb956e65519",
-              "url": "https://files.pythonhosted.org/packages/9e/8f/5a918ac4e2366b61156e16fa9bfb3be52401d81f5309efb1f4e04d99ac39/pytest-asyncio-0.20.1.tar.gz"
+              "hash": "32a87a9836298a881c0ec637ebcc952cfe23a56436bdc0d09d1511941dd8a812",
+              "url": "https://files.pythonhosted.org/packages/eb/db/479f1c43df26c42c9797dfc866dc98bcf28d3765ae49bf2da681ab344b72/pytest-asyncio-0.20.2.tar.gz"
             }
           ],
           "project_name": "pytest-asyncio",
@@ -708,7 +709,7 @@
             "typing-extensions>=3.7.2; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.20.1"
+          "version": "0.20.2"
         },
         {
           "artifacts": [
@@ -736,6 +737,26 @@
           ],
           "requires_python": ">=3.6",
           "version": "3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6e0ce6e57ce3a583cb7e5023f7d1021e19dfec22be41d9ad345bae2fc61caf3b",
+              "url": "https://files.pythonhosted.org/packages/35/a0/effb6cbbccfd1c106c572d3d619b3418d71093afb4cd4f91f51e6a1799d2/pytest_custom_exit_code-0.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "51ffff0ee2c1ddcc1242e2ddb2a5fd02482717e33a2326ef330e3aa430244635",
+              "url": "https://files.pythonhosted.org/packages/92/9d/e1eb0af5e96a5c34f59b9aa69dfb680764420fe60f2ec28cfbc5339f99f8/pytest-custom_exit_code-0.3.0.tar.gz"
+            }
+          ],
+          "project_name": "pytest-custom-exit-code",
+          "requires_dists": [
+            "pytest>=4.0.2"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>2.7",
+          "version": "0.3"
         },
         {
           "artifacts": [
@@ -934,6 +955,7 @@
     "pytest-aiohttp>=1.0.4",
     "pytest-asyncio>=0.19",
     "pytest-cov!=2.12.1,<3.1,>=2.12",
+    "pytest-custom_exit_code>=0.3.0",
     "pytest-dependency>=0.5.1",
     "pytest-mock>=3.8.2",
     "pytest-xdist<3,>=2.5",


### PR DESCRIPTION
* Migrate and update the missing client SDK test suite from backend.ai-client-py repository
* Try using "larger" github action runners to speed up typecheck (8 cores) and test (16 cores)
  - After observing the costs, the exact runner size may be adjusted in the future.
* Add more tests in various components