### PR TITLE
doc: Fix the tutorial to auto-remove the session

### DIFF
--- a/docs/dev/development-setup.rst
+++ b/docs/dev/development-setup.rst
@@ -241,7 +241,7 @@ Open yet another terminal for client and run:
    $ source ./env-local-admin-api.sh  # Use the generated local endpoint and credential config.
    $ # source ./env-local-user-api.sh  # Yo may choose an alternative credential config.
    $ ./backend.ai config
-   $ ./backend.ai run python -c 'print("hello world")'
+   $ ./backend.ai run python --rm -c 'print("hello world")'
    ∙ Session token prefix: fb05c73953
    ✔ [0] Session fb05c73953 is ready.
    hello world


### PR DESCRIPTION
It may be confusing when repeating this example block would cause
unexpected queueing in the scheduler.

<!-- readthedocs-preview sorna start -->
----
:books: Documentation preview :books:: https://sorna--1685.org.readthedocs.build/en/1685/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
:books: Documentation preview :books:: https://sorna-ko--1685.org.readthedocs.build/ko/1685/

<!-- readthedocs-preview sorna-ko end -->