### PR TITLE
fix: Make `RedisHelperConfig` optional and make default configs

### DIFF
--- a/changes/1593.fix.md
+++ b/changes/1593.fix.md
@@ -1,0 +1,1 @@
+Make `RedisHelperConfig` optional and give default values when it is not specified.

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -50,9 +50,10 @@ redis.addr = "localhost:6379"
 # redis.service_name = "mymaster"
 # redis.sentinel = "127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505"
 
-redis.redis_helper_config.socket_timeout = 5
-redis.redis_helper_config.socket_connect_timeout = 2
-redis.redis_helper_config.reconnect_poll_timeout = 0.3
+# redis.redis_helper_config.socket_timeout = 5
+# redis.redis_helper_config.socket_connect_timeout = 2
+# redis.redis_helper_config.reconnect_poll_timeout = 0.3
+
 max_age = 604800  # 1 week
 flush_on_startup = false
 login_block_time = 1200  # 20 min (in sec)

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -121,6 +121,7 @@ redis.addr = "localhost:6379"
 # redis.db = 0
 # redis.password = "mysecret"
 
+# Customizes the settings of the Redis connection object used in the web server.
 # redis.redis_helper_config.socket_timeout = 5
 # redis.redis_helper_config.socket_connect_timeout = 2
 # redis.redis_helper_config.reconnect_poll_timeout = 0.3

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -121,9 +121,9 @@ redis.addr = "localhost:6379"
 # redis.db = 0
 # redis.password = "mysecret"
 
