### PR TITLE
feat: Utilization checker returns `thresholds_check_operator`

### DIFF
--- a/changes/1202.feature.md
+++ b/changes/1202.feature.md
@@ -1,0 +1,1 @@
+Utilization checker returns `thresholds_check_operator`.


### PR DESCRIPTION
Return value will change like below.
The value of `thresholds_check_operator` is "or" or "and".
The resource data is under `utilization.extra.resources` (previously, it is under `utilization.extra`)
```
{
   "utilization":{
      "remaining":-1.0,
      "remaining_time_type":"grace_period",
      "extra":{
         "thresholds_check_operator":"or", # or "and"
         "resources":{
            "cpu_util":[0.11, 10.0],
            "mem":[37, 10],
            "cuda_util":[0.0, 10.0],
            "cuda_mem":[0, 10]
         }
      }
   },
   "session_lifetime":{
      "remaining":null,
      "remaining_time_type":"expire_after",
      "extra":null
   }
}
```