### PR TITLE
setup: downgrade yarl to 1.8

### DIFF
--- a/changes/1261.fix.md
+++ b/changes/1261.fix.md
@@ -1,0 +1,1 @@
+Downgrade yarl to 1.8.2 to fix image scanning feature not working

--- a/python.lock
+++ b/python.lock
@@ -87,7 +87,7 @@
 //     "types-six",
 //     "typing_extensions~=4.3",
 //     "uvloop>=0.17; sys_platform != \"Windows\"",
-//     "yarl>=1.7",
+//     "yarl~=1.8.2",
 //     "zipstream-new~=1.1.8"
 //   ],
 //   "manylinux": "manylinux2014",
@@ -850,36 +850,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ec53175eaf818dfe1eec33f7e165eca957744c1d8a82047a9efbcce9547e5cc9",
-              "url": "https://files.pythonhosted.org/packages/94/a3/c486566579f7e29784e555c438ee1adf9b1e49a4e812286dbde5bbcf2e42/boto3-1.26.124-py3-none-any.whl"
+              "hash": "ded836536be41de9f9bd6a75e9feeb74d61b8c58ed7dc4ea89095082d7a616af",
+              "url": "https://files.pythonhosted.org/packages/92/84/2e66f6c42e7e1a9e4bca87ea85890b691c2f442ac67c9db1f472fc18357b/boto3-1.26.127-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4847855cfa4ff272eb66cf1fc9542068ada6d4816d56573cc9cafde51962d0ef",
-              "url": "https://files.pythonhosted.org/packages/6a/e2/d1a403502d9547cd2f39da7b1b5177e1de3a75e30b0bb305ea8dec7f6a51/boto3-1.26.124.tar.gz"
+              "hash": "ed31b2d35aad31418bd8093c5732c6296f785cc234333330df6b81396424d93b",
+              "url": "https://files.pythonhosted.org/packages/a8/71/98de350aa308781f274eed74118d0c6daf272ccb06e3735d6ad75b707ca7/boto3-1.26.127.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.30.0,>=1.29.124",
+            "botocore<1.30.0,>=1.29.127",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.7.0,>=0.6.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.26.124"
+          "version": "1.26.127"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cbcbd5b084952d332d7b8170577f10509e3e7b3b6abbc2920b1c27e93ad2ab25",
-              "url": "https://files.pythonhosted.org/packages/a2/95/49fa4a1560cd9bde97867f75254717c1b271563154b37466266afd73523f/botocore-1.29.124-py3-none-any.whl"
+              "hash": "cf41d871b2a17d40bd579ce44dace18c875659ac13139a66680540fdf6f1c304",
+              "url": "https://files.pythonhosted.org/packages/69/1d/2fe40731639d30a75eea6706ea65971476db0bd651385a3d4f25b9d9b29d/botocore-1.29.127-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ebe8a83dd1db18180774ce45b1911959c60bb1843ea0db610231495527a3518a",
-              "url": "https://files.pythonhosted.org/packages/bd/8d/2e6a60cf751e7b9faf7da7ce0f0cf84196761b33f7dc22205c815fdbb700/botocore-1.29.124.tar.gz"
+              "hash": "d2f9d00df16058cb4a3572a66bb1831e846e5aaa7c0a3033dd47f9a80e2dd58b",
+              "url": "https://files.pythonhosted.org/packages/4c/fb/a03d4f207ad2c6d07ab1bb17985b44fa9fb582fdc1ff5dbf23c125a9a4dd/botocore-1.29.127.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -890,7 +890,7 @@
             "urllib3<1.27,>=1.25.4"
           ],
           "requires_python": ">=3.7",
