### PR TITLE
feat: Stop using pids cgroup controller

### DIFF
--- a/changes/1005.feature.md
+++ b/changes/1005.feature.md
@@ -1,0 +1,1 @@
+Stop using pids cgroup controller

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -32,6 +32,7 @@ from aiodocker.docker import DockerContainer
 from typing_extensions import Final
 
 from ai.backend.common import identity
+from ai.backend.common.cgroup import get_cgroup_of_pid, get_container_id_of_cgroup
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import PID, ContainerPID, HostPID, KernelId
@@ -297,28 +298,18 @@ async def host_pid_to_container_pid(container_id: str, host_pid: HostPID) -> Con
                 await docker.close()
 
     try:
-        for p in Path("/sys/fs/cgroup/pids/docker").iterdir():
-            if not p.is_dir():
-                continue
-            tasks_path = p / "tasks"
-            cgtasks = [*map(int, tasks_path.read_text().splitlines())]
-            if host_pid not in cgtasks:
-                continue
-            if p.name == container_id:
-                proc_path = Path(f"/proc/{host_pid}/status")
-                proc_status = {
-                    k: v
-                    for k, v in map(
-                        lambda line: line.split(":\t"), proc_path.read_text().splitlines()
-                    )
-                }
-                nspids = [
-                    *map(lambda pid: ContainerPID(PID(int(pid))), proc_status["NSpid"].split())
-                ]
-                return nspids[1]
-            return InOtherContainerPID
-        return NotContainerPID
-    except (ValueError, KeyError, IOError):
+        cgroup = get_cgroup_of_pid("pids", host_pid)
+        cgroup_container_id = get_container_id_of_cgroup(cgroup)
+        if cgroup_container_id is None:
+            return NotContainerPID
+        if cgroup_container_id == container_id:
+            for line in Path(f"/proc/{host_pid}/status").read_text().splitlines():
+                key, value = line.split(":\t", 1)
+                if key == "NSpid":
+                    pid = value.split()[1]
+                    return ContainerPID(PID(int(pid)))
+        return InOtherContainerPID
+    except OSError:
         return NotContainerPID
 
 

--- a/src/ai/backend/common/cgroup.py
+++ b/src/ai/backend/common/cgroup.py
@@ -10,6 +10,9 @@
 # https://docs.kernel.org/admin-guide/cgroup-v2.html
 
 from pathlib import Path
+from typing import Optional
+
+from .types import PID
 
 
 def get_cgroup_mount_point(version: str, controller: str) -> Path:
@@ -24,3 +27,38 @@ def get_cgroup_mount_point(version: str, controller: str) -> Path:
                 if fstype == "cgroup2":
                     return Path(mount_point)
     raise RuntimeError("could not find the cgroup mount point")
+
+
+def get_cgroup_controller_id(controller: str) -> str:
+    # example data
+    # cpu <tab> 1 <tab> ...
+    # cpuacct <tab> 1 <tab> ...
+    for line in Path("/proc/cgroups").read_text().splitlines():
+        name, id, _ = line.split("\t", 2)
+        if name == controller:
+            return id
+    raise RuntimeError(f"could not find the cgroup controller {controller}")
+
+
+def get_cgroup_of_pid(controller: str, pid: PID) -> str:
+    # example data
+    # 1:cpu,cpuacct:/<cgroup>
+    controller_id = get_cgroup_controller_id(controller)
+    for line in Path(f"/proc/{pid}/cgroup").read_text().splitlines():
+        id, name, cgroup = line.split(":", 2)
+        if id == controller_id:
+            return cgroup.removeprefix("/")
+    raise RuntimeError(f"could not find the cgroup of PID {pid}")
+
+
+def get_container_id_of_cgroup(cgroup: str) -> Optional[str]:
+    # cgroupfs driver: docker/<id>
+    cgroupfs_prefix = "docker/"
+    if cgroup.startswith(cgroupfs_prefix):
+        return cgroup.removeprefix(cgroupfs_prefix)
+    # systemd driver: system.slice/docker-<id>.scope
+    systemd_prefix = "system.slice/docker-"
+    systemd_suffix = ".scope"
+    if cgroup.startswith(systemd_prefix) and cgroup.endswith(systemd_suffix):
+        return cgroup.removeprefix(systemd_prefix).removesuffix(systemd_suffix)
+    return None


### PR DESCRIPTION
Instead of using pids cgroup controller to list all PIDs in the given container, get the container ID of the given PID directly from `/proc/PID/cgroup`. 

cc #865