### PR TITLE
fix: change `max_vfolder_count` type from BigInt to Int

### DIFF
--- a/changes/1643.fix.md
+++ b/changes/1643.fix.md
@@ -1,0 +1,1 @@
+To resolve the type mismatch between DB and schema, changed all schema types of `max_vfolder_count` to int.

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -407,7 +407,7 @@ class UserResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = BigInt()
+    max_vfolder_count = graphene.Int()
     max_vfolder_size = BigInt()  # aliased field
     max_quota_scope_size = BigInt()
 
@@ -482,12 +482,12 @@ class UserResourcePolicy(graphene.ObjectType):
 
 
 class CreateUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = BigInt(required=True)
+    max_vfolder_count = graphene.Int(required=True)
     max_quota_scope_size = BigInt(required=True)
 
 
 class ModifyUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = BigInt(required=True)
+    max_vfolder_count = graphene.Int(required=True)
     max_quota_scope_size = BigInt(required=True)
 
 
@@ -585,7 +585,7 @@ class ProjectResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = BigInt()
+    max_vfolder_count = graphene.Int()
     max_vfolder_size = BigInt()  # aliased field
     max_quota_scope_size = BigInt()
 
@@ -660,12 +660,12 @@ class ProjectResourcePolicy(graphene.ObjectType):
 
 
 class CreateProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = BigInt(required=True)
+    max_vfolder_count = graphene.Int(required=True)
     max_quota_scope_size = BigInt(required=True)
 
 
 class ModifyProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = BigInt(required=True)
+    max_vfolder_count = graphene.Int(required=True)
     max_quota_scope_size = BigInt(required=True)
 
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

follows https://github.com/lablup/backend.ai/pull/1417
To resolve type mismatch between DB and schema, unify type of the `max_vfolder_count` to Integer.

| Before | After |
|--------|--------|
| DB (Integer):
https://github.com/lablup/backend.ai/blob/1419cf378b23d6b0e5dfbc9d0f4151bf4acc50f8/src/ai/backend/manager/models/resource_policy.py#L100 | same |
| Schema (BigInt): | Schema (Int): |
|https://github.com/lablup/backend.ai/blob/429c15574f03d37dec6a18b2dcfb00e9f815a9fc/src/ai/backend/manager/models/resource_policy.py#L410 | https://github.com/lablup/backend.ai/blob/7e50143e586db882ac085e4f68a9d726d9b7c208/src/ai/backend/manager/models/resource_policy.py#L485 | 


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
