### PR TITLE
fix: Add an optional param `owner-access-key` to session restart command

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Add an optional parameter `owner` to session restart command.

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -544,7 +544,14 @@ session.command(aliases=["rm", "kill"])(_destroy_cmd())
 
 def _restart_cmd(docs: str = None):
     @click.argument("session_refs", metavar="SESSION_REFS", nargs=-1)
-    def restart(session_refs):
+    @click.option(
+        "-o",
+        "--owner",
+        "--owner-access-key",
+        metavar="ACCESS_KEY",
+        help="Specify the owner of the target session explicitly.",
+    )
+    def restart(session_refs, owner):
         """
         Restart the compute session.
 
@@ -559,7 +566,7 @@ def _restart_cmd(docs: str = None):
             has_failure = False
             for session_ref in session_refs:
                 try:
-                    compute_session = session.ComputeSession(session_ref)
+                    compute_session = session.ComputeSession(session_ref, owner)
                     compute_session.restart()
                 except BackendAPIError as e:
                     print_error(e)


### PR DESCRIPTION
This PR adds an optional parameter `owner-access-key` to session restart command, and updates the corresponding request handler to allow new parameter `owner_access_key` which can be different from `requester_access_key`. `owner_access_key` has been always the same with `requester_access_key`, which means any admin could not restart other user's session.

https://github.com/lablup/backend.ai/blob/dec5284b7e836209af657fbf25fa09515fbf4cab/src/ai/backend/manager/api/session.py#L1349-L1354

https://github.com/lablup/backend.ai/blob/dec5284b7e836209af657fbf25fa09515fbf4cab/src/ai/backend/manager/api/utils.py#L57-L65

| Before | After |
| ------ | ------ |
| <img width="567" alt="스크린샷 2023-10-19 오후 1 55 09" src="https://github.com/lablup/backend.ai/assets/14137676/edf3d362-2e8c-420e-bd15-c3191ec9da47"> | <img width="567" alt="스크린샷 2023-10-19 오후 1 55 49" src="https://github.com/lablup/backend.ai/assets/14137676/fcbe1aae-b143-4bf9-9025-7dbbd81d15eb"> |

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
