### PR TITLE
feat: remove Webserver's "Server" response header

### DIFF
--- a/changes/947.feature
+++ b/changes/947.feature
@@ -1,1 +1,1 @@
-Remove the Server response header from Webserver, which could potentially provide attackers with the detailed server software version.
+Remove the `Server` HTTP response header from the web server since it could potentially expose more attack surfaces to crackers

--- a/changes/947.feature
+++ b/changes/947.feature
@@ -1,0 +1,1 @@
+Remove the Server response header from Webserver, which could potentially provide attackers with the detailed server software version.

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -552,6 +552,13 @@ async def server_main(
     app.on_shutdown.append(server_shutdown)
     app.on_cleanup.append(server_cleanup)
 
+    async def on_prepare(request, response):
+        # Remove "Server" header for a security reason.
+        if "Server" in response.headers:
+            del response.headers["Server"]
+
+    app.on_response_prepare.append(on_prepare)
+
     ssl_ctx = None
     if config["service"]["ssl_enabled"]:
         ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -554,8 +554,7 @@ async def server_main(
 
     async def on_prepare(request, response):
         # Remove "Server" header for a security reason.
-        if "Server" in response.headers:
-            del response.headers["Server"]
+        response.headers.popall("Server", None)
 
     app.on_response_prepare.append(on_prepare)
 


### PR DESCRIPTION
Remove the `Server` response header from Webserver, which could potentially provide attackers with the detailed server software version.