### PR TITLE
feat: Allows field_ref to be used as a key value in fieldset

### DIFF
--- a/src/ai/backend/client/output/types.py
+++ b/src/ai/backend/client/output/types.py
@@ -104,7 +104,9 @@ class FieldSpec:
 
 class FieldSet(UserDict, Mapping[str, FieldSpec]):
     def __init__(self, fields: Sequence[FieldSpec]) -> None:
-        super().__init__({f.alt_name: f for f in fields})
+        fields_set = {f.alt_name: f for f in fields}
+        fields_set.update({f.field_ref: fields_set[f.alt_name] for f in fields})
+        super().__init__(fields_set)
 
 
 T = TypeVar("T")


### PR DESCRIPTION
When using the --format option of session list, previously only the name specified as alt_name could be used.
However, it should be able to work not only with alt_name but also with the original name, field_ref.