### PR TITLE
feat: add `allow_preferred_port` config on webserver

### DIFF
--- a/changes/1178.feature.md
+++ b/changes/1178.feature.md
@@ -1,0 +1,1 @@
+Add a `allow_preferred_port` config on webserver to hide/show Try preferred port.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -56,6 +56,9 @@ force_2FA = false
 # Display "Open port to public" checkbox in the app launcher.
 # If checked, the app will be accessible by anyone who has network to the URL.
 open_port_to_public = false
+# Display "Try preferred port" checkbox in the app launcher.
+# If checked and enter a specific port number, Backend.AI try to assign the entered port number first for the web service.
+allow_preferred_port = false
 # Maximum CPU cores allowed per container (int)
 max_cpu_cores_per_container = 64
 # Maximum memory allowed per container (int)

--- a/docs/install/install-from-package/install-webserver.rst
+++ b/docs/install/install-from-package/install-webserver.rst
@@ -52,6 +52,7 @@ would be:
 
    [resources]
    open_port_to_public = false
+   allow_preferred_port = false
    max_cpu_cores_per_container = 255
    max_memory_per_container = 1000
    max_cuda_devices_per_container = 8

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -58,6 +58,7 @@ config_iv = t.Dict(
         t.Key("resources"): t.Dict(
             {
                 t.Key("open_port_to_public", default=False): t.ToBool,
+                t.Key("allow_preferred_port", default=False): t.ToBool,
                 t.Key("max_cpu_cores_per_container", default=64): t.ToInt,
                 t.Key("max_memory_per_container", default=64): t.ToInt,
                 t.Key("max_cuda_devices_per_container", default=16): t.ToInt,

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -25,6 +25,7 @@ connectionMode = "SESSION"
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}
+{% toml_field "allowPreferredPort" config["resources"]["allow_preferred_port"] %}
 {% toml_field "maxCPUCoresPerContainer" config["resources"]["max_cpu_cores_per_container"] %}
 {% toml_field "maxMemoryPerContainer" config["resources"]["max_memory_per_container"] %}
 {% toml_field "maxCUDADevicesPerContainer" config["resources"]["max_cuda_devices_per_container"] %}


### PR DESCRIPTION
To hide/show `Try preferred port` on the app dialog (WebUI), I added `allow_preferred_port` option on webserver
related: https://github.com/lablup/giftbox/issues/268