### PR TITLE
ci: Do not run the workflow when it is not needed using paths-ignore

### DIFF
--- a/.github/workflows/default-skipped.yml
+++ b/.github/workflows/default-skipped.yml
@@ -1,0 +1,20 @@
+name: Skipped Require default
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/default.yml'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No default required"'
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No default required"'
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No default required"'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/default.yml'
   merge_group:
 
 concurrency:

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -3,6 +3,9 @@ name: timeline-check
 on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
   merge_group:
 
 jobs:


### PR DESCRIPTION
Use paths-ignore to prevent actions from being executed meaninglessly.
When actions are skipped using paths-ignore, required is not satisfied.
Since required is recognized as the name of the job, the job corresponding to the skipped workflow must be forcibly executed.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks