### PR TITLE
fix: Assume cgroup v1 if CgroupVersion key is absent

### DIFF
--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -972,6 +972,10 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     docker_version["ApiVersion"],
                 )
             docker_info = await docker.system.info()
+            docker_info = dict(docker_info)
+            # Assume cgroup v1 if CgroupVersion key is absent
+            if "CgroupVersion" not in docker_info:
+                docker_info["CgroupVersion"] = "1"
             log.info(
                 "Cgroup Driver: {0}, Cgroup Version: {1}",
                 docker_info["CgroupDriver"],

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -75,6 +75,9 @@ class libnuma:
                     except (RuntimeError, aiohttp.ClientError):
                         pass
                     else:
+                        # Assume cgroup v1 if CgroupVersion key is absent
+                        if "CgroupVersion" not in data:
+                            data["CgroupVersion"] = "1"
                         try:
                             driver = data["CgroupDriver"]
                             version = data["CgroupVersion"]


### PR DESCRIPTION
Docker added cgroup v2 support(#865) in [20.10](https://docs.docker.com/engine/release-notes/20.10/) (search for "Support cgroup2"). To support old Docker versions like 19.03, assume cgroup v1 if CgroupVersion key is absent.