### PR TITLE
ci: fix problems of pr-number-assign action

### DIFF
--- a/scripts/pr-number-assign.py
+++ b/scripts/pr-number-assign.py
@@ -25,7 +25,7 @@ def main(pr_number: str) -> None:
     files = [f.name for f in base_path.iterdir() if f.is_file()]
     existing_fragments = []
     for file in files:
-        if file[0 : file.find(".")] == pr_number:
+        if file[0 : file.find(".")] == pr_number and rx_unnumbered_fragment.search(file[file.find(".") :]):
             existing_fragments.append(file)
     if existing_fragments:
         print(f"The news fragment(s) for the PR #{pr_number} already exists:")

--- a/scripts/pr-number-assign.py
+++ b/scripts/pr-number-assign.py
@@ -21,19 +21,19 @@ def main(pr_number: str) -> None:
     rx_unnumbered_fragment = re.compile(
         r"^(\.)?(?P<type>" + "|".join(map(re.escape, news_types)) + r")(\.)?(md)?$"
     )
+    rx_numbered_fragment = re.compile(
+        r"^\d+\.(?P<type>" + "|".join(map(re.escape, news_types)) + r")(\.)?(md)?$"
+    )
 
     files = [f.name for f in base_path.iterdir() if f.is_file()]
     existing_fragments = []
     for file in files:
-        if file[0 : file.find(".")] == pr_number and rx_unnumbered_fragment.search(file[file.find(".") :]):
-            existing_fragments.append(file)
-    if existing_fragments:
-        print(f"The news fragment(s) for the PR #{pr_number} already exists:")
-        for file in existing_fragments:
-            print(file)
-        with open(os.getenv("GITHUB_OUTPUT", os.devnull), "a") as ghoutput:
-            print("has_renamed_pairs=false", file=ghoutput)
-        sys.exit(0)
+        if rx_numbered_fragment.search(file):
+            if file[0 : file.find(".")] == pr_number:
+                existing_fragments.append(file)
+        elif rx_unnumbered_fragment.search(file) is None:
+            print(f"{file} is an invalid news fragment filename.")
+            sys.exit(1)
 
     renamed_pairs = []
     for file in files:
@@ -53,6 +53,12 @@ def main(pr_number: str) -> None:
             rename_results = [f"{pair[0]} -> {pair[1]}" for pair in renamed_pairs]
             print(f"rename_results={json.dumps(rename_results)}", file=ghoutput)
             print("has_renamed_pairs=true", file=ghoutput)
+    elif existing_fragments:
+        print(f"The news fragment(s) for the PR #{pr_number} already exists:")
+        for file in existing_fragments:
+            print(file)
+        with open(os.getenv("GITHUB_OUTPUT", os.devnull), "a") as ghoutput:
+            print("has_renamed_pairs=false", file=ghoutput)
     else:
         print("There are no unnumbered news fragments.")
         with open(os.getenv("GITHUB_OUTPUT", os.devnull), "a") as ghoutput:


### PR DESCRIPTION
close #1507 
- Fixes an issue where pr-number-assign misunderstanding a properly named news fragment file exists even if it is not when the PR number is correct.
- If there are multiple news fragments in one PR, exception handling is provided to handle cases where only some files are in the correct format.