-redis.redis_helper_config.socket_timeout = 5
-redis.redis_helper_config.socket_connect_timeout = 2
-redis.redis_helper_config.reconnect_poll_timeout = 0.3
+# redis.redis_helper_config.socket_timeout = 5
+# redis.redis_helper_config.socket_connect_timeout = 2
+# redis.redis_helper_config.reconnect_poll_timeout = 0.3
 
 max_age = 604800  # 1 week
 flush_on_startup = false

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -857,7 +857,7 @@ configure_backendai() {
     ./backend.ai mgr etcd put config/redis/addr "127.0.0.1:${REDIS_PORT}"
   fi
 
-  ./backend.ai mgr etcd put-json config/redis/redis-helper-config ./configs/manager/sample.etcd.redis-helper.json
+  ./backend.ai mgr etcd put-json config/redis/redis_helper_config ./configs/manager/sample.etcd.redis-helper.json
 
   cp configs/manager/sample.etcd.volumes.json ./dev.etcd.volumes.json
   MANAGER_AUTH_KEY=$(python -c 'import secrets; print(secrets.token_hex(32), end="")')

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -8,11 +8,10 @@ from typing import Any, Dict, Mapping, MutableMapping, Optional, Tuple, Union, c
 import tomli
 import trafaret as t
 
-from ai.backend.common.types import RedisHelperConfig
-
 from . import validators as tx
 from .etcd import AsyncEtcd, ConfigScopes
 from .exception import ConfigurationError
+from .types import RedisHelperConfig
 
 __all__ = (
     "ConfigurationError",
@@ -29,7 +28,6 @@ __all__ = (
     "check",
     "merge",
 )
-
 
 etcd_config_iv = t.Dict(
     {
@@ -68,7 +66,6 @@ redis_config_iv = t.Dict(
         ): redis_helper_config_iv,
     }
 ).allow_extra("*")
-
 
 vfolder_config_iv = t.Dict(
     {

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -64,7 +64,7 @@ redis_config_iv = t.Dict(
         t.Key("password", default=None): t.Null | t.String,
         t.Key(
             "redis_helper_config",
-            redis_helper_default_config,
+            default=redis_helper_default_config,
         ): redis_helper_config_iv,
     }
 ).allow_extra("*")

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, Mapping, MutableMapping, Optional, Tuple, Union, c
 import tomli
 import trafaret as t
 
+from ai.backend.common.types import RedisHelperConfig
+
 from . import validators as tx
 from .etcd import AsyncEtcd, ConfigScopes
 from .exception import ConfigurationError
@@ -17,6 +19,7 @@ __all__ = (
     "etcd_config_iv",
     "redis_config_iv",
     "redis_helper_config_iv",
+    "redis_helper_default_config",
     "vfolder_config_iv",
     "model_definition_iv",
     "read_from_file",
@@ -41,6 +44,12 @@ etcd_config_iv = t.Dict(
     }
 ).allow_extra("*")
 
+redis_helper_default_config: RedisHelperConfig = {
+    "socket_timeout": 5.0,
+    "socket_connect_timeout": 2.0,
+    "reconnect_poll_timeout": 0.3,
+}
+
 redis_helper_config_iv = t.Dict(
     {
         t.Key("socket_timeout", default=5.0): t.Float,
@@ -55,11 +64,7 @@ redis_config_iv = t.Dict(
         t.Key("password", default=None): t.Null | t.String,
         t.Key(
             "redis_helper_config",
-            {
-                "socket_timeout": 5.0,
-                "socket_connect_timeout": 2.0,
-                "reconnect_poll_timeout": 0.3,
-            },
+            redis_helper_default_config,
         ): redis_helper_config_iv,
     }
 ).allow_extra("*")

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -326,11 +326,7 @@ _config_defaults: Mapping[str, Any] = {
     "redis": {
         "addr": None,
         "password": None,
-        "redis_helper_config": {
-            "socket_timeout": 5.0,
-            "socket_connect_timeout": 2.0,
-            "reconnect_poll_timeout": 0.3,
-        },
+        "redis_helper_config": config.redis_helper_default_config,
     },
     "docker": {
         "registry": {},

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -126,7 +126,9 @@ config_iv = t.Dict(
                         ),
                         t.Key("service_name", default=None): t.Null | t.String,
                         t.Key("password", default=None): t.Null | t.String,
-                        t.Key("redis_helper_config"): config.redis_helper_config_iv,
+                        t.Key(
+                            "redis_helper_config", default=config.redis_helper_default_config
+                        ): config.redis_helper_config_iv,
                     }
                 ),
                 t.Key("max_age", default=604800): t.ToInt,  # seconds (default: 1 week)

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -99,11 +99,7 @@ def local_config(test_id, logging_config, etcd_container, redis_container):  # n
             sentinel=None,
             service_name=None,
             password=None,
-            redis_helper_config={
-                "socket_timeout": 5.0,
-                "socket_connect_timeout": 2.0,
-                "reconnect_poll_timeout": 0.3,
-            },
+            redis_helper_config=config.redis_helper_default_config,
         ),
         "plugins": {},
     }

--- a/tests/common/redis_helper/test_connect.py
+++ b/tests/common/redis_helper/test_connect.py
@@ -17,12 +17,12 @@ from tenacity import (
     wait_exponential,
 )
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common import validators as tx
 from ai.backend.common.types import HostPortPair
 
 from .types import RedisClusterInfo
-from .utils import interrupt, redis_helper_config, with_timeout
+from .utils import interrupt, with_timeout
 
 if TYPE_CHECKING:
     from typing import Any
@@ -77,7 +77,7 @@ async def test_instantiate_redisconninfo() -> None:
             "sentinel": sentinels,
             "service_name": "mymaster",
             "password": "develove",
-            "redis_helper_config": redis_helper_config,
+            "redis_helper_config": config.redis_helper_default_config,
         }
     )
 
@@ -95,7 +95,7 @@ async def test_instantiate_redisconninfo() -> None:
             "sentinel": parsed_addresses,
             "service_name": "mymaster",
             "password": "develove",
-            "redis_helper_config": redis_helper_config,
+            "redis_helper_config": config.redis_helper_default_config,
         },
     )
 

--- a/tests/common/redis_helper/test_list.py
+++ b/tests/common/redis_helper/test_list.py
@@ -10,11 +10,11 @@ from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .utils import interrupt, redis_helper_config
+from .utils import interrupt
 
 
 @pytest.mark.redis
@@ -44,7 +44,7 @@ async def test_blist(redis_container: tuple[str, HostPortPair], disruption_metho
     addr = redis_container[1]
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.2),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )
@@ -125,7 +125,7 @@ async def test_blist_with_retrying_rpush(
     addr = redis_container[1]
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.2),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )

--- a/tests/common/redis_helper/test_list_cluster.py
+++ b/tests/common/redis_helper/test_list_cluster.py
@@ -7,11 +7,11 @@ import aiotools
 import pytest
 from redis.asyncio.sentinel import Sentinel
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import RedisConnectionInfo
 
 from .types import RedisClusterInfo
