### PR TITLE
fix: disable collecting per-container statistics on macOS backend

### DIFF
--- a/changes/1231.fix.md
+++ b/changes/1231.fix.md
@@ -1,0 +1,1 @@
+Disable collecting per-container statistics on macOS backend until #1230 is resolved

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -484,6 +484,10 @@ class StatContext:
 
         Intended to be used by the agent.
         """
+        # FIXME: support Docker Desktop backend (#1230)
+        if sys.platform == "darwin":
+            return
+
         async with self._lock:
             pid_map = {}
             pids = []


### PR DESCRIPTION
disabling until #1230 is resolved.