### PR TITLE
fix: storage proxy raising error when watcher is disabled

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fix storage proxy watcher process always being started event if it is not enabled

--- a/src/ai/backend/storage/migration.py
+++ b/src/ai/backend/storage/migration.py
@@ -252,16 +252,18 @@ async def check_and_upgrade(
         event_dispatcher=event_dispatcher,
         watcher=None,
     )
-    volumes_to_upgrade = await check_latest(ctx)
-    for upgrade_info in volumes_to_upgrade:
-        handler = upgrade_handlers[upgrade_info.target_version]
-        await handler(
-            ctx,
-            upgrade_info.volume,
-            outfile,
-            report_path=report_path,
-            force_scan_folder_size=force_scan_folder_size,
-        )
+
+    async with ctx:
+        volumes_to_upgrade = await check_latest(ctx)
+        for upgrade_info in volumes_to_upgrade:
+            handler = upgrade_handlers[upgrade_info.target_version]
+            await handler(
+                ctx,
+                upgrade_info.volume,
+                outfile,
+                report_path=report_path,
+                force_scan_folder_size=force_scan_folder_size,
+            )
 
 
 @click.command()

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -290,15 +290,38 @@ def main(
                 insock_path_prefix = local_config["storage-proxy"]["watcher-insock-path-prefix"]
                 outsock_path_prefix = local_config["storage-proxy"]["watcher-outsock-path-prefix"]
                 num_workers = local_config["storage-proxy"]["num-proc"]
-                aiotools.start_server(
-                    server_main_logwrapper,
-                    num_workers=num_workers,
-                    extra_procs=tuple(
+
+                if local_config["storage-proxy"]["use-watcher"]:
+                    if not _is_root():
+                        raise ValueError(
+                            "Storage proxy must be run as root if watcher is enabled. Else, set"
+                            " `use-wathcer` to false in your local config file."
+                        )
+                    insock_path: str | None = local_config["storage-proxy"][
+                        "watcher-insock-path-prefix"
+                    ]
+                    outsock_path: str | None = local_config["storage-proxy"][
+                        "watcher-outsock-path-prefix"
+                    ]
+                    if insock_path is None or outsock_path is None:
+                        raise ValueError(
+                            "Socket path must be not null. Please set valid socket path to"
+                            " `watcher-insock-path-prefix` and `watcher-outsock-path-prefix` in"
+                            " your local config file."
+                        )
+                    extra_procs = tuple(
                         functools.partial(
                             main_job, worker_pidx, insock_path_prefix, outsock_path_prefix
                         )
                         for worker_pidx in range(num_workers)
-                    ),
+                    )
+                else:
+                    extra_procs = tuple()
+
+                aiotools.start_server(
+                    server_main_logwrapper,
+                    num_workers=num_workers,
+                    extra_procs=extra_procs,
                     args=(local_config, log_endpoint),
                 )
                 log.info("exit.")


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up PR to #1516 and #1495. Fixes storage proxy spamming logs about killed process even if user explicitly opted out from watcher being spawned, along with fixes to vFolder v3 migration script generator not working.
 
**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
