### PR TITLE
fix: add shell script codes to create `version.txt` in `install-dev.sh`

### DIFF
--- a/changes/1438.fix.md
+++ b/changes/1438.fix.md
@@ -1,0 +1,1 @@
+Add shell script codes to setup `version.txt` including vfolder version in `install-dev.sh`.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -786,8 +786,11 @@ configure_backendai() {
   fi
 
   # Virtual folder setup
+  VFOLDER_VERSION="3"
+  VFOLDER_VERSION_TXT="version.txt"
   show_info "Setting up virtual folder..."
   mkdir -p "${ROOT_PATH}/${VFOLDER_REL_PATH}"
+  echo "${VFOLDER_VERSION}" > "${ROOT_PATH}/${VFOLDER_REL_PATH}/${VFOLDER_VERSION_TXT}"
   ./backend.ai mgr etcd put-json volumes "./dev.etcd.volumes.json"
   mkdir -p scratches
   POSTGRES_CONTAINER_ID=$($docker_sudo docker compose -f "docker-compose.halfstack.current.yml" ps | grep "[-_]backendai-half-db[-_]1" | awk '{print $1}')


### PR DESCRIPTION
This PR resolves #1438.
I added shell script codes to create `version.txt` including vfolder version when running `install-dev.sh`.

https://github.com/lablup/backend.ai/blob/5f4e51da796b9121adc491d4ed99153cdeedece2/scripts/install-dev.sh#L788-L793