### PR TITLE
fix: Fix typos and add proper whitespace to the comments and CLI help strings

### DIFF
--- a/changes/1099.fix.md
+++ b/changes/1099.fix.md
@@ -1,0 +1,1 @@
+Fix typos and add proper whitespace in the comment and CLI help strings

--- a/src/ai/backend/client/cli/admin/license.py
+++ b/src/ai/backend/client/cli/admin/license.py
@@ -30,10 +30,10 @@ def show():
             async with rqst.fetch() as resp:
                 data = await resp.json()
             if data["status"] == "valid":
-                print_done("Your Backend.AI lincese is valid.")
+                print_done("Your Backend.AI license is valid.")
                 print(tabulate([(k, v) for k, v in data["certificate"].items()]))
             else:
-                print_warn("Your Backend.AI lincese is valid.")
+                print_warn("Your Backend.AI license is valid.")
 
     try:
         asyncio.run(_show_license())

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -268,7 +268,7 @@ def associate_scaling_group(ctx: CLIContext, scaling_group, domain):
         ctx.output.print_mutation_result(
             data,
             extra_info={
-                "detail_msg": "Scaling group {} is assocatiated with domain {}.".format(
+                "detail_msg": "Scaling group {} is associated with domain {}.".format(
                     scaling_group, domain
                 ),
             },

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -325,7 +325,7 @@ def app(session_name, app, bind, arg, env):
 
 
 @main.command()
-@click.argument("session_name", type=str, metavar="NAME", nargs=1)
+@click.argument("session_name", type=str, metavar="SESSION_ID", nargs=1)
 @click.argument("app_name", type=str, metavar="APP", nargs=-1)
 @click.option("-l", "--list-names", is_flag=True, help="Just print all available services.")
 def apps(session_name, app_name, list_names):

--- a/src/ai/backend/client/cli/dotfile.py
+++ b/src/ai/backend/client/cli/dotfile.py
@@ -45,7 +45,7 @@ def dotfile():
     "-g",
     "--group",
     metavar="GROUP",
-    help="Sepcify the group name or id of group dotfiles. "
+    help="Specify the group name or id of group dotfiles. "
     "(If group name is provided, domain name must be specified with option -d)",
 )
 def create(path, permission, dotfile_path, owner_access_key, domain, group):
@@ -98,7 +98,7 @@ def create(path, permission, dotfile_path, owner_access_key, domain, group):
     "-g",
     "--group",
     metavar="GROUP",
-    help="Sepcify the group name or id of group dotfiles. "
+    help="Specify the group name or id of group dotfiles. "
     "(If group name is provided, domain name must be specified with option -d)",
 )
 def get(path, owner_access_key, domain, group):
@@ -133,12 +133,12 @@ def get(path, owner_access_key, domain, group):
     "-g",
     "--group",
     metavar="GROUP",
-    help="Sepcify the group name or id of group dotfiles. "
+    help="Specify the group name or id of group dotfiles. "
     "(If group name is provided, domain name must be specified with option -d)",
 )
 def list(owner_access_key, domain, group):
     """
-    List availabe user/domain/group dotfiles.
+    List available user/domain/group dotfiles.
     """
     fields = [
         ("Path", "path", None),
@@ -197,7 +197,7 @@ def list(owner_access_key, domain, group):
     "-g",
     "--group",
     metavar="GROUP",
-    help="Sepcify the group name or id of group dotfiles. "
+    help="Specify the group name or id of group dotfiles. "
     "(If group name is provided, domain name must be specified with option -d)",
 )
 def update(path, permission, dotfile_path, owner_access_key, domain, group):
@@ -244,7 +244,7 @@ def update(path, permission, dotfile_path, owner_access_key, domain, group):
     "-g",
     "--group",
     metavar="GROUP",
-    help="Sepcify the group name or id of group dotfiles. "
+    help="Specify the group name or id of group dotfiles. "
     "(If group name is provided, domain name must be specified with option -d)",
 )
 def delete(path, force, owner_access_key, domain, group):

