### PR TITLE
feature: pass manager's RootContext to hook plugins

### DIFF
--- a/changes/1699.feature.md
+++ b/changes/1699.feature.md
@@ -1,0 +1,1 @@
+Pass `manager.api.RootContext` to plugins for easy access to any Manager's context.

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -436,6 +436,7 @@ async def hook_plugin_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     ctx = HookPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     root_ctx.hook_plugin_ctx = ctx
     await ctx.init(
+        context=ctx,
         allowlist=root_ctx.local_config["manager"]["allowed-plugins"],
         blocklist=root_ctx.local_config["manager"]["disabled-plugins"],
     )


### PR DESCRIPTION
Since it is too hard to get `db` or other contexts of Manager from plugins, let's pass `RootContext` to plugins

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
