### PR TITLE
feat: Auto-start SSH agent upon session startup

### DIFF
--- a/changes/1067.feature.md
+++ b/changes/1067.feature.md
@@ -1,0 +1,1 @@
+Auto-start SSH agent upon session startup

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -28,6 +28,12 @@ if [ $USER_ID -eq 0 ]; then
   # Extract dotfiles
   /opt/backend.ai/bin/python /opt/kernel/extract_dotfiles.py
 
+  # Start ssh-agent if it is available
+  if command -v ssh-agent > /dev/null; then
+    eval "$(ssh-agent -s)"
+    setsid ssh-add /home/work/.ssh/id_rsa < /dev/null
+  fi
+
   echo "Generate random alpha-numeric password"
   if [ ! -f "$HOME/.password" ]; then
     /opt/backend.ai/bin/python /opt/kernel/fantompass.py > "$HOME/.password"
@@ -93,6 +99,12 @@ else
 
   # Extract dotfiles
   /opt/kernel/su-exec $USER_ID:$GROUP_ID /opt/backend.ai/bin/python /opt/kernel/extract_dotfiles.py
+
+  # Start ssh-agent if it is available
+  if command -v ssh-agent > /dev/null; then
+    eval "$(ssh-agent -s)"
+    setsid ssh-add /home/work/.ssh/id_rsa < /dev/null
+  fi
 
   echo "Generate random alpha-numeric password"
   if [ ! -f "$HOME/.password" ]; then


### PR DESCRIPTION
Fixes #1053.

Auto-start SSH agent and register the ssh key if it doesn't have a passphrase upon session startup in `entrypoint.sh`.

## Test

I tested the changes manually.

Here are the tested kernels' logs.

### 1. when the ssh key has a passphrase

`ssh-add` fails without pending.

#### How it works

This PR makes `entrypoint.sh` execute `ssh-add` through a new session by `setsid` and pass the *null device* to the stdin of the new session.

Then `ssh-add` try to read the passphrase from the stdin or tty device, but because the null device discards the stdin and there is no available tty device in the session, `ssh-add` fails promptly without entering a pending state as you can see in the log below.

```
Kernel started at: 2023-02-28T02:42:04+00:00
Setting up uid and gid: 501:20
chown: cannot access '/opt/kernel/agent.sock': No such file or directory
Agent pid 35
Enter passphrase for /home/work/.ssh/id_rsa: Generate random alpha-numeric password
Executing the main program: /opt/kernel/su-exec "501:20,42" "/opt/backend.ai/bin/python -m ai.backend.kernel python /usr/bin/python3"...
binding to tcp://*:2000
binding to tcp://*:2001
[74] Feb 28 02:42:08 Not backgrounding
python-kernel: Service sshd has started (pid: 74, port: 2200)
[76] Feb 28 02:42:08 Child connection from 127.0.0.1:47450
[76] Feb 28 02:42:08 Exit before auth from <127.0.0.1:47450>: Exited normally
[2023/02/28 02:42:08:5203] N: ttyd 1.6.3-80c6f66 (libwebsockets 4.2.1-unknown)
[2023/02/28 02:42:08:5204] N: tty configuration:
[2023/02/28 02:42:08:5204] N:   start command: /bin/bash -c /opt/kernel/tmux -2 attach
[2023/02/28 02:42:08:5204] N:   close signal: SIGHUP (1)
[2023/02/28 02:42:08:5204] N:   terminal type: xterm-256color
[2023/02/28 02:42:08:5204] N: LWS: 4.2.1-unknown, loglevel 7
[2023/02/28 02:42:08:5204] N: NET SRV H1 WS MbedTLS ConMon IPV6-off
[2023/02/28 02:42:08:5394] N:  Using foreign event loop...
[2023/02/28 02:42:08:5394] N:  ++ [wsi|0|pipe] (1)
[2023/02/28 02:42:08:5395] N:  ++ [vh|0|netlink] (1)
[2023/02/28 02:42:08:5396] N:  ++ [vh|1|default||7681] (2)
[2023/02/28 02:42:08:5396] N: lws_socket_bind: nowsi: source ads 0.0.0.0
[2023/02/28 02:42:08:5396] N:  ++ [wsi|1|listen|default||7681] (2)
[2023/02/28 02:42:08:5396] N:  Listening on port: 7681
python-kernel: Service ttyd has started (pid: 75, port: 7681)
[2023/02/28 02:42:08:6294] N:  ++ [wsisrv|0|adopted] (1)
[2023/02/28 02:42:08:6294] N: lws_libuv_closewsi: [wsisrv|0|adopted]
[2023/02/28 02:42:08:6294] N: lws_libuv_closewsi: thr 0: [wsisrv|0|adopted] sa left 2: dyn left: 3 (rk 0)
[2023/02/28 02:42:08:6294] N:  -- [wsisrv|0|adopted] (0) 78μs
```

