### PR TITLE
feature: fetch SessionRow after `PRE_START_SESSION` hook

### DIFF
--- a/changes/1700.feature.md
+++ b/changes/1700.feature.md
@@ -1,0 +1,1 @@
+Fetch compute session data after `PRE_START_SESSION` hook to sync any update made by plugins.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1530,7 +1530,6 @@ class SchedulerDispatcher(aobject):
         log_args = (session,)
         log.debug(log_fmt + "try-starting", *log_args)
         try:
-            assert len(session.kernels) > 0
             await self.registry.start_session(sched_ctx, session)
         except Exception as e:
             status_data = convert_to_status_data(e, self.local_config["debug"]["enabled"])


### PR DESCRIPTION
If any Manager's plugin update SessionRow(or sibling KernelRow) data in `PRE_START_SESSION` hook, we should fetch the updated data from DB.

This is related to edu launcher, which appends a bootstrap script in `PRE_START_SESSION` hook.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version