### PR TITLE
test: Let queryfilter test module use PostgreSQL

### DIFF
--- a/tests/manager/test_queryfilter.py
+++ b/tests/manager/test_queryfilter.py
@@ -1,10 +1,14 @@
 import enum
+import secrets
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.declarative import declarative_base
 
+from ai.backend.manager.models.minilang import JSONFieldItem
 from ai.backend.manager.models.minilang.queryfilter import QueryFilterParser
+from ai.backend.testutils.bootstrap import postgres_container  # noqa
 
 
 class UserTypes(enum.Enum):
@@ -13,12 +17,17 @@ class UserTypes(enum.Enum):
 
 
 @pytest.fixture
-def virtual_user_db():
-    engine = sa.engine.create_engine("sqlite:///:memory:", echo=False)
+async def virtual_user_db(postgres_container):  # noqa
+    host, port = postgres_container[1]
+    db_id = secrets.token_hex(16)
+    engine = sa.engine.create_engine(
+        f"postgresql+asyncpg://postgres:develove@{host}:{port}/testing", echo=False
+    )
+    async_engine = AsyncEngine(engine)
     base = declarative_base()
     metadata = base.metadata
     users = sa.Table(
-        "users",
+        f"test_users_{db_id}",
         metadata,
         sa.Column("id", sa.Integer, sa.Sequence("user_id_seq"), primary_key=True),
         sa.Column("name", sa.String(50)),
@@ -26,11 +35,22 @@ def virtual_user_db():
         sa.Column("type", sa.Enum(UserTypes)),
         sa.Column("age", sa.Integer),
         sa.Column("is_active", sa.Boolean),
-        sa.Column("data", sa.Float, nullable=True),
+        sa.Column("value", sa.Float, nullable=True),
+        sa.Column("data", sa.JSON),
+        sa.Column("tags", sa.ARRAY(sa.Text())),
     )
-    metadata.create_all(engine)
-    with engine.connect() as conn:
-        conn.execute(
+
+    def _create_all_sync(conn, engine):
+        metadata.create_all(engine, checkfirst=False)
+
+    def _drop_all_sync(conn, engine):
+        metadata.drop_all(engine, checkfirst=False)
+
+    async with async_engine.begin() as conn:
+        await conn.run_sync(_create_all_sync, engine=engine)
+
+    async with async_engine.begin() as conn:
+        await conn.execute(
             users.insert(),
             [
                 {
@@ -39,7 +59,9 @@ def virtual_user_db():
                     "type": UserTypes.ADMIN,
                     "age": 30,
                     "is_active": True,
-                    "data": 10.5,
+                    "value": 10.5,
+                    "data": {"hobby": "piano"},
+                    "tags": ["aaa", "bbb"],
                 },
                 {
                     "name": 'test"er',
@@ -47,7 +69,9 @@ def virtual_user_db():
                     "type": UserTypes.USER,
                     "age": 40,
                     "is_active": True,
-                    "data": None,
+                    "value": None,
+                    "data": {"hobby": "tennis"},
+                    "tags": ["aaa", "ccc"],
                 },
                 {
                     "name": "test'er",
@@ -55,7 +79,9 @@ def virtual_user_db():
                     "type": UserTypes.USER,
                     "age": 50,
                     "is_active": False,
-                    "data": 2.33,
+                    "value": 2.33,
+                    "data": {"hobby": "running"},
+                    "tags": [],
                 },
                 {
                     "name": "tester ♪",
@@ -63,15 +89,22 @@ def virtual_user_db():
                     "type": UserTypes.USER,
                     "age": 20,
                     "is_active": False,
-                    "data": None,
+                    "value": None,
+                    "data": {"hobby": "cello"},
+                    "tags": ["bbb", "ddd"],
                 },
             ],
         )
+
         yield conn, users
+
+    async with async_engine.begin() as conn:
+        await conn.run_sync(_drop_all_sync, engine=engine)
     engine.dispose()
 
 
-def test_select_queries(virtual_user_db) -> None:
+@pytest.mark.asyncio
+async def test_select_queries(virtual_user_db) -> None:
     conn, users = virtual_user_db
     parser = QueryFilterParser()
 
@@ -79,7 +112,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'full_name == "tester1"',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30)]
     assert test_ret == actual_ret
 
@@ -87,7 +120,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'name == "test\'er"',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("test'er", 50)]
     assert test_ret == actual_ret
 
@@ -95,7 +128,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'name == "test\\"er"',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [('test"er', 40)]
     assert test_ret == actual_ret
 
@@ -103,7 +136,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         '(full_name == "tester1")',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30)]
     assert test_ret == actual_ret
 
@@ -111,7 +144,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'full_name in ["tester1", "tester3", "tester9"]',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30), ("test'er", 50)]
     assert test_ret == actual_ret
 
