### PR TITLE
fix: Additional macOS installer issues

### DIFF
--- a/changes/1731.fix.md
+++ b/changes/1731.fix.md
@@ -1,0 +1,1 @@
+Fix additional installer issues found in a relatively fresher macOS instance

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -255,7 +255,7 @@ class Context(metaclass=ABCMeta):
         sudo = " ".join(self.docker_sudo)
         await self.run_shell(
             f"""
-        {sudo} docker compose up -d && \\
+        {sudo} docker compose up --pull -d && \\
         {sudo} docker compose ps
         """,
             cwd=self.install_info.base_path,

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -861,7 +861,7 @@ class PackageContext(Context):
 
     async def _validate_checksum(self, pkg_path: Path, csum_path: Path) -> None:
         proc = await asyncio.create_subprocess_exec(
-            *["sha256sum", "-c", csum_path.name],
+            *["shasum", "-a", "256", "-c", csum_path.name],
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
             cwd=csum_path.parent,


### PR DESCRIPTION
Yet another follow-up to #1694 and #1716.
Thanks to @reiden21 and @kimjmin !

- a-scie/jump#172
- Replace `sha256sum` with `shasum -a 256` (the latter works with Linux as well!) for when the homebrew setup does not have `coreutils` installed yet.
- Let `docker compose up` to pull if images are missing.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