-from .utils import interrupt, redis_helper_config, with_timeout
+from .utils import interrupt, with_timeout
 
 
 @pytest.mark.redis
@@ -52,7 +52,7 @@ async def test_blist_cluster_sentinel(
 
     r = RedisConnectionInfo(
         s.master_for(service_name="mymaster"),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=s,
         service_name="mymaster",
     )

--- a/tests/common/redis_helper/test_pipeline.py
+++ b/tests/common/redis_helper/test_pipeline.py
@@ -8,11 +8,11 @@ from redis.asyncio import Redis
 from redis.asyncio.client import Pipeline
 from redis.asyncio.sentinel import Sentinel
 
+from ai.backend.common import config
 from ai.backend.common.redis_helper import execute
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .types import RedisClusterInfo
-from .utils import redis_helper_config
 
 
 @pytest.mark.redis
@@ -21,7 +21,7 @@ async def test_pipeline_single_instance(redis_container: Tuple[str, HostPortPair
     addr = redis_container[1]
     rconn = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.5),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )
@@ -46,7 +46,7 @@ async def test_pipeline_single_instance_retries(redis_container: Tuple[str, Host
     addr = redis_container[1]
     rconn = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.5),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )
@@ -90,7 +90,7 @@ async def test_pipeline_sentinel_cluster(redis_cluster: RedisClusterInfo) -> Non
 
     rconn = RedisConnectionInfo(
         s.master_for(service_name="mymaster"),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=s,
         service_name="mymaster",
     )

--- a/tests/common/redis_helper/test_pubsub.py
+++ b/tests/common/redis_helper/test_pubsub.py
@@ -10,11 +10,11 @@ from redis.asyncio.client import PubSub
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .utils import interrupt, redis_helper_config
+from .utils import interrupt
 
 
 @pytest.mark.redis
@@ -42,7 +42,7 @@ async def test_pubsub(redis_container: Tuple[str, HostPortPair], disruption_meth
 
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.5),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )
@@ -131,7 +131,7 @@ async def test_pubsub_with_retrying_pub(
 
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.5),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )

--- a/tests/common/redis_helper/test_stream_consume.py
+++ b/tests/common/redis_helper/test_stream_consume.py
@@ -11,11 +11,11 @@ from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .utils import interrupt, redis_helper_config, with_timeout
+from .utils import interrupt, with_timeout
 
 
 @pytest.mark.redis
@@ -64,7 +64,7 @@ async def test_stream_loadbalance(
 
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.2),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )

--- a/tests/common/redis_helper/test_stream_consume_cluster.py
+++ b/tests/common/redis_helper/test_stream_consume_cluster.py
@@ -9,11 +9,11 @@ import pytest
 from aiotools.context import aclosing
 from redis.asyncio.sentinel import Sentinel
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import RedisConnectionInfo
 
 from .types import RedisClusterInfo
-from .utils import interrupt, redis_helper_config, with_timeout
+from .utils import interrupt, with_timeout
 
 
 @pytest.mark.redis
