### PR TITLE
fix: rollback session cookie name to keep legacy support

### DIFF
--- a/src/ai/backend/common/web/session/__init__.py
+++ b/src/ai/backend/common/web/session/__init__.py
@@ -145,8 +145,8 @@ class Session(MutableMapping[str, Any]):
         self._created = int(time.time())
 
 
-SESSION_KEY = "bai_session"
-STORAGE_KEY = "bai_session_storage"
+SESSION_KEY = "aiohttp_session"
+STORAGE_KEY = "aiohttp_session_storage"
 
 
 async def get_session(request: web.Request) -> Session:
@@ -227,7 +227,7 @@ class AbstractStorage(metaclass=abc.ABCMeta):
     def __init__(
         self,
         *,
-        cookie_name: str = "BAI_SESSION",
+        cookie_name: str = "AIOHTTP_SESSION",
         domain: Optional[str] = None,
         max_age: Optional[int] = None,
         path: str = "/",
@@ -313,7 +313,7 @@ class SimpleCookieStorage(AbstractStorage):
     def __init__(
         self,
         *,
-        cookie_name: str = "BAI_SESSION",
+        cookie_name: str = "AIOHTTP_SESSION",
         domain: Optional[str] = None,
         max_age: Optional[int] = None,
         path: str = "/",

--- a/src/ai/backend/common/web/session/redis_storage.py
+++ b/src/ai/backend/common/web/session/redis_storage.py
@@ -26,7 +26,7 @@ class RedisStorage(AbstractStorage):
         self,
         redis_pool: "aioredis.Redis[bytes]",
         *,
-        cookie_name: str = "BAI_SESSION",
+        cookie_name: str = "AIOHTTP_SESSION",
         domain: Optional[str] = None,
         max_age: Optional[int] = None,
         path: str = "/",


### PR DESCRIPTION
This PR changes cookie name to legacy one to provide legacy web socket proxy support.

Related PR: #899 