### PR TITLE
Fix/typecheck-failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ asyncio_mode = "auto"
 
 [tool.mypy]
 ignore_missing_imports = true
+implicit_optional = true  # FIXME: remove after adding https://github.com/hauntsaninja/no_implicit_optional to fmt
 mypy_path = "stubs:src:tools/pants-plugins"
 namespace_packages = true
 explicit_package_bases = true

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -979,16 +979,16 @@ class KubernetesAgent(
             await loop.run_in_executor(None, shutil.rmtree, str(scratch_dir))
 
     async def create_overlay_network(self, network_name: str) -> None:
-        return await super().create_overlay_network(network_name)
+        raise NotImplementedError
 
     async def destroy_overlay_network(self, network_name: str) -> None:
-        return await super().destroy_overlay_network(network_name)
+        raise NotImplementedError
 
     async def create_local_network(self, network_name: str) -> None:
-        return await super().create_local_network(network_name)
+        raise NotImplementedError
 
     async def destroy_local_network(self, network_name: str) -> None:
-        return await super().destroy_local_network(network_name)
+        raise NotImplementedError
 
     async def restart_kernel__load_config(
         self,

--- a/src/ai/backend/kernel/scheme/__init__.py
+++ b/src/ai/backend/kernel/scheme/__init__.py
@@ -29,10 +29,10 @@ class Runner(BaseRunner):
         pass
 
     async def build_heuristic(self) -> int:
-        pass
+        return 0
 
     async def execute_heuristic(self) -> int:
-        pass
+        return 0
 
     async def query(self, code_text) -> int:
         with tempfile.NamedTemporaryFile(suffix=".scm", dir=".") as tmpf:

--- a/tests/agent/docker/test_agent.py
+++ b/tests/agent/docker/test_agent.py
@@ -14,7 +14,7 @@ from ai.backend.common.types import AutoPullBehavior
 
 class DummyEtcd:
     async def get_prefix(self, key: str) -> Mapping[str, Any]:
-        pass
+        return {}
 
 
 @pytest.fixture

--- a/tests/manager/api/test_bgtask.py
+++ b/tests/manager/api/test_bgtask.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import cast
 
 import attr
 import pytest
@@ -40,7 +41,7 @@ async def test_background_task(etcd_fixture, create_app_and_client) -> None:
         # since assertions inside the handler does not affect the test result
         # because the handlers are executed inside a separate asyncio task.
         update_handler_ctx["event_name"] = event.name
-        update_handler_ctx.update(**attr.asdict(event))
+        update_handler_ctx.update(**attr.asdict(cast(attr.AttrsInstance, event)))
 
     async def done_sub(
         context: web.Application,
@@ -48,7 +49,7 @@ async def test_background_task(etcd_fixture, create_app_and_client) -> None:
         event: BgtaskDoneEvent,
     ) -> None:
         done_handler_ctx["event_name"] = event.name
-        done_handler_ctx.update(**attr.asdict(event))
+        done_handler_ctx.update(**attr.asdict(cast(attr.AttrsInstance, event)))
 
     async def _mock_task(reporter):
         reporter.total_progress = 2
@@ -98,7 +99,7 @@ async def test_background_task_fail(etcd_fixture, create_app_and_client) -> None
         event: BgtaskFailedEvent,
     ) -> None:
         fail_handler_ctx["event_name"] = event.name
-        fail_handler_ctx.update(**attr.asdict(event))
+        fail_handler_ctx.update(**attr.asdict(cast(attr.AttrsInstance, event)))
 
     async def _mock_task(reporter):
         reporter.total_progress = 2


### PR DESCRIPTION
This PR resolves mypy typecheck failing after merging #972. I've added `implicit_optional = true` under mypy setting to resolve massive errors temporarily, but this is just a "temporary" solution. Removing this flag and resolving all related errors will be discussed on a separate issue.