### PR TITLE
fix: handle error in storage API error handler

### DIFF
--- a/changes/1701.fix.md
+++ b/changes/1701.fix.md
@@ -1,0 +1,1 @@
+Handle error in storage proxy's API error handler.

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -106,10 +106,17 @@ def handle_fs_errors(
     except OSError as e:
         related_paths = []
         msg = str(e) if e.strerror is None else e.strerror
+
+        def _append_fpath(fname: Any) -> None:
+            try:
+                related_paths.append(str(volume.strip_vfpath(vfid, Path(fname))))
+            except (ValueError, OSError):
+                related_paths.append(fname)
+
         if e.filename:
-            related_paths.append(str(volume.strip_vfpath(vfid, Path(e.filename))))
+            _append_fpath(e.filename)
         if e.filename2:
-            related_paths.append(str(volume.strip_vfpath(vfid, Path(e.filename2))))
+            _append_fpath(e.filename2)
         raise web.HTTPBadRequest(
             body=json.dumps(
                 {


### PR DESCRIPTION
There are some cases that error occurs in storage proxy's API error handler.
e.g) if it is impossible to resolve a file path because of permission or invalid path, `ValueError` is raised.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
