### PR TITLE
ci: Fix wrong db migration file path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 require:db-migration:
-- any: ['src/ai/backend/manager/alembic/versions/*.py']
+- any: ['src/ai/backend/manager/models/alembic/versions/*.py']
 
 area:docs:
 - any: ['docs/**/*']


### PR DESCRIPTION
Modify that the models path is missing in the middle of the labeler path that sets the required:db-migration label.