### PR TITLE
Add ha dev configure flag to install-dev.sh\

### DIFF
--- a/configs/manager/sample.etcd.redis-sentinel.json
+++ b/configs/manager/sample.etcd.redis-sentinel.json
@@ -1,4 +1,5 @@
 {
-  "sentinel": "127.0.0.1:8217,127.0.0.1:8218,127.0.0.1:8219",
-  "service_name": "manager"
+  "sentinel": "127.0.0.1:9203,127.0.0.1:9204,127.0.0.1:9205",
+  "service_name": "mymaster",
+  "password": "develove"
 }

--- a/configs/redis/sentinel.conf
+++ b/configs/redis/sentinel.conf
@@ -1,6 +1,12 @@
-sentinel monitor mymaster backendai-half-redis-node01 6379 2
-sentinel auth-pass mymaster REDIS_PASSWORD
-sentinel down-after-milliseconds mymaster 3000
-sentinel failover-timeout mymaster 30000
+port REDIS_SENTINEL_SELF_PORT
+requirepass develove
+
+sentinel resolve-hostnames yes
+sentinel announce-ip 192.168.0.18
+sentinel announce-port REDIS_SENTINEL_SELF_PORT
+sentinel auth-pass mymaster develove
+sentinel down-after-milliseconds mymaster 1000
+sentinel failover-timeout mymaster 5000
 sentinel parallel-syncs mymaster 2
+sentinel monitor mymaster 192.168.0.18 9200 2
 protected-mode no

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -47,6 +47,7 @@ auth_token_name = 'sToken'
 [session]
 redis.host = "localhost"
 redis.port = 6379
+# redis.password = "mysecret"
 max_age = 604800  # 1 week
 flush_on_startup = false
 login_block_time = 1200  # 20 min (in sec)

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -3,107 +3,128 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:13.7-alpine
+    image: postgres:15.1-alpine
     command: postgres -c 'max_connections=256'
     networks:
       - half
     ports:
-      - "8200:5432"
+      - "8100:5432"
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-develove}
       - POSTGRES_DB=${POSTGRES_DBNAME:-backend}
     volumes:
       - "./tmp/backend.ai-halfstack-ha/postgres-data:/var/lib/postgresql/data:rw"
 
-  backendai-half-redis-proxy:
-    image: haproxy:2.4-alpine
-    depends_on:
-      - "backendai-half-redis-node01"
-      - "backendai-half-redis-node02"
-      - "backendai-half-redis-node03"
-    volumes:
-      - ./configs/redis/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
-    environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
-    ports:
-      - "8210:6379"
-    networks:
-      - half
-
-  # Initial master is node01.
+  # Initial master is redis-node01.
   backendai-half-redis-node01:
-    image: redis:6.2.7-alpine
+    image: redis:7.0.5-alpine
+    networks:
+    - net_redis_node01
+    ports:
+    - 0.0.0.0:${REDIS_MASTER_PORT}:${REDIS_MASTER_PORT}
     command: >
       redis-server
+      --port ${REDIS_MASTER_PORT}
       --requirepass ${REDIS_PASSWORD:-develove}
       --masterauth ${REDIS_PASSWORD:-develove}
+      --replica-announce-ip 192.168.0.18
+      --replica-announce-port ${REDIS_MASTER_PORT}
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
-    networks:
-      - half
-    cpu_count: 1
-
-  backendai-half-redis-sentinel01:
-    build:
-      context: .
-      dockerfile: redis-sentinel.Dockerfile
-      cache_from:
-        - redis:5-alpine
-    environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
-    networks:
-      - half
-    cpu_count: 1
+    # IMPORTANT: We have INTENTIONALLY OMITTED the healthchecks
+    # because it interferes with pause/unpause of container to simulate
+    # network partitioning.
 
   backendai-half-redis-node02:
-    image: redis:6.2.7-alpine
+    image: redis:7.0.5-alpine
+    networks:
+    - net_redis_node02
+    ports:
+    - 0.0.0.0:${REDIS_SLAVE1_PORT}:${REDIS_SLAVE1_PORT}
     command: >
       redis-server
+      --port ${REDIS_SLAVE1_PORT}
       --requirepass ${REDIS_PASSWORD:-develove}
       --masterauth ${REDIS_PASSWORD:-develove}
-      --slaveof backendai-half-redis-node01 6379
+      --slaveof 192.168.0.18 ${REDIS_MASTER_PORT}
+      --replica-announce-ip 192.168.0.18
+      --replica-announce-port ${REDIS_SLAVE1_PORT}
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
-    networks:
-      - half
-    cpu_count: 1
-
-  backendai-half-redis-sentinel02:
-    build:
-      context: .
-      dockerfile: redis-sentinel.Dockerfile
-      cache_from:
-        - redis:6.2.7-alpine
-    environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
-    networks:
-      - half
-    cpu_count: 1
 
   backendai-half-redis-node03:
