### PR TITLE
ci: change shell of `build-conda-pack-for-windows` to `bash`

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -292,6 +292,7 @@ jobs:
       run: |
         pip install -U 'packaging>=21.3'
     - name: Normalize the package version
+      shell: bash
       run: |
         PKGVER=$(python -c "import packaging.version,pathlib; print(str(packaging.version.Version(pathlib.Path('VERSION').read_text())))")
         echo "PKGVER=$PKGVER" >> $GITHUB_ENV


### PR DESCRIPTION
The corresponding shell script exists in the build-wheels job as well, but since there is no error, I looked into the difference with build-conda-pack-for-windows.
The shell execution environment is the most suspicious part, so the shell has been changed to bash.
