### PR TITLE
feat: check health status of model service actively

### DIFF
--- a/changes/1606.feature.md
+++ b/changes/1606.feature.md
@@ -1,0 +1,1 @@
+Check health status of model service actively

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -86,12 +86,12 @@ from ai.backend.common.events import (
     ExecutionStartedEvent,
     ExecutionTimeoutEvent,
     KernelCreatingEvent,
-    KernelHealthCheckFailedEvent,
     KernelLifecycleEventReason,
     KernelPreparingEvent,
     KernelPullingEvent,
     KernelStartedEvent,
     KernelTerminatedEvent,
+    ModelServiceHealthStatusUpdatedEvent,
     SessionFailureEvent,
     SessionSuccessEvent,
     VolumeMountableNodeType,
@@ -2096,10 +2096,11 @@ class AbstractAgent(
         result = await kernel_obj.start_model_service(model)
         if result["status"] == "failed":
             await self.event_producer.produce_event(
-                KernelHealthCheckFailedEvent(
+                ModelServiceHealthStatusUpdatedEvent(
                     kernel_obj.kernel_id,
                     kernel_obj.session_id,
-                    reason=model["name"],
+                    model["name"],
+                    False,
                 )
             )
 

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -91,7 +91,7 @@ from ai.backend.common.events import (
     KernelPullingEvent,
     KernelStartedEvent,
     KernelTerminatedEvent,
-    ModelServiceHealthStatusUpdatedEvent,
+    ModelServiceStatusEvent,
     SessionFailureEvent,
     SessionSuccessEvent,
     VolumeMountableNodeType,
@@ -2095,8 +2095,10 @@ class AbstractAgent(
         log.debug("starting model service of model {}", model["name"])
         result = await kernel_obj.start_model_service(model)
         if result["status"] == "failed":
+            # handle cases where krunner fails to spawn model service process
+            # if everything went well then krunner itself will report the status via zmq
             await self.event_producer.produce_event(
-                ModelServiceHealthStatusUpdatedEvent(
+                ModelServiceStatusEvent(
                     kernel_obj.kernel_id,
                     kernel_obj.session_id,
                     model["name"],

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -119,6 +119,7 @@ from ai.backend.common.types import (
     KernelCreationConfig,
     KernelCreationResult,
     KernelId,
+    ModelServiceStatus,
     MountPermission,
     MountTypes,
     Sentinel,
@@ -2102,7 +2103,7 @@ class AbstractAgent(
                     kernel_obj.kernel_id,
                     kernel_obj.session_id,
                     model["name"],
-                    False,
+                    ModelServiceStatus.HEALTHY,
                 )
             )
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -43,7 +43,7 @@ from async_timeout import timeout
 
 from ai.backend.common.cgroup import get_cgroup_mount_point
 from ai.backend.common.docker import MAX_KERNELSPEC, MIN_KERNELSPEC, ImageRef
-from ai.backend.common.events import KernelLifecycleEventReason
+from ai.backend.common.events import EventProducer, KernelLifecycleEventReason
 from ai.backend.common.exception import ImageNotAvailable
 from ai.backend.common.logging import BraceStyleAdapter, pretty
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
@@ -152,6 +152,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         kernel_id: KernelId,
         session_id: SessionId,
         agent_id: AgentId,
+        event_producer: EventProducer,
         kernel_config: KernelCreationConfig,
         local_config: Mapping[str, Any],
         computers: MutableMapping[DeviceName, ComputerContext],
@@ -166,6 +167,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             kernel_id,
             session_id,
             agent_id,
+            event_producer,
             kernel_config,
             local_config,
             computers,
@@ -1301,6 +1303,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             kernel_id,
             session_id,
             self.id,
+            self.event_producer,
             kernel_config,
             self.local_config,
             self.computers,

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -19,6 +19,7 @@ from aiotools import TaskGroup
 
 from ai.backend.agent.docker.utils import PersistentServiceContainer
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.events import EventProducer
 from ai.backend.common.lock import FileLock
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AgentId, CommitStatus, KernelId, Sentinel, SessionId
@@ -75,10 +76,12 @@ class DockerKernel(AbstractKernel):
         super().__setstate__(props)
 
     async def create_code_runner(
-        self, *, client_features: FrozenSet[str], api_version: int
+        self, event_producer: EventProducer, *, client_features: FrozenSet[str], api_version: int
     ) -> AbstractCodeRunner:
         return await DockerCodeRunner.new(
             self.kernel_id,
+            self.session_id,
+            event_producer,
             kernel_host=self.data["kernel_host"],
             repl_in_port=self.data["repl_in_port"],
             repl_out_port=self.data["repl_out_port"],
@@ -354,6 +357,8 @@ class DockerCodeRunner(AbstractCodeRunner):
     def __init__(
         self,
         kernel_id,
+        session_id,
+        event_producer,
         *,
         kernel_host,
         repl_in_port,
@@ -361,7 +366,13 @@ class DockerCodeRunner(AbstractCodeRunner):
         exec_timeout=0,
         client_features=None,
     ) -> None:
-        super().__init__(kernel_id, exec_timeout=exec_timeout, client_features=client_features)
+        super().__init__(
+            kernel_id,
+            session_id,
+            event_producer,
+            exec_timeout=exec_timeout,
+            client_features=client_features,
+        )
         self.kernel_host = kernel_host
         self.repl_in_port = repl_in_port
         self.repl_out_port = repl_out_port

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -14,6 +14,7 @@ from typing import (
 
 from ai.backend.common.config import read_from_file
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.events import EventProducer
 from ai.backend.common.types import (
     AgentId,
     AutoPullBehavior,
@@ -51,6 +52,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
         kernel_id: KernelId,
         session_id: SessionId,
         agent_id: AgentId,
+        event_producer: EventProducer,
         kernel_config: KernelCreationConfig,
         local_config: Mapping[str, Any],
         computers: MutableMapping[DeviceName, ComputerContext],
@@ -62,6 +64,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
             kernel_id,
             session_id,
             agent_id,
+            event_producer,
             kernel_config,
             local_config,
             computers,
@@ -276,6 +279,7 @@ class DummyAgent(
             kernel_id,
             session_id,
             self.id,
+            self.event_producer,
             kernel_config,
             self.local_config,
             self.computers,

--- a/src/ai/backend/agent/dummy/kernel.py
+++ b/src/ai/backend/agent/dummy/kernel.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from typing import Any, Dict, FrozenSet, Mapping, Sequence
 
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.events import EventProducer
 from ai.backend.common.types import AgentId, CommitStatus, KernelId, SessionId
 
 from ..kernel import AbstractCodeRunner, AbstractKernel, NextResult, ResultRecord
@@ -49,6 +50,7 @@ class DummyKernel(AbstractKernel):
 
     async def create_code_runner(
         self,
+        event_producer: EventProducer,
         *,
         client_features: FrozenSet[str],
         api_version: int,
@@ -56,6 +58,8 @@ class DummyKernel(AbstractKernel):
         if self.dummy_kernel_cfg["use-fake-code-runner"]:
             return await DummyFakeCodeRunner.new(
                 self.kernel_id,
+                self.session_id,
+                event_producer,
                 kernel_host=self.data["kernel_host"],
                 repl_in_port=self.data["repl_in_port"],
                 repl_out_port=self.data["repl_out_port"],
@@ -65,6 +69,8 @@ class DummyKernel(AbstractKernel):
         else:
             return await DummyCodeRunner.new(
                 self.kernel_id,
+                self.session_id,
+                event_producer,
                 kernel_host=self.data["kernel_host"],
                 repl_in_port=self.data["repl_in_port"],
                 repl_out_port=self.data["repl_out_port"],
@@ -154,6 +160,8 @@ class DummyCodeRunner(AbstractCodeRunner):
     def __init__(
         self,
         kernel_id,
+        session_id,
+        event_producer,
         *,
         kernel_host,
         repl_in_port,
@@ -161,7 +169,13 @@ class DummyCodeRunner(AbstractCodeRunner):
         exec_timeout=0,
         client_features=None,
     ) -> None:
-        super().__init__(kernel_id, exec_timeout=exec_timeout, client_features=client_features)
+        super().__init__(
+            kernel_id,
+            session_id,
+            event_producer,
+            exec_timeout=exec_timeout,
+            client_features=client_features,
+        )
         self.kernel_host = kernel_host
         self.repl_in_port = repl_in_port
         self.repl_out_port = repl_out_port
@@ -185,6 +199,8 @@ class DummyFakeCodeRunner(AbstractCodeRunner):
     def __init__(
         self,
         kernel_id,
+        session_id,
+        event_producer,
         *,
         kernel_host,
         repl_in_port,
@@ -212,6 +228,8 @@ class DummyFakeCodeRunner(AbstractCodeRunner):
         self.kernel_host = kernel_host
         self.repl_in_port = repl_in_port
         self.repl_out_port = repl_out_port
+
+        self.event_producer = event_producer
 
     async def __ainit__(self) -> None:
         return

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -39,7 +39,7 @@ from ai.backend.common.enum_extension import StringSetFlag
 from ai.backend.common.events import (
     EventProducer,
     KernelLifecycleEventReason,
-    ModelServiceHealthStatusUpdatedEvent,
+    ModelServiceStatusEvent,
 )
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AgentId, CommitStatus, KernelId, ServicePort, SessionId, aobject
@@ -949,7 +949,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
                             await self.model_service_queue.put(msg_data)
                         case b"model-service-status":
                             response = json.loads(msg_data)
-                            event = ModelServiceHealthStatusUpdatedEvent(
+                            event = ModelServiceStatusEvent(
                                 self.kernel_id,
                                 self.session_id,
                                 response["model_name"],

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -36,7 +36,13 @@ from ai.backend.common import msgpack
 from ai.backend.common.asyncio import current_loop
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.enum_extension import StringSetFlag
-from ai.backend.common.events import KernelLifecycleEventReason
+from ai.backend.common.events import (
+    AbstractEvent,
+    EventProducer,
+    KernelHealthCheckFailedEvent,
+    KernelHealthyEvent,
+    KernelLifecycleEventReason,
+)
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AgentId, CommitStatus, KernelId, ServicePort, SessionId, aobject
 
@@ -205,7 +211,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         self.runner = None
         self.container_id = None
 
-    async def init(self) -> None:
+    async def init(self, event_producer: EventProducer) -> None:
         log.debug(
             "kernel.init(k:{0}, api-ver:{1}, client-features:{2}): starting new runner",
             self.kernel_id,
@@ -213,7 +219,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
             default_client_features,
         )
         self.runner = await self.create_code_runner(
-            client_features=default_client_features, api_version=default_api_version
+            event_producer, client_features=default_client_features, api_version=default_api_version
         )
 
     def __getstate__(self) -> Mapping[str, Any]:
@@ -254,6 +260,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
     @abstractmethod
     async def create_code_runner(
         self,
+        event_producer: EventProducer,
         *,
         client_features: FrozenSet[str],
         api_version: int,
@@ -369,11 +376,14 @@ _zctx = None
 
 class AbstractCodeRunner(aobject, metaclass=ABCMeta):
     kernel_id: KernelId
+    session_id: SessionId
     started_at: float
     finished_at: Optional[float]
     exec_timeout: float
     max_record_size: int
     client_features: FrozenSet[str]
+
+    event_producer: EventProducer
 
     input_sock: zmq.asyncio.Socket
     output_sock: zmq.asyncio.Socket
@@ -396,17 +406,20 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
     def __init__(
         self,
         kernel_id: KernelId,
+        session_id: SessionId,
+        event_producer: EventProducer,
         *,
         exec_timeout: float = 0,
         client_features: FrozenSet[str] = None,
     ) -> None:
         global _zctx
         self.kernel_id = kernel_id
+        self.session_id = session_id
+        self.event_producer = event_producer
         self.started_at = time.monotonic()
         self.finished_at = None
         if not math.isfinite(exec_timeout) or exec_timeout < 0:
             raise ValueError("execution timeout must be a zero or finite positive number.")
-        self.kernel_id = kernel_id
         self.exec_timeout = exec_timeout
         self.max_record_size = 10 * (2**20)  # 10 MBytes
         self.client_features = client_features or frozenset()
@@ -457,6 +470,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
         del props["status_task"]
         del props["watchdog_task"]
         del props["_closed"]
+        del props["event_producer"]
         return props
 
     def __setstate__(self, props):
@@ -926,49 +940,62 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             try:
                 msg_type, msg_data = await self.output_sock.recv_multipart()
                 try:
-                    if msg_type == b"status":
-                        await self.status_queue.put(msg_data)
-                    elif msg_type == b"completion":
-                        await self.completion_queue.put(msg_data)
-                    elif msg_type == b"service-result":
-                        await self.service_queue.put(msg_data)
-                    elif msg_type == b"model-service-result":
-                        await self.model_service_queue.put(msg_data)
-                    elif msg_type == b"apps-result":
-                        await self.service_apps_info_queue.put(msg_data)
-                    elif msg_type == b"stdout":
-                        if self.output_queue is None:
-                            continue
-                        if len(msg_data) > self.max_record_size:
-                            msg_data = msg_data[: self.max_record_size]
-                        await self.output_queue.put(
-                            ResultRecord(
-                                "stdout",
-                                decoders[0].decode(msg_data),
+                    match msg_type:
+                        case b"status":
+                            await self.status_queue.put(msg_data)
+                        case b"completion":
+                            await self.completion_queue.put(msg_data)
+                        case b"service-result":
+                            await self.service_queue.put(msg_data)
+                        case b"model-service-result":
+                            await self.model_service_queue.put(msg_data)
+                        case b"model-service-status":
+                            response = json.loads(msg_data)
+                            event: AbstractEvent
+                            if response["is_healthy"]:
+                                event = KernelHealthyEvent(
+                                    self.kernel_id, self.session_id, reason=response["model_name"]
+                                )
+                            else:
+                                event = KernelHealthCheckFailedEvent(
+                                    self.kernel_id, self.session_id, reason=response["model_name"]
+                                )
+                            await self.event_producer.produce_event(event)
+                        case b"apps-result":
+                            await self.service_apps_info_queue.put(msg_data)
+                        case b"stdout":
+                            if self.output_queue is None:
+                                continue
+                            if len(msg_data) > self.max_record_size:
+                                msg_data = msg_data[: self.max_record_size]
+                            await self.output_queue.put(
+                                ResultRecord(
+                                    "stdout",
+                                    decoders[0].decode(msg_data),
+                                )
                             )
-                        )
-                    elif msg_type == b"stderr":
-                        if self.output_queue is None:
-                            continue
-                        if len(msg_data) > self.max_record_size:
-                            msg_data = msg_data[: self.max_record_size]
-                        await self.output_queue.put(
-                            ResultRecord(
-                                "stderr",
-                                decoders[1].decode(msg_data),
+                        case b"stderr":
+                            if self.output_queue is None:
+                                continue
+                            if len(msg_data) > self.max_record_size:
+                                msg_data = msg_data[: self.max_record_size]
+                            await self.output_queue.put(
+                                ResultRecord(
+                                    "stderr",
+                                    decoders[1].decode(msg_data),
+                                )
                             )
-                        )
-                    else:
-                        # Normal outputs should go to the current
-                        # output queue.
-                        if self.output_queue is None:
-                            continue
-                        await self.output_queue.put(
-                            ResultRecord(
-                                cast(ResultType, msg_type.decode("ascii")),
-                                msg_data.decode("utf8"),
+                        case _:
+                            # Normal outputs should go to the current
+                            # output queue.
+                            if self.output_queue is None:
+                                continue
+                            await self.output_queue.put(
+                                ResultRecord(
+                                    cast(ResultType, msg_type.decode("ascii")),
+                                    msg_data.decode("utf8"),
+                                )
                             )
-                        )
                 except asyncio.QueueFull:
                     pass
                 if msg_type == b"build-finished":

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -42,7 +42,15 @@ from ai.backend.common.events import (
     ModelServiceStatusEvent,
 )
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.types import AgentId, CommitStatus, KernelId, ServicePort, SessionId, aobject
+from ai.backend.common.types import (
+    AgentId,
+    CommitStatus,
+    KernelId,
+    ModelServiceStatus,
+    ServicePort,
+    SessionId,
+    aobject,
+)
 
 from .exception import UnsupportedBaseDistroError
 from .resources import KernelResourceSpec
@@ -953,7 +961,11 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
                                 self.kernel_id,
                                 self.session_id,
                                 response["model_name"],
-                                response["is_healthy"],
+                                (
+                                    ModelServiceStatus.HEALTHY
+                                    if response["is_healthy"]
+                                    else ModelServiceStatus.UNHEALTHY
+                                ),
                             )
                             await self.event_producer.produce_event(event)
                         case b"apps-result":

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -34,6 +34,7 @@ from kubernetes_asyncio import config as kube_config
 from ai.backend.common.asyncio import current_loop
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events import EventProducer
 from ai.backend.common.logging_utils import BraceStyleAdapter
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
 from ai.backend.common.types import (
@@ -101,6 +102,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
         kernel_id: KernelId,
         session_id: SessionId,
         agent_id: AgentId,
+        event_producer: EventProducer,
         kernel_config: KernelCreationConfig,
         local_config: Mapping[str, Any],
         agent_sockpath: Path,
@@ -113,6 +115,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             kernel_id,
             session_id,
             agent_id,
+            event_producer,
             kernel_config,
             local_config,
             computers,
@@ -1025,6 +1028,7 @@ class KubernetesAgent(
             kernel_id,
             session_id,
             self.id,
+            self.event_producer,
             kernel_config,
             self.local_config,
             self.agent_sockpath,

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -17,6 +17,7 @@ from kubernetes_asyncio import watch
 
 from ai.backend.agent.utils import get_arch_name
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.events import EventProducer
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.common.utils import current_loop
@@ -65,7 +66,7 @@ class KubernetesKernel(AbstractKernel):
         await self.scale(0)
 
     async def create_code_runner(
-        self, *, client_features: FrozenSet[str], api_version: int
+        self, event_producer: EventProducer, *, client_features: FrozenSet[str], api_version: int
     ) -> AbstractCodeRunner:
         scale = await self.scale(1)
         if scale.to_dict()["spec"]["replicas"] == 0:
@@ -80,6 +81,8 @@ class KubernetesKernel(AbstractKernel):
 
         runner = await KubernetesCodeRunner.new(
             self.kernel_id,
+            self.session_id,
+            event_producer,
             kernel_host=self.data["kernel_host"],
             repl_in_port=self.data["repl_in_port"],
             repl_out_port=self.data["repl_out_port"],
@@ -339,6 +342,8 @@ class KubernetesCodeRunner(AbstractCodeRunner):
     def __init__(
         self,
         kernel_id,
+        session_id,
+        event_producer,
         *,
         kernel_host,
         repl_in_port,
@@ -346,7 +351,13 @@ class KubernetesCodeRunner(AbstractCodeRunner):
         exec_timeout=0,
         client_features=None,
     ) -> None:
-        super().__init__(kernel_id, exec_timeout=exec_timeout, client_features=client_features)
+        super().__init__(
+            kernel_id,
+            session_id,
+            event_producer,
+            exec_timeout=exec_timeout,
+            client_features=client_features,
+        )
         self.kernel_host = kernel_host
         self.repl_in_port = repl_in_port
         self.repl_out_port = repl_out_port

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -321,7 +321,7 @@ class KernelCancelledEvent(KernelCreationEventArgs, AbstractEvent):
 
 
 @attrs.define(slots=True, frozen=True)
-class ModelServiceHealthStatusEventArgs:
+class ModelServiceStatusEventArgs:
     kernel_id: KernelId = attrs.field()
     session_id: SessionId = attrs.field()
     model_name: str = attrs.field()
@@ -345,8 +345,8 @@ class ModelServiceHealthStatusEventArgs:
         )
 
 
-class ModelServiceHealthStatusUpdatedEvent(ModelServiceHealthStatusEventArgs, AbstractEvent):
-    name = "model_service_health_status_updated"
+class ModelServiceStatusEvent(ModelServiceStatusEventArgs, AbstractEvent):
+    name = "model_service_status_updated"
 
 
 @attrs.define(slots=True, frozen=True)

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -333,7 +333,7 @@ class ModelServiceStatusEventArgs:
             str(self.kernel_id),
             str(self.session_id),
             self.model_name,
-            str(self.new_status),
+            self.new_status.value,
         )
 
     @classmethod

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -42,6 +42,7 @@ from .types import (
     EtcdRedisConfig,
     KernelId,
     LogSeverity,
+    ModelServiceStatus,
     QuotaScopeID,
     RedisConnectionInfo,
     SessionId,
@@ -325,14 +326,14 @@ class ModelServiceStatusEventArgs:
     kernel_id: KernelId = attrs.field()
     session_id: SessionId = attrs.field()
     model_name: str = attrs.field()
-    is_healthy: bool = attrs.field()
+    new_status: ModelServiceStatus = attrs.field()
 
     def serialize(self) -> tuple:
         return (
             str(self.kernel_id),
             str(self.session_id),
             self.model_name,
-            self.is_healthy,
+            str(self.new_status),
         )
 
     @classmethod
@@ -341,7 +342,7 @@ class ModelServiceStatusEventArgs:
             kernel_id=KernelId(uuid.UUID(value[0])),
             session_id=SessionId(uuid.UUID(value[1])),
             model_name=value[2],
-            is_healthy=value[3],
+            new_status=ModelServiceStatus(value[3]),
         )
 
 

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -320,12 +320,33 @@ class KernelCancelledEvent(KernelCreationEventArgs, AbstractEvent):
     name = "kernel_cancelled"
 
 
-class KernelHealthyEvent(KernelCreationEventArgs, AbstractEvent):
-    name = "kernel_healthy"
+@attrs.define(slots=True, frozen=True)
+class ModelServiceHealthStatusEventArgs:
+    kernel_id: KernelId = attrs.field()
+    session_id: SessionId = attrs.field()
+    model_name: str = attrs.field()
+    is_healthy: bool = attrs.field()
+
+    def serialize(self) -> tuple:
+        return (
+            str(self.kernel_id),
+            str(self.session_id),
+            self.model_name,
+            self.is_healthy,
+        )
+
+    @classmethod
+    def deserialize(cls, value: tuple):
+        return cls(
+            kernel_id=KernelId(uuid.UUID(value[0])),
+            session_id=SessionId(uuid.UUID(value[1])),
+            model_name=value[2],
+            is_healthy=value[3],
+        )
 
 
-class KernelHealthCheckFailedEvent(KernelCreationEventArgs, AbstractEvent):
-    name = "kernel_health_check_failed"
+class ModelServiceHealthStatusUpdatedEvent(ModelServiceHealthStatusEventArgs, AbstractEvent):
+    name = "model_service_health_status_updated"
 
 
 @attrs.define(slots=True, frozen=True)

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -67,6 +67,7 @@ __all__ = (
     "ResourceSlot",
     "ReadableCIDR",
     "HardwareMetadata",
+    "ModelServiceStatus",
     "MountPermission",
     "MountPermissionLiteral",
     "MountTypes",
@@ -1183,3 +1184,8 @@ class RoundRobinState(JSONSerializableMixin):
 
 # States of the round-robin scheduler for each resource group and architecture.
 RoundRobinStates: TypeAlias = dict[str, dict[str, RoundRobinState]]
+
+
+class ModelServiceStatus(enum.Enum):
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -711,7 +711,6 @@ class BaseRunner(metaclass=ABCMeta):
         )
         retries = 0
         is_healthy = False
-        print(json.dumps(model_service_info))
         while True:
             new_is_healthy = False
             try:

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -142,6 +142,10 @@ class BaseRunner(metaclass=ABCMeta):
     # Set by subclasses.
     user_input_queue: Optional[asyncio.Queue[str]]
 
+    _main_task: asyncio.Task
+    _run_task: asyncio.Task
+    _health_check_task: Optional[asyncio.Task]
+
     def __init__(self, runtime_path: Path) -> None:
         self.subproc = None
         self.runtime_path = runtime_path
@@ -247,6 +251,9 @@ class BaseRunner(metaclass=ABCMeta):
             self._main_task.cancel()
             await self._run_task
             await self._main_task
+            if self._health_check_task:
+                self._health_check_task.cancel()
+                await self._health_check_task
             log.debug("terminating service processes...")
             running_procs = [*self.services_running.values()]
             async with self._service_lock:
@@ -655,7 +662,7 @@ class BaseRunner(metaclass=ABCMeta):
         assert self.service_parser is not None
         model_service_info = model_info.get("service")
         result = {}
-        is_healthy = False
+        started = False
         try:
             if model_service_info is None:
                 result = {"status": "failed", "error": "service info not provided"}
@@ -669,39 +676,83 @@ class BaseRunner(metaclass=ABCMeta):
                 "protocol": "http",
                 "options": {},
             }
-            result = await self._start_service(service_info, do_not_wait=True)
-            if (result["status"] == "running" or result["status"] == "started") and (
-                (health_check_info := model_service_info.get("health_check")) is not None
-            ):
-                health_check_endpoint = (
-                    f"http://localhost:{model_service_info['port']}{health_check_info['path']}"
-                )
-                for _ in range(health_check_info["max_retries"]):
-                    try:
-                        async with timeout(health_check_info["max_wait_time"]):
-                            try:
-                                resp = await asyncio.get_running_loop().run_in_executor(
-                                    None, urllib.request.urlopen, health_check_endpoint
-                                )
-                                if resp.status == health_check_info["expected_status_code"]:
-                                    is_healthy = True
-                                    break
-                            except urllib.error.URLError:
-                                pass
-                            # falling to here means that health check has failed, so just wait until
-                            # timeout is fired to fill out the gap between max_wait_time and actual time elapsed
-                            await asyncio.sleep(health_check_info["max_wait_time"])
-                    except asyncio.TimeoutError:
-                        pass
+            result = await self._start_service(
+                service_info, cwd=model_info["model_path"], do_not_wait=True
+            )
+            started = result["status"] == "running" or result["status"] == "started"
         finally:
-            if not is_healthy:
-                result = {"status": "failed", "error": "service unhealthy"}
+            if not started:
+                result = {"status": "failed", "error": "service failed to start"}
             await self.outsock.send_multipart(
                 [
                     b"model-service-result",
                     json.dumps(result).encode("utf8"),
                 ]
             )
+            if started:
+                if model_service_info.get("health_check"):
+                    self._health_check_task = asyncio.create_task(
+                        self.check_model_health(model_info["name"], model_service_info)
+                    )
+                else:
+                    await self.outsock.send_multipart(
+                        [
+                            b"model-service-status",
+                            json.dumps(
+                                {"model_name": model_info["name"], "is_healthy": True}
+                            ).encode("utf8"),
+                        ]
+                    )
+
+    async def check_model_health(self, model_name, model_service_info):
+        health_check_info = model_service_info.get("health_check")
+        health_check_endpoint = (
+            f"http://localhost:{model_service_info['port']}{health_check_info['path']}"
+        )
+        retries = 0
+        is_healthy = False
+        print(json.dumps(model_service_info))
+        while True:
+            new_is_healthy = False
+            try:
+                async with timeout(health_check_info["max_wait_time"]):
+                    try:
+                        resp = await asyncio.get_running_loop().run_in_executor(
+                            None, urllib.request.urlopen, health_check_endpoint
+                        )
+                        if resp.status == health_check_info["expected_status_code"]:
+                            new_is_healthy = True
+                    except urllib.error.URLError:
+                        pass
+                    # falling to here means that health check has failed, so just wait until
+                    # timeout is fired to fill out the gap between max_wait_time and actual time elapsed
+                    await asyncio.sleep(health_check_info["max_wait_time"])
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                if new_is_healthy and not is_healthy:
+                    is_healthy = True
+                    retries = 0
+                    await self.outsock.send_multipart(
+                        [
+                            b"model-service-status",
+                            json.dumps({"model_name": model_name, "is_healthy": True}).encode(
+                                "utf8"
+                            ),
+                        ]
+                    )
+                elif not new_is_healthy:
+                    if retries > health_check_info["max_retries"] and is_healthy:
+                        is_healthy = False
+                        await self.outsock.send_multipart(
+                            [
+                                b"model-service-status",
+                                json.dumps({"model_name": model_name, "is_healthy": False}).encode(
+                                    "utf8"
+                                ),
+                            ]
+                        )
+                    retries += 1
 
     async def _start_service_and_feed_result(self, service_info):
         result = await self._start_service(service_info)
@@ -712,7 +763,7 @@ class BaseRunner(metaclass=ABCMeta):
             ]
         )
 
-    async def _start_service(self, service_info, do_not_wait=False):
+    async def _start_service(self, service_info, *, cwd: Optional[str] = None, do_not_wait=False):
         async with self._service_lock:
             try:
                 if service_info["protocol"] == "preopen":
@@ -722,7 +773,9 @@ class BaseRunner(metaclass=ABCMeta):
                     return {"status": "running"}
                 if service_info["protocol"] == "pty":
                     return {"status": "failed", "error": "not implemented yet"}
-                cwd = Path.cwd()
+                _cwd = Path.cwd()
+                if cwd:
+                    _cwd = Path(cwd)
                 cmdargs: Optional[Sequence[Union[str, os.PathLike]]]
                 env: Mapping[str, str]
                 cmdargs, env = None, {}
@@ -743,7 +796,7 @@ class BaseRunner(metaclass=ABCMeta):
                     if start_info is None:
                         cmdargs, env = None, {}
                     elif len(start_info) == 3:
-                        cmdargs, env, cwd = start_info
+                        cmdargs, env, _cwd = start_info
                     elif len(start_info) == 2:
                         cmdargs, env = start_info
                 if cmdargs is None:
@@ -765,7 +818,7 @@ class BaseRunner(metaclass=ABCMeta):
                     proc = await asyncio.create_subprocess_exec(
                         *map(str, cmdargs),
                         env=service_env,
-                        cwd=cwd,
+                        cwd=_cwd,
                     )
                     self.services_running[service_info["name"]] = proc
                     asyncio.create_task(self._wait_service_proc(service_info["name"], proc))

--- a/src/ai/backend/kernel/service_actions.py
+++ b/src/ai/backend/kernel/service_actions.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import tempfile
 from asyncio import create_subprocess_exec, subprocess
 from pathlib import Path
@@ -40,6 +41,7 @@ async def write_tempfile(
 async def run_command(
     variables: Mapping[str, Any],
     command: Iterable[str],
+    echo=False,
 ) -> Optional[MutableMapping[str, str]]:
     proc = await create_subprocess_exec(
         *(str(piece).format_map(variables) for piece in command),
@@ -47,6 +49,11 @@ async def run_command(
         stderr=subprocess.PIPE
     )
     out, err = await proc.communicate()
+    if echo:
+        sys.stdout.buffer.write(out)
+        sys.stdout.flush()
+        sys.stderr.buffer.write(err)
+        sys.stderr.flush()
     return {"out": out.decode("utf8"), "err": err.decode("utf8")}
 
 

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -338,7 +338,7 @@ async def create(request: web.Request, params: Any) -> web.Response:
         image_row = await ImageRow.resolve(
             session,
             [
-                ImageRef(params["image"], ["*"], params["architecture"]),
+                ImageRef(params["image"], ["*"], "arm64"),
                 params["image"],
             ],
         )
@@ -350,7 +350,7 @@ async def create(request: web.Request, params: Any) -> web.Response:
     await root_ctx.registry.create_session(
         "",
         params["image"],
-        params["architecture"],
+        "arm64",
         UserScope(
             domain_name=params["domain"],
             group_id=group_id,

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -338,7 +338,7 @@ async def create(request: web.Request, params: Any) -> web.Response:
         image_row = await ImageRow.resolve(
             session,
             [
-                ImageRef(params["image"], ["*"], "arm64"),
+                ImageRef(params["image"], ["*"], params["architecture"]),
                 params["image"],
             ],
         )
@@ -350,7 +350,7 @@ async def create(request: web.Request, params: Any) -> web.Response:
     await root_ctx.registry.create_session(
         "",
         params["image"],
-        "arm64",
+        params["architecture"],
         UserScope(
             domain_name=params["domain"],
             group_id=group_id,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -67,7 +67,7 @@ from ai.backend.common.events import (
     KernelStartedEvent,
     KernelTerminatedEvent,
     KernelTerminatingEvent,
-    ModelServiceHealthStatusUpdatedEvent,
+    ModelServiceStatusEvent,
     RouteCreatedEvent,
     SessionCancelledEvent,
     SessionEnqueuedEvent,
@@ -294,7 +294,7 @@ class AgentRegistry:
             name="api.session.kterm",
         )
         evd.consume(
-            ModelServiceHealthStatusUpdatedEvent,
+            ModelServiceStatusEvent,
             self,
             handle_model_service_health_check_result,
         )
@@ -3390,7 +3390,7 @@ async def handle_destroy_session(
 async def handle_model_service_health_check_result(
     context: AgentRegistry,
     source: AgentId,
-    event: ModelServiceHealthStatusUpdatedEvent,
+    event: ModelServiceStatusEvent,
 ) -> None:
     log.info("HANDLE_MODEL_SERVICE_HEALTH_CHECK_RESULT (source:{}, event:{})", source, event)
     try:

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1375,25 +1375,25 @@ class SchedulerDispatcher(aobject):
                 status_filter=[EndpointLifecycle.CREATED, EndpointLifecycle.DESTROYING],
             )
         for endpoint in endpoints:
-            non_error_routings = [
+            active_routings = [
                 r for r in endpoint.routings if r.status != RouteStatus.FAILED_TO_START
             ]
             desired_session_count = endpoint.desired_session_count
             if (
                 endpoint.lifecycle_stage == EndpointLifecycle.DESTROYING
-                and len(non_error_routings) == 0
+                and len(active_routings) == 0
             ):
                 endpoints_to_mark_terminated.add(endpoint)
                 continue
 
-            if len(non_error_routings) > desired_session_count:
+            if len(active_routings) > desired_session_count:
                 # We need to scale down!
-                destroy_count = len(non_error_routings) - desired_session_count
+                destroy_count = len(active_routings) - desired_session_count
                 routes_to_destroy += list(
                     sorted(
                         [
                             route
-                            for route in non_error_routings
+                            for route in active_routings
                             if (
                                 route.status != RouteStatus.PROVISIONING
                                 and route.status != RouteStatus.TERMINATING
@@ -1405,19 +1405,19 @@ class SchedulerDispatcher(aobject):
                 log.debug(
                     "Shrinking {} from {} to {}",
                     endpoint.name,
-                    len(non_error_routings),
+                    len(active_routings),
                     endpoint.desired_session_count,
                 )
-            elif len(non_error_routings) < desired_session_count:
+            elif len(active_routings) < desired_session_count:
                 if endpoint.retries > SERVICE_MAX_RETRIES:
                     continue
                 # We need to scale up!
-                create_count = desired_session_count - len(non_error_routings)
+                create_count = desired_session_count - len(active_routings)
                 endpoints_to_expand[endpoint] = create_count
                 log.debug(
                     "Expanding {} from {} to {}",
                     endpoint.name,
-                    len(non_error_routings),
+                    len(active_routings),
                     endpoint.desired_session_count,
                 )
 

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1359,7 +1359,7 @@ class SchedulerDispatcher(aobject):
             desired_session_count = endpoint.desired_session_count
             if (
                 endpoint.lifecycle_stage == EndpointLifecycle.DESTROYING
-                and len(endpoint.routings) == 0
+                and len(non_error_routings) == 0
             ):
                 endpoints_to_mark_terminated.add(endpoint)
                 continue
@@ -1420,7 +1420,7 @@ class SchedulerDispatcher(aobject):
             try:
                 await self.registry.destroy_session(
                     session,
-                    forced=False,
+                    forced=True,
                     reason=KernelLifecycleEventReason.SERVICE_SCALED_DOWN,
                 )
             except SessionNotFound:


### PR DESCRIPTION
This should help user to deal with cases which server process starts fine at first but dies at sudden point.    
This PR also includes some minor improvements to the model service:
- Server process now starts with cwd set to `model_path` defined under `model-definition.yml`
- `run_command` pre-start action accepts optional argument `echo`, which carries out the stdout/stderr outputs to container log. This is set to false by default.

**Checklist:** (if applicable)

