### PR TITLE
feat: Per-image rescan with improved multi-arch support

### DIFF
--- a/changes/1712.feature.md
+++ b/changes/1712.feature.md
@@ -1,1 +1,1 @@
-Allow per-image metadata sync in the `mgr image rescan` command
+Implement per-image metadata sync in the `mgr image rescan` command and deprecate scanning a whole Docker Hub account to avoid the API rate limit

--- a/changes/1712.feature.md
+++ b/changes/1712.feature.md
@@ -1,0 +1,1 @@
+Allow per-image metadata sync in the `mgr image rescan` command

--- a/src/ai/backend/manager/cli/etcd.py
+++ b/src/ai/backend/manager/cli/etcd.py
@@ -254,7 +254,7 @@ def set_image_resource_limit(
 @cli.command()
 @click.argument("registry")
 @click.pass_obj
-def rescan_images(cli_ctx: CLIContext, registry) -> None:
+def rescan_images(cli_ctx: CLIContext, registry: str) -> None:
     """
     Update the kernel image metadata from all configured docker registries.
 
@@ -269,7 +269,7 @@ def rescan_images(cli_ctx: CLIContext, registry) -> None:
 @click.argument("target")
 @click.argument("architecture")
 @click.pass_obj
-def alias(cli_ctx, alias, target, architecture) -> None:
+def alias(cli_ctx: CLIContext, alias: str, target: str, architecture: str) -> None:
     """Add an image alias from the given alias to the target image reference."""
     log.warn("etcd alias command is deprecated, use image alias instead")
     asyncio.run(alias_impl(cli_ctx, alias, target, architecture))
@@ -278,7 +278,7 @@ def alias(cli_ctx, alias, target, architecture) -> None:
 @cli.command()
 @click.argument("alias")
 @click.pass_obj
-def dealias(cli_ctx, alias) -> None:
+def dealias(cli_ctx: CLIContext, alias: str) -> None:
     """Remove an alias."""
     log.warn("etcd dealias command is deprecated, use image dealias instead")
     asyncio.run(dealias_impl(cli_ctx, alias))
@@ -287,7 +287,7 @@ def dealias(cli_ctx, alias) -> None:
 @cli.command()
 @click.argument("value")
 @click.pass_obj
-def quote(cli_ctx: CLIContext, value) -> None:
+def quote(cli_ctx: CLIContext, value: str) -> None:
     """
     Quote the given string for use as a URL piece in etcd keys.
     Use this to generate argument inputs for aliases and raw image keys.
@@ -298,7 +298,7 @@ def quote(cli_ctx: CLIContext, value) -> None:
 @cli.command()
 @click.argument("value")
 @click.pass_obj
-def unquote(cli_ctx: CLIContext, value) -> None:
+def unquote(cli_ctx: CLIContext, value: str) -> None:
     """
     Unquote the given string used as a URL piece in etcd keys.
     """
@@ -316,7 +316,12 @@ def unquote(cli_ctx: CLIContext, value) -> None:
     help="The configuration scope to put the value.",
 )
 @click.pass_obj
