### PR TITLE
deps: replace snappy with zlib

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,7 +9,6 @@ python_requirements(
         "pycryptodome": ["Crypto"],
         "python-dateutil": ["dateutil", "dateutil.parser", "dateutil.tz"],
         "python-json-logger": ["pythonjsonlogger"],
-        "python-snappy": ["snappy"],
         "pyzmq": ["zmq"],
         "PyYAML": ["yaml"],
         "typing-extensions": ["typing_extensions"],

--- a/changes/1010.deps.md
+++ b/changes/1010.deps.md
@@ -1,0 +1,1 @@
+Remove dependency to `python-snappy`

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -4,7 +4,7 @@ ARG branch=main
 
 RUN pip install -U -q pip setuptools
 RUN apt-get update && \
-    apt-get install -y netcat libzmq3-dev libsnappy-dev
+    apt-get install -y netcat libzmq3-dev
 RUN mkdir /app
 WORKDIR /app
 RUN curl https://raw.githubusercontent.com/eficode/wait-for/master/wait-for --output /usr/local/bin/wait-for && \

--- a/docker/manager/Dockerfile
+++ b/docker/manager/Dockerfile
@@ -4,7 +4,7 @@ ARG branch=main
 
 RUN pip install -U -q pip setuptools
 RUN apt-get update && \
-    apt-get install -y netcat libzmq3-dev libsnappy-dev
+    apt-get install -y netcat libzmq3-dev
 RUN mkdir /app
 WORKDIR /app
 RUN curl https://raw.githubusercontent.com/eficode/wait-for/master/wait-for --output /usr/local/bin/wait-for && \

--- a/python.lock
+++ b/python.lock
@@ -70,7 +70,6 @@
 //     "python-dateutil>=2.8",
 //     "python-dotenv~=0.20.0",
 //     "python-json-logger>=2.0.1",
-//     "python-snappy~=0.6.0",
 //     "pyzmq~=24.0.1",
 //     "redis[hiredis]~=4.3.4",
 //     "rich~=12.2",
@@ -859,36 +858,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f1f13bfcb34d2175cf6f515a632bc432e0b357e4ebee7d4efda7ab5ec2914ef2",
-              "url": "https://files.pythonhosted.org/packages/70/b9/5479adca1e009e7cd8843948c9074787507db647e42cc23e4448a92b44ef/boto3-1.26.57-py3-none-any.whl"
+              "hash": "34ee771a5cc84c16e75d4b9ef4672f51c2bafdce66ec457bbaac630b37d9cd5e",
+              "url": "https://files.pythonhosted.org/packages/dd/f6/e3f21b2971f793bee022a8f1d1db7da4b203e9fe9b1911c558351fdc7322/boto3-1.26.59-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c34ceac30a0672d2b6b030d459eb87f1a02d48f86f347fb4b054de85fb8a4b1",
-              "url": "https://files.pythonhosted.org/packages/d2/22/a2ac9f49e495bbc4a53cd11048dd0d8d9825d51b2b4d246df33660e47251/boto3-1.26.57.tar.gz"
+              "hash": "7d9cebb507fc96e6eb429621ccb2e731b75e7bbb8d6d9f0cf0c08089ee3c1ab7",
+              "url": "https://files.pythonhosted.org/packages/69/48/5ed869a1d6d515962ec0f7446bdc4759f17e7ce8c1b047570643cb3eb8c8/boto3-1.26.59.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.30.0,>=1.29.57",
+            "botocore<1.30.0,>=1.29.59",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.7.0,>=0.6.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.26.57"
+          "version": "1.26.59"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f43382babffc07645a084484b1f08fb9d3fa4744bb08b74065ae0b4b1f4103b6",
-              "url": "https://files.pythonhosted.org/packages/e7/df/30854284b32c904c8bfa6ec73a6a91d3fa0d1f7fd11ec9cbfdf78078d4a0/botocore-1.29.57-py3-none-any.whl"
+              "hash": "5533644ddefaccfaa98460a63eb73e61a46aad019771226d103b1054b0df6103",
+              "url": "https://files.pythonhosted.org/packages/b5/c5/1c0a3442d6cf4dda53fbd8bd02ead47ff98100eb7c3f1d21dbb10b9a7256/botocore-1.29.59-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "02078e37d6b3626794f821385f3357195d87610fa1b25355577ed5393f16f7b8",
-              "url": "https://files.pythonhosted.org/packages/d0/89/4029d11264088b0baf48bd7acb0311581a9ee16ed306a84d3fde11b1faef/botocore-1.29.57.tar.gz"
+              "hash": "bc75d41c5eecf624a2f9875483135aa78088a50c8d29847793f92756697cfed5",
+              "url": "https://files.pythonhosted.org/packages/05/42/7fa8a5090a7381cfdea10f3bad3fea3c867e248caca1f8ee2e6722568db0/botocore-1.29.59.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -899,7 +898,7 @@
             "urllib3<1.27,>=1.25.4"
           ],
           "requires_python": ">=3.7",
