### PR TITLE
deps: update etcetra to 0.1.17

### DIFF
--- a/changes/1537.deps.md
+++ b/changes/1537.deps.md
@@ -1,0 +1,1 @@
+Update etcetra version to 0.1.17

--- a/python.lock
+++ b/python.lock
@@ -43,7 +43,7 @@
 //     "coloredlogs~=15.0",
 //     "cryptography>=2.8",
 //     "dataclasses-json~=0.5.7",
-//     "etcetra==0.1.15",
+//     "etcetra==0.1.17",
 //     "faker~=13.12.0",
 //     "graphene~=2.1.9",
 //     "hiredis~=2.2.3",
@@ -863,36 +863,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d77415f22bbc14f3d72eaed2fc9f96d161f3ba7686922ad26d6bbc9d4985f3df",
-              "url": "https://files.pythonhosted.org/packages/c7/e7/5c557d60eb76ba55ff202bea08e15d1840ba0fe8d1c7bfccf54b8c5a2990/boto3-1.28.35-py3-none-any.whl"
+              "hash": "bd7c760afb195eaeaab907dc6b2c21fa64ddbba3fed4a869e80d820ddbd6cc70",
+              "url": "https://files.pythonhosted.org/packages/81/09/be4b462f1aef33ffd789dbcfbd626a261fa0acc3b1499990ce8b71474d89/boto3-1.28.40-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "580b584e36967155abed7cc9b088b3bd784e8242ae4d8841f58cb50ab05520dc",
-              "url": "https://files.pythonhosted.org/packages/77/57/32ed300facd766f9e0ae52792fafd429525c23aef28c7df4940682edc4c2/boto3-1.28.35.tar.gz"
+              "hash": "6ff9a5b815e106656596064d51c9b6ba97a307807baa5f89634384b7d3f7ecc6",
+              "url": "https://files.pythonhosted.org/packages/fb/00/20a7ddef854c51347165d114c879203d656e12f7d9b7b30dd8cd244adcf1/boto3-1.28.40.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.32.0,>=1.31.35",
+            "botocore<1.32.0,>=1.31.40",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.7.0,>=0.6.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.28.35"
+          "version": "1.28.40"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "943e1465aad66db4933b06809134bd08c5b05e8eb18c19742ffec82f54769457",
-              "url": "https://files.pythonhosted.org/packages/35/5a/effb72e1cee7f9f3538a73b75870687cef1d9a377da7a70b75d7e1a38c5c/botocore-1.31.35-py3-none-any.whl"
+              "hash": "df766969f0d9ef9eda1a9c9946e0e173c10199f37a9e4c92861f11ddb5c9e702",
+              "url": "https://files.pythonhosted.org/packages/ba/2e/8b3b13bcd625115c6d65b0bbfa3312d983ef4508391e3bb09f4887fb34f5/botocore-1.31.40-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7e4534325262f43293a9cc9937cb3f1711365244ffde8b925a6ee862bcf30a83",
-              "url": "https://files.pythonhosted.org/packages/b8/7e/989d7fdebd245cc392995fd6720f2f7769f7caa7aac434887e54a1c6d320/botocore-1.31.35.tar.gz"
+              "hash": "ce22a82ef8674f49691477d09558992cc87e7331f65c6a5b0da897ab192240ca",
+              "url": "https://files.pythonhosted.org/packages/96/b2/810868e32687760da8666ca65d2e307d7f50ed38276b5aef6cdf0a9fde14/botocore-1.31.40.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -903,7 +903,7 @@
             "urllib3<1.27,>=1.25.4"
           ],
           "requires_python": ">=3.7",
-          "version": "1.31.35"
+          "version": "1.31.40"
         },
         {
           "artifacts": [
@@ -1324,13 +1324,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86c1d89da2883d19d8e33cf2c55d114ea7e118c6f50521c5b579c978e807807d",
-              "url": "https://files.pythonhosted.org/packages/52/90/4fe786bb98ad4cb9e8cd86e2449e2652c7f025f5be4c4ba92f3a4d3346d2/etcetra-0.1.15-py3-none-any.whl"
+              "hash": "5771fb86235b3ceffd64a9e65d569e8f36ced70217339b6732769ead988b1f9b",
+              "url": "https://files.pythonhosted.org/packages/98/f0/9b51a30c4b16662c54479e5e70507a8ecb0dd1169f846f811900e0b8c146/etcetra-0.1.17-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd417c7afa49ce6748b1fad6de15feb4588e842674bf15ba6d02e3fa80671f49",
-              "url": "https://files.pythonhosted.org/packages/0f/6b/e0f0b69a44e71f9abcf9c581b79a16bab4516ef7747e2b4ef2db69b45210/etcetra-0.1.15.tar.gz"
+              "hash": "9ab0e0f85127ec25f5538bc056cb0fee035d838e81412f2d067e792d49dd9dd2",
+              "url": "https://files.pythonhosted.org/packages/9c/7d/570279472f280f26762212135da86aa6a25c8d9c4ddf5bf1a74fca1dae32/etcetra-0.1.17.tar.gz"
             }
           ],
           "project_name": "etcetra",
