### PR TITLE
fix: default redis port in webserver conf

### DIFF
--- a/changes/1736.fix.md
+++ b/changes/1736.fix.md
@@ -1,0 +1,1 @@
+Change the Redis port number in the webserver conf for `install_dev.sh` installation.

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -50,7 +50,7 @@ auth_token_name = 'sToken'
 [session]
 
 [session.redis]
-addr = "localhost:6379"
+addr = "localhost:8111"
 # password = "mysecret"
 # service_name = "mymaster"
 # sentinel = "127.0.0.1:9503,127.0.0.1:9504,127.0.0.1:9505"

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -129,7 +129,7 @@ ssl_verify = true
 auth_token_name = 'sToken'
 
 [session]
-redis.addr = "localhost:6379"
+redis.addr = "localhost:8111"
 # redis.db = 0
 # redis.password = "mysecret"
 


### PR DESCRIPTION
Change the Redis port number in the webserver conf for `install_dev.sh` installation.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to demonstrate the difference of before/after
