### PR TITLE
fix: do not try to access undefined variable on client fetch

### DIFF
--- a/changes/1464.fix.md
+++ b/changes/1464.fix.md
@@ -1,0 +1,1 @@
+Add None check to out of scoped variable for correct error response to user.

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -572,6 +572,7 @@ class FetchContextManager:
     async def __aenter__(self) -> Response:
         max_retries = len(self.session.config.endpoints)
         retry_count = 0
+        raw_resp = None
         while True:
             try:
                 retry_count += 1
@@ -596,7 +597,8 @@ class FetchContextManager:
                     continue
             except aiohttp.ClientResponseError as e:
                 msg = "API endpoint response error.\n\u279c {!r}".format(e)
-                await raw_resp.__aexit__(*sys.exc_info())
+                if raw_resp is not None:
+                    await raw_resp.__aexit__(*sys.exc_info())
                 raise BackendClientError(msg) from e
             finally:
                 self.session.config.load_balance_endpoints()

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -572,7 +572,7 @@ class FetchContextManager:
     async def __aenter__(self) -> Response:
         max_retries = len(self.session.config.endpoints)
         retry_count = 0
-        raw_resp = None
+        raw_resp: Optional[_RequestContextManager] = None
         while True:
             try:
                 retry_count += 1

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -572,7 +572,7 @@ class FetchContextManager:
     async def __aenter__(self) -> Response:
         max_retries = len(self.session.config.endpoints)
         retry_count = 0
-        raw_resp: Optional[_RequestContextManager] = None
+        raw_resp: Optional[aiohttp.ClientResponse] = None
         while True:
             try:
                 retry_count += 1


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- resolves https://github.com/lablup/backend.ai-ossca-2023/issues/3
- add check block for `variable is not None`.
- So, that makes correct error response when got ClientResponseError in FetchContextManager.

before

```
✗ [0] cannot access local variable 'raw_resp' where it is not associated with a value
```

after

```
✗ [0] BackendClientError("API endpoint response error.\n➜ ClientResponseError(RequestInfo(url=URL('http://127.0.0.1:6011/session'), method='POST', headers=<CIMultiDictProxy('Host': '127.0.0.1:6011', 'User-Agent': 'Backend.AI Client for Python 23.03.9.dev0', 'X-BackendAI-Domain': 'default', 'X-BackendAI-Version': 'v7.20230615', 'Date': '2023-07-20T08:29:03.767375+00:00', 'Content-Type': 'application/json', 'Authorization': 'BackendAI signMethod=HMAC-SHA256, credential=AKIAIOSFODNN7EXAMPLE:8a8c57ef22208c21eb27c1fe7b68e5e5773de6e21849fd78f2579654c6bf6f4c', 'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'Content-Length': '543')>, real_url=URL('http://127.0.0.1:6011/session')), (), status=400, message='Expected HTTP/')")
```