@@ -1339,10 +1339,10 @@
             "codecov; extra == \"test\"",
             "flake8-commas>=2.1; extra == \"lint\"",
             "flake8>=4.0.1; extra == \"lint\"",
-            "grpcio-tools==1.50.0",
-            "grpcio==1.50.0",
-            "mypy>=0.930; extra == \"typecheck\"",
-            "protobuf~=4.21.6",
+            "grpcio-tools==1.56.2",
+            "grpcio==1.56.2",
+            "mypy>=1.4.1; extra == \"typecheck\"",
+            "protobuf~=4.23.4",
             "pytest-asyncio~=0.16.0; extra == \"test\"",
             "pytest-cov>=2.11; extra == \"test\"",
             "pytest-mock>=3.5.0; extra == \"test\"",
@@ -1353,7 +1353,7 @@
             "wheel>=0.36.2; extra == \"build\""
           ],
           "requires_python": ">=3.10",
-          "version": "0.1.15"
+          "version": "0.1.17"
         },
         {
           "artifacts": [
@@ -1587,6 +1587,11 @@
             },
             {
               "algorithm": "sha256",
+              "hash": "d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47",
+              "url": "https://files.pythonhosted.org/packages/03/1a/dae7e4abc978e3eff4b8e90e76fb6619ba38d3cabac5f10131880fc03091/greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
               "hash": "e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0",
               "url": "https://files.pythonhosted.org/packages/1e/1e/632e55a04d732c8184201238d911207682b119c35cecbb9a573a6c566731/greenlet-2.0.2.tar.gz"
             },
@@ -1630,116 +1635,103 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d144ad10eeca4c1d1ce930faa105899f86f5d99cecfe0d7224f3c4c76265c15e",
-              "url": "https://files.pythonhosted.org/packages/c9/c0/d003228e58a5e9111691a9dee65aca46f1b12fa3d84c3627a09bdbae0d37/grpcio-1.50.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "89a49cc5ad08a38b6141af17e00d1dd482dc927c7605bc77af457b5a0fca807c",
+              "url": "https://files.pythonhosted.org/packages/47/60/bec05dbb5f8f2d61d79d4e16fb7222e7c0f25a50aaa4a9bc5dcf5df6fb38/grpcio-1.56.2-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "156f8009e36780fab48c979c5605eda646065d4695deea4cfcbcfdd06627ddb6",
-              "url": "https://files.pythonhosted.org/packages/2a/91/49f4a4b36425a81339b90d142b6d319875a31239d765a08f0b32e1c89480/grpcio-1.50.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "6108e5933eb8c22cd3646e72d5b54772c29f57482fd4c41a0640aab99eb5071d",
+              "url": "https://files.pythonhosted.org/packages/06/ed/4c7651a5af2628273a80ae55376f21c8e6fcababadfa0d6ec771aa02ee9b/grpcio-1.56.2-cp311-cp311-macosx_10_10_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "12b479839a5e753580b5e6053571de14006157f2ef9b71f38c56dc9b23b95ad6",
-              "url": "https://files.pythonhosted.org/packages/71/87/118ed062bba99c54162f9b3a15cc58f018e157fe2f274edd7bc1a8a5bfe2/grpcio-1.50.0.tar.gz"
+              "hash": "8391cea5ce72f4a12368afd17799474015d5d3dc00c936a907eb7c7eaaea98a5",
+              "url": "https://files.pythonhosted.org/packages/0a/3c/beb0a37a0ed1073642ec59a2b6df1739d425e58557d415feebd18bd93fc3/grpcio-1.56.2-cp311-cp311-manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de411d2b030134b642c092e986d21aefb9d26a28bf5a18c47dd08ded411a3bc5",
-              "url": "https://files.pythonhosted.org/packages/a8/c8/a03979d91a3efa610787fba3d854a51f88648170a19a90cee1b3667a7c48/grpcio-1.50.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "0ff789ae7d8ddd76d2ac02e7d13bfef6fc4928ac01e1dcaa182be51b6bcc0aaa",
+              "url": "https://files.pythonhosted.org/packages/2f/7e/ddf5d42c77418ebf6d57f1503084e2955e8cf1d49671372fbdff7a82cbe5/grpcio-1.56.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a4cd8cb09d1bc70b3ea37802be484c5ae5a576108bad14728f2516279165dd7",
-              "url": "https://files.pythonhosted.org/packages/c9/58/8fd0ea2d4716da43bab5cfb47082c4a52893e33ced5b5e05c7830c8d72be/grpcio-1.50.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "c435f5ce1705de48e08fcbcfaf8aee660d199c90536e3e06f2016af7d6a938dd",
+              "url": "https://files.pythonhosted.org/packages/39/c7/ca186f4414db098ea1dc58928762d70198bc4735d0274dd2747e01639469/grpcio-1.56.2-cp311-cp311-linux_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b611b3de3dfd2c47549ca01abfa9bbb95937eb0ea546ea1d762a335739887be",
-              "url": "https://files.pythonhosted.org/packages/e6/5a/8081a2c3db63372638f8fd90504c47cfad8782301d5596bf7f072a64a68f/grpcio-1.50.0-cp311-cp311-macosx_10_10_x86_64.whl"
+              "hash": "9e04d4e4cfafa7c5264e535b5d28e786f0571bea609c3f0aaab13e891e933e9c",
+              "url": "https://files.pythonhosted.org/packages/55/68/41fc4465ed2f3fbc245d94ebfa14f7089771cd8546112fc91e46ccda2933/grpcio-1.56.2-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca8a2254ab88482936ce941485c1c20cdeaef0efa71a61dbad171ab6758ec998",
-              "url": "https://files.pythonhosted.org/packages/e9/47/c45a5d236183290418531ff5f051d69b9f08010c7fba6d9ff85ca20e6f2d/grpcio-1.50.0-cp311-cp311-linux_armv7l.whl"
+              "hash": "750de923b456ca8c0f1354d6befca45d1f3b3a789e76efc16741bd4132752d95",
+              "url": "https://files.pythonhosted.org/packages/6c/30/503b9d5a36f7f10a77207f1cb3baf13545251efa4283fd161138072c9db9/grpcio-1.56.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "daf2ba1c000cf116de65d21b90e1bbff940bb172797f0d185bfae3eb9fb49da8",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.50.0-cp311-cp311-macosx_10_10_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d14928cc3665c380b94e065bd8396310ddb0c456979b1c8c78816878f33571fc",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio/grpcio-1.50.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "fda2783c12f553cdca11c08e5af6eecbd717280dc8fbe28a110897af1c15a88c",
+              "url": "https://files.pythonhosted.org/packages/b4/29/3ab0489eb3c5dde0a5f05298c70c11a409d3aa5ac02544dc9b8ab8f58e3f/grpcio-1.56.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "grpcio",
           "requires_dists": [
-            "enum34>=1.0.4; python_version < \"3.4\"",
-            "futures>=2.2.0; python_version < \"3.2\"",
-            "grpcio-tools>=1.50.0; extra == \"protobuf\"",
-            "six>=1.5.2"
+            "grpcio-tools>=1.56.2; extra == \"protobuf\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.50.0"
+          "version": "1.56.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ead51910d83123648b1e36e2de8483b66e9ba358ca1d8965005ba7713cbcb7db",
-              "url": "https://files.pythonhosted.org/packages/f5/cd/e333b6f3db280be547a0a82ebe1b310662cd2af7c3a4ffba9ee3a6206728/grpcio_tools-1.50.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "c0640728d63c9fa56e9a1679943ae4e33ad43a10802dd7a93255870731f44d07",
+              "url": "https://files.pythonhosted.org/packages/84/b6/68ec7446ee475a18a21dc62ccc128f2703cdba94bc12fbcf9dde8c69a138/grpcio_tools-1.56.2-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f8178a475de70e6ae0a7e3f6d7ec1415c9dd10680654dbea9a1caf79665b0ed4",
-              "url": "https://files.pythonhosted.org/packages/01/49/137412f482268360f91d12df1bfbbb640fc33171a99aa63cab5f348dc0f6/grpcio_tools-1.50.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "41af279cf5359b123138236c0980440f4cb4d3d18f03b5c1c314cc1512048351",
+              "url": "https://files.pythonhosted.org/packages/06/a3/ac4c38e2a59cca7500e99cfbbc369507e3da8088a31d34bf190d5a90f509/grpcio_tools-1.56.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d9b8b59a76f67270ce8a4fd7af005732356d5b4ebaffa4598343ea63677bad63",
-              "url": "https://files.pythonhosted.org/packages/52/c9/1597630110548a844d95abb849a8a9c376dcb41e982aefbf5aa5fccb8eb2/grpcio_tools-1.50.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "e7009623635ebcd3dd7fe974883fc2d9a3ff0fcef419bfc0a2da8071b372d9f5",
+              "url": "https://files.pythonhosted.org/packages/1a/36/31426616863f132eb740b9fa6a0fad96e1b58188df8717f662eee17bfa3a/grpcio_tools-1.56.2-cp311-cp311-macosx_10_10_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fecbc5e773c1c1971641227d8fcd5de97533dbbc0bd7854b436ceb57243f4b2a",
-              "url": "https://files.pythonhosted.org/packages/5e/dd/c8886b5e7d730f6115f418f2c5718ab78c604c2ec27b6d9bbb1aabb8e945/grpcio_tools-1.50.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "857d72e991d449ec4d2f8337e5e24ddf77b4539965f5cabc84d4b63585832982",
+              "url": "https://files.pythonhosted.org/packages/27/81/6e95d852a3484e58d54a5424a739fda5283367187deb0c4b05f11a596fb1/grpcio_tools-1.56.2-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "88b75f2afd889c7c6939f58d76b58ab84de4723c7de882a1f8448af6632e256f",
-              "url": "https://files.pythonhosted.org/packages/62/02/612ee1b34da2158fcb2ad35a115606bf552856e0d7c82fe2b479cb70d7a7/grpcio-tools-1.50.0.tar.gz"
+              "hash": "c7ca2272022f90b73efe900244aaebe9dd7cf3b379e99e08a88984e2fdd229c2",
+              "url": "https://files.pythonhosted.org/packages/2b/47/0ea575abb273e7338c900f87fe596e737aa731768f08ec49c0aeba5e64c4/grpcio_tools-1.56.2-cp311-cp311-manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1736defd9fc54f942f500dd71555816487e52f07d25b0a58ff4089c375f0b5c3",
-              "url": "https://files.pythonhosted.org/packages/64/04/f3a2c8e1e77ce53f50665e6a2d5dd324c3f2c3b187989cda3df27059ca6e/grpcio_tools-1.50.0-cp311-cp311-macosx_10_10_x86_64.whl"
+              "hash": "82af2f4040084141a732f0ef1ecf3f14fdf629923d74d850415e4d09a077e77a",
+              "url": "https://files.pythonhosted.org/packages/39/a2/ea95bdc99687a454bbfa60f0eeeda151ee0911b6d27ea59fd83d1b587558/grpcio-tools-1.56.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "3995d96635d6decaf9d5d2e071677782b08ea3186d7cb8ad93f6c2dd97ec9097",
-              "url": "https://files.pythonhosted.org/packages/8a/6d/39710b654058e76a6074226bc4d813e03e2e686c632c8b30abf3302d96b8/grpcio_tools-1.50.0-cp311-cp311-linux_armv7l.whl"
+              "hash": "493775d17ea09cea6047ba81e4d3f0eb82e34d2fbd3b96e43f72b44ce74726ee",
+              "url": "https://files.pythonhosted.org/packages/3c/0a/13f28e02ad8d93d23580f26a34694179a02170b6cc726c3a6d0fde5c0213/grpcio_tools-1.56.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f489a853f029ed1080f294cc3e279eb964b872b364b7681d725779bb80b18e6",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio-tools/grpcio_tools-1.50.0-cp311-cp311-macosx_10_10_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b4418d433700f0f148d2df9b30497577bb5249a2d0299bcdf93777df0a500316",
-              "url": "https://media.githubusercontent.com/media/lablup/backend.ai-oven/main/pypi/projects/grpcio-tools/grpcio_tools-1.50.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "6dc43300189a69807857c52a3d782e9d3bbfb1cb72dcb27b4043c25161919601",
+              "url": "https://files.pythonhosted.org/packages/a9/18/05b6135ceecdf0b4258b5cd864b0ffc89f720e8eba853b258d612b076794/grpcio_tools-1.56.2-cp311-cp311-linux_armv7l.whl"
             }
           ],
           "project_name": "grpcio-tools",
           "requires_dists": [
-            "grpcio>=1.50.0",
+            "grpcio>=1.56.2",
             "protobuf<5.0dev,>=4.21.6",
             "setuptools"
           ],
           "requires_python": ">=3.7",
