### PR TITLE
fix: Use logging.getLogger(__name__)

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -132,7 +132,7 @@ from .utils import generate_local_instance_id, get_arch_name
 if TYPE_CHECKING:
     from ai.backend.common.etcd import AsyncEtcd
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.agent"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 _sentinel = Sentinel.TOKEN
 

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -71,7 +71,7 @@ from .kube_object import (
 )
 from .resources import detect_resources
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.kubernetes.agent"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKernel]):

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 
     from aiofiles.threadpool.text import AsyncTextIOWrapper
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.resources"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 known_slot_types: Mapping[SlotName, SlotTypes] = {}
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -77,7 +77,7 @@ from .utils import get_subnet_ip
 if TYPE_CHECKING:
     from .agent import AbstractAgent
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.server"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 deeplearning_image_keys = {
     "tensorflow",

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -54,7 +54,7 @@ __all__ = (
     "Measurement",
 )
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.stats"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 def check_cgroup_available():

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -38,7 +38,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import PID, ContainerPID, HostPID, KernelId
 from ai.backend.common.utils import current_loop
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.utils"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -23,7 +23,7 @@ from ai.backend.common.utils import Fstab
 
 from . import __version__ as VERSION
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.agent.watcher"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 shutdown_enabled = False
 

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -40,7 +40,7 @@ from .session import AsyncSession, BaseSession
 from .session import Session as SyncSession
 from .session import api_session
 
-log = logging.getLogger("ai.backend.client.request")
+log = logging.getLogger(__name__)
 
 __all__ = [
     "Request",

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -26,7 +26,7 @@ from .logging import BraceStyleAdapter
 from .types import AgentId, Sentinel
 
 sentinel: Final = Sentinel.TOKEN
-log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.background"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 TaskResult = Literal["bgtask_done", "bgtask_cancelled", "bgtask_failed"]
 BgtaskEvents: TypeAlias = (
     BgtaskUpdatedEvent | BgtaskDoneEvent | BgtaskCancelledEvent | BgtaskFailedEvent

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -56,7 +56,7 @@ __all__ = (
     "EventProducer",
 )
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.common.events"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 PTGExceptionHandler: TypeAlias = Callable[
     [Type[Exception], Exception, TracebackType], Awaitable[None]

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .config import SharedConfig
     from .models.utils import ExtendedAsyncSAEngine as SAEngine
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.idle"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 class AppStreamingStatus(enum.Enum):

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -33,7 +33,7 @@ from .user import UserRole
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__file__))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from .gql import GraphQueryContext
     from .scaling_group import ScalingGroup
 
-log = BraceStyleAdapter(logging.getLogger(__file__))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -46,7 +46,7 @@ from .storage import StorageSessionManager
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__file__))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -149,7 +149,7 @@ if TYPE_CHECKING:
 MSetType: TypeAlias = Mapping[Union[str, bytes], Union[bytes, float, int, str]]
 __all__ = ["AgentRegistry", "InstanceNotFound"]
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.registry"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 SESSION_NAME_LEN_LIMIT = 10
 _read_only_txn_opts = {

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -27,7 +27,7 @@ from .api.manager import init_manager_app
 from .config import local_config_iv
 from .context import Context
 
-log = BraceStyleAdapter(logging.getLogger("ai.backend.storage.server"))
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 @aiotools.server


### PR DESCRIPTION
While working on background task, I found logs with `ai.backend.manager.background` as name, but there is no such module in Backend.AI. It turns out that it was moved to `ai.backend.common.bgtask` in #306, but logger name was hardcoded as literal and not changed.

It is idiomatic to use `__name__` to prevent this. While fixing the logger name of background task, I went through all calls to `logging.getLogger` and changed literals to `__name__`. Some places were using `__file__` and I fixed them too.