### PR TITLE
fix: When deleting a vfolder and updating its status, use ID instead of name.

### DIFF
--- a/changes/920.fix.md
+++ b/changes/920.fix.md
@@ -1,0 +1,1 @@
+Fix spill-over of the DELETING status update to other vfolders with the same name when deleting a vfolder. This did not cause deletion of actual vfolders and their contents whose status is wrongly marked as DELETING, but causes confusion to the users and admins.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1909,7 +1909,7 @@ async def delete(request: web.Request) -> web.Response:
         query = (
             sa.update(vfolders)
             .values(status=VFolderOperationStatus.DELETING)
-            .where(vfolders.c.name == folder_name)
+            .where(vfolders.c.id == entry["id"])
         )
         await conn.execute(query)
 


### PR DESCRIPTION
A follow-up fix to #713
