### PR TITLE
ci: Change labeler settings to match the newly reorganized label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,13 @@
 require:db-migration:
 - any: ['src/ai/backend/manager/alembic/versions/*.py']
 
-docs:
+area:docs:
 - any: ['docs/**/*']
 
-storage-proxy:
+comp:storage-proxy:
 - any: ['src/ai/backend/storage/**/*.py']
 
-agent:
+comp:agent:
 - any: [
     'src/ai/backend/agent/**/*.py',
     'src/ai/backend/kernel/**/*.py',
@@ -15,21 +15,21 @@ agent:
     'src/ai/backend/helpers/**/*.py',
   ]
 
-manager:
+comp:manager:
 - any: ['src/ai/backend/manager/**/*.py']
 
-common:
+comp:common:
 - any: [
     'src/ai/backend/common/**/*.py',
     'src/ai/backend/plugin/**/*.py',
   ]
 
-client:
+comp:client:
 - any: [
     'src/ai/backend/client/**/*.py',
   ]
 
-cli:
+comp:cli:
 - any: [
     'src/ai/backend/cli/**/*.py',
     'src/ai/backend/client/cli/**/*.py',
@@ -37,17 +37,17 @@ cli:
     'src/ai/backend/agent/cli/**/*.py',
   ]
 
-webserver:
+comp:webserver:
 - any: [
     'src/ai/backend/web/**/*.py',
   ]
 
-webui:
+comp:webui:
 - any: [
     'src/ai/backend/web/static',
   ]
 
-installer:
+comp:installer:
 - any: [
     'scripts/install-dev.sh',
     'scripts/delete-dev.sh',


### PR DESCRIPTION
Labels have been reorganized.
Therefore, the setting of the labeler, which recognizes diff and automatically manages labels, also needs to be changed.
