### PR TITLE
fix: metadata port config not applied

### DIFF
--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -50,6 +50,7 @@ agent_local_config_iv = (
                         ["aiomonitor-termui-port", "aiomonitor-port"], default=48200
                     ): t.ToInt[1:65535],
                     t.Key("aiomonitor-webui-port", default=49200): t.ToInt[1:65535],
+                    t.Key("metadata-server-bind-host", default="0.0.0.0"): t.String,
                     t.Key("metadata-server-port", default=40128): t.ToInt[1:65535],
                     t.Key("allow-compute-plugins", default=None): t.Null | tx.ToSet,
                     t.Key("block-compute-plugins", default=None): t.Null | tx.ToSet,

--- a/src/ai/backend/agent/docker/metadata/server.py
+++ b/src/ai/backend/agent/docker/metadata/server.py
@@ -200,7 +200,7 @@ class MetadataServer(aobject):
         local_config = self.app["_root.context"].local_config
         site = web.TCPSite(
             metadata_server_runner,
-            "0.0.0.0",
+            local_config["agent"]["metadata-server-bind-host"],
             local_config["agent"]["metadata-server-port"],
         )
         self.runner = metadata_server_runner

--- a/src/ai/backend/agent/docker/metadata/server.py
+++ b/src/ai/backend/agent/docker/metadata/server.py
@@ -197,7 +197,12 @@ class MetadataServer(aobject):
         await self.load_metadata_plugins()
         metadata_server_runner = web.AppRunner(self.app)
         await metadata_server_runner.setup()
-        site = web.TCPSite(metadata_server_runner, "0.0.0.0", 40128)
+        local_config = self.app["_root.context"].local_config
+        site = web.TCPSite(
+            metadata_server_runner,
+            "0.0.0.0",
+            local_config["agent"]["metadata-server-port"],
+        )
         self.runner = metadata_server_runner
         await site.start()
 

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -69,6 +69,7 @@ def local_config(test_id, logging_config, etcd_container, redis_container):  # n
             "backend": "docker",
             "rpc-listen-addr": HostPortPair("", 18100 + get_parallel_slot()),
             "agent-sock-port": 18200 + get_parallel_slot(),
+            "metadata-server-bind": "0.0.0.0",
             "metadata-server-port": 18300 + get_parallel_slot(),
             "allow-compute-plugins": set(),
             "block-compute-plugins": set(),


### PR DESCRIPTION
This commit PR fixes host side of metadata server not starting with configured port.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
