### PR TITLE
fix: use of invalid etcd config key when rescanning image

### DIFF
--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -362,7 +362,7 @@ container_registry_iv = t.Dict(
         t.Key("project", default=None): (
             t.Null | t.List(t.String) | tx.StringList(empty_str_as_empty_list=True)
         ),
-        tx.AliasedKey(["ssl-verify", "ssl_verify"], default=True): t.ToBool,
+        tx.AliasedKey(["ssl_verify", "ssl-verify"], default=True): t.ToBool,  # TODO
     }
 ).allow_extra("*")
 

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -362,7 +362,7 @@ container_registry_iv = t.Dict(
         t.Key("project", default=None): (
             t.Null | t.List(t.String) | tx.StringList(empty_str_as_empty_list=True)
         ),
-        tx.AliasedKey(["ssl_verify", "ssl-verify"], default=True): t.ToBool,
+        tx.AliasedKey(["ssl-verify", "ssl_verify"], default=True): t.ToBool,
     }
 ).allow_extra("*")
 

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -362,7 +362,7 @@ container_registry_iv = t.Dict(
         t.Key("project", default=None): (
             t.Null | t.List(t.String) | tx.StringList(empty_str_as_empty_list=True)
         ),
-        tx.AliasedKey(["ssl_verify", "ssl-verify"], default=True): t.ToBool,  # TODO
+        tx.AliasedKey(["ssl_verify", "ssl-verify"], default=True): t.ToBool,
     }
 ).allow_extra("*")
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -64,7 +64,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
 
     async def prepare_client_session(self) -> AsyncIterator[tuple[yarl.URL, aiohttp.ClientSession]]:
         ssl_ctx = None  # default
-        if not self.registry_info["ssl-verify"]:
+        if not self.registry_info["ssl_verify"]:
             ssl_ctx = False
         connector = aiohttp.TCPConnector(ssl=ssl_ctx)
         async with aiohttp.ClientSession(connector=connector) as sess:


### PR DESCRIPTION
This PR fixes an error raised when running image rescan functions: `./backend.ai mgr image rescan` or `./backend.ai admin image rescan`

```sh
2023-08-30 14:52:15.657 INFO ai.backend.manager.models.image [49069] Scanning kernel images from the registry "cr.backend.ai"
2023-08-30 14:52:15.658 ERROR ai.backend.manager.cli.image_impl [49069] An error occurred.
  + Exception Group Traceback (most recent call last):
  |   File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/cli/image_impl.py", line 186, in rescan_images
  |     await rescan_images_func(etcd, db, registry=registry, local=local)
  |     ^^^^^^^^^^^^^^^^^
  |   File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/models/image.py", line 115, in rescan_images
  |     async with aiotools.TaskGroup() as tg:
  |       ^^^^^^^^^^^^^^^^^
  |   File "/Users/rapsealk/Desktop/git/backend.ai-dev/dist/export/python/virtualenvs/python-default/3.11.4/lib/python3.11/site-packages/aiotools/taskgroup/base.py", line 39, in __aexit__
  |     raise TaskGroupError(eg.message, eg.exceptions) from None
  |     ^^^^^^^^^^^^^^^^^
  | aiotools.taskgroup.types.TaskGroupError: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/container_registry/base.py", line 95, in rescan_single_registry
    |     async with actxmgr(self.prepare_client_session)() as (url, client_session):
    |     ^^^^^^^^^^^^^^^^^
    |   File "/Users/rapsealk/.pyenv/versions/3.11.4/lib/python3.11/contextlib.py", line 204, in __aenter__
    |     return await anext(self.gen)
    |     ^^^^^^^^^^^^^^^^^
    |   File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/container_registry/base.py", line 67, in prepare_client_session
    |     if not self.registry_info["ssl-verify"]:
    |     ^^^^^^^^^^^^^^^^^
    | KeyError: 'ssl-verify'
    +------------------------------------
```

As `tx.AliasedKey` takes the first name to map the given value, this PR reorders the given names.

https://github.com/lablup/backend.ai/blob/c0bbaa9012fa3120fa3c657bed963fd96835bc76/src/ai/backend/common/validators.py#L94-L103

Refs
- #1471 


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
