### PR TITLE
docs: fix daily workflows documentation typo

### DIFF
--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -278,9 +278,9 @@ Set the following keys in the workspace settings to configure Python tools:
    * - ``{mypy-type-checker,black-formatter}.importStrategy``
      - ``"fromEnvironment"``
    * - ``ruff.interpreter``
-     - ``["dist/export/python/virtualenvs/black/3.11.4/bin/python"]``
+     - ``["dist/export/python/virtualenvs/ruff/3.11.4/bin/python"]``
    * - ``ruff.path``
-     - ``["dist/export/python/virtualenvs/black/3.11.4/bin/ruff"]``
+     - ``["dist/export/python/virtualenvs/ruff/3.11.4/bin/ruff"]``
 
 .. note:: **Changed in July 2023**
 


### PR DESCRIPTION
This PR fixed typo in daily workflow docs, VSCode settings for Ruff.
- `black` -> `ruff`
- ruff.interpreter
  - ["dist/export/python/virtualenvs/**ruff**/3.11.4/bin/python"]
- ruff.path
  - ["dist/export/python/virtualenvs/**ruff**/3.11.4/bin/ruff"]



<!-- readthedocs-preview sorna start -->
----
:books: Documentation preview :books:: https://sorna--1476.org.readthedocs.build/en/1476/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
:books: Documentation preview :books:: https://sorna-ko--1476.org.readthedocs.build/ko/1476/

<!-- readthedocs-preview sorna-ko end -->