### PR TITLE
ci: add missing source distribution extractables for releases

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -274,6 +274,7 @@ jobs:
         prerelease: ${{ env.IS_PRERELEASE }}
         files: |
           dist/*.whl
+          dist/*.tar.gz
     - name: Upload pants log
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Due to my mistake while editing the workflow, the binary file was not being uploaded to the release assets from version 22.09.18.
You need to manually upload binary files from 22.09.18 to 22.09.21 if necessary.