### PR TITLE
deps: update etcetra to 0.1.15

### DIFF
--- a/python.lock
+++ b/python.lock
@@ -43,7 +43,7 @@
 //     "coloredlogs~=15.0",
 //     "cryptography>=2.8",
 //     "dataclasses-json~=0.5.7",
-//     "etcetra==0.1.14",
+//     "etcetra==0.1.15",
 //     "faker~=13.12.0",
 //     "graphene~=2.1.9",
 //     "hiredis~=2.2.2",
@@ -855,36 +855,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5374c409d0153e5da4ccde3a0f7e3efac81ce7c60e4e18ffc9acc87c67e0c0a3",
-              "url": "https://files.pythonhosted.org/packages/4a/ab/92d35739748e7cf94f315a408f3861cc075cecc0a40f2b455972639b6500/boto3-1.26.88-py3-none-any.whl"
+              "hash": "f4951f8162905b96fd045e32853ba8cf707042faac846a23910817c508ef27d7",
+              "url": "https://files.pythonhosted.org/packages/0e/b5/8758f47b054f3e0558f2d6fa6943baaf1ff04c474bb6138283e97d2d5dcf/boto3-1.26.105-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4839565feeaaca4ef775b74a8df996b79b61d988db62c90571bcc948a9f24c5",
-              "url": "https://files.pythonhosted.org/packages/5a/f0/5e9144029ac56e7dc966a92b2d2181a81b57ab7965500d213cd3f9220780/boto3-1.26.88.tar.gz"
+              "hash": "2914776e0138530ec6464d0e2f05b4aa18e9212ac920c48472f8a93650feaed2",
+              "url": "https://files.pythonhosted.org/packages/12/4f/1b46b6bee208ca96c36bcbdea19475b6efc2c0aecd895fabc8f1e1ad690a/boto3-1.26.105.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.30.0,>=1.29.88",
+            "botocore<1.30.0,>=1.29.105",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.7.0,>=0.6.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.26.88"
+          "version": "1.26.105"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c320275d18ee140005ace4d04e9e720d5b1e30625cfde5267b1fc5133fd4d44d",
-              "url": "https://files.pythonhosted.org/packages/72/33/aeed379b1b44ccb6dea8cc4d427fe045ea69a1104f999efe1d4788c09b66/botocore-1.29.88-py3-none-any.whl"
+              "hash": "06a2838daad3f346cba5460d0d3deb198225b556ff9ca729798d787fadbdebde",
+              "url": "https://files.pythonhosted.org/packages/98/3e/b6cd0cc466982d8634c74276f9b6543b9fee02c0ec45b8ccb56865b78d8e/botocore-1.29.105-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "48ed2af0a10e7c15a3445eda62f665b106a2aba4ffa1ce730d7083022fd9596f",
-              "url": "https://files.pythonhosted.org/packages/26/b7/ba1676a574200bfc0a8f99e41daaf4b454917eaf7eeb09c8512bf36193d4/botocore-1.29.88.tar.gz"
+              "hash": "17c82391dfd6aaa8f96fbbb08cad2c2431ef3cda0ece89e6e6ba444c5eed45c2",
+              "url": "https://files.pythonhosted.org/packages/04/27/784403fa5978e6c19167cc403a8990ed0d335a82b1428debce5b1463e56e/botocore-1.29.105.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -895,7 +895,7 @@
             "urllib3<1.27,>=1.25.4"
           ],
           "requires_python": ">=3.7",
