### PR TITLE
feat: agent gather process stats in container

### DIFF
--- a/changes/916.feature.md
+++ b/changes/916.feature.md
@@ -1,0 +1,1 @@
+feat: Gather process list in container and measure their resource usage. 

--- a/changes/916.feature.md
+++ b/changes/916.feature.md
@@ -1,1 +1,1 @@
-feat: Gather process list in container and measure their resource usage. 
+Gather process list in container and measure their resource usage. 

--- a/src/ai/backend/accelerator/cuda_mock/plugin.py
+++ b/src/ai/backend/accelerator/cuda_mock/plugin.py
@@ -47,6 +47,7 @@ from ai.backend.agent.stats import (
     Measurement,
     MetricTypes,
     NodeMeasurement,
+    ProcessMeasurement,
     StatContext,
 )
 from ai.backend.common import config
@@ -470,6 +471,11 @@ class CUDAPlugin(AbstractComputePlugin):
                 },
             ),
         ]
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
+        return []
 
     async def create_alloc_map(self) -> AbstractAllocMap:
         devices = await self.list_devices()

--- a/src/ai/backend/accelerator/cuda_mock/plugin.py
+++ b/src/ai/backend/accelerator/cuda_mock/plugin.py
@@ -473,7 +473,7 @@ class CUDAPlugin(AbstractComputePlugin):
         ]
 
     async def gather_process_measures(
-        self, ctx: StatContext, pids: Sequence[int]
+        self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
         return []
 

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -272,7 +272,7 @@ class CUDAPlugin(AbstractComputePlugin):
         return []
 
     async def gather_process_measures(
-        self, ctx: StatContext, pids: Sequence[int]
+        self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
         return []
 

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -41,6 +41,7 @@ from ai.backend.agent.stats import (
     Measurement,
     MetricTypes,
     NodeMeasurement,
+    ProcessMeasurement,
     StatContext,
 )
 from ai.backend.agent.types import Container, MountInfo
@@ -268,6 +269,11 @@ class CUDAPlugin(AbstractComputePlugin):
         ctx: StatContext,
         container_ids: Sequence[str],
     ) -> Sequence[ContainerMeasurement]:
+        return []
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
         return []
 
     async def create_alloc_map(self) -> AbstractAllocMap:

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -965,13 +965,17 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 case _:
                     docker_host = "(unknown)"
             log.info("accessing the local Docker daemon via {}", docker_host)
-            if not self._skip_initial_scan:
-                docker_version = await docker.version()
-                log.info(
-                    "running with Docker {0} with API {1}",
-                    docker_version["Version"],
-                    docker_version["ApiVersion"],
-                )
+            docker_version = await docker.version()
+            log.info(
+                "running with Docker {0} with API {1}",
+                docker_version["Version"],
+                docker_version["ApiVersion"],
+            )
+            kernel_version = docker_version["KernelVersion"]
+            if "linuxkit" in kernel_version:
+                self.local_config["agent"]["docker-mode"] = "linuxkit"
+            else:
+                self.local_config["agent"]["docker-mode"] = "native"
             docker_info = await docker.system.info()
             docker_info = dict(docker_info)
             # Assume cgroup v1 if CgroupVersion key is absent

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -38,6 +38,7 @@ from ..stats import (
     Measurement,
     MetricTypes,
     NodeMeasurement,
+    ProcessMeasurement,
     StatContext,
     StatModes,
 )
@@ -249,6 +250,67 @@ class CPUPlugin(AbstractComputePlugin):
                 MetricTypes.USAGE,
                 unit_hint="msec",
                 per_container=per_container_cpu_used,
+            ),
+        ]
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
+        async def proc_impl(pid: int):
+            try:
+                proc_path = Path(f"/proc/{pid}/stat")
+                cpu_user, cpu_kernel = map(int, proc_path.read_text().split(" ")[13:15])
+            except FileNotFoundError:
+                log.warning("cannot read stats: file not found for Process {0}", pid)
+            else:
+                clk_per_sec = os.sysconf("SC_CLK_TCK")
+                cpu_used = Decimal(cpu_user + cpu_kernel) / clk_per_sec * 1000
+                return cpu_used
+            return None
+
+        async def psutil_impl(pid: int):
+            try:
+                p = psutil.Process(pid)
+            except psutil.NoSuchProcess:
+                log.warning("psutil cannot found process {0}", pid)
+            else:
+                cpu_times = p.cpu_times()
+                cpu_used = Decimal(cpu_times.user + cpu_times.system) * 1000
+                return cpu_used
+            return None
+
+        if ctx.mode == StatModes.CGROUP:
+            impl = proc_impl
+        else:
+            impl = psutil_impl
+        per_process_cpu_util = {}
+        per_process_cpu_used = {}
+        tasks = []
+        q = Decimal("0.000")
+        for pid in pids:
+            tasks.append(asyncio.ensure_future(impl(pid)))
+        results = await asyncio.gather(*tasks)
+        for pid, cpu_used in zip(pids, results):
+            if cpu_used is None:
+                continue
+            per_process_cpu_util[pid] = Measurement(
+                Decimal(cpu_used).quantize(q), capacity=Decimal(1000)
+            )
+            per_process_cpu_used[pid] = Measurement(Decimal(cpu_used).quantize(q))
+        return [
+            ProcessMeasurement(
+                MetricKey("cpu_util"),
+                MetricTypes.UTILIZATION,
+                unit_hint="percent",
+                current_hook=lambda metric: metric.stats.rate,
+                stats_filter=frozenset({"avg", "max"}),
+                per_process=per_process_cpu_util,
+            ),
+            ProcessMeasurement(
+                MetricKey("cpu_used"),
+                MetricTypes.USAGE,
+                unit_hint="msec",
+                per_process=per_process_cpu_used,
             ),
         ]
 