-    image: redis:6.2.7-alpine
+    image: redis:7.0.5-alpine
+    ports:
+    - 0.0.0.0:${REDIS_SLAVE2_PORT}:${REDIS_SLAVE2_PORT}
+    networks:
+    - net_redis_node03
     command: >
       redis-server
+      --port ${REDIS_SLAVE2_PORT}
       --requirepass ${REDIS_PASSWORD:-develove}
       --masterauth ${REDIS_PASSWORD:-develove}
-      --slaveof backendai-half-redis-node01 6379
+      --slaveof 192.168.0.18 ${REDIS_MASTER_PORT}
+      --replica-announce-ip 192.168.0.18
+      --replica-announce-port ${REDIS_SLAVE2_PORT}
       --min-slaves-to-write 1
       --min-slaves-max-lag 10
-    networks:
-      - half
-    cpu_count: 1
 
-  backendai-half-redis-sentinel03:
-    build:
-      context: .
-      dockerfile: redis-sentinel.Dockerfile
-      cache_from:
-        - redis:6.2.7-alpine
+  backendai-half-redis-sentinel01:
+    image: redis:7.0.5-alpine
+    networks:
+    - net_sentinel01
+    volumes:
+    - type: bind
+      source: ${COMPOSE_PATH}
+      target: /config
+    ports:
+    - 0.0.0.0:${REDIS_SENTINEL1_PORT}:${REDIS_SENTINEL1_PORT}
+    depends_on:
+    - backendai-half-redis-node01
+    - backendai-half-redis-node02
+    - backendai-half-redis-node03
+    command: >
+      redis-sentinel /config/sentinel01.conf
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
+
+  backendai-half-redis-sentinel02:
+    image: redis:7.0.5-alpine
     networks:
-      - half
-    cpu_count: 1
+    - net_sentinel02
+    volumes:
+    - type: bind
+      source: ${COMPOSE_PATH}
+      target: /config
+    ports:
+    - 0.0.0.0:${REDIS_SENTINEL2_PORT}:${REDIS_SENTINEL2_PORT}
+    depends_on:
+    - backendai-half-redis-node01
+    - backendai-half-redis-node02
+    - backendai-half-redis-node03
+    command: >
+      redis-sentinel /config/sentinel02.conf
+    environment:
+    - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
+
+  backendai-half-redis-sentinel03:
+    image: redis:7.0.5-alpine
+    networks:
+    - net_sentinel03
+    volumes:
+    - type: bind
+      source: ${COMPOSE_PATH}
+      target: /config
+    ports:
+    - 0.0.0.0:${REDIS_SENTINEL3_PORT}:${REDIS_SENTINEL3_PORT}
+    depends_on:
+    - backendai-half-redis-node01
+    - backendai-half-redis-node02
+    - backendai-half-redis-node03
+    command: >
+      redis-sentinel /config/sentinel03.conf
+    environment:
+    - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
 
   backendai-half-etcd-proxy:
     image: quay.io/coreos/etcd:v3.5.4
@@ -196,4 +217,16 @@ services:
       --initial-cluster-state $${STATE}"
 
 networks:
+  net_redis_node01:
+    driver: bridge
+  net_redis_node02:
+    driver: bridge
+  net_redis_node03:
+    driver: bridge
+  net_sentinel01:
+    driver: bridge
+  net_sentinel02:
+    driver: bridge
+  net_sentinel03:
+    driver: bridge
   half:

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -121,6 +121,10 @@ usage() {
   echo "  ${LWHITE}--var-base-path PATH${NC}"
   echo "    The base path for shared data files."
   echo "    (default: ./var/lib/backend.ai)"
+  echo ""
+  echo "  ${LWHITE}--configure-ha ${NC}"
+  echo "    Configure HA dev environment."
+  echo "    (default: false)"
 }
 
 show_error() {
@@ -280,10 +284,12 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHOW_GUIDE=0
 ENABLE_CUDA=0
 ENABLE_CUDA_MOCK=0
+CONFIGURE_HA=0
 EDITABLE_WEBUI=0
 POSTGRES_PORT="8101"
-REDIS_PORT="8111"
-ETCD_PORT="8121"
+[[ "$@" =~ "configure-ha" ]] && REDIS_PORT="8210" || REDIS_PORT="8111"
+[[ "$@" =~ "configure-ha" ]] && ETCD_PORT="8220" || ETCD_PORT="8121"
+
 MANAGER_PORT="8091"
 WEBSERVER_PORT="8090"
 WSPROXY_PORT="5050"
@@ -299,6 +305,14 @@ CODESPACES_ON_CREATE=0
 CODESPACES_POST_CREATE=0
 CODESPACES=${CODESPACES:-"false"}
 _INSTALLED_PYENV=0
+
+# Only Used in HA mode
+REDIS_MASTER_PORT="9200"
+REDIS_SLAVE1_PORT="9201"
+REDIS_SLAVE2_PORT="9202"
+REDIS_SENTINEL1_PORT="9203"
+REDIS_SENTINEL2_PORT="9204"
+REDIS_SENTINEL3_PORT="9205"
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -329,6 +343,7 @@ while [ $# -gt 0 ]; do
     --var-base-path=*)      VAR_BASE_PATH="${1#*=}" ;;
     --codespaces-on-create) CODESPACES_ON_CREATE=1 ;;
     --codespaces-post-create) CODESPACES_POST_CREATE=1 ;;
