### PR TITLE
fix: do null check on `rate_limit`

### DIFF
--- a/changes/1738.fix.md
+++ b/changes/1738.fix.md
@@ -1,0 +1,1 @@
+Do null-check `rate_limit` value when validate user's rate limit.

--- a/src/ai/backend/manager/api/ratelimit.py
+++ b/src/ai/backend/manager/api/ratelimit.py
@@ -67,7 +67,7 @@ async def rlim_middleware(
             remaining = rate_limit
         else:
             rolling_count = int(ret)
-            if rolling_count > rate_limit:
+            if rate_limit is not None and rolling_count > rate_limit:
                 raise RateLimitExceeded
             remaining = rate_limit - rolling_count
         response = await handler(request)


### PR DESCRIPTION
`rate_limit` column of keypairs table is nullable.
we should do null check.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
