### PR TITLE
fix: convert redis config value

### DIFF
--- a/changes/1741.fix.md
+++ b/changes/1741.fix.md
@@ -1,0 +1,1 @@
+Fix some trafaret type checkers of redis config from `Float()` to `ToFloat()`.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -50,9 +50,9 @@ redis_helper_default_config: RedisHelperConfig = {
 
 redis_helper_config_iv = t.Dict(
     {
-        t.Key("socket_timeout", default=5.0): t.Float,
-        t.Key("socket_connect_timeout", default=2.0): t.Float,
-        t.Key("reconnect_poll_timeout", default=0.3): t.Float,
+        t.Key("socket_timeout", default=5.0): t.ToFloat,
+        t.Key("socket_connect_timeout", default=2.0): t.ToFloat,
+        t.Key("reconnect_poll_timeout", default=0.3): t.ToFloat,
     }
 ).allow_extra("*")
 


### PR DESCRIPTION
follow-up: #1585

`trafaret.Float()` does not convert string value into float. It just check whether it can be float or not.
We should rather use `trafaret.ToFloat()`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version