-def set_storage_sftp_scaling_group(cli_ctx: CLIContext, proxy, scaling_groups, scope) -> None:
+def set_storage_sftp_scaling_group(
+    cli_ctx: CLIContext,
+    proxy: str,
+    scaling_groups: str,
+    scope: ConfigScopes,
+) -> None:
     """
     Updates storage proxy node config's SFTP desginated scaling groups.
     To enter multiple scaling groups concatenate names with comma(,).
@@ -346,7 +351,11 @@ def set_storage_sftp_scaling_group(cli_ctx: CLIContext, proxy, scaling_groups, s
     help="The configuration scope to put the value.",
 )
 @click.pass_obj
-def remove_storage_sftp_scaling_group(cli_ctx: CLIContext, proxy, scope) -> None:
+def remove_storage_sftp_scaling_group(
+    cli_ctx: CLIContext,
+    proxy: str,
+    scope: ConfigScopes,
+) -> None:
     """
     Removes storage proxy node config's SFTP desginated scaling groups.
     """

--- a/src/ai/backend/manager/cli/image.py
+++ b/src/ai/backend/manager/cli/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 

--- a/src/ai/backend/manager/cli/image.py
+++ b/src/ai/backend/manager/cli/image.py
@@ -77,7 +77,7 @@ def set_resource_limit(
 
 
 @cli.command()
-@click.argument("registry", required=False, default="")
+@click.argument("registry_or_image", required=False, default="")
 @click.option(
     "--local",
     is_flag=True,
@@ -85,13 +85,13 @@ def set_resource_limit(
     help="Scan the local Docker daemon instead of a registry",
 )
 @click.pass_obj
-def rescan(cli_ctx, registry: str, local: bool) -> None:
+def rescan(cli_ctx, registry_or_image: str, local: bool) -> None:
     """
     Update the kernel image metadata from all configured docker registries.
 
     Pass the name (usually hostname or "lablup") of the Docker registry configured as REGISTRY.
     """
-    asyncio.run(rescan_images_impl(cli_ctx, registry, local))
+    asyncio.run(rescan_images_impl(cli_ctx, registry_or_image, local))
 
 
 @cli.command()

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -150,15 +150,15 @@ async def set_image_resource_limit(
             log.exception("An error occurred.")
 
 
-async def rescan_images(cli_ctx: CLIContext, registry: str, local: bool) -> None:
-    if not registry and not local:
-        raise click.BadArgumentUsage("Please specify a valid registry name.")
+async def rescan_images(cli_ctx: CLIContext, registry_or_image: str, local: bool) -> None:
+    if not registry_or_image and not local:
+        raise click.BadArgumentUsage("Please specify a valid registry or full image name.")
     async with (
         connect_database(cli_ctx.local_config) as db,
         etcd_ctx(cli_ctx) as etcd,
     ):
         try:
-            await rescan_images_func(etcd, db, registry=registry, local=local)
+            await rescan_images_func(etcd, db, registry_or_image, local=local)
         except Exception:
             log.exception("An error occurred.")
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -345,8 +345,14 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                     )
                     progress_msg = f"Skipped {image}:{tag}/{architecture} ({skip_reason})"
                 else:
-                    log.info("Updated image - {0}:{1}/{2}", image, tag, architecture)
-                    progress_msg = f"Updated {image}:{tag}/{architecture}"
+                    log.info(
+                        "Updated image - {0}:{1}/{2} ({3})",
+                        image,
+                        tag,
+                        architecture,
+                        manifest["digest"],
+                    )
+                    progress_msg = f"Updated {image}:{tag}/{architecture} ({manifest['digest']})"
                 if (reporter := progress_reporter.get()) is not None:
                     await reporter.update(1, message=progress_msg)
 

--- a/src/ai/backend/manager/container_registry/docker.py
+++ b/src/ai/backend/manager/container_registry/docker.py
@@ -19,6 +19,12 @@ class DockerHubRegistry(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
     ) -> AsyncIterator[str]:
         # We need some special treatment for the Docker Hub.
+        raise DeprecationWarning(
+            "Rescanning the whole Docker registry is disabled due to rate "
+            "limits of the Docker Hub API."
+        )
+        yield ""
+        """
         params = {"page_size": "30"}
         username = self.registry_info["username"]
         hub_url = yarl.URL("https://hub.docker.com")
@@ -47,6 +53,7 @@ class DockerHubRegistry(BaseContainerRegistry):
                 repo_list_url = hub_url.with_path(next_page_url.path).with_query(
                     next_page_url.query
                 )
+        """
 
 
 class DockerRegistry_v2(BaseContainerRegistry):

--- a/src/ai/backend/manager/container_registry/docker.py
+++ b/src/ai/backend/manager/container_registry/docker.py
@@ -3,6 +3,7 @@ import logging
 from typing import AsyncIterator, Optional, cast
 
 import aiohttp
+import typing_extensions
 import yarl
 
 from ai.backend.common.docker import login as registry_login
@@ -14,17 +15,23 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 
 
 class DockerHubRegistry(BaseContainerRegistry):
+    @typing_extensions.deprecated(
+        "Rescanning a whole Docker Hub account is disabled due to the API rate limit."
+    )
     async def fetch_repositories(
         self,
         sess: aiohttp.ClientSession,
     ) -> AsyncIterator[str]:
         # We need some special treatment for the Docker Hub.
         raise DeprecationWarning(
-            "Rescanning the whole Docker registry is disabled due to rate "
-            "limits of the Docker Hub API."
+            "Rescanning a whole Docker Hub account is disabled due to the API rate limit."
         )
-        yield ""
-        """
+        yield ""  # dead code to ensure the type of method
+
+    async def fetch_repositories_legacy(
+        self,
+        sess: aiohttp.ClientSession,
+    ) -> AsyncIterator[str]:
         params = {"page_size": "30"}
         username = self.registry_info["username"]
         hub_url = yarl.URL("https://hub.docker.com")
