### PR TITLE
fix: typo error on mock-accelerator config

### DIFF
--- a/configs/accelerator/mock-accelerator.toml
+++ b/configs/accelerator/mock-accelerator.toml
@@ -13,7 +13,7 @@ devices = [
 nvidia_driver = "450.0.0"
 cuda_runtime = "11.0"
 
-[formats.devices]
+[formats.device]
 display_unit = "GPU"
 display_icon = "gpu1"
 human_readable_name = "GPU"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR resolves typo error which triggers KeyError when executing agent process.

### Screenshot(s)
<img width="1728" alt="Screenshot 2023-04-24 at 3 53 27 PM" src="https://user-images.githubusercontent.com/46954439/233931773-6417cc38-5c82-4d96-b88f-5495c2eb1e4c.png">
