### PR TITLE
fix: Handle empty list when migrate kernel role

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -44,6 +44,8 @@ def upgrade():
         result = connection.execute(query).fetchall()
         kernel_ids_to_update = [kid[0] for kid in result]
 
+        if not kernel_ids_to_update:
+            break
         query = (
             sa.update(kernels)
             .values(


### PR DESCRIPTION
Let's not query Update or Insert when the value is empty.
