### PR TITLE
ehn: Improve scriptability of `session events` CLI command

### DIFF
--- a/changes/925.fix.md
+++ b/changes/925.fix.md
@@ -1,0 +1,1 @@
+Improve scriptability of the `session events` CLI command by ensuring stdout flush and providing well-formatted JSON outputs of event data

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -1180,7 +1180,11 @@ def _events_cmd(docs: str = None):
                     compute_session = session.ComputeSession(session_name_or_id, owner_access_key)
                 async with compute_session.listen_events(scope=scope) as response:
                     async for ev in response:
-                        print(click.style(ev.event, fg="cyan", bold=True), json.loads(ev.data))
+                        click.echo(
+                            click.style(ev.event, fg="cyan", bold=True)
+                            + " "
+                            + json.dumps(json.loads(ev.data), indent=None)  # as single-line
+                        )
 
         try:
             asyncio_run(_run_events())


### PR DESCRIPTION
- Use `click.echo()` to ensure flushing and stripping ANSI escape
  sequences for redirected outputs.
- Use `json.dumps(..., indent=None)` to ensure JSON-compatible
  single-line output.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
