### PR TITLE
add: add `allow_app_download_panel` option to webserver config

### DIFF
--- a/changes/1664.feature.md
+++ b/changes/1664.feature.md
@@ -1,0 +1,1 @@
+Add a `allow_app_download_panel` config to webserver to show/hide the webui app download panel on the summary page.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -52,6 +52,8 @@ mask_user_info = false
 # hide_agents = true
 # URL to download the webui electron app. If blank, https://github.com/lablup/backend.ai-webui/releases/download will be used.
 # app_download_url = ""
+# Allow users to see the panel downloading the webui app from the summary page.
+# allow_app_download_panel = true
 # Enable/disable 2-Factor-Authentication (TOTP).
 enable_2FA = false
 # Force enable 2-Factor-Authentication (TOTP).

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -66,6 +66,7 @@ config_iv = t.Dict(
                 t.Key("enable_container_commit", default=False): t.ToBool,
                 t.Key("hide_agents", default=True): t.ToBool,
                 t.Key("app_download_url", default=""): t.String(allow_blank=True),
+                t.Key("allow_app_download_panel", default=True): t.ToBool,
                 t.Key("enable_2FA", default=False): t.ToBool(),
                 t.Key("force_2FA", default=False): t.ToBool(),
                 t.Key("system_SSH_image", default=""): t.String(allow_blank=True),

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -21,6 +21,7 @@ connectionMode = "SESSION"
 {% toml_field "enableContainerCommit" config["service"]["enable_container_commit"] %}
 {% toml_field "hideAgents" config["service"]["hide_agents"] %}
 {% toml_field "appDownloadUrl" config["service"]["app_download_url"] %}
+{% toml_field "allowAppDownloadPanel" config["service"]["allow_app_download_panel"] %}
 {% toml_field "enable2FA" config["service"]["enable_2FA"] %}
 {% toml_field "force2FA" config["service"]["force_2FA"] %}
 {% toml_field "systemSSHImage" config["service"]["system_SSH_image"] %}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

related PR: https://github.com/lablup/backend.ai-webui/pull/1996
Add `allow_app_download_panel` option to webserver config file to display or hide the webui app download panel.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [x] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
