### PR TITLE
feature: Manage session status in registry during session creation

### DIFF
--- a/changes/1171.feature.md
+++ b/changes/1171.feature.md
@@ -1,0 +1,1 @@
+Manage session status change during session creation in registry to reduce too many DB lock.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1501,7 +1501,7 @@ class AbstractAgent(
         async with throttle_sema:
             if not restarting:
                 await self.produce_event(
-                    KernelPreparingEvent(kernel_id),
+                    KernelPreparingEvent(kernel_id, session_id),
                 )
 
             # Initialize the creation context
@@ -1541,13 +1541,13 @@ class AbstractAgent(
             )
             if do_pull:
                 await self.produce_event(
-                    KernelPullingEvent(kernel_id, ctx.image_ref.canonical),
+                    KernelPullingEvent(kernel_id, session_id, ctx.image_ref.canonical),
                 )
                 await self.pull_image(ctx.image_ref, kernel_config["image"]["registry"])
 
             if not restarting:
                 await self.produce_event(
-                    KernelCreatingEvent(kernel_id),
+                    KernelCreatingEvent(kernel_id, session_id),
                 )
 
             # Get the resource spec from existing kernel scratches
@@ -1855,6 +1855,7 @@ class AbstractAgent(
             await self.produce_event(
                 KernelStartedEvent(
                     kernel_id,
+                    session_id,
                     creation_info={
                         **kernel_creation_info,
                         "id": str(KernelId(kernel_id)),

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -228,12 +228,14 @@ class KernelLifecycleEventReason(str, enum.Enum):
 @attrs.define(slots=True, frozen=True)
 class KernelCreationEventArgs:
     kernel_id: KernelId = attrs.field()
+    session_id: SessionId = attrs.field()
     reason: str = attrs.field(default="")
     creation_info: Mapping[str, Any] = attrs.field(factory=dict)
 
     def serialize(self) -> tuple:
         return (
             str(self.kernel_id),
+            str(self.session_id),
             self.reason,
             self.creation_info,
         )
@@ -242,8 +244,9 @@ class KernelCreationEventArgs:
     def deserialize(cls, value: tuple):
         return cls(
             kernel_id=KernelId(uuid.UUID(value[0])),
-            reason=value[1],
-            creation_info=value[2],
+            session_id=SessionId(uuid.UUID(value[1])),
+            reason=value[2],
+            creation_info=value[3],
         )
 
 


### PR DESCRIPTION
To reduce DB hits and DB locks during session creation, save session statuses into `session_creation_tracker` in manager registry.
```
session_creation_tracker = {
  <session_id_1> : SessionCache(
    session_id_1,
    kernels, # a map of KernelCache
   start_event, # asyncio.Event, to announce session is running.
  )
}
```