### PR TITLE
fix: Let agents fire storage (un)mount completion events even when coexisting with storage-proxy

### DIFF
--- a/changes/1570.fix.md
+++ b/changes/1570.fix.md
@@ -1,0 +1,1 @@
+Let agents skip mount/umount task and just produce task succeeded event rather than just return.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2364,6 +2364,14 @@ async def handle_volume_mount(
 ) -> None:
     if context.local_config["agent"]["cohabiting-storage-proxy"]:
         log.debug("Storage proxy is in the same node. Skip the volume task.")
+        await context.event_producer.produce_event(
+            VolumeMounted(
+                str(context.id),
+                VolumeMountableNodeType.AGENT,
+                "",
+                event.quota_scope_id,
+            )
+        )
         return
     mount_prefix = await context.etcd.get("volumes/_mount")
     volume_mount_prefix: str | None = context.local_config["agent"]["mount-path"]
@@ -2401,6 +2409,14 @@ async def handle_volume_umount(
 ) -> None:
     if context.local_config["agent"]["cohabiting-storage-proxy"]:
         log.debug("Storage proxy is in the same node. Skip the volume task.")
+        await context.event_producer.produce_event(
+            VolumeUnmounted(
+                str(context.id),
+                VolumeMountableNodeType.AGENT,
+                "",
+                event.quota_scope_id,
+            )
+        )
         return
     mount_prefix = await context.etcd.get("volumes/_mount")
     timeout = await context.etcd.get("config/watcher/file-io-timeout")


### PR DESCRIPTION
When there is any cohabiting storage with agents, agents should skip mount/umount task and just produce succeed event rather than just return.

If https://github.com/lablup/backend.ai/pull/1560 merged earlier than this PR, this should be closed.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version