### PR TITLE
ci: Rewrite the alembic multi-head check workflow to do static analysis

### DIFF
--- a/.github/workflows/alembic-head-check.yml
+++ b/.github/workflows/alembic-head-check.yml
@@ -15,29 +15,10 @@ jobs:
     - name: Parse versions from config
       run: |
         PYTHON_VERSION=$(grep -oP '(?<=CPython==)([^"]+)' pants.toml)
-        ALEMBIC_VERSION=$(grep 'alembic' requirements.txt)
         echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
-        echo "PROJECT_ALEMBIC_VERSION=$ALEMBIC_VERSION" >> $GITHUB_ENV
-    - name: Set up Python for Pants
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
     - name: Set up Python as Runtime
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PROJECT_PYTHON_VERSION }}
-    - name: Prepare cache dir for Pants
-      run: mkdir -p .tmp
-    - name: Bootstrap Pants
-      uses: pantsbuild/actions/init-pants@v2
-      # See: https://github.com/pantsbuild/actions/tree/main/init-pants/
-      # See: https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml#L27-L47
-      with:
-        pants-python-version: "3.9"
-        gha-cache-key: pants-cache0-alembic-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
-        named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
-        cache-lmdb-store: 'true'
-    - name: Create venv
-      run: ./pants export --resolve=python-default
     - name: Check for multiple heads
-      run: ./py scripts/check-multiple-alembic-heads.py
+      run: python scripts/check-multiple-alembic-heads.py

--- a/scripts/check-multiple-alembic-heads.py
+++ b/scripts/check-multiple-alembic-heads.py
@@ -1,18 +1,53 @@
-from unittest import mock
+import ast
+import graphlib
 import sys
+from pathlib import Path
 
-from alembic.config import Config
-from alembic.script import ScriptDirectory
 
-import_mock = mock.MagicMock()
-import_mock.return_value = import_mock
+def build_revision_map():
+    rev_map = {}
+    current_rev = None
+    for p in Path("src/ai/backend/manager/models/alembic/versions").glob("*.py"):
+        src = p.read_text()
+        tree = ast.parse(src, filename=p)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                target = node.targets[0]
+                if isinstance(target, ast.Name) and target.id in ("revision", "down_revision"):
+                    values = []
+                    assigned_value = node.value
+                    match assigned_value:
+                        case ast.Constant():
+                            values.append(assigned_value.value)
+                        case ast.Tuple():
+                            for el in assigned_value.elts:
+                                if isinstance(el, ast.Constant):
+                                    values.append(el.value)
+                    match target.id:
+                        case "revision":
+                            current_rev = values[0]
+                            rev_map[current_rev] = {}
+                        case "down_revision":
+                            rev_map[current_rev] = {*values}
+    return rev_map
 
-with mock.patch('builtins.__import__', side_effect=import_mock):
-    cfg = Config()
-    cfg.set_main_option("script_location", "src/ai/backend/manager/models/alembic")
-    script = ScriptDirectory.from_config(cfg)
 
-    heads = script.get_revisions("heads")
+def find_heads(rev_map):
+    sorter = graphlib.TopologicalSorter(rev_map)
+    heads = {*rev_map.keys()}
+    for rev in reversed([*sorter.static_order()]):
+        for down_rev in rev_map.get(rev, []):
+            heads.discard(down_rev)
+    return heads
+
+
+def main():
+    rev_map = build_revision_map()
+    heads = find_heads(rev_map)
+    print(f"Detected head revisions: {', '.join(heads)}")
     if len(heads) > 1:
-        print('multiple alembic heads detected!')
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- This is much faster and does not require importing/installing the
  source packages.

This resolves #1106 in the other way.
