### PR TITLE
feat: corresponds to client-py to CRUD scaling group's `use_host_network` option

### DIFF
--- a/changes/941.feature.md
+++ b/changes/941.feature.md
@@ -1,0 +1,1 @@
+Support setting the `use_host_network` option of scaling group in the client-py.

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -82,8 +82,17 @@ def list(ctx: CLIContext) -> None:
     default="{}",
     help="Set scheduler options as a JSON string.",
 )
+@click.option("--use-host-network", is_flag=True, help="Set host networking mode")
 def add(
-    ctx: CLIContext, name, description, inactive, driver, driver_opts, scheduler, scheduler_opts
+    ctx: CLIContext,
+    name,
+    description,
+    inactive,
+    driver,
+    driver_opts,
+    scheduler,
+    scheduler_opts,
+    use_host_network,
 ):
     """
     Add a new scaling group.
@@ -100,6 +109,7 @@ def add(
                 driver_opts=driver_opts,
                 scheduler=scheduler,
                 scheduler_opts=scheduler_opts,
+                use_host_network=use_host_network,
             )
         except Exception as e:
             ctx.output.print_mutation_error(
@@ -137,8 +147,17 @@ def add(
     default=None,
     help="Set scheduler options as a JSON string.",
 )
+@click.option("--use-host-network", is_flag=True, help="Set host networking mode")
 def update(
-    ctx: CLIContext, name, description, inactive, driver, driver_opts, scheduler, scheduler_opts
+    ctx: CLIContext,
+    name,
+    description,
+    inactive,
+    driver,
+    driver_opts,
+    scheduler,
+    scheduler_opts,
+    use_host_network,
 ):
     """
     Update existing scaling group.
@@ -155,6 +174,7 @@ def update(
                 driver_opts=driver_opts,
                 scheduler=scheduler,
                 scheduler_opts=scheduler_opts,
+                use_host_network=use_host_network,
             )
         except Exception as e:
             ctx.output.print_mutation_error(

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -82,7 +82,9 @@ def list(ctx: CLIContext) -> None:
     default="{}",
     help="Set scheduler options as a JSON string.",
 )
-@click.option("--use-host-network", is_flag=True, help="Set host networking mode")
+@click.option(
+    "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
+)
 def add(
     ctx: CLIContext,
     name,
@@ -147,7 +149,9 @@ def add(
     default=None,
     help="Set scheduler options as a JSON string.",
 )
-@click.option("--use-host-network", is_flag=True, help="Set host networking mode")
+@click.option(
+    "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
+)
 def update(
     ctx: CLIContext,
     name,

--- a/src/ai/backend/client/func/scaling_group.py
+++ b/src/ai/backend/client/func/scaling_group.py
@@ -18,6 +18,7 @@ _default_list_fields = (
     scaling_group_fields["created_at"],
     scaling_group_fields["driver"],
     scaling_group_fields["scheduler"],
+    scaling_group_fields["use_host_network"],
 )
 
 _default_detail_fields = (
@@ -29,6 +30,7 @@ _default_detail_fields = (
     scaling_group_fields["driver_opts"],
     scaling_group_fields["scheduler"],
     scaling_group_fields["scheduler_opts"],
+    scaling_group_fields["use_host_network"],
 )
 
 
@@ -121,6 +123,7 @@ class ScalingGroup(BaseFunction):
         driver_opts: Mapping[str, str] = None,
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
+        use_host_network: bool = False,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """
@@ -148,6 +151,7 @@ class ScalingGroup(BaseFunction):
                 "driver_opts": json.dumps(driver_opts),
                 "scheduler": scheduler,
                 "scheduler_opts": json.dumps(scheduler_opts),
+                "use_host_network": use_host_network,
             },
         }
         data = await api_session.get().Admin._query(query, variables)
@@ -164,6 +168,7 @@ class ScalingGroup(BaseFunction):
         driver_opts: Mapping[str, str] = None,
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
+        use_host_network: bool = False,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """
@@ -191,6 +196,7 @@ class ScalingGroup(BaseFunction):
                 "driver_opts": None if driver_opts is None else json.dumps(driver_opts),
                 "scheduler": scheduler,
                 "scheduler_opts": None if scheduler_opts is None else json.dumps(scheduler_opts),
+                "use_host_network": use_host_network,
             },
         }
         data = await api_session.get().Admin._query(query, variables)

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -158,6 +158,7 @@ scaling_group_fields = FieldSet(
         FieldSpec("driver_opts", formatter=nested_dict_formatter),
         FieldSpec("scheduler"),
         FieldSpec("scheduler_opts", formatter=nested_dict_formatter),
+        FieldSpec("use_host_network"),
     ]
 )
 

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -261,6 +261,7 @@ class ScalingGroup(graphene.ObjectType):
     driver_opts = graphene.JSONString()
     scheduler = graphene.String()
     scheduler_opts = graphene.JSONString()
+    use_host_network = graphene.Boolean()
 
     @classmethod
     def from_row(
@@ -280,6 +281,7 @@ class ScalingGroup(graphene.ObjectType):
             driver_opts=row["driver_opts"],
             scheduler=row["scheduler"],
             scheduler_opts=row["scheduler_opts"].to_json(),
+            use_host_network=row["use_host_network"],
         )
 
     @classmethod
@@ -432,6 +434,7 @@ class CreateScalingGroupInput(graphene.InputObjectType):
     driver_opts = graphene.JSONString(required=False, default={})
     scheduler = graphene.String(required=True)
     scheduler_opts = graphene.JSONString(required=False, default={})
+    use_host_network = graphene.Boolean(required=False, default=False)
 
 
 class ModifyScalingGroupInput(graphene.InputObjectType):
@@ -442,6 +445,7 @@ class ModifyScalingGroupInput(graphene.InputObjectType):
     driver_opts = graphene.JSONString(required=False)
     scheduler = graphene.String(required=False)
     scheduler_opts = graphene.JSONString(required=False)
+    use_host_network = graphene.Boolean(required=False)
 
 
 class CreateScalingGroup(graphene.Mutation):
@@ -473,6 +477,7 @@ class CreateScalingGroup(graphene.Mutation):
             "driver_opts": props.driver_opts,
             "scheduler": props.scheduler,
             "scheduler_opts": ScalingGroupOpts.from_json(props.scheduler_opts),
+            "use_host_network": bool(props.use_host_network),
         }
         insert_query = sa.insert(scaling_groups).values(data)
         return await simple_db_mutate_returning_item(
@@ -512,6 +517,7 @@ class ModifyScalingGroup(graphene.Mutation):
         set_if_set(
             props, data, "scheduler_opts", clean_func=lambda v: ScalingGroupOpts.from_json(v)
         )
+        set_if_set(props, data, "use_host_network")
         update_query = sa.update(scaling_groups).values(data).where(scaling_groups.c.name == name)
         return await simple_db_mutate(cls, info.context, update_query)
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
follows #838 

This PR enables CRUD the `use_host_network` option of scaling group in the client-py.
related PR: https://github.com/lablup/backend.ai-control-panel/pull/459