-          "version": "1.29.88"
+          "version": "1.29.105"
         },
         {
           "artifacts": [
@@ -1222,58 +1222,48 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0",
-              "url": "https://files.pythonhosted.org/packages/e8/5c/9e47aac90fb5923d09c413909af6bf6ad4af2bfeeff707a2485c3f2af8be/cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "cf91e428c51ef692b82ce786583e214f58392399cf65c341bc7301d096fa3ba2",
+              "url": "https://files.pythonhosted.org/packages/10/2b/485100eb127268fcc72eaf3b0ee643523718b2a23f8ba3904ef027fdbbb2/cryptography-40.0.1-cp36-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97",
-              "url": "https://files.pythonhosted.org/packages/26/d2/85480f4e754375c6d8e4a18cc8d2f28ef1984cf2843395c4d1ea396331d3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472",
+              "url": "https://files.pythonhosted.org/packages/15/d9/c679e9eda76bfc0d60c9d7a4084ca52d0631d9f24ef04f818012f6d1282e/cryptography-40.0.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7",
-              "url": "https://files.pythonhosted.org/packages/3c/0c/ac188ca210fbc02102d34ad8dba6956fe16fc566e5c5110a7f7bdbd30138/cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl"
+              "hash": "0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405",
+              "url": "https://files.pythonhosted.org/packages/92/65/bead02abece1e8b3f0dee942e216cb42df2630aa7efb41d2831d99a9bb68/cryptography-40.0.1-cp36-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612",
-              "url": "https://files.pythonhosted.org/packages/3c/5a/6c180b745336f989e9b298e1790af0ef5b37640edb861fc536b5663726e3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+              "hash": "9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797",
+              "url": "https://files.pythonhosted.org/packages/a1/e0/4fa9f4d0c15040ea0b0c19f8442c62a5cebc4846db4a745177a85b7a6d82/cryptography-40.0.1-cp36-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011",
-              "url": "https://files.pythonhosted.org/packages/9c/30/e787edf59f35192799d340a0a36976870ce487ba32948f086c29dc5d54ab/cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122",
+              "url": "https://files.pythonhosted.org/packages/b6/2e/16f5531d29034554aeca5b6fafb83a2afc75e29666269233f26f9372af05/cryptography-40.0.1-cp36-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06",
-              "url": "https://files.pythonhosted.org/packages/c5/8a/6dcd53c995506d4ff0de3a7da2202715654493fd12d7875f2a43b3a44150/cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl"
+              "hash": "1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356",
+              "url": "https://files.pythonhosted.org/packages/c0/ea/76eb113bafc97f2e8d9872eda85eb59383892a3559ebbec7595753785fd2/cryptography-40.0.1-cp36-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5",
-              "url": "https://files.pythonhosted.org/packages/d3/26/da69282ae3b350ee869536994e6816ac77057a7b5970068fabe56c644624/cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "918cb89086c7d98b1b86b9fdb70c712e5a9325ba6f7d7cfb509e784e0cfc6917",
+              "url": "https://files.pythonhosted.org/packages/c7/0c/5eeec6973710b2dacff598be034b13f3812ca8a563e8b324b129a93d0214/cryptography-40.0.1-cp36-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a",
-              "url": "https://files.pythonhosted.org/packages/d6/99/12d3b9c8df83b52799f9994da17bb67bb4565c418b3a8284ed1f79b692e1/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "3a4805a4ca729d65570a1b7cac84eac1e431085d40387b7d3bbaa47e39890b88",
+              "url": "https://files.pythonhosted.org/packages/e9/79/b258803f573bfb202e29f9f56cd73e2b2e2fee1fe2e9cdf03f388919d8cc/cryptography-40.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536",
-              "url": "https://files.pythonhosted.org/packages/f4/6d/1afb19efbe093f0b1af7a788bb8a693e495dc6c1d2139316b05b40f5e1dd/cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828",
-              "url": "https://files.pythonhosted.org/packages/f7/c0/daaeedc40e3385f01bb1af8c001ac214dcea6716b61efebabf9066b6f619/cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f",
-              "url": "https://files.pythonhosted.org/packages/fa/f3/f4b8c175ea9a1de650b0085858059050b7953a93d66c97ed89b93b232996/cryptography-39.0.2.tar.gz"
+              "hash": "63dac2d25c47f12a7b8aa60e528bfb3c51c5a6c5a9f7c86987909c6c79765554",
+              "url": "https://files.pythonhosted.org/packages/ed/d0/f7470892f9f496f3d403fca9b141367b1d5350fcd953ef5761674afafaa7/cryptography-40.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -1282,7 +1272,6 @@
             "black; extra == \"pep8test\"",
             "cffi>=1.12",
             "check-manifest; extra == \"pep8test\"",
-            "hypothesis!=3.79.2,>=1.11.4; extra == \"test\"",
             "iso8601; extra == \"test\"",
             "mypy; extra == \"pep8test\"",
             "pretend; extra == \"test\"",
@@ -1294,19 +1283,16 @@
             "pytest-subtests; extra == \"test\"",
             "pytest-xdist; extra == \"test\"",
             "pytest>=6.2.0; extra == \"test\"",
-            "pytz; extra == \"test\"",
             "ruff; extra == \"pep8test\"",
             "setuptools-rust>=0.11.4; extra == \"sdist\"",
             "sphinx-rtd-theme>=1.1.1; extra == \"docs\"",
             "sphinx>=5.3.0; extra == \"docs\"",
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\"",
             "tox; extra == \"tox\"",
-            "twine>=1.12.0; extra == \"docstest\"",
-            "types-pytz; extra == \"pep8test\"",
-            "types-requests; extra == \"pep8test\""
+            "twine>=1.12.0; extra == \"docstest\""
           ],
           "requires_python": ">=3.6",
-          "version": "39.0.2"
+          "version": "40.0.1"
         },
         {
           "artifacts": [
@@ -1343,13 +1329,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b742e9699a2ed75df4a3e5e3162dfec539ae5a09467d6a74a708caf770adca59",
-              "url": "https://files.pythonhosted.org/packages/f4/07/9aa39a0d0a5f2b15fa01106e167d669282e4ebc63451f89f58188b0d3d29/etcetra-0.1.14-py3-none-any.whl"
+              "hash": "86c1d89da2883d19d8e33cf2c55d114ea7e118c6f50521c5b579c978e807807d",
+              "url": "https://files.pythonhosted.org/packages/52/90/4fe786bb98ad4cb9e8cd86e2449e2652c7f025f5be4c4ba92f3a4d3346d2/etcetra-0.1.15-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9300c6b64f7b0489c07498c39c94fee5d9cc803d2c119a8dd6c2d604977131f7",
-              "url": "https://files.pythonhosted.org/packages/e0/0e/bf48b10ce1caa8ddb93738650d1ea7ced0ed7b74209930f450514a7b6b05/etcetra-0.1.14.tar.gz"
+              "hash": "dd417c7afa49ce6748b1fad6de15feb4588e842674bf15ba6d02e3fa80671f49",
+              "url": "https://files.pythonhosted.org/packages/0f/6b/e0f0b69a44e71f9abcf9c581b79a16bab4516ef7747e2b4ef2db69b45210/etcetra-0.1.15.tar.gz"
             }
           ],
           "project_name": "etcetra",
