### PR TITLE
ci: Manage actions version with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    allow: "actions/*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Manage the version of github actions with dependabot.
First, only actions officially provided by the github actions team are applied first.

In the case of other external actions, there may be unknown update history, so I think it is necessary to check.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
