### PR TITLE
setup: Preserve the etcd config made by the installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ ENV/
 /docker-compose.halfstack.current.yml
 /alembic.ini
 /dev.etcd.volumes.json
+/dev.etcd.installed.json
 /env-*.sh
 
 # Local temp

--- a/changes/1061.feature.md
+++ b/changes/1061.feature.md
@@ -1,0 +1,1 @@
+Make the dev-setup installer to preserve a full dump of the initial etcd configuration as `./dev.etcd.installed.json` for easier restoration of etcd if corrupted during development

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -899,6 +899,9 @@ configure_backendai() {
   ## sed_inplace "s@export BACKENDAI_TEST_CLIENT_VENV=/home/user/.pyenv/versions/venv-dev-client@export BACKENDAI_TEST_CLIENT_VENV=${VENV_PATH}@" ./env-tester-user.sh
   ## sed_inplace "s@export BACKENDAI_TEST_CLIENT_ENV=/home/user/bai-dev/client-py/my-backend-session.sh@export BACKENDAI_TEST_CLIENT_ENV=${INSTALL_PATH}/client-py/${CLIENT_USER_CONF_FOR_API}@" ./env-tester-user.sh
 
+  show_info "Dumping the installed etcd configuration to ./dev.etcd.installed.json as a backup."
+  ./backend.ai mgr etcd get --prefix '' > ./dev.etcd.installed.json
+
   show_info "Installation finished."
   show_note "Check out the default API keypairs and account credentials for local development and testing:"
   echo "> ${WHITE}cat env-local-admin-api.sh${NC}"


### PR DESCRIPTION
Make `scripts/install-dev.sh` to preserve the full etcd content as `./dev.etcd.installed.json`
so that it could be used to easily restore the etcd container corrupted during development.
