### PR TITLE
fix: manager vFolder API failing

### DIFF
--- a/changes/1333.fix.md
+++ b/changes/1333.fix.md
@@ -1,0 +1,1 @@
+Fix some of manager's vFolder API raising error

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -791,6 +791,10 @@ class VFolderID:
     quota_scope_id: str | None
     folder_id: uuid.UUID
 
+    @classmethod
+    def from_row(cls, row: Any) -> VFolderID:
+        return VFolderID(quota_scope_id=row["quota_scope_id"], folder_id=row["id"])
+
     def __str__(self) -> str:
         if self.quota_scope_id is None:
             return self.folder_id.hex

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -58,6 +58,7 @@ from ai.backend.common.types import (
     AgentId,
     ClusterMode,
     SessionTypes,
+    VFolderID,
 )
 
 from ..config import DEFAULT_CHUNK_SIZE
@@ -1824,7 +1825,7 @@ async def get_task_logs(request: web.Request, params: Any) -> web.StreamResponse
             "folder/file/fetch",
             json={
                 "volume": volume_name,
-                "vfid": str(log_vfolder["id"]),
+                "vfid": str(VFolderID.from_row(log_vfolder)),
                 "relpath": str(
                     PurePosixPath("task")
                     / kernel_id_str[:2]

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -889,7 +889,7 @@ async def get_info(request: web.Request, row: VFolderRow) -> web.Response:
         "folder/usage",
         json={
             "volume": volume_name,
-            "vfid": str(row["id"]),
+            "vfid": str(VFolderID.from_row(row)),
         },
     ) as (_, storage_resp):
         usage = await storage_resp.json()
@@ -929,7 +929,7 @@ async def get_info(request: web.Request, row: VFolderRow) -> web.Response:
     )
 )
 async def get_quota(request: web.Request, params: Any) -> web.Response:
-    await ensure_vfolder_status(request, VFolderAccessStatus.READABLE, params["id"])
+    vfolder_row = await ensure_vfolder_status(request, VFolderAccessStatus.READABLE, params["id"])
     root_ctx: RootContext = request.app["_root.context"]
     proxy_name, volume_name = root_ctx.storage_manager.split_host(params["folder_host"])
     log.info(
@@ -966,7 +966,7 @@ async def get_quota(request: web.Request, params: Any) -> web.Response:
         "volume/quota",
         json={
             "volume": volume_name,
-            "vfid": str(params["id"]),
+            "vfid": str(VFolderID.from_row(vfolder_row)),
         },
     ) as (_, storage_resp):
         storage_reply = await storage_resp.json()
@@ -985,7 +985,7 @@ async def get_quota(request: web.Request, params: Any) -> web.Response:
     ),
 )
 async def update_quota(request: web.Request, params: Any) -> web.Response:
-    await ensure_vfolder_status(request, VFolderAccessStatus.UPDATABLE, params["id"])
+    vfolder_row = await ensure_vfolder_status(request, VFolderAccessStatus.UPDATABLE, params["id"])
     root_ctx: RootContext = request.app["_root.context"]
     folder_host = params["folder_host"]
     proxy_name, volume_name = root_ctx.storage_manager.split_host(folder_host)
@@ -1041,7 +1041,7 @@ async def update_quota(request: web.Request, params: Any) -> web.Response:
         "volume/quota",
         json={
             "volume": volume_name,
-            "vfid": str(params["id"]),
+            "vfid": str(VFolderID.from_row(vfolder_row)),
             "size_bytes": quota,
         },
     ):
@@ -2272,7 +2272,7 @@ async def delete_by_name(request: web.Request) -> web.Response:
 
     await initiate_vfolder_removal(
         root_ctx.db,
-        [VFolderDeletionInfo(entry["id"], folder_host)],
+        [VFolderDeletionInfo(VFolderID.from_row(entry), folder_host)],
         root_ctx.storage_manager,
         app_ctx.storage_ptask_group,
     )

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import relationship
 
 from ai.backend.common import msgpack
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.types import ResourceSlot
+from ai.backend.common.types import ResourceSlot, VFolderID
 
 from ..api.exceptions import VFolderOperationFailed
 from ..defs import RESERVED_DOTFILES
