### PR TITLE
ci,test: Pass the build root path explicitly when running tests

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -37,6 +37,9 @@ root_patterns = [
     "/tools/pants-plugins",
 ]
 
+[test]
+extra_env_vars = ["BACKEND_BUILD_ROOT=%(buildroot)s"]
+
 [python]
 enable_resolves = true
 # When changing this main Python version:

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -3,6 +3,7 @@ import collections
 import configparser
 import itertools
 import logging
+import os
 from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
@@ -145,6 +146,8 @@ def scan_entrypoint_from_plugin_checkouts(group_name: str) -> Iterator[EntryPoin
 
 
 def find_build_root(path: Optional[Path] = None) -> Path:
+    if env_build_root := os.environ.get("BACKEND_BUILD_ROOT", None):
+        return Path(env_build_root)
     cwd = Path.cwd() if path is None else path
     while True:
         if (cwd / "BUILD_ROOT").exists():


### PR DESCRIPTION
This PR fixes plugin discovery failures after #1317.
