### PR TITLE
feat: expose `preopen_ports` information on `Kernel` GQL Query

### DIFF
--- a/changes/1479.feature.md
+++ b/changes/1479.feature.md
@@ -1,0 +1,1 @@
+Support for displaying `preopen_ports` in the `session info` command.

--- a/changes/1479.feature.md
+++ b/changes/1479.feature.md
@@ -1,1 +1,1 @@
-Support for displaying `preopen_ports` in the `session info` command.
+Add support for displaying `preopen_ports` when executing `session info` CLI command.

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -32,7 +32,7 @@ container_fields = FieldSet(
         FieldSpec("container_id"),
         FieldSpec("resource_opts", formatter=nested_dict_formatter),
         FieldSpec("occupied_slots", formatter=resource_slot_formatter),
-        FieldSpec("preopen_ports", "Pre-opened Ports"),
+        FieldSpec("preopen_ports", "Preopen Ports"),
         FieldSpec("live_stat", formatter=KernelStatFormatter()),
         FieldSpec("last_stat", formatter=KernelStatFormatter()),
     ]

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -32,6 +32,7 @@ container_fields = FieldSet(
         FieldSpec("container_id"),
         FieldSpec("resource_opts", formatter=nested_dict_formatter),
         FieldSpec("occupied_slots", formatter=resource_slot_formatter),
+        FieldSpec("preopen_ports", "Pre-opened Ports"),
         FieldSpec("live_stat", formatter=KernelStatFormatter()),
         FieldSpec("last_stat", formatter=KernelStatFormatter()),
     ]

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -798,6 +798,7 @@ class ComputeContainer(graphene.ObjectType):
     occupied_slots = graphene.JSONString()
     live_stat = graphene.JSONString()
     last_stat = graphene.JSONString()
+    preopen_ports = graphene.List(lambda: graphene.Int, required=False)
 
     @classmethod
     def parse_row(cls, ctx: GraphQueryContext, row: Row) -> Mapping[str, Any]:
@@ -840,6 +841,7 @@ class ComputeContainer(graphene.ObjectType):
             "agent_addr": row["agent_addr"] if not hide_agents else None,
             "container_id": row["container_id"] if not hide_agents else None,
             "resource_opts": row["resource_opts"],
+            "preopen_ports": row["preopen_ports"],
             # statistics
             # last_stat is resolved by Graphene (resolve_last_stat method)
         }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
resolves https://github.com/lablup/backend.ai/issues/1351

result of `./backend.ai session info <session_id>`
<img width="823" alt="image" src="https://github.com/lablup/backend.ai/assets/28584164/bd000588-d1d3-4b0e-a6c0-582e81aff520">
