### PR TITLE
chore: add task_name to all `GlobalTimer`

### DIFF
--- a/changes/1553.feature.md
+++ b/changes/1553.feature.md
@@ -1,0 +1,1 @@
+Add `task_name` to all `GlobalTimer._tick_task` for better debugging.

--- a/src/ai/backend/manager/api/logs.py
+++ b/src/ai/backend/manager/api/logs.py
@@ -261,6 +261,7 @@ async def init(app: web.Application) -> None:
         lambda: DoLogCleanupEvent(),
         20.0,
         initial_delay=17.0,
+        task_name="log_cleanup_task",
     )
     await app_ctx.log_cleanup_timer.join()
 

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -189,6 +189,7 @@ class SchedulerDispatcher(aobject):
             self.event_producer,
             lambda: DoScheduleEvent(),
             interval=10.0,
+            task_name="schedule_timer",
         )
         self.prepare_timer = GlobalTimer(
             self.lock_factory(LockID.LOCKID_PREPARE_TIMER, 10.0),
@@ -196,6 +197,7 @@ class SchedulerDispatcher(aobject):
             lambda: DoPrepareEvent(),
             interval=10.0,
             initial_delay=5.0,
+            task_name="prepare_timer",
         )
         self.scale_timer = GlobalTimer(
             self.lock_factory(LockID.LOCKID_SCALE_TIMER, 10.0),
@@ -203,6 +205,7 @@ class SchedulerDispatcher(aobject):
             lambda: DoScaleEvent(),
             interval=10.0,
             initial_delay=7.0,
+            task_name="scale_timer",
         )
         await self.schedule_timer.join()
         await self.prepare_timer.join()


### PR DESCRIPTION
Let's add `task_name` to all `GlobalTimer._tick_task` for better debugging.