### PR TITLE
fix: allow setting storage proxy watcher socket path config to null

### DIFF
--- a/configs/storage-proxy/sample.toml
+++ b/configs/storage-proxy/sample.toml
@@ -50,8 +50,8 @@ session-expire = "1d"
 # The socket fd path prefix to communicate with storage proxy watcher
 # The path should not have any permission issue with UID/GID
 # The full socket fd name will be like this. `/path/to/file/socket-<PIDx>`
-watcher-insock-path-prefix = ""
-watcher-outsock-path-prefix = ""
+# watcher-insock-path-prefix = ""
+# watcher-outsock-path-prefix = ""
 
 
 # Watcher delegates root permission and do privileged tasks. This option enables the use of watcher.

--- a/src/ai/backend/storage/config.py
+++ b/src/ai/backend/storage/config.py
@@ -60,8 +60,12 @@ local_config_iv = (
                         ["aiomonitor-termui-port", "aiomonitor-port"], default=48300
                     ): t.ToInt[1:65535],
                     t.Key("aiomonitor-webui-port", default=49300): t.ToInt[1:65535],
-                    t.Key("watcher-insock-path-prefix"): t.String(allow_blank=False),
-                    t.Key("watcher-outsock-path-prefix"): t.String(allow_blank=False),
+                    t.Key("watcher-insock-path-prefix", default=None): t.Null | t.String(
+                        allow_blank=False
+                    ),
+                    t.Key("watcher-outsock-path-prefix", default=None): t.Null | t.String(
+                        allow_blank=False
+                    ),
                     t.Key("use-watcher", default=False): t.Bool(),
                 },
             ),

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -119,8 +119,14 @@ async def server_main(
                     "Storage proxy must be run as root if watcher is enabled. Else, set"
                     " `use-wathcer` to false in your local config file."
                 )
-            insock_path = local_config["storage-proxy"]["watcher-insock-path-prefix"]
-            outsock_path = local_config["storage-proxy"]["watcher-outsock-path-prefix"]
+            insock_path: str | None = local_config["storage-proxy"]["watcher-insock-path-prefix"]
+            outsock_path: str | None = local_config["storage-proxy"]["watcher-outsock-path-prefix"]
+            if insock_path is None or outsock_path is None:
+                raise ValueError(
+                    "Socket path must be not null. Please set valid socket path to"
+                    " `watcher-insock-path-prefix` and `watcher-outsock-path-prefix` in your local"
+                    " config file."
+                )
             watcher_client = WatcherClient(pidx, insock_path, outsock_path)
             await watcher_client.init()
         else:


### PR DESCRIPTION
follow-up #1495 

change watcher socket path to nullable in config and raise error only when watcher is enabled.