### PR TITLE
fix: Use CLI unicode symbols that appear more consistently

### DIFF
--- a/changes/917.fix.md
+++ b/changes/917.fix.md
@@ -1,0 +1,1 @@
+Use more consistently appearing unicode symbols in the CLI's pretty output

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -80,9 +80,9 @@ def print_pretty(msg, *, status=PrintStatus.NONE, file=None):
         assert "\n" not in msg, "Waiting message must be a single line."
         indicator = style("\u22EF", fg="bright_yellow", reset=False)
     elif status == PrintStatus.DONE:
-        indicator = style("\u2714", fg="bright_green", reset=False)
+        indicator = style("\u2713", fg="bright_green", reset=False)
     elif status == PrintStatus.FAILED:
-        indicator = style("\u2718", fg="bright_red", reset=False)
+        indicator = style("\u2717", fg="bright_red", reset=False)
     elif status == PrintStatus.WARNING:
         indicator = style("\u2219", fg="yellow", reset=False)
     else:


### PR DESCRIPTION
- "heavy" check/ballot marks -> plain check/ballot marks
  ✔, ✘ -> ✓, ✗
- Pants CLI and GitHub CLI are using the plain symbols.
- Many platforms treats heavy checkmarks as emoji icons and renders very differently when copy-and-pasted into browsers and office apps.

Windows Edge:
<img width="124" alt="image" src="https://user-images.githubusercontent.com/555156/206057031-1a26ccb5-f521-45fa-aaf1-c4a71adc7211.png">

macOS Chrome:
<img width="109" alt="image" src="https://user-images.githubusercontent.com/555156/206057086-dd494841-198d-4254-990d-26a800d056f4.png">
