### PR TITLE
ci: Upgrade auto-label-in-issue action

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -11,4 +11,4 @@ jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: Yaminyam/auto-label-in-issue@1.3.0
+      - uses: lablup/auto-label-in-issue@1.3.0

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -11,4 +11,4 @@ jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: Yaminyam/auto-label-in-issue@1.2.0
+      - uses: Yaminyam/auto-label-in-issue@1.3.0


### PR DESCRIPTION
If the label of linkingissue is empty in version 1.2.0, there was an error and we upgraded it to version 1.3.0 that solved the problem.
