### PR TITLE
chore: Update docstring from `ai.backend.common.validators.TimeDuration` with valid keyword arguments

### DIFF
--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -523,13 +523,13 @@ class TimeDuration(t.Trafaret):
 
     Example:
     >>> t = datetime(2020, 2, 29)
-    >>> t + check_and_return(years=1)
+    >>> t + check_and_return("1yr")
     datetime.datetime(2021, 2, 28, 0, 0)
-    >>> t + check_and_return(years=2)
+    >>> t + check_and_return("2yr")
     datetime.datetime(2022, 2, 28, 0, 0)
-    >>> t + check_and_return(years=3)
+    >>> t + check_and_return("3yr")
     datetime.datetime(2023, 2, 28, 0, 0)
-    >>> t + check_and_return(years=4)
+    >>> t + check_and_return("4yr")
     datetime.datetime(2024, 2, 29, 0, 0)  # preserves the same day of month
     """
 


### PR DESCRIPTION
This PR updates some keyword argument mismatches shown in several examples.

https://github.com/lablup/backend.ai/blob/ac6e0f45d427df05bcd6633b05b0559e5d063c07/src/ai/backend/common/validators.py#L539-L581


<!-- readthedocs-preview sorna start -->
----
:books: Documentation preview :books:: https://sorna--1377.org.readthedocs.build/en/1377/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
:books: Documentation preview :books:: https://sorna-ko--1377.org.readthedocs.build/ko/1377/

<!-- readthedocs-preview sorna-ko end -->