-          "version": "1.50.0"
+          "version": "1.56.2"
         },
         {
           "artifacts": [
@@ -2002,13 +1994,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7441af0c0672edc5d28035e92ba5e32fadcfa8a4e608a434c228836a89df6158",
-              "url": "https://files.pythonhosted.org/packages/29/24/0491f7837cedf39ae0f96d9b3e4db2fae31cc4dd5eac00a98ab0db996c9b/jupyter_client-8.3.0-py3-none-any.whl"
+              "hash": "5eb9f55eb0650e81de6b7e34308d8b92d04fe4ec41cd8193a913979e33d8e1a5",
+              "url": "https://files.pythonhosted.org/packages/73/d4/3c13d6a300be9e894561aea0b81e7aed46e8f98029b7d9369d90b1fc7ac5/jupyter_client-8.3.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3af69921fe99617be1670399a0b857ad67275eefcfa291e2c81a160b7b650f5f",
-              "url": "https://files.pythonhosted.org/packages/f9/bb/454464291217af5dc1d0dfc636f7f6b68227758319dad5f64b341ffd54f5/jupyter_client-8.3.0.tar.gz"
+              "hash": "60294b2d5b869356c893f57b1a877ea6510d60d45cf4b38057f1672d85699ac9",
+              "url": "https://files.pythonhosted.org/packages/41/6d/01d701db0d4242da9a6ac094a2dfd2984a294b9e6c8318d4119397477c00/jupyter_client-8.3.1.tar.gz"
             }
           ],
           "project_name": "jupyter-client",
