### PR TITLE
fix: codespaces not bootstrapped 

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -391,9 +391,10 @@ set_brew_python_build_flags() {
 
 install_python() {
   if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
-  PANTS_PYTHON_VERSION=$(pyenv latest 3.9)
-  show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
-  pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
+    PANTS_PYTHON_VERSION=$(pyenv latest 3.9)
+    show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
+    pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
+  fi
   if [ -z "$(pyenv versions | grep -E "^\\*?[[:space:]]+${PYTHON_VERSION//./\\.}([[:blank:]]+.*)?$")" ]; then
     if [ "$DISTRO" = "Darwin" ]; then
       export PYTHON_CONFIGURE_OPTS="--enable-framework --with-tcl-tk"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -391,7 +391,7 @@ set_brew_python_build_flags() {
 
 install_python() {
   if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
-    PANTS_PYTHON_VERSION=$(pyenv latest 3.9)
+    PANTS_PYTHON_VERSION=$(pyenv latest 3.9 || '3.9.12')
     show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
     pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
   fi

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -391,7 +391,7 @@ set_brew_python_build_flags() {
 
 install_python() {
   if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
-    PANTS_PYTHON_VERSION=$(pyenv latest 3.9 || '3.9.12')
+    PANTS_PYTHON_VERSION=$(pyenv latest 3.9 || echo '3.9.12')
     show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
     pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
   fi

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -390,6 +390,10 @@ set_brew_python_build_flags() {
 }
 
 install_python() {
+  if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
+  PANTS_PYTHON_VERSION=$(pyenv latest 3.9)
+  show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
+  pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
   if [ -z "$(pyenv versions | grep -E "^\\*?[[:space:]]+${PYTHON_VERSION//./\\.}([[:blank:]]+.*)?$")" ]; then
     if [ "$DISTRO" = "Darwin" ]; then
       export PYTHON_CONFIGURE_OPTS="--enable-framework --with-tcl-tk"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -391,7 +391,8 @@ set_brew_python_build_flags() {
 
 install_python() {
   if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
-    PANTS_PYTHON_VERSION=$(pyenv latest 3.9 || echo '3.9.12')
+    PYTHON_39_LATEST_MINOR=$(pyenv install -l | grep -i -E '^\s+3\.9\..+' | awk -F. '{print $3}' | sort -nr | head -n 1)
+    PANTS_PYTHON_VERSION="3.9.${PYTHON_39_LATEST_MINOR}"
     show_info "Installing python ${PANTS_PYTHON_VERSION} for pants to run"
     pyenv install --skip-existing "${PANTS_PYTHON_VERSION}"
   fi


### PR DESCRIPTION
This PR makes install-dev.sh install latest release of Python 3.9  when running on codespaces.