@@ -65,7 +65,7 @@ async def test_stream_loadbalance_cluster(
 
     r = RedisConnectionInfo(
         s.master_for(service_name="mymaster"),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=s,
         service_name="mymaster",
     )

--- a/tests/common/redis_helper/test_stream_subscribe.py
+++ b/tests/common/redis_helper/test_stream_subscribe.py
@@ -10,11 +10,11 @@ from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import HostPortPair, RedisConnectionInfo
 
 from .docker import DockerRedisNode
-from .utils import interrupt, redis_helper_config
+from .utils import interrupt
 
 
 @pytest.mark.redis
@@ -51,7 +51,7 @@ async def test_stream_fanout(
 
     r = RedisConnectionInfo(
         Redis.from_url(url=f"redis://{addr.host}:{addr.port}", socket_timeout=0.2),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=None,
         service_name=None,
     )

--- a/tests/common/redis_helper/test_stream_subscribe_cluster.py
+++ b/tests/common/redis_helper/test_stream_subscribe_cluster.py
@@ -9,11 +9,11 @@ import pytest
 from aiotools.context import aclosing
 from redis.asyncio.sentinel import Sentinel
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.types import RedisConnectionInfo
 
 from .types import RedisClusterInfo
-from .utils import interrupt, redis_helper_config, with_timeout
+from .utils import interrupt, with_timeout
 
 
 @pytest.mark.redis
@@ -56,7 +56,7 @@ async def test_stream_fanout_cluster(
 
     r = RedisConnectionInfo(
         s.master_for(service_name="mymaster"),
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
         sentinel=s,
         service_name="mymaster",
     )

--- a/tests/common/redis_helper/utils.py
+++ b/tests/common/redis_helper/utils.py
@@ -20,8 +20,6 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from typing_extensions import ParamSpec
 
-from ai.backend.common.types import RedisHelperConfig
-
 if TYPE_CHECKING:
     from .types import AbstractRedisNode
 
@@ -35,12 +33,6 @@ disruptions: Final = {
         "begin": "pause",
         "end": "unpause",
     },
-}
-
-redis_helper_config: RedisHelperConfig = {
-    "socket_timeout": 5.0,
-    "socket_connect_timeout": 2.0,
-    "reconnect_poll_timeout": 0.3,
 }
 
 

--- a/tests/common/test_distributed.py
+++ b/tests/common/test_distributed.py
@@ -17,23 +17,12 @@ import pytest
 from etcetra.types import HostPortPair as EtcdHostPortPair
 from redis.asyncio import Redis
 
+from ai.backend.common import config
 from ai.backend.common.distributed import GlobalTimer
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.events import AbstractEvent, EventDispatcher, EventProducer
 from ai.backend.common.lock import AbstractDistributedLock, EtcdLock, FileLock, RedisLock
-from ai.backend.common.types import (
-    AgentId,
-    EtcdRedisConfig,
-    HostPortPair,
-    RedisConnectionInfo,
-    RedisHelperConfig,
-)
-
-redis_helper_config: RedisHelperConfig = {
-    "socket_timeout": 5.0,
-    "socket_connect_timeout": 2.0,
-    "reconnect_poll_timeout": 0.3,
-}
+from ai.backend.common.types import AgentId, EtcdRedisConfig, HostPortPair, RedisConnectionInfo
 
 
 @dataclass
@@ -94,7 +83,9 @@ async def run_timer(
         print("_tick")
         event_records.append(time.monotonic())
 
-    redis_config = EtcdRedisConfig(addr=redis_addr, redis_helper_config=redis_helper_config)
+    redis_config = EtcdRedisConfig(
+        addr=redis_addr, redis_helper_config=config.redis_helper_default_config
+    )
     event_dispatcher = await EventDispatcher.new(
         redis_config,
         consumer_group=EVENT_DISPATCHER_CONSUMER_GROUP,
@@ -136,7 +127,7 @@ def etcd_timer_node_process(
             queue.put(time.monotonic())
 
         redis_config = EtcdRedisConfig(
-            addr=timer_ctx.redis_addr, redis_helper_config=redis_helper_config
+            addr=timer_ctx.redis_addr, redis_helper_config=config.redis_helper_default_config
         )
         event_dispatcher = await EventDispatcher.new(
             redis_config,
@@ -202,7 +193,7 @@ class TimerNode(threading.Thread):
             self.event_records.append(time.monotonic())
 
         redis_config = EtcdRedisConfig(
-            addr=self.redis_addr, redis_helper_config=redis_helper_config
+            addr=self.redis_addr, redis_helper_config=config.redis_helper_default_config
         )
         event_dispatcher = await EventDispatcher.new(
             redis_config,
@@ -284,7 +275,7 @@ async def test_gloal_timer_redlock(test_case_ns, redis_container) -> None:
         Redis.from_url(f"redis://{redis_addr.host}:{redis_addr.port}"),
         sentinel=None,
         service_name=None,
-        redis_helper_config=redis_helper_config,
+        redis_helper_config=config.redis_helper_default_config,
     )
     lock_factory = lambda: RedisLock(f"{test_case_ns}lock", r, debug=True)
 
@@ -388,7 +379,9 @@ async def test_global_timer_join_leave(request, test_case_ns, redis_container) -
         print("_tick")
         event_records.append(time.monotonic())
 
-    redis_config = EtcdRedisConfig(addr=redis_container[1], redis_helper_config=redis_helper_config)
+    redis_config = EtcdRedisConfig(
+        addr=redis_container[1], redis_helper_config=config.redis_helper_default_config
+    )
     event_dispatcher = await EventDispatcher.new(
         redis_config,
         consumer_group=EVENT_DISPATCHER_CONSUMER_GROUP,

--- a/tests/common/test_events.py
+++ b/tests/common/test_events.py
@@ -6,7 +6,7 @@ import aiotools
 import attrs
 import pytest
 
-from ai.backend.common import redis_helper
+from ai.backend.common import config, redis_helper
 from ai.backend.common.events import (
     AbstractEvent,
     CoalescingOptions,
@@ -14,13 +14,7 @@ from ai.backend.common.events import (
     EventDispatcher,
     EventProducer,
 )
-from ai.backend.common.types import AgentId, EtcdRedisConfig, RedisHelperConfig
-
-redis_helper_config: RedisHelperConfig = {
-    "socket_timeout": 5.0,
-    "socket_connect_timeout": 2.0,
-    "reconnect_poll_timeout": 0.3,
-}
+from ai.backend.common.types import AgentId, EtcdRedisConfig
 
 
 @attrs.define(slots=True, frozen=True)
@@ -44,7 +38,9 @@ EVENT_DISPATCHER_CONSUMER_GROUP = "test"
 async def test_dispatch(redis_container) -> None:
     app = object()
 
-    redis_config = EtcdRedisConfig(addr=redis_container[1], redis_helper_config=redis_helper_config)
+    redis_config = EtcdRedisConfig(
+        addr=redis_container[1], redis_helper_config=config.redis_helper_default_config
+    )
     dispatcher = await EventDispatcher.new(
         redis_config,
         consumer_group=EVENT_DISPATCHER_CONSUMER_GROUP,
@@ -96,7 +92,9 @@ async def test_error_on_dispatch(redis_container) -> None:
     ) -> None:
         exception_log.append(type(exc).__name__)
 
-    redis_config = EtcdRedisConfig(addr=redis_container[1], redis_helper_config=redis_helper_config)
+    redis_config = EtcdRedisConfig(
+        addr=redis_container[1], redis_helper_config=config.redis_helper_default_config
+    )
     dispatcher = await EventDispatcher.new(
         redis_config,
         consumer_group=EVENT_DISPATCHER_CONSUMER_GROUP,

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -33,6 +33,7 @@ from aiohttp import web
 from dateutil.tz import tzutc
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
+from ai.backend.common import config
 from ai.backend.common.auth import PublicKey, SecretKey
 from ai.backend.common.config import ConfigurationError, etcd_config_iv, redis_config_iv
 from ai.backend.common.logging import LocalLogger
@@ -69,10 +70,8 @@ from ai.backend.manager.models.scaling_group import ScalingGroupOpts
 from ai.backend.manager.models.utils import connect_database
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.server import build_root_app
-from ai.backend.testutils.bootstrap import (  # noqa: F401
-    etcd_container,
-    postgres_container,
-    redis_container,
+from ai.backend.testutils.bootstrap import (
+    postgres_container,  # noqa: F401
 )
 from ai.backend.testutils.pants import get_parallel_slot
 
@@ -171,11 +170,7 @@ def local_config(
                         "host": redis_addr.host,
                         "port": redis_addr.port,
                     },
-                    "redis_helper_config": {
-                        "socket_timeout": 5.0,
-                        "socket_connect_timeout": 2.0,
-                        "reconnect_poll_timeout": 0.3,
-                    },
+                    "redis_helper_config": config.redis_helper_default_config,
                 }
             ),
             "db": {

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -70,8 +70,10 @@ from ai.backend.manager.models.scaling_group import ScalingGroupOpts
 from ai.backend.manager.models.utils import connect_database
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.server import build_root_app
-from ai.backend.testutils.bootstrap import (
-    postgres_container,  # noqa: F401
+from ai.backend.testutils.bootstrap import (  # noqa: F401
+    etcd_container,
+    postgres_container,
+    redis_container,
 )
 from ai.backend.testutils.pants import get_parallel_slot
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR makes `RedisHelperConfig` optional and makes a default value when is not specified.

And also add `redis_helper_default_config` to remove useless code redundancy of the test codes in the `common/config.py`.
