### PR TITLE
feat: add `force_2FA` config on webserver

### DIFF
--- a/changes/1161.feature.md
+++ b/changes/1161.feature.md
@@ -1,0 +1,1 @@
+Add a `force_2FA` option to force the use of 2-Factor-Authenticaiton.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -49,6 +49,8 @@ mask_user_info = false
 # app_download_url = ""
 # Enable/disable 2-Factor-Authentication (TOTP).
 enable_2FA = false
+# Force enable 2-Factor-Authentication (TOTP).
+force_2FA = false
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -52,6 +52,7 @@ config_iv = t.Dict(
                 t.Key("hide_agents", default=True): t.ToBool,
                 t.Key("app_download_url", default=""): t.String(allow_blank=True),
                 t.Key("enable_2FA", default=False): t.ToBool(),
+                t.Key("force_2FA", default=False): t.ToBool(),
             }
         ).allow_extra("*"),
         t.Key("resources"): t.Dict(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -21,6 +21,7 @@ connectionMode = "SESSION"
 {% toml_field "hideAgents" config["service"]["hide_agents"] %}
 {% toml_field "appDownloadUrl" config["service"]["app_download_url"] %}
 {% toml_field "enable2FA" config["service"]["enable_2FA"] %}
+{% toml_field "force_2FA" config["service"]["force_2FA"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -21,7 +21,7 @@ connectionMode = "SESSION"
 {% toml_field "hideAgents" config["service"]["hide_agents"] %}
 {% toml_field "appDownloadUrl" config["service"]["app_download_url"] %}
 {% toml_field "enable2FA" config["service"]["enable_2FA"] %}
-{% toml_field "force_2FA" config["service"]["force_2FA"] %}
+{% toml_field "force2FA" config["service"]["force_2FA"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
- Add `force_2FA` option to compose the corresponding WebUI config
- resolves [Add an option to enforce users 2FA#261](https://github.com/lablup/giftbox/issues/261)
- related PR: https://github.com/lablup/backend.ai-webui/pull/1628
