### PR TITLE
fix: Remove unused loop in cli function and rename it

### DIFF
--- a/changes/1007.fix.md
+++ b/changes/1007.fix.md
@@ -1,0 +1,1 @@
+Remove unused loop in CLI generate_paginated_results function, remove some vars of the function and rename the function.

--- a/src/ai/backend/client/func/agent.py
+++ b/src/ai/backend/client/func/agent.py
@@ -5,7 +5,7 @@ from typing import Sequence
 
 from ai.backend.client.output.fields import agent_fields
 from ai.backend.client.output.types import FieldSpec, PaginatedResult
-from ai.backend.client.pagination import generate_paginated_results
+from ai.backend.client.pagination import fetch_paginated_result
 from ai.backend.client.request import Request
 from ai.backend.client.session import api_session
 
@@ -68,7 +68,7 @@ class Agent(BaseFunction):
         Lists the keypairs.
         You need an admin privilege for this operation.
         """
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "agent_list",
             {
                 "status": (status, "String"),

--- a/src/ai/backend/client/func/keypair.py
+++ b/src/ai/backend/client/func/keypair.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Sequence, Union
 
 from ai.backend.client.output.fields import keypair_fields
 from ai.backend.client.output.types import FieldSpec, PaginatedResult
-from ai.backend.client.pagination import generate_paginated_results
+from ai.backend.client.pagination import fetch_paginated_result
 from ai.backend.client.session import api_session
 
 from .base import BaseFunction, api_function
@@ -192,7 +192,7 @@ class KeyPair(BaseFunction):
         }
         if user_id is not None:
             variables["email"] = (user_id, "String")
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "keypair_list",
             variables,
             fields,

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -32,7 +32,7 @@ from ai.backend.client.output.types import FieldSpec, PaginatedResult
 from ..compat import current_loop
 from ..config import DEFAULT_CHUNK_SIZE
 from ..exceptions import BackendClientError
-from ..pagination import generate_paginated_results
+from ..pagination import fetch_paginated_result
 from ..request import (
     AttachedFile,
     Request,
@@ -113,7 +113,7 @@ class ComputeSession(BaseFunction):
         :param is_active: Fetches active or inactive users only if not None.
         :param fields: Additional per-user query fields to fetch.
         """
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "compute_session_list",
             {
                 "status": (status, "String"),

--- a/src/ai/backend/client/func/storage.py
+++ b/src/ai/backend/client/func/storage.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 from ai.backend.client.output.fields import storage_fields
 from ai.backend.client.output.types import FieldSpec, PaginatedResult
-from ai.backend.client.pagination import generate_paginated_results
+from ai.backend.client.pagination import fetch_paginated_result
 from ai.backend.client.session import api_session
 
 from .base import BaseFunction, api_function
@@ -54,7 +54,7 @@ class Storage(BaseFunction):
         Lists the keypairs.
         You need an admin privilege for this operation.
         """
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "storage_volume_list",
             {
                 "filter": (filter, "String"),

--- a/src/ai/backend/client/func/user.py
+++ b/src/ai/backend/client/func/user.py
@@ -8,7 +8,7 @@ from typing import Iterable, Sequence, Union
 from ai.backend.client.auth import AuthToken, AuthTokenTypes
 from ai.backend.client.output.fields import user_fields
 from ai.backend.client.output.types import FieldSpec, PaginatedResult
-from ai.backend.client.pagination import generate_paginated_results
+from ai.backend.client.pagination import fetch_paginated_result
 from ai.backend.client.request import Request
 from ai.backend.client.session import api_session
 
@@ -156,7 +156,7 @@ class User(BaseFunction):
         :param group: Fetch users in a specific group.
         :param fields: Additional per-user query fields to fetch.
         """
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "user_list",
             {
                 "status": (status, "String"),

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -23,7 +23,7 @@ from ai.backend.client.output.types import FieldSpec, PaginatedResult
 from ..compat import current_loop
 from ..config import DEFAULT_CHUNK_SIZE, MAX_INFLIGHT_CHUNKS
 from ..exceptions import BackendClientError
-from ..pagination import generate_paginated_results
+from ..pagination import fetch_paginated_result
 from ..request import Request
 from .base import BaseFunction, api_function
 
@@ -111,7 +111,7 @@ class VFolder(BaseFunction):
         :param group: Fetch vfolders in a specific group.
         :param fields: Additional per-vfolder query fields to fetch.
         """
-        return await generate_paginated_results(
+        return await fetch_paginated_result(
             "vfolder_list",
             {
                 "group_id": (group, "UUID"),

--- a/src/ai/backend/client/pagination.py
+++ b/src/ai/backend/client/pagination.py
@@ -52,7 +52,7 @@ async def execute_paginated_query(
     )
 
 
-async def generate_paginated_results(
+async def fetch_paginated_result(
     root_field: str,
     variables: Dict[str, Tuple[Any, str]],
     fields: Sequence[FieldSpec],
@@ -70,15 +70,11 @@ async def generate_paginated_results(
         # should remove to work with older managers
         variables.pop("filter")
         variables.pop("order")
-    offset = page_offset
-    while True:
-        limit = page_size
-        result = await execute_paginated_query(
-            root_field,
-            variables,
-            fields,
-            limit=limit,
-            offset=offset,
-        )
-        offset += page_size
-        return result
+    result = await execute_paginated_query(
+        root_field,
+        variables,
+        fields,
+        limit=page_size,
+        offset=page_offset,
+    )
+    return result


### PR DESCRIPTION
Remove unused loop in CLI `generate_paginated_results` function, remove some vars of the function and rename it