@@ -53,7 +60,6 @@ class DockerHubRegistry(BaseContainerRegistry):
                 repo_list_url = hub_url.with_path(next_page_url.path).with_query(
                     next_page_url.query
                 )
-        """
 
 
 class DockerRegistry_v2(BaseContainerRegistry):

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import urllib.parse
-from pprint import pprint
 from typing import Any, AsyncIterator, Mapping, Optional, cast
 
 import aiohttp
@@ -200,9 +199,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
                 or reference["platform"]["architecture"] == "unknown"
             ):
                 continue
-            print("process_oci_index: ", end="")
-            pprint(image_info)
-            pprint(reference)
             digests.append((reference["child_digest"], reference["platform"]["architecture"]))
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += len(digests)

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -1,15 +1,24 @@
+from __future__ import annotations
+
+import json
 import logging
 import urllib.parse
+from pprint import pprint
 from typing import Any, AsyncIterator, Mapping, Optional, cast
 
 import aiohttp
 import aiotools
 import yarl
 
+from ai.backend.common.docker import arch_name_aliases
 from ai.backend.common.docker import login as registry_login
 from ai.backend.common.logging import BraceStyleAdapter
 
-from .base import BaseContainerRegistry
+from .base import (
+    BaseContainerRegistry,
+    concurrency_sema,
+    progress_reporter,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
@@ -152,10 +161,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
                                     await self._process_docker_v2_multiplatform_image(
                                         tg, sess, rqst_args, image, image_info
                                     )
-                                case _:
-                                    await self._process_docker_v2_image(
-                                        tg, sess, rqst_args, image, image_info
-                                    )
+                                # case _:
+                                #     await self._process_docker_v2_image(
+                                #         tg, sess, rqst_args, image, image_info
+                                #     )
                         finally:
                             if skip_reason:
                                 log.warn("Skipped image - {}:{} ({})", image, tag, skip_reason)
@@ -179,21 +188,30 @@ class HarborRegistry_v2(BaseContainerRegistry):
         if not rqst_args.get("headers"):
             rqst_args["headers"] = {}
         rqst_args["headers"].update({"Accept": "application/vnd.oci.image.manifest.v1+json"})
-        digests: list[str] = []
+        digests: list[tuple[str, str]] = []
+        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
                 or reference["platform"]["architecture"] == "unknown"
             ):
                 continue
-            digests.append(reference["child_digest"])
-        if (reporter := self.reporter.get()) is not None:
+            print("process_oci_index: ", end="")
+            pprint(image_info)
+            pprint(reference)
+            digests.append((reference["child_digest"], reference["platform"]["architecture"]))
+        if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += len(digests)
         async with aiotools.TaskGroup() as tg:
-            for digest in digests:
+            for digest, architecture in digests:
                 tg.create_task(
                     self._scan_tag(
-                        sess, rqst_args, image, digest, tag=image_info["tags"][0]["name"]
+                        sess,
+                        rqst_args,
+                        image,
+                        digest=digest,
+                        tag=tag_name,
+                        architecture=architecture,
                     )
                 )
 
@@ -211,21 +229,27 @@ class HarborRegistry_v2(BaseContainerRegistry):
         rqst_args["headers"].update(
             {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
         )
-        digests: list[str] = []
+        digests: list[tuple[str, str]] = []
+        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
                 or reference["platform"]["architecture"] == "unknown"
             ):
                 continue
-            digests.append(reference["child_digest"])
-        if (reporter := self.reporter.get()) is not None:
+            digests.append((reference["child_digest"], reference["platform"]["architecture"]))
+        if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += len(digests)
         async with aiotools.TaskGroup() as tg:
-            for digest in digests:
+            for digest, architecture in digests:
                 tg.create_task(
                     self._scan_tag(
-                        sess, rqst_args, image, digest, tag=image_info["tags"][0]["name"]
+                        sess,
+                        rqst_args,
+                        image,
+                        digest=digest,
+                        tag=tag_name,
+                        architecture=architecture,
                     )
                 )
 
@@ -243,7 +267,73 @@ class HarborRegistry_v2(BaseContainerRegistry):
         rqst_args["headers"].update(
             {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
         )
-        if (reporter := self.reporter.get()) is not None:
+        if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
+        tag_name = image_info["tags"][0]["name"]
         async with aiotools.TaskGroup() as tg:
-            tg.create_task(self._scan_tag(sess, rqst_args, image, image_info["tags"][0]["name"]))
+            # TODO: re-implement
+            tg.create_task(
+                self._scan_tag(sess, rqst_args, image, digest="", tag=tag_name, architecture="")
+            )
+
+    async def _scan_tag(
+        self,
+        sess: aiohttp.ClientSession,
+        rqst_args: dict[str, Any],
+        image: str,
+        *,
+        digest: str,
+        tag: str,
+        architecture: str,
+    ) -> None:
+        manifests = {}
+        async with concurrency_sema.get():
+            async with sess.get(
+                self.registry_url / f"v2/{image}/manifests/{digest}", **rqst_args
+            ) as resp:
+                if resp.status == 404:
+                    # ignore missing tags
+                    # (may occur after deleting an image from the docker hub)
+                    return
+                resp.raise_for_status()
+                top_manifest = await resp.json()
+                architecture = arch_name_aliases.get(architecture, architecture)
+                config_digest = top_manifest["config"]["digest"]
+                size_bytes = (
+                    sum(layer["size"] for layer in top_manifest["layers"])
+                    + top_manifest["config"]["size"]
+                )
+                async with sess.get(
+                    self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
+                ) as resp:
+                    resp.raise_for_status()
+                    data = json.loads(await resp.read())
+                    labels = {}
+                    if "container_config" in data:
+                        raw_labels = data["container_config"].get("Labels")
+                        if raw_labels:
+                            labels.update(raw_labels)
+                        else:
+                            log.warn(
+                                "label not found on image {}:{}/{}",
+                                image,
+                                tag,
+                                architecture,
+                            )
+                    else:
+                        raw_labels = data["config"].get("Labels")
+                        if raw_labels:
+                            labels.update(raw_labels)
+                        else:
+                            log.warn(
+                                "label not found on image {}:{}/{}",
+                                image,
+                                tag,
+                                architecture,
+                            )
+                    manifests[architecture] = {
+                        "size": size_bytes,
+                        "labels": labels,
+                        "digest": config_digest,
+                    }
+            await self._read_manifest(image, tag, manifests)

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import enum
 import functools
 import logging
@@ -87,7 +86,6 @@ async def rescan_images(
 ) -> None:
     # cannot import ai.backend.manager.config at start due to circular import
     from ..config import container_registry_iv
-    from ..container_registry.base import all_updates, concurrency_sema
 
     if local:
         registries = {
@@ -123,13 +121,7 @@ async def rescan_images(
                     )
                     scanner_cls = get_container_registry_cls(registry_info)
                     scanner = scanner_cls(db, registry_name, registry_info)
-                    all_updates_token = all_updates.set({})
-                    sema_token = concurrency_sema.set(asyncio.Semaphore(1))
-                    try:
-                        await scanner.scan_single_ref(repo_with_tag)
-                    finally:
-                        concurrency_sema.reset(sema_token)
-                        all_updates.reset(all_updates_token)
+                    await scanner.scan_single_ref(repo_with_tag)
                     return
             else:
                 # treat it as a normal registry name


### PR DESCRIPTION
This PR resolves #1621.

* Implement rescanning a single image's metadata by specifying the full image and tag name.
* Disallow and deprecate rescanning a whole Docker Hub account (e.g., index.docker.io/lablup) to avoid the API rate limit.
* Ensure multi-arch compatibility with both Harbor and Docker Hub.

```shell
# example to (re)scan an entire registry
./backend.ai mgr image rescan cr.backend.ai
# example to (re)scan a single image
./backend.ai mgr image rescan index.docker.io/lablup/python:3.9-ubuntu22.04

# does not work due to parsing issues
./backend.ai mgr image rescan lablup/python:3.9-ubuntu22.04
```

> **Note**
> - Both rescanning registries or individual images require explicit configuration of registries (including credentials if required) in the shared config (etcd's `config/docker/registry` keys)
> - Users must specify the full image name including `index.docker.io` for Docker Hub images for consistent parsing of image names. (It does not work with `lablup/python:3.9-ubuntu22.04`)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
