### PR TITLE
fix: modified to avoid repeated type casting with UUID

### DIFF
--- a/changes/1561.fix.md
+++ b/changes/1561.fix.md
@@ -1,1 +1,1 @@
-Resolve the issue where folder deletion is not possible due to repeated type casting.
+Fix vFolder removal failing due to repeated type casting

--- a/changes/1561.fix.md
+++ b/changes/1561.fix.md
@@ -1,0 +1,1 @@
+Resolve the issue where folder deletion is not possible due to repeated type casting.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -683,7 +683,7 @@ async def delete_by_id(request: web.Request, params: Any) -> web.Response:
             domain_name=domain_name,
             permission=VFolderHostPermission.DELETE,
         )
-    folder_id = VFolderID(quota_scope_id, uuid.UUID(params["id"]))
+    folder_id = VFolderID(quota_scope_id, params["id"])
     await initiate_vfolder_removal(
         root_ctx.db,
         [VFolderDeletionInfo(folder_id, folder_host)],


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- follows https://github.com/lablup/backend.ai/pull/1517
- resolves https://github.com/lablup/backend.ai-control-panel/issues/672
- AttributeError occurs because folder id is typecast to UUID once again, even though folder id is entered as UUID.
- To Avoid AttributeError and make it possible to delete by vfolder id, I removed the repeated type casting with UUID.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
