### PR TITLE
fix: `ssh-add` not working due to missing env-var inheritance and wrong process ownership

### DIFF
--- a/changes/1141.fix.md
+++ b/changes/1141.fix.md
@@ -1,0 +1,1 @@
+ssh-add not working bug due to permission issue

--- a/src/ai/backend/kernel/app/__init__.py
+++ b/src/ai/backend/kernel/app/__init__.py
@@ -4,7 +4,6 @@ which do not provide query/batch-mode code execution.
 """
 
 import logging
-import os
 from typing import List
 
 from .. import BaseRunner
@@ -17,27 +16,6 @@ DEFAULT_PYFLAGS: List[str] = []
 class Runner(BaseRunner):
     log_prefix = "app-kernel"
     default_runtime_path = "/opt/backend.ai/bin/python"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": ":".join(
-            [
-                "/usr/local/nvidia/bin",
-                "/usr/local/cuda/bin",
-                "/usr/local/sbin",
-                "/usr/local/bin",
-                "/usr/sbin",
-                "/usr/bin",
-                "/sbin",
-                "/bin",
-            ]
-        ),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -143,6 +143,7 @@ class BaseRunner(metaclass=ABCMeta):
     def __init__(self, runtime_path: Path) -> None:
         self.subproc = None
         self.runtime_path = runtime_path
+        self.child_env = {**os.environ, **self.default_child_env}
         if "PATH" not in self.child_env:
             # set the default PATH env-var only when it's missing from the image
             self.child_env["PATH"] = self.default_child_env_path

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -154,7 +154,7 @@ class BaseRunner(metaclass=ABCMeta):
             path_env = promote_path(path_env, "/usr/local/cuda/bin")
         if Path("/usr/local/nvidia/bin").is_dir():
             path_env = promote_path(path_env, "/usr/local/nvidia/bin")
-        path_env = promote_path(path_env, "/home/work/.local.bin")
+        path_env = promote_path(path_env, "/home/work/.local/bin")
         self.child_env["PATH"] = path_env
 
         self.started_at: float = time.monotonic()

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -104,7 +104,6 @@ class BaseRunner(metaclass=ABCMeta):
     default_runtime_path: ClassVar[Optional[str]] = None
     default_child_env: ClassVar[dict[str, str]] = {
         "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash" if Path("/bin/ash").is_file() else "/bin/bash",
         "HOME": "/home/work",
         "TERM": "xterm",
         "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
@@ -122,6 +121,7 @@ class BaseRunner(metaclass=ABCMeta):
             "/bin",
         ]
     )
+    default_child_env_shell = "/bin/ash" if Path("/bin/ash").is_file() else "/bin/bash"
     jupyter_kspec_name: ClassVar[str] = ""
     kernel_mgr: Optional[AsyncKernelManager] = None
     kernel_client: Optional[AsyncKernelClient] = None
@@ -144,9 +144,11 @@ class BaseRunner(metaclass=ABCMeta):
         self.subproc = None
         self.runtime_path = runtime_path
         self.child_env = {**os.environ, **self.default_child_env}
+        # set some defaults only when they are missing from the image
         if "PATH" not in self.child_env:
-            # set the default PATH env-var only when it's missing from the image
             self.child_env["PATH"] = self.default_child_env_path
+        if "SHELL" not in self.child_env:
+            self.child_env["SHELL"] = self.default_child_env_shell
         config_dir = Path("/home/config")
         try:
             evdata = (config_dir / "environ.txt").read_text()

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -80,7 +80,16 @@ async def terminate_and_wait(proc: asyncio.subprocess.Process, timeout: float = 
         pass
 
 
-def promote_path(path_env: str, path_to_promote: Union[Path, str]) -> str:
+def glob_path(base: Path | str, pattern: str) -> Path | None:
+    paths = [*Path(base).glob(pattern)]
+    if paths:
+        return paths[0]
+    return None
+
+
+def promote_path(path_env: str, path_to_promote: Path | str | None) -> str:
+    if not path_to_promote:
+        return path_env
     paths = path_env.split(":")
     path_to_promote = os.fsdecode(path_to_promote)
     result_paths = [p for p in paths if path_to_promote != p]

--- a/src/ai/backend/kernel/c/__init__.py
+++ b/src/ai/backend/kernel/c/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -15,16 +14,6 @@ DEFAULT_LDFLAGS = ["-lrt", "-lm", "-lpthread", "-ldl"]
 class Runner(BaseRunner):
     log_prefix = "c-kernel"
     default_runtime_path = "/usr/bin/g++"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/cpp/__init__.py
+++ b/src/ai/backend/kernel/cpp/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -14,16 +13,6 @@ DEFAULT_LDFLAGS = ["-lrt", "-lm", "-lpthread", "-ldl"]
 class Runner(BaseRunner):
     log_prefix = "cpp-kernel"
     default_runtime_path = "/usr/bin/g++"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/git/__init__.py
+++ b/src/ai/backend/kernel/git/__init__.py
@@ -14,23 +14,12 @@ from .. import BaseRunner, Terminal
 
 log = logging.getLogger()
 
-CHILD_ENV = {
-    "TERM": "xterm",
-    "LANG": "C.UTF-8",
-    "SHELL": "/bin/bash",
-    "USER": "work",
-    "HOME": "/home/work",
-    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-    "LD_PRELOAD": os.environ.get("LD_PRELOAD", "/home/backend.ai/libbaihook.so"),
-}
-
 
 class Runner(BaseRunner):
     log_prefix = "shell-kernel"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.child_env.update(CHILD_ENV)
 
     async def init_with_loop(self):
         self.user_input_queue = asyncio.Queue()

--- a/src/ai/backend/kernel/golang/__init__.py
+++ b/src/ai/backend/kernel/golang/__init__.py
@@ -1,10 +1,10 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 from typing import List
 
 from .. import BaseRunner
+from ..base import promote_path
 
 log = logging.getLogger()
 
@@ -15,20 +15,17 @@ class Runner(BaseRunner):
     log_prefix = "go-kernel"
     default_runtime_path = "/usr/local/bin/go"
     default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/home/work/bin:/go/bin:/usr/local/go/bin:"
-        + "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        **BaseRunner.default_child_env,
         "GOPATH": "/home/work",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
     }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        path_env = self.child_env["PATH"]
+        path_env = promote_path(path_env, "/go/bin")
+        path_env = promote_path(path_env, "/usr/local/go/bin")
+        path_env = promote_path(path_env, "/home/work/bin")
+        self.child_env["PATH"] = path_env
 
     async def init_with_loop(self):
         pass

--- a/src/ai/backend/kernel/haskell/__init__.py
+++ b/src/ai/backend/kernel/haskell/__init__.py
@@ -1,10 +1,10 @@
 import logging
-import os
 import shlex
 import tempfile
 from pathlib import Path
 
 from .. import BaseRunner
+from ..base import promote_path
 
 log = logging.getLogger()
 
@@ -12,23 +12,16 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "haskell-kernel"
     default_runtime_path = "/usr/bin/ghc"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": (
-            "/root/.cabal/bin:/root/.local/bin:/opt/cabal/2.0/bin:"
-            "/opt/ghc/8.2.1/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:"
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        ),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        path_env = self.child_env["PATH"]
+        path_env = promote_path(path_env, "/opt/happy/1.19.5/bin")
+        path_env = promote_path(path_env, "/opt/alex/3.1.7/bin")
+        path_env = promote_path(path_env, "/opt/cabal/2.0/bin")
+        path_env = promote_path(path_env, "/opt/ghc/8.2.1/bin")
+        path_env = promote_path(path_env, "/home/work/.cabal/bin")
+        self.child_env["PATH"] = path_env
 
     async def init_with_loop(self):
         pass

--- a/src/ai/backend/kernel/haskell/__init__.py
+++ b/src/ai/backend/kernel/haskell/__init__.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 from .. import BaseRunner
-from ..base import promote_path
+from ..base import glob_path, promote_path
 
 log = logging.getLogger()
 
@@ -16,10 +16,10 @@ class Runner(BaseRunner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         path_env = self.child_env["PATH"]
-        path_env = promote_path(path_env, "/opt/happy/1.19.5/bin")
-        path_env = promote_path(path_env, "/opt/alex/3.1.7/bin")
-        path_env = promote_path(path_env, "/opt/cabal/2.0/bin")
-        path_env = promote_path(path_env, "/opt/ghc/8.2.1/bin")
+        path_env = promote_path(path_env, glob_path("/opt/happy", "*/bin"))
+        path_env = promote_path(path_env, glob_path("/opt/alex", "*/bin"))
+        path_env = promote_path(path_env, glob_path("/opt/cabal", "*/bin"))
+        path_env = promote_path(path_env, glob_path("/opt/ghc", "*/bin"))
         path_env = promote_path(path_env, "/home/work/.cabal/bin")
         self.child_env["PATH"] = path_env
 

--- a/src/ai/backend/kernel/java/__init__.py
+++ b/src/ai/backend/kernel/java/__init__.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 
 from .. import BaseRunner
-from ..base import promote_path
+from ..base import glob_path, promote_path
 
 log = logging.getLogger()
 
@@ -25,13 +25,13 @@ DEFAULT_JFLAGS = [
 
 class Runner(BaseRunner):
     log_prefix = "java-kernel"
-    default_runtime_path = "/usr/lib/jvm/java-1.8-openjdk/bin/java"
+    default_runtime_path = os.fsdecode(glob_path("/usr/lib/jvm", "java-*/bin/java") or "/usr/bin")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         path_env = self.child_env["PATH"]
-        path_env = promote_path(path_env, "/usr/lib/jvm/java-1.8-openjdk/jre/bin")
-        path_env = promote_path(path_env, "/usr/lib/jvm/java-1.8-openjdk/bin")
+        path_env = promote_path(path_env, glob_path("/usr/lib/jvm", "java-*/jre/bin"))
+        path_env = promote_path(path_env, glob_path("/usr/lib/jvm", "java-*/bin"))
         self.child_env["PATH"] = path_env
 
     def _code_for_user_input_server(self, code: str) -> str:

--- a/src/ai/backend/kernel/java/__init__.py
+++ b/src/ai/backend/kernel/java/__init__.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 from .. import BaseRunner
+from ..base import promote_path
 
 log = logging.getLogger()
 
@@ -25,23 +26,13 @@ DEFAULT_JFLAGS = [
 class Runner(BaseRunner):
     log_prefix = "java-kernel"
     default_runtime_path = "/usr/lib/jvm/java-1.8-openjdk/bin/java"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": (
-            "/usr/lib/jvm/java-1.8-openjdk/jre/bin:"
-            "/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        ),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        path_env = self.child_env["PATH"]
+        path_env = promote_path(path_env, "/usr/lib/jvm/java-1.8-openjdk/jre/bin")
+        path_env = promote_path(path_env, "/usr/lib/jvm/java-1.8-openjdk/bin")
+        self.child_env["PATH"] = path_env
 
     def _code_for_user_input_server(self, code: str) -> str:
         # TODO: More elegant way of not touching user code? This method does not work

--- a/src/ai/backend/kernel/julia/__init__.py
+++ b/src/ai/backend/kernel/julia/__init__.py
@@ -1,11 +1,11 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
 import janus
 
 from .. import BaseRunner
+from ..base import promote_path
 
 log = logging.getLogger()
 
@@ -14,17 +14,8 @@ class Runner(BaseRunner):
     log_prefix = "julia-kernel"
     default_runtime_path = "/usr/local/julia"
     default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash" if Path("/bin/ash").is_file() else "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": (
-            "/usr/local/julia:/usr/local/julia/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        ),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "JULIA_LOAD_PATH": ":/opt/julia",
+        **BaseRunner.default_child_env,
+        "JULIA_LOAD_PATH": "/opt/julia:/usr/local/julia",
     }
     jupyter_kspec_name = "julia"
 
@@ -32,6 +23,12 @@ class Runner(BaseRunner):
         super().__init__(*args, **kwargs)
         self.input_queue = None
         self.output_queue = None
+        path_env = self.child_env["PATH"]
+        path_env = promote_path(path_env, "/usr/local/cuda/bin")
+        path_env = promote_path(path_env, "/usr/local/nvidia/bin")
+        path_env = promote_path(path_env, "/usr/local/julia/bin")
+        path_env = promote_path(path_env, "/opt/julia/bin")
+        self.child_env["PATH"] = path_env
 
     async def init_with_loop(self):
         self.input_queue = janus.Queue()

--- a/src/ai/backend/kernel/lua/__init__.py
+++ b/src/ai/backend/kernel/lua/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,16 +10,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "lua-kernel"
     default_runtime_path = "/usr/local/bin/lua"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/nodejs/__init__.py
+++ b/src/ai/backend/kernel/nodejs/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,16 +10,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "nodejs-kernel"
     default_runtime_path = "/usr/bin/local/node"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/octave/__init__.py
+++ b/src/ai/backend/kernel/octave/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,16 +10,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "octave-kernel"
     default_runtime_path = "/usr/bin/octave-cli"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/php/__init__.py
+++ b/src/ai/backend/kernel/php/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,17 +10,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "php-kernel"
     default_runtime_path = "/usr/bin/php"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "GOPATH": "/home/work",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/python/__init__.py
+++ b/src/ai/backend/kernel/python/__init__.py
@@ -20,27 +20,8 @@ class Runner(BaseRunner):
     log_prefix = "python-kernel"
     default_runtime_path = "/usr/bin/python"
     default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash" if Path("/bin/ash").is_file() else "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": os.environ.get(
-            "PATH",
-            ":".join(
-                [
-                    "/usr/local/sbin",
-                    "/usr/local/bin",
-                    "/usr/sbin",
-                    "/usr/bin",
-                    "/sbin",
-                    "/bin",
-                ]
-            ),
-        ),
+        **BaseRunner.default_child_env,
         "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
     }
     jupyter_kspec_name = "python"
 
@@ -68,10 +49,6 @@ class Runner(BaseRunner):
         stdout, _ = await proc.communicate()
         user_site = stdout.decode("utf8").strip()
         self.child_env["PYTHONPATH"] = promote_path(self.child_env["PYTHONPATH"], user_site)
-        path_env = self.child_env["PATH"]
-        path_env = promote_path(path_env, "/usr/local/nvidia/bin")
-        path_env = promote_path(path_env, "/usr/local/cuda/bin")
-        self.child_env["PATH"] = path_env
 
         # Add support for interactive input in batch mode by copying
         # sitecustomize.py to USER_SITE of runtime python.

--- a/src/ai/backend/kernel/r/__init__.py
+++ b/src/ai/backend/kernel/r/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -13,15 +12,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "r-kernel"
     default_runtime_path = "/usr/bin/R"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash" if Path("/bin/ash").is_file() else "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-    }
     jupyter_kspec_name = "ir"
 
     def __init__(self, *args, **kwargs):

--- a/src/ai/backend/kernel/rust/__init__.py
+++ b/src/ai/backend/kernel/rust/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 
@@ -15,17 +14,6 @@ RUSTC = "rustc"
 class Runner(BaseRunner):
     log_prefix = "rust-kernel"
     default_runtime_path = "/usr/bin/rustc"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "GOPATH": "/home/work",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/scheme/__init__.py
+++ b/src/ai/backend/kernel/scheme/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 
 from .. import BaseRunner
@@ -10,16 +9,6 @@ log = logging.getLogger()
 class Runner(BaseRunner):
     log_prefix = "scheme-kernel"
     default_runtime_path = "/usr/bin/rustc"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/ash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/kernel/vendor/h2o/__init__.py
+++ b/src/ai/backend/kernel/vendor/h2o/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import tempfile
 from pathlib import Path
 from typing import List
@@ -15,27 +14,6 @@ DEFAULT_PYFLAGS: List[str] = []
 class Runner(BaseRunner):
     log_prefix = "h2o-kernel"
     default_runtime_path = "/opt/h2oai/dai/python/bin/python"
-    default_child_env = {
-        "TERM": "xterm",
-        "LANG": "C.UTF-8",
-        "SHELL": "/bin/bash",
-        "USER": "work",
-        "HOME": "/home/work",
-        "PATH": ":".join(
-            [
-                "/usr/local/nvidia/bin",
-                "/usr/local/cuda/bin",
-                "/usr/local/sbin",
-                "/usr/local/bin",
-                "/usr/sbin",
-                "/usr/bin",
-                "/sbin",
-                "/bin",
-            ]
-        ),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "LD_PRELOAD": os.environ.get("LD_PRELOAD", ""),
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -102,12 +102,12 @@ else
 
   # Start ssh-agent if it is available
   if command -v ssh-agent > /dev/null; then
-    AGENT_ENVIRONMENT_PATH="/home/work/ssh-agent.env"
+    SSH_ENV_PATH="/home/work/ssh-agent.env"
 
-    /opt/kernel/su-exec $USER_ID:$GROUP_ID ssh-agent > $AGENT_ENVIRONMENT_PATH
-    chmod +x $AGENT_ENVIRONMENT_PATH
-    . $AGENT_ENVIRONMENT_PATH
-    rm $AGENT_ENVIRONMENT_PATH
+    /opt/kernel/su-exec $USER_ID:$GROUP_ID ssh-agent > $SSH_ENV_PATH
+    chmod +x $SSH_ENV_PATH
+    . $SSH_ENV_PATH
+    rm $SSH_ENV_PATH
 
     setsid ssh-add /home/work/.ssh/id_rsa < /dev/null
   fi

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -102,13 +102,7 @@ else
 
   # Start ssh-agent if it is available
   if command -v ssh-agent > /dev/null; then
-    SSH_ENV_PATH="/home/work/ssh-agent.env"
-
-    /opt/kernel/su-exec $USER_ID:$GROUP_ID ssh-agent > $SSH_ENV_PATH
-    chmod +x $SSH_ENV_PATH
-    . $SSH_ENV_PATH
-    rm $SSH_ENV_PATH
-
+    eval "$(/opt/kernel/su-exec $USER_ID:$GROUP_ID ssh-agent)"
     setsid ssh-add /home/work/.ssh/id_rsa < /dev/null
   fi
 

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -102,7 +102,13 @@ else
 
   # Start ssh-agent if it is available
   if command -v ssh-agent > /dev/null; then
-    eval "$(ssh-agent -s)"
+    AGENT_ENVIRONMENT_PATH="/home/work/ssh-agent.env"
+
+    /opt/kernel/su-exec $USER_ID:$GROUP_ID ssh-agent > $AGENT_ENVIRONMENT_PATH
+    chmod +x $AGENT_ENVIRONMENT_PATH
+    . $AGENT_ENVIRONMENT_PATH
+    rm $AGENT_ENVIRONMENT_PATH
+
     setsid ssh-add /home/work/.ssh/id_rsa < /dev/null
   fi
 


### PR DESCRIPTION
Fixes https://github.com/lablup/giftbox/issues/216.

When `$USER_ID` is not 0 (root account), `ssh-agent` must run through the user account (`/home/work`).

This PR accomplish this by using `su-exec`.

## Test

Tested manually.

<img width="567" alt="테스트" src="https://user-images.githubusercontent.com/18283033/223640037-fd6effcf-b3f8-4c11-a9d7-8e392e2be11d.png">



