### PR TITLE
test: Remove healthchecks for redis containers in fixtures to avoid intermittent hangup

### DIFF
--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -83,7 +83,7 @@ class FileLock(AbstractDistributedLock):
         assert not self._locked
         if not self._path.exists():
             self._path.touch()
-        self._file = open(self._path, "rb")
+        self._file = open(self._path, "wb")
         stop_func = stop_never if self._timeout <= 0 else stop_after_delay(self._timeout)
         try:
             async for attempt in AsyncRetrying(

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -59,6 +59,9 @@ def wait_health_check(container_id):
             capture_output=True,
         )
         container_info = json.loads(proc.stdout)
+        if not container_info:  # maybe empty if container is not yet initialized
+            time.sleep(0.1)
+            continue
         health_info = container_info[0]["State"].get("Health")
         if health_info is not None and health_info["Status"].lower() != "healthy":
             time.sleep(0.2)

--- a/tests/common/redis/conftest.py
+++ b/tests/common/redis/conftest.py
@@ -1,32 +1,29 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from typing import AsyncIterator
 
 import pytest
 
 from .docker import DockerComposeRedisSentinelCluster
-from .native import NativeRedisSentinelCluster
 from .types import RedisClusterInfo
 from .utils import wait_redis_ready
 
+# from .native import NativeRedisSentinelCluster  # unused now
 # A simple "redis_container" fixture is defined in ai.backend.testutils.bootstrap.
 
 
 @pytest.fixture
 async def redis_cluster(test_ns, test_case_ns) -> AsyncIterator[RedisClusterInfo]:
-    if sys.platform.startswith("darwin"):
-        impl = NativeRedisSentinelCluster
-    else:
-        impl = DockerComposeRedisSentinelCluster
+    impl = DockerComposeRedisSentinelCluster
     cluster = impl(test_ns, test_case_ns, password="develove", service_name="mymaster")
     async with cluster.make_cluster() as info:
-        node_wait_tasks = [
-            wait_redis_ready(host, port, "develove") for host, port in info.node_addrs
-        ]
-        sentinel_wait_tasks = [
-            wait_redis_ready(host, port, None) for host, port in info.sentinel_addrs
-        ]
-        await asyncio.gather(*node_wait_tasks, *sentinel_wait_tasks)
+        async with asyncio.TaskGroup() as tg:
+            for host, port in info.node_addrs:
+                tg.create_task(wait_redis_ready(host, port, "develove"))
+            for host, port in info.sentinel_addrs:
+                tg.create_task(wait_redis_ready(host, port, None))
+        # Give the nodes a grace period to sync up.
+        # This is important to reduce intermittent failure of tests.
+        await asyncio.sleep(0.3)
         yield info

--- a/tests/common/redis/docker.py
+++ b/tests/common/redis/docker.py
@@ -158,24 +158,26 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                 "REDIS_SENTINEL2_PORT": await _get_free_port(),
                 "REDIS_SENTINEL3_PORT": await _get_free_port(),
             }
