### PR TITLE
docs: fix backend endpoint to 8091

### DIFF
--- a/docs/dev/development-setup.rst
+++ b/docs/dev/development-setup.rst
@@ -238,7 +238,7 @@ Open yet another terminal for client and run:
 
 .. code-block:: console
 
-   $ export BACKEND_ENDPOINT=http://127.0.0.1:8081/  # change the port number if customized
+   $ export BACKEND_ENDPOINT=http://127.0.0.1:8091/  # change the port number if customized
    $ export BACKEND_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
    $ export BACKEND_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
    $ ./backend.ai config


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
Hello,

Currently, the server is exposed by port number 8091.
Thus, the environment variable BACKEND_ENDPOINT should end with 8091.