### PR TITLE
ci: Excluding lock files from size calculations

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -26,3 +26,4 @@ jobs:
       uses: "lablup/size-label-action@master"
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        IGNORED: "*.lock"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -26,4 +26,4 @@ jobs:
       uses: "lablup/size-label-action@master"
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        IGNORED: "*.lock"
+        IGNORED: "**/*.lock"


### PR DESCRIPTION
Exclude lock files from calculating size labels.
This leads to confusion about the size of pr.