@@ -1372,7 +1358,7 @@
             "wheel>=0.36.2; extra == \"build\""
           ],
           "requires_python": ">=3.10",
-          "version": "0.1.14"
+          "version": "0.1.15"
         },
         {
           "artifacts": [
@@ -1477,13 +1463,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2fef3cf94876d1a0e204afece58bb4d83fb57228aaa366c64045039fda6770a2",
-              "url": "https://files.pythonhosted.org/packages/93/c4/16f8ad44ed7544244a9883f35cc99dc96378652a0ec7cc39028b1c697a1e/google_auth-2.16.2-py2.py3-none-any.whl"
+              "hash": "357ff22a75b4c0f6093470f21816a825d2adee398177569824e37b6c10069e19",
+              "url": "https://files.pythonhosted.org/packages/a8/aa/bfc8597c205da910dbaf9ec692d71bfb37b1599ca2985c9fbf9eea4f58e3/google_auth-2.17.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07e14f34ec288e3f33e00e2e3cc40c8942aa5d4ceac06256a28cd8e786591420",
-              "url": "https://files.pythonhosted.org/packages/09/be/56d3c1db93d85e53ffa4eb26a2f41b0df9ba00317ee1f253121c63489d03/google-auth-2.16.2.tar.gz"
+              "hash": "8f379b46bad381ad2a0b989dfb0c13ad28d3c2a79f27348213f8946a1d15d55a",
+              "url": "https://files.pythonhosted.org/packages/c8/ee/a028aa9ce069fe78d3cf8a86020d366fdb65b54fc33a9e317b4eafa1445e/google-auth-2.17.1.tar.gz"
             }
           ],
           "project_name": "google-auth",
