### PR TITLE
fix: enhance stability of `kernels.role` migration script

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -32,7 +32,7 @@ def upgrade():
     for idx in range(int(count / 100) + 1):
         query = sa.select([kernels.c.id, kernels.c.image]).select_from(kernels).limit(100)
         if idx > 0:
-            query = query.skip(idx * 100)
+            query = query.offset(idx * 100)
         chunked_kernels = connection.execute(query).fetchall()
         for kernel in chunked_kernels:
             query = (

--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -43,7 +43,6 @@ def upgrade():
         )
         result = connection.execute(query).fetchall()
         kernel_ids_to_update = [kid[0] for kid in result]
-        print(kernel_ids_to_update)
 
         query = (
             sa.update(kernels)
@@ -71,7 +70,6 @@ def upgrade():
         )
         result = connection.execute(query)
         total_rowcount += result.rowcount
-        print(f"total processed count: {total_rowcount} (~{kernel_ids_to_update[-1]})")
 
         if result.rowcount < batch_size:
             break

--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -48,10 +48,10 @@ def upgrade():
             sa.update(kernels)
             .values(
                 {
-                    "role": cast(  # Explicit casting as described in `image_type_to_kernelrole` case.
+                    "role": cast(
                         coalesce(
-                            # `sa.func.min` is introduced since it is possible (not prevented) for two
-                            # records have the same image name. Without `sa.func.min`, the records
+                            # `limit(1)` is introduced since it is possible (not prevented) for two
+                            # records have the same image name. Without `limit(1)`, the records
                             # raises multiple values error.
                             sa.select([images.c.labels.op("->>")("ai.backend.role")])
                             .select_from(images)

--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -70,6 +70,7 @@ def upgrade():
         )
         result = connection.execute(query)
         total_rowcount += result.rowcount
+        print(f"total processed count: {total_rowcount} (~{kernel_ids_to_update[-1]})")
 
         if result.rowcount < batch_size:
             break


### PR DESCRIPTION
This PR updates migration script which creates `kernels.role` column to read maximum of 100 kernels at once.