### PR TITLE
fix: infinite loop when malformed symbolic link exists in container

### DIFF
--- a/changes/1673.fix.md
+++ b/changes/1673.fix.md
@@ -1,0 +1,1 @@
+Fix infinite loop when malformed symbolic link exists in container

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -312,7 +312,11 @@ class DockerKernel(AbstractKernel):
 
         files = []
         for f in os.scandir(sys.argv[1]):
-            fstat = f.stat()
+            if f.is_symlink():
+                fstat = os.lstat(f)
+            else:
+                fstat = f.stat()
+
             ctime = fstat.st_ctime  # TODO: way to get concrete create time?
             mtime = fstat.st_mtime
             atime = fstat.st_atime

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -312,10 +312,7 @@ class DockerKernel(AbstractKernel):
 
         files = []
         for f in os.scandir(sys.argv[1]):
-            if f.is_symlink():
-                fstat = os.lstat(f)
-            else:
-                fstat = f.stat()
+            fstat = f.stat(follow_symlinks=False)
 
             ctime = fstat.st_ctime  # TODO: way to get concrete create time?
             mtime = fstat.st_mtime

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -298,10 +298,7 @@ class KubernetesKernel(AbstractKernel):
 
         files = []
         for f in os.scandir(sys.argv[1]):
-            if f.is_symlink():
-                fstat = os.lstat(f)
-            else:
-                fstat = f.stat()
+            fstat = f.stat(follow_symlinks=False)
 
             ctime = fstat.st_ctime  # TODO: way to get concrete create time?
             mtime = fstat.st_mtime

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -298,7 +298,11 @@ class KubernetesKernel(AbstractKernel):
 
         files = []
         for f in os.scandir(sys.argv[1]):
-            fstat = f.stat()
+            if f.is_symlink():
+                fstat = os.lstat(f)
+            else:
+                fstat = f.stat()
+
             ctime = fstat.st_ctime  # TODO: way to get concrete create time?
             mtime = fstat.st_mtime
             atime = fstat.st_atime


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Related PR: https://github.com/lablup/backend.ai/pull/1665

If you create a symlink pointing to itself in a container and then connect the container by ssh, you will get a `Too many levels of symbolic links` error like below. (the symlink named 'abc' which could be created by `ln -s abc abc`)

```
work@main1[tzB9zs8e-session]:~$ ls -la
total 64
drwxr-xr-x 8 work work 4096 Oct 31 00:39 .
drwxr-xr-x 1 root root 4096 Oct 31 00:37 ..
-rw-rw-r-- 1 work work  147 Oct 31 00:37 .bash_profile
-rw-rw-r-- 1 work work  249 Oct 31 00:37 .bashrc
drwxr-xr-x 3 work work 4096 Oct 31 00:37 .cache
drwxr-xr-x 3 work work 4096 Oct 31 00:37 .config
drwxr-xr-x 3 work work 4096 Oct 31 00:37 .ipython
drwxrwxr-x 3 work work 4096 Oct 31 00:37 .jupyter
drwxr-xr-x 3 work work 4096 Oct 31 00:37 .local
-rw-r--r-- 1 root root   48 Oct 31 00:37 .password
drwx------ 2 work work 4096 Oct 31 00:37 .ssh
-rw-rw-r-- 1 work work 2195 Oct 31 00:37 .tmux.conf
-rw-rw-r-- 1 work work  501 Oct 31 00:37 .vimrc
-rw-rw-r-- 1 work work  472 Oct 31 00:37 .zshrc
-rw-rw-r-- 1 work work  540 Oct 27 00:55 DO_NOT_STORE_PERSISTENT_FILES_HERE.md
lrwxrwxrwx 1 work work    3 Oct 31 00:39 abc -> abc
-rw------- 1 work work 1675 Oct 31 00:37 id_container
work@main1[tzB9zs8e-session]:~$ logout
Connection to localhost closed.

❯ ./backend.ai session ls tzB9zs8e-session
✗ Traceback (most recent call last):
    File "<string>", line 9, in <module>
  OSError: [Errno 40] Too many levels of symbolic links: '/home/work/abc'
```

This PR fixes this by calling the stat for the symlink itself instead of the original file.

```
❯ ./backend.ai session ls zMgkgFXk-session
✓ Retrived.
File name                              Size       Modified              Mode
-------------------------------------  ---------  --------------------  ----------
id_container                           1.6 KiB    Oct 31 2023 03:35:06  -rw-------
.jupyter                               4.0 KiB    Oct 31 2023 03:35:05  drwxrwxr-x
.bash_history                          21 Bytes   Oct 31 2023 03:45:33  -rw-------
.cache                                 4.0 KiB    Oct 31 2023 03:35:07  drwxr-xr-x
.password                              59 Bytes   Oct 31 2023 03:35:05  -rw-r--r--
.config                                4.0 KiB    Oct 31 2023 03:35:07  drwxr-xr-x
DO_NOT_STORE_PERSISTENT_FILES_HERE.md  540 Bytes  Oct 27 2023 00:55:30  -rw-rw-r--
.vimrc                                 501 Bytes  Oct 31 2023 03:35:05  -rw-rw-r--
abc                                    3 Bytes    Oct 31 2023 03:45:30  lrwxrwxrwx
.bashrc                                249 Bytes  Oct 31 2023 03:35:05  -rw-rw-r--
.zshrc                                 472 Bytes  Oct 31 2023 03:35:05  -rw-rw-r--
.bash_profile                          147 Bytes  Oct 31 2023 03:35:05  -rw-rw-r--
.local                                 4.0 KiB    Oct 31 2023 03:35:06  drwxr-xr-x
.ipython                               4.0 KiB    Oct 31 2023 03:35:06  drwxr-xr-x
.tmux.conf                             2.1 KiB    Oct 31 2023 03:35:05  -rw-rw-r--
.ssh                                   4.0 KiB    Oct 31 2023 03:35:06  drwx------

```


Tested manually.