-          "version": "1.29.57"
+          "version": "1.29.59"
         },
         {
           "artifacts": [
@@ -1282,24 +1281,6 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f",
-              "url": "https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4",
-              "url": "https://files.pythonhosted.org/packages/ea/8d/a7121ffe5f402dc015277d2d31eb82d2187334503a011c18f2e78ecbb9b2/entrypoints-0.4.tar.gz"
-            }
-          ],
-          "project_name": "entrypoints",
-          "requires_dists": [],
-          "requires_python": ">=3.6",
-          "version": "0.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
               "hash": "b742e9699a2ed75df4a3e5e3162dfec539ae5a09467d6a74a708caf770adca59",
               "url": "https://files.pythonhosted.org/packages/f4/07/9aa39a0d0a5f2b15fa01106e167d669282e4ebc63451f89f58188b0d3d29/etcetra-0.1.14-py3-none-any.whl"
             },
@@ -1579,50 +1560,49 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fb412b7db83fe56847df9c47b6fe3f13911b06339c2aa02dcc09dce8bbf582cd",
-              "url": "https://files.pythonhosted.org/packages/8d/34/bcd0848d4f748831058aabf76749f5979bc3c656770be511a11cbd58da4f/greenlet-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91",
+              "url": "https://files.pythonhosted.org/packages/17/f9/7f5d755380d329e44307c2f6e52096740fdebb92e7e22516811aeae0aec0/greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0722c9be0797f544a3ed212569ca3fe3d9d1a1b13942d10dd6f0e8601e484d26",
-              "url": "https://files.pythonhosted.org/packages/3b/c4/01247dcd15d3f9919760bc8c0846f97020e5bacc35b7899cf5cb02313a16/greenlet-2.0.1-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df",
+              "url": "https://files.pythonhosted.org/packages/0a/46/96b37dcfe9c9d39b2d2f060a5775139ce8a440315a1ca2667a6b83a2860e/greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "be35822f35f99dcc48152c9839d0171a06186f2d71ef76dc57fa556cc9bf6b45",
-              "url": "https://files.pythonhosted.org/packages/63/62/26fe837a910eadb48973458641f2d084967dbfdf000a7fefbb89bef8a753/greenlet-2.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0",
+              "url": "https://files.pythonhosted.org/packages/1e/1e/632e55a04d732c8184201238d911207682b119c35cecbb9a573a6c566731/greenlet-2.0.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4d37990425b4687ade27810e3b1a1c37825d242ebc275066cfee8cb6b8829ccd",
-              "url": "https://files.pythonhosted.org/packages/b5/c5/827149685292c53e5da546351e4f40f5a8513f200d920ae80423963dadef/greenlet-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470",
+              "url": "https://files.pythonhosted.org/packages/6e/11/a1f1af20b6a1a8069bc75012569d030acb89fd7ef70f888b6af2f85accc6/greenlet-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c140e7eb5ce47249668056edf3b7e9900c6a2e22fb0eaf0513f18a1b2c14e1da",
-              "url": "https://files.pythonhosted.org/packages/dd/5e/7309beef044bb4ceb0f052dc3797678a5f4eb6d07789787b2e4a15803b7a/greenlet-2.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a",
+              "url": "https://files.pythonhosted.org/packages/c4/92/bbd9373fb022c21d1c41bc74b043d8d007825f80bb9534f0dd2f7ed62bca/greenlet-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d21681f09e297a5adaa73060737e3aa1279a13ecdcfcc6ef66c292cb25125b2d",
-              "url": "https://files.pythonhosted.org/packages/e1/1f/b5b8099362fd1c4a45a1763981a2c8885344d19952970bebefa2b73edc0d/greenlet-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088",
+              "url": "https://files.pythonhosted.org/packages/c5/ab/a69a875a45474cc5776b879258bfa685e99aae992ab310a0b8f773fe56a0/greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42e602564460da0e8ee67cb6d7236363ee5e131aa15943b6670e44e5c2ed0f67",
-              "url": "https://files.pythonhosted.org/packages/fd/6a/f07b0028baff9bca61ecfcd9ee021e7e33369da8094f00eff409f2ff32be/greenlet-2.0.1.tar.gz"
+              "hash": "9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb",
+              "url": "https://files.pythonhosted.org/packages/cd/e8/1ebc8f07d795c3677247e37dae23463a655636a4be387b0d739fa8fd9b2f/greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             }
           ],
           "project_name": "greenlet",
           "requires_dists": [
             "Sphinx; extra == \"docs\"",
             "docutils<0.18; python_version < \"3\" and extra == \"docs\"",
-            "faulthandler; (python_version == \"2.7\" and platform_python_implementation == \"CPython\") and extra == \"test\"",
             "objgraph; extra == \"test\"",
             "psutil; extra == \"test\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "2.0.1"
+          "version": "2.0.2"
         },
         {
           "artifacts": [
@@ -1808,13 +1788,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8830ebf2d65d0395c1bd4c79189ad71e023f277c2c7ae00f263124432e6f2ffa",
-              "url": "https://files.pythonhosted.org/packages/9d/fc/28d2b631c5220b2a594d5d13b6ad79ee60d50688f1cd43f6707c06fb0db4/humanize-4.4.0-py3-none-any.whl"
+              "hash": "127e333677183070b82e90e0faef9440f9a16dab92143e52f4523afb08ca9290",
+              "url": "https://files.pythonhosted.org/packages/ab/bf/4e526ef224ca00f0a2f14513895c8a728aa94682ebbe756447de41230baa/humanize-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "efb2584565cc86b7ea87a977a15066de34cdedaf341b11c851cfcfd2b964779c",
-              "url": "https://files.pythonhosted.org/packages/51/19/3e1adf0e7a8c8361496b085edcab2ddcd85410735a2b6fdd044247fc5b75/humanize-4.4.0.tar.gz"
+              "hash": "d6ed00ed4dc59a66df71012e3d69cf655d7d21b02112d435871998969e8aedc8",
+              "url": "https://files.pythonhosted.org/packages/de/ec/c9fa9a0e2b917bd74c18f9752912fd389b7d8e796cfb864e3c485a9bda5d/humanize-4.5.0.tar.gz"
             }
           ],
           "project_name": "humanize",
