### PR TITLE
feat: add API for changing vfolder ownership

### DIFF
--- a/changes/1182.feature.md
+++ b/changes/1182.feature.md
@@ -1,0 +1,1 @@
+Support to change the owner of (user) vfolder to only among users with an access to the vfolder's storage host

--- a/src/ai/backend/client/cli/admin/vfolder.py
+++ b/src/ai/backend/client/cli/admin/vfolder.py
@@ -377,3 +377,24 @@ def remove_shared_vf_permission(vfolder_id, user_id):
             print_error(e)
             sys.exit(ExitCode.FAILURE)
         print(resp)
+
+
+@vfolder.command()
+@click.argument("vfolder_id", type=str)
+@click.argument("user_id", type=str)
+def change_vfolder_ownership(vfolder_id, user_id):
+    """
+    Change the ownership of vfolder
+
+    \b
+    VFOLDER_ID: ID of a virtual folder.
+    USER_ID: ID of user to have the ownership of current vfolder
+    """
+    with Session() as session:
+        try:
+            resp = session.VFolder.change_vfolder_ownership(vfolder_id, user_id)
+            print(f"Now ownership of VFolder:{vfolder_id} goes to User:{user_id}")
+        except Exception as e:
+            print_error(e)
+            sys.exit(ExitCode.FAILURE)
+        print(resp)

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -625,7 +625,7 @@ class VFolder(BaseFunction):
     @api_function
     @classmethod
     async def change_vfolder_ownership(cls, vfolder: str, user: str):
-        rqst = Request("POST", "/folders/_/change_ownership")
+        rqst = Request("POST", "/folders/_/change-ownership")
         rqst.set_json(
             {
                 "vfolder": vfolder,

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -633,4 +633,4 @@ class VFolder(BaseFunction):
             }
         )
         async with rqst.fetch() as resp:
-            return await resp.json()
+            return await resp.text()

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -633,4 +633,4 @@ class VFolder(BaseFunction):
             }
         )
         async with rqst.fetch() as resp:
-            return await resp.text()
+            return await resp.json()

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -621,3 +621,16 @@ class VFolder(BaseFunction):
         )
         async with rqst.fetch() as resp:
             return await resp.json()
+
+    @api_function
+    @classmethod
+    async def change_vfolder_ownership(cls, vfolder: str, user: str):
+        rqst = Request("POST", "/folders/_/change_ownership")
+        rqst.set_json(
+            {
+                "vfolder": vfolder,
+                "user": user,
+            }
+        )
+        async with rqst.fetch() as resp:
+            return await resp.json()

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3008,7 +3008,7 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
 
     # TODO: Implement Change ownership using DB transaction
     log.info(
-        "VFOLDER.CHANGE_VFOLDER_OWNERSHIP(emial:{}, ak:{}, vfid:{}, uid:{})",
+        "VFOLDER.CHANGE_VFOLDER_OWNERSHIP(email:{}, ak:{}, vfid:{}, uid:{})",
         request["user"]["email"],
         access_key,
         vfolder_id,

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -48,6 +48,7 @@ from ..models import (
     AgentStatus,
     KernelStatus,
     UserRole,
+    UserStatus,
     VFolderAccessStatus,
     VFolderCloneInfo,
     VFolderDeletionInfo,
@@ -3021,7 +3022,7 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
         query = (
             sa.select([users.c.email, users.c.domain_name, keypairs.c.resource_policy])
             .select_from(j)
-            .where(users.c.uuid == user_uuid & users.c.status == users.UserStatus.ACTIVE)
+            .where(users.c.uuid == user_uuid & users.c.status == UserStatus.ACTIVE)
         )
         try:
             result = await conn.execute(query)

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3127,7 +3127,7 @@ def create_app(default_cors_options):
     cors.add(add_route("GET", r"/_/mounts", list_mounts))
     cors.add(add_route("POST", r"/_/mounts", mount_host))
     cors.add(add_route("DELETE", r"/_/mounts", umount_host))
-    cors.add(add_route("POST", r"/_/change_ownership", change_vfolder_ownership))
+    cors.add(add_route("POST", r"/_/change-ownership", change_vfolder_ownership))
     cors.add(add_route("GET", r"/_/quota", get_quota))
     cors.add(add_route("POST", r"/_/quota", update_quota))
     cors.add(add_route("GET", r"/_/usage", get_usage))

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3070,7 +3070,7 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
 
     await execute_with_retry(_update)
 
-    return web.Response(status=200)
+    return web.json_response({}, status=200)
 
 
 @attrs.define(slots=True, auto_attribs=True, init=False)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR partially resolves #408.

FYI: 
- Support changing the `owner` of vfolder, not `creator`.
- Support only users who can access the same storage host that vfolder is located. (It will be expanded in phase 2)
- Support changing `user` type of vfolder, not `group(project)` type. (This also will be implemented in phase 2)