@@ -119,14 +152,14 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'type in ["USER", "ADMIN"]',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     assert len(actual_ret) == 4
 
     sa_query = parser.append_filter(
         sa.select([users.c.name, users.c.age]).select_from(users),
         'full_name == "tester1" & age == 20',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = []
     assert test_ret == actual_ret
 
@@ -134,7 +167,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         '(full_name == "tester1") & (age == 20)',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = []
     assert test_ret == actual_ret
 
@@ -142,7 +175,7 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         '(full_name == "tester1") | (age == 20)',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30), ("tester ♪", 20)]
     assert test_ret == actual_ret
 
@@ -150,40 +183,48 @@ def test_select_queries(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         '(name contains "test") & (age > 30) & (is_active is true)',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [('test"er', 40)]
     assert test_ret == actual_ret
 
     sa_query = parser.append_filter(
         sa.select([users.c.name, users.c.age]).select_from(users),
-        "data isnot null",
+        "value isnot null",
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30), ("test'er", 50)]
     assert test_ret == actual_ret
 
     sa_query = parser.append_filter(
         sa.select([users.c.name, users.c.age]).select_from(users),
-        "data is null",
+        "value is null",
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [('test"er', 40), ("tester ♪", 20)]
     assert test_ret == actual_ret
 
     sa_query = parser.append_filter(
         sa.select([users.c.name, users.c.age]).select_from(users),
-        "data is null | data isnot null",
+        "value is null | value isnot null",
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     assert len(actual_ret) == 4  # all rows
 
     sa_query = parser.append_filter(
         sa.select([users.c.name, users.c.age]).select_from(users),
-        "data < 9.4",
+        "value < 9.4",
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("test'er", 50)]  # Note: null values are not matched
     assert test_ret == actual_ret
+
+    # sa_query = parser.append_filter(
+    #     sa.select([users.c.name, users.c.age]).select_from(users),
+    #     'tag ilike "Bb"',
+    # )
+    # actual_ret = list(conn.execute(sa_query))
+    # test_ret = [("tester", 30), ("tester ♪", 20)]
+    # assert test_ret == actual_ret
 
     # invalid syntax
     with pytest.raises(ValueError):
@@ -230,7 +271,8 @@ def test_select_queries(virtual_user_db) -> None:
         )
 
 
-def test_modification_queries(virtual_user_db) -> None:
+@pytest.mark.asyncio
+async def test_modification_queries(virtual_user_db) -> None:
     conn, users = virtual_user_db
     parser = QueryFilterParser()
 
@@ -238,24 +280,26 @@ def test_modification_queries(virtual_user_db) -> None:
         sa.update(users).values({"name": "hello"}),
         'full_name == "tester1"',
     )
-    result = conn.execute(sa_query)
+    result = await conn.execute(sa_query)
     assert result.rowcount == 1
 
     sa_query = parser.append_filter(
         sa.delete(users),
         'full_name like "tester%"',
     )
-    result = conn.execute(sa_query)
+    result = await conn.execute(sa_query)
     assert result.rowcount == 4
 
 
-def test_fieldspec(virtual_user_db) -> None:
+@pytest.mark.asyncio
+async def test_fieldspec(virtual_user_db) -> None:
     conn, users = virtual_user_db
     parser = QueryFilterParser(
         {
             "n1": ("name", None),
             "n2": ("full_name", lambda s: s.lower()),
             "t1": ("type", lambda s: UserTypes[s]),
+            "hobby": (JSONFieldItem("data", "hobby"), None),
         }
     )
 
@@ -263,7 +307,7 @@ def test_fieldspec(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'n1 == "tester"',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30)]
     assert test_ret == actual_ret
 
@@ -271,7 +315,7 @@ def test_fieldspec(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'n2 == "TESTER1"',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [("tester", 30)]
     assert test_ret == actual_ret
 
@@ -279,7 +323,7 @@ def test_fieldspec(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         'n2 in ["TESTER2", "TESTER4"]',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     test_ret = [('test"er', 40), ("tester ♪", 20)]
     assert test_ret == actual_ret
 
@@ -287,8 +331,17 @@ def test_fieldspec(virtual_user_db) -> None:
         sa.select([users.c.name, users.c.age]).select_from(users),
         't1 in ["USER", "ADMIN"]',
     )
-    actual_ret = list(conn.execute(sa_query))
+    actual_ret = list(await conn.execute(sa_query))
     assert len(actual_ret) == 4
+
+    # A fieldspec to match against a field in a JSON object column
+    sa_query = parser.append_filter(
+        sa.select([users.c.name, users.c.age]).select_from(users),
+        'hobby == "piano"',
+    )
+    actual_ret = list(await conn.execute(sa_query))
+    test_ret = [("tester", 30)]
+    assert test_ret == actual_ret
 
     # non-existent column in fieldspec
     with pytest.raises(ValueError):


### PR DESCRIPTION
- This ensures full compatibiltiy with the PostgreSQL-specific dialects
  including array column types.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
