### PR TITLE
ci: Add `skip:changelog` label to dependabot pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+      timezone: "Asia/Seoul"
+    labels:
+      - "skip:changelog"
+      - "area:infrastructure"


### PR DESCRIPTION
Add skip:changelog label to prevent dependabot pr from failing towncrier ci.
Also, the schedule does not work at the intended time, so change the timezone setting.
