### PR TITLE
fix: Show up the manager cli help when called without sub-command

### DIFF
--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -24,7 +24,7 @@ from .context import CLIContext, init_logger, redis_ctx
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
 
 
-@click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(invoke_without_command=False, context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "-f",
     "--config-path",


### PR DESCRIPTION
A manager command seems not used alone (always used with arguments).
This PR prevents the manager command invocation without the arguments and makes the command print the default help message.

resolves: #969