### PR TITLE
Chore: Correct description for --assign-agent option

### DIFF
--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -232,8 +232,8 @@ def _create_cmd(docs: str = None):
         default=None,
         type=list_expr,
         help=(
-            "Show mapping list of tuple which mapped containers with agent. "
-            "When user role is Super Admin. "
+            "Assign the session to specific agents. "
+            "This option is only applicable when the user role is Super Admin. "
             "(e.g., --assign-agent agent_id_1,agent_id_2,...)"
         ),
     )


### PR DESCRIPTION
Description:

What changes:
This Pull Request corrects the description of the --assign-agent option in the Backend.AI CLI. The previous description suggested that this option is used to display a mapping list of tuples which mapped containers with agents.

Justification:
The --assign-agent option is actually used to assign specific agents to a session. This functionality is only applicable when the user role is a Super Admin. This discrepancy between the actual functionality and the description in the code can lead to confusion for users and developers.

**Before:**

```python
@click.option(
    "--assign-agent",
    default=None,
    type=list_expr,
    help=(
        "Show mapping list of tuple which mapped containers with agent. "
        "When user role is Super Admin. "
        "(e.g., --assign-agent agent_id_1,agent_id_2,...)"
    ),
)
**After:**

@click.option(
    "--assign-agent",
    default=None,
    type=list_expr,
    help=(
        "Assign specific agents to the session. "
        "This option is only applicable when the user role is Super Admin. "
        "(e.g., --assign-agent agent_id_1,agent_id_2,...)"
    ),
)

