### PR TITLE
fix: wrong exception handling logic of `SchedulerDispatcher` 

### DIFF
--- a/changes/1401.fix.md
+++ b/changes/1401.fix.md
@@ -1,0 +1,1 @@
+Wrong exception handling logics of `SchedulerDispatcher`

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -905,10 +905,10 @@ class SchedulerDispatcher(aobject):
                             else:
                                 raise InstanceNotAvailable(
                                     extra_msg=(
-                                        f"The designated agent ({agent.id}) does not have the"
-                                        f" enough remaining capacity ({key}, requested:"
-                                        f" {sess_ctx.requested_slots[key]}, remaining:"
-                                        f" {available_slots[key] - occupied_slots[key]})."
+                                        f"The designated agent ({agent.id}) does not have "
+                                        f"the enough remaining capacity ({key}, "
+                                        f"requested: {sess_ctx.requested_slots[key]}, "
+                                        f"remaining: {available_slots[key] - occupied_slots[key]})."
                                     ),
                                 )
                         agent_id = agent.id


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR fixes some wrong exception-handling logics of `SchedulerDispatcher`.

(Errors occurring when attempting to explicitly allocate a session via the `--assign-agent` and the agent runs out of one of its resource slots.)

## Test 

Tested manually by the below command.

```
❯ ./backend.ai run python -c 'print("hello world")' --assign-agent=i-ubuntu
(when the specified agent's resource slot is not enough)
```

<img width="2355" alt="스크린샷 2023-09-22 오후 7 53 30" src="https://github.com/lablup/backend.ai/assets/18283033/86570aec-b15a-4ea0-bfb5-60ef3ac53689">

