### PR TITLE
ci: use local wheels as a secondary repo

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -394,6 +394,11 @@ jobs:
           PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
           echo "PANTS_CONFIG_FILES=pants.ci.toml" >> $GITHUB_ENV
           echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
+      - name: Download wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/backend.ai-client.Dockerfile
+++ b/backend.ai-client.Dockerfile
@@ -1,7 +1,8 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION} AS builder
 ARG PKGVER
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-client==${PKGVER}
+COPY dist /dist
+RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-client==${PKGVER} --find-links=/dist
 
 FROM python:${PYTHON_VERSION}
 COPY --from=builder /wheels /wheels


### PR DESCRIPTION
close #1508 
In the build-client-image job of the default workflow, there was an issue where package download sometimes failed due to slow pypi indexing, so we have improved it so that packages can be found locally.
