### PR TITLE
fix: Finalize per-kernel scheduling results using the correct kernel IDs

### DIFF
--- a/changes/1380.fix.md
+++ b/changes/1380.fix.md
@@ -1,0 +1,1 @@
+Finalize per-kernel scheduling results using the correct kernel IDs.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1456,7 +1456,7 @@ class AgentRegistry:
                         "Options": {},
                     }
                     if mtu:
-                        create_options["Options"] = {"com.docker.network.driver.mtu": mtu}
+                        create_options["Options"] = {"com.docker.network.driver.mtu": str(mtu)}
                     await self.docker.networks.create(create_options)
                 except Exception:
                     log.exception(f"Failed to create an overlay network {network_name}")

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -722,27 +722,28 @@ class SchedulerDispatcher(aobject):
             agent_ids: list[AgentId] = []
             async with self.db.begin_session() as db_sess:
                 now = datetime.now(tzutc())
-                kernel_query = (
-                    sa.update(KernelRow)
-                    .values(
-                        agent=agent_alloc_ctx.agent_id,
-                        agent_addr=agent_alloc_ctx.agent_addr,
-                        scaling_group=sgroup_name,
-                        status=KernelStatus.SCHEDULED,
-                        status_info="scheduled",
-                        status_data={},
-                        status_changed=now,
-                        status_history=sql_json_merge(
-                            KernelRow.status_history,
-                            (),
-                            {
-                                KernelStatus.SCHEDULED.name: now.isoformat(),
-                            },
-                        ),
+                for kernel in sess_ctx.kernels:
+                    kernel_query = (
+                        sa.update(KernelRow)
+                        .values(
+                            agent=agent_alloc_ctx.agent_id,
+                            agent_addr=agent_alloc_ctx.agent_addr,
+                            scaling_group=sgroup_name,
+                            status=KernelStatus.SCHEDULED,
+                            status_info="scheduled",
+                            status_data={},
+                            status_changed=now,
+                            status_history=sql_json_merge(
+                                KernelRow.status_history,
+                                (),
+                                {
+                                    KernelStatus.SCHEDULED.name: now.isoformat(),
+                                },
+                            ),
+                        )
+                        .where(KernelRow.id == kernel.id)
                     )
-                    .where(KernelRow.session_id == sess_ctx.id)
-                )
-                await db_sess.execute(kernel_query)
+                    await db_sess.execute(kernel_query)
                 if agent_alloc_ctx.agent_id is not None:
                     agent_ids.append(agent_alloc_ctx.agent_id)
 
@@ -947,7 +948,7 @@ class SchedulerDispatcher(aobject):
                                 },
                             ),
                         )
-                        .where(KernelRow.session_id == sess_ctx.id)
+                        .where(KernelRow.session_id == binding.kernel.id)
                     )
                     await db_sess.execute(kernel_query)
                     if binding.agent_alloc_ctx.agent_id is not None:


### PR DESCRIPTION
This is a follow-up hotfix found from a recent deployment.

- Some Docker versions do not accept integer values in `com.docker.network.driver.mtu` network creation option but only strings. Let's force stringification always.
- We should use the kernel IDs insetad of session IDs when recording the scheduling results. It's a regression from #325. It has prevented working of multi-container sessions.