### PR TITLE
ci: Correct incorrectly stated job name

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -117,6 +117,7 @@ jobs:
         path: .pants.d/pants.log
       if: always()  # We want the log even on failures.
 
+
   test:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
@@ -317,7 +318,7 @@ jobs:
 
 
   deploy-to-pypi:
-    needs: [windows-conda-build]
+    needs: [windows-conda-package]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Modify failed workflow because deploy-to-pypi has an invalid job name from needs.