### PR TITLE
fix: allow `Undefined` value to `ModifyGroupInput.user_update_mode`

### DIFF
--- a/changes/1698.fix.md
+++ b/changes/1698.fix.md
@@ -1,0 +1,1 @@
+Allow any value of `user_update_mode` since it raises error when client-py requests group update.

--- a/changes/1698.fix.md
+++ b/changes/1698.fix.md
@@ -1,1 +1,1 @@
-Allow any value of `user_update_mode` since it raises error when client-py requests group update.
+Allow `Undefined` value of `ModifyGroupInput.user_update_mode` field to enable client-py updates group.

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -486,8 +486,6 @@ class ModifyGroup(graphene.Mutation):
 
         if "name" in data and _rx_slug.search(data["name"]) is None:
             raise ValueError("invalid name format. slug format required.")
-        if props.user_update_mode not in (None, "add", "remove"):
-            raise ValueError("invalid user_update_mode")
         if not props.user_uuids:
             props.user_update_mode = None
         if not data and props.user_update_mode is None:

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -20,6 +20,7 @@ import aiotools
 import graphene
 import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
+from graphql import Undefined
 from sqlalchemy.engine.row import Row
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.orm import relationship
@@ -486,6 +487,8 @@ class ModifyGroup(graphene.Mutation):
 
         if "name" in data and _rx_slug.search(data["name"]) is None:
             raise ValueError("invalid name format. slug format required.")
+        if props.user_update_mode not in (None, Undefined, "add", "remove"):
+            raise ValueError("invalid user_update_mode")
         if not props.user_uuids:
             props.user_update_mode = None
         if not data and props.user_update_mode is None:


### PR DESCRIPTION
follow-up #1688 
partial fix of #1697 

`ModifyGroupInput.user_update_mode` field can have `Undefined` value since #1688, let's allow the value.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
