### PR TITLE
fix: add type check conditions when awaiting gather_process_measures …

### DIFF
--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -7,6 +7,7 @@ Reference: https://www.datadoghq.com/blog/how-to-collect-docker-metrics/
 import asyncio
 import enum
 import logging
+import psutil
 import sys
 import time
 from decimal import Decimal
@@ -525,10 +526,14 @@ class StatContext:
             updated_cids: Set[ContainerId] = set()
             for result in results:
                 if isinstance(result, Exception):
-                    log.error(
-                        "collect_per_container_process_stat(): gather_process_measures() error",
-                        exc_info=result,
-                    )
+                    if type(result) == psutil.NoSuchProcess:    
+                        log.debug(f"{result}")
+                        pass
+                    else:
+                        log.error(
+                            "collect_per_container_process_stat(): gather_process_measures() error",
+                            exc_info=result,
+                        )
                     continue
                 for proc_measure in result:
                     metric_key = proc_measure.key


### PR DESCRIPTION
resolves: #1408


I initially wanted to handle **NoSuchProcess** error at the function `gather_process_measures` but it already exsisted.


https://github.com/lablup/backend.ai/blob/f346699c0110f40ce78f3fcdbcf2c3e3a2f85354/src/ai/backend/agent/docker/intrinsic.py#L764-L774


So, I added a if/else condition at `src/ai/backend/agent/stats.py to check if the result of gather_process_measures task is psutil.NoSuchProcess` or not, and added a debug message of it's result.


This is before handling.
![image](https://github.com/lablup/backend.ai/assets/68985625/67d47bfd-42e9-4bf6-bc7c-6cfc5b824bdc)


This is after handling.
![image2](https://github.com/lablup/backend.ai/assets/68985625/d9830000-9b8a-493b-880f-00999e98f715)


