### PR TITLE
fix: restore removed graphene fields and set them deprecated

### DIFF
--- a/changes/1677.fix.md
+++ b/changes/1677.fix.md
@@ -1,0 +1,1 @@
+Restore removed graphene fields of resource policies and set them deprecated.

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -417,9 +417,9 @@ class UserResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = graphene.Int()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
     max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.1")
-    max_quota_scope_size = BigInt()
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
     @classmethod
     def from_row(
@@ -434,7 +434,6 @@ class UserResourcePolicy(graphene.ObjectType):
             name=row.name,
             created_at=row.created_at,
             max_vfolder_count=row.max_vfolder_count,
-            max_vfolder_size=row.max_quota_scope_size,  # aliased field
             max_quota_scope_size=row.max_quota_scope_size,
         )
 
@@ -492,13 +491,13 @@ class UserResourcePolicy(graphene.ObjectType):
 
 
 class CreateUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int()
-    max_quota_scope_size = BigInt()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
 
 class ModifyUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int()
-    max_quota_scope_size = BigInt()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
 
 class CreateUserResourcePolicy(graphene.Mutation):
@@ -595,9 +594,9 @@ class ProjectResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = graphene.Int()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
     max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.1")
-    max_quota_scope_size = BigInt()
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
     @classmethod
     def from_row(
@@ -670,13 +669,13 @@ class ProjectResourcePolicy(graphene.ObjectType):
 
 
 class CreateProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int()
-    max_quota_scope_size = BigInt()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
 
 class ModifyProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int()
-    max_quota_scope_size = BigInt()
+    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
+    max_quota_scope_size = BigInt(description="Added since 24.03.1")
 
 
 class CreateProjectResourcePolicy(graphene.Mutation):

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -143,6 +143,10 @@ class KeyPairResourcePolicy(graphene.ObjectType):
     idle_timeout = BigInt()
     allowed_vfolder_hosts = graphene.JSONString()
 
+    max_vfolder_count = graphene.Int(deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.4")
+    max_quota_scope_size = BigInt(deprecation_reason="Deprecated since 23.09.4")
+
     @classmethod
     def from_row(
         cls,
@@ -161,6 +165,9 @@ class KeyPairResourcePolicy(graphene.ObjectType):
             max_containers_per_session=row["max_containers_per_session"],
             idle_timeout=row["idle_timeout"],
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
+            max_vfolder_count=0,
+            max_vfolder_size=0,
+            max_quota_scope_size=0,
         )
 
     @classmethod

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -165,9 +165,6 @@ class KeyPairResourcePolicy(graphene.ObjectType):
             max_containers_per_session=row["max_containers_per_session"],
             idle_timeout=row["idle_timeout"],
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
-            max_vfolder_count=0,
-            max_vfolder_size=0,
-            max_quota_scope_size=0,
         )
 
     @classmethod

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -165,6 +165,9 @@ class KeyPairResourcePolicy(graphene.ObjectType):
             max_containers_per_session=row["max_containers_per_session"],
             idle_timeout=row["idle_timeout"],
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
+            max_vfolder_count=0,
+            max_vfolder_size=0,
+            max_quota_scope_size=0,
         )
 
     @classmethod

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -165,9 +165,6 @@ class KeyPairResourcePolicy(graphene.ObjectType):
             max_containers_per_session=row["max_containers_per_session"],
             idle_timeout=row["idle_timeout"],
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
-            max_vfolder_count=0,
-            max_vfolder_size=0,
-            max_quota_scope_size=0,
         )
 
     @classmethod
@@ -297,6 +294,9 @@ class CreateKeyPairResourcePolicyInput(graphene.InputObjectType):
     max_containers_per_session = graphene.Int(required=True)
     idle_timeout = BigInt(required=True)
     allowed_vfolder_hosts = graphene.JSONString(required=False)
+    max_vfolder_count = graphene.Int(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_quota_scope_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
 
 
 class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):
@@ -307,6 +307,9 @@ class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):
     max_containers_per_session = graphene.Int(required=False)
     idle_timeout = BigInt(required=False)
     allowed_vfolder_hosts = graphene.JSONString(required=False)
