### PR TITLE
fix: set `resp` after setting `user_uuid` to avoid AttributeError

### DIFF
--- a/changes/954.fix.md
+++ b/changes/954.fix.md
@@ -1,0 +1,1 @@
+Change the setting position of the `resp` to avoid AttributeError that occurs during converting from str to hex.

--- a/src/ai/backend/manager/api/session_template.py
+++ b/src/ai/backend/manager/api/session_template.py
@@ -63,10 +63,6 @@ async def create(request: web.Request, params: Any) -> web.Response:
         for st in body["session_templates"]:
             template_data = check_task_template(st["template"])
             template_id = uuid.uuid4().hex
-            resp = {
-                "id": template_id,
-                "user": user_uuid.hex,
-            }
             name = st["name"] if "name" in st else template_data["metadata"]["name"]
             if "group_id" in st:
                 group_id = st["group_id"]
@@ -85,6 +81,10 @@ async def create(request: web.Request, params: Any) -> web.Response:
                 }
             )
             result = await conn.execute(query)
+            resp = {
+                "id": template_id,
+                "user": user_uuid,
+            }
             assert result.rowcount == 1
     return web.json_response(resp)
 

--- a/src/ai/backend/manager/api/session_template.py
+++ b/src/ai/backend/manager/api/session_template.py
@@ -83,7 +83,7 @@ async def create(request: web.Request, params: Any) -> web.Response:
             result = await conn.execute(query)
             resp = {
                 "id": template_id,
-                "user": user_uuid,
+                "user": user_uuid if isinstance(user_uuid, str) else user_uuid.hex,
             }
             assert result.rowcount == 1
     return web.json_response(resp)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
In order to avoid the following attribute error during converting from string to hex, the `resp` setting position was changed.
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/28584164/210536233-14b8e65b-8ffe-4fbe-827c-5a56bc54aa30.png">