@@ -1825,7 +1805,7 @@
             "pytest; extra == \"tests\""
           ],
           "requires_python": ">=3.7",
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
@@ -1948,42 +1928,43 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "214668aaea208195f4c13d28eb272ba79f945fc0cf3f11c7092c20b2ca1980e7",
-              "url": "https://files.pythonhosted.org/packages/fd/a7/ef3b7c8b9d6730a21febdd0809084e4cea6d2a7e43892436adecdd0acbd4/jupyter_client-7.4.9-py3-none-any.whl"
+              "hash": "6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba",
+              "url": "https://files.pythonhosted.org/packages/01/50/fa91c838fb87aa7d101c135c96c45a551119178f37a00a4b3b69ed227c07/jupyter_client-8.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "52be28e04171f07aed8f20e1616a5a552ab9fee9cbbe6c1896ae170c3880d392",
-              "url": "https://files.pythonhosted.org/packages/1e/33/71778cdd2c69445bcd3bb6029da2e43cc9b5cbbeef4f4982ef3aaf396650/jupyter_client-7.4.9.tar.gz"
+              "hash": "3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007",
+              "url": "https://files.pythonhosted.org/packages/e5/6d/e0d0034826e61b8a0d6ba850e7765c1342045f8cf8934516a8ba2e57b679/jupyter_client-8.0.1.tar.gz"
             }
           ],
           "project_name": "jupyter-client",
           "requires_dists": [
             "codecov; extra == \"test\"",
             "coverage; extra == \"test\"",
-            "entrypoints",
-            "ipykernel; extra == \"doc\"",
-            "ipykernel>=6.12; extra == \"test\"",
-            "ipython; extra == \"test\"",
-            "jupyter-core>=4.9.2",
+            "importlib-metadata>=4.8.3; python_version < \"3.10\"",
+            "ipykernel; extra == \"docs\"",
+            "ipykernel>=6.14; extra == \"test\"",
+            "jupyter-core!=5.0.*,>=4.12",
             "mypy; extra == \"test\"",
-            "myst-parser; extra == \"doc\"",
-            "nest-asyncio>=1.5.4",
+            "myst-parser; extra == \"docs\"",
+            "paramiko; sys_platform == \"win32\" and extra == \"test\"",
             "pre-commit; extra == \"test\"",
-            "pytest-asyncio>=0.18; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
             "pytest-cov; extra == \"test\"",
+            "pytest-jupyter[client]>=0.4.1; extra == \"test\"",
             "pytest-timeout; extra == \"test\"",
             "pytest; extra == \"test\"",
             "python-dateutil>=2.8.2",
             "pyzmq>=23.0",
-            "sphinx-rtd-theme; extra == \"doc\"",
-            "sphinx>=1.3.6; extra == \"doc\"",
-            "sphinxcontrib-github-alt; extra == \"doc\"",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinx>=4; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
             "tornado>=6.2",
-            "traitlets"
+            "traitlets>=5.3"
           ],
