### PR TITLE
fix: Automatic module naming for logging

### DIFF
--- a/changes/1064.fix.md
+++ b/changes/1064.fix.md
@@ -1,0 +1,1 @@
+Fix the agent logs partially missing depending on how the `ai.backend.agent.server` module is executed

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -132,7 +132,7 @@ from .utils import generate_local_instance_id, get_arch_name
 if TYPE_CHECKING:
     from ai.backend.common.etcd import AsyncEtcd
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _sentinel = Sentinel.TOKEN
 

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -132,7 +132,7 @@ from .utils import generate_local_instance_id, get_arch_name
 if TYPE_CHECKING:
     from ai.backend.common.etcd import AsyncEtcd
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _sentinel = Sentinel.TOKEN
 

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -37,7 +37,7 @@ from .exception import (
 if TYPE_CHECKING:
     from .resources import AbstractComputeDevice
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 log_alloc_map: bool = False
 T = TypeVar("T")
 

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -37,7 +37,7 @@ from .exception import (
 if TYPE_CHECKING:
     from .resources import AbstractComputeDevice
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 log_alloc_map: bool = False
 T = TypeVar("T")
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -90,7 +90,7 @@ from .utils import PersistentServiceContainer
 if TYPE_CHECKING:
     from ai.backend.common.etcd import AsyncEtcd
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 eof_sentinel = Sentinel.TOKEN
 
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -90,7 +90,7 @@ from .utils import PersistentServiceContainer
 if TYPE_CHECKING:
     from ai.backend.common.etcd import AsyncEtcd
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 eof_sentinel = Sentinel.TOKEN
 
 

--- a/src/ai/backend/agent/docker/files.py
+++ b/src/ai/backend/agent/docker/files.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 # the names of following AWS variables follow boto3 convention.
 s3_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "dummy-access-key")

--- a/src/ai/backend/agent/docker/files.py
+++ b/src/ai/backend/agent/docker/files.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 # the names of following AWS variables follow boto3 convention.
 s3_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "dummy-access-key")

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -46,7 +46,7 @@ from ..vendor.linux import libnuma
 from .agent import Container
 from .resources import get_resource_spec_from_container
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def fetch_api_stats(container: DockerContainer) -> Optional[Dict[str, Any]]:

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -46,7 +46,7 @@ from ..vendor.linux import libnuma
 from .agent import Container
 from .resources import get_resource_spec_from_container
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def fetch_api_stats(container: DockerContainer) -> Optional[Dict[str, Any]]:

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -29,7 +29,7 @@ from ..kernel import AbstractCodeRunner, AbstractKernel
 from ..resources import KernelResourceSpec
 from ..utils import closing_async, get_arch_name
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 DEFAULT_CHUNK_SIZE: Final = 256 * 1024  # 256 KiB
 DEFAULT_INFLIGHT_CHUNKS: Final = 8

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -29,7 +29,7 @@ from ..kernel import AbstractCodeRunner, AbstractKernel
 from ..resources import KernelResourceSpec
 from ..utils import closing_async, get_arch_name
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 DEFAULT_CHUNK_SIZE: Final = 256 * 1024  # 256 KiB
 DEFAULT_INFLIGHT_CHUNKS: Final = 8

--- a/src/ai/backend/agent/docker/metadata/plugin.py
+++ b/src/ai/backend/agent/docker/metadata/plugin.py
@@ -8,7 +8,7 @@ from ai.backend.agent.types import WebMiddleware
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.plugin import AbstractPlugin
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 NewMetadataPluginResponse = NamedTuple(
     "NewMetadataPluginResponse",

--- a/src/ai/backend/agent/docker/metadata/plugin.py
+++ b/src/ai/backend/agent/docker/metadata/plugin.py
@@ -8,7 +8,7 @@ from ai.backend.agent.types import WebMiddleware
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.plugin import AbstractPlugin
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 NewMetadataPluginResponse = NamedTuple(
     "NewMetadataPluginResponse",

--- a/src/ai/backend/agent/docker/metadata/server.py
+++ b/src/ai/backend/agent/docker/metadata/server.py
@@ -19,7 +19,7 @@ from ai.backend.common.types import KernelId, aobject
 from .plugin import MetadataPlugin
 from .root import ContainerMetadataPlugin
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class MetadataPluginContext(BasePluginContext[MetadataPlugin]):

--- a/src/ai/backend/agent/docker/metadata/server.py
+++ b/src/ai/backend/agent/docker/metadata/server.py
@@ -19,7 +19,7 @@ from ai.backend.common.types import KernelId, aobject
 from .plugin import MetadataPlugin
 from .root import ContainerMetadataPlugin
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class MetadataPluginContext(BasePluginContext[MetadataPlugin]):

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -17,7 +17,7 @@ from ..resources import (
     known_slot_types,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def detect_resources(

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -17,7 +17,7 @@ from ..resources import (
     known_slot_types,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def detect_resources(

--- a/src/ai/backend/agent/docker/utils.py
+++ b/src/ai/backend/agent/docker/utils.py
@@ -14,7 +14,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ..exception import InitializationError
 from ..utils import closing_async, get_arch_name, update_nested_dict
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class PersistentServiceContainer:

--- a/src/ai/backend/agent/docker/utils.py
+++ b/src/ai/backend/agent/docker/utils.py
@@ -14,7 +14,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ..exception import InitializationError
 from ..utils import closing_async, get_arch_name, update_nested_dict
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class PersistentServiceContainer:

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -43,7 +43,7 @@ from ai.backend.common.types import KernelId, ServicePort, aobject
 from .exception import UnsupportedBaseDistroError
 from .resources import KernelResourceSpec
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 # msg types visible to the API client.
 # (excluding control signals such as 'finished' and 'waiting-input'

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -43,7 +43,7 @@ from ai.backend.common.types import KernelId, ServicePort, aobject
 from .exception import UnsupportedBaseDistroError
 from .resources import KernelResourceSpec
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 # msg types visible to the API client.
 # (excluding control signals such as 'finished' and 'waiting-input'

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -71,7 +71,7 @@ from .kube_object import (
 )
 from .resources import detect_resources
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKernel]):

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -71,7 +71,7 @@ from .kube_object import (
 )
 from .resources import detect_resources
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKernel]):

--- a/src/ai/backend/agent/kubernetes/files.py
+++ b/src/ai/backend/agent/kubernetes/files.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 # the names of following AWS variables follow boto3 convention.
 s3_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "dummy-access-key")

--- a/src/ai/backend/agent/kubernetes/files.py
+++ b/src/ai/backend/agent/kubernetes/files.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 # the names of following AWS variables follow boto3 convention.
 s3_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "dummy-access-key")

