### PR TITLE
ci: Print the copyright year as the current year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
+from datetime import datetime
 project = "Backend.AI Documentation"
-copyright = "2015-2022, Lablup Inc."
+copyright = "2015-" + datetime.today().strftime('%Y') + ", Lablup Inc."
 author = "Lablup Inc."
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,9 +61,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-from datetime import datetime
+from datetime import date
 project = "Backend.AI Documentation"
-copyright = "2015-" + datetime.today().strftime('%Y') + ", Lablup Inc."
+copyright = f"2015-{date.today().year}, Lablup Inc."
 author = "Lablup Inc."
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Having the copyright year in the previous year gives the impression of a poorly managed project.
So, the copyright year display is improved to display the current year.
close #1368 

<!-- readthedocs-preview sorna start -->
----
:books: Documentation preview :books:: https://sorna--1485.org.readthedocs.build/en/1485/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
:books: Documentation preview :books:: https://sorna-ko--1485.org.readthedocs.build/ko/1485/

<!-- readthedocs-preview sorna-ko end -->