### PR TITLE
fix: ensure type of `agent_id` to be consistent

### DIFF
--- a/changes/1325.fix.md
+++ b/changes/1325.fix.md
@@ -1,0 +1,1 @@
+Fix to check type of `agent_id` strictly when schedule multi-node session.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -846,7 +846,7 @@ class SchedulerDispatcher(aobject):
                                 sched_ctx,
                                 agent_db_sess,
                                 sgroup_name,
-                                agent.id,
+                                agent,
                                 kernel.requested_slots,
                                 extra_conds=agent_query_extra_conds,
                             )

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -803,7 +803,6 @@ class SchedulerDispatcher(aobject):
                             raise GenericBadRequest(f"No such agent: {agent.id}")
                         for key in available_agent_slots:
                             if available_agent_slots[key] >= kernel.requested_slots[key]:
-                                agent_id = agent.id
                                 continue
                             else:
                                 raise InstanceNotAvailable(
@@ -814,6 +813,7 @@ class SchedulerDispatcher(aobject):
                                         f"available: {available_agent_slots[key]})."
                                     ),
                                 )
+                        agent_id = agent.id
                     else:
                         # Each kernel may have different images and different architectures
                         compatible_candidate_agents = [


### PR DESCRIPTION
Currently variable `agent` has an inconsistent type in `SchedulerDispatcher._schedule_multi_node_session()`.
It can be `AgentRow` type or `AgentId`(string) type depending on the condition.
Let's check the type strictly.