### PR TITLE
fix: `/start-service` API failing

### DIFF
--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1258,7 +1258,7 @@ async def start_service(request: web.Request, params: Mapping[str, Any]) -> web.
     query = (
         sa.select([scaling_groups.c.wsproxy_addr])
         .select_from(scaling_groups)
-        .where((scaling_groups.c.name == session.main_kernel.scaling_group))
+        .where((scaling_groups.c.name == session.scaling_group_name))
     )
 
     async with root_ctx.db.begin_readonly() as conn:


### PR DESCRIPTION
This fixes session.py's `/start-service` API failing to execute due to invalid reference on table column.