### PR TITLE
hotfix(ci): Add missing dependencies during build-conda-pack-for-windows

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -312,6 +312,9 @@ jobs:
       with:
         python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
+    - name: Install local dependencies for packaging
+      run: |
+        pip install -U 'packaging>=21.3'
     - name: Normalize the package version
       run: |
         PKGVER=$(python -c "import packaging.version,pathlib; print(str(packaging.version.Version(pathlib.Path('VERSION').read_text())))")


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/4555894319/jobs/8035687984
Fix an issue where an action fails due to lack of a packaging dependency.