--- a/src/ai/backend/agent/kubernetes/intrinsic.py
+++ b/src/ai/backend/agent/kubernetes/intrinsic.py
@@ -28,7 +28,7 @@ from ..stats import ContainerMeasurement, NodeMeasurement, StatContext
 from .agent import Container
 from .resources import get_resource_spec_from_container
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def fetch_api_stats(container: DockerContainer) -> Optional[Dict[str, Any]]:

--- a/src/ai/backend/agent/kubernetes/intrinsic.py
+++ b/src/ai/backend/agent/kubernetes/intrinsic.py
@@ -28,7 +28,7 @@ from ..stats import ContainerMeasurement, NodeMeasurement, StatContext
 from .agent import Container
 from .resources import get_resource_spec_from_container
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def fetch_api_stats(container: DockerContainer) -> Optional[Dict[str, Any]]:

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -25,7 +25,7 @@ from ai.backend.plugin.entrypoint import scan_entrypoints
 from ..kernel import AbstractCodeRunner, AbstractKernel
 from ..resources import KernelResourceSpec
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class KubernetesKernel(AbstractKernel):

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -25,7 +25,7 @@ from ai.backend.plugin.entrypoint import scan_entrypoints
 from ..kernel import AbstractCodeRunner, AbstractKernel
 from ..resources import KernelResourceSpec
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class KubernetesKernel(AbstractKernel):