### 2. when the ssh key doesn't have a passphrase

`ssh-add` adds identity successfully.

```
Kernel started at: 2023-02-28T03:24:40+00:00
Setting up uid and gid: 501:20
chown: cannot access '/opt/kernel/agent.sock': No such file or directory
Agent pid 34
Identity added: /home/work/.ssh/id_rsa (jopemachine@Gyubongs-MBP.office.lablup)
Generate random alpha-numeric password
Executing the main program: /opt/kernel/su-exec "501:20,42" "/opt/backend.ai/bin/python -m ai.backend.kernel python /usr/bin/python3"...
binding to tcp://*:2000
binding to tcp://*:2001
[73] Feb 28 03:24:44 Not backgrounding
python-kernel: Service sshd has started (pid: 73, port: 2200)
[75] Feb 28 03:24:44 Child connection from 127.0.0.1:58268
[75] Feb 28 03:24:44 Exit before auth from <127.0.0.1:58268>: Exited normally
[2023/02/28 03:24:44:6258] N: ttyd 1.6.3-80c6f66 (libwebsockets 4.2.1-unknown)
[2023/02/28 03:24:44:6258] N: tty configuration:
[2023/02/28 03:24:44:6258] N:   start command: /bin/bash -c /opt/kernel/tmux -2 attach
[2023/02/28 03:24:44:6258] N:   close signal: SIGHUP (1)
[2023/02/28 03:24:44:6258] N:   terminal type: xterm-256color
[2023/02/28 03:24:44:6258] N: LWS: 4.2.1-unknown, loglevel 7
[2023/02/28 03:24:44:6258] N: NET SRV H1 WS MbedTLS ConMon IPV6-off
[2023/02/28 03:24:44:6450] N:  Using foreign event loop...
[2023/02/28 03:24:44:6450] N:  ++ [wsi|0|pipe] (1)
[2023/02/28 03:24:44:6451] N:  ++ [vh|0|netlink] (1)
[2023/02/28 03:24:44:6451] N:  ++ [vh|1|default||7681] (2)
[2023/02/28 03:24:44:6452] N: lws_socket_bind: nowsi: source ads 0.0.0.0
[2023/02/28 03:24:44:6452] N:  ++ [wsi|1|listen|default||7681] (2)
[2023/02/28 03:24:44:6452] N:  Listening on port: 7681
python-kernel: Service ttyd has started (pid: 74, port: 7681)
[2023/02/28 03:24:44:7355] N:  ++ [wsisrv|0|adopted] (1)
[2023/02/28 03:24:44:7357] N: lws_libuv_closewsi: [wsisrv|0|adopted]
[2023/02/28 03:24:44:7357] N: lws_libuv_closewsi: thr 0: [wsisrv|0|adopted] sa left 2: dyn left: 3 (rk 0)
[2023/02/28 03:24:44:7357] N:  -- [wsisrv|0|adopted] (0) 207μs
```

And then I can clone my private repository using the registered ssh key.

<img width="800" alt="스크린샷 2023-02-28 오후 12 39 42" src="https://user-images.githubusercontent.com/18283033/221747739-f011f3c9-6f39-4fa6-a1ad-6e0a956231b0.png">
