### PR TITLE
fix: delete permissions and invitation rows of transferred vFolder

### DIFF
--- a/changes/1186.fix.md
+++ b/changes/1186.fix.md
@@ -1,0 +1,1 @@
+Add delete transactions vfolder_invitations and vfolder_permissions table when new owner and invitee of vfolder are same

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3070,27 +3070,22 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
 
     await execute_with_retry(_update)
 
-    # delete vfolder_invitation if the new owner user has already been shared with the vfolder
-    async def _delete_vfolder_invitations() -> None:
+    async def _delete_vfolder_related_rows() -> None:
         async with root_ctx.db.begin() as conn:
+            # delete vfolder_invitation if the new owner user has already been shared with the vfolder
             query = sa.delete(vfolder_invitations).where(
                 (vfolder_invitations.c.invitee == user_info.email)
                 & (vfolder_invitations.c.vfolder == vfolder_id)
             )
             await conn.execute(query)
-
-    await execute_with_retry(_delete_vfolder_invitations)
-
-    # delete vfolder_permission if the new owner user has already been shared with the vfolder
-    async def _delete_vfolder_permissions() -> None:
-        async with root_ctx.db.begin() as conn:
+            # delete vfolder_permission if the new owner user has already been shared with the vfolder
             query = sa.delete(vfolder_permissions).where(
                 (vfolder_permissions.c.vfolder == vfolder_id)
                 & (vfolder_permissions.c.user == user_uuid)
             )
             await conn.execute(query)
 
-    await execute_with_retry(_delete_vfolder_permissions)
+    await execute_with_retry(_delete_vfolder_related_rows)
 
     return web.json_response({}, status=200)
 

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3070,6 +3070,28 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
 
     await execute_with_retry(_update)
 
+    # delete vfolder_invitation if the new owner user has already been shared with the vfolder
+    async def _delete_vfolder_invitations() -> None:
+        async with root_ctx.db.begin() as conn:
+            query = sa.delete(vfolder_invitations).where(
+                (vfolder_invitations.c.invitee == user_info.email)
+                & (vfolder_invitations.c.vfolder == vfolder_id)
+            )
+            await conn.execute(query)
+
+    await execute_with_retry(_delete_vfolder_invitations)
+
+    # delete vfolder_permission if the new owner user has already been shared with the vfolder
+    async def _delete_vfolder_permissions() -> None:
+        async with root_ctx.db.begin() as conn:
+            query = sa.delete(vfolder_permissions).where(
+                (vfolder_permissions.c.vfolder == vfolder_id)
+                & (vfolder_permissions.c.user == user_uuid)
+            )
+            await conn.execute(query)
+
+    await execute_with_retry(_delete_vfolder_permissions)
+
     return web.json_response({}, status=200)
 
 

--- a/src/ai/backend/runner/jail.ubuntu16.04.x86_64.bin
+++ b/src/ai/backend/runner/jail.ubuntu16.04.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ad7d9eea555876b906bfb5eb8c83b6d5df820c409a0849acce5f9c21efbe207
+size 4590720


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Related PR: #1182.

This PR resolves the logical error that can possibly occur during changing `ownership` of vfolder.
That is, deleting row(s) in `vfolder_invitations` and `vfolder_permissions` when the new owner of the vfolder and invitee are the same user.

Assume that User A created vfolder `foo` and shared it with User B with certain permissions.
After sharing, for some reason, the ownership of vfolder `foo` is changed from User A to User B.
Without removing "sharing log"(stored as a row in `vfolder_invitations` and `vfolder_permissions` table) when owner and invitee are identical, the shared vfolder remains and brings certain errors such as causing exceptions on deleting vfolder.
Therefore, I added two deleting transactions on two tables respectively that I mentioned above in the situation.