### PR TITLE
feat: add `users.totp_activated_at` column

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/3efd66393bd0_add_totp_activated_at_column.py
+++ b/src/ai/backend/manager/models/alembic/versions/3efd66393bd0_add_totp_activated_at_column.py
@@ -1,0 +1,25 @@
+"""add totp_activated_at column
+
+Revision ID: 3efd66393bd0
+Revises: ac4e179c57fe
+Create Date: 2023-02-18 23:50:57.504752
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3efd66393bd0"
+down_revision = "ac4e179c57fe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users", sa.Column("totp_activated_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("users", "totp_activated_at")

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -132,6 +132,7 @@ users = sa.Table(
     sa.Column("allowed_client_ip", pgsql.ARRAY(IPColumn), nullable=True),
     sa.Column("totp_key", sa.String(length=32)),
     sa.Column("totp_activated", sa.Boolean),
+    sa.Column("totp_activated_at", sa.DateTime(timezone=True), nullable=True),
 )
 
 
@@ -196,6 +197,7 @@ class User(graphene.ObjectType):
     role = graphene.String()
     allowed_client_ip = graphene.List(lambda: graphene.String)
     totp_activated = graphene.Boolean()
+    totp_activated_at = GQLDateTime()
 
     groups = graphene.List(lambda: UserGroup)
 
@@ -231,6 +233,7 @@ class User(graphene.ObjectType):
             role=row["role"],
             allowed_client_ip=row["allowed_client_ip"],
             totp_activated=row["totp_activated"],
+            totp_activated_at=row["totp_activated_at"],
         )
 
     @classmethod
@@ -284,6 +287,7 @@ class User(graphene.ObjectType):
         "role": ("role", lambda s: UserRole[s]),
         "allowed_client_ip": ("allowed_client_ip", None),
         "totp_activated": ("totp_activated", None),
+        "totp_activated_at": ("totp_activated_at", dtparse),
     }
 
     _queryorder_colmap = {


### PR DESCRIPTION
This PR adds `users.totp_created_at` column, which should be automatically set when user opts in to 2FA. 