### PR TITLE
deps: Upgrade halfstack (postgresql, redis, etcd)

### DIFF
--- a/docker-compose.halfstack-2309.yml
+++ b/docker-compose.halfstack-2309.yml
@@ -1,0 +1,71 @@
+version: "2.4"
+
+services:
+
+  backendai-half-db:
+    image: postgres:16.0-alpine
+    restart: unless-stopped
+    command: postgres -c 'max_connections=256'
+    networks:
+      - half
+    ports:
+      - "8100:5432"
+    environment:
+      - POSTGRES_PASSWORD=develove
+      - POSTGRES_DB=backend
+    volumes:
+      - "./volumes/${DATADIR_PREFIX:-.}/postgres-data:/var/lib/postgresql/data:rw"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  backendai-half-redis:
+    image: redis:7.2.3-alpine
+    restart: unless-stopped
+    networks:
+      - half
+    ports:
+      - "8110:6379"
+    volumes:
+      - "./volumes/${DATADIR_PREFIX:-.}/redis-data:/data:rw"
+    command: >
+      redis-server
+      --appendonly yes
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  backendai-half-etcd:
+    image: quay.io/coreos/etcd:v3.5.10
+    restart: unless-stopped
+    volumes:
+      - "./volumes/${DATADIR_PREFIX:-.}/etcd-data:/etcd-data:rw"
+    networks:
+      - half
+    ports:
+      - "8120:2379"
+    command: >
+      /usr/local/bin/etcd
+      --name backendai-etcd
+      --data-dir /etcd-data
+      --listen-client-urls http://0.0.0.0:2379
+      --advertise-client-urls http://0.0.0.0:2379
+      --listen-peer-urls http://0.0.0.0:2380
+      --initial-advertise-peer-urls http://0.0.0.0:2380
+      --initial-cluster backendai-etcd=http://0.0.0.0:2380
+      --initial-cluster-token backendai-etcd-token
+      --initial-cluster-state new
+      --enable-v2=true
+      --auto-compaction-retention 1
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+networks:
+  half:

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   backendai-half-db:
-    image: postgres:15.1-alpine
+    image: postgres:16.0-alpine
     command: postgres -c 'max_connections=256'
     networks:
       - half
@@ -17,7 +17,7 @@ services:
 
   # Initial master is redis-node01.
   backendai-half-redis-node01:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: node01
     networks:
     - half
@@ -37,7 +37,7 @@ services:
     # network partitioning.
 
   backendai-half-redis-node02:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: node02
     networks:
     - half
@@ -55,7 +55,7 @@ services:
       --min-slaves-max-lag 10
 
   backendai-half-redis-node03:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: node03
     ports:
     - 0.0.0.0:${REDIS_SLAVE2_PORT}:${REDIS_SLAVE2_PORT}
@@ -73,7 +73,7 @@ services:
       --min-slaves-max-lag 10
 
   backendai-half-redis-sentinel01:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: sentinel01
     networks:
     - half
@@ -93,7 +93,7 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
 
   backendai-half-redis-sentinel02:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: sentinel02
     networks:
     - half
@@ -113,7 +113,7 @@ services:
     - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
 
   backendai-half-redis-sentinel03:
-    image: redis:7.0.5-alpine
+    image: redis:7.2.3-alpine
     hostname: sentinel03
     networks:
     - half
@@ -133,7 +133,7 @@ services:
     - REDIS_PASSWORD=${REDIS_PASSWORD:-develove}
 
   backendai-half-etcd-proxy:
-    image: quay.io/coreos/etcd:v3.5.4
+    image: quay.io/coreos/etcd:v3.5.10
     depends_on:
       - "backendai-half-etcd-node01"
       - "backendai-half-etcd-node02"
@@ -151,7 +151,7 @@ services:
       --listen-addr=0.0.0.0:2379"
 
   backendai-half-etcd-node01:
-    image: quay.io/coreos/etcd:v3.5.4
+    image: quay.io/coreos/etcd:v3.5.10
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd01-data:/etcd-data:rw"
     networks:
@@ -175,7 +175,7 @@ services:
       --initial-cluster-state $${STATE}"
 
   backendai-half-etcd-node02:
-    image: quay.io/coreos/etcd:v3.5.4
+    image: quay.io/coreos/etcd:v3.5.10
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd02-data:/etcd-data:rw"
     networks:
@@ -199,7 +199,7 @@ services:
       --initial-cluster-state $${STATE}"
 
   backendai-half-etcd-node03:
-    image: quay.io/coreos/etcd:v3.5.4
+    image: quay.io/coreos/etcd:v3.5.10
     volumes:
       - "./tmp/backend.ai-halfstack-ha/etcd03-data:/etcd-data:rw"
     networks:

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -1,1 +1,1 @@
-docker-compose.halfstack-2303.yml
+docker-compose.halfstack-2309.yml


### PR DESCRIPTION
 postgresql: 15.2  -> 16.0
 redis:      7.0.5 -> 7.2.3
 etcd:       3.5.6 -> 3.5.10

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
