### PR TITLE
fix: update concurrency by number of session rather kernel

### DIFF
--- a/changes/1029.fix.md
+++ b/changes/1029.fix.md
@@ -1,1 +1,1 @@
-Update concurrency by number of session rather kernel.
+Update `concurrency_used` per access key by number of sessions rather kernels.

--- a/changes/1029.fix.md
+++ b/changes/1029.fix.md
@@ -1,0 +1,1 @@
+Update concurrency by number of session rather kernel.


### PR DESCRIPTION
Session concurrency has been calculated depending on the number of kernels, not sessions.
Let's calculate concurrency by the number of sessions.