### PR TITLE
fix: allow empty `auto_terminate_abusing_kernel` field from agent heartbeat

### DIFF
--- a/changes/1715.fix.md
+++ b/changes/1715.fix.md
@@ -1,0 +1,1 @@
+Allow empty `auto_terminate_abusing_kernel` field from agent heartbeat.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2695,7 +2695,7 @@ class AgentRegistry:
         )
         current_addr = agent_info["addr"]
         sgroup = agent_info.get("scaling_group", "default")
-        auto_terminate_abusing_kernel = agent_info["auto_terminate_abusing_kernel"]
+        auto_terminate_abusing_kernel = agent_info.get("auto_terminate_abusing_kernel", False)
         async with self.heartbeat_lock:
             instance_rejoin = False
 


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version