### PR TITLE
test: Improve stability of flaky tests

### DIFF
--- a/tests/common/redis/test_stream_consume_cluster.py
+++ b/tests/common/redis/test_stream_consume_cluster.py
@@ -112,5 +112,5 @@ async def test_stream_loadbalance_cluster(
     # loss may happen
     all_messages = set(map(int, received_messages["c1"])) | set(map(int, received_messages["c2"]))
     print(f"{all_messages=}")
-    assert all_messages >= set(range(0, 2)) | set(range(4, 6))
+    assert all_messages >= set(range(0, 2)) | set(range(5, 6))
     assert len(all_messages) >= 4


### PR DESCRIPTION
- `tests/common/test_etcd.py`: Prefer timeouts with explicit waits for the results instead relying on sleeps.
- `tests/common/redis/test_stream_consume_cluster.py`: Relax the result check for allowed loss of messages.