### PR TITLE
fix: Add missing vfolder api endpoint

### DIFF
--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -265,7 +265,6 @@ vfolder_fields = FieldSet([
     FieldSpec("status"),
     FieldSpec("unmanaged_path"),
     FieldSpec("usage_mode"),
-    FieldSpec("status"),
     FieldSpec("permission"),
     FieldSpec("ownership_type"),
     FieldSpec("max_files"),

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3298,6 +3298,7 @@ def create_app(default_cors_options):
     cors.add(add_route("GET", r"/_/allowed_types", list_allowed_types))  # legacy underbar
     cors.add(add_route("GET", r"/_/perf-metric", get_volume_perf_metric))
     cors.add(add_route("POST", r"/{name}/purge", purge))
+    cors.add(add_route("POST", r"/{name}/recover", recover))
     cors.add(add_route("POST", r"/{name}/rename", rename_vfolder))
     cors.add(add_route("POST", r"/{name}/update-options", update_vfolder_options))
     cors.add(add_route("POST", r"/{name}/mkdir", mkdir))


### PR DESCRIPTION
The folder/recover API endpoint is missing after implementation, so it is added.
The status of vfolder fields was added redundantly in https://github.com/lablup/backend.ai/pull/835, so I deleted it again.