### PR TITLE
doc: Update the help msg of  `vfolder upload -b`

### DIFF
--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -264,7 +264,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     "--base-dir",
     type=Path,
     default=None,
-    help="The local parent directory which contains the file to be downloaded.  "
+    help="The local parent directory which will contain the file to be downloaded.  "
     "[default: current working directry]",
 )
 @click.option(

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -264,7 +264,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     "--base-dir",
     type=Path,
     default=None,
-    help="The local parent directory which will contain the file to be downloaded.  "
+    help="The local parent directory which will contain the downloaded file.  "
     "[default: current working directry]",
 )
 @click.option(

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -264,7 +264,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     "--base-dir",
     type=Path,
     default=None,
-    help="The local parent directory which contains the file to be uploaded.  "
+    help="The local parent directory which contains the file to be downloaded.  "
     "[default: current working directry]",
 )
 @click.option(

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -211,7 +211,7 @@ def info(name):
     "--base-dir",
     type=Path,
     default=None,
-    help="Set the parent directory from where the file is uploaded.  "
+    help="The local parent directory which contains the file to be uploaded.  "
     "[default: current working directry]",
 )
 @click.option(
@@ -264,7 +264,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     "--base-dir",
     type=Path,
     default=None,
-    help="Set the parent directory from where the file is uploaded.  "
+    help="The local parent directory which contains the file to be uploaded.  "
     "[default: current working directry]",
 )
 @click.option(


### PR DESCRIPTION
Modified the help message printed when the following are ran:
`./backend.ai vfolder upload --help`
`./backend.ai vfolder download --help`

(This is my first PR!)

fixes #883

