### PR TITLE
fix: Raise error when a created docker container exposes no port

### DIFF
--- a/changes/1645.fix.md
+++ b/changes/1645.fix.md
@@ -1,0 +1,1 @@
+Handle `None` value of newly created Docker container's port.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -917,7 +917,10 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 if container_config["HostConfig"].get("NetworkMode") == "host":
                     host_port = host_ports[idx]
                 else:
-                    host_port = int((await container.port(port))[0]["HostPort"])
+                    ports: list[dict[str, Any]] | None = await container.port(port)
+                    if ports is None:
+                        raise ContainerCreationError(container_id=cid)
+                    host_port = int(ports[0]["HostPort"])
                     assert host_port == host_ports[idx]
                 if port == 2000:  # intrinsic
                     repl_in_port = host_port


### PR DESCRIPTION
Docker containers do not expose their ports if they use macvlan.
Let's handle it for better debug.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
