### PR TITLE
feature: use AsyncRedisLock sleep

### DIFF
--- a/changes/1501.feature.md
+++ b/changes/1501.feature.md
@@ -1,1 +1,1 @@
-Set sleep argument on `AsyncRedisLock` to sleep after every poll.
+Set the sleep argument of `AsyncRedisLock` to preevnt flooding the Redis server due to a high rate of polling requests

--- a/changes/1501.feature.md
+++ b/changes/1501.feature.md
@@ -1,0 +1,1 @@
+Set sleep argument on `AsyncRedisLock` to sleep after every poll.


### PR DESCRIPTION
When we use `RedisLock` with multiple managers, the managers do polling to get lock every 0.1 second.
Since it can cause a huge burden to Redis, let's reduce it by passing `sleep` argument to `AsyncRedisLock` to sleep for every polling.