### PR TITLE
fix: Resolve keypair last_used from Redis

### DIFF
--- a/changes/1571.fix.md
+++ b/changes/1571.fix.md
@@ -1,0 +1,1 @@
+Resolve `last_used` field of `KeyPair` Gql object from Redis.

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -251,10 +251,12 @@ class KeyPair(graphene.ObjectType):
             return int(concurrency_used)
         return 0
 
-    async def resolve_last_used(self, info: graphene.ResolveInfo) -> datetime:
+    async def resolve_last_used(self, info: graphene.ResolveInfo) -> datetime | None:
         ctx: GraphQueryContext = info.context
         last_call_time_key = f"kp:{self.access_key}:last_call_time"
         row_ts = await redis_helper.execute(ctx.redis_stat, lambda r: r.get(last_call_time_key))
+        if row_ts is None:
+            return None
         return datetime.fromtimestamp(float(row_ts))
 
     @classmethod

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import secrets
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple, TypedDict
 
 import graphene
@@ -209,7 +210,6 @@ class KeyPair(graphene.ObjectType):
             is_admin=row["is_admin"],
             resource_policy=row["resource_policy"],
             created_at=row["created_at"],
-            last_used=row["last_used"],
             rate_limit=row["rate_limit"],
             user=row["user"],
             ssh_public_key=row["ssh_public_key"],
@@ -250,6 +250,12 @@ class KeyPair(graphene.ObjectType):
         if concurrency_used is not None:
             return int(concurrency_used)
         return 0
+
+    async def resolve_last_used(self, info: graphene.ResolveInfo) -> datetime:
+        ctx: GraphQueryContext = info.context
+        last_call_time_key = f"kp:{self.access_key}:last_call_time"
+        row_ts = await redis_helper.execute(ctx.redis_stat, lambda r: r.get(last_call_time_key))
+        return datetime.fromtimestamp(float(row_ts))
 
     @classmethod
     async def load_all(


### PR DESCRIPTION
follow-up #1533 

Since we migrate the `last_used` field of `keypairs` table into redis, we need to support resolver for `KeyPair` gql object.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
