### PR TITLE
feat: update POST `/service` API to also accept vFolder name

### DIFF
--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -114,7 +114,7 @@ def info(ctx: CLIContext, service_name_or_id: str):
 @service.command()
 @pass_ctx_obj
 @click.argument("image", metavar="IMAGE", type=str)
-@click.argument("model_id_or_name", metavar="MODEL_ID", type=str)
+@click.argument("model_name_or_id", metavar="MODEL_NAME_OR_ID", type=str)
 @click.argument("initial_session_count", metavar="COUNT", type=int)
 @click.option("-t", "--name", metavar="NAME", type=str, default=None)
 @click.option("--model-version", metavar="VERSION", type=str, default=None)
@@ -228,7 +228,7 @@ def info(ctx: CLIContext, service_name_or_id: str):
 def create(
     ctx: CLIContext,
     image: str,
-    model_id_or_name: str,
+    model_name_or_id: str,
     initial_session_count: int,
     *,
     name: Optional[str],
@@ -287,7 +287,7 @@ def create(
         try:
             result = session.Service.create(
                 image,
-                model_id_or_name,
+                model_name_or_id,
                 initial_session_count,
                 **body,
             )

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -17,6 +17,7 @@ __all__ = ("Service",)
 
 _default_fields: Sequence[FieldSpec] = (
     service_fields["endpoint_id"],
+    service_fields["name"],
     service_fields["image"],
     service_fields["desired_session_count"],
     service_fields["routings"],
@@ -30,9 +31,12 @@ class Service(BaseFunction):
 
     @api_function
     @classmethod
-    async def list(cls):
+    async def list(cls, name: Optional[str] = None):
         """ """
-        rqst = Request("GET", "/services")
+        params = {}
+        if name:
+            params["name"] = name
+        rqst = Request("GET", "/services", params=params)
         async with rqst.fetch() as resp:
             return await resp.json()
 
@@ -81,7 +85,7 @@ class Service(BaseFunction):
     async def create(
         cls,
         image: str,
-        model_id: str,
+        model_id_or_name: str,
         initial_session_count: int,
         *,
         service_name: Optional[str] = None,
@@ -154,7 +158,7 @@ class Service(BaseFunction):
                 "owner_access_key": owner_access_key,
                 "open_to_public": expose_to_public,
                 "config": {
-                    "model_id": model_id,
+                    "model": model_id_or_name,
                     "model_version": model_version,
                     "model_mount_destination": model_mount_destination,
                     "environ": envs,


### PR DESCRIPTION
Follow-up PR of #1278. Update API and CLI to also accept vFolder name and endpoint name as valid identifier.