### PR TITLE
ci: If there are changes to graphql schema, add this as a comment

### DIFF
--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -1,0 +1,16 @@
+name: GraphQL Inspector
+
+on: [push]
+
+jobs:
+  graphql-inspector:
+    name: Check Schema
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kamilkisiela/graphql-inspector@release-1689086705050
+        with:
+          schema: 'main:src/ai/backend/manager/api/schema.graphql'
+          rules: |
+            custom-rule.js

--- a/custom-rule.js
+++ b/custom-rule.js
@@ -1,0 +1,78 @@
+module.exports = (props) => {
+  const { changes, newSchema, oldSchema } = props;
+  return changes.map((change) => {
+    // console.log(change);
+    if (
+      [
+        "FIELD_DEPRECATION_REASON_ADDED",
+        "FIELD_DEPRECATION_REASON_CHANGED",
+      ].includes(change.type) &&
+      change.criticality.level !== "BREAKING"
+    ) {
+      const newReason =
+        change.meta.addedDeprecationReason || change.meta.newDeprecationReason;
+      const regex = /Deprecated since (\d{2}\.\d{2})/;
+      if (!newReason.match(regex)) {
+        change.criticality.level = "BREAKING";
+        change.criticality.reason =
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX"';
+        change.message =
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX", ' +
+          change.message;
+      }
+    } else if (
+      ["FIELD_ADDED", "INPUT_FIELD_ADDED"].includes(change.type) &&
+      change.criticality.level !== "BREAKING"
+    ) {
+      const [typeName, fieldName] = change.path.split(".");
+      const description = newSchema.getTypeMap()[typeName].getFields()[
+        fieldName
+      ].astNode.description?.value;
+      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+        change.criticality.level = "BREAKING";
+        change.criticality.reason =
+          'New fields must include a description with a version number in the format "since XX.XX"';
+        change.message =
+          'New fields must include a description with a version number in the format "XX.XX", ' +
+          change.message;
+      }
+    } else if (
+      change.type === "TYPE_ADDED" &&
+      change.criticality.level !== "BREAKING"
+    ) {
+      const typeName = change.path.split(".")[0];
+      const description =
+        newSchema.getTypeMap()[typeName].astNode.description?.value;
+      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+        change.criticality.level = "BREAKING";
+        change.criticality.reason =
+          'New types must include a description with a version number in the format "since XX.XX"';
+        change.message =
+          'New types must include a description with a version number in the format "XX.XX", ' +
+          change.message;
+      }
+    } else if (
+      ["FIELD_ARGUMENT_ADDED", "FIELD_ARGUMENT_DESCRIPTION_CHANGED"].includes(
+        change.type
+      ) &&
+      change.criticality.level !== "BREAKING"
+    ) {
+      const [type, filedName, argumentName] = change.path.split(".");
+      const field = newSchema.getTypeMap()[type].getFields()[filedName];
+      const description = field.args.find(
+        (arg) => arg.name === argumentName
+      )?.description;
+
+      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+        change.criticality.level = "BREAKING";
+        change.criticality.reason =
+          'New arguments must include a description with a version number in the format "since XX.XX"';
+        change.message =
+          'New arguments must include a description with a version number in the format "XX.XX", ' +
+          change.message;
+      }
+    }
+    return change;
+  });
+};
+// TODO: update the rule to check for the version number in the description.


### PR DESCRIPTION
This will work properly only if #1671 is merged first.

When the graphql schema changes, the changes are written as comments in the schema file.