### PR TITLE
fix: minor config name spelling change

### DIFF
--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -29,7 +29,7 @@ connectionMode = "SESSION"
 {% toml_field "maxCountForPreopenPorts" config["session"]["max_count_for_preopen_ports"] %}
 {% toml_field "allowCustomResourceAllocation" config["service"]["allow_custom_resource_allocation"] %}
 {% toml_field "isDirectorySizeVisible" config["service"]["is_directory_size_visible"] %}
-{% toml_field "eduAppnamePrefix" config["service"]["edu_appname_prefix"] %}
+{% toml_field "eduAppNamePrefix" config["service"]["edu_appname_prefix"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
refer #1735 

just a minor spelling change on a configuration name

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
