### PR TITLE
feat: Use `ui.menu_blocklist` to hide pipeline menu button

### DIFF
--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,0 +1,1 @@
+Use `ui.menu_blocklist` to hide pipeline menu button and delete `pipeline.hide-side-menu-button`.

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -34,7 +34,6 @@ max_file_upload_size = 4294967296
 [pipeline]
 endpoint = "http://127.0.0.1:9500"
 frontend-endpoint = "http://127.0.0.1:3000"
-hide-side-menu-button = false
 jwt.secret = "7<:~[X,^Z1XM!*,Pe:PHR!bv,H~Q#l177<7gf_XHD6.<*<.t<[o|V5W(=0x:jTh-"
 
 [ui]

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -105,8 +105,6 @@ max_file_upload_size = 4294967296
 #endpoint = "http://127.0.0.1:9500"
 # Endpoint to the pipeline service's frontend
 #frontend-endpoint = "http://127.0.0.1:3000"
-# Hide pipeline service shortcut button
-#hide-side-menu-button = false
 # A secret to sign JWTs used to authenticate users from the pipeline service
 #jwt.secret = "7<:~[X,^Z1XM!*,Pe:PHR!bv,H~Q#l177<7gf_XHD6.<*<.t<[o|V5W(=0x:jTh-"
 
@@ -117,7 +115,7 @@ brand = "Lablup Cloud"
 # Default environment to import GitHub repositories / notebooks
 # default_import_environment = 'index.docker.io/lablup/python:3.6-ubuntu18.04'
 # Comma-separated sidebar menu pages
-#menu_blocklist = "statistics"
+#menu_blocklist = "statistics,pipeline"
 
 [api]
 domain = "default"

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -21,7 +21,6 @@ _config_defaults: Mapping[str, Any] = {
     "pipeline": {
         "endpoint": yarl.URL("http://127.0.0.1:9500"),
         "frontend-endpoint": yarl.URL("http://127.0.0.1:3000"),
-        "hide-side-menu-button": False,
         "jwt": {
             "secret": "7<:~[X,^Z1XM!*,Pe:PHR!bv,H~Q#l177<7gf_XHD6.<*<.t<[o|V5W(=0x:jTh-",
         },
@@ -112,10 +111,6 @@ config_iv = t.Dict(
                     ["frontend_endpoint", "frontend-endpoint"],
                     default=_config_defaults["pipeline"]["frontend-endpoint"],
                 ): tx.URL,
-                tx.AliasedKey(
-                    ["hide_side_menu_button", "hide-side-menu-button"],
-                    default=_config_defaults["pipeline"]["hide-side-menu-button"],
-                ): t.ToBool,
                 t.Key("jwt", default=_config_defaults["pipeline"]["jwt"]): t.Dict(
                     {
                         t.Key(

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -67,4 +67,3 @@ connectionMode = "SESSION"
 [pipeline]
 {% toml_field "endpoint" config["pipeline"]["endpoint"]|string %}
 {% toml_field "frontendEndpoint" config["pipeline"]["frontend_endpoint"]|string %}
-{% toml_field "hideSideMenuButton" config["pipeline"]["hide_side_menu_button"] %}


### PR DESCRIPTION
This PR is a counterpart against lablup/backend.ai-webui#2036 and partially reverts #1692 

This PR removes recently added `pipeline.hide-side-menu-button` and uses `ui.menu_blocklist` which already has been used to manage various menu buttons, to enhance maintenance.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
