### PR TITLE
fix: Regression of `session watch` command

### DIFF
--- a/changes/1103.fix.md
+++ b/changes/1103.fix.md
@@ -1,1 +1,1 @@
-Fix session watch not working bug
+Fix a regression bug in `session watch` command

--- a/changes/1103.fix.md
+++ b/changes/1103.fix.md
@@ -1,0 +1,1 @@
+Fix session watch not working bug

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -1241,7 +1241,7 @@ def _fetch_session_names():
             order=None,
         )
 
-    return tuple(map(lambda x: x.get("session_id"), sessions.items))
+    return tuple(map(lambda x: x.get("name"), sessions.items))
 
 
 def _watch_cmd(docs: Optional[str] = None):


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

## Before

```
$ ./backend.ai watch mysession

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/cli/__main__.py", line 10, in <module>
    main(max_content_width=shutil.get_terminal_size().columns - 2)
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/cli/extensions.py", line 25, in main
    super().main(
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.11.2/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/client/cli/session.py", line 1304, in watch
    if session_name.startswith(session_name_or_id[0]):
       ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'

```

## After 

```
$ ./backend.ai watch mysession
✓ kernel_terminating
✓ kernel_terminated
```

I changed the `session_id` to `name`, not `id` because the function name is `_fetch_session_names`.