### PR TITLE
fix: enhance vfolder v3 directory migration script

### DIFF
--- a/changes/1357.fix.md
+++ b/changes/1357.fix.md
@@ -1,0 +1,1 @@
+Enhance vfolder v3 directory migration script.


### PR DESCRIPTION
- Error handling for missing `quota_scope_ids` to prevent migration errors.
- Ensure target directories are created before moving source directories.
- Append file suffix in output migration filename to support multiple vfolder root volumes.