### PR TITLE
feat: add aliased key of `session_name`

### DIFF
--- a/changes/1395.fix.md
+++ b/changes/1395.fix.md
@@ -1,0 +1,1 @@
+Add `session_name` to aliased key of `session_name`

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -163,7 +163,7 @@ async def get_info(request: web.Request) -> web.Response:
 @check_api_params(
     t.Dict(
         {
-            tx.AliasedKey(["name", "clientSessionToken"])
+            tx.AliasedKey(["name", "session_name", "clientSessionToken"])
             >> "service_name": t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
             tx.AliasedKey(["desired_session_count", "desiredSessionCount"]): t.Int,
             tx.AliasedKey(["image", "lang"]): t.String,

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -163,7 +163,7 @@ async def get_info(request: web.Request) -> web.Response:
 @check_api_params(
     t.Dict(
         {
-            tx.AliasedKey(["name", "session_name", "clientSessionToken"])
+            tx.AliasedKey(["name", "service_name", "clientSessionToken"])
             >> "service_name": t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
             tx.AliasedKey(["desired_session_count", "desiredSessionCount"]): t.Int,
             tx.AliasedKey(["image", "lang"]): t.String,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -378,7 +378,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
     t.Dict(
         {
             tx.AliasedKey(["template_id", "templateId"]): t.Null | tx.UUID,
-            tx.AliasedKey(["name", "clientSessionToken"], default=undefined)
+            tx.AliasedKey(["name", "session_name", "clientSessionToken"], default=undefined)
             >> "session_name": UndefChecker | t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
             tx.AliasedKey(["image", "lang"], default=undefined): UndefChecker | t.Null | t.String,
             tx.AliasedKey(["arch", "architecture"], default=DEFAULT_IMAGE_ARCH)
@@ -564,7 +564,7 @@ async def create_from_template(request: web.Request, params: dict[str, Any]) -> 
 @check_api_params(
     t.Dict(
         {
-            tx.AliasedKey(["name", "clientSessionToken"])
+            tx.AliasedKey(["name", "session_name", "clientSessionToken"])
             >> "session_name": t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
             tx.AliasedKey(["image", "lang"]): t.String,
             tx.AliasedKey(["arch", "architecture"], default=DEFAULT_IMAGE_ARCH)
@@ -1062,7 +1062,7 @@ async def report_stats(root_ctx: RootContext, interval: float) -> None:
 @check_api_params(
     t.Dict(
         {
-            tx.AliasedKey(["name", "clientSessionToken"])
+            tx.AliasedKey(["name", "session_name", "clientSessionToken"])
             >> "session_name": t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
         }
     ),


### PR DESCRIPTION
When request creating session API, response notes that "session_name" is required.

<img width="696" alt="MicrosoftTeams-image (1)" src="https://github.com/lablup/backend.ai/assets/59244452/ac00cd7e-353f-4de4-8390-3ccb69b8835f">

> 

but when request parameter contain "session_name", response notes that "session_name" is not allowed key.

<img width="696" alt="MicrosoftTeams-image (2)" src="https://github.com/lablup/backend.ai/assets/59244452/057faa78-a958-44b6-b32d-23343fc09895">

To resolve this ambiguity, session_name is added to the aliased key of session_name.

So, request contained "session_name" is allowed.
