### PR TITLE
fix: fallback to legacy allocation logic when there is no devices in allocation hint

### DIFF
--- a/changes/901.fix
+++ b/changes/901.fix
@@ -1,0 +1,1 @@
+Fallback to the legacy logic of getting current allocation if there is no devices in affinity hint which prevented to launch a compute session with CPU and memory only for a single numa node system.

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -123,7 +123,7 @@ class AbstractAllocMap(metaclass=ABCMeta):
         self, affinity_hint: Optional[AffinityHint], slot_name: SlotName
     ) -> Sequence[tuple[DeviceId, Decimal]]:
         device_name = DeviceName(slot_name.partition(".")[0])
-        if affinity_hint is None:  # for legacy
+        if affinity_hint is None or not affinity_hint.devices:  # for legacy
             return sorted(
                 self.allocations[slot_name].items(),  # k: slot_name, v: per-device alloc
                 key=lambda pair: self.device_slots[pair[0]].amount - pair[1],


### PR DESCRIPTION
This PR fixes a bug which raises `zeroDivisionError: integer division or modulo by zero` when creating a compute session with CPU and memory only for a single numa node system. I'm not sure this is an optimal solution, so please feel free to update this PR.
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/7539358/204138293-28577450-ec96-47fd-b81c-798f4e0a5a21.png">