--- a/src/ai/backend/agent/kubernetes/resources.py
+++ b/src/ai/backend/agent/kubernetes/resources.py
@@ -17,7 +17,7 @@ from ..resources import (
     known_slot_types,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def detect_resources(

--- a/src/ai/backend/agent/kubernetes/resources.py
+++ b/src/ai/backend/agent/kubernetes/resources.py
@@ -17,7 +17,7 @@ from ..resources import (
     known_slot_types,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def detect_resources(

--- a/src/ai/backend/agent/kubernetes/utils.py
+++ b/src/ai/backend/agent/kubernetes/utils.py
@@ -13,7 +13,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from ..utils import update_nested_dict
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class PersistentServiceContainer:

--- a/src/ai/backend/agent/kubernetes/utils.py
+++ b/src/ai/backend/agent/kubernetes/utils.py
@@ -13,7 +13,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from ..utils import update_nested_dict
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class PersistentServiceContainer:

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 
     from aiofiles.threadpool.text import AsyncTextIOWrapper
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 known_slot_types: Mapping[SlotName, SlotTypes] = {}
 

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 
     from aiofiles.threadpool.text import AsyncTextIOWrapper
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 known_slot_types: Mapping[SlotName, SlotTypes] = {}
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -835,7 +835,6 @@ def main(
         click.echo("--debug options will soon change to --log-level TEXT option.")
         log_level = LogSeverity.DEBUG
 
-    click.echo("Selected logging level for agent : " + log_level.value)
     # Determine where to read configuration.
     raw_cfg, cfg_src_path = config.read_from_file(config_path, "agent")
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -78,7 +78,7 @@ from .utils import get_subnet_ip
 if TYPE_CHECKING:
     from .agent import AbstractAgent
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 deeplearning_image_keys = {
     "tensorflow",

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -78,7 +78,7 @@ from .utils import get_subnet_ip
 if TYPE_CHECKING:
     from .agent import AbstractAgent
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 deeplearning_image_keys = {
     "tensorflow",

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -54,7 +54,7 @@ __all__ = (
     "Measurement",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 def check_cgroup_available():

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -54,7 +54,7 @@ __all__ = (
     "Measurement",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 def check_cgroup_available():

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -38,7 +38,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import PID, ContainerPID, HostPID, KernelId
 from ai.backend.common.utils import current_loop
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -38,7 +38,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import PID, ContainerPID, HostPID, KernelId
 from ai.backend.common.utils import current_loop
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -12,7 +12,7 @@ from ai.backend.common.cgroup import get_cgroup_mount_point
 from ai.backend.common.docker import get_docker_connector
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 _numa_supported = False
 
 if sys.platform == "linux":

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -12,7 +12,7 @@ from ai.backend.common.cgroup import get_cgroup_mount_point
 from ai.backend.common.docker import get_docker_connector
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 _numa_supported = False
 
 if sys.platform == "linux":

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -358,8 +358,6 @@ def main(cli_ctx, config_path, log_level, debug=False):
         click.echo("--debug options will soon change to --log-level TEXT option.")
         log_level = LogSeverity.DEBUG
 
-    click.echo("Selected logging level for watcher : " + log_level.value)
-
     watcher_config_iv = (
         t.Dict(
             {

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -24,7 +24,7 @@ from ai.backend.common.utils import Fstab
 
 from . import __version__ as VERSION
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 shutdown_enabled = False
 

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -24,7 +24,7 @@ from ai.backend.common.utils import Fstab
 
 from . import __version__ as VERSION
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 shutdown_enabled = False
 

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -40,7 +40,7 @@ from .session import AsyncSession, BaseSession
 from .session import Session as SyncSession
 from .session import api_session
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 __all__ = [
     "Request",

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -40,7 +40,7 @@ from .session import AsyncSession, BaseSession
 from .session import Session as SyncSession
 from .session import api_session
 
-log = logging.getLogger(__spec__.name)
+log = logging.getLogger(__spec__.name)  # type: ignore[name-defined]
 
 __all__ = [
     "Request",

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -38,7 +38,7 @@ from .logging import BraceStyleAdapter
 from .types import AgentId, Sentinel
 
 sentinel: Final = Sentinel.TOKEN
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 TaskResult = Literal["bgtask_done", "bgtask_cancelled", "bgtask_failed"]
 BgtaskEvents: TypeAlias = (
     BgtaskUpdatedEvent | BgtaskDoneEvent | BgtaskCancelledEvent | BgtaskFailedEvent

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -38,7 +38,7 @@ from .logging import BraceStyleAdapter
 from .types import AgentId, Sentinel
 
 sentinel: Final = Sentinel.TOKEN
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 TaskResult = Literal["bgtask_done", "bgtask_cancelled", "bgtask_failed"]
 BgtaskEvents: TypeAlias = (
     BgtaskUpdatedEvent | BgtaskDoneEvent | BgtaskCancelledEvent | BgtaskFailedEvent

--- a/src/ai/backend/common/distributed.py
+++ b/src/ai/backend/common/distributed.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .lock import AbstractDistributedLock
 
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class GlobalTimer:

--- a/src/ai/backend/common/distributed.py
+++ b/src/ai/backend/common/distributed.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .lock import AbstractDistributedLock
 
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class GlobalTimer:

--- a/src/ai/backend/common/etcd.py
+++ b/src/ai/backend/common/etcd.py
@@ -51,7 +51,7 @@ __all__ = (
 
 Event = namedtuple("Event", "key event value")
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class ConfigScopes(enum.Enum):

--- a/src/ai/backend/common/etcd.py
+++ b/src/ai/backend/common/etcd.py
@@ -51,7 +51,7 @@ __all__ = (
 
 Event = namedtuple("Event", "key event value")
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class ConfigScopes(enum.Enum):

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -56,7 +56,7 @@ __all__ = (
     "EventProducer",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 PTGExceptionHandler: TypeAlias = Callable[
     [Type[Exception], Exception, TracebackType], Awaitable[None]

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -56,7 +56,7 @@ __all__ = (
     "EventProducer",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 PTGExceptionHandler: TypeAlias = Callable[
     [Type[Exception], Exception, TracebackType], Awaitable[None]

--- a/src/ai/backend/common/identity.py
+++ b/src/ai/backend/common/identity.py
@@ -23,7 +23,7 @@ __all__ = (
     "get_instance_region",
 )
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 
 def is_containerized() -> bool:

--- a/src/ai/backend/common/identity.py
+++ b/src/ai/backend/common/identity.py
@@ -23,7 +23,7 @@ __all__ = (
     "get_instance_region",
 )
 
-log = logging.getLogger(__spec__.name)
+log = logging.getLogger(__spec__.name)  # type: ignore[name-defined]
 
 
 def is_containerized() -> bool:

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -28,7 +28,7 @@ from ai.backend.common.types import RedisConnectionInfo
 
 from .logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class AbstractDistributedLock(metaclass=abc.ABCMeta):

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -28,7 +28,7 @@ from ai.backend.common.types import RedisConnectionInfo
 
 from .logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class AbstractDistributedLock(metaclass=abc.ABCMeta):

--- a/src/ai/backend/common/plugin/__init__.py
+++ b/src/ai/backend/common/plugin/__init__.py
@@ -14,7 +14,7 @@ from ..etcd import AsyncEtcd
 from ..exception import ConfigurationError
 from ..logging_utils import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = (
     "AbstractPlugin",

--- a/src/ai/backend/common/plugin/__init__.py
+++ b/src/ai/backend/common/plugin/__init__.py
@@ -14,7 +14,7 @@ from ..etcd import AsyncEtcd
 from ..exception import ConfigurationError
 from ..logging_utils import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 __all__ = (
     "AbstractPlugin",

--- a/src/ai/backend/common/plugin/hook.py
+++ b/src/ai/backend/common/plugin/hook.py
@@ -10,7 +10,7 @@ import attrs
 from ..logging_utils import BraceStyleAdapter
 from . import AbstractPlugin, BasePluginContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 __all__ = (
     "HookHandler",

--- a/src/ai/backend/common/plugin/hook.py
+++ b/src/ai/backend/common/plugin/hook.py
@@ -10,7 +10,7 @@ import attrs
 from ..logging_utils import BraceStyleAdapter
 from . import AbstractPlugin, BasePluginContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = (
     "HookHandler",

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -66,7 +66,7 @@ _default_conn_opts: Mapping[str, Any] = {
 
 _scripts: Dict[str, str] = {}
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class ConnectionNotAvailable(Exception):

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -66,7 +66,7 @@ _default_conn_opts: Mapping[str, Any] = {
 
 _scripts: Dict[str, str] = {}
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class ConnectionNotAvailable(Exception):

--- a/src/ai/backend/manager/api/acl.py
+++ b/src/ai/backend/manager/api/acl.py
@@ -11,7 +11,7 @@ from ..models.acl import get_all_permissions
 from .auth import auth_required
 from .manager import ALL_ALLOWED, server_status_required
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @auth_required

--- a/src/ai/backend/manager/api/acl.py
+++ b/src/ai/backend/manager/api/acl.py
@@ -11,7 +11,7 @@ from ..models.acl import get_all_permissions
 from .auth import auth_required
 from .manager import ALL_ALLOWED, server_status_required
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @auth_required

--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -28,7 +28,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _rx_mutation_hdr = re.compile(r"^mutation(\s+\w+)?\s*(\(|{|@)", re.M)
 

--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -28,7 +28,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _rx_mutation_hdr = re.compile(r"^mutation(\s+\w+)?\s*(\(|{|@)", re.M)
 

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -45,7 +45,7 @@ from .utils import check_api_params, get_handler_attr, set_handler_attr
 if TYPE_CHECKING:
     from .context import RootContext
 
-log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _whois_timezone_info: Final = {
     "A": 1 * 3600,

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -45,7 +45,7 @@ from .utils import check_api_params, get_handler_attr, set_handler_attr
 if TYPE_CHECKING:
     from .context import RootContext
 
-log: Final = BraceStyleAdapter(logging.getLogger(__name__))
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _whois_timezone_info: Final = {
     "A": 1 * 3600,

--- a/src/ai/backend/manager/api/cluster_template.py
+++ b/src/ai/backend/manager/api/cluster_template.py
@@ -32,7 +32,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/cluster_template.py
+++ b/src/ai/backend/manager/api/cluster_template.py
@@ -32,7 +32,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/domainconfig.py
+++ b/src/ai/backend/manager/api/domainconfig.py
@@ -26,7 +26,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/domainconfig.py
+++ b/src/ai/backend/manager/api/domainconfig.py
@@ -26,7 +26,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/etcd.py
+++ b/src/ai/backend/manager/api/etcd.py
@@ -18,7 +18,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def get_resource_slots(request: web.Request) -> web.Response:

--- a/src/ai/backend/manager/api/etcd.py
+++ b/src/ai/backend/manager/api/etcd.py
@@ -18,7 +18,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def get_resource_slots(request: web.Request) -> web.Response:

--- a/src/ai/backend/manager/api/events.py
+++ b/src/ai/backend/manager/api/events.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .context import RootContext
     from .types import CORSOptions, WebMiddleware
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 sentinel: Final = Sentinel.token
 

--- a/src/ai/backend/manager/api/events.py
+++ b/src/ai/backend/manager/api/events.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .context import RootContext
     from .types import CORSOptions, WebMiddleware
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 sentinel: Final = Sentinel.token
 

--- a/src/ai/backend/manager/api/groupconfig.py
+++ b/src/ai/backend/manager/api/groupconfig.py
@@ -30,7 +30,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/groupconfig.py
+++ b/src/ai/backend/manager/api/groupconfig.py
@@ -30,7 +30,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/logs.py
+++ b/src/ai/backend/manager/api/logs.py
@@ -31,7 +31,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class DoLogCleanupEvent(EmptyEventArgs, AbstractEvent):

--- a/src/ai/backend/manager/api/logs.py
+++ b/src/ai/backend/manager/api/logs.py
@@ -31,7 +31,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class DoLogCleanupEvent(EmptyEventArgs, AbstractEvent):

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class SchedulerOps(enum.Enum):

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class SchedulerOps(enum.Enum):

--- a/src/ai/backend/manager/api/ratelimit.py
+++ b/src/ai/backend/manager/api/ratelimit.py
@@ -18,7 +18,7 @@ from .context import RootContext
 from .exceptions import RateLimitExceeded
 from .types import CORSOptions, WebMiddleware, WebRequestHandler
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _time_prec: Final = Decimal("1e-3")  # msec
 _rlim_window: Final = 60 * 15

--- a/src/ai/backend/manager/api/ratelimit.py
+++ b/src/ai/backend/manager/api/ratelimit.py
@@ -18,7 +18,7 @@ from .context import RootContext
 from .exceptions import RateLimitExceeded
 from .types import CORSOptions, WebMiddleware, WebRequestHandler
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _time_prec: Final = Decimal("1e-3")  # msec
 _rlim_window: Final = 60 * 15

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -56,7 +56,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _json_loads = functools.partial(json.loads, parse_float=Decimal)
 

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -56,7 +56,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _json_loads = functools.partial(json.loads, parse_float=Decimal)
 

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -22,7 +22,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @dataclass(unsafe_hash=True)

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -22,7 +22,7 @@ from .utils import check_api_params
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @dataclass(unsafe_hash=True)

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -148,7 +148,7 @@ from .utils import catch_unexpected, check_api_params, get_access_key_scopes, un
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _json_loads = functools.partial(json.loads, parse_float=Decimal)
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -148,7 +148,7 @@ from .utils import catch_unexpected, check_api_params, get_access_key_scopes, un
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _json_loads = functools.partial(json.loads, parse_float=Decimal)
 

--- a/src/ai/backend/manager/api/session_template.py
+++ b/src/ai/backend/manager/api/session_template.py
@@ -25,7 +25,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/session_template.py
+++ b/src/ai/backend/manager/api/session_template.py
@@ -25,7 +25,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/stream.py
+++ b/src/ai/backend/manager/api/stream.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from ..config import SharedConfig
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/stream.py
+++ b/src/ai/backend/manager/api/stream.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from ..config import SharedConfig
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/userconfig.py
+++ b/src/ai/backend/manager/api/userconfig.py
@@ -32,7 +32,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/userconfig.py
+++ b/src/ai/backend/manager/api/userconfig.py
@@ -32,7 +32,7 @@ from .utils import check_api_params, get_access_key_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @server_status_required(READ_ALLOWED)

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -38,7 +38,7 @@ from .exceptions import GenericForbidden, InvalidAPIParameters, QueryNotImplemen
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _rx_sitepkg_path = re.compile(r"^.+/site-packages/")
 

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -38,7 +38,7 @@ from .exceptions import GenericForbidden, InvalidAPIParameters, QueryNotImplemen
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _rx_sitepkg_path = re.compile(r"^.+/site-packages/")
 

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -91,7 +91,7 @@ from .utils import check_api_params, get_user_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 VFolderRow = Mapping[str, Any]
 

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -91,7 +91,7 @@ from .utils import check_api_params, get_user_scopes
 if TYPE_CHECKING:
     from .context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 VFolderRow = Mapping[str, Any]
 

--- a/src/ai/backend/manager/api/wsproxy.py
+++ b/src/ai/backend/manager/api/wsproxy.py
@@ -17,7 +17,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from ..config import DEFAULT_CHUNK_SIZE
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class ServiceProxy(metaclass=ABCMeta):

--- a/src/ai/backend/manager/api/wsproxy.py
+++ b/src/ai/backend/manager/api/wsproxy.py
@@ -17,7 +17,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from ..config import DEFAULT_CHUNK_SIZE
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class ServiceProxy(metaclass=ABCMeta):

--- a/src/ai/backend/manager/cli/dbschema.py
+++ b/src/ai/backend/manager/cli/dbschema.py
@@ -20,7 +20,7 @@ from ..models.utils import create_async_engine
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/dbschema.py
+++ b/src/ai/backend/manager/cli/dbschema.py
@@ -20,7 +20,7 @@ from ..models.utils import create_async_engine
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/etcd.py
+++ b/src/ai/backend/manager/cli/etcd.py
@@ -29,7 +29,7 @@ from .image_impl import set_image_resource_limit as set_image_resource_limit_imp
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/etcd.py
+++ b/src/ai/backend/manager/cli/etcd.py
@@ -29,7 +29,7 @@ from .image_impl import set_image_resource_limit as set_image_resource_limit_imp
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/fixture.py
+++ b/src/ai/backend/manager/cli/fixture.py
@@ -17,7 +17,7 @@ from ..models.base import populate_fixture
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/fixture.py
+++ b/src/ai/backend/manager/cli/fixture.py
@@ -17,7 +17,7 @@ from ..models.base import populate_fixture
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/gql.py
+++ b/src/ai/backend/manager/cli/gql.py
@@ -13,7 +13,7 @@ from ..models.gql import Mutations, Queries
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/gql.py
+++ b/src/ai/backend/manager/cli/gql.py
@@ -13,7 +13,7 @@ from ..models.gql import Mutations, Queries
 if TYPE_CHECKING:
     from .context import CLIContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/image.py
+++ b/src/ai/backend/manager/cli/image.py
@@ -14,7 +14,7 @@ from .image_impl import list_images as list_images_impl
 from .image_impl import rescan_images as rescan_images_impl
 from .image_impl import set_image_resource_limit as set_image_resource_limit_impl
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/image.py
+++ b/src/ai/backend/manager/cli/image.py
@@ -14,7 +14,7 @@ from .image_impl import list_images as list_images_impl
 from .image_impl import rescan_images as rescan_images_impl
 from .image_impl import set_image_resource_limit as set_image_resource_limit_impl
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -14,7 +14,7 @@ from ai.backend.manager.models.image import ImageAliasRow, ImageRow
 from ai.backend.manager.models.image import rescan_images as rescan_images_func
 from ai.backend.manager.models.utils import connect_database
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @contextlib.asynccontextmanager

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -14,7 +14,7 @@ from ai.backend.manager.models.image import ImageAliasRow, ImageRow
 from ai.backend.manager.models.image import rescan_images as rescan_images_func
 from ai.backend.manager.models.utils import connect_database
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @contextlib.asynccontextmanager

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -203,7 +203,7 @@ from ..manager.defs import INTRINSIC_SLOTS
 from .api import ManagerStatus
 from .api.exceptions import ServerMisconfiguredError
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 _max_cpu_count = os.cpu_count()
 _file_perm = (Path(__file__).parent / "server.py").stat()

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -203,7 +203,7 @@ from ..manager.defs import INTRINSIC_SLOTS
 from .api import ManagerStatus
 from .api.exceptions import ServerMisconfiguredError
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 _max_cpu_count = os.cpu_count()
 _file_perm = (Path(__file__).parent / "server.py").stat()

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -20,7 +20,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.manager.models.image import ImageRow, ImageType
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class BaseContainerRegistry(metaclass=ABCMeta):

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -20,7 +20,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.manager.models.image import ImageRow, ImageType
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class BaseContainerRegistry(metaclass=ABCMeta):

--- a/src/ai/backend/manager/container_registry/docker.py
+++ b/src/ai/backend/manager/container_registry/docker.py
@@ -10,7 +10,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from .base import BaseContainerRegistry
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class DockerHubRegistry(BaseContainerRegistry):

--- a/src/ai/backend/manager/container_registry/docker.py
+++ b/src/ai/backend/manager/container_registry/docker.py
@@ -10,7 +10,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from .base import BaseContainerRegistry
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class DockerHubRegistry(BaseContainerRegistry):

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -8,7 +8,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from .base import BaseContainerRegistry
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class HarborRegistry_v1(BaseContainerRegistry):

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -8,7 +8,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 from .base import BaseContainerRegistry
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class HarborRegistry_v1(BaseContainerRegistry):

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .config import SharedConfig
     from .models.utils import ExtendedAsyncSAEngine as SAEngine
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class AppStreamingStatus(enum.Enum):

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .config import SharedConfig
     from .models.utils import ExtendedAsyncSAEngine as SAEngine
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class AppStreamingStatus(enum.Enum):

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
 SAFE_MIN_INT = -9007199254740991
 SAFE_MAX_INT = 9007199254740991
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 # The common shared metadata instance
 convention = {

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
 SAFE_MIN_INT = -9007199254740991
 SAFE_MAX_INT = 9007199254740991
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 # The common shared metadata instance
 convention = {

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -33,7 +33,7 @@ from .user import UserRole
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -33,7 +33,7 @@ from .user import UserRole
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from .gql import GraphQueryContext
     from .scaling_group import ScalingGroup
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from .gql import GraphQueryContext
     from .scaling_group import ScalingGroup
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 __all__ = (
     "rescan_images",

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = (
     "rescan_images",

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -42,7 +42,7 @@ __all__ = (
     "StorageVolume",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @attrs.define(auto_attribs=True, slots=True, frozen=True)

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -42,7 +42,7 @@ __all__ = (
     "StorageVolume",
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @attrs.define(auto_attribs=True, slots=True, frozen=True)

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -47,7 +47,7 @@ from .utils import ExtendedAsyncSAEngine
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -47,7 +47,7 @@ from .utils import ExtendedAsyncSAEngine
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 from ..defs import LockID
 from ..types import Sentinel
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 column_constraints = ["nullable", "index", "unique", "primary_key"]
 
 # TODO: Implement begin(), begin_readonly() for AsyncSession also

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 from ..defs import LockID
 from ..types import Sentinel
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 column_constraints = ["nullable", "index", "unique", "primary_key"]
 
 # TODO: Implement begin(), begin_readonly() for AsyncSession also

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -66,7 +66,7 @@ __all__: Sequence[str] = (
 )
 
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class VFolderUsageMode(str, enum.Enum):

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -66,7 +66,7 @@ __all__: Sequence[str] = (
 )
 
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class VFolderUsageMode(str, enum.Enum):

--- a/src/ai/backend/manager/plugin/error_monitor.py
+++ b/src/ai/backend/manager/plugin/error_monitor.py
@@ -15,7 +15,7 @@ from ..models import error_logs
 if TYPE_CHECKING:
     from ai.backend.manager.api.context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class ErrorMonitor(AbstractErrorReporterPlugin):

--- a/src/ai/backend/manager/plugin/error_monitor.py
+++ b/src/ai/backend/manager/plugin/error_monitor.py
@@ -15,7 +15,7 @@ from ..models import error_logs
 if TYPE_CHECKING:
     from ai.backend.manager.api.context import RootContext
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class ErrorMonitor(AbstractErrorReporterPlugin):

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -149,7 +149,7 @@ if TYPE_CHECKING:
 MSetType: TypeAlias = Mapping[Union[str, bytes], Union[bytes, float, int, str]]
 __all__ = ["AgentRegistry", "InstanceNotFound"]
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 SESSION_NAME_LEN_LIMIT = 10
 _read_only_txn_opts = {

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -149,7 +149,7 @@ if TYPE_CHECKING:
 MSetType: TypeAlias = Mapping[Union[str, bytes], Union[bytes, float, int, str]]
 __all__ = ["AgentRegistry", "InstanceNotFound"]
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 SESSION_NAME_LEN_LIMIT = 10
 _read_only_txn_opts = {

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -801,8 +801,6 @@ def main(
         click.echo("--debug options will soon change to --log-level TEXT option.")
         log_level = LogSeverity.DEBUG
 
-    click.echo("Selected logging level for manager : " + log_level.value)
-
     cfg = load_config(config_path, log_level.value)
 
     if ctx.invoked_subcommand is None:

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -106,7 +106,7 @@ LATEST_REV_DATES: Final = {
 }
 LATEST_API_VERSION: Final = "v6.20220615"
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 PUBLIC_INTERFACES: Final = [
     "pidx",

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -106,7 +106,7 @@ LATEST_REV_DATES: Final = {
 }
 LATEST_API_VERSION: Final = "v6.20220615"
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 PUBLIC_INTERFACES: Final = [
     "pidx",

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -7,7 +7,7 @@ from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
-log = logging.getLogger(__spec__.name)
+log = logging.getLogger(__spec__.name)  # type: ignore[name-defined]
 
 
 def scan_entrypoints(

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -7,7 +7,7 @@ from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 
 def scan_entrypoints(

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -27,7 +27,7 @@ from ..exception import InvalidAPIParameters
 from ..types import SENTINEL
 from ..utils import CheckParamSource, check_params
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 DEFAULT_CHUNK_SIZE: Final = 256 * 1024  # 256 KiB
 DEFAULT_INFLIGHT_CHUNKS: Final = 8

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -27,7 +27,7 @@ from ..exception import InvalidAPIParameters
 from ..types import SENTINEL
 from ..utils import CheckParamSource, check_params
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 DEFAULT_CHUNK_SIZE: Final = 256 * 1024  # 256 KiB
 DEFAULT_INFLIGHT_CHUNKS: Final = 8

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -25,7 +25,7 @@ from ..exception import InvalidSubpathError, VFolderNotFoundError
 from ..types import VFolderCreationOptions
 from ..utils import check_params, log_manager_api_entry
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @web.middleware

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -25,7 +25,7 @@ from ..exception import InvalidSubpathError, VFolderNotFoundError
 from ..types import VFolderCreationOptions
 from ..utils import check_params, log_manager_api_entry
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @web.middleware

--- a/src/ai/backend/storage/gpfs/__init__.py
+++ b/src/ai/backend/storage/gpfs/__init__.py
@@ -14,7 +14,7 @@ from ..exception import VFolderCreationError
 from .exceptions import GPFSJobFailedError, GPFSNoMetricError
 from .gpfs_client import GPFSAPIClient
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class GPFSVolume(BaseVolume):

--- a/src/ai/backend/storage/gpfs/__init__.py
+++ b/src/ai/backend/storage/gpfs/__init__.py
@@ -14,7 +14,7 @@ from ..exception import VFolderCreationError
 from .exceptions import GPFSJobFailedError, GPFSNoMetricError
 from .gpfs_client import GPFSAPIClient
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class GPFSVolume(BaseVolume):

--- a/src/ai/backend/storage/gpfs/gpfs_client.py
+++ b/src/ai/backend/storage/gpfs/gpfs_client.py
@@ -32,7 +32,7 @@ from .types import (
     GPFSSystemHealthState,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 def error_handler(inner):

--- a/src/ai/backend/storage/gpfs/gpfs_client.py
+++ b/src/ai/backend/storage/gpfs/gpfs_client.py
@@ -32,7 +32,7 @@ from .types import (
     GPFSSystemHealthState,
 )
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 def error_handler(inner):

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -180,8 +180,6 @@ def main(cli_ctx, config_path, log_level, debug=False):
         click.echo("--debug options will soon change to --log-level TEXT option.")
         log_level = LogSeverity.DEBUG
 
-    click.echo("Selected logging level for storage : " + log_level.value)
-
     # Determine where to read configuration.
     raw_cfg, cfg_src_path = config.read_from_file(config_path, "storage-proxy")
 

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -28,7 +28,7 @@ from .api.manager import init_manager_app
 from .config import local_config_iv
 from .context import Context
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @aiotools.server

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -28,7 +28,7 @@ from .api.manager import init_manager_app
 from .config import local_config_iv
 from .context import Context
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @aiotools.server

--- a/src/ai/backend/storage/utils.py
+++ b/src/ai/backend/storage/utils.py
@@ -11,7 +11,7 @@ from aiohttp import web
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class CheckParamSource(enum.Enum):

--- a/src/ai/backend/storage/utils.py
+++ b/src/ai/backend/storage/utils.py
@@ -11,7 +11,7 @@ from aiohttp import web
 
 from ai.backend.common.logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class CheckParamSource(enum.Enum):

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -32,7 +32,7 @@ from ..types import (
 )
 from ..utils import fstime2datetime
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def run(cmd: Sequence[Union[str, Path]]) -> str:

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -32,7 +32,7 @@ from ..types import (
 )
 from ..utils import fstime2datetime
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 async def run(cmd: Sequence[Union[str, Path]]) -> str:

--- a/src/ai/backend/storage/weka/__init__.py
+++ b/src/ai/backend/storage/weka/__init__.py
@@ -16,7 +16,7 @@ from ai.backend.storage.vfs import BaseVolume
 from .exceptions import WekaAPIError, WekaInitError, WekaNoMetricError, WekaNotFoundError
 from .weka_client import WekaAPIClient
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 class WekaVolume(BaseVolume):

--- a/src/ai/backend/storage/weka/__init__.py
+++ b/src/ai/backend/storage/weka/__init__.py
@@ -16,7 +16,7 @@ from ai.backend.storage.vfs import BaseVolume
 from .exceptions import WekaAPIError, WekaInitError, WekaNoMetricError, WekaNotFoundError
 from .weka_client import WekaAPIClient
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class WekaVolume(BaseVolume):

--- a/src/ai/backend/storage/weka/weka_client.py
+++ b/src/ai/backend/storage/weka/weka_client.py
@@ -15,7 +15,7 @@ from ai.backend.common.types import BinarySize
 
 from .exceptions import WekaAPIError, WekaInvalidBodyError, WekaNotFoundError, WekaUnauthorizedError
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
 @dataclass

--- a/src/ai/backend/storage/weka/weka_client.py
+++ b/src/ai/backend/storage/weka/weka_client.py
@@ -15,7 +15,7 @@ from ai.backend.common.types import BinarySize
 
 from .exceptions import WekaAPIError, WekaInvalidBodyError, WekaNotFoundError, WekaUnauthorizedError
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @dataclass

--- a/src/ai/backend/storage/xfs/__init__.py
+++ b/src/ai/backend/storage/xfs/__init__.py
@@ -15,7 +15,7 @@ from ..exception import ExecutionError, VFolderCreationError
 from ..types import VFolderCreationOptions, VFolderUsage
 from ..vfs import BaseVolume, run
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 LOCK_FILE = Path("/tmp/backendai-xfs-file-lock")
 Path(LOCK_FILE).touch()

--- a/src/ai/backend/storage/xfs/__init__.py
+++ b/src/ai/backend/storage/xfs/__init__.py
@@ -15,7 +15,7 @@ from ..exception import ExecutionError, VFolderCreationError
 from ..types import VFolderCreationOptions, VFolderUsage
 from ..vfs import BaseVolume, run
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 LOCK_FILE = Path("/tmp/backendai-xfs-file-lock")
 Path(LOCK_FILE).touch()

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -11,7 +11,7 @@ import pytest
 from ai.backend.common.types import HostPortPair
 from ai.backend.testutils.pants import get_parallel_slot
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__spec__.name)
 
 
 def wait_health_check(container_id):

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -11,7 +11,7 @@ import pytest
 from ai.backend.common.types import HostPortPair
 from ai.backend.testutils.pants import get_parallel_slot
 
-log = logging.getLogger(__spec__.name)
+log = logging.getLogger(__spec__.name)  # type: ignore[name-defined]
 
 
 def wait_health_check(container_id):

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -19,7 +19,7 @@ from ai.backend.common.web.session import STORAGE_KEY, extra_config_headers, get
 from .auth import fill_x_forwarded_for_header_to_api_session, get_anonymous_session, get_api_session
 from .logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 HTTP_HEADERS_TO_FORWARD = [
     "Accept-Language",

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -19,7 +19,7 @@ from ai.backend.common.web.session import STORAGE_KEY, extra_config_headers, get
 from .auth import fill_x_forwarded_for_header_to_api_session, get_anonymous_session, get_api_session
 from .logging import BraceStyleAdapter
 
-log = BraceStyleAdapter(logging.getLogger(__name__))
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 HTTP_HEADERS_TO_FORWARD = [
     "Accept-Language",


### PR DESCRIPTION
Follow-up of #1030
Resolves #1060

- fix: Use `__spec__.name` instead of `__name__` when making loggers
- fix: Remove bogus debug prints

https://peps.python.org/pep-0451/ says:
> One notable exception is that case where a module is run as a script by using the `-m` flag. In that case `module.__spec__.name` will reflect the actual module name while `module.__name__` will be `__main__`.

Tip:
```shell
find src/ai/backend -name '*.py' -type f -exec sed -i 's/getLogger(__name__)/getLogger(__spec__.name)/' {} +
```