### PR TITLE
fix: handle external error in storage proxy API

### DIFF
--- a/changes/1591.fix.md
+++ b/changes/1591.fix.md
@@ -1,0 +1,1 @@
+Handle external error of storage proxy to return error response with detail message rather than just leaving it.


### PR DESCRIPTION
Let's handle external error of storage proxy to return error response with detail message rather than just leaving it.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version