### PR TITLE
hotfix: match to kernel id instead of session_id

### DIFF
--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -948,7 +948,7 @@ class SchedulerDispatcher(aobject):
                                 },
                             ),
                         )
-                        .where(KernelRow.session_id == binding.kernel.id)
+                        .where(KernelRow.id == binding.kernel.id)
                     )
                     await db_sess.execute(kernel_query)
                     if binding.agent_alloc_ctx.agent_id is not None:


### PR DESCRIPTION
follow up #1380 