### PR TITLE
fix: Workaround infinite restarting of UNIX socket-relay on Docker Desktop for Mac with virtiofs

### DIFF
--- a/changes/986.fix.md
+++ b/changes/986.fix.md
@@ -1,1 +1,1 @@
-Add routine to disable socket proxy on macOS that enables docker for mac+virtioFS enhancement.
+Disable the socket-relay container on macOS to avoid UNIX socket bind-mount compatibility issue in for macOS + virtiofs setups

--- a/changes/986.fix.md
+++ b/changes/986.fix.md
@@ -1,0 +1,1 @@
+Add routine to disable socket proxy on macOS that enables docker for mac+virtioFS enhancement.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -961,28 +961,30 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         ipc_base_path = self.local_config["agent"]["ipc-base-path"]
         (ipc_base_path / "container").mkdir(parents=True, exist_ok=True)
         self.agent_sockpath = ipc_base_path / "container" / f"agent.{self.local_instance_id}.sock"
-        socket_relay_name = f"backendai-socket-relay.{self.local_instance_id}"
-        socket_relay_container = PersistentServiceContainer(
-            "backendai-socket-relay:latest",
-            {
-                "Cmd": [
-                    f"UNIX-LISTEN:/ipc/{self.agent_sockpath.name},unlink-early,fork,mode=777",
-                    f"TCP-CONNECT:127.0.0.1:{self.local_config['agent']['agent-sock-port']}",
-                ],
-                "HostConfig": {
-                    "Mounts": [
-                        {
-                            "Type": "bind",
-                            "Source": str(ipc_base_path / "container"),
-                            "Target": "/ipc",
-                        },
+        # Workaround for bypassing Docker for mac socket problem
+        if sys.platform != "darwin":
+            socket_relay_name = f"backendai-socket-relay.{self.local_instance_id}"
+            socket_relay_container = PersistentServiceContainer(
+                "backendai-socket-relay:latest",
+                {
+                    "Cmd": [
+                        f"UNIX-LISTEN:/ipc/{self.agent_sockpath.name},unlink-early,fork,mode=777",
+                        f"TCP-CONNECT:127.0.0.1:{self.local_config['agent']['agent-sock-port']}",
                     ],
-                    "NetworkMode": "host",
+                    "HostConfig": {
+                        "Mounts": [
+                            {
+                                "Type": "bind",
+                                "Source": str(ipc_base_path / "container"),
+                                "Target": "/ipc",
+                            },
+                        ],
+                        "NetworkMode": "host",
+                    },
                 },
-            },
-            name=socket_relay_name,
-        )
-        await socket_relay_container.ensure_running_latest()
+                name=socket_relay_name,
+            )
+            await socket_relay_container.ensure_running_latest()
         self.agent_sock_task = asyncio.create_task(self.handle_agent_socket())
         self.monitor_docker_task = asyncio.create_task(self.monitor_docker_events())
         self.monitor_swarm_task = asyncio.create_task(self.check_swarm_status(as_task=True))

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -961,7 +961,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         ipc_base_path = self.local_config["agent"]["ipc-base-path"]
         (ipc_base_path / "container").mkdir(parents=True, exist_ok=True)
         self.agent_sockpath = ipc_base_path / "container" / f"agent.{self.local_instance_id}.sock"
-        # Workaround for bypassing Docker for mac socket problem
+        # Workaround for Docker Desktop for Mac's UNIX socket mount failure with virtiofs
         if sys.platform != "darwin":
             socket_relay_name = f"backendai-socket-relay.{self.local_instance_id}"
             socket_relay_container = PersistentServiceContainer(


### PR DESCRIPTION
This PR lets the agent skip initialization of socket-relay container which is not working with Docker Desktop for Mac with the virtiofs file-sharing driver. (part of #976)

Ultimately we need to migrate VSOCK to avoid sharing paths of UNIX sockets between containers and the macOS host, but for now, we can simply temporarily disable the socket-relay because we don't have other places that use the socket-relay container actually on macOS setups.