### PR TITLE
fix: Deprecates querying projects from KeyPair query

### DIFF
--- a/src/ai/backend/client/cli/admin/keypair.py
+++ b/src/ai/backend/client/cli/admin/keypair.py
@@ -72,7 +72,6 @@ def list(ctx: CLIContext, user_id, is_active, filter_, order, offset, limit) -> 
     """
     fields = [
         keypair_fields["user_id"],
-        keypair_fields["projects"],
         keypair_fields["full_name"],
         keypair_fields["access_key"],
         keypair_fields["secret_key"],

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -105,7 +105,6 @@ keypair_fields = FieldSet([
         alt_name="full_name",
         formatter=SubFieldOutputFormatter("full_name"),
     ),
-    FieldSpec("projects"),
     FieldSpec("access_key"),
     FieldSpec("secret_key"),
     FieldSpec("is_active"),


### PR DESCRIPTION
follow-up #1022 

After #1022 , it has been possible to query `projects` from `KeyPair` GraphQL query, which shows what projects the owner of the user of the keypair are associated with.
BUT according to the reasons below, we decided to deprecate query `projects` in `KeyPair`.
- we decided `KeyPair` should be used only as authentication of users and not used as any other purpose.
- It causes too many left outer joins.


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