@@ -2037,7 +2029,7 @@
             "traitlets>=5.3"
           ],
           "requires_python": ">=3.8",
-          "version": "8.3.0"
+          "version": "8.3.1"
         },
         {
           "artifacts": [
@@ -2677,39 +2669,34 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462",
-              "url": "https://files.pythonhosted.org/packages/d4/9f/5cb64224bdd4695f5b024a05a4bea31af1d8e3127d45a74161631fe8180e/protobuf-4.21.12-py3-none-any.whl"
+              "hash": "e9d0be5bf34b275b9f87ba7407796556abeeba635455d036c7351f7c183ef8ff",
+              "url": "https://files.pythonhosted.org/packages/b0/07/fb712cce15ba456f7c24b82b97c8a7db2233f07037ffe61c9011660c592a/protobuf-4.23.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791",
-              "url": "https://files.pythonhosted.org/packages/05/b6/6e9b82445e3561132a871e38f5601b12749beb5305eaa085d7f0c59728c9/protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl"
+              "hash": "effeac51ab79332d44fba74660d40ae79985901ac21bca408f8dc335a81aa597",
+              "url": "https://files.pythonhosted.org/packages/01/cb/445b3e465abdb8042a41957dc8f60c54620dc7540dbcf9b458a921531ca2/protobuf-4.23.4-cp37-abi3-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97",
-              "url": "https://files.pythonhosted.org/packages/76/74/28f42d3e6b0c7bffaa04348a631de7a22c3d81d1564753301d058c80fff5/protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl"
+              "hash": "fee88269a090ada09ca63551bf2f573eb2424035bcf2cb1b121895b01a46594a",
+              "url": "https://files.pythonhosted.org/packages/71/42/3a7fc57f360f728f38eca6656e8d00edaf22bc0ffc35dd2936f23e5fbb3e/protobuf-4.23.4-cp37-abi3-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab",
-              "url": "https://files.pythonhosted.org/packages/ba/dd/f8a01b146bf45ac12a829bbc599e6590aa6a6849ace7d28c42d77041d6ab/protobuf-4.21.12.tar.gz"
+              "hash": "8547bf44fe8cec3c69e3042f5c4fb3e36eb2a7a013bb0a44c018fc1e427aafbd",
+              "url": "https://files.pythonhosted.org/packages/cb/d3/a164038605494d49acc4f9cda1c0bc200b96382c53edd561387263bb181d/protobuf-4.23.4-cp37-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5",
-              "url": "https://files.pythonhosted.org/packages/c6/3b/33f3bd47dbfdd17ed87024b6473b26ee3a8c3303f019e91557b2654703a4/protobuf-4.21.12-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7",
-              "url": "https://files.pythonhosted.org/packages/e7/a2/3273c05fc5d959fa90de6453ebd6d45c6d4fab3ec212d631625ea5780921/protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl"
+              "hash": "ccd9430c0719dce806b93f89c91de7977304729e55377f872a92465d548329a9",
+              "url": "https://files.pythonhosted.org/packages/d3/1c/de86d82a5fc780feca36ef52c1231823bb3140266af8a04ed6286957aa6e/protobuf-4.23.4.tar.gz"
             }
           ],
           "project_name": "protobuf",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.21.12"
