### PR TITLE
fix: set agent's `mount-path` config nullable

### DIFF
--- a/configs/agent/halfstack.toml
+++ b/configs/agent/halfstack.toml
@@ -18,7 +18,7 @@ var-base-path = "./var/lib/backend.ai"
 # allow-compute-plugins = []
 # block-compute-plugins = []
 image-commit-path = "./tmp/backend.ai/commit/"
-mount-path = "/vfroot"
+mount-path = "./vfroot/local"
 cohabiting-storage-proxy = true
 
 

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -781,7 +781,7 @@ configure_backendai() {
   sed_inplace "s/port = 6009/port = ${AGENT_WATCHER_PORT}/" ./agent.toml
   sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./agent.toml
   sed_inplace "s@\(# \)\{0,1\}var-base-path = .*@var-base-path = "'"'"${VAR_BASE_PATH}"'"'"@" ./agent.toml
-  sed_inplace "s@\(# \)\{0,1\}mount-path = .*@mount-path = "'"'"${VFOLDER_REL_PATH}"'"'"@" ./agent.toml
+  sed_inplace "s@\(# \)\{0,1\}mount-path = .*@mount-path = "'"'"${ROOT_PATH}/${VFOLDER_REL_PATH}"'"'"@" ./agent.toml
   if [ $ENABLE_CUDA -eq 1 ]; then
     sed_inplace "s/# allow-compute-plugins =.*/allow-compute-plugins = [\"ai.backend.accelerator.cuda_open\"]/" ./agent.toml
   elif [ $ENABLE_CUDA_MOCK -eq 1 ]; then

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2344,7 +2344,9 @@ async def handle_volume_mount(
         log.debug("Storage proxy is in the same node. Skip the volume task.")
         return
     mount_prefix = await context.etcd.get("volumes/_mount")
-    volume_mount_prefix = context.local_config["agent"]["mount-path"]
+    volume_mount_prefix: str | None = context.local_config["agent"]["mount-path"]
+    if volume_mount_prefix is None:
+        volume_mount_prefix = "./"
     real_path = Path(volume_mount_prefix, event.dir_name)
     err_msg: str | None = None
     try:

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -33,7 +33,9 @@ agent_local_config_iv = (
                     t.Key("var-base-path", default="./var/lib/backend.ai"): tx.Path(
                         type="dir", auto_create=True
                     ),
-                    t.Key("mount-path"): tx.Path(type="dir", auto_create=True),
+                    t.Key("mount-path", default=None): t.Null | tx.Path(
+                        type="dir", auto_create=True
+                    ),
                     t.Key("cohabiting-storage-proxy", default=True): t.Bool(),
                     t.Key("public-host", default=None): t.Null | t.String,
                     t.Key("region", default=None): t.Null | t.String,


### PR DESCRIPTION
follow-up #1495 
Set agent's `mount-path` local config to nullable since it is used only when `mount` or `umount` happens.