-          "requires_python": ">=3.7",
-          "version": "7.4.9"
+          "requires_python": ">=3.8",
+          "version": "8.0.1"
         },
         {
           "artifacts": [
@@ -2414,24 +2395,6 @@
           "requires_dists": [],
           "requires_python": null,
           "version": "1.8"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8",
-              "url": "https://files.pythonhosted.org/packages/e9/1a/6dd9ec31cfdb34cef8fea0055b593ee779a6f63c8e8038ad90d71b7f53c0/nest_asyncio-1.5.6-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290",
-              "url": "https://files.pythonhosted.org/packages/35/76/64c51c1cbe704ad79ef6ec82f232d1893b9365f2ff194111787dc91b004f/nest_asyncio-1.5.6.tar.gz"
-            }
-          ],
-          "project_name": "nest-asyncio",
-          "requires_dists": [],
-          "requires_python": ">=3.5",
-          "version": "1.5.6"
         },
         {
           "artifacts": [
@@ -2896,49 +2859,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6016269bb56caf0327f6d42e7bad1247e08b78407446dff562240c65f85d5a5e",
-              "url": "https://files.pythonhosted.org/packages/cc/6e/87f121ee4a0c3e4261c7ab06ddfc96ba4825d1fa777b6144cb38f644e2a1/pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "909e36a43fe4a8a3163e9c7fc103867825d14a2ecb852a63d3905250b308a4e5",
+              "url": "https://files.pythonhosted.org/packages/bc/14/c37136acac4aa4fa3980bdbae5d167b36b039775eeeef6cd61529840f2bf/pycryptodome-3.17-cp35-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e45d2d852a66ecfb904f090c3f87dc0dfb89a499570abad8590f10d9cffb350",
-              "url": "https://files.pythonhosted.org/packages/0d/66/5e4a14e91ffeac819e6888037771286bc1b86869f25d74d60bc4a61d2c1e/pycryptodome-3.16.0.tar.gz"
+              "hash": "e7debd9c439e7b84f53be3cf4ba8b75b3d0b6e6015212355d6daf44ac672e210",
+              "url": "https://files.pythonhosted.org/packages/05/6e/ffedda1885ccb5ab52911cfd38ee834c5fa1df1f500f0da34f92b52f70e1/pycryptodome-3.17-cp35-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "47c71a0347847b747ba1349767b16cde049bc36f21654eb09cc82306ef5fdcf8",
-              "url": "https://files.pythonhosted.org/packages/30/d5/9de00491de712a31d8724d8f8c12bbcb60e26a8e810c2ff8ac306f04f6df/pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "80ea8333b6a5f2d9e856ff2293dba2e3e661197f90bf0f4d5a82a0a6bc83a626",
+              "url": "https://files.pythonhosted.org/packages/14/58/77278d7a078241b55b515f6073b90108125fb0d197b384a0f372c5f61c80/pycryptodome-3.17-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "856ebf822d08d754af62c22e2b93626509a72773214f92db1551e2b68d9e2a1b",
-              "url": "https://files.pythonhosted.org/packages/32/97/9ed3d306d1ebc73be7f948a25628803da1af651a31df391d6f61ecf600f8/pycryptodome-3.16.0-cp35-abi3-musllinux_1_1_i686.whl"
+              "hash": "1a30f51b990994491cec2d7d237924e5b6bd0d445da9337d77de384ad7f254f9",
+              "url": "https://files.pythonhosted.org/packages/52/54/70c63a8cf3280ad0ea317f4078333b02854170b78080e421c4b56294019e/pycryptodome-3.17-cp35-abi3-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b12a88566a98617b1a34b4e5a805dff2da98d83fc74262aff3c3d724d0f525d6",
-              "url": "https://files.pythonhosted.org/packages/3d/33/c305d6153c9598b65d33a98246ab774413de70245e4189d2889b7a0ae86d/pycryptodome-3.16.0-cp35-abi3-macosx_10_9_x86_64.whl"
+              "hash": "c133f6721fba313722a018392a91e3c69d3706ae723484841752559e71d69dc6",
+              "url": "https://files.pythonhosted.org/packages/57/ed/2cfec0ee52cb1089cc1a4d0fb79492b2c84460a3fd2b6beaab8e77754a51/pycryptodome-3.17-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d67a2d2fe344953e4572a7d30668cceb516b04287b8638170d562065e53ee2e0",
-              "url": "https://files.pythonhosted.org/packages/3e/88/aa01eff759e2e3c71900c06d40bde77a79974c2397744611b3a66d31c30d/pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "bce2e2d8e82fcf972005652371a3e8731956a0c1fbb719cc897943b3695ad91b",
+              "url": "https://files.pythonhosted.org/packages/b8/2e/cf9cfd1ae6429381d3d9c14c8df79d91ae163929972f245a76058ea9d37d/pycryptodome-3.17.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "e750a21d8a265b1f9bfb1a28822995ea33511ba7db5e2b55f41fb30781d0d073",
-              "url": "https://files.pythonhosted.org/packages/79/71/ced0ee573f4c0ff7832306fe79dea782f0dd058145ad1a5f443eefd2ccb3/pycryptodome-3.16.0-cp35-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "dc22cc00f804485a3c2a7e2010d9f14a705555f67020eb083e833cabd5bd82e4",
+              "url": "https://files.pythonhosted.org/packages/d2/f4/55bafc39cd2b268398eba63f8846e5649923590977f3826e625a663998fa/pycryptodome-3.17-cp35-abi3-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "69adf32522b75968e1cbf25b5d83e87c04cd9a55610ce1e4a19012e58e7e4023",
-              "url": "https://files.pythonhosted.org/packages/83/9c/c2446a368edaa1d2828a0b89247f850ed8fc44074b4958dd478c59d25217/pycryptodome-3.16.0-cp35-abi3-manylinux2014_aarch64.whl"
+              "hash": "ca1ceb6303be1282148f04ac21cebeebdb4152590842159877778f9cf1634f09",
+              "url": "https://files.pythonhosted.org/packages/ea/7d/690febdf9d8831f13531b452e38258925e369246cbefbb1c325b0210f053/pycryptodome-3.17-cp35-abi3-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "333306eaea01fde50a73c4619e25631e56c4c61bd0fb0a2346479e67e3d3a820",
+              "url": "https://files.pythonhosted.org/packages/eb/e5/cf0c2809e18619d593504fd17a8c2284a76a269f57499226d7aaca360cfb/pycryptodome-3.17-cp35-abi3-musllinux_1_1_aarch64.whl"
             }
           ],
           "project_name": "pycryptodome",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "3.16.0"
