### PR TITLE
fix: Raise error when fail to acquire `RedisLock`

### DIFF
--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -240,13 +240,13 @@ class RedisLock(AbstractDistributedLock):
             thread_local=False,
             sleep=self._lock_acquire_pause,
         )
-        await self._lock.acquire()
+        await self._lock.__aenter__()
         if self._debug:
             log.debug("RedisLock.__aenter__(): lock acquired")
 
     async def __aexit__(self, *exc_info) -> Optional[bool]:
         assert self._lock is not None
-        await self._lock.release()
+        await self._lock.__aexit__(*exc_info)
         if self._debug:
             log.debug("RedisLock.__aexit__(): lock released")
 


### PR DESCRIPTION
https://github.com/redis/redis-py/blob/master/redis/asyncio/lock.py#L159-L187
According to `redis-py`, we need to use `redis.asyncio.Lock.__aenter__()` to acquire lock rather than `redis.asyncio.Lock.acquire()` because `acquire()` returns `True` or `False`, not raising an error.
