### PR TITLE
feat: introduce the k8s agent backend mode to install-dev.sh

### DIFF
--- a/changes/1526.feature.md
+++ b/changes/1526.feature.md
@@ -1,0 +1,1 @@
+Introduce the k8s agent backend mode to install-dev.sh with --agent-backend

--- a/configs/agent/halfstack.toml
+++ b/configs/agent/halfstack.toml
@@ -29,6 +29,8 @@ sandbox-type = "docker"
 scratch-type = "hostdir"
 scratch-root = "./scratches"
 scratch-size = "1G"
+scratch-nfs-address = ""
+scratch-nfs-options = ""
 
 
 [watcher]

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -114,6 +114,10 @@ usage() {
   echo "    The port for the agent's watcher service."
   echo "    (default: 6019)"
   echo ""
+  echo "  ${LWHITE}--agent-backend mode${NC}"
+  echo "    Mode for backend agent(docker, kubernetes)."
+  echo "    (default: docker)"
+  echo ""
   echo "  ${LWHITE}--ipc-base-path PATH${NC}"
   echo "    The base path for IPC sockets and shared temporary files."
   echo "    (default: /tmp/backend.ai/ipc)"
@@ -289,6 +293,7 @@ WEBSERVER_PORT="8090"
 WSPROXY_PORT="5050"
 AGENT_RPC_PORT="6011"
 AGENT_WATCHER_PORT="6019"
+AGENT_BACKEND="docker"
 IPC_BASE_PATH="/tmp/backend.ai/ipc"
 VAR_BASE_PATH=$(relpath "${ROOT_PATH}/var/lib/backend.ai")
 VFOLDER_REL_PATH="vfroot/local"
@@ -329,6 +334,8 @@ while [ $# -gt 0 ]; do
     --var-base-path=*)      VAR_BASE_PATH="${1#*=}" ;;
     --codespaces-on-create) CODESPACES_ON_CREATE=1 ;;
     --codespaces-post-create) CODESPACES_POST_CREATE=1 ;;
+    --agent-backend)        AGENT_BACKEND=$2; shift ;;
+    --agent-backend=*)      AGENT_BACKEND="${1#*=}" ;;
     *)
       echo "Unknown option: $1"
       echo "Run '$0 --help' for usage."
@@ -781,6 +788,15 @@ configure_backendai() {
   sed_inplace "s/port = 6009/port = ${AGENT_WATCHER_PORT}/" ./agent.toml
   sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./agent.toml
   sed_inplace "s@\(# \)\{0,1\}var-base-path = .*@var-base-path = "'"'"${VAR_BASE_PATH}"'"'"@" ./agent.toml
+
+  # configure backend mode
+  if [ $AGENT_BACKEND = "k8s" ] || [ $AGENT_BACKEND = "kubernetes" ]; then 
+    sed_inplace "s/mode = \"docker\"/mode = \"kubernetes\"/" ./agent.toml
+    sed_inplace "s/scratch-type = \"hostdir\"/scratch-type = \"k8s-nfs\"/" ./agent.toml
+  elif [ $AGENT_BACKEND = "docker" ]; then
+    sed '/scratch-nfs-/d' ./agent.toml > ./agent.toml.sed
+    mv ./agent.toml.sed ./agent.toml
+  fi
   if [ $ENABLE_CUDA -eq 1 ]; then
     sed_inplace "s/# allow-compute-plugins =.*/allow-compute-plugins = [\"ai.backend.accelerator.cuda_open\"]/" ./agent.toml
   elif [ $ENABLE_CUDA_MOCK -eq 1 ]; then


### PR DESCRIPTION
resolves: #1361 

This pr only includes introducing k8s agent backend mode with cli in install-dev.sh

The reason I added only k8s/kubernetes in the option is that the python kubernetes client uses local kubernetes context in `~/.kube/config`. So, using micro-k8s in local and any external kubernetes cluster makes no difference in configuration.

It just need's it's context added in `~/.kube/config`.

