### PR TITLE
fix: Retry untill acquire `RedisLock`

### DIFF
--- a/changes/1559.fix.md
+++ b/changes/1559.fix.md
@@ -1,0 +1,1 @@
+Let `RedisLock` retry until acquire lock.

--- a/changes/1559.fix.md
+++ b/changes/1559.fix.md
@@ -1,1 +1,1 @@
-Let `RedisLock` retry until acquire lock.
+Let `RedisLock` retry until it acquires lock.

--- a/src/ai/backend/common/distributed.py
+++ b/src/ai/backend/common/distributed.py
@@ -58,6 +58,8 @@ class GlobalTimer:
                             return
                         await asyncio.sleep(self.interval)
                 except asyncio.TimeoutError:  # timeout raised from etcd lock
+                    if self._stopped:
+                        return
                     log.warn("timeout raised while trying to acquire lock. retrying...")
         except asyncio.CancelledError:
             pass


### PR DESCRIPTION
Let `RedisLock` retry until acquire lock by re-raising `redis.LockError` as `asyncio.TimeoutError`