### PR TITLE
chore: Upgrade Pants (2.16.0 -> 2.17.0)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.16.0"
+pants_version = "2.17.0"
 pythonpath = ["%(buildroot)s/tools/pants-plugins"]
 backend_packages = [
     "pants.backend.python",
@@ -53,6 +53,9 @@ tailor_pex_binary_targets = false
 
 [python-bootstrap]
 search_path = ["<PYENV>", "<ASDF>"]
+
+[python-infer]
+use_rust_parser = true
 
 [python-repos]
 indexes = ["https://dist.backend.ai/pypi/simple/", "https://pypi.org/simple/"]

--- a/tools/pants-plugins/setupgen/register.py
+++ b/tools/pants-plugins/setupgen/register.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from pants.backend.python.goals.setup_py import SetupKwargs, SetupKwargsRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.package_dists import SetupKwargs, SetupKwargsRequest
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Target
@@ -49,10 +49,8 @@ async def setup_kwargs_plugin(
     # Validate that required fields are set.
     if not kwargs["name"].startswith("backend.ai-"):
         raise ValueError(
-            (
-                f"Invalid `name` kwarg in the `provides` field for {request.target.address}. The"
-                f" name must start with 'backend.ai-', but was {kwargs['name']}."
-            ),
+            f"Invalid `name` kwarg in the `provides` field for {request.target.address}. The"
+            f" name must start with 'backend.ai-', but was {kwargs['name']}.",
         )
     if "description" not in kwargs:
         raise ValueError(
@@ -134,11 +132,9 @@ async def setup_kwargs_plugin(
     conflicting_hardcoded_kwargs = set(kwargs.keys()).intersection(hardcoded_kwargs.keys())
     if conflicting_hardcoded_kwargs:
         raise ValueError(
-            (
-                "These kwargs should not be set in the `provides` field for"
-                f" {request.target.address} because Pants's internal plugin will automatically set"
-                f" them: {sorted(conflicting_hardcoded_kwargs)}"
-            ),
+            "These kwargs should not be set in the `provides` field for"
+            f" {request.target.address} because Pants's internal plugin will automatically set"
+            f" them: {sorted(conflicting_hardcoded_kwargs)}",
         )
     kwargs.update(hardcoded_kwargs)
 


### PR DESCRIPTION
* Updated the setupgen plugin to use the new imports.
* Added `[python-infer].use_rust_parser = true` for faster dependency resolution.
* Confirmed wheel packaging works like before, using our platform-specific dependency injection plugin.

You don't have to do anything special as pants will self-upgrade automatically.