### PR TITLE
fix: do not raise error in deleting a vfolder when intermediate parent directories are not exist

### DIFF
--- a/changes/1040.fix
+++ b/changes/1040.fix
@@ -1,0 +1,1 @@
+Unable to delete a data folder (vfolder) when its host directory or intermediate parent directories were not exist.

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -85,10 +85,16 @@ class BaseVolume(AbstractVolume):
             except FileNotFoundError:
                 pass
             # remove intermediate prefix directories if they become empty
-            if not os.listdir(vfpath.parent):
-                vfpath.parent.rmdir()
-            if not os.listdir(vfpath.parent.parent):
-                vfpath.parent.parent.rmdir()
+            try:
+                if not os.listdir(vfpath.parent):
+                    vfpath.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            try:
+                if not os.listdir(vfpath.parent.parent):
+                    vfpath.parent.parent.rmdir()
+            except FileNotFoundError:
+                pass
 
         await loop.run_in_executor(None, _delete_vfolder)
 


### PR DESCRIPTION
Resolves https://github.com/lablup/giftbox/issues/74.