### PR TITLE
fix: password not updated when calling modify_user mutation

### DIFF
--- a/changes/1787.fix.md
+++ b/changes/1787.fix.md
@@ -1,0 +1,1 @@
+Fix `modify_user` mutation not working

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -716,6 +716,8 @@ class ModifyUser(graphene.Mutation):
         set_if_set(props, data, "resource_policy")
         set_if_set(props, data, "sudo_session_enabled")
         set_if_set(props, data, "main_access_key")
+        if data.get("password") is None:
+            data.pop("password", None)
         if not data and not props.group_ids:
             return cls(ok=False, msg="nothing to update", user=None)
         if data.get("status") is None and props.is_active is not None:


### PR DESCRIPTION
Follow-up of #1674. This PR fixes `modify_user` mutation raising error when password is not supplied.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
