### PR TITLE
feat: add failure message when login failed

### DIFF
--- a/changes/1305.feature.md
+++ b/changes/1305.feature.md
@@ -1,0 +1,1 @@
+Add failure reason to the CLI login process in case of login failure.

--- a/src/ai/backend/client/cli/config.py
+++ b/src/ai/backend/client/cli/config.py
@@ -143,6 +143,7 @@ def login():
 
             if not result["authenticated"]:
                 print_fail("Login failed.")
+                print_fail(result["data"]["details"])
                 sys.exit(ExitCode.FAILURE)
             print_done("Login succeeded.")
 


### PR DESCRIPTION
This PR resolves #1305 .
I just added code to print the reason for login failure.

**ScreenShot:** 

![image](https://github.com/lablup/backend.ai/assets/84405002/fcb3a6e9-0cd6-4ca8-9fa6-49ead3d7d36f)
