### PR TITLE
setup: Unify `./pants` for linux-aarch64 platforms

### DIFF
--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -21,6 +21,12 @@ Key concepts
 
       $ ./pants [GLOBAL_OPTS] GOAL [GOAL_OPTS] [TARGET ...]
 
+  .. warning::
+
+      If your ``scripts/install-dev.sh`` says that you need to use
+      ``./pants-local`` instead of ``./pants``, replace all ``./pants``
+      in the following command examples with ``./pants-local``.
+
 * Goal: an action to execute
 
   - You may think this as the root node of the task graph executed by Pants.

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -21,12 +21,6 @@ Key concepts
 
       $ ./pants [GLOBAL_OPTS] GOAL [GOAL_OPTS] [TARGET ...]
 
-  .. warning::
-
-      If your ``scripts/install-dev.sh`` says that you need to use
-      ``./pants-local`` instead of ``./pants``, replace all ``./pants``
-      in the following command examples with ``./pants-local``.
-
 * Goal: an action to execute
 
   - You may think this as the root node of the task graph executed by Pants.

--- a/pants
+++ b/pants
@@ -363,6 +363,7 @@ function bootstrap_pants {
   else
     maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
    fi
+  maybe_find_links="--find-links=https://dist.backend.ai/pypi/simple/pantsbuild-pants/index.html $maybe_find_links"
   local python_major_minor_version
   python_major_minor_version="$(get_python_major_minor_version "${python}")"
   local target_folder_name="${pants_version}_py${python_major_minor_version}"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -492,6 +492,9 @@ bootstrap_pants() {
     # In macOS with Apple Silicon, let Pants use Python 3.9 from pyenv
     local _PYENV_PYVER=$(search_pants_python_from_pyenv)
     echo "export PYTHON=\$(pyenv prefix $_PYENV_PYVER)/bin/python" > "$ROOT_PATH/.pants.bootstrap"
+  elif [ "$(uname -m)" = "aarch64" ]; then
+    local _PYENV_PYVER=$(search_pants_python_from_pyenv)
+    echo "export PYTHON=\$(pyenv prefix $_PYENV_PYVER)/bin/python" > "$ROOT_PATH/.pants.bootstrap"
   fi
   PANTS="./pants"
   ./pants version

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,3 +1,3 @@
-# backend.ai monorepo standard pre-push hook
+# backend.ai monorepo standard pre-commit hook
 BASE_PATH=$(cd "$(dirname "$0")"/../.. && pwd)
 ${BASE_PATH}/scripts/pre-commit.sh "$@"


### PR DESCRIPTION
- Now we can use the same `./pants` in linux-aarch64 platforms
- doc: No longer `./pants-local`
- fix: Prevent duplication of pre-commit hook when retrying installs
