### PR TITLE
fix: delete vfolder conditions of checking host while creating/cloning vfolders

### DIFF
--- a/changes/1398.fix.md
+++ b/changes/1398.fix.md
@@ -1,1 +1,1 @@
-Prevent creating/cloneing vfolders with duplicate names on different hosts by deleting conditions checking host.
+Prevent creating/cloning vfolders with duplicate names on different hosts by deleting conditions checking host.

--- a/changes/1398.fix.md
+++ b/changes/1398.fix.md
@@ -1,0 +1,1 @@
+Prevent creating/cloneing vfolders with duplicate names on different hosts by deleting conditions checking host.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -469,10 +469,8 @@ async def create(request: web.Request, params: Any) -> web.Response:
         # ):
         #     params["quota"] = max_vfolder_size
 
-        # Prevent creation of vfolder with duplicated name.
+        # Prevent creation of vfolder with duplicated name on all hosts.
         extra_vf_conds = [vfolders.c.name == params["name"]]
-        if not unmanaged_path:
-            extra_vf_conds.append(vfolders.c.host == folder_host)
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,
@@ -2451,9 +2449,8 @@ async def clone(request: web.Request, params: Any, row: VFolderRow) -> web.Respo
             if result >= resource_policy["max_vfolder_count"]:
                 raise InvalidAPIParameters("You cannot create more vfolders.")
 
-        # Prevent creation of vfolder with duplicated name.
+        # Prevent creation of vfolder with duplicated name on all hosts.
         extra_vf_conds = [vfolders.c.name == params["target_name"]]
-        extra_vf_conds.append(vfolders.c.host == target_folder_host)
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,


### PR DESCRIPTION
resolves: #1398 

**Done**

Originally `when creating/cloning vfolders` we `checked if two conditions are the same`, it's `name` and `host`.

To block creating/cloning vfolders with duplicate names even on different hosts, I `deleted a condition that checked whether if the host is same or not`. (Only conditions of checking names remains).

This will gradually make it impossible to create vfolder with names, whatever the host is.

**Test**

I executed postgres querys directly into it's docker container and checked if this works. 