+          "version": "4.23.4"
         },
         {
           "artifacts": [
@@ -3008,13 +2995,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-              "url": "https://files.pythonhosted.org/packages/33/b2/741130cbcf2bbfa852ed95a60dc311c9e232c7ed25bac3d9b8880a8df4ae/pytest-7.4.0-py3-none-any.whl"
+              "hash": "460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f",
+              "url": "https://files.pythonhosted.org/packages/78/af/1a79db43409ea8569a8a91d0a87db4445c7de4cefcf6141e9a5c77dda2d6/pytest-7.4.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a",
-              "url": "https://files.pythonhosted.org/packages/a7/f3/dadfbdbf6b6c8b5bd02adb1e08bc9fbb45ba51c68b0893fa536378cdf485/pytest-7.4.0.tar.gz"
+              "hash": "2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab",
+              "url": "https://files.pythonhosted.org/packages/5b/a2/4db5b065b0694b330f2b3c47e64abda0a470839da5119a404610d6349a11/pytest-7.4.1.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -3037,7 +3024,7 @@
             "xmlschema; extra == \"testing\""
           ],
           "requires_python": ">=3.7",
-          "version": "7.4.0"
+          "version": "7.4.1"
         },
         {
           "artifacts": [
@@ -3134,8 +3121,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
-              "url": "https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
+              "url": "https://files.pythonhosted.org/packages/03/5c/c4671451b2f1d76ebe352c0945d4cd13500adb5d05f5a51ee296d80152f7/PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -3151,6 +3138,11 @@
               "algorithm": "sha256",
               "hash": "42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
               "url": "https://files.pythonhosted.org/packages/5e/94/7d5ee059dfb92ca9e62f4057dcdec9ac08a9e42679644854dc01177f8145/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+              "url": "https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -4051,19 +4043,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0c1618fb14850cb482adbec602bbb519c43f24942d66d66196bc7528320f33b1",
-              "url": "https://files.pythonhosted.org/packages/07/4d/45fcb91a19a82b0b04442ce5f728f01d14fb73495afa0eb56df59d51678d/types_setuptools-68.1.0.0-py3-none-any.whl"
+              "hash": "a9a0d2ca1da8a15924890d464adcee4004deb07b6a99bd0b1881eac5c73cb3a7",
+              "url": "https://files.pythonhosted.org/packages/50/fb/bd066eafa33cc0061fadeacaf44b74462e0cad01bac39dc1246c366add88/types_setuptools-68.1.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2bc9b0c0818f77bdcec619970e452b320a423bb3ac074f5f8bc9300ac281c4ae",
-              "url": "https://files.pythonhosted.org/packages/28/5c/08d1db8c7d3a0101b10ec400a55728a6440bcb3c73e7f51cc93943adf5b0/types-setuptools-68.1.0.0.tar.gz"
+              "hash": "271ed8da44885cd9a701c86e48cc6d3cc988052260e72b3ce26c26b3028f86ed",
+              "url": "https://files.pythonhosted.org/packages/a7/b3/19bc83fe656d60591b428a12fbff3b72f8a619fc0f410f6bfb110b167d69/types-setuptools-68.1.0.1.tar.gz"
             }
           ],
           "project_name": "types-setuptools",
           "requires_dists": [],
           "requires_python": null,
