### PR TITLE
fix: Update etcd port script for storage proxy config

### DIFF
--- a/changes/1514.feature.md
+++ b/changes/1514.feature.md
@@ -1,1 +1,0 @@
-Add auto update etcd port script in `install-dev.sh` for `storage-proxy.toml`.

--- a/changes/1514.feature.md
+++ b/changes/1514.feature.md
@@ -1,0 +1,1 @@
+Add auto update etcd port script in `install-dev.sh` for `storage-proxy.toml`.

--- a/changes/1514.fix.md
+++ b/changes/1514.fix.md
@@ -1,0 +1,1 @@
+Add missing update of the etcd port in `storage-proxy.toml` by the `install-dev.sh` script

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -795,6 +795,7 @@ configure_backendai() {
   # configure storage-proxy
   cp configs/storage-proxy/sample.toml ./storage-proxy.toml
   STORAGE_PROXY_RANDOM_KEY=$(python -c 'import secrets; print(secrets.token_hex(32), end="")')
+  sed_inplace "s/port = 2379/port = ${ETCD_PORT}/" ./storage-proxy.toml
   sed_inplace "s/secret = \"some-secret-private-for-storage-proxy\"/secret = \"${STORAGE_PROXY_RANDOM_KEY}\"/" ./storage-proxy.toml
   sed_inplace "s/secret = \"some-secret-shared-with-manager\"/secret = \"${MANAGER_AUTH_KEY}\"/" ./storage-proxy.toml
   sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./storage-proxy.toml


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- resolves https://github.com/lablup/backend.ai-ossca-2023/issues/18, the second problem.
- just update etcd port as defined in `install-dev.sh`.
