### PR TITLE
feature: preserve GlobalTimer tick termination logs

### DIFF
--- a/changes/1541.feature.md
+++ b/changes/1541.feature.md
@@ -1,0 +1,1 @@
+Preserve the log of idle checker in task monitoring.

--- a/changes/1541.feature.md
+++ b/changes/1541.feature.md
@@ -1,1 +1,1 @@
-Preserve the log of idle checker in task monitoring.
+Preserve the GlobalTimer tick termination logs in task monitoring.

--- a/src/ai/backend/common/distributed.py
+++ b/src/ai/backend/common/distributed.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Callable, Final
 
+from aiomonitor.task import preserve_termination_log
+
 from .logging import BraceStyleAdapter
 
 if TYPE_CHECKING:
@@ -29,6 +31,8 @@ class GlobalTimer:
         event_factory: Callable[[], AbstractEvent],
         interval: float = 10.0,
         initial_delay: float = 0.0,
+        *,
+        task_name: str | None = None,
     ) -> None:
         self._dist_lock = dist_lock
         self._event_producer = event_producer
@@ -36,7 +40,9 @@ class GlobalTimer:
         self._stopped = False
         self.interval = interval
         self.initial_delay = initial_delay
+        self.task_name = task_name
 
+    @preserve_termination_log
     async def generate_tick(self) -> None:
         try:
             await asyncio.sleep(self.initial_delay)
@@ -58,6 +64,8 @@ class GlobalTimer:
 
     async def join(self) -> None:
         self._tick_task = asyncio.create_task(self.generate_tick())
+        if self.task_name is not None:
+            self._tick_task.set_name(self.task_name)
 
     async def leave(self) -> None:
         self._stopped = True

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -216,6 +216,7 @@ class IdleCheckerHost:
             self._event_producer,
             lambda: DoIdleCheckEvent(),
             self.check_interval,
+            task_name="idle_checker",
         )
         self._evh_idle_check = self._event_dispatcher.consume(
             DoIdleCheckEvent,


### PR DESCRIPTION
Let's preserve the GlobalTimer tick termination logs and set name for idle checker task for better debugging.