### PR TITLE
fix: prevent scanning every sub-directories in listing vfolder files when `recursive` is `False`

### DIFF
--- a/changes/1355.fix.md
+++ b/changes/1355.fix.md
@@ -1,0 +1,1 @@
+Prevent scanning every sub-directories for listing vfolder files for requests with non-`recursive` option.

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -254,8 +254,10 @@ class BaseFSOpModel(AbstractFSOpModel):
                         if entry.is_dir() and not entry.is_symlink():
                             next_paths.append(Path(entry.path))
                         count += 1
-                        if recursive and limit > 0 and count == limit:
+                        if limit > 0 and count == limit:
                             break
+                    if not recursive:
+                        break
 
         async def _scan_task(q: janus.Queue[Sentinel | DirEntry]) -> None:
             try:

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -251,13 +251,11 @@ class BaseFSOpModel(AbstractFSOpModel):
                             symlink_target=symlink_target,
                         )
                         q.put(item)
-                        if entry.is_dir() and not entry.is_symlink():
+                        if recursive and entry.is_dir() and not entry.is_symlink():
                             next_paths.append(Path(entry.path))
                         count += 1
                         if limit > 0 and count == limit:
                             break
-                    if not recursive:
-                        break
 
         async def _scan_task(q: janus.Queue[Sentinel | DirEntry]) -> None:
             try:

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -206,7 +206,7 @@ class BaseFSOpModel(AbstractFSOpModel):
     def scan_tree(
         self,
         target_path: Path,
-        recursive=True,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
         q: janus.Queue[Sentinel | DirEntry] = janus.Queue()
         loop = asyncio.get_running_loop()

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -220,6 +220,8 @@ class BaseFSOpModel(AbstractFSOpModel):
                 next_path = next_paths.popleft()
                 with os.scandir(next_path) as scanner:
                     for entry in scanner:
+                        if limit > 0 and count == limit:
+                            break
                         symlink_target = ""
                         entry_type = DirEntryType.FILE
                         try:
@@ -254,8 +256,6 @@ class BaseFSOpModel(AbstractFSOpModel):
                         if recursive and entry.is_dir() and not entry.is_symlink():
                             next_paths.append(Path(entry.path))
                         count += 1
-                        if limit > 0 and count == limit:
-                            break
 
         async def _scan_task(q: janus.Queue[Sentinel | DirEntry]) -> None:
             try:

--- a/tests/storage-proxy/test_fsop_base.py
+++ b/tests/storage-proxy/test_fsop_base.py
@@ -1,0 +1,75 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ai.backend.storage.vfs import BaseFSOpModel
+
+
+@pytest.fixture
+def dummy_path():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        # Create some dummy files and dirs
+        (tmpdir_path / "a.txt").write_bytes(b"123")
+        (tmpdir_path / "b.txt").write_bytes(b"456")
+        (tmpdir_path / "c.txt").write_bytes(b"789")
+        (tmpdir_path / "inner1").mkdir()
+        (tmpdir_path / "inner1" / "d.txt").write_bytes(b"qwer")
+        (tmpdir_path / "inner2").mkdir()
+        (tmpdir_path / "inner2" / "inner3").mkdir()
+        (tmpdir_path / "inner2" / "inner3" / "e.txt").write_bytes(b"asdf")
+        (tmpdir_path / "x.txt").write_bytes(b"zzz")
+
+        yield tmpdir_path
+
+
+@pytest.mark.asyncio
+async def test_scan_tree(dummy_path) -> None:
+    fsop_model = BaseFSOpModel(dummy_path, 10)
+
+    result = []
+    async for item in fsop_model.scan_tree(dummy_path, recursive=True):
+        result.append(item)
+    names = {item.name for item in result}
+    assert "a.txt" in names
+    assert "b.txt" in names
+    assert "c.txt" in names
+    assert "inner1" in names
+    assert "inner2" in names
+    assert "inner3" in names
+    assert "d.txt" in names
+    assert "e.txt" in names
+    assert "x.txt" in names
+
+    result = []
+    async for item in fsop_model.scan_tree(dummy_path, recursive=False):
+        result.append(item)
+    names = {item.name for item in result}
+    assert "a.txt" in names
+    assert "b.txt" in names
+    assert "c.txt" in names
+    assert "inner1" in names
+    assert "inner2" in names
+    assert "inner3" not in names
+    assert "d.txt" not in names
+    assert "e.txt" not in names
+    assert "x.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_scan_tree_with_limit(dummy_path) -> None:
+    fsop_model = BaseFSOpModel(dummy_path, 5)
+
+    result = []
+    async for item in fsop_model.scan_tree(dummy_path, recursive=True):
+        result.append(item)
+    # There is no guaranteed ordering of os.scandir(), so Cannot
+    # deterministically test which file/dir is included or not.
+    assert len(result) == 5
+
+    result = []
+    async for item in fsop_model.scan_tree(dummy_path, recursive=False):
+        result.append(item)
+    assert len(result) == 5

--- a/tests/storage-proxy/test_fsop_base.py
+++ b/tests/storage-proxy/test_fsop_base.py
@@ -65,7 +65,7 @@ async def test_scan_tree_with_limit(dummy_path) -> None:
     result = []
     async for item in fsop_model.scan_tree(dummy_path, recursive=True):
         result.append(item)
-    # There is no guaranteed ordering of os.scandir(), so Cannot
+    # There is no guaranteed ordering of os.scandir(), so we cannot
     # deterministically test which file/dir is included or not.
     assert len(result) == 5
 


### PR DESCRIPTION
The File Listing API scans all sub-directories under a data folder in the current implementation, even when the 'recursive' option is off.

For example, for a data folder which contains `CI` directory only at the root,
<img width="1283" alt="image" src="https://github.com/lablup/backend.ai/assets/7539358/92e00cb0-7257-4c21-bdfd-81123b10882d">

the file listing API returns every file under the data folder by scanning all of the sub-directories.
<img width="883" alt="image" src="https://github.com/lablup/backend.ai/assets/7539358/b6e45d16-fea4-4f74-8ed7-e2a5ecaccd24">

This PR prevents this by not scanning every sub-directory when the `recursive` option is off. With this PR, only the `CI` directory is shown like image below.
<img width="1011" alt="image" src="https://github.com/lablup/backend.ai/assets/7539358/d13f3ba9-4dcb-4661-8e85-9e9d36a8b4ba">
