### PR TITLE
refactor: Modify login failure message for an `inactive` account

### DIFF
--- a/changes/1420.fix.md
+++ b/changes/1420.fix.md
@@ -1,0 +1,1 @@
+Modify login failure message when attempting to log in to an account that is inactive

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -703,7 +703,7 @@ async def authorize(request: web.Request, params: Any) -> web.Response:
     if user["status"] == UserStatus.BEFORE_VERIFICATION:
         raise AuthorizationFailed("This account needs email verification.")
     if user["status"] in INACTIVE_USER_STATUSES:
-        raise AuthorizationFailed("User credential mismatch.")
+        raise AuthorizationFailed("This account is inactive.")
     async with root_ctx.db.begin() as conn:
         query = (
             sa.select([keypairs.c.access_key, keypairs.c.secret_key])


### PR DESCRIPTION
This PR resolves #1420.
I modified login failure message when attempting to log in `inactive` account.

# Screenshots:

## CLI

![스크린샷 2023-07-28 오후 4 07 38](https://github.com/lablup/backend.ai/assets/84405002/8115e339-41d4-4793-a46e-1a5237a2ac9b)

## webUI:
![스크린샷 2023-07-28 오후 4 07 14](https://github.com/lablup/backend.ai/assets/84405002/4f6eeb5a-5a35-4314-ae58-132097356aa0)
