### PR TITLE
chore: Add the python version to the classifiers of package

### DIFF
--- a/tools/pants-plugins/setupgen/register.py
+++ b/tools/pants-plugins/setupgen/register.py
@@ -59,6 +59,15 @@ async def setup_kwargs_plugin(
             f"Missing a `description` kwarg in the `provides` field for {request.target.address}.",
         )
 
+    # Override the interpreter compatibility range
+    interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
+    python_requires = next(str(ic.specifier) for ic in interpreter_constraints)  # type: ignore
+    m = re.search(r"==(?P<major>\d+)\.(?P<minor>\d+)", python_requires)
+    if m is not None:
+        major = int(m.group("major"))
+        minor = int(m.group("minor"))
+        kwargs["python_requires"] = f">={major}.{minor},<{major}.{minor + 1}"
+
     # Add classifiers. We preserve any that were already set.
     standard_classifiers = [
         "Intended Audience :: Developers",
@@ -80,6 +89,7 @@ async def setup_kwargs_plugin(
         standard_classifiers.append("Development Status :: 4 - Beta")
     else:
         standard_classifiers.append("Development Status :: 5 - Production/Stable")
+    standard_classifiers.append("Programming Language :: Python :: " + f"{major}.{minor}")
 
     license_classifier = license_classifier_map.get(kwargs["license"])
     if license_classifier:
@@ -131,15 +141,6 @@ async def setup_kwargs_plugin(
             ),
         )
     kwargs.update(hardcoded_kwargs)
-
-    # Override the interpreter compatibility range
-    interpreter_constraints = InterpreterConstraints(python_setup.interpreter_constraints)
-    python_requires = next(str(ic.specifier) for ic in interpreter_constraints)  # type: ignore
-    m = re.search(r"==(?P<major>\d+)\.(?P<minor>\d+)", python_requires)
-    if m is not None:
-        major = int(m.group("major"))
-        minor = int(m.group("minor"))
-        kwargs["python_requires"] = f">={major}.{minor},<{major}.{minor + 1}"
 
     return SetupKwargs(kwargs, address=request.target.address)
 


### PR DESCRIPTION
https://pypi.org/project/backend.ai/
https://pypi.org/project/backend.ai-manager/
Packages prior to the existing monorepo included more information in the classifier.
In particular, the python version is indicated in required, but I thought it would be nice to have it in the package classification information, so I added it.