### PR TITLE
fix: Typo in runner BUILD file for Apple intel mac

### DIFF
--- a/src/ai/backend/runner/BUILD
+++ b/src/ai/backend/runner/BUILD
@@ -55,7 +55,7 @@ platform_resources(
     dependency_map={
         "linux_x86_64": ":linux-x86_64-binaries",
         "linux_arm64": ":linux-arm64-binaries",
-        "macos_x86_64": ":linux-x86-64-binaries",
+        "macos_x86_64": ":linux-x86_64-binaries",
         "macos_arm64": ":linux-arm64-binaries",
     },
 )


### PR DESCRIPTION
This PR support for modifying typo in runner.BUILD dependency map table.
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
