### PR TITLE
ci: cancel previously executed duplicated workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
If you commit while all actions have not been executed, they will be executed simultaneously with new actions.
In this case, it cancels the previous actions action.

I think it will help reduce the cost by reducing the execution time of actions.