### PR TITLE
fix: use session_id to destroy kernels instead of kernel.session_id

### DIFF
--- a/changes/1304.fix.md
+++ b/changes/1304.fix.md
@@ -1,0 +1,1 @@
+Use `session_id` to update status of destroyed session rather `kernel.session_id`.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1621,14 +1621,14 @@ class AgentRegistry:
                                 main_stat = {"status": "cancelled"}
                                 await SessionRow.set_session_status(
                                     self.db,
-                                    kernel.session_id,
+                                    session_id,
                                     SessionStatus.CANCELLED,
                                     reason=reason,
                                     status_changed_at=now,
                                 )
                                 await self.event_producer.produce_event(
                                     SessionCancelledEvent(
-                                        kernel.session_id,
+                                        session_id,
                                         kernel.session_creation_id,
                                         reason,
                                     ),


### PR DESCRIPTION
In `destroy_session()`, using `kernel.session_id` which is not eager-loaded occurs error.
This pr fix it by using `session_id` which is already loaded.