### PR TITLE
fix: Change pants' notation from `./pants` to `pants`

### DIFF
--- a/py
+++ b/py
@@ -1,7 +1,7 @@
 #! /bin/bash
 if [ ! -d dist/export/python/virtualenvs/python-default ]; then
   >&2 echo "The exported virtualenv does not exist."
-  >&2 echo "Please run './pants export' first and try again."
+  >&2 echo "Please run 'pants export' first and try again."
   exit 1
 fi
 PYTHON_VERSION=$(cat pants.toml | python3 -c 'import sys,re;m=re.search("CPython==([^\"]+)", sys.stdin.read());print(m.group(1) if m else sys.exit(1))')


### PR DESCRIPTION
This PR changes old pants' notation(`./pants`) to the new one(`pants`).