+    --configure-ha)         CONFIGURE_HA=1 ;;
     *)
       echo "Unknown option: $1"
       echo "Run '$0 --help' for usage."
@@ -743,17 +758,66 @@ setup_environment() {
   # Install postgresql, etcd packages via docker
   show_info "Creating docker compose configuration file for \"halfstack\"..."
   mkdir -p "$HALFSTACK_VOLUME_PATH"
-  SOURCE_COMPOSE_PATH="docker-compose.halfstack-${CURRENT_BRANCH//.}.yml"
-  if [ ! -f "${SOURCE_COMPOSE_PATH}" ]; then
-    SOURCE_COMPOSE_PATH="docker-compose.halfstack-main.yml"
+  if [ $CONFIGURE_HA -eq 1 ]; then
+    SOURCE_COMPOSE_PATH="docker-compose.halfstack-ha.yml"
+
+    cp "${SOURCE_COMPOSE_PATH}" "docker-compose.halfstack.current.yml"
+    sed_inplace "s/8100:5432/${POSTGRES_PORT}:5432/" "docker-compose.halfstack.current.yml"
+    sed_inplace "s/8110:6379/${REDIS_PORT}:6379/" "docker-compose.halfstack.current.yml"
+    sed_inplace "s/8120:2379/${ETCD_PORT}:2379/" "docker-compose.halfstack.current.yml"
+
+    sed_inplace 's/\${REDIS_MASTER_PORT}/9200/g' "docker-compose.halfstack.current.yml"
+    sed_inplace 's/\${REDIS_SLAVE1_PORT}/9201/g' "docker-compose.halfstack.current.yml"
+    sed_inplace 's/\${REDIS_SLAVE2_PORT}/9202/g' "docker-compose.halfstack.current.yml"
+    sed_inplace 's/\${REDIS_SENTINEL1_PORT}/9203/g' "docker-compose.halfstack.current.yml"
+    sed_inplace 's/\${REDIS_SENTINEL2_PORT}/9204/g' "docker-compose.halfstack.current.yml"
+    sed_inplace 's/\${REDIS_SENTINEL3_PORT}/9205/g' "docker-compose.halfstack.current.yml"
+
+    mkdir -p "./tmp/backend.ai-halfstack-ha/configs"
+
+    sentinel01_cfg_path="./tmp/backend.ai-halfstack-ha/configs/sentinel01.conf"
+    sentinel02_cfg_path="./tmp/backend.ai-halfstack-ha/configs/sentinel02.conf"
+    sentinel03_cfg_path="./tmp/backend.ai-halfstack-ha/configs/sentinel03.conf"
+
+    cp ./configs/redis/sentinel.conf $sentinel01_cfg_path
+    cp ./configs/redis/sentinel.conf $sentinel02_cfg_path
+    cp ./configs/redis/sentinel.conf $sentinel03_cfg_path
+
+    sed_inplace "s/\${COMPOSE_PATH}/${ROOT_PATH//\//\\/}\/tmp\/backend\.ai-halfstack-ha\/configs\//g" "docker-compose.halfstack.current.yml"
+
+    # Appends the given text to sentinel01.conf
+    echo "" >> $sentinel01_cfg_path
+    sed_inplace "s/REDIS_SENTINEL_SELF_HOST/sentinel01/g" "$sentinel01_cfg_path"
+    sed_inplace "s/REDIS_PASSWORD/develove/g" "$sentinel01_cfg_path"
+    sed_inplace "s/REDIS_SENTINEL_SELF_PORT/9203/g" "$sentinel01_cfg_path"
+
+    # Appends the given text to sentinel02.conf
+    echo "" >> $sentinel02_cfg_path
+    sed_inplace "s/REDIS_SENTINEL_SELF_HOST/sentinel02/g" "$sentinel02_cfg_path"
+    sed_inplace "s/REDIS_PASSWORD/develove/g" "$sentinel02_cfg_path"
+    sed_inplace "s/REDIS_SENTINEL_SELF_PORT/9204/g" "$sentinel02_cfg_path"
+
+    # Appends the given text to sentinel03.conf
+    echo "" >> $sentinel03_cfg_path
+    sed_inplace "s/REDIS_SENTINEL_SELF_HOST/sentinel03/g" "$sentinel03_cfg_path"
+    sed_inplace "s/REDIS_PASSWORD/develove/g" "$sentinel03_cfg_path"
+    sed_inplace "s/REDIS_SENTINEL_SELF_PORT/9205/g" "$sentinel03_cfg_path"
+  else
+    SOURCE_COMPOSE_PATH="docker-compose.halfstack-${CURRENT_BRANCH//.}.yml"
+    if [ ! -f "${SOURCE_COMPOSE_PATH}" ]; then
+      SOURCE_COMPOSE_PATH="docker-compose.halfstack-main.yml"
+    fi
+    cp "${SOURCE_COMPOSE_PATH}" "docker-compose.halfstack.current.yml"
   fi
-  cp "${SOURCE_COMPOSE_PATH}" "docker-compose.halfstack.current.yml"
+
   sed_inplace "s/8100:5432/${POSTGRES_PORT}:5432/" "docker-compose.halfstack.current.yml"
   sed_inplace "s/8110:6379/${REDIS_PORT}:6379/" "docker-compose.halfstack.current.yml"
   sed_inplace "s/8120:2379/${ETCD_PORT}:2379/" "docker-compose.halfstack.current.yml"
+
   mkdir -p "${HALFSTACK_VOLUME_PATH}/postgres-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/etcd-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/redis-data"
+
   $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" pull
 
   show_info "Pre-pulling frequently used kernel images..."
@@ -784,7 +848,15 @@ configure_backendai() {
   sed_inplace "s@\(# \)\{0,1\}ipc-base-path = .*@ipc-base-path = "'"'"${IPC_BASE_PATH}"'"'"@" ./manager.toml
   cp configs/manager/halfstack.alembic.ini ./alembic.ini
   sed_inplace "s/localhost:8100/localhost:${POSTGRES_PORT}/" ./alembic.ini
-  ./backend.ai mgr etcd put config/redis/addr "127.0.0.1:${REDIS_PORT}"
+
+  if [ $CONFIGURE_HA -eq 1 ]; then
+    ./backend.ai mgr etcd put config/redis/sentinel "127.0.0.1:${REDIS_SENTINEL1_PORT},127.0.0.1:${REDIS_SENTINEL2_PORT},127.0.0.1:${REDIS_SENTINEL3_PORT}"
+    ./backend.ai mgr etcd put config/redis/service_name "mymaster"
+    ./backend.ai mgr etcd put config/redis/password "develove"
+  else
+    ./backend.ai mgr etcd put config/redis/addr "127.0.0.1:${REDIS_PORT}"
+  fi
+
   cp configs/manager/sample.etcd.volumes.json ./dev.etcd.volumes.json
   MANAGER_AUTH_KEY=$(python -c 'import secrets; print(secrets.token_hex(32), end="")')
   sed_inplace "s/\"secret\": \"some-secret-shared-with-storage-proxy\"/\"secret\": \"${MANAGER_AUTH_KEY}\"/" ./dev.etcd.volumes.json
@@ -831,7 +903,14 @@ configure_backendai() {
   # configure webserver
   cp configs/webserver/halfstack.conf ./webserver.conf
   sed_inplace "s/https:\/\/api.backend.ai/http:\/\/127.0.0.1:${MANAGER_PORT}/" ./webserver.conf
-  sed_inplace "s/redis.port = 6379/redis.port = ${REDIS_PORT}/" ./webserver.conf
+
+  if [ $CONFIGURE_HA -eq 1 ]; then
+    sed_inplace "s/redis.port = 6379/redis.port = ${REDIS_MASTER_PORT}/" ./webserver.conf
+    sed_inplace "s/# redis.password = \"mysecret\"/redis.password = \"develove\"/" ./webserver.conf
+  else
+    sed_inplace "s/redis.port = 6379/redis.port = ${REDIS_PORT}/" ./webserver.conf
+  fi
+
   # install and configure webui
   if [ $EDITABLE_WEBUI -eq 1 ]; then
     install_editable_webui


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR adds the `--configure-ha` flag to `install-dev.sh`, allowing automatic setup of the Backend.AI HA environment with a single command like below.

```
$ ./scripts/install-dev.sh --editable-webui --configure-ha
```

Note: This PR can be used to test the #1513 PR.

TODO: Work is needed to replace the hardcoded IP addresses with automatic input.