### PR TITLE
ci: remove invalid package name from changlog

### DIFF
--- a/changes/template.md
+++ b/changes/template.md
@@ -1,7 +1,5 @@
 {%- if top_line -%}
 {{ top_line }}
-{%- elif versiondata.name -%}
-{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
 {%- else -%}
 {{ versiondata.version }} ({{ versiondata.date }})
 {%- endif -%}


### PR DESCRIPTION
close #1077
I removed versiondata.name from template from template.md because towncrier is operating based on the package, so towncrier fails when I modify the pakcage value.