### PR TITLE
fix: infinite loop when malformed symbolic link exists in VFolder

### DIFF
--- a/changes/1665.fix.md
+++ b/changes/1665.fix.md
@@ -1,0 +1,1 @@
+Fix symbolic link loop error of vfolder

--- a/src/ai/backend/storage/netapp/__init__.py
+++ b/src/ai/backend/storage/netapp/__init__.py
@@ -261,12 +261,13 @@ class XCPFSOpModel(BaseFSOpModel):
                             entry_type = DirEntryType.FILE
                     symlink_target = ""
                     if entry_type == DirEntryType.SYMLINK:
-                        symlink_dst = Path(item_abspath).resolve()
                         try:
+                            symlink_dst = Path(item_abspath).resolve()
                             symlink_dst = symlink_dst.relative_to(target_path)
-                        except ValueError:
+                        except (ValueError, RuntimeError):
                             pass
-                        symlink_target = os.fsdecode(symlink_dst)
+                        else:
+                            symlink_target = os.fsdecode(symlink_dst)
                     await entry_queue.put(
                         DirEntry(
                             name=item_path.name,

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -256,7 +256,6 @@ class BaseFSOpModel(AbstractFSOpModel):
                                 entry_type = DirEntryType.DIRECTORY
                             if entry.is_symlink():
                                 entry_type = DirEntryType.SYMLINK
-
                                 try:
                                     symlink_dst = Path(entry).resolve()
                                     symlink_dst = symlink_dst.relative_to(target_path)

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -251,7 +251,6 @@ class BaseFSOpModel(AbstractFSOpModel):
                             break
                         symlink_target = ""
                         entry_type = DirEntryType.FILE
-
                         try:
                             if entry.is_dir(follow_symlinks=False):
                                 entry_type = DirEntryType.DIRECTORY
@@ -266,12 +265,10 @@ class BaseFSOpModel(AbstractFSOpModel):
                                     pass
                                 else:
                                     symlink_target = os.fsdecode(symlink_dst)
-
                             entry_stat = entry.stat(follow_symlinks=False)
                         except (FileNotFoundError, PermissionError):
                             # the filesystem may be changed during scan
                             continue
-
                         item = DirEntry(
                             name=entry.name,
                             path=Path(entry.path).relative_to(target_path),

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -260,7 +260,7 @@ class BaseFSOpModel(AbstractFSOpModel):
                                 try:
                                     symlink_dst = Path(entry).resolve()
                                     symlink_dst = symlink_dst.relative_to(target_path)
-                                except RuntimeError:
+                                except (ValueError, RuntimeError):
                                     # ValueError and ELOOP
                                     pass
                                 else:


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

When opening the file browser in WebUI and the there is a symbolic link pointing to itself,
below error occurs and file browser doesn't appear.

```
2023-10-27 07:19:30.941 INFO ai.backend.manager.api.vfolder [570498] VFOLDER.LIST_FILES (email:admin@lablup.com, ak:AKIAIOSFODNN7EXAMPLE, vf:test, path:.)
2023-10-27 07:19:30.973 DEBUG ai.backend.manager.plugin.error_monitor [570498] collected an error log [ERROR] "ai.backend.manager.api.exceptions.InvalidAPIParameters: Missing or invalid API parameters. (Too many levels of symbolic links)
-> extra_data: {'errno': 40, 'paths': ['upstage']}" from manager
```

This PR resolves this error by leaving `symlink_dst` empty when an ELOOP error occurs.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77b4fec</samp>

This pull request fixes a bug that caused symbolic link loops in virtual folders to crash the `_scandir` function. It changes the logic of `src/ai/backend/storage/vfs/__init__.py` to avoid following symlinks when scanning directories and to handle the `RuntimeError` exception gracefully.
