### PR TITLE
refactor: Remove no longer required `kernel_creation_id`

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1391,7 +1391,6 @@ class AbstractAgent(
 
     async def create_kernel(
         self,
-        creation_id: str,
         session_id: SessionId,
         kernel_id: KernelId,
         kernel_config: KernelCreationConfig,
@@ -1405,7 +1404,7 @@ class AbstractAgent(
 
         if not restarting:
             await self.produce_event(
-                KernelPreparingEvent(kernel_id, creation_id),
+                KernelPreparingEvent(kernel_id),
             )
 
         # Initialize the creation context
@@ -1445,13 +1444,13 @@ class AbstractAgent(
         )
         if do_pull:
             await self.produce_event(
-                KernelPullingEvent(kernel_id, creation_id, ctx.image_ref.canonical),
+                KernelPullingEvent(kernel_id, ctx.image_ref.canonical),
             )
             await self.pull_image(ctx.image_ref, kernel_config["image"]["registry"])
 
         if not restarting:
             await self.produce_event(
-                KernelCreatingEvent(kernel_id, creation_id),
+                KernelCreatingEvent(kernel_id),
             )
 
         # Get the resource spec from existing kernel scratches
@@ -1748,7 +1747,6 @@ class AbstractAgent(
         await self.produce_event(
             KernelStartedEvent(
                 kernel_id,
-                creation_id,
                 creation_info={
                     **kernel_creation_info,
                     "id": str(KernelId(kernel_id)),
@@ -1852,7 +1850,6 @@ class AbstractAgent(
 
     async def restart_kernel(
         self,
-        creation_id: str,
         session_id: SessionId,
         kernel_id: KernelId,
         updating_kernel_config: KernelCreationConfig,
@@ -1898,7 +1895,6 @@ class AbstractAgent(
             else:
                 try:
                     await self.create_kernel(
-                        creation_id,
                         session_id,
                         kernel_id,
                         kernel_config,

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -351,7 +351,6 @@ class AgentRPCServer(aobject):
     @collect_error
     async def create_kernels(
         self,
-        creation_id: str,
         raw_session_id: str,
         raw_kernel_ids: Sequence[str],
         raw_configs: Sequence[dict],
@@ -371,7 +370,6 @@ class AgentRPCServer(aobject):
             kernel_config = cast(KernelCreationConfig, raw_config)
             coros.append(
                 self.agent.create_kernel(
-                    creation_id,
                     session_id,
                     kernel_id,
                     kernel_config,
@@ -446,14 +444,12 @@ class AgentRPCServer(aobject):
     @collect_error
     async def restart_kernel(
         self,
-        creation_id: str,
         session_id: str,
         kernel_id: str,
         updated_config: dict,
     ) -> dict[str, Any]:
         log.info("rpc::restart_kernel(s:{0}, k:{1})", session_id, kernel_id)
         return await self.agent.restart_kernel(
-            creation_id,
             SessionId(UUID(session_id)),
             KernelId(UUID(kernel_id)),
             cast(KernelCreationConfig, updated_config),

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -230,14 +230,12 @@ class KernelLifecycleEventReason(str, enum.Enum):
 @attrs.define(slots=True, frozen=True)
 class KernelCreationEventArgs:
     kernel_id: KernelId = attrs.field()
-    creation_id: str = attrs.field()
     reason: str = attrs.field(default="")
     creation_info: Mapping[str, Any] = attrs.field(factory=dict)
 
     def serialize(self) -> tuple:
         return (
             str(self.kernel_id),
-            self.creation_id,
             self.reason,
             self.creation_info,
         )
@@ -246,14 +244,9 @@ class KernelCreationEventArgs:
     def deserialize(cls, value: tuple):
         return cls(
             kernel_id=KernelId(uuid.UUID(value[0])),
-            creation_id=value[1],
-            reason=value[2],
-            creation_info=value[3],
+            reason=value[1],
+            creation_info=value[2],
         )
-
-
-class KernelEnqueuedEvent(KernelCreationEventArgs, AbstractEvent):
-    name = "kernel_enqueued"
 
 
 class KernelPreparingEvent(KernelCreationEventArgs, AbstractEvent):


### PR DESCRIPTION
kernel_creation_id is now unused so I removed it.