### PR TITLE
feat: concurrency limit for system sessions

### DIFF
--- a/changes/1299.feature.md
+++ b/changes/1299.feature.md
@@ -1,0 +1,1 @@
+Intoduce separate concurrency limit for SFTP upload sessions

--- a/src/ai/backend/manager/models/alembic/versions/210c4d9be768_add_keypair_resource_policy_max_.py
+++ b/src/ai/backend/manager/models/alembic/versions/210c4d9be768_add_keypair_resource_policy_max_.py
@@ -1,0 +1,29 @@
+"""add keypair_resource_policy.max_concurrent_sftp_sessions column
+
+Revision ID: 210c4d9be768
+Revises: d6a02307a057
+Create Date: 2023-05-24 11:14:03.460405
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "210c4d9be768"
+down_revision = "d6a02307a057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "keypair_resource_policies",
+        sa.Column("max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        "keypair_resource_policies",
+        "max_concurrent_sftp_sessions",
+    )

--- a/src/ai/backend/manager/models/alembic/versions/210c4d9be768_add_keypair_resource_policy_max_.py
+++ b/src/ai/backend/manager/models/alembic/versions/210c4d9be768_add_keypair_resource_policy_max_.py
@@ -18,7 +18,7 @@ depends_on = None
 def upgrade():
     op.add_column(
         "keypair_resource_policies",
-        sa.Column("max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default="1"),
     )
 
 

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -560,6 +560,10 @@ class KernelRow(Base):
             return self.cluster_role
         return self.cluster_role + str(self.cluster_idx)
 
+    @property
+    def is_private(self) -> bool:
+        return self.role in PRIVATE_KERNEL_ROLES
+
     @staticmethod
     async def get_kernel(
         db: ExtendedAsyncSAEngine, kern_id: uuid.UUID, allow_stale: bool = False

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -57,6 +57,9 @@ keypair_resource_policies = sa.Table(
     sa.Column("total_resource_slots", ResourceSlotColumn(), nullable=False),
     sa.Column("max_session_lifetime", sa.Integer(), nullable=False, server_default=sa.text("0")),
     sa.Column("max_concurrent_sessions", sa.Integer(), nullable=False),
+    sa.Column(
+        "max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default=sa.text("0")
+    ),
     sa.Column("max_containers_per_session", sa.Integer(), nullable=False),
     sa.Column("max_vfolder_count", sa.Integer(), nullable=False),
     sa.Column("max_vfolder_size", sa.BigInteger(), nullable=False),

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -58,7 +58,7 @@ keypair_resource_policies = sa.Table(
     sa.Column("max_session_lifetime", sa.Integer(), nullable=False, server_default=sa.text("0")),
     sa.Column("max_concurrent_sessions", sa.Integer(), nullable=False),
     sa.Column(
-        "max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default=sa.text("0")
+        "max_concurrent_sftp_sessions", sa.Integer(), nullable=False, server_default=sa.text("1")
     ),
     sa.Column("max_containers_per_session", sa.Integer(), nullable=False),
     sa.Column("max_vfolder_count", sa.Integer(), nullable=False),

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -69,7 +69,7 @@ from .base import (
     batch_result_in_session,
 )
 from .group import GroupRow
-from .kernel import PRIVATE_KERNEL_ROLES, ComputeContainer, KernelRow, KernelStatus
+from .kernel import ComputeContainer, KernelRow, KernelStatus
 from .minilang.ordering import QueryOrderParser
 from .minilang.queryfilter import QueryFilterParser
 from .user import UserRow
@@ -704,8 +704,8 @@ class SessionRow(Base):
         return {kern.cluster_hostname: kern.resource_opts for kern in self.kernels}
 
     @property
-    def is_private_session(self) -> bool:
-        return any([kernel.role in PRIVATE_KERNEL_ROLES for kernel in self.kernels])
+    def is_private(self) -> bool:
+        return any([kernel.is_private for kernel in self.kernels])
 
     def get_kernel_by_cluster_name(self, cluster_name: str) -> KernelRow:
         kerns = tuple(kern for kern in self.kernels if kern.cluster_name == cluster_name)

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -1118,6 +1118,10 @@ class PurgeUser(graphene.Mutation):
                 redis_conn,
                 lambda r: r.delete(f"keypair.concurrency_used.{access_key}"),
             )
+            await redis_helper.execute(
+                redis_conn,
+                lambda r: r.delete(f"keypair.sftp_concurrency_used.{access_key}"),
+            )
         result = await conn.execute(
             sa.delete(keypairs).where(keypairs.c.user == user_uuid),
         )

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1370,6 +1370,9 @@ class AgentRegistry:
         concurrency_used_per_key: MutableMapping[str, set] = defaultdict(
             set
         )  # key: access_key, value: set of session_id
+        sftp_concurrency_used_per_key: MutableMapping[str, set] = defaultdict(
+            set
+        )  # key: access_key, value: set of session_id
 
         async def _recalc() -> None:
             occupied_slots_per_agent: MutableMapping[str, ResourceSlot] = defaultdict(
@@ -1392,18 +1395,17 @@ class AgentRegistry:
                             kernels.c.session_id,
                             kernels.c.agent,
                             kernels.c.occupied_slots,
+                            kernels.c.role,
                         ]
                     )
-                    .where(
-                        (
-                            kernels.c.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES)
-                            & kernels.c.role.not_in(PRIVATE_KERNEL_ROLES)
-                        )
-                    )
+                    .where(kernels.c.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
                     .order_by(sa.asc(kernels.c.access_key))
                 )
                 async for row in await conn.stream(query):
-                    concurrency_used_per_key[row.access_key].add(row.session_id)
+                    if kernels.c.role in PRIVATE_KERNEL_ROLES:
+                        sftp_concurrency_used_per_key[row.access_key].add(row.session_id)
+                    else:
+                        concurrency_used_per_key[row.access_key].add(row.session_id)
 
                 if len(occupied_slots_per_agent) > 0:
                     # Update occupied_slots for agents with running containers.
@@ -1432,11 +1434,15 @@ class AgentRegistry:
 
         # Update keypair resource usage for keypairs with running containers.
         kp_key = "keypair.concurrency_used"
+        sftp_kp_key = "keypair.sftp_concurrency_used"
 
         async def _update(r: Redis):
             updates = {
                 f"{kp_key}.{ak}": len(session_ids)
                 for ak, session_ids in concurrency_used_per_key.items()
+            } | {
+                f"{sftp_kp_key}.{ak}": len(session_ids)
+                for ak, session_ids in sftp_concurrency_used_per_key.items()
             }
             if updates:
                 await r.mset(typing.cast(MSetType, updates))
@@ -1448,6 +1454,11 @@ class AgentRegistry:
                 session_concurrency = concurrency_used_per_key.get(ak)
                 usage = len(session_concurrency) if session_concurrency is not None else 0
                 updates[f"{kp_key}.{ak}"] = usage
+            keys = await r.keys(f"{sftp_kp_key}.*")
+            for ak in keys:
+                session_concurrency = sftp_concurrency_used_per_key.get(ak)
+                usage = len(session_concurrency) if session_concurrency is not None else 0
+                updates[f"{sftp_kp_key}.{ak}"] = usage
             if updates:
                 await r.mset(typing.cast(MSetType, updates))
 
@@ -1668,16 +1679,17 @@ class AgentRegistry:
                                         .where(KernelRow.id == kernel.id),
                                     )
 
-                            if (
-                                kernel.cluster_role == DEFAULT_ROLE
-                                and kernel.role not in PRIVATE_KERNEL_ROLES
-                            ):
+                            if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
                                 # decrement the user's concurrency counter
+                                if kernel.role in PRIVATE_KERNEL_ROLES:
+                                    kp_key = "keypair.sftp_concurrency_used"
+                                else:
+                                    kp_key = "keypair.concurrency_used"
                                 await redis_helper.execute(
                                     self.redis_stat,
                                     lambda r: r.incrby(
-                                        f"keypair.concurrency_used.{kernel.access_key}",
+                                        f"{kp_key}.{kernel.access_key}",
                                         -1,
                                     ),
                                 )
@@ -1712,16 +1724,17 @@ class AgentRegistry:
                                         .where(KernelRow.id == kernel.id),
                                     )
 
-                            if (
-                                kernel.cluster_role == DEFAULT_ROLE
-                                and kernel.role not in PRIVATE_KERNEL_ROLES
-                            ):
+                            if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
                                 # decrement the user's concurrency counter
+                                if kernel.role in PRIVATE_KERNEL_ROLES:
+                                    kp_key = "keypair.sftp_concurrency_used"
+                                else:
+                                    kp_key = "keypair.concurrency_used"
                                 await redis_helper.execute(
                                     self.redis_stat,
                                     lambda r: r.incrby(
-                                        f"keypair.concurrency_used.{kernel.access_key}",
+                                        f"{kp_key}.{kernel.access_key}",
                                         -1,
                                     ),
                                 )

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1402,7 +1402,7 @@ class AgentRegistry:
                     .order_by(sa.asc(kernels.c.access_key))
                 )
                 async for row in await conn.stream(query):
-                    if kernels.c.role in PRIVATE_KERNEL_ROLES:
+                    if row.role in PRIVATE_KERNEL_ROLES:
                         sftp_concurrency_used_per_key[row.access_key].add(row.session_id)
                     else:
                         concurrency_used_per_key[row.access_key].add(row.session_id)
@@ -1682,7 +1682,7 @@ class AgentRegistry:
                             if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
                                 # decrement the user's concurrency counter
-                                if kernel.role in PRIVATE_KERNEL_ROLES:
+                                if kernel.is_private:
                                     kp_key = "keypair.sftp_concurrency_used"
                                 else:
                                     kp_key = "keypair.concurrency_used"
@@ -1727,7 +1727,7 @@ class AgentRegistry:
                             if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
                                 # decrement the user's concurrency counter
-                                if kernel.role in PRIVATE_KERNEL_ROLES:
+                                if kernel.is_private:
                                     kp_key = "keypair.sftp_concurrency_used"
                                 else:
                                     kp_key = "keypair.concurrency_used"

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -380,7 +380,7 @@ class SchedulerDispatcher(aobject):
                         ("dependencies", check_dependencies(db_sess, sched_ctx, sess_ctx)),
                         ("concurrency", check_concurrency(db_sess, sched_ctx, sess_ctx)),
                     ]
-                    if not sess_ctx.is_private_session:
+                    if not sess_ctx.is_private:
                         predicates += [
                             (
                                 "keypair_resource_limit",
@@ -462,7 +462,7 @@ class SchedulerDispatcher(aobject):
                             .where(SessionRow.id == sess_ctx.id)
                         )
                         await db_sess.execute(query)
-                        if sess_ctx.is_private_session:
+                        if sess_ctx.is_private:
                             await _apply_cancellation(db_sess, [sess_ctx.id])
                             await self.event_producer.produce_event(
                                 SessionCancelledEvent(

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -32,7 +32,7 @@ from ai.backend.common.events import (
     SessionTerminatedEvent,
 )
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, aobject
+from ai.backend.common.types import AgentId, ClusterMode, ResourceSlot, SessionId, aobject
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.types import DistributedLockFactory
 from ai.backend.plugin.entrypoint import scan_entrypoints
@@ -42,7 +42,6 @@ from ..defs import LockID
 from ..exceptions import convert_to_status_data
 from ..models import (
     AgentStatus,
-    KernelRole,
     KernelRow,
     KernelStatus,
     ScalingGroupRow,
@@ -266,6 +265,45 @@ class SchedulerDispatcher(aobject):
         sched_ctx: SchedulingContext,
         sgroup_name: str,
     ) -> None:
+        async def _apply_cancellation(
+            db_sess: SASession, session_ids: list[SessionId], reason="pending-timeout"
+        ):
+            now = datetime.now(tzutc())
+            kernel_query = (
+                sa.update(KernelRow)
+                .values(
+                    status=KernelStatus.CANCELLED,
+                    status_info=reason,
+                    terminated_at=now,
+                    status_history=sql_json_merge(
+                        KernelRow.status_history,
+                        (),
+                        {
+                            KernelStatus.CANCELLED.name: now.isoformat(),
+                        },
+                    ),
+                )
+                .where(KernelRow.session_id.in_(session_ids))
+            )
+            await db_sess.execute(kernel_query)
+            query = (
+                sa.update(SessionRow)
+                .values(
+                    status=SessionStatus.CANCELLED,
+                    status_info=reason,
+                    terminated_at=now,
+                    status_history=sql_json_merge(
+                        SessionRow.status_history,
+                        (),
+                        {
+                            SessionStatus.CANCELLED.name: now.isoformat(),
+                        },
+                    ),
+                )
+                .where(SessionRow.id.in_(session_ids))
+            )
+            await db_sess.execute(query)
+
         async with self.db.begin_readonly_session() as db_sess:
             scheduler = await self._load_scheduler(db_sess, sgroup_name)
             existing_sessions, pending_sessions, cancelled_sessions = await _list_managed_sessions(
@@ -273,47 +311,13 @@ class SchedulerDispatcher(aobject):
             )
 
         if cancelled_sessions:
-            now = datetime.now(tzutc())
             session_ids = [item.id for item in cancelled_sessions]
 
-            async def _apply_cancellation():
+            async def _update():
                 async with self.db.begin_session() as db_sess:
-                    kernel_query = (
-                        sa.update(KernelRow)
-                        .values(
-                            status=KernelStatus.CANCELLED,
-                            status_info="pending-timeout",
-                            terminated_at=now,
-                            status_history=sql_json_merge(
-                                KernelRow.status_history,
-                                (),
-                                {
-                                    KernelStatus.CANCELLED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(KernelRow.session_id.in_(session_ids))
-                    )
-                    await db_sess.execute(kernel_query)
-                    query = (
-                        sa.update(SessionRow)
-                        .values(
-                            status=SessionStatus.CANCELLED,
-                            status_info="pending-timeout",
-                            terminated_at=now,
-                            status_history=sql_json_merge(
-                                SessionRow.status_history,
-                                (),
-                                {
-                                    SessionStatus.CANCELLED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(SessionRow.id.in_(session_ids))
-                    )
-                    await db_sess.execute(query)
+                    await _apply_cancellation(db_sess, session_ids)
 
-            await execute_with_retry(_apply_cancellation)
+            await execute_with_retry(_update)
             for item in cancelled_sessions:
                 await self.event_producer.produce_event(
                     SessionCancelledEvent(
@@ -374,10 +378,10 @@ class SchedulerDispatcher(aobject):
                             check_reserved_batch_session(db_sess, sched_ctx, sess_ctx),
                         ),
                         ("dependencies", check_dependencies(db_sess, sched_ctx, sess_ctx)),
+                        ("concurrency", check_concurrency(db_sess, sched_ctx, sess_ctx)),
                     ]
-                    if any([kernel.role != KernelRole.SYSTEM for kernel in sess_ctx.kernels]):
+                    if not sess_ctx.is_private_session:
                         predicates += [
-                            ("concurrency", check_concurrency(db_sess, sched_ctx, sess_ctx)),
                             (
                                 "keypair_resource_limit",
                                 check_keypair_resource_limit(db_sess, sched_ctx, sess_ctx),
@@ -438,7 +442,7 @@ class SchedulerDispatcher(aobject):
             if has_failure:
                 log.debug(log_fmt + "predicate-checks-failed (temporary)", *log_args)
 
-                async def _update() -> None:
+                async def _cancel_failed_system_session() -> None:
                     async with self.db.begin_session() as db_sess:
                         await _rollback_predicate_mutations(
                             db_sess,
@@ -458,14 +462,23 @@ class SchedulerDispatcher(aobject):
                             .where(SessionRow.id == sess_ctx.id)
                         )
                         await db_sess.execute(query)
+                        if sess_ctx.is_private_session:
+                            await _apply_cancellation(db_sess, [sess_ctx.id])
+                            await self.event_producer.produce_event(
+                                SessionCancelledEvent(
+                                    sess_ctx.id,
+                                    sess_ctx.creation_id,
+                                    reason=KernelLifecycleEventReason.PENDING_TIMEOUT,
+                                )
+                            )
 
-                await execute_with_retry(_update)
+                await execute_with_retry(_cancel_failed_system_session)
                 # Predicate failures are *NOT* permanent errors.
                 # We need to retry the scheduling afterwards.
                 continue
             else:
 
-                async def _update() -> None:
+                async def _update_session_status_data() -> None:
                     async with self.db.begin_session() as db_sess:
                         kernel_query = (
                             sa.update(KernelRow)
@@ -492,7 +505,7 @@ class SchedulerDispatcher(aobject):
                         )
                         await db_sess.execute(session_query)
 
-                await execute_with_retry(_update)
+                await execute_with_retry(_update_session_status_data)
 
             async with self.db.begin_readonly_session() as db_sess:
                 schedulable_sess = await SessionRow.get_session_by_id(

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -84,7 +84,6 @@ async def check_concurrency(
         redis_key = f"keypair.sftp_concurrency_used.{sess_ctx.access_key}"
     else:
         redis_key = f"keypair.concurrency_used.{sess_ctx.access_key}"
-    log.debug("updating {}", redis_key)
     ok, concurrency_used = await redis_helper.execute_script(
         sched_ctx.registry.redis_stat,
         "check_keypair_concurrency_used",

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -69,7 +69,7 @@ async def check_concurrency(
         resouce_policy_q = sa.select(KeyPairRow.resource_policy).where(
             KeyPairRow.access_key == sess_ctx.access_key
         )
-        if sess_ctx.is_private_session:
+        if sess_ctx.is_private:
             concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sftp_sessions
         else:
             concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sessions
@@ -80,7 +80,7 @@ async def check_concurrency(
         return result.scalar()
 
     max_concurrent_sessions = await execute_with_retry(_get_max_concurrent_sessions)
-    if sess_ctx.is_private_session:
+    if sess_ctx.is_private:
         redis_key = f"keypair.sftp_concurrency_used.{sess_ctx.access_key}"
     else:
         redis_key = f"keypair.concurrency_used.{sess_ctx.access_key}"

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -69,18 +69,27 @@ async def check_concurrency(
         resouce_policy_q = sa.select(KeyPairRow.resource_policy).where(
             KeyPairRow.access_key == sess_ctx.access_key
         )
-        select_query = sa.select(KeyPairResourcePolicyRow.max_concurrent_sessions).where(
+        if sess_ctx.is_private_session:
+            concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sftp_sessions
+        else:
+            concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sessions
+        select_query = sa.select(concurrent_session_column).where(
             KeyPairResourcePolicyRow.name == resouce_policy_q.scalar_subquery()
         )
         result = await db_sess.execute(select_query)
         return result.scalar()
 
     max_concurrent_sessions = await execute_with_retry(_get_max_concurrent_sessions)
+    if sess_ctx.is_private_session:
+        redis_key = f"keypair.sftp_concurrency_used.{sess_ctx.access_key}"
+    else:
+        redis_key = f"keypair.concurrency_used.{sess_ctx.access_key}"
+    log.debug("updating {}", redis_key)
     ok, concurrency_used = await redis_helper.execute_script(
         sched_ctx.registry.redis_stat,
         "check_keypair_concurrency_used",
         _check_keypair_concurrency_script,
-        [f"keypair.concurrency_used.{sess_ctx.access_key}"],
+        [redis_key],
         [max_concurrent_sessions],
     )
     if ok == 0:


### PR DESCRIPTION
Follow-up of #1243. This PR introduces `keypair_resource_policies.max_concurrent_sftp_sessions` column. Sessions created from SFTP scaling groups will now follow this rule, overriding previous behavior, which does not limit maximum number of SFTP upload sessions. In contrast to normal sesions, `SYSTEM` sessions (also known as SFTP upload sessions) failing concurrency check will instantly transit to `CANCELLED` status rather than keeping its state at `SCHEDULING`. This is to feedback UI that user has reached its own concurrency limit.