+    max_vfolder_count = graphene.Int(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_quota_scope_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
 
 
 class CreateKeyPairResourcePolicy(graphene.Mutation):

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -28,6 +28,7 @@ from .base import (
 )
 from .keypair import keypairs
 from .user import UserRole
+from .utils import deprecation_reason_msg, description_msg
 
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
@@ -55,6 +56,34 @@ __all__: Sequence[str] = (
     "ModifyProjectResourcePolicy",
     "DeleteProjectResourcePolicy",
 )
+
+
+def user_max_vfolder_count(required: bool = False):
+    return graphene.Int(
+        required=required,
+        description=description_msg("24.03.1", "Limitation of the number of user vfolders."),
+    )
+
+
+def user_max_quota_scope_size(required: bool = False):
+    return BigInt(
+        required=required,
+        description=description_msg("24.03.1", "Limitation of the quota size of user vfolders."),
+    )
+
+
+def project_max_vfolder_count(required: bool = False):
+    return graphene.Int(
+        required=required,
+        description=description_msg("24.03.1", "Limitation of the number of project vfolders."),
+    )
+
+
+def project_max_quota_scope_size(required: bool = False):
+    return BigInt(
+        required=required,
+        description=description_msg("24.03.1", "Limitation of the quota size of project vfolders."),
+    )
 
 
 keypair_resource_policies = sa.Table(
@@ -143,9 +172,9 @@ class KeyPairResourcePolicy(graphene.ObjectType):
     idle_timeout = BigInt()
     allowed_vfolder_hosts = graphene.JSONString()
 
-    max_vfolder_count = graphene.Int(deprecation_reason="Deprecated since 23.09.4")
-    max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.4")
-    max_quota_scope_size = BigInt(deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_count = graphene.Int(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_vfolder_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_quota_scope_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
 
     @classmethod
     def from_row(
@@ -294,9 +323,9 @@ class CreateKeyPairResourcePolicyInput(graphene.InputObjectType):
     max_containers_per_session = graphene.Int(required=True)
     idle_timeout = BigInt(required=True)
     allowed_vfolder_hosts = graphene.JSONString(required=False)
-    max_vfolder_count = graphene.Int(required=False, deprecation_reason="Deprecated since 23.09.4")
-    max_vfolder_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
-    max_quota_scope_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_count = graphene.Int(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_vfolder_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_quota_scope_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
 
 
 class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):
@@ -307,9 +336,9 @@ class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):
     max_containers_per_session = graphene.Int(required=False)
     idle_timeout = BigInt(required=False)
     allowed_vfolder_hosts = graphene.JSONString(required=False)
-    max_vfolder_count = graphene.Int(required=False, deprecation_reason="Deprecated since 23.09.4")
-    max_vfolder_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
-    max_quota_scope_size = BigInt(required=False, deprecation_reason="Deprecated since 23.09.4")
+    max_vfolder_count = graphene.Int(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_vfolder_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
+    max_quota_scope_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.4"))
 
 
 class CreateKeyPairResourcePolicy(graphene.Mutation):
@@ -417,9 +446,9 @@ class UserResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = user_max_vfolder_count()
+    max_quota_scope_size = user_max_quota_scope_size()
+    max_vfolder_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.1"))
 
     @classmethod
     def from_row(
@@ -491,13 +520,13 @@ class UserResourcePolicy(graphene.ObjectType):
 
 
 class CreateUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = user_max_vfolder_count()
+    max_quota_scope_size = user_max_quota_scope_size()
 
 
 class ModifyUserResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = user_max_vfolder_count()
+    max_quota_scope_size = user_max_quota_scope_size()
 
 
 class CreateUserResourcePolicy(graphene.Mutation):
@@ -594,9 +623,9 @@ class ProjectResourcePolicy(graphene.ObjectType):
     id = graphene.ID(required=True)
     name = graphene.String(required=True)
     created_at = GQLDateTime(required=True)
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = project_max_vfolder_count()
+    max_quota_scope_size = project_max_quota_scope_size()
+    max_vfolder_size = BigInt(deprecation_reason=deprecation_reason_msg("23.09.1"))
 
     @classmethod
     def from_row(
@@ -669,13 +698,13 @@ class ProjectResourcePolicy(graphene.ObjectType):
 
 
 class CreateProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = project_max_vfolder_count()
+    max_quota_scope_size = project_max_quota_scope_size()
 
 
 class ModifyProjectResourcePolicyInput(graphene.InputObjectType):
-    max_vfolder_count = graphene.Int(description="Added since 24.03.1")
-    max_quota_scope_size = BigInt(description="Added since 24.03.1")
+    max_vfolder_count = project_max_vfolder_count()
+    max_quota_scope_size = project_max_quota_scope_size()
 
 
 class CreateProjectResourcePolicy(graphene.Mutation):

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -364,12 +364,15 @@ def is_db_retry_error(e: Exception) -> bool:
     return isinstance(e, DBAPIError) and getattr(e.orig, "pgcode", None) == "40001"
 
 
-def description_msg(version: str, detail: str | None = None):
+def description_msg(version: str, detail: str | None = None) -> str:
     val = f"Added since {version}."
     if detail:
         val = f"{val} {detail}"
     return val
 
 
-def deprecation_reason_msg(version: str):
-    return f"Deprecated since {version}."
+def deprecation_reason_msg(version: str, detail: str | None = None) -> str:
+    val = f"Deprecated since {version}."
+    if detail:
+        val = f"{val} {detail}"
+    return val

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -358,3 +358,14 @@ def agg_to_str(column: sa.Column) -> sa.sql.functions.Function:
 
 def agg_to_array(column: sa.Column) -> sa.sql.functions.Function:
     return sa.func.array_agg(psql.aggregate_order_by(column, column.asc()))
+
+
+def description_msg(version: str, detail: str | None = None):
+    val = f"Added since {version}."
+    if detail:
+        val = f"{val} {detail}"
+    return val
+
+
+def deprecation_reason_msg(version: str):
+    return f"Deprecated since {version}."


### PR DESCRIPTION
Deprecated graphql fields should not be removed.
The fields to be deleted should be marked with a deprecation message and deleted after a specified support period.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)