@@ -1504,7 +1490,7 @@
             "six>=1.9.0"
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "2.16.2"
+          "version": "2.17.1"
         },
         {
           "artifacts": [
@@ -2023,13 +2009,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "be48ac6bd659cbbddb7a674cf06b3b8afbf53f228253cf58bde604c03bd487b0",
-              "url": "https://files.pythonhosted.org/packages/78/11/562517956f801607c4f7855ebf8c545e9a9f62ef936f0da1bdec9cd1a7aa/jupyter_client-8.0.3-py3-none-any.whl"
+              "hash": "d5b8e739d7816944be50f81121a109788a3d92732ecf1ad1e4dadebc948818fe",
+              "url": "https://files.pythonhosted.org/packages/31/6c/96771d6b3ce94da927f7688be821899f169306f16023dd0af5ef55f71a52/jupyter_client-8.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed65498bea6d876ef9d8da3e0db3dd33c5d129f5b2645f56ae03993782966bd0",
-              "url": "https://files.pythonhosted.org/packages/2a/82/3bb00614ba16b4df15896119a34bc6c9b4838cc3fc4e5a09157ca6ee3985/jupyter_client-8.0.3.tar.gz"
+              "hash": "3fbab64100a0dcac7701b1e0f1a4412f1ccb45546ff2ad9bc4fcbe4e19804811",
+              "url": "https://files.pythonhosted.org/packages/bd/3d/a65f5f54ebaa2ad32eec08fc8ba471608dbb4a0cb0e91dc8d58ac3bdc3d4/jupyter_client-8.1.0.tar.gz"
             }
           ],
           "project_name": "jupyter-client",
@@ -2059,19 +2045,19 @@
             "traitlets>=5.3"
           ],
           "requires_python": ">=3.8",
-          "version": "8.0.3"
+          "version": "8.1.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0",
-              "url": "https://files.pythonhosted.org/packages/c2/63/86691c2c6014b034c7eccc3000512c58532b4a11343e01faddd74c80a9de/jupyter_core-5.2.0-py3-none-any.whl"
+              "hash": "d4201af84559bc8c70cead287e1ab94aeef3c512848dde077b7684b54d67730d",
+              "url": "https://files.pythonhosted.org/packages/41/1e/92a67f333b9335f04ce409799c030dcfb291712658b9d9d13997f7c91e5a/jupyter_core-5.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f",
-              "url": "https://files.pythonhosted.org/packages/aa/81/f1700beb330c715e3ecf72c6713849f18ed653d49fb2f621705cae2d3b56/jupyter_core-5.2.0.tar.gz"
+              "hash": "6db75be0c83edbf1b7c9f91ec266a9a24ef945da630f3120e1a0046dc13713fc",
+              "url": "https://files.pythonhosted.org/packages/9a/d3/b80e7179e9615f5a7f055edc55eb665fa2534f11a4599349db3bab6fdeb5/jupyter_core-5.3.0.tar.gz"
             }
           ],
           "project_name": "jupyter-core",
@@ -2083,7 +2069,7 @@
             "pytest-cov; extra == \"test\"",
             "pytest-timeout; extra == \"test\"",
             "pytest; extra == \"test\"",
-            "pywin32>=1.0; sys_platform == \"win32\" and platform_python_implementation != \"PyPy\"",
+            "pywin32>=300; sys_platform == \"win32\" and platform_python_implementation != \"PyPy\"",
             "sphinx-autodoc-typehints; extra == \"docs\"",
             "sphinxcontrib-github-alt; extra == \"docs\"",
             "sphinxcontrib-spelling; extra == \"docs\"",
@@ -2091,7 +2077,7 @@
             "traitlets>=5.3"
           ],
           "requires_python": ">=3.8",
