### PR TITLE
fix: Add `BaseException` to the checklist to filter out `asyncio.CancelledError` raised during kernel creation

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,1 +1,1 @@
-Add `BaseException` to the checklist to filter out `asyncio.CancelledError` during kernel creation process
+Add `BaseException` to the checklist to filter out `asyncio.CancelledError` raised during kernel creation process

--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Add `BaseException` to the checklist to filter out `asyncio.CancelledError` during kernel creation process

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -377,7 +377,7 @@ class AgentRPCServer(aobject):
                 )
             )
         results = await asyncio.gather(*coros, return_exceptions=True)
-        errors = [*filter(lambda item: isinstance(item, Exception), results)]
+        errors = [*filter(lambda item: isinstance(item, (BaseException, Exception)), results)]
         if errors:
             # Raise up the first error.
             if len(errors) == 1:


### PR DESCRIPTION
This PR resolves #1128 