### PR TITLE
chore: Add asdf-managed Python versions to the interpreter search target

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -52,7 +52,7 @@ interpreter_constraints = ["CPython==3.11.4"]
 tailor_pex_binary_targets = false
 
 [python-bootstrap]
-search_path = ["<PYENV>"]
+search_path = ["<PYENV>", "<ASDF>"]
 
 [python-repos]
 indexes = ["https://dist.backend.ai/pypi/simple/", "https://pypi.org/simple/"]


### PR DESCRIPTION
This allows Pantsbuild to find [asdf](https://asdf-vm.com/)-managed Python versions in addition to [pyenv](https://github.com/pyenv/pyenv)-managed Python versions.
The main advantage is unification of multiple runtime version managers like nvm, rbenv, etc.

To make the `./py` and `./backend.ai` commands to work, you may need to run:
```console
$ pants export --resolve=python-default
$ asdf local python "path:$(pwd)/dist/export/python/virtualenvs/python-default/3.11.4"
```

Existing pyenv-based setups should work like before.

If you are migrating from pyenv to asdf, you need to re-run `pants export` commands.