### PR TITLE
fix: CLI command unable to create keypair

### DIFF
--- a/changes/1661.fix.md
+++ b/changes/1661.fix.md
@@ -1,0 +1,1 @@
+Fix CLI command to create keypair and display the result.

--- a/changes/1661.fix.md
+++ b/changes/1661.fix.md
@@ -1,1 +1,1 @@
-Fix CLI command to create keypair and display the result.
+Fix CLI command unable to create keypair and display the result.

--- a/docs/manager/admin-api/keypairs.rst
+++ b/docs/manager/admin-api/keypairs.rst
@@ -36,9 +36,10 @@ Mutation Schema
 
    input KeyPairInput {
      is_active: Boolean
-     resource_policy: String
+     is_admin: Boolean
+     resource_policy: String!
      concurrency_limit: Int
-     rate_limit: Int
+     rate_limit: Int!
    }
 
    input ModifyKeyPairInput {


### PR DESCRIPTION
This PR resolves #1657 by implementing an additional post processing function to aggregate `groups_name` field.

### Before
```sh
$ ./backend.ai --output=json admin keypair add test@lablup.com default
{
  "ok": false,
  "msg": "unexpected error: Could not locate column in row for column 'groups_name'",
  "item_name": "keypair",
  "action_name": "add"
}
```

### After
```sh
$ ./backend.ai --output=json admin keypair add test@lablup.com default
{
  "ok": true,
  "msg": "success",
  "access_key": "AKIA6ACO4EJOYRDUV6AG",
  "secret_key": "dNdJcNf7NWNqnIYev8tabyedNvJjvZT2c1UBRCx-",
  "keypair": {
    "access_key": "AKIA6ACO4EJOYRDUV6AG",
    "secret_key": "dNdJcNf7NWNqnIYev8tabyedNvJjvZT2c1UBRCx-"
  }
}
```

Refs
- #1022

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
