### PR TITLE
fix: set session status not being set as `PULLING`

### DIFF
--- a/changes/1326.fix.md
+++ b/changes/1326.fix.md
@@ -1,0 +1,1 @@
+Set session status `PULLING` when any sibling kernel is pulling image.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3376,6 +3376,7 @@ async def handle_kernel_creation_lifecycle(
         await KernelRow.set_kernel_status(
             context.db, event.kernel_id, KernelStatus.PULLING, reason=event.reason
         )
+        await SessionRow.set_session_status(context.db, event.session_id, SessionStatus.PULLING)
     elif isinstance(event, KernelCreatingEvent):
         await KernelRow.set_kernel_status(
             context.db, event.kernel_id, KernelStatus.PREPARING, reason=event.reason


### PR DESCRIPTION
Set session status `PULLING` when any sibling kernel is pulling image.
