### PR TITLE
fix: Restrict destroy of terminated sessions

### DIFF
--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2144,6 +2144,10 @@ class AgentRegistry:
                     await self.event_producer.produce_event(
                         SessionTerminatingEvent(session_id, reason),
                     )
+                case SessionStatus.TERMINATED:
+                    raise GenericForbidden(
+                        "Cannot destroy sessions that has already been already terminated"
+                    )
                 case _:
                     await SessionRow.set_session_status(
                         self.db, session_id, SessionStatus.TERMINATING


### PR DESCRIPTION
destroy() API determines determines what to do based on the status of the session. It should not do anything if the session is already terminated.


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
