### PR TITLE
ci: stop supplying `token` on news-fragments workflow

### DIFF
--- a/.github/workflows/pr-number-assign.yml
+++ b/.github/workflows/pr-number-assign.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-        token: ${{ secrets.WORKFLOW_PAT }}
 
     - name: Extract Python version from pants.toml
       run: |


### PR DESCRIPTION
Our repo is public and thus we won't need any special privileges to clone the repository.
