### PR TITLE
chore: Prefer local pyenv/asdf Python versions

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -52,7 +52,7 @@ interpreter_constraints = ["CPython==3.11.6"]
 tailor_pex_binary_targets = false
 
 [python-bootstrap]
-search_path = ["<PYENV>", "<ASDF>"]
+search_path = ["<PYENV_LOCAL>", "<ASDF_LOCAL>", "<PYENV>", "<ASDF>"]
 
 [python-infer]
 use_rust_parser = true


### PR DESCRIPTION
- This is to avoid some potential bugs in pants' asdf version resolution
  when the global version is different from what's in pants.toml.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
