### PR TITLE
feat: CRUD `wsproxy_addr`, `wsproxy_api_token` in CLI

### DIFF
--- a/changes/1460.feature.md
+++ b/changes/1460.feature.md
@@ -1,0 +1,1 @@
+Support setting the `wsproxy_addr` and `wsproxy_api_token` option of scaling group in the client-py.

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -69,7 +69,7 @@ def list(ctx: CLIContext) -> None:
 @scaling_group.command()
 @pass_ctx_obj
 @click.argument("name", type=str, metavar="NAME")
-@click.option("-d", "--description", type=str, default="", help="Description of new scaling group")
+@click.option("-d", "--description", type=str, default="", help="Description of new scaling group.")
 @click.option("-i", "--inactive", is_flag=True, help="New scaling group will be inactive.")
 @click.option(
     "-p",
@@ -94,6 +94,8 @@ def list(ctx: CLIContext) -> None:
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
+@click.option("--wsproxy_addr", type=str, default="", help="Set app proxy address.")
+@click.option("--wsproxy_api_token", type=str, default="", help="Set app proxy API token.")
 def add(
     ctx: CLIContext,
     name,
@@ -105,6 +107,8 @@ def add(
     scheduler,
     scheduler_opts,
     use_host_network,
+    wsproxy_addr,
+    wsproxy_api_token,
 ):
     """
     Add a new scaling group.
@@ -123,6 +127,8 @@ def add(
                 scheduler=scheduler,
                 scheduler_opts=scheduler_opts,
                 use_host_network=use_host_network,
+                wsproxy_addr=wsproxy_addr,
+                wsproxy_api_token=wsproxy_api_token,
             )
         except Exception as e:
             ctx.output.print_mutation_error(
@@ -172,6 +178,8 @@ def add(
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
+@click.option("--wsproxy_addr", type=str, default="", help="Set app proxy address.")
+@click.option("--wsproxy_api_token", type=str, default="", help="Set app proxy API token.")
 def update(
     ctx: CLIContext,
     name,
@@ -183,6 +191,8 @@ def update(
     scheduler,
     scheduler_opts,
     use_host_network,
+    wsproxy_addr,
+    wsproxy_api_token,
 ):
     """
     Update existing scaling group.
@@ -201,6 +211,8 @@ def update(
                 scheduler=scheduler,
                 scheduler_opts=scheduler_opts,
                 use_host_network=use_host_network,
+                wsproxy_addr=wsproxy_addr,
+                wsproxy_api_token=wsproxy_api_token,
             )
         except Exception as e:
             ctx.output.print_mutation_error(

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -94,8 +94,8 @@ def list(ctx: CLIContext) -> None:
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
-@click.option("--wsproxy_addr", type=str, default="", help="Set app proxy address.")
-@click.option("--wsproxy_api_token", type=str, default="", help="Set app proxy API token.")
+@click.option("--wsproxy-addr", type=str, default="", help="Set app proxy address.")
+@click.option("--wsproxy-api-token", type=str, default="", help="Set app proxy API token.")
 def add(
     ctx: CLIContext,
     name,
@@ -153,7 +153,7 @@ def add(
 @scaling_group.command()
 @pass_ctx_obj
 @click.argument("name", type=str, metavar="NAME")
-@click.option("-d", "--description", type=str, default="", help="Description of new scaling group")
+@click.option("-d", "--description", type=str, default="", help="Description of new scaling group.")
 @click.option("-i", "--inactive", is_flag=True, help="New scaling group will be inactive.")
 @click.option(
     "-p",
@@ -178,8 +178,8 @@ def add(
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
-@click.option("--wsproxy_addr", type=str, default="", help="Set app proxy address.")
-@click.option("--wsproxy_api_token", type=str, default="", help="Set app proxy API token.")
+@click.option("--wsproxy-addr", type=str, default="", help="Set app proxy address.")
+@click.option("--wsproxy-api-token", type=str, default="", help="Set app proxy API token.")
 def update(
     ctx: CLIContext,
     name,

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -94,8 +94,8 @@ def list(ctx: CLIContext) -> None:
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
-@click.option("--wsproxy-addr", type=str, default="", help="Set app proxy address.")
-@click.option("--wsproxy-api-token", type=str, default="", help="Set app proxy API token.")
+@click.option("--wsproxy-addr", type=str, default=None, help="Set app proxy address.")
+@click.option("--wsproxy-api-token", type=str, default=None, help="Set app proxy API token.")
 def add(
     ctx: CLIContext,
     name,
@@ -178,8 +178,8 @@ def add(
 @click.option(
     "--use-host-network", is_flag=True, help="If true, run containers on host networking mode."
 )
-@click.option("--wsproxy-addr", type=str, default="", help="Set app proxy address.")
-@click.option("--wsproxy-api-token", type=str, default="", help="Set app proxy API token.")
+@click.option("--wsproxy-addr", type=str, default=None, help="Set app proxy address.")
+@click.option("--wsproxy-api-token", type=str, default=None, help="Set app proxy API token.")
 def update(
     ctx: CLIContext,
     name,

--- a/src/ai/backend/client/func/scaling_group.py
+++ b/src/ai/backend/client/func/scaling_group.py
@@ -1,6 +1,6 @@
 import json
 import textwrap
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Optional, Sequence
 
 from ai.backend.client.output.fields import scaling_group_fields
 from ai.backend.client.output.types import FieldSpec
@@ -127,8 +127,8 @@ class ScalingGroup(BaseFunction):
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
         use_host_network: bool = False,
-        wsproxy_addr: str = None,
-        wsproxy_api_token: str = None,
+        wsproxy_addr: Optional[str] = None,
+        wsproxy_api_token: Optional[str] = None,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """
@@ -176,8 +176,8 @@ class ScalingGroup(BaseFunction):
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
         use_host_network: bool = False,
-        wsproxy_addr: str = None,
-        wsproxy_api_token: str = None,
+        wsproxy_addr: Optional[str] = None,
+        wsproxy_api_token: Optional[str] = None,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """

--- a/src/ai/backend/client/func/scaling_group.py
+++ b/src/ai/backend/client/func/scaling_group.py
@@ -20,6 +20,8 @@ _default_list_fields = (
     scaling_group_fields["driver"],
     scaling_group_fields["scheduler"],
     scaling_group_fields["use_host_network"],
+    scaling_group_fields["wsproxy_addr"],
+    scaling_group_fields["wsproxy_api_token"],
 )
 
 _default_detail_fields = (
@@ -33,6 +35,8 @@ _default_detail_fields = (
     scaling_group_fields["scheduler"],
     scaling_group_fields["scheduler_opts"],
     scaling_group_fields["use_host_network"],
+    scaling_group_fields["wsproxy_addr"],
+    scaling_group_fields["wsproxy_api_token"],
 )
 
 
@@ -123,6 +127,8 @@ class ScalingGroup(BaseFunction):
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
         use_host_network: bool = False,
+        wsproxy_addr: str = None,
+        wsproxy_api_token: str = None,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """
@@ -150,6 +156,8 @@ class ScalingGroup(BaseFunction):
                 "scheduler": scheduler,
                 "scheduler_opts": json.dumps(scheduler_opts),
                 "use_host_network": use_host_network,
+                "wsproxy_addr": wsproxy_addr,
+                "wsproxy_api_token": wsproxy_api_token,
             },
         }
         data = await api_session.get().Admin._query(query, variables)
@@ -168,6 +176,8 @@ class ScalingGroup(BaseFunction):
         scheduler: str = None,
         scheduler_opts: Mapping[str, str] = None,
         use_host_network: bool = False,
+        wsproxy_addr: str = None,
+        wsproxy_api_token: str = None,
         fields: Iterable[FieldSpec | str] = None,
     ) -> dict:
         """
@@ -195,6 +205,8 @@ class ScalingGroup(BaseFunction):
                 "scheduler": scheduler,
                 "scheduler_opts": None if scheduler_opts is None else json.dumps(scheduler_opts),
                 "use_host_network": use_host_network,
+                "wsproxy_addr": wsproxy_addr,
+                "wsproxy_api_token": wsproxy_api_token,
             },
         }
         data = await api_session.get().Admin._query(query, variables)

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -163,6 +163,8 @@ scaling_group_fields = FieldSet(
         FieldSpec("scheduler"),
         FieldSpec("scheduler_opts", formatter=nested_dict_formatter),
         FieldSpec("use_host_network"),
+        FieldSpec("wsproxy_addr"),
+        FieldSpec("wsproxy_api_token"),
     ]
 )
 

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -294,6 +294,7 @@ class ScalingGroup(graphene.ObjectType):
     is_public = graphene.Boolean()
     created_at = GQLDateTime()
     wsproxy_addr = graphene.String()
+    wsproxy_api_token = graphene.String()
     driver = graphene.String()
     driver_opts = graphene.JSONString()
     scheduler = graphene.String()
@@ -315,6 +316,7 @@ class ScalingGroup(graphene.ObjectType):
             is_public=row["is_public"],
             created_at=row["created_at"],
             wsproxy_addr=row["wsproxy_addr"],
+            wsproxy_api_token=row["wsproxy_api_token"],
             driver=row["driver"],
             driver_opts=row["driver_opts"],
             scheduler=row["scheduler"],
@@ -469,6 +471,7 @@ class CreateScalingGroupInput(graphene.InputObjectType):
     is_active = graphene.Boolean(required=False, default=True)
     is_public = graphene.Boolean(required=False, default=True)
     wsproxy_addr = graphene.String(required=False)
+    wsproxy_api_token = graphene.String(required=False)
     driver = graphene.String(required=True)
     driver_opts = graphene.JSONString(required=False, default={})
     scheduler = graphene.String(required=True)
@@ -481,6 +484,7 @@ class ModifyScalingGroupInput(graphene.InputObjectType):
     is_active = graphene.Boolean(required=False)
     is_public = graphene.Boolean(required=False)
     wsproxy_addr = graphene.String(required=False)
+    wsproxy_api_token = graphene.String(required=False)
     driver = graphene.String(required=False)
     driver_opts = graphene.JSONString(required=False)
     scheduler = graphene.String(required=False)
@@ -513,6 +517,7 @@ class CreateScalingGroup(graphene.Mutation):
             "is_active": bool(props.is_active),
             "is_public": bool(props.is_public),
             "wsproxy_addr": props.wsproxy_addr,
+            "wsproxy_api_token": props.wsproxy_api_token,
             "driver": props.driver,
             "driver_opts": props.driver_opts,
             "scheduler": props.scheduler,
@@ -552,6 +557,7 @@ class ModifyScalingGroup(graphene.Mutation):
         set_if_set(props, data, "is_public")
         set_if_set(props, data, "driver")
         set_if_set(props, data, "wsproxy_addr")
+        set_if_set(props, data, "wsproxy_api_token")
         set_if_set(props, data, "driver_opts")
         set_if_set(props, data, "scheduler")
         set_if_set(


### PR DESCRIPTION
- Add `wsproxy_api_token` column to manager/model.
- Make it possible to CRUD `wsproxy_addr` and `wsproxy_api_token` in CLI.
follows https://github.com/lablup/backend.ai/pull/1278
related: https://github.com/lablup/backend.ai-control-panel/issues/660
