### PR TITLE
feat: write `.ssh/id_rsa` in container start

### DIFF
--- a/changes/1038.feature
+++ b/changes/1038.feature
@@ -1,0 +1,1 @@
+Adds `~/.ssh/id_rsa` in addition to `id_container`, so ease users not to specify the SSH private key always, for example, in cloning a GitHub private repository from terminal.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -620,6 +620,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     ssh_dir.chmod(0o700)
                     (ssh_dir / "authorized_keys").write_bytes(pubkey)
                     (ssh_dir / "authorized_keys").chmod(0o600)
+                    if not (ssh_dir / "id_rsa").is_file():
+                        (ssh_dir / "id_rsa").write_bytes(privkey)
+                        (ssh_dir / "id_rsa").chmod(0o600)
                     (self.work_dir / "id_container").write_bytes(privkey)
                     (self.work_dir / "id_container").chmod(0o600)
                     if KernelFeatures.UID_MATCH in self.kernel_features:
@@ -628,6 +631,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                         if os.geteuid() == 0:  # only possible when I am root.
                             os.chown(ssh_dir, uid, gid)
                             os.chown(ssh_dir / "authorized_keys", uid, gid)
+                            os.chown(ssh_dir / "id_rsa", uid, gid)
                             os.chown(self.work_dir / "id_container", uid, gid)
 
                 await loop.run_in_executor(None, _populate_ssh_config)


### PR DESCRIPTION
We recently added a feature to update SSH keypair with GUI by #1032 and lablup/backend.ai-webui#1578. However, user-uploaded private key is written on `/home/work/id_container`, but not `/home/work/.ssh/id_rsa`, so user always specify the `id_container` file to issue a command that uses SSH private key.

This PR adds `~/.ssh/id_rsa` in addition to `id_container`, so ease users not to specify the SSH private key always, for example, in cloning a GitHub private repository from terminal.