### PR TITLE
fix: Mismatch of kernel and container hostnames in the host networking mode

### DIFF
--- a/changes/907.fix.md
+++ b/changes/907.fix.md
@@ -1,1 +1,1 @@
-Fix occasionally random mismatch of cluster hostnames and actual container hostnames in cluster sessions under the host networking mode
+Fix occasional random mismatch of cluster hostnames and actual container hostnames in cluster sessions under the host networking mode

--- a/changes/907.fix.md
+++ b/changes/907.fix.md
@@ -1,0 +1,1 @@
+Fix occasionally random mismatch of cluster hostnames and actual container hostnames in cluster sessions under the host networking mode

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1304,7 +1304,7 @@ class AgentRegistry:
                             agent_addr = item.agent_alloc_ctx.agent_addr.replace(
                                 "tcp://", ""
                             ).split(":", maxsplit=1)[0]
-                            cluster_ssh_port_mapping[f"{cluster_role}{index+1}"] = (
+                            cluster_ssh_port_mapping[item.kernel.cluster_hostname] = (
                                 agent_addr,
                                 port,
                             )


### PR DESCRIPTION
A follow-up fix to #838
