### PR TITLE
feat: ProgressViewer on client

### DIFF
--- a/changes/1049.feature.md
+++ b/changes/1049.feature.md
@@ -1,0 +1,1 @@
+Add ProgressViewer for the progress background tasks which support both spinner and tqdm progress bar.

--- a/src/ai/backend/client/cli/admin/image.py
+++ b/src/ai/backend/client/cli/admin/image.py
@@ -2,7 +2,6 @@ import json
 import sys
 
 import click
-from tqdm import tqdm
 
 from ai.backend.cli.types import ExitCode
 from ai.backend.client.func.image import _default_list_fields_admin
@@ -11,7 +10,7 @@ from ai.backend.client.session import Session
 from ...compat import asyncio_run
 from ...session import AsyncSession
 from ..extensions import pass_ctx_obj
-from ..pretty import print_done, print_error, print_fail, print_warn
+from ..pretty import ProgressViewer, print_done, print_error, print_fail, print_warn
 from ..types import CLIContext
 
 # from ai.backend.client.output.fields import image_fields
@@ -69,23 +68,27 @@ def rescan(registry: str) -> None:
             bgtask = session.BackgroundTask(bgtask_id)
             try:
                 completion_msg_func = lambda: print_done("Finished registry scanning.")
-                with tqdm(unit="image") as pbar:
-                    async with bgtask.listen_events() as response:
-                        async for ev in response:
-                            data = json.loads(ev.data)
-                            if ev.event == "bgtask_updated":
-                                pbar.total = data["total_progress"]
-                                pbar.write(data["message"])
-                                pbar.update(data["current_progress"] - pbar.n)
-                            elif ev.event == "bgtask_failed":
-                                error_msg = data["message"]
-                                completion_msg_func = lambda: print_fail(
-                                    f"Error occurred: {error_msg}"
-                                )
-                            elif ev.event == "bgtask_cancelled":
-                                completion_msg_func = lambda: print_warn(
-                                    "Registry scanning has been " "cancelled in the middle."
-                                )
+                async with (
+                    bgtask.listen_events() as response,
+                    ProgressViewer(
+                        spinner_msg="Scanning the registry...",
+                        unit="image",
+                    ) as (pv, pbar),
+                ):
+                    async for ev in response:
+                        data = json.loads(ev.data)
+                        if ev.event == "bgtask_updated":
+                            await pv.to_tqdm()
+                            pbar.total = data["total_progress"]
+                            pbar.write(data["message"])
+                            pbar.update(data["current_progress"] - pbar.n)
+                        elif ev.event == "bgtask_failed":
+                            error_msg = data["message"]
+                            completion_msg_func = lambda: print_fail(f"Error occurred: {error_msg}")
+                        elif ev.event == "bgtask_cancelled":
+                            completion_msg_func = lambda: print_warn(
+                                "Registry scanning has been " "cancelled in the middle."
+                            )
             finally:
                 completion_msg_func()
 

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -242,7 +242,7 @@ class ProgressViewer:
 
     def __init__(self, spinner_msg: str, unit: str = "it", delay: float = 0.3):
         self.spinner = Spinner(spinner_msg, delay)
-        self.tqdm = tqdm(unit=unit)
+        self.tqdm = tqdm(total=0, unit=unit)
         print(end="\x1b[2K\r", file=sys.stderr)  # clear line
 
     async def __aenter__(self):
@@ -251,6 +251,8 @@ class ProgressViewer:
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.spinner.stop()
+        if self.tqdm.total == 0:
+            self.tqdm.disable = True
         self.tqdm.close()
 
     async def to_tqdm(self):

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -217,6 +217,26 @@ class Spinner:
 
 
 class ProgressViewer:
+    """
+
+    A context manager that displays a spinner and a tqdm progress bar.
+
+    It shows the spinner until it is switched explicitly to the tqdm progress bar.
+
+    Usage:
+
+    ```
+    async with ProgressViewer("Waiting...") as (viewer, tqdm):
+        for i in range(10):
+            await asyncio.sleep(0.2)
+        await viewer.to_tqdm()
+        tqdm.total = 10
+        for i in range(10):
+            await asyncio.sleep(0.2)
+            tqdm.update(1)
+    ```
+    """
+
     spinner: Spinner
     tqdm: tqdm
 

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -729,15 +729,17 @@ def clone(name, target_name, target_host, usage_mode, permission):
                     ProgressViewer(
                         "Cloning the vfolder... "
                         "(This may take a while depending on its size and number of files!)",
-                    ) as (pv, pbar),
+                    ) as viewer,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)
                         if ev.event == "bgtask_updated":
