### PR TITLE
fix: correct session `Fieldspec` of CLI

### DIFF
--- a/src/ai/backend/client/cli/admin/session.py
+++ b/src/ai/backend/client/cli/admin/session.py
@@ -243,7 +243,7 @@ def _info_cmd(docs: str = None):
                 session_fields["name"],
             ]
             if session_.api_version[0] >= 6:
-                fields.append(session_fields["id"])
+                fields.append(session_fields["session_id"])
                 fields.append(session_fields["main_kernel_id"])
             fields.extend(
                 [

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -1220,7 +1220,7 @@ def _fetch_session_names():
     )
     fields: List[FieldSpec] = [
         session_fields["name"],
-        session_fields["id"],
+        session_fields["session_id"],
         session_fields["group_name"],
         session_fields["main_kernel_id"],
         session_fields["image"],


### PR DESCRIPTION
Since `Fieldspec` uses `alt_name` for key, we need to get the value by `session_id` not `id`.
<img width="523" alt="image" src="https://user-images.githubusercontent.com/44239739/218349513-ee90634b-8ef2-4937-892e-164b8f6f7710.png">

How to test
```
./backend.ai admin session info <session_id>
```
<img width="1182" alt="image" src="https://user-images.githubusercontent.com/44239739/218349582-b41ecca7-cd48-4ce9-813c-7f21aec76ba1.png">
