### PR TITLE
refactor: Remove no longer used codes

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1799,30 +1799,10 @@ class AbstractAgent(
         """
 
     @abstractmethod
-    async def create_overlay_network(self, network_name: str) -> None:
-        """
-        Create an overlay network for a multi-node multicontainer session, where containers in different
-        agents can connect to each other using cluster hostnames without explicit port mapping.
-
-        This is called by the manager before kernel creation.
-        It may raise :exc:`NotImplementedError` and then the manager
-        will cancel creation of the session.
-        """
-
-    @abstractmethod
-    async def destroy_overlay_network(self, network_name: str) -> None:
-        """
-        Destroy an overlay network.
-
-        This is called by the manager after kernel destruction.
-        """
-
-    @abstractmethod
     async def create_local_network(self, network_name: str) -> None:
         """
         Create a local bridge network for a single-node multicontainer session, where containers in the
         same agent can connect to each other using cluster hostnames without explicit port mapping.
-        Depending on the backend, this may be an alias to :meth:`create_overlay_network()`.
 
         This is called by the manager before kernel creation.
         It may raise :exc:`NotImplementedError` and then the manager
@@ -1832,8 +1812,7 @@ class AbstractAgent(
     @abstractmethod
     async def destroy_local_network(self, network_name: str) -> None:
         """
-        Destroy a local bridge network.
-        Depending on the backend, this may be an alias to :meth:`destroy_overlay_network()`.
+        Destroy a local bridge network used for a single-node multi-container session.
 
         This is called by the manager after kernel destruction.
         """

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -67,7 +67,7 @@ from ai.backend.common.types import (
 from ai.backend.common.utils import AsyncFileWriter, current_loop
 
 from ..agent import ACTIVE_STATUS_SET, AbstractAgent, AbstractKernelCreationContext, ComputerContext
-from ..exception import ContainerCreationError, InitializationError, UnsupportedResource
+from ..exception import ContainerCreationError, UnsupportedResource
 from ..fs import create_scratch_filesystem, destroy_scratch_filesystem
 from ..kernel import AbstractKernel, KernelFeatures
 from ..proxy import DomainSocketProxy, proxy_connection
@@ -956,9 +956,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     docker_version["ApiVersion"],
                 )
         await super().__ainit__()
-        await self.check_swarm_status()
-        if self.heartbeat_extra_info["swarm_enabled"]:
-            log.info("The Docker Swarm cluster is configured and enabled")
         ipc_base_path = self.local_config["agent"]["ipc-base-path"]
         (ipc_base_path / "container").mkdir(parents=True, exist_ok=True)
         self.agent_sockpath = ipc_base_path / "container" / f"agent.{self.local_instance_id}.sock"
@@ -988,7 +985,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             await socket_relay_container.ensure_running_latest()
         self.agent_sock_task = asyncio.create_task(self.handle_agent_socket())
         self.monitor_docker_task = asyncio.create_task(self.monitor_docker_events())
-        self.monitor_swarm_task = asyncio.create_task(self.check_swarm_status(as_task=True))
         self.docker_ptask_group = aiotools.PersistentTaskGroup()
 
         self.metadata_server = await MetadataServer.new(
@@ -1015,10 +1011,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             if self.monitor_docker_task is not None:
                 self.monitor_docker_task.cancel()
                 await self.monitor_docker_task
-
-        if self.monitor_swarm_task is not None:
-            self.monitor_swarm_task.cancel()
-            await self.monitor_swarm_task
 
         await self.metadata_server.cleanup()
         if self.docker:
@@ -1065,34 +1057,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
 
             await asyncio.gather(*fetch_tasks, return_exceptions=True)
         return result
-
-    async def check_swarm_status(self, as_task=False):
-        try:
-            while True:
-                if as_task:
-                    await asyncio.sleep(30)
-                try:
-                    swarm_enabled = self.local_config["container"].get("swarm-enabled", False)
-                    if not swarm_enabled:
-                        continue
-                    async with closing_async(Docker()) as docker:
-                        docker_info = await docker.system.info()
-                        if docker_info["Swarm"]["LocalNodeState"] == "inactive":
-                            raise InitializationError(
-                                "The swarm mode is enabled but the node state of "
-                                "the local Docker daemon is inactive.",
-                            )
-                except InitializationError as e:
-                    log.exception(str(e))
-                    swarm_enabled = False
-                finally:
-                    self.heartbeat_extra_info = {
-                        "swarm_enabled": swarm_enabled,
-                    }
-                    if not as_task:
-                        return
-        except asyncio.CancelledError:
-            pass
 
     async def scan_images(self) -> Mapping[str, str]:
         async with closing_async(Docker()) as docker:
@@ -1405,29 +1369,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     pass
                 except FileNotFoundError:
                     pass
-
-    async def create_overlay_network(self, network_name: str) -> None:
-        if not self.heartbeat_extra_info["swarm_enabled"]:
-            raise RuntimeError("This agent has not joined to a swarm cluster.")
-        async with closing_async(Docker()) as docker:
-            await docker.networks.create(
-                {
-                    "Name": network_name,
-                    "Driver": "overlay",
-                    "Attachable": True,
-                    "Labels": {
-                        "ai.backend.cluster-network": "1",
-                    },
-                }
-            )
-
-    async def destroy_overlay_network(self, network_name: str) -> None:
-        docker = Docker()
-        try:
-            network = await docker.networks.get(network_name)
-            await network.delete()
-        finally:
-            await docker.close()
 
     async def create_local_network(self, network_name: str) -> None:
         async with closing_async(Docker()) as docker:

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -978,12 +978,6 @@ class KubernetesAgent(
             scratch_dir = self.local_config["container"]["scratch-root"] / str(kernel_id)
             await loop.run_in_executor(None, shutil.rmtree, str(scratch_dir))
 
-    async def create_overlay_network(self, network_name: str) -> None:
-        raise NotImplementedError
-
-    async def destroy_overlay_network(self, network_name: str) -> None:
-        raise NotImplementedError
-
     async def create_local_network(self, network_name: str) -> None:
         raise NotImplementedError
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -631,18 +631,6 @@ class AgentRPCServer(aobject):
 
     @rpc_function
     @collect_error
-    async def create_overlay_network(self, network_name: str) -> None:
-        log.debug("rpc::create_overlay_network(name:{})", network_name)
-        return await self.agent.create_overlay_network(network_name)
-
-    @rpc_function
-    @collect_error
-    async def destroy_overlay_network(self, network_name: str) -> None:
-        log.debug("rpc::destroy_overlay_network(name:{})", network_name)
-        return await self.agent.destroy_overlay_network(network_name)
-
-    @rpc_function
-    @collect_error
     async def create_local_network(self, network_name: str) -> None:
         log.debug("rpc::create_local_network(name:{})", network_name)
         return await self.agent.create_local_network(network_name)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2263,7 +2263,6 @@ class AgentRegistry:
                 network_name = f'bai-multinode-{session["session_id"]}'
                 try:
                     try:
-                        # await rpc.call.destroy_overlay_network(network_name)
                         await asyncio.sleep(2.0)
                         network = await self.docker.networks.get(network_name)
                         await network.delete()


### PR DESCRIPTION
Overlay network creation is now handled by the manager.
For the k8s agent backend, it won't support our multi-node multi-container sessions because it is impossible for two different k8s clusters to share a single overlay network.