+          "version": "3.17"
         },
         {
           "artifacts": [
@@ -3116,54 +3084,6 @@
           "requires_dists": [],
           "requires_python": ">=3.5",
           "version": "2.0.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "d017775851a778ec9cc32651c4464079d06d927303c2dde9ae9830ccf6fe94e1",
-              "url": "https://files.pythonhosted.org/packages/b3/db/2e1f3d55aec9b4ae83ed9781dafcae08ce2829b72afc541d9235778a9f1f/python_snappy-0.6.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b7f920eaf46ebf41bd26f9df51c160d40f9e00b7b48471c3438cb8d027f7fb9b",
-              "url": "https://files.pythonhosted.org/packages/32/d2/52ca2c822787425e31f742c038bba7f05fe6ca98d605c584ec285204215a/python_snappy-0.6.1-cp310-cp310-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "cb18d9cd7b3f35a2f5af47bb8ed6a5bdbf4f3ddee37f3daade4ab7864c292f5b",
-              "url": "https://files.pythonhosted.org/packages/4b/57/02864670fc97cc6691846a4a56a69d9e4b0e30951547c98d825ba68bdb22/python_snappy-0.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b6a107ab06206acc5359d4c5632bd9b22d448702a79b3169b0c62e0fb808bb2a",
-              "url": "https://files.pythonhosted.org/packages/98/7a/44a24bad98335b2c72e4cadcdecf79f50197d1bab9f22f863a274f104b96/python-snappy-0.6.1.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "4ec533a8c1f8df797bded662ec3e494d225b37855bb63eb0d75464a07947477c",
-              "url": "https://files.pythonhosted.org/packages/9e/48/94d6a98d9fdecd4b747225376aa1e5fbc2d1e0ab8ca141242753185e2d26/python_snappy-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b265cde49774752aec9ca7f5d272e3f98718164afc85521622a8a5394158a2b5",
-              "url": "https://files.pythonhosted.org/packages/b3/9f/81050aafd77fd1337e0da83fc5e300633618c2f50874e8b2162a2e9923b0/python_snappy-0.6.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "8d0c019ee7dcf2c60e240877107cddbd95a5b1081787579bf179938392d66480",
-              "url": "https://files.pythonhosted.org/packages/f4/fc/fd274c00c7776a17c8740281ec0790bf83dec503ab5d42ef2e02aa93bdec/python_snappy-0.6.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "6f8bf4708a11b47517baf962f9a02196478bbb10fdb9582add4aa1459fa82380",
-              "url": "https://files.pythonhosted.org/packages/f5/6d/1d5c0de6fe8ef83c063ba9841ddfa77e777aafa1ce8a74b6aa7a49780f2a/python_snappy-0.6.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl"
-            }
-          ],
-          "project_name": "python-snappy",
-          "requires_dists": [],
-          "requires_python": null,
-          "version": "0.6.1"
         },
         {
           "artifacts": [
@@ -3500,13 +3420,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b",
-              "url": "https://files.pythonhosted.org/packages/c2/8b/abb577ca6ab2c71814d535b1ed1464c5f4aaefe1a31bbeb85013eb9b2401/setuptools-66.1.1-py3-none-any.whl"
+              "hash": "9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d",
+              "url": "https://files.pythonhosted.org/packages/bf/27/969c914650fdf0d08b0b92bdbddfc08bea9df6d86aeefd75ba4730f50bc9/setuptools-67.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8",
-              "url": "https://files.pythonhosted.org/packages/3c/7b/00030a938499c8f8345be02ab5b7d748d359ea59c2f020b7b0a21b82f832/setuptools-66.1.1.tar.gz"
+              "hash": "883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6",
+              "url": "https://files.pythonhosted.org/packages/fe/db/68d856066c59bd9f05e827c3cf80164d870b8b6af37dc5ad6c87a71d20f2/setuptools-67.0.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -3558,7 +3478,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "66.1.1"
+          "version": "67.0.0"
         },
         {
           "artifacts": [
@@ -4090,13 +4010,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fc25550bc108908a32bb47cfdecde8d2155b6b7e40688af99a4bacbd7e3e857e",
-              "url": "https://files.pythonhosted.org/packages/cd/09/90006b93c3e2ec9282e5383232ca927acfe0662e10cbabdef5b10a1011b6/types_redis-4.4.0.3-py3-none-any.whl"
+              "hash": "802e893ad3f88e03d3a2feb0d23a715d60b0bb330bc598a52f1de237fc2547a5",
+              "url": "https://files.pythonhosted.org/packages/22/38/b68da1e702e47fb6ace57da611c39f49d30eea5f836a01bf7175f3310316/types_redis-4.4.0.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "99fc86307fb19b775a0ad5de91d2fc0ccdb9a2be7ac790f4553911d2f2abdf61",
-              "url": "https://files.pythonhosted.org/packages/a8/7f/ef694f1d0be2fcc267ed03a2b756f0d3819ccef712f82b311b8c47cca819/types-redis-4.4.0.3.tar.gz"
+              "hash": "b70829ca3401d3153d628e28d860070eff1b36b2fa3e5af3e583c1d167383cab",
+              "url": "https://files.pythonhosted.org/packages/97/0f/39cea29c0d14a09c64f97415be339b9b3fea446e4602ef6fa26940fd07ae/types-redis-4.4.0.4.tar.gz"
             }
           ],
           "project_name": "types-redis",
@@ -4105,7 +4025,7 @@
             "types-pyOpenSSL"
           ],
           "requires_python": null,
