### PR TITLE
feat: update utilization based idle checker policy

### DIFF
--- a/changes/1185.feature.md
+++ b/changes/1185.feature.md
@@ -1,0 +1,1 @@
+Add possible expire time of utilization checker to idle check result.

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -87,7 +87,6 @@ from ai.backend.common.plugin.monitor import GAUGE
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
-    BinarySize,
     ClusterMode,
     KernelEnqueueingConfig,
     KernelId,
@@ -2025,11 +2024,7 @@ async def get_info(request: web.Request) -> web.Response:
 
         resp["numQueriesExecuted"] = sess.num_queries
         resp["lastStat"] = sess.last_stat
-        idle_report = await root_ctx.idle_checker_host.get_idle_check_report(sess.id)
-        avg_utils = idle_report["utilization"]
-        if avg_utils is not None and "mem" in avg_utils:
-            avg_utils["mem"] = BinarySize.from_str(str(int(avg_utils["mem"])))
-        resp["idleChecks"] = idle_report
+        resp["idleChecks"] = await root_ctx.idle_checker_host.get_idle_check_report(sess.id)
 
         # Resource limits collected from agent heartbeats were erased, as they were deprecated
         # TODO: factor out policy/image info as a common repository

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -78,16 +78,10 @@ class IdleCheckerError(TaskGroupError):
     """
 
 
-RESOURCE_UNIT_MAP = {
-    "mem": lambda v: BinarySize(int(v)),
-    "cuda_mem": lambda v: BinarySize(int(v)),
-}
-
-
 def parse_unit(resource_name: str, value: float | int) -> float | int:
-    if (func := RESOURCE_UNIT_MAP.get(resource_name)) is not None:
-        return func(value)
-    return value
+    if resource_name.find("mem") == -1:
+        return value
+    return BinarySize(int(value))
 
 
 class UtilizationExtraInfo(NamedTuple):

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    Optional,
     Sequence,
     Set,
     Type,
@@ -243,15 +244,17 @@ class IdleCheckerHost:
     async def get_idle_check_report(
         self,
         session_id: SessionId,
-    ) -> Mapping[str, Any]:
-        report = {
+    ) -> dict[str, Any]:
+        report: dict[str, Any] = {
             "timeout": None,
             "session_lifetime": None,
             "utilization": None,
         }
         for checker in self._checkers:
-            result = await checker.get_checker_result(self._redis_live, session_id)
-            report[checker.report_key] = result
+            report[checker.report_key] = await checker.get_checker_result(
+                self._redis_live, session_id
+            )
+            report[checker.extra_info_key] = await checker.get_extra_info(session_id)
         return report
 
 
@@ -259,6 +262,7 @@ class BaseIdleChecker(metaclass=ABCMeta):
     terminate_reason: KernelLifecycleEventReason
     name: ClassVar[str] = "base"
     report_key: ClassVar[str] = "base"
+    extra_info_key: ClassVar[str] = "base_extra"
 
     def __init__(
         self,
@@ -289,6 +293,10 @@ class BaseIdleChecker(metaclass=ABCMeta):
         return f"session.{session_id}.{cls.name}.report"
 
     @abstractmethod
+    async def get_extra_info(self, session_id: SessionId) -> Optional[dict[str, Any]]:
+        return None
+
+    @abstractmethod
     async def check_idleness(
         self, kernel: Row, dbconn: SAConnection, policy: Row, redis_obj: RedisConnectionInfo
     ) -> bool:
@@ -303,7 +311,7 @@ class BaseIdleChecker(metaclass=ABCMeta):
         self,
         redis_obj: RedisConnectionInfo,
         session_id: SessionId,
-    ) -> Any:
+    ) -> Optional[float]:
         """
         Get check result of the given session.
         """
@@ -320,6 +328,7 @@ class TimeoutIdleChecker(BaseIdleChecker):
     terminate_reason: KernelLifecycleEventReason = KernelLifecycleEventReason.IDLE_TIMEOUT
     name: ClassVar[str] = "timeout"
     report_key: ClassVar[str] = "timeout"
+    extra_info_key: ClassVar[str] = "timeout_extra"
 
     _config_iv = t.Dict(
         {
@@ -416,6 +425,9 @@ class TimeoutIdleChecker(BaseIdleChecker):
     ) -> None:
         await self._update_timeout(event.session_id)
 
+    async def get_extra_info(self, session_id: SessionId) -> Optional[dict[str, Any]]:
+        return None
+
     async def check_idleness(
         self, kernel: Row, dbconn: SAConnection, policy: Row, redis_obj: RedisConnectionInfo
     ) -> bool:
@@ -471,7 +483,7 @@ class TimeoutIdleChecker(BaseIdleChecker):
         self,
         redis_obj: RedisConnectionInfo,
         session_id: SessionId,
-    ) -> Any:
+    ) -> Optional[float]:
         key = self.get_report_key(session_id)
         data = await redis_helper.execute(redis_obj, lambda r: r.get(key))
         return msgpack.unpackb(data) if data is not None else None
@@ -481,9 +493,13 @@ class SessionLifetimeChecker(BaseIdleChecker):
     terminate_reason: KernelLifecycleEventReason = KernelLifecycleEventReason.IDLE_SESSION_LIFETIME
     name: ClassVar[str] = "session_lifetime"
     report_key: ClassVar[str] = "session_lifetime"
+    extra_info_key: ClassVar[str] = "session_lifetime_extra"
 
     async def populate_config(self, config: Mapping[str, Any]) -> None:
         pass
+
+    async def get_extra_info(self, session_id: SessionId) -> Optional[dict[str, Any]]:
+        return None
 
     async def check_idleness(
         self, kernel: Row, dbconn: SAConnection, policy: Row, redis_obj: RedisConnectionInfo
@@ -517,7 +533,7 @@ class SessionLifetimeChecker(BaseIdleChecker):
         self,
         redis_obj: RedisConnectionInfo,
         session_id: SessionId,
-    ) -> Any:
+    ) -> Optional[float]:
         key = self.get_report_key(session_id)
         data = await redis_helper.execute(redis_obj, lambda r: r.get(key))
         return msgpack.unpackb(data) if data is not None else None
@@ -531,6 +547,7 @@ class UtilizationIdleChecker(BaseIdleChecker):
     terminate_reason: KernelLifecycleEventReason = KernelLifecycleEventReason.IDLE_UTILIZATION
     name: ClassVar[str] = "utilization"
     report_key: ClassVar[str] = "utilization"
+    extra_info_key: ClassVar[str] = "utilization_extra"
 
     _config_iv = t.Dict(
         {
@@ -589,17 +606,49 @@ class UtilizationIdleChecker(BaseIdleChecker):
             f"time-window({self.time_window.total_seconds()}s)",
         )
 
-    async def _report_redis(
-        self, redis_obj: RedisConnectionInfo, session_id: SessionId, avg_utils: dict[str, float]
-    ) -> None:
+    def get_extra_info_key(self, session_id: SessionId) -> str:
+        return f"session.{session_id}.{self.extra_info_key}"
+
+    async def get_extra_info(self, session_id: SessionId) -> Optional[dict[str, Any]]:
+        data = await redis_helper.execute(
+            self._redis_live,
+            lambda r: r.get(
+                self.get_extra_info_key(session_id),
+            ),
+        )
+        return msgpack.unpackb(data) if data is not None else None
+
+    async def report_expire_time(self, policy: Row, session_id: SessionId) -> None:
+        expire_time = await self.get_expire_time(policy, session_id)
         await redis_helper.execute(
-            redis_obj,
+            self._redis_live,
             lambda r: r.set(
                 self.get_report_key(session_id),
-                msgpack.packb(avg_utils),
+                msgpack.packb(expire_time),
                 ex=int(DEFAULT_CHECK_INTERVAL) * 10,
             ),
         )
+
+    def get_timeout(self, policy: Row) -> float:
+        if (idle_timeout := policy["idle_timeout"]) > 0:
+            return float(idle_timeout)
+        return self.time_window.total_seconds()
+
+    def get_last_collected_key(self, session_id: SessionId) -> str:
+        return f"session.{session_id}.util_last_collected"
+
+    async def get_expire_time(self, policy: Row, session_id: SessionId) -> float:
+        timeout = self.get_timeout(policy)
+        t = await redis_helper.execute(self._redis_live, lambda r: r.time())
+        now = t[0] + (t[1] / (10**6))
+        raw_util_last_collected = await redis_helper.execute(
+            self._redis_live,
+            lambda r: r.get(self.get_last_collected_key(session_id)),
+        )
+        util_last_collected: float = (
+            float(raw_util_last_collected) if raw_util_last_collected else 0
+        )
+        return timeout - (now - util_last_collected)
 
     async def check_idleness(
         self, kernel: Row, dbconn: SAConnection, policy: Row, redis_obj: RedisConnectionInfo
@@ -611,22 +660,24 @@ class UtilizationIdleChecker(BaseIdleChecker):
         session_id = kernel["session_id"]
 
         interval = IdleCheckerHost.check_interval
-        window_size = int(self.time_window.total_seconds() / interval)
+        time_window = self.time_window.total_seconds()
         occupied_slots = kernel["occupied_slots"]
         unavailable_resources: Set[str] = set()
 
         util_series_key = f"session.{session_id}.util_series"
-        util_last_collected_key = f"session.{session_id}.util_last_collected"
+        util_last_collected_key = self.get_last_collected_key(session_id)
 
         # Wait until the time "interval" is passed after the last udpated time.
         t = await redis_helper.execute(self._redis_live, lambda r: r.time())
-        t = t[0] + (t[1] / (10**6))
+        util_now: float = t[0] + (t[1] / (10**6))
         raw_util_last_collected = await redis_helper.execute(
             self._redis_live,
             lambda r: r.get(util_last_collected_key),
         )
-        util_last_collected = float(raw_util_last_collected) if raw_util_last_collected else 0
-        if t - util_last_collected < interval:
+        util_last_collected: float = (
+            float(raw_util_last_collected) if raw_util_last_collected else 0.0
+        )
+        if util_now - util_last_collected < interval:
             return True
 
         # Respect initial grace period (no termination of the session)
@@ -647,28 +698,11 @@ class UtilizationIdleChecker(BaseIdleChecker):
             if unique_res_map[slot] == 0:
                 unavailable_resources.update(self.slot_resource_map[slot])
 
-        raw_util_series = await redis_helper.execute(
-            self._redis_live, lambda r: r.get(util_series_key)
-        )
-
-        try:
-            util_series = msgpack.unpackb(raw_util_series, use_list=True)
-        except TypeError:
-            util_series = {k: [] for k in self.resource_thresholds.keys()}
-
-        def _avg(util_list: list[float]) -> float:
-            try:
-                return sum(util_list) / len(util_list)
-            except ZeroDivisionError:
-                return 0.0
-
-        avg_utils = {k: _avg(v) for k, v in util_series.items()}
-
         # Respect idle_timeout, from keypair resource policy, over time_window.
-        if policy["idle_timeout"] >= 0:
-            window_size = int(float(policy["idle_timeout"]) / interval)
+        time_window = float(policy["idle_timeout"]) if policy["idle_timeout"] >= 0 else time_window
+        window_size = int(time_window / interval)
         if (window_size <= 0) or (math.isinf(window_size) and window_size > 0):
-            await self._report_redis(redis_obj, session_id, avg_utils)
+            await self.report_expire_time(policy, session_id)
             return True
 
         # Get current utilization data from all containers of the session.
@@ -682,10 +716,19 @@ class UtilizationIdleChecker(BaseIdleChecker):
             kernel_ids = [kernel["id"]]
         current_utilizations = await self.get_current_utilization(kernel_ids, occupied_slots)
         if current_utilizations is None:
-            await self._report_redis(redis_obj, session_id, avg_utils)
+            await self.report_expire_time(policy, session_id)
             return True
 
         # Update utilization time-series data.
+        raw_util_series = await redis_helper.execute(
+            self._redis_live, lambda r: r.get(util_series_key)
+        )
+
+        try:
+            util_series: dict[str, list[float]] = msgpack.unpackb(raw_util_series, use_list=True)
+        except TypeError:
+            util_series = {k: [] for k in self.resource_thresholds.keys()}
+
         not_enough_data = False
 
         for k in util_series:
@@ -711,17 +754,33 @@ class UtilizationIdleChecker(BaseIdleChecker):
             ),
         )
 
-        if not_enough_data:
-            await self._report_redis(redis_obj, session_id, avg_utils)
-            return True
+        def _avg(util_list: list[float]) -> float:
+            try:
+                return sum(util_list) / len(util_list)
+            except ZeroDivisionError:
+                return 0.0
 
-        # Check over-utilized (not to be collected) resources.
-        sufficiently_utilized = {
-            k: (float(avg_utils[k]) >= float(threshold))
+        avg_utils: Mapping[str, float] = {k: _avg(v) for k, v in util_series.items()}
+        exceeding_utils: Mapping[str, float] = {
+            k: (float(avg_utils[k]) - float(threshold))
             for k, threshold in self.resource_thresholds.items()
             if (threshold is not None) and (k not in unavailable_resources)
         }
+        await redis_helper.execute(
+            self._redis_live,
+            lambda r: r.set(
+                self.get_extra_info_key(session_id),
+                msgpack.packb(exceeding_utils),
+                ex=int(DEFAULT_CHECK_INTERVAL) * 10,
+            ),
+        )
 
+        if not_enough_data:
+            await self.report_expire_time(policy, session_id)
+            return True
+
+        # Check over-utilized (not to be collected) resources.
+        sufficiently_utilized: Mapping[str, bool] = {k: v >= 0 for k, v in exceeding_utils.items()}
         check_result = True
         if len(sufficiently_utilized) < 1:
             check_result = True
@@ -736,7 +795,15 @@ class UtilizationIdleChecker(BaseIdleChecker):
                 avg_utils,
                 self.thresholds_check_operator,
             )
-        await self._report_redis(redis_obj, session_id, avg_utils)
+        else:
+            await redis_helper.execute(
+                redis_obj,
+                lambda r: r.set(
+                    self.get_report_key(session_id),
+                    msgpack.packb(self.get_timeout(policy)),
+                    ex=int(DEFAULT_CHECK_INTERVAL) * 10,
+                ),
+            )
         return check_result
 
     async def get_current_utilization(
@@ -786,7 +853,7 @@ class UtilizationIdleChecker(BaseIdleChecker):
         self,
         redis_obj: RedisConnectionInfo,
         session_id: SessionId,
-    ) -> Any:
+    ) -> Optional[float]:
         key = self.get_report_key(session_id)
         data = await redis_helper.execute(redis_obj, lambda r: r.get(key))
         return msgpack.unpackb(data) if data is not None else None
@@ -818,6 +885,7 @@ async def init_idle_checkers(
     enabled_checkers = await shared_config.etcd.get("config/idle/enabled")
     if enabled_checkers:
         for checker_name in enabled_checkers.split(","):
+            checker_name = checker_name.strip()
             checker_cls = checker_registry.get(checker_name, None)
             if checker_cls is None:
                 log.warning("ignoring an unknown idle checker name: {}", checker_name)

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm import noload, relationship, selectinload
 
 from ai.backend.common.types import (
     AccessKey,
-    BinarySize,
     ClusterMode,
     ResourceSlot,
     SessionId,
@@ -1232,11 +1231,7 @@ class ComputeSession(graphene.ObjectType):
 
     async def resolve_idle_checks(self, info: graphene.ResolveInfo) -> Mapping[str, Any]:
         graph_ctx: GraphQueryContext = info.context
-        idle_report = await graph_ctx.idle_checker_host.get_idle_check_report(self.session_id)
-        avg_utils = idle_report["utilization"]
-        if avg_utils is not None and "mem" in avg_utils:
-            avg_utils["mem"] = BinarySize.from_str(str(int(avg_utils["mem"])))
-        return idle_report
+        return await graph_ctx.idle_checker_host.get_idle_check_report(self.session_id)
 
     _queryfilter_fieldspec = {
         "id": ("sessions_id", None),


### PR DESCRIPTION
follow up #1160 

Update utilization idle checker's policy

## Utilization expire time policy
- If the time window is infinite or zero, expire time is always `None`
- if the kernel's running time is shorter than initial grace period, expire time is  (initial grace period + time window size - (now - kernel creation time))
```
if now - kernel["created_at"] <= self.initial_grace_period + window_size)
-> expire_time = self.initial_grace_period + window_size - (now - kernel["created_at"])
```
- else, expire time is `None`.

Plus, the `utilization_extra` key of response has data like below
```
{
  <RESOURCE_NAME_1> : [average_utilization, threshold],
  <RESOURCE_NAME_2> : [average_utilization, threshold],
  ...
}
```
