### PR TITLE
feat: add pipeline endpoint to the webserver templates

### DIFF
--- a/changes/1576.feature.md
+++ b/changes/1576.feature.md
@@ -1,0 +1,1 @@
+Add pipeline option to the `config.toml.j2` so that webui can access it.

--- a/scripts/pr-number-assign.py
+++ b/scripts/pr-number-assign.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import tomlkit
 
-exempted_files = ["README.md", "template.md"]
 
 def read_news_types() -> set[str]:
     with open("./pyproject.toml", "r") as f:
@@ -26,7 +25,7 @@ def main(pr_number: str) -> None:
         r"^\d+\.(?P<type>" + "|".join(map(re.escape, news_types)) + r")(\.)?(md)?$"
     )
 
-    files = [f.name for f in base_path.iterdir() if f.is_file() and f.name not in exempted_files]
+    files = [f.name for f in base_path.iterdir() if f.is_file()]
     existing_fragments = []
     for file in files:
         if rx_numbered_fragment.search(file):
@@ -69,7 +68,7 @@ def main(pr_number: str) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: python {sys.argv[0]} <PR Number>")
+        print(f"Usage: python ${sys.argv[0]} <PR Number>")
         sys.exit(1)
     pr_number = sys.argv[1]
     main(pr_number)

--- a/scripts/pr-number-assign.py
+++ b/scripts/pr-number-assign.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import tomlkit
 
+exempted_files = ["README.md", "template.md"]
 
 def read_news_types() -> set[str]:
     with open("./pyproject.toml", "r") as f:
@@ -25,7 +26,7 @@ def main(pr_number: str) -> None:
         r"^\d+\.(?P<type>" + "|".join(map(re.escape, news_types)) + r")(\.)?(md)?$"
     )
 
-    files = [f.name for f in base_path.iterdir() if f.is_file()]
+    files = [f.name for f in base_path.iterdir() if f.is_file() and f.name not in exempted_files]
     existing_fragments = []
     for file in files:
         if rx_numbered_fragment.search(file):
@@ -68,7 +69,7 @@ def main(pr_number: str) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: python ${sys.argv[0]} <PR Number>")
+        print(f"Usage: python {sys.argv[0]} <PR Number>")
         sys.exit(1)
     pr_number = sys.argv[1]
     main(pr_number)

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -56,3 +56,5 @@ connectionMode = "SESSION"
 {% toml_field "validSince" config["license"]["valid_since"] %}
 {% toml_field "validUntil" config["license"]["valid_until"] %}
 
+[pipeline]
+endpoint = {% config["pipeline"]["endpoint"] %}

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -57,4 +57,4 @@ connectionMode = "SESSION"
 {% toml_field "validUntil" config["license"]["valid_until"] %}
 
 [pipeline]
-endpoint = {% config["pipeline"]["endpoint"] %}
+{% toml_field "endpoint" config["pipeline"]["endpoint"] %}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
For resolving https://github.com/lablup/backend.ai-webui/issues/1919, make webui possible to read pipeline endpoint config from the webserver.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