-          "version": "68.1.0.0"
+          "version": "68.1.0.1"
         },
         {
           "artifacts": [
@@ -4422,7 +4414,7 @@
     "coloredlogs~=15.0",
     "cryptography>=2.8",
     "dataclasses-json~=0.5.7",
-    "etcetra==0.1.15",
+    "etcetra==0.1.17",
     "faker~=13.12.0",
     "graphene~=2.1.9",
     "hiredis~=2.2.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ coloredlogs~=15.0
 colorama>=0.4.4
 cryptography>=2.8
 dataclasses-json~=0.5.7
-etcetra==0.1.15
+etcetra==0.1.17
 faker~=13.12.0
 graphene~=2.1.9
 hiredis~=2.2.3

--- a/tools/pytest.lock
+++ b/tools/pytest.lock
@@ -170,21 +170,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c",
-              "url": "https://files.pythonhosted.org/packages/d6/c1/8991e7c5385b897b8c020cdaad718c5b087a6626d1d11a23e1ea87e325a7/async_timeout-4.0.2-py3-none-any.whl"
+              "hash": "7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028",
+              "url": "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
-              "url": "https://files.pythonhosted.org/packages/54/6e/9678f7b2993537452710ffb1750c62d2c26df438aa621ad5fa9d1507a43a/async-timeout-4.0.2.tar.gz"
+              "hash": "4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f",
+              "url": "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz"
             }
           ],
           "project_name": "async-timeout",
           "requires_dists": [
             "typing-extensions>=3.6.5; python_version < \"3.8\""
           ],
