### PR TITLE
fix: typos

### DIFF
--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1333,7 +1333,7 @@ class Queries(graphene.ObjectType):
 
     @staticmethod
     @privileged_query(UserRole.SUPERADMIN)
-    async def resolve_scaling_groups_for_group(
+    async def resolve_scaling_groups_for_user_group(
         executor: AsyncioExecutor,
         info: graphene.ResolveInfo,
         user_group,


### PR DESCRIPTION
`resolve_scaling_groups_for_group` -> `resolve_scaling_groups_for_user_group`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
