### PR TITLE
feat: add `system_SSH_Image` webserver config to specify the system-role ssh image for fast file uploading.

### DIFF
--- a/changes/1250.feature.md
+++ b/changes/1250.feature.md
@@ -1,0 +1,1 @@
+Add `system_SSH_image` config to webserver so that system-role ssh image used to support fast scp and sftp in file browser dialog can be specified.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -54,6 +54,8 @@ mask_user_info = false
 enable_2FA = false
 # Force enable 2-Factor-Authentication (TOTP).
 force_2FA = false
+# This image is used to launch ssh session (using system role image) to support fast uploading.
+# system_SSH_image = ""
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -54,7 +54,8 @@ mask_user_info = false
 enable_2FA = false
 # Force enable 2-Factor-Authentication (TOTP).
 force_2FA = false
-# This image is used to launch ssh session (using system role image) to support fast uploading.
+# Container image to use SSH/SFTP file upload when storage proxy configuration supports independent resource group for file transfer. 
+# If the appropriate settings are not made, please leave it blank.
 # system_SSH_image = ""
 
 [resources]

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -55,6 +55,7 @@ config_iv = t.Dict(
                 t.Key("app_download_url", default=""): t.String(allow_blank=True),
                 t.Key("enable_2FA", default=False): t.ToBool(),
                 t.Key("force_2FA", default=False): t.ToBool(),
+                t.Key("system_SSH_image", default=""): t.String(allow_blank=True),
             }
         ).allow_extra("*"),
         t.Key("resources"): t.Dict(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -22,6 +22,7 @@ connectionMode = "SESSION"
 {% toml_field "appDownloadUrl" config["service"]["app_download_url"] %}
 {% toml_field "enable2FA" config["service"]["enable_2FA"] %}
 {% toml_field "force2FA" config["service"]["force_2FA"] %}
+{% toml_field "systemSSHImage" config["service"]["system_SSH_image"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
Add `system_SSH_image` config to webserver so that system-role ssh image used to support fast scp and sftp in file browser dialog can be specified.

related PR: https://github.com/lablup/backend.ai-webui/pull/1694