### PR TITLE
fix: Lazy-load the local config in the manager CLI

### DIFF
--- a/changes/1686.fix.md
+++ b/changes/1686.fix.md
@@ -1,0 +1,1 @@
+Allow running manager CLI commands without having `manager.toml` when they do not need it

--- a/src/ai/backend/common/logging.py
+++ b/src/ai/backend/common/logging.py
@@ -55,7 +55,13 @@ logging_config_iv = t.Dict(
         t.Key("level", default="INFO"): loglevel_iv,
         t.Key("pkg-ns", default=default_pkg_ns): t.Mapping(t.String(allow_blank=True), loglevel_iv),
         t.Key("drivers", default=["console"]): t.List(t.Enum("console", "logstash", "file")),
-        t.Key("console", default=None): t.Null | t.Dict(
+        t.Key(
+            "console",
+            default={
+                "colored": None,
+                "format": "verbose",
+            },
+        ): t.Dict(
             {
                 t.Key("colored", default=None): t.Null | t.Bool,
                 t.Key("format", default="verbose"): logformat_iv,

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -19,7 +19,6 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import LogSeverity
 from ai.backend.common.validators import TimeDuration
 
-from ..config import load as load_config
 from .context import CLIContext, redis_ctx
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
@@ -60,9 +59,8 @@ def main(
     """
     Manager Administration CLI
     """
-    local_config = load_config(config_path, "DEBUG" if debug else log_level)
-    setproctitle(f"backend.ai: manager.cli {local_config['etcd']['namespace']}")
-    ctx.obj = ctx.with_resource(CLIContext(local_config=local_config))
+    setproctitle("backend.ai: manager.cli")
+    ctx.obj = ctx.with_resource(CLIContext(config_path, log_level))
 
 
 @main.command(
@@ -342,9 +340,15 @@ def fixture():
     """Command set for managing fixtures."""
 
 
+@main.group(cls=LazyGroup, import_name="ai.backend.manager.cli.api:cli")
+def api():
+    """Command set for GraphQL schema."""
+
+
 @main.group(cls=LazyGroup, import_name="ai.backend.manager.cli.gql:cli")
 def gql():
     """Command set for GraphQL schema."""
+    # Deprecated in favor of "api" but kept for backward compatibility
 
 
 @main.group(cls=LazyGroup, import_name="ai.backend.manager.cli.image:cli")

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -342,7 +342,7 @@ def fixture():
 
 @main.group(cls=LazyGroup, import_name="ai.backend.manager.cli.api:cli")
 def api():
-    """Command set for GraphQL schema."""
+    """Command set for API schema inspection and manipulation."""
 
 
 @main.group(cls=LazyGroup, import_name="ai.backend.manager.cli.gql:cli")

--- a/src/ai/backend/manager/cli/api.py
+++ b/src/ai/backend/manager/cli/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING
 
 import click
@@ -22,11 +21,7 @@ def cli(args) -> None:
 
 @cli.command()
 @click.pass_obj
-def show(cli_ctx: CLIContext) -> None:
-    warnings.warn(
-        "The 'gql' subcommand is deprecated. Use the 'api' subcommand.",
-        DeprecationWarning,
-    )
+def dump_gql_schema(cli_ctx: CLIContext) -> None:
     schema = graphene.Schema(query=Queries, mutation=Mutations, auto_camelcase=False)
     log.info("======== GraphQL API Schema ========")
     print(str(schema))

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -234,8 +234,10 @@ def etcd_fixture(
     # Clear and reset etcd namespace using CLI functions.
     redis_addr = local_config["redis"]["addr"]
     cli_ctx = CLIContext(
-        local_config=local_config,
+        config_path=Path.cwd() / "dummy-manager.toml",
+        log_level="DEBUG",
     )
+    cli_ctx._local_config = local_config  # override the lazy-loaded config
     with tempfile.NamedTemporaryFile(mode="w", suffix=".etcd.json") as f:
         etcd_fixture = {
             "volumes": {
@@ -385,8 +387,10 @@ def database(request, local_config, test_db):
 
     # Load the database schema using CLI function.
     cli_ctx = CLIContext(
-        local_config=local_config,
+        config_path=Path.cwd() / "dummy-manager.toml",
+        log_level="DEBUG",
     )
+    cli_ctx._local_config = local_config  # override the lazy-loaded config
     sqlalchemy_url = f"postgresql+asyncpg://{db_user}:{db_pass}@{db_addr}/{test_db}"
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf8") as alembic_cfg:
         alembic_cfg_data = alembic_config_template.format(


### PR DESCRIPTION
resolves #1681

Now we can run commands that do not require full "manager.toml" without
making dummy "manager.toml" and related config files.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
