### PR TITLE
fix: Use FILL allocation strategy for the memory

### DIFF
--- a/changes/908.fix.md
+++ b/changes/908.fix.md
@@ -1,0 +1,1 @@
+Always use the FILL allocation strategy for the main memory to avoid conflicts with NUMA allocator where all the main memory is coerced as a single NUMA node "root"

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -12,6 +12,7 @@ import psutil
 from aiodocker.docker import Docker, DockerContainer
 from aiodocker.exceptions import DockerError
 
+from ai.backend.agent.alloc_map import AllocationStrategy
 from ai.backend.agent.types import MountInfo
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
@@ -570,6 +571,7 @@ class MemoryPlugin(AbstractComputePlugin):
     async def create_alloc_map(self) -> AbstractAllocMap:
         devices = await self.list_devices()
         return DiscretePropertyAllocMap(
+            allocation_strategy=AllocationStrategy.FILL,
             device_slots={
                 dev.device_id: DeviceSlotInfo(
                     SlotTypes.BYTES, SlotName("mem"), Decimal(dev.memory_size)

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -12,7 +12,6 @@ import psutil
 from aiodocker.docker import Docker, DockerContainer
 from aiodocker.exceptions import DockerError
 
-from ai.backend.agent.alloc_map import AllocationStrategy
 from ai.backend.agent.types import MountInfo
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
@@ -26,6 +25,7 @@ from ai.backend.common.types import (
 from ai.backend.common.utils import current_loop, nmget
 
 from .. import __version__
+from ..alloc_map import AllocationStrategy
 from ..resources import (
     AbstractAllocMap,
     AbstractComputeDevice,

--- a/src/ai/backend/agent/kubernetes/intrinsic.py
+++ b/src/ai/backend/agent/kubernetes/intrinsic.py
@@ -15,6 +15,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import DeviceId, DeviceModelInfo, DeviceName, SlotName, SlotTypes
 
 from .. import __version__
+from ..alloc_map import AllocationStrategy
 from ..resources import (
     AbstractAllocMap,
     AbstractComputeDevice,
@@ -290,6 +291,7 @@ class MemoryPlugin(AbstractComputePlugin):
     async def create_alloc_map(self) -> AbstractAllocMap:
         devices = await self.list_devices()
         return DiscretePropertyAllocMap(
+            allocation_strategy=AllocationStrategy.FILL,
             device_slots={
                 dev.device_id: DeviceSlotInfo(
                     SlotTypes.BYTES, SlotName("mem"), Decimal(dev.memory_size)


### PR DESCRIPTION
- The main memory can be treated as a continuous bulk, regardless of
  the even-distribution policy or NUMA nodes.

A follow-up fix to #491 