### PR TITLE
feat: Add custom NPU device per node limit

### DIFF
--- a/changes/1696.feature.md
+++ b/changes/1696.feature.md
@@ -1,0 +1,1 @@
+Add option to control maximum number of NPU per session

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -81,8 +81,12 @@ config_iv = t.Dict(
                 t.Key("max_cpu_cores_per_container", default=64): t.ToInt,
                 t.Key("max_memory_per_container", default=64): t.ToInt,
                 t.Key("max_cuda_devices_per_container", default=16): t.ToInt,
-                t.Key("max_ipu_devices_per_container", default=8): t.ToInt,
                 t.Key("max_cuda_shares_per_container", default=16): t.ToInt,
+                t.Key("max_rocm_devices_per_container", default=10): t.ToInt,
+                t.Key("max_tpu_devices_per_container", default=8): t.ToInt,
+                t.Key("max_ipu_devices_per_container", default=8): t.ToInt,
+                t.Key("max_atom_devices_per_container", default=8): t.ToInt,
+                t.Key("max_warboy_devices_per_container", default=8): t.ToInt,
                 t.Key("max_shm_per_container", default=2): t.ToFloat,
                 t.Key("max_file_upload_size", default=4294967296): t.ToInt,
             }

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -35,8 +35,12 @@ connectionMode = "SESSION"
 {% toml_field "maxCPUCoresPerContainer" config["resources"]["max_cpu_cores_per_container"] %}
 {% toml_field "maxMemoryPerContainer" config["resources"]["max_memory_per_container"] %}
 {% toml_field "maxCUDADevicesPerContainer" config["resources"]["max_cuda_devices_per_container"] %}
-{% toml_field "maxIPUDevicesPerContainer" config["resources"]["max_ipu_devices_per_container"] %}
 {% toml_field "maxCUDASharesPerContainer" config["resources"]["max_cuda_shares_per_container"] %}
+{% toml_field "maxROCMDevicesPerContainer" config["resources"]["max_rocm_devices_per_container"] %}
+{% toml_field "maxTPUDevicesPerContainer" config["resources"]["max_tpu_devices_per_container"] %}
+{% toml_field "maxIPUDevicesPerContainer" config["resources"]["max_ipu_devices_per_container"] %}
+{% toml_field "maxATOMDevicesPerContainer" config["resources"]["max_atom_devices_per_container"] %}
+{% toml_field "maxWarboyDevicesPerContainer" config["resources"]["max_warboy_devices_per_container"] %}
 {% toml_field "maxShmPerContainer" config["resources"]["max_shm_per_container"] %}
 {% toml_field "maxFileUploadSize" config["resources"]["max_file_upload_size"] %}
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 53fe78f</samp>

### Summary
:sparkles::wrench::gear:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for supporting more hardware options for Backend.AI kernels.
2.  :wrench: - This emoji represents the adjustment of configuration or settings, which is the case for adding new configuration keys for the accelerator devices and updating the template file for generating the configuration file.
3.  :gear: - This emoji represents the improvement or refinement of internal mechanisms or processes, which is the case for validating the configuration schema with the new configuration keys.
-->
This pull request adds new configuration keys and schema validation for different types of accelerator devices, such as `ROCm`, `TPU`, `ATOM`, and `Warboy`, to enable more hardware options for Backend.AI kernels. The changes affect the files `config.py` and `config.toml.j2` in the web module.

> _`config_iv` grows_
> _New keys for devices added_
> _Winter of hardware_

### Walkthrough
* Add new configuration keys for different types of accelerator devices ([link](https://github.com/lablup/backend.ai/pull/1696/files?diff=unified&w=0#diff-276f2227b885560cf0185256069926271e7bdc8d795952bce6ceb14c02651d3cL84-R89), [link](https://github.com/lablup/backend.ai/pull/1696/files?diff=unified&w=0#diff-1780d1f94e6dd2238a08c71e0b4e02034ce06c4a6e6e142807bb6109a7226003L38-R43))



**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
