### PR TITLE
feat: use `full_name` instead of `username` on certain queries

### DIFF
--- a/changes/1167.feature.md
+++ b/changes/1167.feature.md
@@ -1,0 +1,1 @@
+Replace `username` in the `compute_session` (and `compute_session_list`) GQL query with `full_name` and expose `full_name` to `get_container_stats_for_period` so that administrators can easily recognize users.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -339,6 +339,7 @@ async def get_container_stats_for_period(
                     kernels.c.cluster_mode,
                     groups.c.name,
                     users.c.email,
+                    users.c.full_name,
                 ]
             )
             .select_from(j)
@@ -419,6 +420,7 @@ async def get_container_stats_for_period(
             "name": row["session_name"],
             "access_key": row["access_key"],
             "email": row["email"],
+            "full_name": row["full_name"],
             "agent": row["agent"],
             "cpu_allocated": float(row.occupied_slots.get("cpu", 0)),
             "cpu_used": float(nmget(last_stat, "cpu_used.current", 0)),

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -1055,7 +1055,7 @@ class ComputeSession(graphene.ObjectType):
     group_name = graphene.String()
     group_id = graphene.UUID()
     user_email = graphene.String()
-    user_name = graphene.String()
+    full_name = graphene.String()
     user_id = graphene.UUID()
     access_key = graphene.String()
     created_user_email = graphene.String()
@@ -1097,7 +1097,7 @@ class ComputeSession(graphene.ObjectType):
     def parse_row(cls, ctx: GraphQueryContext, row: Row) -> Mapping[str, Any]:
         assert row is not None
         email = getattr(row, "email")
-        user_name = getattr(row, "username")
+        full_name = getattr(row, "full_name")
         group_name = getattr(row, "group_name")
         row = row.SessionRow
         return {
@@ -1121,7 +1121,7 @@ class ComputeSession(graphene.ObjectType):
             "group_name": group_name,
             "group_id": row.group_id,
             "user_email": email,
-            "user_name": user_name,
+            "full_name": full_name,
             "user_id": row.user_uuid,
             "access_key": row.access_key,
             "created_user_email": None,  # TODO: implement
@@ -1227,7 +1227,7 @@ class ComputeSession(graphene.ObjectType):
         "domain_name": ("sessions_domain_name", None),
         "group_name": ("groups_name", None),
         "user_email": ("users_email", None),
-        "user_name": ("users_username", None),
+        "full_name": ("users_full_name", None),
         "access_key": ("sessions_access_key", None),
         "scaling_group": ("sessions_scaling_group_name", None),
         "cluster_mode": ("sessions_cluster_mode", lambda s: ClusterMode[s]),
@@ -1251,7 +1251,7 @@ class ComputeSession(graphene.ObjectType):
         "domain_name": "sessions_domain_name",
         "group_name": "groups_name",
         "user_email": "users_email",
-        "user_name": "users_username",
+        "full_name": "users_full_name",
         "access_key": "sessions_access_key",
         "scaling_group": "sessions_scaling_group_name",
         "cluster_mode": "sessions_cluster_mode",
@@ -1327,7 +1327,7 @@ class ComputeSession(graphene.ObjectType):
                 SessionRow,
                 GroupRow.name.label("group_name"),
                 UserRow.email,
-                UserRow.username,
+                UserRow.full_name,
             )
             .select_from(j)
             .options(selectinload(SessionRow.kernels))
@@ -1370,7 +1370,7 @@ class ComputeSession(graphene.ObjectType):
                 SessionRow,
                 GroupRow.name.label("group_name"),
                 UserRow.email,
-                UserRow.username,
+                UserRow.full_name,
             )
             .select_from(j)
             .where(SessionRow.id.in_(session_ids))


### PR DESCRIPTION
- Add `full_name` instead of `username` to `ComputeSession`.
- Add `full_name` to `get_container_stats_for_period`.
- Admins have struggled with recognizing the user using the email. But for now, by this PR, admins can recognize the user easily.
- related PR: https://github.com/lablup/backend.ai-control-panel/pull/576
- follows https://github.com/lablup/backend.ai/pull/1149