### PR TITLE
test: Parallelize more!

### DIFF
--- a/tests/common/redis/test_list.py
+++ b/tests/common/redis/test_list.py
@@ -7,7 +7,6 @@ from typing import List, Tuple
 import aiotools
 import pytest
 from redis.asyncio import Redis
-from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -15,8 +14,7 @@ from ai.backend.common import redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .types import RedisClusterInfo
-from .utils import interrupt, with_timeout
+from .utils import interrupt
 
 
 @pytest.mark.redis
@@ -173,106 +171,3 @@ async def test_blist_with_retrying_rpush(
     assert set(range(0, 2)) < all_messages
     assert set(range(5, 6)) < all_messages  # more msgs may be lost during restart
     assert all_messages <= set(range(0, 6))
-
-
-@pytest.mark.redis
-@pytest.mark.asyncio
-@pytest.mark.xfail
-@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
-@with_timeout(30.0)
-async def test_blist_cluster_sentinel(
-    redis_cluster: RedisClusterInfo,
-    disruption_method: str,
-) -> None:
-    do_pause = asyncio.Event()
-    paused = asyncio.Event()
-    do_unpause = asyncio.Event()
-    unpaused = asyncio.Event()
-    received_messages: List[str] = []
-
-    async def pop(s: RedisConnectionInfo, key: str) -> None:
-        try:
-            async with aiotools.aclosing(
-                redis_helper.blpop(
-                    s,
-                    key,
-                    reconnect_poll_interval=0.2,
-                    service_name="mymaster",
-                ),
-            ) as agen:
-                async for raw_msg in agen:
-                    msg = raw_msg.decode()
-                    received_messages.append(msg)
-        except asyncio.CancelledError:
-            pass
-
-    s = RedisConnectionInfo(
-        Sentinel(
-            redis_cluster.sentinel_addrs,
-            password="develove",
-            socket_timeout=0.2,
-        ),
-        service_name="mymaster",
-    )
-    await redis_helper.execute(s, lambda r: r.delete("bl1"))
-
-    pop_task = asyncio.create_task(pop(s, "bl1"))
-    interrupt_task = asyncio.create_task(
-        interrupt(
-            disruption_method,
-            redis_cluster.nodes[0],
-            do_pause=do_pause,
-            do_unpause=do_unpause,
-            paused=paused,
-            unpaused=unpaused,
-            redis_password="develove",
-        )
-    )
-    await asyncio.sleep(0)
-
-    for i in range(2):
-        await redis_helper.execute(
-            s,
-            lambda r: r.rpush("bl1", str(i)),
-            service_name="mymaster",
-        )
-        await asyncio.sleep(0.1)
-    do_pause.set()
-    await paused.wait()
-
-    async def wakeup():
-        await asyncio.sleep(2.0)
-        do_unpause.set()
-
-    wakeup_task = asyncio.create_task(wakeup())
-    for i in range(2):
-        await redis_helper.execute(
-            s,
-            lambda r: r.rpush("bl1", str(2 + i)),
-            service_name="mymaster",
-        )
-        await asyncio.sleep(0.1)
-    await wakeup_task
-
-    await unpaused.wait()
-    for i in range(2):
-        await redis_helper.execute(
-            s,
-            lambda r: r.rpush("bl1", str(4 + i)),
-            service_name="mymaster",
-        )
-        await asyncio.sleep(0.1)
-
-    await interrupt_task
-    pop_task.cancel()
-    await pop_task
-    assert pop_task.done()
-
-    if disruption_method == "stop":
-        assert [*map(int, received_messages)] == [*range(0, 6)]
-    else:
-        # loss happens during failover
-        all_messages = set(map(int, received_messages))
-        assert set(range(0, 2)) < all_messages
-        assert set(range(4, 6)) < all_messages
-        assert all_messages <= set(range(0, 6))

--- a/tests/common/redis/test_list_cluster.py
+++ b/tests/common/redis/test_list_cluster.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import aiotools
+import pytest
+from redis.asyncio.sentinel import Sentinel
+
+from ai.backend.common import redis_helper
+from ai.backend.common.types import RedisConnectionInfo
+
+from .types import RedisClusterInfo
+from .utils import interrupt, with_timeout
+
+
+@pytest.mark.redis
+@pytest.mark.asyncio
+@pytest.mark.xfail
+@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
+@with_timeout(30.0)
+async def test_blist_cluster_sentinel(
+    redis_cluster: RedisClusterInfo,
+    disruption_method: str,
+) -> None:
+    do_pause = asyncio.Event()
+    paused = asyncio.Event()
+    do_unpause = asyncio.Event()
+    unpaused = asyncio.Event()
+    received_messages: List[str] = []
+
+    async def pop(s: RedisConnectionInfo, key: str) -> None:
+        try:
+            async with aiotools.aclosing(
+                redis_helper.blpop(
+                    s,
+                    key,
+                    reconnect_poll_interval=0.2,
+                    service_name="mymaster",
+                ),
+            ) as agen:
+                async for raw_msg in agen:
+                    msg = raw_msg.decode()
+                    received_messages.append(msg)
+        except asyncio.CancelledError:
+            pass
+
+    s = RedisConnectionInfo(
+        Sentinel(
+            redis_cluster.sentinel_addrs,
+            password="develove",
+            socket_timeout=0.2,
+        ),
+        service_name="mymaster",
+    )
+    await redis_helper.execute(s, lambda r: r.delete("bl1"))
+
+    pop_task = asyncio.create_task(pop(s, "bl1"))
+    interrupt_task = asyncio.create_task(
+        interrupt(
+            disruption_method,
+            redis_cluster.nodes[0],
+            do_pause=do_pause,
+            do_unpause=do_unpause,
+            paused=paused,
+            unpaused=unpaused,
+            redis_password="develove",
+        )
+    )
+    await asyncio.sleep(0)
+
+    for i in range(2):
+        await redis_helper.execute(
+            s,
+            lambda r: r.rpush("bl1", str(i)),
+            service_name="mymaster",
+        )
+        await asyncio.sleep(0.1)
+    do_pause.set()
+    await paused.wait()
+
+    async def wakeup():
+        await asyncio.sleep(2.0)
+        do_unpause.set()
+
+    wakeup_task = asyncio.create_task(wakeup())
+    for i in range(2):
+        await redis_helper.execute(
+            s,
+            lambda r: r.rpush("bl1", str(2 + i)),
+            service_name="mymaster",
+        )
+        await asyncio.sleep(0.1)
+    await wakeup_task
+
+    await unpaused.wait()
+    for i in range(2):
+        await redis_helper.execute(
+            s,
+            lambda r: r.rpush("bl1", str(4 + i)),
+            service_name="mymaster",
+        )
+        await asyncio.sleep(0.1)
+
+    await interrupt_task
+    pop_task.cancel()
+    await pop_task
+    assert pop_task.done()
+
+    if disruption_method == "stop":
+        assert [*map(int, received_messages)] == [*range(0, 6)]
+    else:
+        # loss happens during failover
+        all_messages = set(map(int, received_messages))
+        assert set(range(0, 2)) < all_messages
+        assert set(range(4, 6)) < all_messages
+        assert all_messages <= set(range(0, 6))

--- a/tests/common/redis/test_stream_consume.py
+++ b/tests/common/redis/test_stream_consume.py
@@ -5,11 +5,9 @@ import sys
 import traceback
 from typing import Dict, List, Tuple
 
-import aiotools
 import pytest
 from aiotools.context import aclosing
 from redis.asyncio import Redis
-from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -17,7 +15,6 @@ from ai.backend.common import redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .types import RedisClusterInfo
 from .utils import interrupt, with_timeout
 
 
@@ -127,106 +124,6 @@ async def test_stream_loadbalance(
     await asyncio.gather(*consumer_tasks, return_exceptions=True)
 
     # loss happens
-    all_messages = set(map(int, received_messages["c1"])) | set(map(int, received_messages["c2"]))
-    print(f"{all_messages=}")
-    assert all_messages >= set(range(0, 2)) | set(range(4, 6))
-    assert len(all_messages) >= 4
-
-
-@pytest.mark.redis
-@pytest.mark.asyncio
-@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
-@with_timeout(30.0)
-async def test_stream_loadbalance_cluster(
-    redis_cluster: RedisClusterInfo, disruption_method: str, chaos_generator
-) -> None:
-    do_pause = asyncio.Event()
-    paused = asyncio.Event()
-    do_unpause = asyncio.Event()
-    unpaused = asyncio.Event()
-    received_messages: Dict[str, List[str]] = {
-        "c1": [],
-        "c2": [],
-    }
-
-    async def consume(
-        group_name: str,
-        consumer_id: str,
-        r: RedisConnectionInfo,
-        key: str,
-    ) -> None:
-        try:
-            async with aclosing(
-                redis_helper.read_stream_by_group(
-                    r,
-                    key,
-                    group_name,
-                    consumer_id,
-                    autoclaim_idle_timeout=500,
-                )
-            ) as agen:
-                async for msg_id, msg_data in agen:
-                    print(f"-> message: {msg_id} {msg_data!r}")
-                    received_messages[consumer_id].append(msg_data[b"idx"])
-        except asyncio.CancelledError:
-            return
-        except Exception:
-            traceback.print_exc()
-            return
-
-    s = RedisConnectionInfo(
-        Sentinel(
-            redis_cluster.sentinel_addrs,
-            password="develove",
-            socket_timeout=0.2,
-        ),
-        service_name="mymaster",
-    )
-    _execute = aiotools.apartial(redis_helper.execute, s)
-    await _execute(lambda r: r.delete("stream1"))
-    await _execute(lambda r: r.xgroup_create("stream1", "group1", b"$", mkstream=True))
-
-    consumer_tasks = [
-        asyncio.create_task(consume("group1", "c1", s, "stream1")),
-        asyncio.create_task(consume("group1", "c2", s, "stream1")),
-    ]
-    await asyncio.sleep(0.1)
-    interrupt_task = asyncio.create_task(
-        interrupt(
-            disruption_method,
-            redis_cluster.nodes[0],
-            do_pause=do_pause,
-            do_unpause=do_unpause,
-            paused=paused,
-            unpaused=unpaused,
-            redis_password="develove",
-        )
-    )
-    await asyncio.sleep(0)
-
-    try:
-        for i in range(2):
-            await _execute(lambda r: r.xadd("stream1", {"idx": i}))
-            await asyncio.sleep(0.1)
-        do_pause.set()
-        await paused.wait()
-        loop = asyncio.get_running_loop()
-        loop.call_later(2.0, do_unpause.set)
-        for i in range(2):
-            # The Redis server is dead temporarily...
-            await _execute(lambda r: r.xadd("stream1", {"idx": 2 + i}))
-            await asyncio.sleep(0.1)
-        await unpaused.wait()
-        for i in range(2):
-            await _execute(lambda r: r.xadd("stream1", {"idx": 4 + i}))
-            await asyncio.sleep(0.1)
-    finally:
-        await interrupt_task
-        for t in consumer_tasks:
-            t.cancel()
-        await asyncio.gather(*consumer_tasks, return_exceptions=True)
-
-    # loss may happen
     all_messages = set(map(int, received_messages["c1"])) | set(map(int, received_messages["c2"]))
     print(f"{all_messages=}")
     assert all_messages >= set(range(0, 2)) | set(range(4, 6))

--- a/tests/common/redis/test_stream_consume_cluster.py
+++ b/tests/common/redis/test_stream_consume_cluster.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import traceback
+from typing import Dict, List
+
+import aiotools
+import pytest
+from aiotools.context import aclosing
+from redis.asyncio.sentinel import Sentinel
+
+from ai.backend.common import redis_helper
+from ai.backend.common.types import RedisConnectionInfo
+
+from .types import RedisClusterInfo
+from .utils import interrupt, with_timeout
+
+
+@pytest.mark.redis
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
+@with_timeout(30.0)
+async def test_stream_loadbalance_cluster(
+    redis_cluster: RedisClusterInfo, disruption_method: str, chaos_generator
+) -> None:
+    do_pause = asyncio.Event()
+    paused = asyncio.Event()
+    do_unpause = asyncio.Event()
+    unpaused = asyncio.Event()
+    received_messages: Dict[str, List[str]] = {
+        "c1": [],
+        "c2": [],
+    }
+
+    async def consume(
+        group_name: str,
+        consumer_id: str,
+        r: RedisConnectionInfo,
+        key: str,
+    ) -> None:
+        try:
+            async with aclosing(
+                redis_helper.read_stream_by_group(
+                    r,
+                    key,
+                    group_name,
+                    consumer_id,
+                    autoclaim_idle_timeout=500,
+                )
+            ) as agen:
+                async for msg_id, msg_data in agen:
+                    print(f"-> message: {msg_id} {msg_data!r}")
+                    received_messages[consumer_id].append(msg_data[b"idx"])
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            traceback.print_exc()
+            return
+
+    s = RedisConnectionInfo(
+        Sentinel(
+            redis_cluster.sentinel_addrs,
+            password="develove",
+            socket_timeout=0.2,
+        ),
+        service_name="mymaster",
+    )
+    _execute = aiotools.apartial(redis_helper.execute, s)
+    await _execute(lambda r: r.delete("stream1"))
+    await _execute(lambda r: r.xgroup_create("stream1", "group1", b"$", mkstream=True))
+
+    consumer_tasks = [
+        asyncio.create_task(consume("group1", "c1", s, "stream1")),
+        asyncio.create_task(consume("group1", "c2", s, "stream1")),
+    ]
+    await asyncio.sleep(0.1)
+    interrupt_task = asyncio.create_task(
+        interrupt(
+            disruption_method,
+            redis_cluster.nodes[0],
+            do_pause=do_pause,
+            do_unpause=do_unpause,
+            paused=paused,
+            unpaused=unpaused,
+            redis_password="develove",
+        )
+    )
+    await asyncio.sleep(0)
+
+    try:
+        for i in range(2):
+            await _execute(lambda r: r.xadd("stream1", {"idx": i}))
+            await asyncio.sleep(0.1)
+        do_pause.set()
+        await paused.wait()
+        loop = asyncio.get_running_loop()
+        loop.call_later(2.0, do_unpause.set)
+        for i in range(2):
+            # The Redis server is dead temporarily...
+            await _execute(lambda r: r.xadd("stream1", {"idx": 2 + i}))
+            await asyncio.sleep(0.1)
+        await unpaused.wait()
+        for i in range(2):
+            await _execute(lambda r: r.xadd("stream1", {"idx": 4 + i}))
+            await asyncio.sleep(0.1)
+    finally:
+        await interrupt_task
+        for t in consumer_tasks:
+            t.cancel()
+        await asyncio.gather(*consumer_tasks, return_exceptions=True)
+
+    # loss may happen
+    all_messages = set(map(int, received_messages["c1"])) | set(map(int, received_messages["c2"]))
+    print(f"{all_messages=}")
+    assert all_messages >= set(range(0, 2)) | set(range(4, 6))
+    assert len(all_messages) >= 4

--- a/tests/common/redis/test_stream_subscribe.py
+++ b/tests/common/redis/test_stream_subscribe.py
@@ -4,11 +4,9 @@ import asyncio
 import sys
 from typing import Dict, List, Tuple
 
-import aiotools
 import pytest
 from aiotools.context import aclosing
 from redis.asyncio import Redis
-from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -16,8 +14,7 @@ from ai.backend.common import redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .types import RedisClusterInfo
-from .utils import interrupt, with_timeout
+from .utils import interrupt
 
 
 @pytest.mark.redis
@@ -115,97 +112,3 @@ async def test_stream_fanout(
         # pause keeps the TCP connection and the messages are delivered late.
         assert [*map(int, received_messages["c1"])] == [*range(0, 6)]
         assert [*map(int, received_messages["c2"])] == [*range(0, 6)]
-
-
-@pytest.mark.redis
-@pytest.mark.asyncio
-@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
-@with_timeout(30.0)
-async def test_stream_fanout_cluster(
-    redis_cluster: RedisClusterInfo, disruption_method: str, chaos_generator
-) -> None:
-    do_pause = asyncio.Event()
-    paused = asyncio.Event()
-    do_unpause = asyncio.Event()
-    unpaused = asyncio.Event()
-    received_messages: Dict[str, List[str]] = {
-        "c1": [],
-        "c2": [],
-    }
-
-    async def consume(
-        consumer_id: str,
-        r: RedisConnectionInfo,
-        key: str,
-    ) -> None:
-        try:
-            async with aclosing(redis_helper.read_stream(r, key)) as agen:
-                async for msg_id, msg_data in agen:
-                    print(f"XREAD[{consumer_id}]", msg_id, repr(msg_data), file=sys.stderr)
-                    received_messages[consumer_id].append(msg_data[b"idx"])
-        except asyncio.CancelledError:
-            return
-        except Exception as e:
-            print("STREAM_FANOUT.CONSUME: unexpected error", repr(e), file=sys.stderr)
-            raise
-
-    s = RedisConnectionInfo(
-        Sentinel(
-            redis_cluster.sentinel_addrs,
-            password="develove",
-            socket_timeout=0.2,
-        ),
-        service_name="mymaster",
-    )
-    _execute = aiotools.apartial(redis_helper.execute, s)
-    await _execute(lambda r: r.delete("stream1"))
-
-    consumer_tasks = [
-        asyncio.create_task(consume("c1", s, "stream1")),
-        asyncio.create_task(consume("c2", s, "stream1")),
-    ]
-    await asyncio.sleep(0.1)
-    interrupt_task = asyncio.create_task(
-        interrupt(
-            disruption_method,
-            redis_cluster.nodes[0],
-            do_pause=do_pause,
-            do_unpause=do_unpause,
-            paused=paused,
-            unpaused=unpaused,
-            redis_password="develove",
-        )
-    )
-    await asyncio.sleep(0)
-
-    try:
-        for i in range(2):
-            await _execute(lambda r: r.xadd("stream1", {"idx": i}))
-            await asyncio.sleep(0.1)
-        do_pause.set()
-        await paused.wait()
-        loop = asyncio.get_running_loop()
-        loop.call_later(2.0, do_unpause.set)
-        for i in range(2):
-            await _execute(lambda r: r.xadd("stream1", {"idx": 2 + i}))
-            await asyncio.sleep(0.1)
-        await unpaused.wait()
-        for i in range(2):
-            await _execute(lambda r: r.xadd("stream1", {"idx": 4 + i}))
-            await asyncio.sleep(0.1)
-    finally:
-        await interrupt_task
-        for t in consumer_tasks:
-            t.cancel()
-            await t
-        for t in consumer_tasks:
-            assert t.done()
-
-    if disruption_method == "stop":
-        # loss does not happen due to retries
-        assert [*map(int, received_messages["c1"])] == [*range(0, 6)]
-        assert [*map(int, received_messages["c2"])] == [*range(0, 6)]
-    else:
-        # loss happens during failover
-        assert {*map(int, received_messages["c1"])} >= {*range(0, 2)} | {*range(4, 6)}
-        assert {*map(int, received_messages["c2"])} >= {*range(0, 2)} | {*range(4, 6)}

--- a/tests/common/redis/test_stream_subscribe_cluster.py
+++ b/tests/common/redis/test_stream_subscribe_cluster.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Dict, List
+
+import aiotools
+import pytest
+from aiotools.context import aclosing
+from redis.asyncio.sentinel import Sentinel
+
+from ai.backend.common import redis_helper
+from ai.backend.common.types import RedisConnectionInfo
+
+from .types import RedisClusterInfo
+from .utils import interrupt, with_timeout
+
+
+@pytest.mark.redis
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disruption_method", ["stop", "pause"])
+@with_timeout(30.0)
+async def test_stream_fanout_cluster(
+    redis_cluster: RedisClusterInfo, disruption_method: str, chaos_generator
+) -> None:
+    do_pause = asyncio.Event()
+    paused = asyncio.Event()
+    do_unpause = asyncio.Event()
+    unpaused = asyncio.Event()
+    received_messages: Dict[str, List[str]] = {
+        "c1": [],
+        "c2": [],
+    }
+
+    async def consume(
+        consumer_id: str,
+        r: RedisConnectionInfo,
+        key: str,
+    ) -> None:
+        try:
+            async with aclosing(redis_helper.read_stream(r, key)) as agen:
+                async for msg_id, msg_data in agen:
+                    print(f"XREAD[{consumer_id}]", msg_id, repr(msg_data), file=sys.stderr)
+                    received_messages[consumer_id].append(msg_data[b"idx"])
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            print("STREAM_FANOUT.CONSUME: unexpected error", repr(e), file=sys.stderr)
+            raise
+
+    s = RedisConnectionInfo(
+        Sentinel(
+            redis_cluster.sentinel_addrs,
+            password="develove",
+            socket_timeout=0.2,
+        ),
+        service_name="mymaster",
+    )
+    _execute = aiotools.apartial(redis_helper.execute, s)
+    await _execute(lambda r: r.delete("stream1"))
+
+    consumer_tasks = [
+        asyncio.create_task(consume("c1", s, "stream1")),
+        asyncio.create_task(consume("c2", s, "stream1")),
+    ]
+    await asyncio.sleep(0.1)
+    interrupt_task = asyncio.create_task(
+        interrupt(
+            disruption_method,
+            redis_cluster.nodes[0],
+            do_pause=do_pause,
+            do_unpause=do_unpause,
+            paused=paused,
+            unpaused=unpaused,
+            redis_password="develove",
+        )
+    )
+    await asyncio.sleep(0)
+
+    try:
+        for i in range(2):
+            await _execute(lambda r: r.xadd("stream1", {"idx": i}))
+            await asyncio.sleep(0.1)
+        do_pause.set()
+        await paused.wait()
+        loop = asyncio.get_running_loop()
+        loop.call_later(2.0, do_unpause.set)
+        for i in range(2):
+            await _execute(lambda r: r.xadd("stream1", {"idx": 2 + i}))
+            await asyncio.sleep(0.1)
+        await unpaused.wait()
+        for i in range(2):
+            await _execute(lambda r: r.xadd("stream1", {"idx": 4 + i}))
+            await asyncio.sleep(0.1)
+    finally:
+        await interrupt_task
+        for t in consumer_tasks:
+            t.cancel()
+            await t
+        for t in consumer_tasks:
+            assert t.done()
+
+    if disruption_method == "stop":
+        # loss does not happen due to retries
+        assert [*map(int, received_messages["c1"])] == [*range(0, 6)]
+        assert [*map(int, received_messages["c2"])] == [*range(0, 6)]
+    else:
+        # loss happens during failover
+        assert {*map(int, received_messages["c1"])} >= {*range(0, 2)} | {*range(4, 6)}
+        assert {*map(int, received_messages["c2"])} >= {*range(0, 2)} | {*range(4, 6)}


### PR DESCRIPTION
Thanks to #1281, now we can safely parallelize our tests more!

This PR reduces the execution time of `pants test tests:: -- -m 'not integration'` to about 1min 20secs in a M1 Pro/Max machine.