### PR TITLE
fix: PDF not generated on macOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,8 +95,9 @@ Building PDF requires following libraries to be present on your system.
 2. Follow [here](http://wiki.ktug.org/wiki/wiki.php/KtugPrivateRepository) (Korean) to set up KTUG repository.
 3. Exceute following command to install missing dependencies.   
 ```console
-latexmk tex-gyre fncychap wrapfig capt-of framed needspace kotex-utf collection-langkorean collection-fontsrecommended unfonts-base-type1
+sudo tlmgr install latexmk tex-gyre fncychap wrapfig capt-of framed needspace collection-langkorean collection-fontsrecommended tabulary varwidth titlesec
 ```
+4. Install both Pretendard (used for main font) and D2Coding (used to draw monospace characters) fonts on your system.
 
 ## Advanced Settings
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,21 +164,18 @@ htmlhelp_basename = "BackendAIDoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_engine = "pdflatex"
+latex_engine = "xelatex"
 
 latex_elements = {
     "papersize": "a4paper",
     "pointsize": "12pt",
-    "preamble": (
-        "\n".join(
-            [
-                "\\usepackage[T1]{fontenc}",
-                "\\usepackage{kotex}",
-                "\\usepackage{dhucs-nanumfont}",
-            ]
-        )
-        + "\n"
-    ),
+    "fontpkg": "\n".join([
+        "\\usepackage{fontspec}",
+        "\\setmainfont{Pretendard}",
+        "\\setmonofont{D2Coding}",
+        "\\usepackage{kotex}",
+        ""
+    ])
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }


### PR DESCRIPTION
Follow-up PR of #1525. Updates docs/conf.py to switch PDF building engine to xelatex instead of pdflatex.

<!-- readthedocs-preview sorna start -->
----
:books: Documentation preview :books:: https://sorna--1529.org.readthedocs.build/en/1529/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
:books: Documentation preview :books:: https://sorna-ko--1529.org.readthedocs.build/ko/1529/

<!-- readthedocs-preview sorna-ko end -->