### PR TITLE
fix: Installer regression by #1724 and refactor docker connector for richer debug info

### DIFF
--- a/changes/1732.fix.md
+++ b/changes/1732.fix.md
@@ -1,0 +1,1 @@
+Fix an installer regression in #1724 to inappropriately cache an aiohttp connector instance used to access the local Docker API

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -67,9 +67,9 @@ class libnuma:
 
         async def read_cgroup_cpuset() -> tuple[set[int], str] | None:
             try:
-                _, docker_host, connector = get_docker_connector()
-                async with aiohttp.ClientSession(connector=connector) as sess:
-                    async with sess.get(docker_host / "info") as resp:
+                connector = get_docker_connector()
+                async with aiohttp.ClientSession(connector=connector.connector) as sess:
+                    async with sess.get(connector.docker_host / "info") as resp:
                         data = await resp.json()
             except (RuntimeError, aiohttp.ClientError):
                 return None
@@ -151,9 +151,9 @@ class libnuma:
                 case "darwin" | "win32":
                     try:
                         cpuset_source = "the cpus accessible by the docker service"
-                        _, docker_host, connector = get_docker_connector()
-                        async with aiohttp.ClientSession(connector=connector) as sess:
-                            async with sess.get(docker_host / "info") as resp:
+                        connector = get_docker_connector()
+                        async with aiohttp.ClientSession(connector=connector.connector) as sess:
+                            async with sess.get(connector.docker_host / "info") as resp:
                                 data = await resp.json()
                                 return {idx for idx in range(data["NCPU"])}
                     except (RuntimeError, aiohttp.ClientError):

--- a/src/ai/backend/common/cgroup.py
+++ b/src/ai/backend/common/cgroup.py
@@ -31,9 +31,9 @@ class CgroupVersion:
 
 
 async def get_docker_cgroup_version() -> CgroupVersion:
-    _, docker_host, connector = get_docker_connector()
-    async with aiohttp.ClientSession(connector=connector) as sess:
-        async with sess.get(docker_host / "info") as resp:
+    connector = get_docker_connector()
+    async with aiohttp.ClientSession(connector=connector.connector) as sess:
+        async with sess.get(connector.docker_host / "info") as resp:
             data = await resp.json()
             return CgroupVersion(data["CgroupVersion"], data["CgroupDriver"])
 

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -218,7 +218,6 @@ def get_docker_connector() -> DockerConnector:
             DockerConnectorSource.USER_CONTEXT,
         )
     sock_path, docker_host, connector = search_docker_socket_files()