-            os.environ.update({k: str(v) for k, v in ports.items()})
-            os.environ["DOCKER_BUILDKIT"] = "0"  # ref: https://stackoverflow.com/q/73240283
-            async with async_timeout.timeout(30.0):
-                p = await simple_run_cmd(
-                    [
-                        *compose_cmd,
-                        "-p",
-                        project_name,
-                        "-f",
-                        str(compose_cfg),
-                        "up",
-                        "-d",
-                        "--build",
-                    ],
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                )
-                assert p.returncode == 0, "Compose cluster creation has failed."
+
+        os.environ.update({k: str(v) for k, v in ports.items()})
+        os.environ["DOCKER_BUILDKIT"] = "0"  # ref: https://stackoverflow.com/q/73240283
+        async with async_timeout.timeout(30.0):
+            p = await simple_run_cmd(
+                [
+                    *compose_cmd,
+                    "-p",
+                    project_name,
+                    "-f",
+                    str(compose_cfg),
+                    "up",
+                    "-d",
+                    "--build",
+                ],
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            assert p.returncode == 0, "Compose cluster creation has failed."
+
         await asyncio.sleep(2)
         try:
             p = await simple_run_cmd(

--- a/tests/common/redis/docker.py
+++ b/tests/common/redis/docker.py
@@ -158,25 +158,24 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                 "REDIS_SENTINEL2_PORT": await _get_free_port(),
                 "REDIS_SENTINEL3_PORT": await _get_free_port(),
             }
-
-        os.environ.update({k: str(v) for k, v in ports.items()})
-        os.environ["DOCKER_BUILDKIT"] = "0"  # ref: https://stackoverflow.com/q/73240283
-        async with async_timeout.timeout(30.0):
-            p = await simple_run_cmd(
-                [
-                    *compose_cmd,
-                    "-p",
-                    project_name,
-                    "-f",
-                    str(compose_cfg),
-                    "up",
-                    "-d",
-                    "--build",
-                ],
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            assert p.returncode == 0, "Compose cluster creation has failed."
+            os.environ.update({k: str(v) for k, v in ports.items()})
+            os.environ["DOCKER_BUILDKIT"] = "0"  # ref: https://stackoverflow.com/q/73240283
+            async with async_timeout.timeout(30.0):
+                p = await simple_run_cmd(
+                    [
+                        *compose_cmd,
+                        "-p",
+                        project_name,
+                        "-f",
+                        str(compose_cfg),
+                        "up",
+                        "-d",
+                        "--build",
+                    ],
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                assert p.returncode == 0, "Compose cluster creation has failed."
 
         await asyncio.sleep(2)
         try:

--- a/tests/common/redis/redis-cluster.yml
+++ b/tests/common/redis/redis-cluster.yml
@@ -16,10 +16,9 @@ services:
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s
+    # IMPORTANT: We have INTENTIONALLY OMITTED the healthchecks
+    # because it interferes with pause/unpause of container to simulate
+    # network partitioning.
 
   backendai-half-redis-node02:
     image: redis:6-alpine
@@ -35,10 +34,6 @@ services:
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s
 
   backendai-half-redis-node03:
     image: redis:6-alpine
@@ -54,10 +49,6 @@ services:
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s
 
   backendai-half-redis-sentinel01:
     build:
@@ -75,10 +66,6 @@ services:
       - backendai-half-redis-node02
       - backendai-half-redis-node03
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s
 
   backendai-half-redis-sentinel02:
     build:
@@ -96,10 +83,6 @@ services:
       - backendai-half-redis-node02
       - backendai-half-redis-node03
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s
 
   backendai-half-redis-sentinel03:
     build:
@@ -117,7 +100,3 @@ services:
       - backendai-half-redis-node02
       - backendai-half-redis-node03
     network_mode: host
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      start_period: 1s

--- a/tests/common/redis/utils.py
+++ b/tests/common/redis/utils.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import asyncio
 import functools
 import sys
-from typing import TYPE_CHECKING, Awaitable, Callable, Final, Sequence, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Final,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 import async_timeout
 from redis.asyncio import Redis
@@ -36,7 +45,7 @@ async def simple_run_cmd(
     return p
 
 
-async def wait_redis_ready(host: str, port: int, password: str = None) -> None:
+async def wait_redis_ready(host: str, port: int, password: Optional[str] = None) -> None:
     r = Redis.from_url(f"redis://{host}:{port}", password=password, socket_timeout=0.2)
     while True:
         try:


### PR DESCRIPTION
The root cause was the healthchecks—they hang randomly when we run `docker unpause`, causing the Docker Engine to fail with:
<img width="1613" alt="docker-hang-unpause-with-healthchecks" src="https://github.com/lablup/backend.ai/assets/555156/7b5347be-27c8-47fa-b8fa-d911c95dc8db">

This makes an indefinite delay of several test cases and causes timeouts on other tests.

Note that, in production setups, there is no need to `pause` and `unpause` the database containers because the test suite uses them to simulate network partitioning, i.e., unresponsiveness of specific Redis containers when they form a Sentinel-based Redis cluster for an HA setup.