### PR TITLE
docs: add instructions about generating PDF document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,12 +74,21 @@ $ make -e SPHINXOPTS="-D language='ko'" html
 ```
 
 
-## 🚧 Building PDF document (WIP) 🚧
+## Building PDF document
 
-> Help wanted!
+```console
+$ make latexpdf
+```
 
-We are looking for people to help with a short guide for building PDF document based on html files derived from sphinx.
+The compiled documentation is under `_build/latex/BackendAIDoc.pdf`.
 
+### Dependency
+
+* TeX Live 
+  - ko.TeX (texlive-lang-korean)
+  - latexmk
+* ImageMagick
+* Font files (All required font files must be installed)
 
 ## Advanced Settings
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ Building PDF requires following libraries to be present on your system.
 2. Follow [here](http://wiki.ktug.org/wiki/wiki.php/KtugPrivateRepository) (Korean) to set up KTUG repository.
 3. Exceute following command to install missing dependencies.   
 ```console
-latexmk tex-gyre fncychap wrapfig capt-of framed needspace kotex-utf collection-langkorean collection-fontsrecommended unfonts-base
+latexmk tex-gyre fncychap wrapfig capt-of framed needspace kotex-utf collection-langkorean collection-fontsrecommended unfonts-base-type1
 ```
 
 ## Advanced Settings

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,13 +82,21 @@ $ make latexpdf
 
 The compiled documentation is under `_build/latex/BackendAIDoc.pdf`.
 
-### Dependency
+Building PDF requires following libraries to be present on your system.
 
 * TeX Live 
   - ko.TeX (texlive-lang-korean)
   - latexmk
 * ImageMagick
 * Font files (All required font files must be installed)
+
+### Installing dependencies on macOS
+1. Install MacTeX from [here](https://www.tug.org/mactex/). There are two types of MacTeX distributions; The BasicTeX one is more lightweight and MacTeX contains most of the libraries commonly used.
+2. Follow [here](http://wiki.ktug.org/wiki/wiki.php/KtugPrivateRepository) (Korean) to set up KTUG repository.
+3. Exceute following command to install missing dependencies.   
+```console
+latexmk tex-gyre fncychap wrapfig capt-of framed needspace kotex-utf collection-langkorean collection-fontsrecommended unfonts-base
+```
 
 ## Advanced Settings
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
+    "sphinx.ext.imgconverter",
     "sphinx_rtd_theme",
     "sphinxcontrib_trio",
     "sphinxcontrib.mermaid",


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Goal: Building pdf document

+ Add Sphinx extension to use SVG img in PDF https://github.com/lablup/backend.ai/commit/c2496fa9d70af564eaf86d890fa98c3d0c410ec9
+ Add guide for building PDF document https://github.com/lablup/backend.ai/commit/3294e3903d5f1f722f44bbe8ef35202bda212655
  - Command
  - Dependency


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
