### PR TITLE
setup,doc: Streamline editable webui's build artifact path config

### DIFF
--- a/changes/.enhance.md
+++ b/changes/.enhance.md
@@ -1,0 +1,1 @@
+Automatically set the proper webui build artifact path in `webserver.conf` when installed with `--editable-webui` and document it in the sample configuration

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -13,6 +13,9 @@ wsproxy.url = ""
 
 # Manually set the static path for site customization.
 # (default: the directory where the package ai.backend.web.static is installed)
+# TIP: If you clone the backend.ai-webui repository under src/ai/backend/webui,
+# this could be set "src/ai/backend/webui/build/rollup" to directly serve
+# the compiled result from the source.
 #static_path = "/absolute/path/to/static/resources/"
 
 # "webui" mode is for serving "backend.ai-webui" PWA,

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -748,10 +748,10 @@ configure_backendai() {
   sed_inplace "s/https:\/\/api.backend.ai/http:\/\/127.0.0.1:${MANAGER_PORT}/" ./webserver.conf
   sed_inplace "s/ssl-verify = true/ssl-verify = false/" ./webserver.conf
   sed_inplace "s/redis.port = 6379/redis.port = ${REDIS_PORT}/" ./webserver.conf
-
   # install and configure webui
   if [ $EDITABLE_WEBUI -eq 1 ]; then
     install_editable_webui
+    sed_inplace "s@\(# \)\{0,1\}static_path = .*@static_path = "'"src/ai/backend/webui/build/rollup"'"@" ./webserver.conf
   fi
 
   # configure tester


### PR DESCRIPTION
- doc: Add a tip for using editable clone of webui with the webserver
- setup: Set the proper build artifact path with `--editable-webui`
- doc: Add news fragment

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