-          "version": "5.2.0"
+          "version": "5.3.0"
         },
         {
           "artifacts": [
@@ -2618,30 +2604,30 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a",
-              "url": "https://files.pythonhosted.org/packages/ca/de/a33823fe54d52ea72fdae011115d737a2642d441c93b68ed17455a328e4c/platformdirs-3.1.0-py3-none-any.whl"
+              "hash": "ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e",
+              "url": "https://files.pythonhosted.org/packages/b2/f3/4fb5fae710fc9f22a42cd90dc0547da18ec83e2e139294ab94f04c449cf5/platformdirs-3.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef",
-              "url": "https://files.pythonhosted.org/packages/8f/5f/01180534cebac14f3a792bf2f74fc99d34531c950c308fdebd9721e85550/platformdirs-3.1.0.tar.gz"
+              "hash": "d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08",
+              "url": "https://files.pythonhosted.org/packages/15/04/3f882b46b454ab374ea75425c6f931e499150ec1385a73e55b3f45af615a/platformdirs-3.2.0.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
-            "covdefaults>=2.2.2; extra == \"test\"",
+            "covdefaults>=2.3; extra == \"test\"",
             "furo>=2022.12.7; extra == \"docs\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4; extra == \"test\"",
             "pytest-mock>=3.10; extra == \"test\"",
-            "pytest>=7.2.1; extra == \"test\"",
+            "pytest>=7.2.2; extra == \"test\"",
             "sphinx-autodoc-typehints!=1.23.4,>=1.22; extra == \"docs\"",
             "sphinx>=6.1.3; extra == \"docs\"",
-            "typing-extensions>=4.4; python_version < \"3.8\""
+            "typing-extensions>=4.5; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.1.0"
+          "version": "3.2.0"
         },
         {
           "artifacts": [
@@ -3263,33 +3249,33 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3d4351c563aba4ae7d4e0b821a234d48bc748f45b74e3f38b50cba3857b57acb",
-              "url": "https://files.pythonhosted.org/packages/76/3a/fd9d3558ae0df9aaa8d9468c391a8d510c4658a17cee3474a44c0bbc43aa/readchar-4.0.3-py3-none-any.whl"
+              "hash": "76ec784a5dd2afac3b7da8003329834cdd9824294c260027f8c8d2e4d0a78f43",
+              "url": "https://files.pythonhosted.org/packages/cd/14/730280df294e52e395a70111f4d9b07be94f5ba7a69db7eba3c324f113b2/readchar-4.0.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d920d0e9ab76ec5d42192a68d15af2562663b5dfbf4a67cf9eba520e1ca57e6",
-              "url": "https://files.pythonhosted.org/packages/75/d1/eddb559d5911fd889f2ec0de052a88edd0fa8fc4746f29da0d384d29e10e/readchar-4.0.3.tar.gz"
+              "hash": "08a456c2d7c1888cde3f4688b542621b676eb38cd6cfed7eb6cb2e2905ddc826",
+              "url": "https://files.pythonhosted.org/packages/a1/57/439aaa28659e66265518232bf4291ae5568aa01cd9e0e0f6f8fe3b300e9e/readchar-4.0.5.tar.gz"
             }
           ],
           "project_name": "readchar",
           "requires_dists": [
             "setuptools>=41.0"
           ],
-          "requires_python": ">=3.6",
-          "version": "4.0.3"
+          "requires_python": ">=3.7",
+          "version": "4.0.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "46652271dc7525cd5a9667e5b0ca983c848c75b2b8f7425403395bb8379dcf25",
-              "url": "https://files.pythonhosted.org/packages/76/ad/dd7b6423295394b95e03d961d454e3046b569715dcc2dd4a030bb43a7cff/redis-4.3.5-py3-none-any.whl"
+              "hash": "1ea4018b8b5d8a13837f0f1c418959c90bfde0a605cb689e8070cff368a3b177",
+              "url": "https://files.pythonhosted.org/packages/d6/f6/19237b28c632935c7359bddf703395ba13bbd134fc5e2eb297c4c120398c/redis-4.3.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30c07511627a4c5c4d970e060000772f323174f75e745a26938319817ead7a12",
-              "url": "https://files.pythonhosted.org/packages/c9/33/8841abbbb9b9f0202fac6e96539cfb98728a709a9b0c5b2ccfb745fb8211/redis-4.3.5.tar.gz"
+              "hash": "7a462714dcbf7b1ad1acd81f2862b653cc8535cdfc879e28bf4947140797f948",
+              "url": "https://files.pythonhosted.org/packages/f2/52/2a4b3ceffe59483cdea5e653aaa40ebd7a90241612c40212dfc10fde9215/redis-4.3.6.tar.gz"
             }
           ],
           "project_name": "redis",
