### PR TITLE
fix: Invalid default value of the agent's affinity-policy config option

### DIFF
--- a/changes/905.fix.md
+++ b/changes/905.fix.md
@@ -1,0 +1,1 @@
+Fix the invalid default value of the agent's new `affinity-policy` option

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -83,7 +83,7 @@ agent_local_config_iv = (
                     t.Key(
                         "allocation-order", default=["cuda", "rocm", "tpu", "cpu", "mem"]
                     ): t.List(t.String),
-                    t.Key("affinity-policy", default=AffinityPolicy.INTERLEAVED): tx.Enum(
+                    t.Key("affinity-policy", default=AffinityPolicy.INTERLEAVED.name): tx.Enum(
                         AffinityPolicy,
                         use_name=True,
                     ),


### PR DESCRIPTION
Follow-up of #491 