-          "version": "1.29.124"
+          "version": "1.29.127"
         },
         {
           "artifacts": [
@@ -1746,79 +1746,79 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d8bc89c7e33fecb083a199ade0131a34d20365a8c32239e218da57290987ca9a",
-              "url": "https://files.pythonhosted.org/packages/d3/5f/aec4a9526bf1ca3cd22a2f14a488200b2d406bcef568a4f8be17dc293bb6/hiredis-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "071c5814b850574036506a8118034f97c3cbf2fe9947ff45a27b07a48da56240",
+              "url": "https://files.pythonhosted.org/packages/05/0a/8e5ae10854b1d67f8cd9e1b187e1128bde911f6b44ac6db4ad714514ef27/hiredis-2.2.3-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c446a2007985ae49c2ecd946dd819dea72b931beb5f647ba08655a1a1e133fa8",
-              "url": "https://files.pythonhosted.org/packages/03/d6/25318939297352df38c2af88cb192d744b0971cbb5a19888db8551befec1/hiredis-2.2.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "4e43e2b5acaad09cf48c032f7e4926392bb3a3f01854416cf6d82ebff94d5467",
+              "url": "https://files.pythonhosted.org/packages/03/f3/e34dbb46f8f0d1a0e6c6aecf082c22de7a683df02c2bc29f74f9ce680eb0/hiredis-2.2.3-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10dc34854e9acfb3e7cc4157606e2efcb497b1c6fca07bd6c3be34ae5e413f13",
-              "url": "https://files.pythonhosted.org/packages/04/fd/f830390946897e1f9bb2502960ff04f707e1a775a3a1b760485ed5f232a0/hiredis-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "2fb9300959a0048138791f3d68359d61a788574ec9556bddf1fec07f2dbc5320",
+              "url": "https://files.pythonhosted.org/packages/12/c6/cb1f5bccabf3cc05a1ee56978177a2dcc444e19d743ec95adfcfbb2a1405/hiredis-2.2.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "02b9f928dc6cd43ed0f0ffc1c75fb209fb180f004b7e2e19994805f998d247aa",
-              "url": "https://files.pythonhosted.org/packages/06/1b/ade74d965ab4202bcd632d823dba74ac682df8b6f1c8b169142fa9afb395/hiredis-2.2.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "126623b03c31cb6ac3e0d138feb6fcc36dd43dd34fc7da7b7a0c38b5d75bc896",
+              "url": "https://files.pythonhosted.org/packages/1b/cc/14789efd9707a1d799c9cb1fbac630044e5cec2764eca4bd28aa60dda80a/hiredis-2.2.3-cp311-cp311-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "75349f7c8f77eb0fd33ede4575d1e5b0a902a8176a436bf03293d7fec4bd3894",
-              "url": "https://files.pythonhosted.org/packages/0a/26/a7f87b8497708a1b23267d4257c89d3ca2b58772f3854900e2a51a656336/hiredis-2.2.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "3f5446068197b35a11ccc697720c41879c8657e2e761aaa8311783aac84cef20",
+              "url": "https://files.pythonhosted.org/packages/29/e5/b6022797834c9e935ff814dcf96d03abea2b669e8359be69a7ed96e36a57/hiredis-2.2.3-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a9b306f4e870747eea8b008dcba2e9f1e4acd12b333a684bc1cc120e633a280e",
-              "url": "https://files.pythonhosted.org/packages/14/95/38d9aed56fdc0a3f5238dda9773da7340215a68d3887c35fa4957bc7fcfd/hiredis-2.2.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+              "hash": "7df645b6b7800e8b748c217fbd6a4ca8361bcb9a1ae6206cc02377833ec8a1aa",
+              "url": "https://files.pythonhosted.org/packages/67/b9/513511d1ceaf2e519f202a0aecfacc3d3d8eeea8042946e96f8955cbcaa0/hiredis-2.2.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c270bd0567a9c60673284e000132f603bb4ecbcd707567647a68f85ef45c4d4",
-              "url": "https://files.pythonhosted.org/packages/18/89/16f2020639e434387b5d38b0c844e345e28404b7fe925f3002711e8e5fbf/hiredis-2.2.2.tar.gz"
+              "hash": "8eceffca3941775b646cd585cd19b275d382de43cc3327d22f7c75d7b003d481",
+              "url": "https://files.pythonhosted.org/packages/76/98/3b99c70981d4e882c65bcfe5a0b3b26afc6da5d4a3c51f964e20ee0b41d6/hiredis-2.2.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1eb39b34d15220095dc49ad1e1082580d35cd3b6d9741def52988b5075e4ff03",
-              "url": "https://files.pythonhosted.org/packages/45/b0/df09ed7d80323cff6385f097fda48f3cf27edaac580847f4cd663554408b/hiredis-2.2.2-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "a7205497d7276a81fe92951a29616ef96562ed2f91a02066f72b6f93cb34b40e",
+              "url": "https://files.pythonhosted.org/packages/88/43/14d2ab141cc10a30fd8dcb00addfc38c0bb7911165314b0b5dca493c4033/hiredis-2.2.3-cp311-cp311-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "544d52fde3a8dac7854673eac20deca05214758193c01926ffbb0d57c6bf4ffe",
-              "url": "https://files.pythonhosted.org/packages/5b/5b/1aeda94625c3cf06903b9eb91342d06c34fbe41baaa9798007937b2c7654/hiredis-2.2.2-cp311-cp311-macosx_10_12_x86_64.whl"
+              "hash": "b17baf702c6e5b4bb66e1281a3efbb1d749c9d06cdb92b665ad81e03118f78fc",
+              "url": "https://files.pythonhosted.org/packages/98/a5/6c0297dceb719ff2d9412072ec86673e1eea12c9e23e1215279dc59f4a1f/hiredis-2.2.3-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2a355aff8dfa02ebfe67f0946dd706e490bddda9ea260afac9cdc43942310c53",
-              "url": "https://files.pythonhosted.org/packages/69/19/2f81e11b4ea0712f09210edeef67d779ea160f0471de6179e98cbb2f8c27/hiredis-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2d7e459fe7313925f395148d36d9b7f4f8dac65be06e45d7af356b187cef65fc",
+              "url": "https://files.pythonhosted.org/packages/a1/ce/641fdcfc7d6003a1d2ada35dd5741d9aac9b4e94b15515c9ea33db1b32dc/hiredis-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "688b9b7458b4f3f452fea6ed062c04fa1fd9a69d9223d95c6cb052581aba553b",
-              "url": "https://files.pythonhosted.org/packages/98/80/e5cb09bfe8f3c52e8c4dfe3fac83c5bd1247201d3167b135c3c81774fb8b/hiredis-2.2.2-cp311-cp311-macosx_10_12_universal2.whl"
+              "hash": "e75163773a309e56a9b58165cf5a50e0f84b755f6ff863b2c01a38918fe92daa",
+              "url": "https://files.pythonhosted.org/packages/b0/04/dab6792584fc548803ffa50b5bb2b99f01d3ab04d7c7f64e85f1a22fb847/hiredis-2.2.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "990916e8b0b4eedddef787e73549b562f8c9e73a7fea82f9b8ff517806774ad0",
-              "url": "https://files.pythonhosted.org/packages/b8/91/b2baf7d0c01a0da2e676667540b4077c1b925330d776ae3d0929f193de00/hiredis-2.2.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "4c3b8be557e08b234774925622e196f0ee36fe4eab66cd19df934d3efd8f3743",
+              "url": "https://files.pythonhosted.org/packages/b1/80/f018c72cf5100da89b47b62ba6f14086bacd0eff58c4e112ee215ce7faeb/hiredis-2.2.3-cp311-cp311-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "831461abe5b63e73719621a5f31d8fc175528a05dc09d5a8aa8ef565d6deefa4",
-              "url": "https://files.pythonhosted.org/packages/c1/06/e8153c57db8eae2a6aa0bd209a73884c69cd3673dd71ad9ecc746dace1dc/hiredis-2.2.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "d115790f18daa99b5c11a506e48923b630ef712e9e4b40482af942c3d40638b8",
+              "url": "https://files.pythonhosted.org/packages/d7/7a/a8855c545512ea07cae0c859983a6fce9a82e6b321889e5c2e1dcb50eb7e/hiredis-2.2.3-cp311-cp311-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "03dfb4ab7a2136ce1be305592553f102e1bd91a96068ab2778e3252aed20d9bc",
-              "url": "https://files.pythonhosted.org/packages/fd/d6/04557a5964eeb3dec600583c4daee152f26066f1116c42d112c80ff20405/hiredis-2.2.2-cp311-cp311-musllinux_1_1_s390x.whl"
+              "hash": "aa17a3b22b3726d54d7af20394f65d4a1735a842a4e0f557dc67a90f6965c4bc",
+              "url": "https://files.pythonhosted.org/packages/ea/6d/4d230772220486fb7fa0991d3d36c8592c3d941f765b1aea8cf1d5468bee/hiredis-2.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "hiredis",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2.2.2"
+          "version": "2.2.3"
         },
         {
           "artifacts": [
@@ -3290,13 +3290,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
-              "url": "https://files.pythonhosted.org/packages/cf/e1/2aa539876d9ed0ddc95882451deb57cfd7aa8dbf0b8dbce68e045549ba56/requests-2.29.0-py3-none-any.whl"
+              "hash": "10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294",
+              "url": "https://files.pythonhosted.org/packages/96/80/034ffeca15c0f4e01b7b9c6ad0fb704b44e190cde4e757edbd60be404c41/requests-2.30.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059",
-              "url": "https://files.pythonhosted.org/packages/4c/d2/70fc708727b62d55bc24e43cc85f073039023212d482553d853c44e57bdb/requests-2.29.0.tar.gz"
+              "hash": "239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4",
+              "url": "https://files.pythonhosted.org/packages/e0/69/122171604bcef06825fa1c05bd9e9b1d43bc9feb8c6c0717c42c92cc6f3c/requests-2.30.0.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -3306,10 +3306,10 @@
             "chardet<6,>=3.0.2; extra == \"use_chardet_on_py3\"",
             "charset-normalizer<4,>=2",
             "idna<4,>=2.5",
-            "urllib3<1.27,>=1.21.1"
+            "urllib3<3,>=1.21.1"
           ],
           "requires_python": ">=3.7",
-          "version": "2.29.0"
+          "version": "2.30.0"
         },
         {
           "artifacts": [
@@ -3394,13 +3394,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd",
-              "url": "https://files.pythonhosted.org/packages/5e/c6/af903b5fab3f9b5b1e883f49a770066314c6dcceb589cf938d48c89556c1/s3transfer-0.6.0-py3-none-any.whl"
+              "hash": "3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
+              "url": "https://files.pythonhosted.org/packages/ec/fa/9416461ee05efabe477d588288bdd88acb69a51ee4b31a9b73d3b5b716fc/s3transfer-0.6.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947",
-              "url": "https://files.pythonhosted.org/packages/e1/eb/e57c93d5cd5edf8c1d124c831ef916601540db70acd96fa21fe60cef1365/s3transfer-0.6.0.tar.gz"
+              "hash": "640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9",
+              "url": "https://files.pythonhosted.org/packages/49/bd/def2ab4c04063a5e114963aae90bcd3e3aca821a595124358b3b00244407/s3transfer-0.6.1.tar.gz"
             }
           ],
           "project_name": "s3transfer",
@@ -3409,7 +3409,7 @@
             "botocore[crt]<2.0a.0,>=1.20.29; extra == \"crt\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.6.0"
+          "version": "0.6.1"
         },
         {
           "artifacts": [
@@ -4062,73 +4062,73 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "822b30a0f22e588b32d3120f6d41e4ed021806418b4c9f0bc3048b8c8cb3f92a",
-              "url": "https://files.pythonhosted.org/packages/d5/8b/5a30baa12464d55b308c684a4a953df6b2190f7733c92719f194fcd42421/yarl-1.9.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "6d88056a04860a98341a0cf53e950e3ac9f4e51d1b6f61a53b0609df342cc8b2",
+              "url": "https://files.pythonhosted.org/packages/7f/13/a4b6ffff8f3278c020d6b7c42fee53133f6165d347db94bdd9ae394ba4f8/yarl-1.8.2-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4e2c6d555e77b37288eaf45b8f60f0737c9efa3452c6c44626a5455aeb250b9",
-              "url": "https://files.pythonhosted.org/packages/1d/78/a273c991086df02837676dc68ccf50d56b2fe624d75258d521c651a65d82/yarl-1.9.2-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "2a1fca9588f360036242f379bfea2b8b44cae2721859b1c56d033adfd5893634",
+              "url": "https://files.pythonhosted.org/packages/02/51/c33498373d2e0ff5d7f3e76038b7057003927d481405780d22f140906b24/yarl-1.8.2-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ec53a0ea2a80c5cd1ab397925f94bff59222aa3cf9c6da938ce05c9ec20428d",
-              "url": "https://files.pythonhosted.org/packages/35/0f/a68344daf90536755f4a890dbbab65dc6ca58c4a0268cf79bd7c5ddc1468/yarl-1.9.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "0978f29222e649c351b173da2b9b4665ad1feb8d1daa9d971eb90df08702668a",
+              "url": "https://files.pythonhosted.org/packages/20/23/9ed12660f860962f179bca719b1d8a895c572c5dbb75098d35d074d35703/yarl-1.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b8cc1863402472f16c600e3e93d542b7e7542a540f95c30afd472e8e549fc3f7",
-              "url": "https://files.pythonhosted.org/packages/3b/b2/34e45989fa5fcf406dd471c517697a5bf483fb1bcaebcf2bedd2b86e0cbb/yarl-1.9.2-cp311-cp311-musllinux_1_1_s390x.whl"
+              "hash": "4d04acba75c72e6eb90745447d69f84e6c9056390f7a9724605ca9c56b4afcc6",
+              "url": "https://files.pythonhosted.org/packages/52/e4/7bcabff7bc7b8421bef266bc955367f586d48667eb0a6ae812852feb51e8/yarl-1.8.2-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "832b7e711027c114d79dffb92576acd1bd2decc467dec60e1cac96912602d0e6",
-              "url": "https://files.pythonhosted.org/packages/50/af/93f1b6d02e936d49e664a8eb4374877e5bacfef115c956939729ac9e2ca8/yarl-1.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "75c16b2a900b3536dfc7014905a128a2bea8fb01f9ee26d2d7d8db0a08e7cb2c",
+              "url": "https://files.pythonhosted.org/packages/5f/3c/59d045a4094f11dea659b69bfca8338803f6cb161da5b039d35cb415a84d/yarl-1.8.2-cp311-cp311-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b25322201585c69abc7b0e89e72790469f7dad90d26754717f3310bfe30331c2",
-              "url": "https://files.pythonhosted.org/packages/53/87/f5588bdc6eba3ca4521bd37094563e8442ba2cff3d6b7e5a2cab48fdc96d/yarl-1.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "42430ff511571940d51e75cf42f1e4dbdded477e71c1b7a17f4da76c1da8ea76",
+              "url": "https://files.pythonhosted.org/packages/7c/9a/6f2039a5578f2af2d36f22173abf22c957970e908617b90e12552f7dfc9a/yarl-1.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "04ab9d4b9f587c06d801c2abfe9317b77cdf996c65a90d5e84ecc45010823571",
-              "url": "https://files.pythonhosted.org/packages/5f/3f/04b3c5e57844fb9c034b09c5cb6d2b43de5d64a093c30529fd233e16cf09/yarl-1.9.2.tar.gz"
+              "hash": "c15163b6125db87c8f53c98baa5e785782078fbd2dbeaa04c6141935eb6dab7a",
+              "url": "https://files.pythonhosted.org/packages/9b/d2/7813ebb6fe192e568c78ba56658f7a26caeceff6302a96808512f5ee40fd/yarl-1.8.2-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "783185c75c12a017cc345015ea359cc801c3b29a2966c2655cd12b233bf5a2be",
-              "url": "https://files.pythonhosted.org/packages/62/c8/b8e048ba98a0f41d46a22060a57f913b4f9ed9c4f6862de36b8137bb67e2/yarl-1.9.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+              "hash": "3150078118f62371375e1e69b13b48288e44f6691c1069340081c3fd12c94d5b",
+              "url": "https://files.pythonhosted.org/packages/ba/85/f9e3350daa31161d1f4dfb10e195951df4ac22d8f201603cf894b37510c8/yarl-1.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "646d663eb2232d7909e6601f1a9107e66f9791f290a1b3dc7057818fe44fc2b6",
-              "url": "https://files.pythonhosted.org/packages/84/c1/eaebee42cbcace2d5b5eb103cae668dec1c239f5c82b90da4b3b20f39419/yarl-1.9.2-cp311-cp311-macosx_10_9_universal2.whl"
+              "hash": "388a45dc77198b2460eac0aca1efd6a7c09e976ee768b0d5109173e521a19daf",
+              "url": "https://files.pythonhosted.org/packages/c0/fd/2f7a640dc157cc2d111114106e3036a69ba3408460d38580f681377c122d/yarl-1.8.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a83503934c6273806aed765035716216cc9ab4e0364f7f066227e1aaea90b8d0",
-              "url": "https://files.pythonhosted.org/packages/b3/81/fb394392ec748d8fce66212b29dc2fd9b2fd8e30d56d818a6a866708e534/yarl-1.9.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562",
+              "url": "https://files.pythonhosted.org/packages/c4/1e/1b204050c601d5cd82b45d5c8f439cb6f744a2ce0c0a6f83be0ddf0dc7b2/yarl-1.8.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "22a94666751778629f1ec4280b08eb11815783c63f52092a5953faf73be24191",
-              "url": "https://files.pythonhosted.org/packages/b7/aa/8b53bceea5454d0b5602ffc81aaf3b80cc2e9b793fe1e054f690beb82429/yarl-1.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "e7fd20d6576c10306dea2d6a5765f46f0ac5d6f53436217913e952d19237efc4",
+              "url": "https://files.pythonhosted.org/packages/c6/1c/4a992306ad86a8ae5a1fb4745bd76c590e7bcdb01ce2203dfd38dc830dfe/yarl-1.8.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "95d2ecefbcf4e744ea952d073c6922e72ee650ffc79028eb1e320e732898d7e8",
-              "url": "https://files.pythonhosted.org/packages/de/3f/5a8fcff69c8628ce4dab00612981f4c0598fb9aabd90d01a1ebb037bb6f6/yarl-1.9.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "f37db05c6051eff17bc832914fe46869f8849de5b92dc4a3466cd63095d23dfd",
+              "url": "https://files.pythonhosted.org/packages/ca/f3/2ef9870409b3ea57a5890e4e49b6bfd6e347a45fe92f6b2e9567abfefb59/yarl-1.8.2-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "159d81f22d7a43e6eabc36d7194cb53f2f15f498dbbfa8edc8a3239350f59fe7",
-              "url": "https://files.pythonhosted.org/packages/ee/8d/55467943a172b97c1b5d9569433c1a70f86f1f9b0f1c6574285f8ad02fc2/yarl-1.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2305517e332a862ef75be8fad3606ea10108662bc6fe08509d5ca99503ac2aee",
+              "url": "https://files.pythonhosted.org/packages/cb/82/91f74496b653ac9a6220ee499510377c03a4ff768c5bd945f6759b23ebb8/yarl-1.8.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aff634b15beff8902d1f918012fc2a42e0dbae6f469fce134c8a0dc51ca423bb",
-              "url": "https://files.pythonhosted.org/packages/fe/7d/9d85f658b6f7c041ca3ba371d133040c4dc41eb922aef0a6ba917291d187/yarl-1.9.2-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "77e913b846a6b9c5f767b14dc1e759e5aff05502fe73079f6f4176359d832581",
+              "url": "https://files.pythonhosted.org/packages/e6/d3/5f5b39db2c8c09f6923418c9329a04fe6f68825f27d2cb9776871d75ddc3/yarl-1.8.2-cp311-cp311-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "yarl",
@@ -4138,7 +4138,7 @@
             "typing-extensions>=3.7.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.9.2"
+          "version": "1.8.2"
         },
         {
           "artifacts": [
@@ -4245,7 +4245,7 @@
     "types-six",
     "typing_extensions~=4.3",
     "uvloop>=0.17; sys_platform != \"Windows\"",
-    "yarl>=1.7",
+    "yarl~=1.8.2",
     "zipstream-new~=1.1.8"
   ],
   "requires_python": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ trafaret~=2.1
 typeguard~=2.10
 typing_extensions~=4.3
 uvloop>=0.17; sys_platform != "Windows"
-yarl>=1.7
+yarl~=1.8.2  # FIXME: revert to >=1.7 after aio-libs/yarl#862 is resolved
 zipstream-new~=1.1.8
 
 # required by ai.backend.test (integration test suite)


### PR DESCRIPTION
Downgrading (again!) yarl version to 1.8 since [another regression](https://github.com/aio-libs/yarl/issues/862) is discovered which crashes image scanning on our side.