@@ -3304,7 +3290,7 @@
             "typing-extensions; python_version < \"3.8\""
           ],
           "requires_python": ">=3.6",
-          "version": "4.3.5"
+          "version": "4.3.6"
         },
         {
           "artifacts": [
@@ -3450,13 +3436,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2",
-              "url": "https://files.pythonhosted.org/packages/c3/9e/8a7ba2c9984a060daa6c6f9fff4d576b7ace3936239d6b771541eab972ed/setuptools-67.6.0-py3-none-any.whl"
+              "hash": "e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078",
+              "url": "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077",
-              "url": "https://files.pythonhosted.org/packages/25/f3/d68c20919bc774c6cb127f1762f2f2f999d700a58198556e883dd3700e58/setuptools-67.6.0.tar.gz"
+              "hash": "257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a",
+              "url": "https://files.pythonhosted.org/packages/cb/46/22ec35f286a77e6b94adf81b4f0d59f402ed981d4251df0ba7b992299146/setuptools-67.6.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -3508,7 +3494,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "67.6.0"
+          "version": "67.6.1"
         },
         {
           "artifacts": [
@@ -3532,23 +3518,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "69fac0a7054d86b997af12dc23f581cf0b25fb1c7d1fed43257dee3af32d3d6d",
-              "url": "https://files.pythonhosted.org/packages/cd/29/19c2455deb2fcaa5aa951eda2c8a878aba5c7211e73d9201303441c63ccc/SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e3b67bda733da1dcdccaf354e71ef01b46db483a4f6236450d3f9a61efdba35a",
+              "url": "https://files.pythonhosted.org/packages/bc/ee/e7678a05310ebeba2655e4651426e3933cd3d076c57bf2df5e0a827ec3e6/SQLAlchemy-1.4.47-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d68e1762997bfebf9e5cf2a9fd0bcf9ca2fdd8136ce7b24bbd3bbfa4328f3e4a",
-              "url": "https://files.pythonhosted.org/packages/82/77/2e514172a644f8c579a47f4d3125b057a5895ac9afc67971c5a33fed9550/SQLAlchemy-1.4.46-cp311-cp311-macosx_10_9_universal2.whl"
+              "hash": "795b5b9db573d3ed61fae74285d57d396829e3157642794d3a8f72ec2a5c719b",
+              "url": "https://files.pythonhosted.org/packages/8d/78/e4c2076e6d8cc8e4f27c6cfe19c9bd5b43399d4a7f55cf39f0c7d1307b84/SQLAlchemy-1.4.47-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6913b8247d8a292ef8315162a51931e2b40ce91681f1b6f18f697045200c4a30",
-              "url": "https://files.pythonhosted.org/packages/af/ae/8d8e67f2691f0fdb845df90013d68c12a9127e009b4dedc34a3228f4e5ad/SQLAlchemy-1.4.46.tar.gz"
+              "hash": "95fc02f7fc1f3199aaa47a8a757437134cf618e9d994c84effd53f530c38586f",
+              "url": "https://files.pythonhosted.org/packages/a0/08/3e8923b1094b61736960dc372633b0dfddbf2e12f5a0b8dd1203f7dcc8f7/SQLAlchemy-1.4.47.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4d112b0f3c1bc5ff70554a97344625ef621c1bfe02a73c5d97cac91f8cd7a41e",
-              "url": "https://files.pythonhosted.org/packages/e0/c9/21d0e10bff602b673f21ed99cc641e8883fef54983b23b09d5216fca3872/SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "989c62b96596b7938cbc032e39431e6c2d81b635034571d6a43a13920852fb65",
+              "url": "https://files.pythonhosted.org/packages/b3/a4/83e82039405186102842ccc7a522b67dcca7a500ccd5686467f53e32b9e3/SQLAlchemy-1.4.47-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "sqlalchemy",
@@ -3585,7 +3571,7 @@
             "typing-extensions!=3.10.0.1; extra == \"aiosqlite\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.4.46"
+          "version": "1.4.47"
         },
         {
           "artifacts": [
@@ -3700,19 +3686,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b",
-              "url": "https://files.pythonhosted.org/packages/2b/df/971fa5db3250bb022105d17f340339370f73d502e65e687a94ca1a4c4b1f/tomlkit-0.11.6-py3-none-any.whl"
+              "hash": "5325463a7da2ef0c6bbfefb62a3dc883aebe679984709aee32a317907d0a8d3c",
+              "url": "https://files.pythonhosted.org/packages/c0/83/eb757ef200543637c40f136e370ef05158d4079ad61da2cf455fe34c508d/tomlkit-0.11.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73",
-              "url": "https://files.pythonhosted.org/packages/ff/04/58b4c11430ed4b7b8f1723a5e4f20929d59361e9b17f0872d69681fd8ffd/tomlkit-0.11.6.tar.gz"
+              "hash": "f392ef70ad87a672f02519f99967d28a4d3047133e2d1df936511465fbb3791d",
+              "url": "https://files.pythonhosted.org/packages/4d/4e/6cb8a301134315e37929763f7a45c3598dfb21e8d9b94e6846c87531886c/tomlkit-0.11.7.tar.gz"
             }
           ],
           "project_name": "tomlkit",
           "requires_dists": [],
-          "requires_python": ">=3.6",
-          "version": "0.11.6"
+          "requires_python": ">=3.7",
+          "version": "0.11.7"
         },
         {
           "artifacts": [
@@ -3886,19 +3872,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d7f74db8ca79f9620107465ce9ddf8c0d2bffd45461f719f14c1479cdaf2d2a9",
-              "url": "https://files.pythonhosted.org/packages/5d/d4/d9d6e87da767feaf49970029171c162df7cfdc00e1d44faad677752bd255/types_six-1.16.21.7-py3-none-any.whl"
+              "hash": "e118ebebb4944af96b4c022b15c0769c065af09126eb148b7797023e905e0652",
+              "url": "https://files.pythonhosted.org/packages/7b/d7/044dfd93663b08ec93e77bef6d346792a069944509202a7badb000b9bc9e/types_six-1.16.21.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9ce4eb910e694ab0f94400361994c44c2186e0b62cef09095a8e4c92ce011e4f",
-              "url": "https://files.pythonhosted.org/packages/eb/a5/897019948261c6861332acee1b970a88d5fd91f39c7c142f04a6d9223c04/types-six-1.16.21.7.tar.gz"
+              "hash": "02a892ff8f423c4c5d15de7c6f4d433e643c863bcbefabd19251b478cbb284ab",
+              "url": "https://files.pythonhosted.org/packages/a7/bc/faaea420291c4d9ec3d4d34115cb0e37c9ff79b4bcb0b9889bc57e9438bb/types-six-1.16.21.8.tar.gz"
             }
           ],
           "project_name": "types-six",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.16.21.7"
+          "version": "1.16.21.8"
         },
         {
           "artifacts": [
@@ -3944,13 +3930,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1",
-              "url": "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl"
+              "hash": "aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42",
+              "url": "https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-              "url": "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
+              "hash": "8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
+              "url": "https://files.pythonhosted.org/packages/21/79/6372d8c0d0641b4072889f3ff84f279b738cd8595b64c8e0496d4e848122/urllib3-1.26.15.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -3967,7 +3953,7 @@
             "urllib3-secure-extra; extra == \"secure\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.26.14"
+          "version": "1.26.15"
         },
         {
           "artifacts": [
@@ -4221,7 +4207,7 @@
     "coloredlogs~=15.0",
     "cryptography>=2.8",
     "dataclasses-json~=0.5.7",
-    "etcetra==0.1.14",
+    "etcetra==0.1.15",
     "faker~=13.12.0",
     "graphene~=2.1.9",
     "hiredis~=2.2.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ coloredlogs~=15.0
 colorama>=0.4.4
 cryptography>=2.8
 dataclasses-json~=0.5.7
-etcetra==0.1.14
+etcetra==0.1.15
 faker~=13.12.0
 graphene~=2.1.9
 hiredis~=2.2.2


### PR DESCRIPTION
This PR updates dependecy version of etcetra, an etcd client library to `0.1.15`. Etcetra `0.1.15` includes a patch which fixes lock TTL operating in a wrong manner.