### PR TITLE
fix: ignore `os.setxattr` lint

### DIFF
--- a/src/ai/backend/storage/cephfs/__init__.py
+++ b/src/ai/backend/storage/cephfs/__init__.py
@@ -67,9 +67,9 @@ class CephDirQuotaModel(BaseQuotaModel):
             None,
             # without type: ignore mypy will raise error when trying to run on macOS
             # because os.setxattr() exists only for linux
-            lambda: os.setxattr(
+            lambda: os.setxattr(  # type: ignore[attr-defined]
                 qspath, "ceph.quota.max_bytes", str(int(config.limit_bytes)).encode()
-            ),  # type: ignore[attr-defined]
+            ),
         )
 
     async def unset_quota(self, quota_scope_id: QuotaScopeID) -> None:


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
