### PR TITLE
feat: Spinner on client

### DIFF
--- a/changes/1033.feature.md
+++ b/changes/1033.feature.md
@@ -1,0 +1,1 @@
+Add spinner on client for long background task

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -1,3 +1,4 @@
+import asyncio
 import enum
 import functools
 import sys
@@ -182,3 +183,26 @@ def show_warning(message, category, filename, lineno, file=None, line=None):
         ),
         file=file,
     )
+
+
+class Spinner:
+    def __init__(self, fixed_msg: str, delay: float = 0.3):
+        self.fixed_msg = fixed_msg
+        self.spinner_task = None
+        self.delay = delay
+
+    async def __aenter__(self):
+        self.spinner_task = asyncio.create_task(self.run())
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.spinner_task.cancel()
+        await self.spinner_task
+
+    async def run(self):
+        try:
+            while True:
+                for char in "|/-\\":
+                    print_wait("{} {}".format(self.fixed_msg, char))
+                    await asyncio.sleep(self.delay)
+        except asyncio.CancelledError:
+            pass

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -710,6 +710,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
             print_error(e)
             sys.exit(ExitCode.FAILURE)
 
+    # NOTE: Tracking the progress from the storage-proxy is not supported yet. (See #1033)
     async def clone_vfolder_tracker(bgtask_id):
         async with AsyncSession() as session:
             try:

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2417,6 +2417,7 @@ async def clone(request: web.Request, params: Any, row: VFolderRow) -> web.Respo
             raise InvalidAPIParameters
 
     # Start the clone operation as a background task.
+    # NOTE: Tracking the progress from the storage-proxy is not supported yet. (See #1033)
     async def _clone_bgtask(reporter: ProgressReporter) -> None:
         async with root_ctx.storage_manager.request(
             source_folder_host,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Spinners are intended to be used in long background task which doesn't provide progress.
(If the background task can provide the progress, we can show the progress more visually by using like tqdm)

![ScreenShot 2023-02-10 at 15 11 05](https://user-images.githubusercontent.com/37946887/218016357-1a33f009-99d2-49b2-a9e0-ea81253e5670.gif)


The use case is `vfolder clone`
 - Reporting the progress from storage-proxy is not supported yet.
 - Storage-proxy has various backends (VFS, PureStorage, CephFS, ..), and most of the storage backend operation doesn't provide the progress feature.
 - Making our own operation on each backend for reporting the progress is not easy.
 - Currently, if there is a large amount of files that need to be cloned, it will seem as if they are stuck on the client.
 
Tested on VFS.

refs: #898