### PR TITLE
feat: add `allow_custom_resource_allocation` to webserver config

### DIFF
--- a/changes/1666.feature.md
+++ b/changes/1666.feature.md
@@ -1,0 +1,1 @@
+Add a `allow_custom_resource_allocation` config to webserver to show/hide the custom allocation on the session launcher.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -61,6 +61,8 @@ force_2FA = false
 # system_SSH_image = ""
 # If true, display the amount of usage per directory such as folder capacity, and number of files and directories.
 directory_based_usage = false
+# If true, display the custom allocation on the session launcher.
+# allow_custom_resource_allocation = true
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -70,6 +70,7 @@ config_iv = t.Dict(
                 t.Key("force_2FA", default=False): t.ToBool(),
                 t.Key("system_SSH_image", default=""): t.String(allow_blank=True),
                 t.Key("directory_based_usage", default=False): t.ToBool(),
+                t.Key("allow_custom_resource_allocation", default=True): t.ToBool(),
             }
         ).allow_extra("*"),
         t.Key("resources"): t.Dict(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -26,6 +26,7 @@ connectionMode = "SESSION"
 {% toml_field "systemSSHImage" config["service"]["system_SSH_image"] %}
 {% toml_field "directoryBasedUsage" config["service"]["directory_based_usage"] %}
 {% toml_field "maxCountForPreopenPorts" config["session"]["max_count_for_preopen_ports"] %}
+{% toml_field "allowCustomResourceAllocation" config["service"]["allow_custom_resource_allocation"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
related PR: https://github.com/lablup/backend.ai-webui/pull/1998
Add `allow_custom_resource_allocation` option to webserver config file to display or hide the custom resource allocation on the session launcher.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [x] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
