### PR TITLE
feat: add `session_id` and `cluster_mode` column to `get_container_stats_for_period` API

### DIFF
--- a/changes/949.feature.md
+++ b/changes/949.feature.md
@@ -1,0 +1,1 @@
+Add the `cluster_mode` column to `get_container_stats_for_period` API.

--- a/changes/949.feature.md
+++ b/changes/949.feature.md
@@ -1,1 +1,1 @@
-Add the `cluster_mode` column to `get_container_stats_for_period` API.
+Add the `session_id` and `cluster_mode` columns to `get_container_stats_for_period` API to provide container statistics in response to multi-node sessions.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -325,6 +325,7 @@ async def get_container_stats_for_period(
                     kernels.c.status_history,
                     kernels.c.created_at,
                     kernels.c.terminated_at,
+                    kernels.c.cluster_mode,
                     groups.c.name,
                     users.c.email,
                 ]
@@ -430,6 +431,7 @@ async def get_container_stats_for_period(
             "status": row["status"].name,
             "status_changed": str(row["status_changed"]),
             "status_history": row["status_history"] or {},
+            "cluster_mode": row["cluster_mode"],
         }
         if group_id not in objs_per_group:
             objs_per_group[group_id] = {

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -308,6 +308,7 @@ async def get_container_stats_for_period(
                 [
                     kernels.c.id,
                     kernels.c.container_id,
+                    kernels.c.session_id,
                     kernels.c.session_name,
                     kernels.c.access_key,
                     kernels.c.agent,
@@ -400,6 +401,7 @@ async def get_container_stats_for_period(
             gpu_allocated = row.occupied_slots["cuda.shares"]
         c_info = {
             "id": str(row["id"]),
+            "session_id": str(row["session_id"]),
             "container_id": row["container_id"],
             "domain_name": row["domain_name"],
             "group_id": str(row["group_id"]),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
- Add a `session_id` column.
- Add a `cluster_mode` column to get to know if the corresponding session is single-node or multi-node.


related PR: https://github.com/lablup/backend.ai-control-panel/pull/464