### PR TITLE
fix: trailing comma added to container's `service-ports` label

### DIFF
--- a/changes/1359.fix.md
+++ b/changes/1359.fix.md
@@ -1,0 +1,1 @@
+Removing trailling comma from container's `service-ports` label.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -825,13 +825,11 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             self.computer_docker_args["HostConfig"]["MemorySwap"] -= shmem
             self.computer_docker_args["HostConfig"]["Memory"] -= shmem
 
-        image_service_ports = image_labels.get("ai.backend.service-ports", "")
-        encoded_preopen_ports = ",".join(
-            f"{port_no}:preopen:{port_no}" for port_no in preopen_ports
-        )
-        container_config["Labels"]["ai.backend.service-ports"] = ",".join(
-            ports for ports in [image_service_ports, encoded_preopen_ports] if ports
-        )
+        service_ports_label: list[str] = []
+        service_ports_label += image_labels.get("ai.backend.service-ports", "").split(",")
+        service_ports_label += [f"{port_no}:preopen:{port_no}" for port_no in preopen_ports]
+
+        container_config["Labels"]["ai.backend.service-ports"] = ",".join(service_ports_label)
         update_nested_dict(container_config, self.computer_docker_args)
         kernel_name = f"kernel.{self.image_ref.name.split('/')[-1]}.{self.kernel_id}"
         if self.local_config["debug"]["log-kernel-config"]:

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -829,9 +829,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         encoded_preopen_ports = ",".join(
             f"{port_no}:preopen:{port_no}" for port_no in preopen_ports
         )
-        container_config["Labels"]["ai.backend.service-ports"] = (
-            image_service_ports + "," if image_service_ports else ""
-        ) + encoded_preopen_ports
+        container_config["Labels"]["ai.backend.service-ports"] = ",".join(
+            ports for ports in [image_service_ports, encoded_preopen_ports] if ports
+        )
         update_nested_dict(container_config, self.computer_docker_args)
         kernel_name = f"kernel.{self.image_ref.name.split('/')[-1]}.{self.kernel_id}"
         if self.local_config["debug"]["log-kernel-config"]:


### PR DESCRIPTION
Previous container's `service-ports` label:
```
"ai.backend.service-ports": "ipython:pty:3000,jupyter:http:8091,jupyterlab:http:8090,vscode:http:8180,tensorboard:http:6006,mlflow-ui:preopen:5000,nniboard:preopen:8080,",
```

Trailing comma causes session creation failure when image's `service-ports` is empty (`""`), which leaves a leading comma for the container's `service-ports`.

After this PR:
```
"ai.backend.service-ports": "ipython:pty:3000,jupyter:http:8091,jupyterlab:http:8090,vscode:http:8180,tensorboard:http:6006,mlflow-ui:preopen:5000,nniboard:preopen:8080",
```