### PR TITLE
fix: storage proxy reporting wrong stat on some backends

### DIFF
--- a/changes/1376.fix.md
+++ b/changes/1376.fix.md
@@ -1,0 +1,1 @@
+Fix `get_fs_usage()` API reporting capacity as usage and usage as capacity on GPFS and Weka backend

--- a/src/ai/backend/storage/gpfs/__init__.py
+++ b/src/ai/backend/storage/gpfs/__init__.py
@@ -188,7 +188,10 @@ class GPFSVolume(BaseVolume):
                 continue
             total += pool.totalDataInKB
             free += pool.freeDataInKB
-        return CapacityUsage(BinarySize(total - free) * 1024, BinarySize(total) * 1024)
+        return CapacityUsage(
+            used_bytes=BinarySize(total - free) * 1024,
+            capacity_bytes=BinarySize(total) * 1024,
+        )
 
     async def get_performance_metric(self) -> FSPerfMetric:
         # ref: https://www.ibm.com/docs/en/spectrum-scale/5.0.3?topic=2-perfmondata-get

--- a/src/ai/backend/storage/weka/__init__.py
+++ b/src/ai/backend/storage/weka/__init__.py
@@ -55,7 +55,9 @@ class WekaQuotaModel(BaseQuotaModel):
         qs_relpath = qspath.relative_to(self.mount_path).as_posix()
         if not qs_relpath.startswith("/"):
             qs_relpath = "/" + qs_relpath
-        await self.api_client.set_quota_v1(qs_relpath, inode_id, hard_limit=config.limit_bytes)
+        await self.api_client.set_quota_v1(
+            qs_relpath, inode_id, soft_limit=config.limit_bytes, hard_limit=config.limit_bytes
+        )
 
     async def describe_quota_scope(self, quota_scope_id: QuotaScopeID) -> Optional[QuotaUsage]:
         qspath = self.mangle_qspath(quota_scope_id)
@@ -151,8 +153,8 @@ class WekaVolume(BaseVolume):
         assert self._fs_uid is not None
         fs = await self.api_client.get_fs(self._fs_uid)
         return CapacityUsage(
-            fs.total_budget,
-            fs.used_total,
+            capacity_bytes=fs.total_budget,
+            used_bytes=fs.used_total,
         )
 
     async def get_performance_metric(self) -> FSPerfMetric:


### PR DESCRIPTION
Follow-up PR of #1191. Fixes lablup/giftbox#439. Updates implementation of `get_fs_usage()` in GPFS and Weka backend to explicitly mention name of the attr parameters, since without it the order matters when initiating `CapacitiyUsage()` object.