### PR TITLE
fix: pending timeout cancellation failing for PENDING session

### DIFF
--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -612,9 +612,6 @@ class SessionRow(Base):
         nullable=False,
         index=True,
     )
-    # status_changed = sa.Column(
-    #     "status_changed", sa.DateTime(timezone=True), nullable=True, index=True
-    # )
     status_info = sa.Column("status_info", sa.Unicode(), nullable=True, default=sa.null())
 
     status_data = sa.Column("status_data", pgsql.JSONB(), nullable=True, default=sa.null())

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -47,7 +47,6 @@ from ..models import (
     ScalingGroupRow,
     SessionRow,
     SessionStatus,
-    kernels,
     list_schedulable_agents_by_sgroup,
     recalc_agent_resource_occupancy,
     recalc_concurrency_used,
@@ -281,11 +280,10 @@ class SchedulerDispatcher(aobject):
                         sa.update(SessionRow)
                         .values(
                             status=SessionStatus.CANCELLED,
-                            status_changed=now,
                             status_info="pending-timeout",
                             terminated_at=now,
                             status_history=sql_json_merge(
-                                kernels.c.status_history,
+                                SessionRow.status_history,
                                 (),
                                 {
                                     SessionStatus.CANCELLED.name: now.isoformat(),


### PR DESCRIPTION
After #576 , `status_changed` column is removed but session cancellation in scheduler still fetch an update statement to update `status_changed` column and wrong `status_history` value.