-          "version": "4.4.0.3"
+          "version": "4.4.0.4"
         },
         {
           "artifacts": [
@@ -4511,7 +4431,6 @@
     "python-dateutil>=2.8",
     "python-dotenv~=0.20.0",
     "python-json-logger>=2.0.1",
-    "python-snappy~=0.6.0",
     "pyzmq~=24.0.1",
     "redis[hiredis]~=4.3.4",
     "rich~=12.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,6 @@ psutil~=5.9.1
 pycryptodome>=3.14.1
 python-dateutil>=2.8
 python-dotenv~=0.20.0
-python-snappy~=0.6.0
 python-json-logger>=2.0.1
 pyzmq~=24.0.1
 PyJWT~=2.0

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -382,11 +382,10 @@ set_brew_python_build_flags() {
   local _prefix_gdbm="$(brew --prefix gdbm)"
   local _prefix_tcltk="$(brew --prefix tcl-tk)"
   local _prefix_xz="$(brew --prefix xz)"
-  local _prefix_snappy="$(brew --prefix snappy)"
   local _prefix_libffi="$(brew --prefix libffi)"
   local _prefix_protobuf="$(brew --prefix protobuf)"
-  export CFLAGS="-I${_prefix_openssl}/include -I${_prefix_sqlite3}/include -I${_prefix_readline}/include -I${_prefix_zlib}/include -I${_prefix_gdbm}/include -I${_prefix_tcltk}/include -I${_prefix_xz}/include -I${_prefix_snappy}/include -I${_prefix_libffi}/include -I${_prefix_protobuf}/include"
-  export LDFLAGS="-L${_prefix_openssl}/lib -L${_prefix_sqlite3}/lib -L${_prefix_readline}/lib -L${_prefix_zlib}/lib -L${_prefix_gdbm}/lib -L${_prefix_tcltk}/lib -L${_prefix_xz}/lib -L${_prefix_snappy}/lib -L${_prefix_libffi}/lib -L${_prefix_protobuf}/lib"
+  export CFLAGS="-I${_prefix_openssl}/include -I${_prefix_sqlite3}/include -I${_prefix_readline}/include -I${_prefix_zlib}/include -I${_prefix_gdbm}/include -I${_prefix_tcltk}/include -I${_prefix_xz}/include -I${_prefix_libffi}/include -I${_prefix_protobuf}/include"
+  export LDFLAGS="-L${_prefix_openssl}/lib -L${_prefix_sqlite3}/lib -L${_prefix_readline}/lib -L${_prefix_zlib}/lib -L${_prefix_gdbm}/lib -L${_prefix_tcltk}/lib -L${_prefix_xz}/lib -L${_prefix_libffi}/lib -L${_prefix_protobuf}/lib"
 }
 
 install_python() {
@@ -582,15 +581,6 @@ if [ $ENABLE_CUDA -eq 1 ] && [ $ENABLE_CUDA_MOCK -eq 1 ]; then
   exit 1
 fi
 
-check_snappy() {
-  pip download python-snappy
-  local pkgfile=$(ls | grep snappy)
-  if [[ $pkgfile =~ .*\.tar.gz ]]; then
-    # source build is required!
-    install_system_pkg "libsnappy-dev" "snappy-devel" "snappy"
-  fi
-  rm -f $pkgfile
-}
 read -r -d '' pyenv_init_script <<"EOS"
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
@@ -655,7 +645,6 @@ setup_environment() {
   show_info "Using the current working-copy directory as the installation path..."
 
   show_info "Creating the unified virtualenv for IDEs..."
-  check_snappy
   $PANTS export \
     --resolve=python-default \
     --resolve=python-kernel \

--- a/scripts/storage-proxy-spawn-ceph-clusters/install_storage_proxy.sh
+++ b/scripts/storage-proxy-spawn-ceph-clusters/install_storage_proxy.sh
@@ -4,7 +4,7 @@
 sudo chmod 755 /
 cd $HOME/
 sudo apt update
-sudo apt-get install -y build-essential git-core libreadline-dev libsqlite3-dev libssl-dev libbz2-dev tk-dev libzmq3-dev libsnappy-dev libffi-dev zlib1g-dev wget curl llvm libncursesw5-dev xz-utils  libxml2-dev libxmlsec1-dev  liblzma-dev
+sudo apt-get install -y build-essential git-core libreadline-dev libsqlite3-dev libssl-dev libbz2-dev tk-dev libzmq3-dev libffi-dev zlib1g-dev wget curl llvm libncursesw5-dev xz-utils  libxml2-dev libxmlsec1-dev  liblzma-dev
 
 curl -fsSL https://get.docker.com -o get-docker.sh
 sudo sh get-docker.sh

--- a/src/ai/backend/agent/README.k8s.md
+++ b/src/ai/backend/agent/README.k8s.md
@@ -24,7 +24,6 @@ and come back here again.
 
 #### Prequisites
 
-* `libsnappy-dev` or `snappy-devel` system package depending on your distro
 * Python 3.6 or higher with [pyenv](https://github.com/pyenv/pyenv)
 and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) (optional but recommneded)
 * Docker 18.03 or later with docker-compose (18.09 or later is recommended)

--- a/src/ai/backend/agent/README.md
+++ b/src/ai/backend/agent/README.md
@@ -80,7 +80,6 @@ so that `sysctl` could set the `net.netfilter.nf_conntrack_*` values.
 
 #### Prerequisites
 
-* `libsnappy-dev` or `snappy-devel` system package depending on your distro
 * Python 3.6 or higher with [pyenv](https://github.com/pyenv/pyenv)
 and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) (optional but recommneded)
 * Docker 18.03 or later with docker-compose (18.09 or later is recommended)

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -12,6 +12,7 @@ import sys
 import time
 import traceback
 import weakref
+import zlib
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from decimal import Decimal
@@ -47,7 +48,6 @@ from uuid import UUID
 import aiotools
 import attrs
 import pkg_resources
-import snappy
 import zmq
 import zmq.asyncio
 from async_timeout import timeout
@@ -729,9 +729,10 @@ class AbstractAgent(
                     }
                     for key, computer in self.computers.items()
                 },
-                "images": snappy.compress(
+                "images": zlib.compress(
                     msgpack.packb([(repo_tag, digest) for repo_tag, digest in self.images.items()])
                 ),
+                "images.opts": {"compression": "zlib"},  # compression: zlib or None
                 "architecture": get_arch_name(),
             }
             await self.produce_event(AgentHeartbeatEvent(agent_info))

--- a/src/ai/backend/manager/README.md
+++ b/src/ai/backend/manager/README.md
@@ -50,7 +50,6 @@ net.ipv4.tcp_wmem=4096 12582912 16777216
 
 #### Prerequisites
 
-* `libnsappy-dev` or `snappy-devel` system package depending on your distro
 * Python 3.6 or higher with [pyenv](https://github.com/pyenv/pyenv)
 and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) (optional but recommneded)
 * Docker 18.03 or later with docker-compose (18.09 or later is recommended)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -10,6 +10,7 @@ import time
 import typing
 import uuid
 import weakref
+import zlib
 from collections import defaultdict
 from contextlib import asynccontextmanager as actxmgr
 from contextvars import ContextVar
@@ -34,7 +35,6 @@ from typing import (
 
 import aiodocker
 import aiotools
-import snappy
 import sqlalchemy as sa
 import zmq
 from async_timeout import timeout as _timeout
@@ -2381,7 +2381,7 @@ class AgentRegistry:
 
             # Update the mapping of kernel images to agents.
             known_registries = await get_known_registries(self.shared_config.etcd)
-            loaded_images = msgpack.unpackb(snappy.decompress(agent_info["images"]))
+            loaded_images = msgpack.unpackb(zlib.decompress(agent_info["images"]))
 
             async def _pipe_builder(r: Redis):
                 pipe = r.pipeline()

--- a/tests/manager/test_registry.py
+++ b/tests/manager/test_registry.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import zlib
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import snappy
 from sqlalchemy.sql.dml import Insert, Update
 
 from ai.backend.common import msgpack
@@ -37,7 +37,7 @@ async def test_handle_heartbeat(
     mocker.patch("ai.backend.common.plugin.scan_entrypoints", mocked_entrypoints)
 
     registry, mock_dbconn, mock_dbsess, mock_dbresult, mock_shared_config, _, _ = registry_ctx
-    image_data = snappy.compress(
+    image_data = zlib.compress(
         msgpack.packb(
             [
                 ("index.docker.io/lablup/python:3.6-ubuntu18.04",),


### PR DESCRIPTION
This PR removes dependency to external module `python-snappy` and refactors compression/decompression steps to use zlib.