@@ -620,7 +620,7 @@ class PurgeGroup(graphene.Mutation):
         try:
             deleted_count = await initiate_vfolder_removal(
                 engine,
-                [VFolderDeletionInfo(vf["id"], vf["host"]) for vf in target_vfs],
+                [VFolderDeletionInfo(VFolderID.from_row(vf), vf["host"]) for vf in target_vfs],
                 storage_manager,
                 storage_ptask_group,
             )

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -22,7 +22,7 @@ from sqlalchemy.types import VARCHAR, TypeDecorator
 
 from ai.backend.common import redis_helper
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.types import RedisConnectionInfo
+from ai.backend.common.types import RedisConnectionInfo, VFolderID
 
 from ..api.exceptions import VFolderOperationFailed
 from .base import (
@@ -1005,7 +1005,7 @@ class PurgeUser(graphene.Mutation):
         try:
             deleted_count = await initiate_vfolder_removal(
                 engine,
-                [VFolderDeletionInfo(vf["id"], vf["host"]) for vf in target_vfs],
+                [VFolderDeletionInfo(VFolderID.from_row(vf), vf["host"]) for vf in target_vfs],
                 storage_manager,
                 storage_ptask_group,
             )

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -796,7 +796,7 @@ async def initiate_vfolder_clone(
     storage_manager: StorageSessionManager,
     background_task_manager: BackgroundTaskManager,
 ) -> tuple[uuid.UUID, uuid.UUID]:
-    source_vf_cond = vfolders.c.id == vfolder_info.source_vfolder_id
+    source_vf_cond = vfolders.c.id == vfolder_info.source_vfolder_id.folder_id
 
     async def _update_status() -> None:
         async with db_engine.begin_session() as db_session:
@@ -817,7 +817,7 @@ async def initiate_vfolder_clone(
     #       the actual object (with RETURNING clause).  In that case, we need to temporarily
     #       mark the object to be "unusable-yet" until the storage proxy craetes the destination
     #       vfolder.  After done, we need to make another transaction to clear the unusable state.
-    target_folder_id = uuid.uuid4()
+    target_folder_id = VFolderID(vfolder_info.source_vfolder_id.quota_scope_id, uuid.uuid4())
 
     async def _clone(reporter: ProgressReporter) -> None:
         try:
@@ -833,12 +833,12 @@ async def initiate_vfolder_clone(
             ):
                 pass
         except aiohttp.ClientResponseError:
-            raise VFolderOperationFailed(extra_msg=str(target_folder_id))
+            raise VFolderOperationFailed(extra_msg=str(target_folder_id.folder_id))
 
         async def _insert_vfolder() -> None:
             async with db_engine.begin_session() as db_session:
                 insert_values = {
-                    "id": target_folder_id,
+                    "id": target_folder_id.folder_id,
                     "name": vfolder_info.target_vfolder_name,
                     "usage_mode": vfolder_info.usage_mode,
                     "permission": vfolder_info.permission,
@@ -851,6 +851,7 @@ async def initiate_vfolder_clone(
                     "group": None,
                     "unmanaged_path": "",
                     "cloneable": vfolder_info.cloneable,
+                    "quota_scope_id": vfolder_info.source_vfolder_id.quota_scope_id,
                 }
                 insert_query = sa.insert(vfolders, insert_values)
                 try:
@@ -889,7 +890,7 @@ async def initiate_vfolder_clone(
         await execute_with_retry(_update_source_vfolder)
 
     task_id = await background_task_manager.start(_clone)
-    return task_id, target_folder_id
+    return task_id, target_folder_id.folder_id
 
 
 async def initiate_vfolder_removal(
@@ -899,7 +900,7 @@ async def initiate_vfolder_removal(
     storage_ptask_group: aiotools.PersistentTaskGroup,
 ) -> int:
     vfolder_info_len = len(requested_vfolders)
-    vfolder_ids = tuple(vf_id for vf_id, _ in requested_vfolders)
+    vfolder_ids = tuple(vf_id.folder_id for vf_id, _ in requested_vfolders)
     cond = vfolders.c.id.in_(vfolder_ids)
     if vfolder_info_len == 0:
         return 0


### PR DESCRIPTION
Follow-up PR of #1191. Updates vFolder API logics which are utilizing old vFolder ID structure to use latest one, which causes `400` HTTP error when calling storage proxy API.