### PR TITLE
feat: Support cgroup v2 on get_available_cores()

### DIFF
--- a/changes/992.feature.md
+++ b/changes/992.feature.md
@@ -1,0 +1,1 @@
+Support cgroup v2 on get_available_cores

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -3,7 +3,6 @@ import ctypes.util
 import logging
 import os
 import sys
-from pathlib import Path
 from typing import Iterator
 
 import aiohttp

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -82,18 +82,17 @@ class libnuma:
 
                             match driver:
                                 case "cgroupfs":
-                                    cgroup = "docker"
+                                    cgroup_parent = "docker"
                                 case "systemd":
-                                    cgroup = "system.slice/docker.service"
+                                    cgroup_parent = "system.slice"
 
                             match version:
                                 case "1":
-                                    # FIXME: systemd & cgroup v1 path doesn't exists
                                     cpuset_source_name = "cpuset.effective_cpus"
                                 case "2":
                                     cpuset_source_name = "cpuset.cpus.effective"
 
-                            docker_cpuset_path = mount_point / cgroup / cpuset_source_name
+                            docker_cpuset_path = mount_point / cgroup_parent / cpuset_source_name
                             log.debug(f"docker_cpuset_path: {docker_cpuset_path}")
                             cpuset_source = "the docker cgroup (v{})".format(version)
                         except RuntimeError:

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -67,11 +67,18 @@ class libnuma:
         try:
             match sys.platform:
                 case "linux":
-                    docker_cpuset_path = Path("/sys/fs/cgroup/cpuset/docker/cpuset.cpus")
+                    docker_cpuset_path = Path(
+                        "/sys/fs/cgroup/system.slice/docker.service/cpuset.cpus.effective"
+                    )
+                    cpuset_source = "the docker cgroup (v2)"
+                    if not docker_cpuset_path.exists():
+                        docker_cpuset_path = Path(
+                            "/sys/fs/cgroup/cpuset/docker/cpuset.effective_cpus"
+                        )
+                        cpuset_source = "the docker cgroup (v1)"
                     try:
                         docker_cpuset = docker_cpuset_path.read_text()
                         cpuset = {*parse_cpuset(docker_cpuset)}
-                        cpuset_source = "the docker cgroup"
                         return cpuset
                     except (IOError, ValueError):
                         try:


### PR DESCRIPTION
This PR is part of #865 

The source of the number of available cores for the docker daemon now changed.

**Before**
- In cgroup v1, `/sys/fs/cgroup/cpuset/docker/cpuset.cpus`

**After**
- In cgroup v2, `/sys/fs/cgroup/system.slice/docker.service/cpuset.cpus.effective` 
- In cgroup v1, `/sys/fs/cgroup/cpuset/docker/cpuset.effective_cpus`

**Reason**
- In cgroup v2, `cpuset.cpus` represents the number of requested cores, not the number of available cores. However, it may be ignored by the parent cgroup and the actual number of available cores may be less than `cpuset.cpus`.
- But `cpuset.effective_cpus` and `cpuset.cpus.effective` represents the actual number of available cores, considering these constraints, so it is reasonable to use them.
- In cgroup v1, `cpuset.cpus` represents the number of available cores, same as `cpuset.effective_cpus`, but I just synchronized with cgroup v2 for better understand.