-    assert not connector.closed  # TODO: why is it starting as closed at the second run???????
     return DockerConnector(
         sock_path,
         docker_host,

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -196,7 +196,7 @@ def search_docker_socket_files() -> tuple[Path | None, yarl.URL, aiohttp.BaseCon
     return (
         sock_path,
         docker_host,
-        connector_cls(os.fsdecode(sock_path)),
+        connector_cls(os.fsdecode(sock_path), force_close=True),
     )
 
 

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -206,6 +206,7 @@ def get_docker_connector() -> DockerConnector:
             DockerConnectorSource.USER_CONTEXT,
         )
     sock_path, docker_host, connector = search_docker_socket_files()
+    assert not connector.closed  # TODO: why is it starting as closed at the second run???????
     return DockerConnector(
         sock_path,
         docker_host,

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import functools
 import ipaddress
 import itertools
@@ -8,6 +9,7 @@ import logging
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     Any,
@@ -98,6 +100,20 @@ inference_image_label_schema = t.Dict(
 ).ignore_extra("*")
 
 
+class DockerConnectorSource(enum.Enum):
+    ENV_VAR = enum.auto()
+    USER_CONTEXT = enum.auto()
+    KNOWN_LOCATION = enum.auto()
+
+
+@dataclass()
+class DockerConnector:
+    sock_path: Path | None
+    docker_host: yarl.URL
+    connector: aiohttp.BaseConnector
+    source: DockerConnectorSource
+
+
 @functools.lru_cache()
 def get_docker_context_host() -> str | None:
     try:
@@ -172,12 +188,30 @@ def search_docker_socket_files() -> tuple[Path | None, yarl.URL, aiohttp.BaseCon
         raise RuntimeError(f"could not find the docker socket; tried: {searched_paths}")
 
 
-def get_docker_connector() -> tuple[Path | None, yarl.URL, aiohttp.BaseConnector]:
+def get_docker_connector() -> DockerConnector:
     if raw_docker_host := os.environ.get("DOCKER_HOST", None):
-        return parse_docker_host_url(yarl.URL(raw_docker_host))
+        sock_path, docker_host, connector = parse_docker_host_url(yarl.URL(raw_docker_host))
+        return DockerConnector(
+            sock_path,
+            docker_host,
+            connector,
+            DockerConnectorSource.ENV_VAR,
+        )
     if raw_docker_host := get_docker_context_host():
-        return parse_docker_host_url(yarl.URL(raw_docker_host))
-    return search_docker_socket_files()
+        sock_path, docker_host, connector = parse_docker_host_url(yarl.URL(raw_docker_host))
+        return DockerConnector(
+            sock_path,
+            docker_host,
+            connector,
+            DockerConnectorSource.USER_CONTEXT,
+        )
+    sock_path, docker_host, connector = search_docker_socket_files()
+    return DockerConnector(
+        sock_path,
+        docker_host,
+        connector,
+        DockerConnectorSource.KNOWN_LOCATION,
+    )
 
 
 async def login(

--- a/src/ai/backend/install/docker.py
+++ b/src/ai/backend/install/docker.py
@@ -118,7 +118,10 @@ async def detect_system_docker(ctx: Context) -> str:
     async with aiohttp.ClientSession(connector=connector.connector) as sess:
         async with sess.get(connector.docker_host / "version") as r:
             if r.status != 200:
-                raise RuntimeError("Failed to query the Docker daemon API")
+                raise RuntimeError(
+                    "The Docker daemon API responded with unexpected response:"
+                    f" {r.status} {r.reason}"
+                )
             response_data = await r.json()
             return response_data["Version"]
 
@@ -187,6 +190,8 @@ async def check_docker(ctx: Context) -> None:
         else:
             fail_with_system_docker_install_request()
 
+    # Compose is not a part of the docker API but a client-side plugin.
+    # We need to execute the client command to get information about it.
     proc = await asyncio.create_subprocess_exec(
         *ctx.docker_sudo, "docker", "compose", "version", stdout=asyncio.subprocess.PIPE
     )

--- a/src/ai/backend/install/docker.py
+++ b/src/ai/backend/install/docker.py
@@ -162,6 +162,7 @@ async def get_preferred_pants_local_exec_root(ctx: Context) -> str:
 
 async def determine_docker_sudo() -> bool:
     connector = get_docker_connector()
+    assert not connector.connector.closed  # TODO: why this works??????????
     try:
         async with aiohttp.ClientSession(connector=connector.connector) as sess:
             async with sess.get(connector.docker_host / "version") as r:

--- a/src/ai/backend/install/docker.py
+++ b/src/ai/backend/install/docker.py
@@ -162,7 +162,6 @@ async def get_preferred_pants_local_exec_root(ctx: Context) -> str:
 
 async def determine_docker_sudo() -> bool:
     connector = get_docker_connector()
-    assert not connector.connector.closed  # TODO: why this works??????????
     try:
         async with aiohttp.ClientSession(connector=connector.connector) as sess:
             async with sess.get(connector.docker_host / "version") as r:

--- a/src/ai/backend/manager/container_registry/local.py
+++ b/src/ai/backend/manager/container_registry/local.py
@@ -25,9 +25,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 class LocalRegistry(BaseContainerRegistry):
     @actxmgr
     async def prepare_client_session(self) -> AsyncIterator[tuple[yarl.URL, aiohttp.ClientSession]]:
-        _, url, connector = get_docker_connector()
-        async with aiohttp.ClientSession(connector=connector) as sess:
-            yield url, sess
+        connector = get_docker_connector()
+        async with aiohttp.ClientSession(connector=connector.connector) as sess:
+            yield connector.docker_host, sess
 
     async def fetch_repositories(
         self,

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -46,7 +46,7 @@ async def test_get_docker_connector(monkeypatch):
         connector = get_docker_connector()
         assert str(connector.docker_host) == "http://localhost"
         assert isinstance(connector.connector, aiohttp.UnixConnector)
-        assert connector.path == "/run/docker.sock"
+        assert connector.sock_path == "/run/docker.sock"
 
     get_docker_context_host.cache_clear()
     search_docker_socket_files.cache_clear()


### PR DESCRIPTION
- Fix an installer regression in #1724 to inappropriately cache an aiohttp connector instance used to access the local Docker API
- Refactor the return value of `common.docker.get_docker_connector()` to provide richer information with extensible set of fields, by changing the tuple to a dataclass.
- Catch `ClientConnectorError` which wraps `PermissionError`, hiding the actual OS error instance. `except PermissionError:` was not properly executed.... :(

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