@@ -594,6 +656,84 @@ class MemoryPlugin(AbstractComputePlugin):
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_container=per_container_io_scratch_size,
+            ),
+        ]
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
+        async def procfs_impl(pid):
+            proc_prefix = f"/proc/{pid}/"
+            proc_path = Path(proc_prefix + "status")
+            io_path = Path(proc_prefix + "io")
+            try:
+                proc_status = {
+                    k: v
+                    for k, v in map(lambda l: l.split(":\t"), proc_path.read_text().splitlines())
+                }
+                io_status = {
+                    k: v for k, v in map(lambda l: l.split(":"), io_path.read_text().splitlines())
+                }
+            except FileNotFoundError:
+                log.warning("cannot read stats: file not found for Process {0}", pid)
+            else:
+                mem_cur_bytes = int(proc_status["VmHWM"].lstrip().split(" ")[0]) * 1024
+                io_read_bytes = int(io_status["read_bytes"])
+                io_write_bytes = int(io_status["write_bytes"])
+                return mem_cur_bytes, io_read_bytes, io_write_bytes
+            return None
+
+        async def psutil_impl(pid):
+            try:
+                p = psutil.Process(pid)
+            except psutil.NoSuchProcess:
+                log.warning("psutil cannot found process {0}", pid)
+            else:
+                stats = p.as_dict(attrs=["memory_info", "io_counters"])
+                mem_cur_bytes = stats["memory_info"].rss
+                io_read_bytes = stats["io_counters"].read_bytes
+                io_write_bytes = stats["io_counters"].write_bytes
+                return mem_cur_bytes, io_read_bytes, io_write_bytes
+            return None
+
+        if ctx.mode == StatModes.CGROUP:
+            impl = procfs_impl
+        else:
+            impl = psutil_impl
+        per_process_mem_used_bytes = {}
+        per_process_io_read_bytes = {}
+        per_process_io_write_bytes = {}
+        tasks = []
+        for pid in pids:
+            tasks.append(asyncio.ensure_future(impl(pid)))
+        results = await asyncio.gather(*tasks)
+        for pid, result in zip(pids, results):
+            if result is None:
+                continue
+            per_process_mem_used_bytes[pid] = Measurement(Decimal(result[0]))
+            per_process_io_read_bytes[pid] = Measurement(Decimal(result[1]))
+            per_process_io_write_bytes[pid] = Measurement(Decimal(result[2]))
+        return [
+            ProcessMeasurement(
+                MetricKey("mem"),
+                MetricTypes.USAGE,
+                unit_hint="bytes",
+                stats_filter=frozenset({"max"}),
+                per_process=per_process_mem_used_bytes,
+            ),
+            ProcessMeasurement(
+                MetricKey("io_read"),
+                MetricTypes.USAGE,
+                unit_hint="bytes",
+                stats_filter=frozenset({"rate"}),
+                per_process=per_process_io_read_bytes,
+            ),
+            ProcessMeasurement(
+                MetricKey("io_write"),
+                MetricTypes.USAGE,
+                unit_hint="bytes",
+                stats_filter=frozenset({"rate"}),
+                per_process=per_process_io_write_bytes,
             ),
         ]
 

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -507,10 +507,7 @@ LinuxKit_CMD_EXEC_PREFIX = [
 
 
 async def prepare_kernel_metadata_uri_handling(local_config: Mapping[str, Any]) -> None:
-    async with closing_async(Docker()) as docker:
-        kernel_version = (await docker.version())["KernelVersion"]
-    if "linuxkit" in kernel_version:
-        local_config["agent"]["docker-mode"] = "linuxkit"
+    if local_config["agent"]["docker-mode"] == "linuxkit":
         # Docker Desktop mode
         arch = get_arch_name()
         proxy_worker_binary = pkg_resources.resource_filename(
@@ -577,6 +574,3 @@ async def prepare_kernel_metadata_uri_handling(local_config: Mapping[str, Any]) 
             log.info("Inserted the iptables rules.")
         else:
             log.info("The iptables rule already exists.")
-    else:
-        # Linux Mode
-        local_config["agent"]["docker-mode"] = "native"

--- a/src/ai/backend/agent/kubernetes/intrinsic.py
+++ b/src/ai/backend/agent/kubernetes/intrinsic.py
@@ -24,7 +24,7 @@ from ..resources import (
     DiscretePropertyAllocMap,
     MountInfo,
 )
-from ..stats import ContainerMeasurement, NodeMeasurement, StatContext
+from ..stats import ContainerMeasurement, NodeMeasurement, ProcessMeasurement, StatContext
 from .agent import Container
 from .resources import get_resource_spec_from_container
 
@@ -144,6 +144,11 @@ class CPUPlugin(AbstractComputePlugin):
     ) -> Sequence[ContainerMeasurement]:
         # TODO: Implement Kubernetes-specific container metric collection
 
+        return []
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
         return []
 
     async def create_alloc_map(self) -> AbstractAllocMap:
@@ -286,6 +291,11 @@ class MemoryPlugin(AbstractComputePlugin):
         self, ctx: StatContext, container_ids: Sequence[str]
     ) -> Sequence[ContainerMeasurement]:
         # TODO: Implement Kubernetes-specific container metric collection
