### PR TITLE
fix: `session ls` not working

### DIFF
--- a/changes/1100.fix.md
+++ b/changes/1100.fix.md
@@ -1,0 +1,1 @@
+Fix session ls not working bug

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -284,11 +284,10 @@ class DockerKernel(AbstractKernel):
         container_id = self.data["container_id"]
 
         # Confine the lookable paths in the home directory
-        home_path = Path("/home/work")
-        try:
-            resolved_path = (home_path / container_path).resolve()
-            resolved_path.relative_to(home_path)
-        except ValueError:
+        home_path = Path("/home/work").resolve()
+        resolved_path = (home_path / container_path).resolve()
+
+        if str(os.path.commonpath([resolved_path, home_path])) != str(home_path):
             raise PermissionError("You cannot list files outside /home/work")
 
         # Gather individual file information in the target path.

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import lzma
+import os
 import re
 import shutil
 import textwrap
@@ -272,11 +273,10 @@ class KubernetesKernel(AbstractKernel):
         core_api = kube_client.CoreV1Api()
 
         # Confine the lookable paths in the home directory
-        home_path = Path("/home/work")
-        try:
-            resolved_path = (home_path / container_path).resolve()
-            resolved_path.relative_to(home_path)
-        except ValueError:
+        home_path = Path("/home/work").resolve()
+        resolved_path = (home_path / container_path).resolve()
+
+        if str(os.path.commonpath([resolved_path, home_path])) != str(home_path):
             raise PermissionError("You cannot list files outside /home/work")
 
         # Gather individual file information in the target path.


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Tested manually.

## Before

Tested commands:

```
$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228
$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228 /home/work
$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228 /home/work/.ssh
```

Above commands failed with the below error.

### Manager's log

```
2023-02-24 14:09:35.509 ERROR ai.backend.manager.api.session [17278] LIST_FILES: exception
Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/api/session.py", line 2414, in list_files
    result = await root_ctx.registry.list_files(session, path)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/registry.py", line 2201, in list_files
    async with handle_session_exception(self.db, "list_files", session.id):
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/.pyenv/versions/3.11.2/lib/python3.11/contextlib.py", line 222, in __aexit__
    await self.gen.athrow(typ, value, traceback)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/session.py", line 407, in handle_session_exception
    raise exc_class("FAILURE", e) from None
    ^^^^^^^^^^^^^^^^^
ai.backend.manager.api.exceptions.KernelExecutionFailed: Agent-side exception occurred. (PermissionError('You cannot list files outside /home/work'))
```

It said it is agent bug.

### Agent's log

```
2023-02-24 14:27:27.267 ERROR ai.backend.agent.server [41660] unexpected error
Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 158, in _inner
    return await meth(
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 133, in _inner
    return await meth(self, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 621, in list_files
    return await self.agent.list_files(KernelId(UUID(kernel_id)), path)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/agent.py", line 2011, in list_files
    return await self.kernel_registry[kernel_id].list_files(path)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/docker/kernel.py", line 292, in list_files
    raise PermissionError("You cannot list files outside /home/work")
    ^^^^^^^^^^^^^^^^^
PermissionError: You cannot list files outside /home/work
2023-02-24 14:27:27.267 ERROR callosum.rpc.channel.Peer [41660] RPC user error
Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/callosum/rpc/channel.py", line 281, in _func_task
    result = await self._func_scheduler.get_fut(server_request_id)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/callosum/ordering.py", line 224, in get_fut
    return await task
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 158, in _inner
    return await meth(
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 133, in _inner
    return await meth(self, *args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/server.py", line 621, in list_files
    return await self.agent.list_files(KernelId(UUID(kernel_id)), path)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/agent.py", line 2011, in list_files
    return await self.kernel_registry[kernel_id].list_files(path)
    ^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/agent/docker/kernel.py", line 292, in list_files
    raise PermissionError("You cannot list files outside /home/work")
    ^^^^^^^^^^^^^^^^^
PermissionError: You cannot list files outside /home/work
```

## After

```
$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228
✓ Retrived.
File name                              Size       Modified              Mode
-------------------------------------  ---------  --------------------  ----------
.bash_history                          40 Bytes   Feb 23 2023 17:19:59  -rw-------
.bash_profile                          147 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
.bashrc                                249 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
.cache                                 96 Bytes   Feb 23 2023 16:05:32  drwxr-xr-x
.config                                96 Bytes   Feb 23 2023 16:05:32  drwxr-xr-x
.ipython                               96 Bytes   Feb 23 2023 16:05:30  drwxr-xr-x
.jupyter                               96 Bytes   Feb 23 2023 16:05:27  drwxr-xr-x
.local                                 96 Bytes   Feb 23 2023 16:05:29  drwxr-xr-x
.password                              54 Bytes   Feb 23 2023 16:05:28  -rw-r--r--
.ssh                                   96 Bytes   Feb 23 2023 16:05:30  drwx------
.tmux.conf                             2.0 KiB    Feb 23 2023 16:05:27  -rw-r--r--
.vimrc                                 501 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
DO_NOT_STORE_PERSISTENT_FILES_HERE.md  540 Bytes  Nov 09 2022 16:50:39  -rw-r--r--
LICENSE                                7.5 KiB    Feb 23 2023 17:19:44  -rw-r--r--
id_container                           1.6 KiB    Feb 23 2023 16:05:30  -rw-------

$  ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228 /home/work/
✓ Retrived.
File name                              Size       Modified              Mode
-------------------------------------  ---------  --------------------  ----------
.bash_history                          40 Bytes   Feb 23 2023 17:19:59  -rw-------
.bash_profile                          147 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
.bashrc                                249 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
.cache                                 96 Bytes   Feb 23 2023 16:05:32  drwxr-xr-x
.config                                96 Bytes   Feb 23 2023 16:05:32  drwxr-xr-x
.ipython                               96 Bytes   Feb 23 2023 16:05:30  drwxr-xr-x
.jupyter                               96 Bytes   Feb 23 2023 16:05:27  drwxr-xr-x
.local                                 96 Bytes   Feb 23 2023 16:05:29  drwxr-xr-x
.password                              54 Bytes   Feb 23 2023 16:05:28  -rw-r--r--
.ssh                                   96 Bytes   Feb 23 2023 16:05:30  drwx------
.tmux.conf                             2.0 KiB    Feb 23 2023 16:05:27  -rw-r--r--
.vimrc                                 501 Bytes  Feb 23 2023 16:05:27  -rw-r--r--
DO_NOT_STORE_PERSISTENT_FILES_HERE.md  540 Bytes  Nov 09 2022 16:50:39  -rw-r--r--
LICENSE                                7.5 KiB    Feb 23 2023 17:19:44  -rw-r--r--
id_container                           1.6 KiB    Feb 23 2023 16:05:30  -rw-------


$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228 /home/work/.ssh
✓ Retrived.
File name        Size       Modified              Mode
---------------  ---------  --------------------  ----------
authorized_keys  391 Bytes  Feb 23 2023 16:05:30  -rw-------

// Expected Error
$ ./backend.ai session ls 6b4ea30d-cd4b-42bc-8307-dcb9e7746228 /work/.ssh
✘ BackendAPIError: 500 Internal Server Error
  Executing user code in the kernel has failed.
  ➜ This is an agent-side error. Check the agent status or ask the administrator for help.
  ➜ PermissionError('You cannot list files outside /home/work')
  ➜ Agent-side exception occurred.

```

