### PR TITLE
ci: Add sbom report to release artifact

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -401,9 +401,11 @@ jobs:
         path: .pants.d/pants.log
       if: always()  # We want the log even on failures.
 
+  build-sbom:
+    uses: ./.github/workflows/sbom.yml
 
   make-final-release:
-    needs: [build-scies, build-wheels]
+    needs: [build-scies, build-wheels, build-sbom]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: deploy-to-pypi
@@ -445,8 +447,6 @@ jobs:
       with:
         name: local-proxy
         path: dist
-    - name: SBOM report generation
-      uses: ./.github/workflows/sbom.yml
     - name: Download SBOM report
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -445,6 +445,13 @@ jobs:
       with:
         name: local-proxy
         path: dist
+    - name: SBOM report generation
+      uses: ./.github/workflows/sbom.yml
+    - name: Download SBOM report
+      uses: actions/download-artifact@v3
+      with:
+        name: SBOM report
+        path: dist
     - name: Release to GitHub
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,6 +1,6 @@
 name: SBOM report
 
-on: [workflow_dispatch]
+on: [workflow_dispatch, workflow_call]
 
 jobs:
   sbom:


### PR DESCRIPTION
When releasing the sbom workflow that was previously executed manually, it is included and added to the artifact.
