### PR TITLE
fix: Check kernel creation tracker cancellation before set result

### DIFF
--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1494,6 +1494,7 @@ async def handle_kernel_creation_lifecycle(
             tracker.set_result(None)
     elif isinstance(event, KernelCancelledEvent):
         if (tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id)) and not tracker.done():
+            log.warning(f"Kernel cancelled, {event.reason = }")
             tracker.cancel()
 
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1247,16 +1247,18 @@ class AgentRegistry:
             except (asyncio.TimeoutError, asyncio.CancelledError) as e:
                 for binding in items:
                     kernel_id = binding.kernel.kernel_id
-                    self.kernel_creation_tracker[kernel_id].cancel()
-                    self._post_kernel_creation_infos[kernel_id].set_exception(e)
+                    if not self.kernel_creation_tracker[kernel_id].done():
+                        self.kernel_creation_tracker[kernel_id].cancel()
+                        self._post_kernel_creation_infos[kernel_id].set_exception(e)
                 await asyncio.gather(*post_tasks, return_exceptions=True)
             except Exception as e:
                 # The agent has already cancelled or issued the destruction lifecycle event
                 # for this batch of kernels.
                 for binding in items:
                     kernel_id = binding.kernel.id
-                    self.kernel_creation_tracker[kernel_id].cancel()
-                    self._post_kernel_creation_infos[kernel_id].set_exception(e)
+                    if not self.kernel_creation_tracker[kernel_id].done():
+                        self.kernel_creation_tracker[kernel_id].cancel()
+                        self._post_kernel_creation_infos[kernel_id].set_exception(e)
                     ex = e
 
                     async def _update_failure() -> None:


### PR DESCRIPTION
related to #1058 

manager's registry has `kernel_creation_tracker` field and it is set by manager's event handler and set in `_create_kernels_in_one_agent` method.
`InvalidStateError` can be raised since `kernel_creation_tracker` is set by two independent methods.
This PR let check the tracker is done.