### PR TITLE
fix: update query statement to check occupying resource from session related kernels

### DIFF
--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -36,6 +36,8 @@ from ..models import (
     LIVE_STATUS,
     RESOURCE_USAGE_KERNEL_STATUSES,
     AgentStatus,
+    KernelRow,
+    SessionRow,
     agents,
     association_groups_users,
     domains,
@@ -205,17 +207,18 @@ async def check_presets(request: web.Request, params: Any) -> web.Response:
         }
 
         # Per scaling group resource using from resource occupying kernels.
+        j = sa.join(KernelRow, SessionRow, KernelRow.session_id == SessionRow.id)
         query = (
-            sa.select([kernels.c.occupied_slots, kernels.c.scaling_group])
-            .select_from(kernels)
+            sa.select([KernelRow.occupied_slots, SessionRow.scaling_group_name])
+            .select_from(j)
             .where(
-                (kernels.c.user_uuid == request["user"]["uuid"])
-                & (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                & (kernels.c.scaling_group.in_(sgroup_names)),
+                (KernelRow.user_uuid == request["user"]["uuid"])
+                & (KernelRow.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+                & (SessionRow.scaling_group_name.in_(sgroup_names)),
             )
         )
         async for row in (await conn.stream(query)):
-            per_sgroup[row["scaling_group"]]["using"] += row["occupied_slots"]
+            per_sgroup[row["scaling_group_name"]]["using"] += row["occupied_slots"]
 
         # Per scaling group resource remaining from agents stats.
         sgroup_remaining = ResourceSlot({k: Decimal(0) for k in known_slot_types.keys()})


### PR DESCRIPTION
Update query statement for checking resource occupancy of kernel Since kernel table's `scaling_group` column is empty and has been migrated to session table.