### PR TITLE
ci: Change trigger of auto-label-in-issue to pull_request_target

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: 'Auto Label'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
auto-label-in-issue doesn't work properly with pull_request from a forked repo.
This is a problem caused by the permission of github_token.
This is solved by using pull_request_target.
auto-label-in-issue is not related to changes in the code, so it doesn't matter if it is executed based on the target branch.