### PR TITLE
fix: Optimize monthly stat API

### DIFF
--- a/changes/1214.fix.md
+++ b/changes/1214.fix.md
@@ -1,0 +1,1 @@
+Optimize monthly stat API by reducing the number of iteration and fetch to Redis.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -611,11 +611,10 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
         rows = result.fetchall()
 
     # Build time-series of time-binned stats.
-    now_ts = now.timestamp()
     start_date_ts = start_date.timestamp()
     time_series_list: list[dict[str, Any]] = [
         {
-            "date": idx * time_window + now_ts,
+            "date": start_date_ts + (idx * time_window),
             "num_sessions": {
                 "value": 0,
                 "unit_hint": "count",

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -661,7 +661,7 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
             last_stat = msgpack.unpackb(raw_stat)
             io_read_byte = int(nmget(last_stat, "io_read.current", 0))
             io_write_byte = int(nmget(last_stat, "io_write.current", 0))
-            disk_used = int(nmget(last_stat, "io_scratch_size/stats.max", 0, "/"))
+            disk_used = int(nmget(last_stat, "io_scratch_size.stats.max", 0, "/"))
         else:
             io_read_byte = 0
             io_write_byte = 0
@@ -679,8 +679,6 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
         end_index = int((kernel_terminated_at - start_date_ts) // time_window) + 1
         if start_index < 0:
             start_index = 0
-        if end_index >= stat_length:
-            end_index = stat_length - 1
         for time_series in time_series_list[start_index:end_index]:
             time_series["num_sessions"]["value"] += 1
             time_series["cpu_allocated"]["value"] += cpu_value


### PR DESCRIPTION
So far, monthly stat API do iteration for (2880 * num_kernels) times constantly and fetch Kernel stats from Redis for every iteration.
This PR reduce the iteration and the number of Redis fetch.

# Before
Waiting for server response 4.77 s
* Not "milisecond", it is "second"
<img width="880" alt="image" src="https://user-images.githubusercontent.com/44239739/230557332-6ba5d2c0-b481-4c98-94b7-09036d0ec0da.png">


# After
Waiting for server response 140.08 ms
<img width="889" alt="image" src="https://user-images.githubusercontent.com/44239739/230557240-4b7bf7c7-b817-458c-9b3c-d8b81aef3be2.png">
