### PR TITLE
fix: handle request format changes on session template API

### DIFF
--- a/changes/1668.fix.md
+++ b/changes/1668.fix.md
@@ -1,0 +1,1 @@
+Update the parameter of session-template update API to follow-up change of session-template create API.

--- a/src/ai/backend/manager/api/session_template.py
+++ b/src/ai/backend/manager/api/session_template.py
@@ -269,7 +269,7 @@ async def put(request: web.Request, params: Any) -> web.Response:
             body = yaml.safe_load(params["payload"])
         except (yaml.YAMLError, yaml.MarkedYAMLError):
             raise InvalidAPIParameters("Malformed payload")
-        for st in body["session_templates"]:
+        for st in body:
             template_data = check_task_template(st["template"])
             name = st["name"] if "name" in st else template_data["metadata"]["name"]
             if "group_id" in st:


### PR DESCRIPTION
After https://github.com/lablup/backend.ai/pull/1406 is merged, request format for session template creation/update API has changed.
This PR updates the parameter of UPDATE API handler accordingly.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
