### PR TITLE
fix: unable to list keypairs by email or access key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ ENV/
 /vfroot/
 /*.pid
 /scratches/
+logs
 
 # Additional clones for editable components
 /src/ai/backend/webui/

--- a/changes/1358.fix.md
+++ b/changes/1358.fix.md
@@ -1,0 +1,1 @@
+Add `groups_name` aggregated field in querying keypairs by email or access key to prevent field reference error.

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -408,14 +408,27 @@ class KeyPair(graphene.ObjectType):
         domain_name: str = None,
         is_active: bool = None,
     ) -> Sequence[Sequence[Optional[KeyPair]]]:
+        from .group import association_groups_users, groups
         from .user import users
 
-        j = sa.join(
-            keypairs,
-            users,
-            keypairs.c.user == users.c.uuid,
+        j = (
+            sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
+            .join(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
+            .join(groups, association_groups_users.c.group_id == groups.c.id)
         )
-        query = sa.select([keypairs]).select_from(j).where(keypairs.c.user_id.in_(user_ids))
+        query = (
+            sa.select(
+                [
+                    keypairs,
+                    users.c.email,
+                    users.c.full_name,
+                    agg_to_array(groups.c.name).label("groups_name"),
+                ]
+            )
+            .select_from(j)
+            .where(keypairs.c.user_id.in_(user_ids))
+            .group_by(keypairs, users.c.email, users.c.full_name)
+        )
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)
         if is_active is not None:
@@ -438,14 +451,27 @@ class KeyPair(graphene.ObjectType):
         *,
         domain_name: str = None,
     ) -> Sequence[Optional[KeyPair]]:
+        from .group import association_groups_users, groups
         from .user import users
 
-        j = sa.join(
-            keypairs,
-            users,
-            keypairs.c.user == users.c.uuid,
+        j = (
+            sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
+            .join(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
+            .join(groups, association_groups_users.c.group_id == groups.c.id)
         )
-        query = sa.select([keypairs]).select_from(j).where(keypairs.c.access_key.in_(access_keys))
+        query = (
+            sa.select(
+                [
+                    keypairs,
+                    users.c.email,
+                    users.c.full_name,
+                    agg_to_array(groups.c.name).label("groups_name"),
+                ]
+            )
+            .select_from(j)
+            .where(keypairs.c.access_key.in_(access_keys))
+            .group_by(keypairs, users.c.email, users.c.full_name)
+        )
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)
         async with graph_ctx.db.begin_readonly() as conn:


### PR DESCRIPTION
In querying keypair list from clients, the following error is raised:
```
File "/home/devops/backend.ai-main/backend.ai/src/ai/backend/manager/models/keypair.py", line 452, in batch_load_by_ak
return await batch_result(
^^^^^^^^^^^^^^^^^^^
File "/home/devops/backend.ai-main/backend.ai/src/ai/backend/manager/models/base.py", line 635, in batch_result
objs_per_key[key_getter(row)] = obj_type.from_row(graph_ctx, row)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/devops/backend.ai-main/backend.ai/src/ai/backend/manager/models/keypair.py", line 217, in from_row
projects=row["groups_name"],
~~~^^^^^^^^^^^^^^^
File "/home/devops/backend.ai-main/backend.ai/dist/export/python/virtualenvs/python-default/3.11.3/lib/python3.11/site-packages/sqlalchemy/engine/cursor.py", line 628, in _key_fallback
util.raise_(
File "/home/devops/backend.ai-main/backend.ai/dist/export/python/virtualenvs/python-default/3.11.3/lib/python3.11/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
raise exception
graphql.error.located_error.GraphQLLocatedError: Could not locate column in row for column 'groups_name'
```

This PR joins additional tables and select more columns in the `batch_load_by_email` and `batch_load_by_ak` functions of the `KeyPair` class to include the user's email, full name, and group names in the GraphQL query responses for keypairs ([link](https://github.com/lablup/backend.ai/pull/1358/files?diff=unified&w=0#diff-0295d34e9357811027091018a818a3a8ca27eadd4bf49ee8080b992abf2cbc10L411-R431), [link](https://github.com/lablup/backend.ai/pull/1358/files?diff=unified&w=0#diff-0295d34e9357811027091018a818a3a8ca27eadd4bf49ee8080b992abf2cbc10L441-R474)) in `src/ai/backend/manager/models/keypair.py`

Follow-up of #1022.