--- a/src/ai/backend/client/cli/model.py
+++ b/src/ai/backend/client/cli/model.py
@@ -114,7 +114,7 @@ def info(ctx: CLIContext, model_name):
     type=str,
     default="rw",
     help="Folder's innate permission. "
-    'Group folders can be shared as read-only by setting this option to "ro".'
+    'Group folders can be shared as read-only by setting this option to "ro". '
     "Invited folders override this setting by its own invitation permission.",
 )
 @click.option(

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -514,7 +514,7 @@ def run(
 
     \b
     IMAGE: The name (and version/platform tags appended after a colon) of session
-          runtime or programming language.')
+           runtime or programming language.
     FILES: The code file(s). Can be added multiple times.
     """
     if quiet:

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -429,7 +429,7 @@ def _create_from_template_cmd(docs: str = None):
         metavar="CALLBACK_URL",
         type=str,
         default=None,
-        help="Callback URL which will be called upon sesison lifecycle events.",
+        help="Callback URL which will be called upon session lifecycle events.",
     )
     # execution environment
     @click.option(
@@ -566,8 +566,7 @@ def _create_from_template_cmd(docs: str = None):
         command.
 
         \b
-        IMAGE: The name (and version/platform tags appended after a colon) of session
-               runtime or programming language.
+        TEMPLATE_ID: The template ID to create a session from.
         """
         if name is undefined:
             name = f"pysdk-{secrets.token_hex(5)}"

--- a/src/ai/backend/client/cli/session_template.py
+++ b/src/ai/backend/client/cli/session_template.py
@@ -112,7 +112,7 @@ def get(template_id, template_format, owner_access_key):
 )
 def list(list_all):
     """
-    List all availabe task templates by user.
+    List all available task templates by user.
     """
     fields = [
         ("Name", "name"),

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -93,8 +93,8 @@ def list_allowed_types():
     type=str,
     default="rw",
     help="Folder's innate permission. "
-    'Group folders can be shared as read-only by setting this option to "ro".'
-    "Invited folders override this setting by its own invitation permission.",
+    'Group folders can be shared as read-only by setting this option to "ro". '
+    "Invited folders override this setting by its own invitation permission. ",
 )
 @click.option(
     "-q",
@@ -153,6 +153,7 @@ def create(name, host, group, host_path, usage_mode, permission, quota, cloneabl
 def delete(name):
     """Delete the given virtual folder. This operation is irreversible!
 
+    \b
     NAME: Name of a virtual folder.
     """
     with Session() as session:
@@ -173,6 +174,7 @@ def rename(old_name, new_name):
     and the new name must be unique among all your accessible vfolders
     including the shared ones.
 
+    \b
     OLD_NAME: The current name of a virtual folder.
     NEW_NAME: The new name of a virtual folder.
     """
@@ -190,6 +192,7 @@ def rename(old_name, new_name):
 def info(name):
     """Show the information of the given virtual folder.
 
+    \b
     NAME: Name of a virtual folder.
     """
     with Session() as session:
@@ -219,8 +222,8 @@ def info(name):
     "--base-dir",
     type=Path,
     default=None,
-    help="The local parent directory which contains the file to be uploaded.  "
-    "[default: current working directry]",
+    help="The local parent directory which contains the file to be uploaded. "
+    "[default: current working directory]",
 )
 @click.option(
     "--chunk-size",
@@ -242,7 +245,7 @@ def info(name):
 def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     """
     TUS Upload a file to the virtual folder from the current working directory.
-    The files with the same names will be overwirtten.
+    The files with the same names will be overwritten.
 
     \b
     NAME: Name of a virtual folder.
@@ -273,7 +276,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
     type=Path,
     default=None,
     help="The local parent directory which will contain the downloaded file.  "
-    "[default: current working directry]",
+    "[default: current working directory]",
 )
 @click.option(
     "--chunk-size",
@@ -301,7 +304,7 @@ def upload(name, filenames, base_dir, chunk_size, override_storage_proxy):
 def download(name, filenames, base_dir, chunk_size, override_storage_proxy, max_retries):
     """
     Download a file from the virtual folder to the current working directory.
-    The files with the same names will be overwirtten.
+    The files with the same names will be overwritten.
 
     \b
     NAME: Name of a virtual folder.
@@ -329,7 +332,7 @@ def download(name, filenames, base_dir, chunk_size, override_storage_proxy, max_
 @click.argument("filename", type=Path)
 def request_download(name, filename):
     """
-    Request JWT-formated download token for later use.
+    Request JWT-formatted download token for later use.
 
     \b
     NAME: Name of a virtual folder.
@@ -349,6 +352,7 @@ def request_download(name, filename):
 def cp(filenames):
     """An scp-like shortcut for download/upload commands.
 
+    \b
     FILENAMES: Paths of the files to operate on. The last one is the target while all
                others are the sources.  Either source paths or the target path should
                be prefixed with "<vfolder-name>:" like when using the Linux scp
@@ -488,7 +492,7 @@ def ls(name, path):
                 mtime = mdt.strftime("%b %d %Y %H:%M:%S")
                 row = [file["filename"], file["size"], mtime, file["mode"]]
                 table.append(row)
-            print_done("Retrived.")
+            print_done("Retrieved.")
             print(tabulate(table, headers=headers))
         except Exception as e:
             print_error(e)
@@ -649,8 +653,9 @@ def unshare(name, emails):
     help="The ID of the person who wants to leave (the person who shared the vfolder).",
 )
 def leave(name, shared_user_uuid):
-    """Leave the shared virutal folder.
+    """Leave the shared virtual folder.
 
+    \b
     NAME: Name of a virtual folder
     """
     with Session() as session:

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -194,8 +194,8 @@ class APIConfig:
         "read_timeout": "0",
     }
     """
-    The default values for config parameterse settable via environment variables
-    xcept the access and secret keys.
+    The default values for config parameters settable via environment variables
+    except the access and secret keys.
     """
 
     _endpoints: List[URL]

--- a/src/ai/backend/client/func/admin.py
+++ b/src/ai/backend/client/func/admin.py
@@ -10,7 +10,7 @@ __all__ = ("Admin",)
 
 class Admin(BaseFunction):
     """
-    Provides the function interface for making admin GrapQL queries.
+    Provides the function interface for making admin GraphQL queries.
 
     .. note::
 

--- a/src/ai/backend/client/func/resource.py
+++ b/src/ai/backend/client/func/resource.py
@@ -25,7 +25,7 @@ class Resource(BaseFunction):
     @classmethod
     async def check_presets(cls):
         """
-        Lists all resource presets in the current scaling group with additiona
+        Lists all resource presets in the current scaling group with additional
         information.
         """
         rqst = Request("POST", "/resource/check-presets")
@@ -65,7 +65,7 @@ class Resource(BaseFunction):
     @classmethod
     async def usage_per_period(cls, group_id: str, start_date: str, end_date: str):
         """
-        Get usage statistics for a group specified by `group_id` for time betweeen
+        Get usage statistics for a group specified by `group_id` for time between
         `start_date` and `end_date`.
 
         :param start_date: start date in string format (yyyymmdd).

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -229,11 +229,11 @@ class ComputeSession(BaseFunction):
             of it.
 
             .. versionadded:: 19.09.0
-        :param mounts: The list of vfolder names that belongs to the currrent API
+        :param mounts: The list of vfolder names that belongs to the current API
             access key.
         :param mount_map: Mapping which contains custom path to mount vfolder.
             Key and value of this map should be vfolder name and custom path.
-            Defalut mounts or relative paths are under /home/work.
+            Default mounts or relative paths are under /home/work.
             If you want different paths, names should be absolute paths.
             The target mount path of vFolders should not overlap with the linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
@@ -413,11 +413,11 @@ class ComputeSession(BaseFunction):
             of it.
 
             .. versionadded:: 19.09.0
-        :param mounts: The list of vfolder names that belongs to the currrent API
+        :param mounts: The list of vfolder names that belongs to the current API
             access key.
         :param mount_map: Mapping which contains custom path to mount vfolder.
             Key and value of this map should be vfolder name and custom path.
-            Defalut mounts or relative paths are under /home/work.
+            Default mounts or relative paths are under /home/work.
             If you want different paths, names should be absolute paths.
             The target mount path of vFolders should not overlap with the linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
@@ -1086,7 +1086,7 @@ class ComputeSession(BaseFunction):
 
 class InferenceSession(BaseFunction):
     """
-    Provides various iteractions with inference sessions in Backend.AI.
+    Provides various interactions with inference sessions in Backend.AI.
     """
 
     id: Optional[UUID]

--- a/src/ai/backend/client/func/storage.py
+++ b/src/ai/backend/client/func/storage.py
@@ -29,7 +29,7 @@ _default_detail_fields = (
 class Storage(BaseFunction):
     """
     Provides a shortcut of :func:`Admin.query()
-    <ai.backend.client.admin.Admin.query>` that fetches various straoge volume
+    <ai.backend.client.admin.Admin.query>` that fetches various storage volume
     information keyed by vfolder hosts.
 
     .. note::

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -144,7 +144,7 @@ class Request:
         :param BaseSession session: The session where this request is executed on.
 
         :param str path: The query path. When performing requests, the version number
-                         prefix will be automatically perpended if required.
+                         prefix will be automatically prepended if required.
 
         :param RequestContent content: The API query body which will be encoded as
                                        JSON.

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -459,7 +459,7 @@ class Session(BaseSession):
                 if payload["enabled"]:
                     self.config.announcement_handler(payload["message"])
             except (BackendClientError, BackendAPIError):
-                # The server may be an old one without annoucement API.
+                # The server may be an old one without announcement API.
                 pass
         return self
 
@@ -515,7 +515,7 @@ class AsyncSession(BaseSession):
                 if payload["enabled"]:
                     self.config.announcement_handler(payload["message"])
             except (BackendClientError, BackendAPIError):
-                # The server may be an old one without annoucement API.
+                # The server may be an old one without announcement API.
                 pass
         return self
 

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -65,7 +65,7 @@ PTGExceptionHandler: TypeAlias = Callable[
 
 class AbstractEvent(metaclass=abc.ABCMeta):
 
-    # derivatives shoudld define the fields.
+    # derivatives should define the fields.
 
     name: ClassVar[str] = "undefined"
 

--- a/src/ai/backend/common/logging.py
+++ b/src/ai/backend/common/logging.py
@@ -79,7 +79,7 @@ logging_config_iv = t.Dict(
                 t.Key("protocol", default="tcp"): t.Enum("zmq.push", "zmq.pub", "tcp", "udp"),
                 t.Key("ssl-enabled", default=True): t.Bool,
                 t.Key("ssl-verify", default=True): t.Bool,
-                # NOTE: logstash does not have format optoin.
+                # NOTE: logstash does not have format option.
             }
         ).allow_extra("*"),
     }

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -168,9 +168,9 @@ def generate_keypair(cli_ctx: CLIContext):
     type=bool,
     default=False,
     help="Reclaim storage occupied by dead tuples."
-    "If not set or set False, it will run VACUUM without FULL."
-    "If set True, it will run VACUUM FULL."
-    "When VACUUM FULL is being processed, the database is locked."
+    "If not set or set False, it will run VACUUM without FULL. "
+    "If set True, it will run VACUUM FULL. "
+    "When VACUUM FULL is being processed, the database is locked. "
     "[default: False]",
 )
 @click.pass_obj


### PR DESCRIPTION
Fix typos and add proper whitespace in the comment and CLI help strings.