### PR TITLE
fix: add command line logging option

### DIFF
--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -23,7 +23,6 @@ from .context import CLIContext, init_logger, redis_ctx
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
 
-
 @click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "-f",
@@ -34,12 +33,12 @@ log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
     help="The config file path. (default: ./manager.conf and /etc/backend.ai/manager.conf)",
 )
 @click.option(
-    "--debug",
-    is_flag=True,
-    help="Enable the debug mode and override the global log level to DEBUG.",
+    "--log-level",
+    default="info",
+    help="Choose logging level from... debug, info, warning, error, critical",
 )
 @click.pass_context
-def main(ctx, config_path, debug):
+def main(ctx, config_path, log_level):
     """
     Manager Administration CLI
     """
@@ -49,6 +48,7 @@ def main(ctx, config_path, debug):
         logger=init_logger(local_config),
         local_config=local_config,
     )
+
 
 
 @main.command(

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -434,7 +434,7 @@ class LocalConfig(AbstractConfig):
         raise NotImplementedError
 
 
-def load(config_path: Path = None, debug: bool = False) -> LocalConfig:
+def load(config_path: Path = None, log_level: str = "info") -> LocalConfig:
 
     # Determine where to read configuration.
     raw_cfg, cfg_src_path = config.read_from_file(config_path, "manager")
@@ -465,11 +465,11 @@ def load(config_path: Path = None, debug: bool = False) -> LocalConfig:
     config.override_with_env(
         raw_cfg, ("docker-registry", "ssl-verify"), "BACKEND_SKIP_SSLCERT_VALIDATION"
     )
-    if debug:
-        config.override_key(raw_cfg, ("debug", "enabled"), True)
-        config.override_key(raw_cfg, ("logging", "level"), "DEBUG")
-        config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), "DEBUG")
-        config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), "DEBUG")
+    
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level=="debug")
+    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level.upper())
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -778,17 +778,17 @@ async def server_main_logwrapper(
     help="The config file path. (default: ./manager.toml and /etc/backend.ai/manager.toml)",
 )
 @click.option(
-    "--debug",
-    is_flag=True,
-    help="Enable the debug mode and override the global log level to DEBUG.",
+    "--log-level",
+    default="info",
+    help="Choose logging level from... debug, info, warning, error, critical",
 )
 @click.pass_context
-def main(ctx: click.Context, config_path: Path, debug: bool) -> None:
+def main(ctx: click.Context, config_path: Path, log_level: str) -> None:
     """
     Start the manager service as a foreground process.
     """
 
-    cfg = load_config(config_path, debug)
+    cfg = load_config(config_path, log_level)   # go to src/ai/backend/manager/config.py 
 
     if ctx.invoked_subcommand is None:
         cfg["manager"]["pid-file"].write_text(str(os.getpid()))


### PR DESCRIPTION

"mindgitrwx" wanted to use various logging options directly on command line. 

But we can only use 'debug' option. (In fact, we can use 'info' option by simply removing  "--debug" in `./backend.ai mgr start-server --debug` command)

So, I accepted the demand for "mindgitrwx". 

From now on, we can use options such as debug, info, warning, error and critical.

To run manager server, type in terminal
 `./backend.ai mgr start-server --log-level=~`   (~ is one of the logging options: debug, info, warning, error, critical)
instead of `./backend.ai mgr start-server --debug`

Plus, according to changed code, the default logging option is info so if you just type `./backend.ai mgr start-server` in terminal, then logging option is info.
 