### PR TITLE
fix: Add `empty_str_as_empty_list=True` option in StringList

### DIFF
--- a/changes/1447.fix.md
+++ b/changes/1447.fix.md
@@ -1,0 +1,1 @@
+ Add the `empty_str_as_empty_list=True` option to store `[]` instead of `['']` in etcd.

--- a/changes/1447.fix.md
+++ b/changes/1447.fix.md
@@ -1,1 +1,1 @@
- Add the `empty_str_as_empty_list=True` option to store `[]` instead of `['']` in etcd.
+Ensure the interpretation of the `project` field to be a list when adding/updating container registries, even with empty strings

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -339,7 +339,9 @@ container_registry_iv = t.Dict(
         t.Key("type", default="docker"): t.String,
         t.Key("username", default=None): t.Null | t.String,
         t.Key("password", default=None): t.Null | t.String,
-        t.Key("project", default=None): t.Null | tx.StringList(allow_blank=True) | t.List(t.String),
+        t.Key("project", default=None): t.Null | tx.StringList(
+            allow_blank=True, empty_str_as_empty_list=True
+        ),
         t.Key("ssl-verify", default=True): t.ToBool,
     }
 ).allow_extra("*")


### PR DESCRIPTION
This PR resolves #1447.

I added the `empty_str_as_empty_list=True` option to store `[]` instead of `['']` in etcd. 
However, we still need to resolve the issue of the registry project name responding as a string (e.g., `'[]'`) instead of a JSON array.