-          "requires_python": ">=3.6",
-          "version": "4.0.2"
+          "requires_python": ">=3.7",
+          "version": "4.0.3"
         },
         {
           "artifacts": [
@@ -313,56 +313,56 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0e1f928eaf5469c11e886fe0885ad2bf1ec606434e79842a879277895a50942a",
-              "url": "https://files.pythonhosted.org/packages/68/5f/d2bd0f02aa3c3e0311986e625ccf97fdc511b52f4f1a063e4f37b624772f/coverage-7.2.7-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "7a9baf8e230f9621f8e1d00c580394a0aa328fdac0df2b3f8384387c44083c0f",
+              "url": "https://files.pythonhosted.org/packages/c5/ad/1559ab85952a47531004f9a32bcac51f9755e9541fb03eae42a9358e00dd/coverage-7.3.0-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "48c19d2159d433ccc99e729ceae7d5293fbffa0bdb94952d3579983d1c8c9d97",
-              "url": "https://files.pythonhosted.org/packages/04/fa/43b55101f75a5e9115259e8be70ff9279921cb6b17f04c34a5702ff9b1f7/coverage-7.2.7-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "4c8e31cf29b60859876474034a83f59a14381af50cbe8a9dbaadbf70adc4b214",
+              "url": "https://files.pythonhosted.org/packages/2a/b2/f2b519d33ececf73cf3d616fc7d051a73aa9609859fde376e902d79b69ce/coverage-7.3.0-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59",
-              "url": "https://files.pythonhosted.org/packages/45/8b/421f30467e69ac0e414214856798d4bc32da1336df745e49e49ae5c1e2a8/coverage-7.2.7.tar.gz"
+              "hash": "3c9834d5e3df9d2aba0275c9f67989c590e05732439b3318fa37a725dff51e74",
+              "url": "https://files.pythonhosted.org/packages/44/39/809e546b31d871e9636315d0097891ae3177e0f6da2021c489f64dbe00b7/coverage-7.3.0-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5baa06420f837184130752b7c5ea0808762083bf3487b5038d68b012e5937dbe",
-              "url": "https://files.pythonhosted.org/packages/67/d7/cd8fe689b5743fffac516597a1222834c42b80686b99f5b44ef43ccc2a43/coverage-7.2.7-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "49dbb19cdcafc130f597d9e04a29d0a032ceedf729e41b181f51cd170e6ee865",
+              "url": "https://files.pythonhosted.org/packages/4e/87/c0163d39ac70cab62ebcaee164c988215cd312919a78940c2251a2fcfabb/coverage-7.3.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "fdec9e8cbf13a5bf63290fc6013d216a4c7232efb51548594ca3631a7f13c3a3",
-              "url": "https://files.pythonhosted.org/packages/8c/95/16eed713202406ca0a37f8ac259bbf144c9d24f9b8097a8e6ead61da2dbb/coverage-7.2.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "fac440c43e9b479d1241fe9d768645e7ccec3fb65dc3a5f6e90675e75c3f3e3a",
+              "url": "https://files.pythonhosted.org/packages/55/63/f2dcc8f7f1587ae54bf8cc1c3b08e07e442633a953537dfaf658a0cbac2c/coverage-7.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "afb17f84d56068a7c29f5fa37bfd38d5aba69e3304af08ee94da8ed5b0865833",
-              "url": "https://files.pythonhosted.org/packages/8f/a8/12cc7b261f3082cc299ab61f677f7e48d93e35ca5c3c2f7241ed5525ccea/coverage-7.2.7-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "b543302a3707245d454fc49b8ecd2c2d5982b50eb63f3535244fd79a4be0c99d",
+              "url": "https://files.pythonhosted.org/packages/56/61/0bc551ef5e4cd459c34e769969b080d667ea9b2b3265819d4ae1f8d07702/coverage-7.3.0-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "63426706118b7f5cf6bb6c895dc215d8a418d5952544042c8a2d9fe87fcf09cb",
-              "url": "https://files.pythonhosted.org/packages/a7/cd/3ce94ad9d407a052dc2a74fbeb1c7947f442155b28264eb467ee78dea812/coverage-7.2.7-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "13c6cbbd5f31211d8fdb477f0f7b03438591bdd077054076eec362cf2207b4a7",
+              "url": "https://files.pythonhosted.org/packages/62/b9/de6fc3a608b4c0438b96e120fe83304d39b6be640b14363004843602118d/coverage-7.3.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "52edc1a60c0d34afa421c9c37078817b2e67a392cab17d97283b64c5833f427f",
-              "url": "https://files.pythonhosted.org/packages/c1/49/4d487e2ad5d54ed82ac1101e467e8994c09d6123c91b2a962145f3d262c2/coverage-7.2.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "ad0f87826c4ebd3ef484502e79b39614e9c03a5d1510cfb623f4a4a051edc6fd",
+              "url": "https://files.pythonhosted.org/packages/7a/6b/f16c757f34adaf76413b061ff412d599958a299dba5dfb9371e5567b77d9/coverage-7.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "06a9a2be0b5b576c3f18f1a241f0473575c4a26021b52b2a85263a00f034d51f",
-              "url": "https://files.pythonhosted.org/packages/c6/fa/529f55c9a1029c840bcc9109d5a15ff00478b7ff550a1ae361f8745f8ad5/coverage-7.2.7-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "74c160285f2dfe0acf0f72d425f3e970b21b6de04157fc65adc9fd07ee44177f",
+              "url": "https://files.pythonhosted.org/packages/a6/c5/c94da7b5ee14a0e7b046b2d59b50fe37d50ae78046e3459639961d3dccf5/coverage-7.3.0-cp311-cp311-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "coverage",
           "requires_dists": [
             "tomli; python_full_version <= \"3.11.0a6\" and extra == \"toml\""
           ],
-          "requires_python": ">=3.7",
-          "version": "7.2.7"
+          "requires_python": ">=3.8",
+          "version": "7.3.0"
         },
         {
           "artifacts": [
@@ -578,37 +578,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
-              "url": "https://files.pythonhosted.org/packages/51/32/4a79112b8b87b21450b066e102d6608907f4c885ed7b04c3fdb085d4d6ae/pluggy-1.2.0-py3-none-any.whl"
+              "hash": "d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7",
+              "url": "https://files.pythonhosted.org/packages/05/b8/42ed91898d4784546c5f06c60506400548db3f7a4b3fb441cba4e5c17952/pluggy-1.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3",
-              "url": "https://files.pythonhosted.org/packages/8a/42/8f2833655a29c4e9cb52ee8a2be04ceac61bcff4a680fb338cbd3d1e322d/pluggy-1.2.0.tar.gz"
+              "hash": "cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+              "url": "https://files.pythonhosted.org/packages/36/51/04defc761583568cae5fd533abda3d40164cbdcf22dee5b7126ffef68a40/pluggy-1.3.0.tar.gz"
             }
           ],
           "project_name": "pluggy",
           "requires_dists": [
-            "importlib-metadata>=0.12; python_version < \"3.8\"",
             "pre-commit; extra == \"dev\"",
             "pytest-benchmark; extra == \"testing\"",
             "pytest; extra == \"testing\"",
             "tox; extra == \"dev\""
           ],
-          "requires_python": ">=3.7",
-          "version": "1.2.0"
+          "requires_python": ">=3.8",
+          "version": "1.3.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-              "url": "https://files.pythonhosted.org/packages/33/b2/741130cbcf2bbfa852ed95a60dc311c9e232c7ed25bac3d9b8880a8df4ae/pytest-7.4.0-py3-none-any.whl"
+              "hash": "460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f",
+              "url": "https://files.pythonhosted.org/packages/78/af/1a79db43409ea8569a8a91d0a87db4445c7de4cefcf6141e9a5c77dda2d6/pytest-7.4.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a",
-              "url": "https://files.pythonhosted.org/packages/a7/f3/dadfbdbf6b6c8b5bd02adb1e08bc9fbb45ba51c68b0893fa536378cdf485/pytest-7.4.0.tar.gz"
+              "hash": "2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab",
+              "url": "https://files.pythonhosted.org/packages/5b/a2/4db5b065b0694b330f2b3c47e64abda0a470839da5119a404610d6349a11/pytest-7.4.1.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -631,7 +630,7 @@
             "xmlschema; extra == \"testing\""
           ],
           "requires_python": ">=3.7",
-          "version": "7.4.0"
+          "version": "7.4.1"
         },
         {
           "artifacts": [


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR updates pinned version of etcetra dependency to 0.1.17. Updating etcetra to latest will also update its peer dependecy, `grpcio` and `grpcio-tools` to latest, which contains pre-built wheels for both macOS and Linux with aarch64 architectures. Yay!

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
