### PR TITLE
fix: heartbeat failing when public-host is set

### DIFF
--- a/changes/1332.fix.md
+++ b/changes/1332.fix.md
@@ -1,0 +1,1 @@
+Fix agent refusing to send heartbeat when `public-host` is set

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -796,7 +796,7 @@ class AbstractAgent(
                 "region": self.local_config["agent"]["region"],
                 "scaling_group": self.local_config["agent"]["scaling-group"],
                 "addr": f"tcp://{self.local_config['agent']['rpc-listen-addr']}",
-                "public_host": self._get_public_host(),
+                "public_host": str(self._get_public_host()),
                 "resource_slots": res_slots,
                 "version": VERSION,
                 "compute_plugins": {


### PR DESCRIPTION
This PR fixes heartbeat failing when public-host is set. 