-                            await pv.to_tqdm()
-                            pbar.total = data["total_progress"]
-                            pbar.write(data["message"])
-                            pbar.update(data["current_progress"] - pbar.n)
+                            if viewer.tqdm is None:
+                                pbar = await viewer.to_tqdm()
+                            else:
+                                pbar.total = data["total_progress"]
+                                pbar.write(data["message"])
+                                pbar.update(data["current_progress"] - pbar.n)
                         elif ev.event == "bgtask_failed":
                             error_msg = data["message"]
                             completion_msg_func = lambda: print_fail(

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -16,7 +16,15 @@ from ai.backend.client.session import Session
 from ..compat import asyncio_run
 from ..session import AsyncSession
 from .params import ByteSizeParamCheckType, ByteSizeParamType, CommaSeparatedKVListParamType
-from .pretty import Spinner, print_done, print_error, print_fail, print_info, print_wait, print_warn
+from .pretty import (
+    ProgressViewer,
+    print_done,
+    print_error,
+    print_fail,
+    print_info,
+    print_wait,
+    print_warn,
+)
 
 
 @main.group()
@@ -716,25 +724,30 @@ def clone(name, target_name, target_host, usage_mode, permission):
             try:
                 bgtask = session.BackgroundTask(bgtask_id)
                 completion_msg_func = lambda: print_done("Cloning the vfolder is complete.")
-                async with bgtask.listen_events() as response:
-                    async with Spinner(
+                async with (
+                    bgtask.listen_events() as response,
+                    ProgressViewer(
                         "Cloning the vfolder... "
                         "(This may take a while depending on its size and number of files!)",
-                    ):
-                        async for ev in response:
-                            data = json.loads(ev.data)
-                            if ev.event == "bgtask_updated":
-                                pass  # currently, we don't show any progress
-                            elif ev.event == "bgtask_failed":
-                                error_msg = data["message"]
-                                completion_msg_func = lambda: print_fail(
-                                    f"Error during the operation: {error_msg}",
-                                )
-                            elif ev.event == "bgtask_cancelled":
-                                completion_msg_func = lambda: print_warn(
-                                    "The operation has been cancelled in the middle. "
-                                    "(This may be due to server shutdown.)",
-                                )
+                    ) as (pv, pbar),
+                ):
+                    async for ev in response:
+                        data = json.loads(ev.data)
+                        if ev.event == "bgtask_updated":
+                            await pv.to_tqdm()
+                            pbar.total = data["total_progress"]
+                            pbar.write(data["message"])
+                            pbar.update(data["current_progress"] - pbar.n)
+                        elif ev.event == "bgtask_failed":
+                            error_msg = data["message"]
+                            completion_msg_func = lambda: print_fail(
+                                f"Error during the operation: {error_msg}",
+                            )
+                        elif ev.event == "bgtask_cancelled":
+                            completion_msg_func = lambda: print_warn(
+                                "The operation has been cancelled in the middle. "
+                                "(This may be due to server shutdown.)",
+                            )
             finally:
                 completion_msg_func()
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR includes a wrapper `ProgressViewer` that supports both spinner and tqdm for the progress of background tasks.

It always starts with the spinner and you can switch it to tqdm mode with the `ProgressViewer.to_tqdm()` method, mostly when you handle the `bgtask_update` event from SSE messages.


It could be applied to any background tasks regardless the backend operation supports the tracking feature. Currently applied on `image rescan` and `vfolder clone`.

![ScreenShot 2023-02-13 at 18 34 30](https://user-images.githubusercontent.com/37946887/218430087-2a3fe789-6689-43f2-b085-e74bfdfaa8e0.gif)

![ScreenShot 2023-02-13 at 19 08 21](https://user-images.githubusercontent.com/37946887/218430012-8c4dfa06-a888-4f76-a90c-9de8e4885bb4.gif)

