### PR TITLE
ci: Bump checkout from v3 to v4

### DIFF
--- a/.github/workflows/alembic-head-check.yml
+++ b/.github/workflows/alembic-head-check.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'require:db-migration') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Parse versions from config

--- a/.github/workflows/check-requirement.yml
+++ b/.github/workflows/check-requirement.yml
@@ -7,7 +7,7 @@ jobs:
   check-requirement:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check if a precompiled binary file exists in dependencies
         run: |
             cat python.lock | grep -v '^//' | jq -r '.locked_resolves[].locked_requirements[]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || (!contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == true) }}
     runs-on: [ubuntu-latest-8-cores, self-hosted]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Create LFS file hash list

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -22,7 +22,7 @@ jobs:
         else
           echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
         fi
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
     - name: Extract Python version from pants.toml
@@ -40,7 +40,7 @@ jobs:
         echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_CACHE_WRITE=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_INSTANCE_NAME=main" >> $GITHUB_ENV
-      env: 
+      env:
         REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT }}
       if: ${{ env.REMOTE_CACHE_BACKEND_ENDPOINT != '' }}
     - name: Bootstrap Pants
@@ -91,7 +91,7 @@ jobs:
         else
           echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
         fi
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
     - name: Extract Python version from pants.toml
@@ -109,7 +109,7 @@ jobs:
         echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_CACHE_WRITE=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_INSTANCE_NAME=main" >> $GITHUB_ENV
-      env: 
+      env:
         REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT }}
       if: ${{ env.REMOTE_CACHE_BACKEND_ENDPOINT != '' }}
     - name: Bootstrap Pants
@@ -154,7 +154,7 @@ jobs:
         else
           echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
         fi
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
     - name: Create LFS file hash list
@@ -182,7 +182,7 @@ jobs:
         echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_CACHE_WRITE=true" >> $GITHUB_ENV
         echo "PANTS_REMOTE_INSTANCE_NAME=main" >> $GITHUB_ENV
-      env: 
+      env:
         REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT }}
       if: ${{ env.REMOTE_CACHE_BACKEND_ENDPOINT != '' }}
     - name: Bootstrap Pants
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: deploy-to-pypi
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Fetch remote tags
       run: git fetch origin 'refs/tags/*:refs/tags/*' -f
     - name: Create LFS file hash list
@@ -319,7 +319,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Create LFS file hash list
       run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
     - name: Restore LFS cache
@@ -377,7 +377,7 @@ jobs:
     runs-on: [ubuntu-latest-8-cores, self-hosted]
     environment: deploy-to-docker-hub
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Create LFS file hash list

--- a/.github/workflows/pr-number-assign.yml
+++ b/.github/workflows/pr-number-assign.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,7 +7,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Extract Python version from pants.toml

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Get PR's fetch depth
       run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: ${{ env.PR_FETCH_DEPTH }}


### PR DESCRIPTION
As nodejs v16 ends support on September 11th, we will upgrade checkout v3, which uses nodejs v16, to checkout v4, which uses nodejs v20.
https://endoflife.date/nodejs

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
