### PR TITLE
fix: correct query condition of select statments to remove cartesian products

### DIFF
--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -148,7 +148,7 @@ async def check_presets(request: web.Request, params: Any) -> web.Response:
             .where(
                 (association_groups_users.c.user_id == request["user"]["uuid"])
                 & (groups.c.name == params["group"])
-                & (domains.c.name == domain_name),
+                & (groups.c.domain_name == domain_name),
             )
         )
         result = await conn.execute(query)

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -533,7 +533,7 @@ async def get_allowed_vfolder_hosts_by_user(
         sa.select([groups.c.allowed_vfolder_hosts])
         .select_from(j)
         .where(
-            (domains.c.name == domain_name) & (groups.c.is_active),
+            (groups.c.domain_name == domain_name) & (groups.c.is_active),
         )
     )
     if rows := (await conn.execute(query)).fetchall():


### PR DESCRIPTION
There are some select statements which have a wrong condition.
This warning message occurs when we query such statments.
<img width="1578" alt="image" src="https://user-images.githubusercontent.com/44239739/218308854-900899a4-70b5-4375-8b56-b4a011aa3189.png">

This PR remove all cartesian products, by correcting select statement conditions.
