### PR TITLE
ci: register on integrated project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,3 +16,7 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/lablup/projects/11
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/lablup/projects/20
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
`add-to-project` to automatically add issues to the integration board when they are generated.
