### PR TITLE
fix: Correct null check in kernel role migration

### DIFF
--- a/changes/1500.fix.md
+++ b/changes/1500.fix.md
@@ -1,0 +1,1 @@
+Correct null check when migrate `role` column in `kernels` table.

--- a/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/bedd92de93af_add_role_column_on_kernels_table.py
@@ -37,7 +37,7 @@ def upgrade():
         # `order_by` is not necessary, but helpful to display the currently processing kernels.
         query = (
             sa.select([kernels.c.id])
-            .where(kernels.c.role is None)
+            .where(kernels.c.role.is_(None))
             .order_by(kernels.c.id)
             .limit(batch_size)
         )


### PR DESCRIPTION
```
kernels.c.role is None
```
SQL query condition like  this will not work as is.