### PR TITLE
feat: Support cgroup v2 for container stat measures

### DIFF
--- a/changes/1006.feature.md
+++ b/changes/1006.feature.md
@@ -1,0 +1,1 @@
+Supports cgroup v2 for measuring container stats (cpu, mem, io)


### PR DESCRIPTION
This is the following PR of #1000
This PR makes measuring container stats supports cgroup v2.

Like #1000, Following Backend.AI configuration is needed to test:

```toml
# agent.toml

[container]
stats-type = "cgroup"

[debug]
log-stats = true
```