### PR TITLE
fix: Remove script snippets relate to `.pants.env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,6 @@ ENV/
 /storage-proxy.toml
 /webserver.conf
 /cuda-mock.toml
-/.pants.env
 /.pants.bootstrap
 /docker-compose.halfstack.current.yml
 /alembic.ini

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ ENV/
 /storage-proxy.toml
 /webserver.conf
 /cuda-mock.toml
+/.pants.env
 /.pants.bootstrap
 /docker-compose.halfstack.current.yml
 /alembic.ini

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -116,7 +116,7 @@ fi
 echo ""
 echo "(FYI) To reset Pants and its cache data, run:"
 echo "  $ killall pantsd"
-echo "  $ rm -r .tmp .pants.d .pants.env pants-local ~/.cache/pants"
+echo "  $ rm -r .tmp .pants.d pants-local ~/.cache/pants"
 
 echo ""
 echo "Done."

--- a/tools/pants-local
+++ b/tools/pants-local
@@ -8,15 +8,6 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-if [ -f '.pants.env' ]; then
-  source .pants.env
-fi
-if [ -z "$PY" ]; then
-  echo "The Python version for source-built Pants is not configured in ./.pants.env"
-  exit 1
-else
-  export PY=$PY
-fi
 PANTS_SOURCE="${PANTS_SOURCE:-$(pwd)/tools/pants-src}"
 
 # When running pants from sources you are likely to be modifying those sources, so


### PR DESCRIPTION
Support for `.pants.env` has been stopped after 24e5a1f.
Therefore, this PR removes several scripts relate to `.pants.env`.