+        return []
+
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
         return []
 
     async def create_alloc_map(self) -> AbstractAllocMap:

--- a/src/ai/backend/agent/kubernetes/intrinsic.py
+++ b/src/ai/backend/agent/kubernetes/intrinsic.py
@@ -147,7 +147,7 @@ class CPUPlugin(AbstractComputePlugin):
         return []
 
     async def gather_process_measures(
-        self, ctx: StatContext, pids: Sequence[int]
+        self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
         return []
 
@@ -294,7 +294,7 @@ class MemoryPlugin(AbstractComputePlugin):
         return []
 
     async def gather_process_measures(
-        self, ctx: StatContext, pids: Sequence[int]
+        self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
         return []
 

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -47,7 +47,7 @@ from .alloc_map import AllocationStrategy as AllocationStrategy  # noqa: F401
 from .alloc_map import DeviceSlotInfo as DeviceSlotInfo  # noqa: F401
 from .alloc_map import DiscretePropertyAllocMap as DiscretePropertyAllocMap  # noqa: F401
 from .alloc_map import FractionAllocMap as FractionAllocMap  # noqa: F401
-from .stats import ContainerMeasurement, NodeMeasurement, StatContext
+from .stats import ContainerMeasurement, NodeMeasurement, ProcessMeasurement, StatContext
 from .types import Container as SessionContainer
 from .types import MountInfo
 
@@ -309,6 +309,15 @@ class AbstractComputePlugin(AbstractPlugin, metaclass=ABCMeta):
     ) -> Sequence[ContainerMeasurement]:
         """
         Return the container-level statistic metrics.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def gather_process_measures(
+        self, ctx: StatContext, pids: Sequence[int]
+    ) -> Sequence[ProcessMeasurement]:
+        """
+        Return the process statistic metrics in container.
         """
         raise NotImplementedError
 

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -314,7 +314,7 @@ class AbstractComputePlugin(AbstractPlugin, metaclass=ABCMeta):
 
     @abstractmethod
     async def gather_process_measures(
-        self, ctx: StatContext, pids: Sequence[int]
+        self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
         """
         Return the process statistic metrics in container.

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -7,7 +7,6 @@ Reference: https://www.datadoghq.com/blog/how-to-collect-docker-metrics/
 import asyncio
 import enum
 import logging
-import os
 import sys
 import time
 from decimal import Decimal
@@ -494,9 +493,7 @@ class StatContext:
                     try:
                         result = await docker._query_json(f"containers/{cid}/top", method="GET")
                         procs = result["Processes"]
-                        pids = [PID(int(proc[1])) for proc in procs if proc[0] != "root"]
-                        if os.getuid() == 0:
-                            pids.extend([PID(int(proc[1])) for proc in procs if proc[0] == "root"])
+                        pids = [PID(int(proc[1])) for proc in procs]
                         unused_pids = set(self.process_metrics[cid].keys()) - set(pids)
                     except (KeyError, aiodocker.exceptions.DockerError):
                         log.debug(

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -7,6 +7,7 @@ Reference: https://www.datadoghq.com/blog/how-to-collect-docker-metrics/
 import asyncio
 import enum
 import logging
+import os
 import sys
 import time
 from decimal import Decimal
@@ -494,6 +495,8 @@ class StatContext:
                     result = await docker._query_json(f"containers/{cid}/top", method="GET")
                     procs = result["Processes"]
                     pids = [PID(int(proc[1])) for proc in procs if proc[0] != "root"]
+                    if os.getuid() == 0:
+                        pids.extend([PID(int(proc[1])) for proc in procs if proc[0] == "root"])
                     unused_pids = set(self.process_metrics[cid].keys()) - set(pids)
                 except (KeyError, aiodocker.exceptions.DockerError):
                     log.warning(


### PR DESCRIPTION
This PR support that agent gather process list and process resource usage.
1. Collect process's cpu, mem, I/O usage stats using proc filesystem or 3rd party module.
2. Timer retrieve stats.
3. exclude to collect process stats from root user.
resolve #696 
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
