### PR TITLE
doc: Add Client SDK examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ max_line_length = 100
 indent_style = space
 indent_size = 4
 
+[*.md]
+trim_trailing_whitespace = false
+
 [*.rst]
 max_line_length = 0
 indent_style = space

--- a/changes/1789.fix.md
+++ b/changes/1789.fix.md
@@ -1,0 +1,1 @@
+Add a missing `ComputeSession.start_service()` functional API in the client SDK with documentation updates

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,12 +29,14 @@ $ pip install -U \
     -r requirements.txt
 ```
 
+
 ## Building API Reference JSON file
 ```console
 $ ./py -m ai.backend.manager.openapi docs/manager/rest-reference/openapi.json
 ```
 This script must be executed on behalf of the virtual environment managed by pants, not by the venv for the sphinx.
 Generated OpenAPI JSON file will be located at under `manager/rest-reference/openapi.json`.
+
 
 ## Building HTML document
 
@@ -49,15 +51,16 @@ $ make html
 The compiled documentation is under `_build/html/index.html`.
 You may serve it for local inspection using `python -m http.server --directory _build/html`.
 
+
 ## Translation
 
-#### Generate/update pot (Portable Object Template) files
+### Generate/update pot (Portable Object Template) files
 
 ```console
 $ make gettext
 ```
 
-#### Build po (Portable Object) files using sphinx-intl
+### Build po (Portable Object) files using sphinx-intl
 
 ```console
 $ sphinx-intl update -p _build/locale/ -l ko
@@ -66,7 +69,7 @@ $ sphinx-intl update -p _build/locale/ -l ko
 The `.po` message files are under `locales/ko/LC_MESSAGES/`.
 Edit them by filling missing translations.
 
-#### Build HTML files with translated version
+### Build HTML files with translated version
 
 ```console
 $ sphinx-intl build
@@ -84,7 +87,7 @@ The compiled documentation is under `_build/latex/BackendAIDoc.pdf`.
 
 Building PDF requires following libraries to be present on your system.
 
-* TeX Live 
+* TeX Live
   - ko.TeX (texlive-lang-korean)
   - latexmk
 * ImageMagick
@@ -93,11 +96,12 @@ Building PDF requires following libraries to be present on your system.
 ### Installing dependencies on macOS
 1. Install MacTeX from [here](https://www.tug.org/mactex/). There are two types of MacTeX distributions; The BasicTeX one is more lightweight and MacTeX contains most of the libraries commonly used.
 2. Follow [here](http://wiki.ktug.org/wiki/wiki.php/KtugPrivateRepository) (Korean) to set up KTUG repository.
-3. Exceute following command to install missing dependencies.   
+3. Exceute following command to install missing dependencies.
 ```console
 sudo tlmgr install latexmk tex-gyre fncychap wrapfig capt-of framed needspace collection-langkorean collection-fontsrecommended tabulary varwidth titlesec
 ```
 4. Install both Pretendard (used for main font) and D2Coding (used to draw monospace characters) fonts on your system.
+
 
 ## Advanced Settings
 
@@ -126,12 +130,32 @@ Example:
 
 Please ask the docs maintainer for help.
 
-### Previewing built HTML documentation
-Simply create a nginx server which serves `_build/html` folder. For example (docker required): 
+
+## Preview
+
+### The HTML documentation
+
+Simply create a nginx server which serves `_build/html` folder. For example (docker required):
 ```bash
 docker run --rm -it -v $(pwd)/_build/html:/usr/share/nginx/html -p 8000:80 nginx
 ```
 Executing the command above inside `docs` folder will serve the documentation page on port 8000 (http://localhost:8000).
+
+### Interactive GraphQL browser
+
+1. Ensure you have the access to the manager server.
+   The manager's etcd configuration should say `config/api/allow-graphql-schema-introspection` is true.
+1. Run `backend.ai proxy` command of the client SDK.
+   Depending on your setup, adjust `--bind` and `--port` options.
+   Use the client SDK version 21.03.7+ or 20.09.9+ at least to avoid unexpected CORS issues.
+1. Copy `index.html` from https://gist.github.com/achimnol/dc9996aeffc7cf15e96478e635eb0699
+1. Replace `"<proxy-address>"` with the real address (host:port) of the proxy, which can be accessed from your browser as well.
+1. Run `python -m http.server` command in the directory where `index.html` is located.
+1. Open the page served by the HTTP server in the step 3 in your web browser.
+   Enjoy auto-completion and schema introspection of Backend.AI admin API!
+
+For more details about GraphiQL, check out https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql.
+
 
 ## References for newcomers
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,23 +135,29 @@ Please ask the docs maintainer for help.
 
 ### The HTML documentation
 
-Simply create a nginx server which serves `_build/html` folder. For example (docker required):
-```bash
-docker run --rm -it -v $(pwd)/_build/html:/usr/share/nginx/html -p 8000:80 nginx
-```
-Executing the command above inside `docs` folder will serve the documentation page on port 8000 (http://localhost:8000).
+You may open `_build/html/index.html` from the local filesystem directly on your browser,
+but the REST API reference (as of 23.09) which uses a dedicated Javascript-based viewer won't work.
+
+To preview the full documentation including the REST API reference seamlessly, you need to run a local nginx server.
+
+1. Simply create a nginx server which serves `_build/html` folder. For example (docker required):
+   ```bash
+   docker run --rm -it -v $(pwd)/_build/html:/usr/share/nginx/html -p 8000:80 nginx
+   ```
+2. Executing the command above inside `docs` folder will serve the documentation page on port 8000 (http://localhost:8000).
 
 ### Interactive GraphQL browser
 
-1. Ensure you have the access to the manager server.
-   The manager's etcd configuration should say `config/api/allow-graphql-schema-introspection` is true.
-1. Run `backend.ai proxy` command of the client SDK.
-   Depending on your setup, adjust `--bind` and `--port` options.
+You may use GraphiQL to interact and inspect the Backend.AI Manager's GraphQL API.
+
+1. Ensure you have the access to the manager server.  
+   The manager's *etcd* configuration should say `config/api/allow-graphql-schema-introspection` is true.
+2. Run `backend.ai proxy` command of the client SDK.  Depending on your setup, adjust `--bind` and `--port` options.  
    Use the client SDK version 21.03.7+ or 20.09.9+ at least to avoid unexpected CORS issues.
-1. Copy `index.html` from https://gist.github.com/achimnol/dc9996aeffc7cf15e96478e635eb0699
-1. Replace `"<proxy-address>"` with the real address (host:port) of the proxy, which can be accessed from your browser as well.
-1. Run `python -m http.server` command in the directory where `index.html` is located.
-1. Open the page served by the HTTP server in the step 3 in your web browser.
+3. Copy `index.html` from https://gist.github.com/achimnol/dc9996aeffc7cf15e96478e635eb0699
+4. Replace `"<proxy-address>"` with the real address (host:port) of the proxy, which can be accessed from your browser as well.
+5. Run `python -m http.server` command in the directory where `index.html` is located.
+6. Open the page served by the HTTP server in the previous step in your web browser.  
    Enjoy auto-completion and schema introspection of Backend.AI admin API!
 
 For more details about GraphiQL, check out https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql.

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,9 +142,9 @@ but the REST API reference (as of 24.03) which uses a dedicated Javascript-based
 
 To preview the full documentation including the REST API reference seamlessly, you need to run a local nginx server.
 
-1. Simply create a nginx server which serves `_build/html` folder. For example (docker required):
+1. Create a HTTP server which serves `_build/html` folder. For example:
    ```bash
-   docker run --rm -it -v $(pwd)/_build/html:/usr/share/nginx/html -p 8000:80 nginx
+   python -m http.server --directory _build/html 8000
    ```
 2. Executing the command above inside `docs` folder will serve the documentation page on port 8000 (http://localhost:8000).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,12 +21,7 @@ $ git clone https://github.com/lablup/backend.ai bai-dev
 $ cd ./bai-dev/docs
 $ pyenv local bai-docs
 $ pip install -U pip setuptools wheel
-$ pip install -U \
-    --find-links=https://dist.backend.ai/pypi/simple/grpcio \
-    --find-links=https://dist.backend.ai/pypi/simple/grpcio-tools \
-    --find-links=https://dist.backend.ai/pypi/simple/hiredis \
-    --find-links=https://dist.backend.ai/pypi/simple/psycopg-binary \
-    -r requirements.txt
+$ pip install -U -r requirements.txt
 ```
 
 
@@ -40,7 +35,8 @@ Generated OpenAPI JSON file will be located at under `manager/rest-reference/ope
 
 ## Building HTML document
 
-> 📌 NOTE: Please ensure that you are inside the `docs` directory and the virtualenv is activated.
+> [!NOTE]
+> Please ensure that you are inside the `docs` directory and the virtualenv is activated.
 
 ### Make the html version
 
@@ -133,10 +129,16 @@ Please ask the docs maintainer for help.
 
 ## Preview
 
+### The PR previews
+
+Our ReadTheDocs bot automatically builds the HTML preview for each commit of a PR that changes
+the contents of the `docs` directory.
+You may simply click the link in the PR comment written by the bot.
+
 ### The HTML documentation
 
 You may open `_build/html/index.html` from the local filesystem directly on your browser,
-but the REST API reference (as of 23.09) which uses a dedicated Javascript-based viewer won't work.
+but the REST API reference (as of 24.03) which uses a dedicated Javascript-based viewer won't work.
 
 To preview the full documentation including the REST API reference seamlessly, you need to run a local nginx server.
 
@@ -148,7 +150,8 @@ To preview the full documentation including the REST API reference seamlessly, y
 
 ### Interactive GraphQL browser
 
-You may use GraphiQL to interact and inspect the Backend.AI Manager's GraphQL API.
+You may use [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql)
+to interact and inspect the Backend.AI Manager's GraphQL API.
 
 1. Ensure you have the access to the manager server.  
    The manager's *etcd* configuration should say `config/api/allow-graphql-schema-introspection` is true.
@@ -159,8 +162,6 @@ You may use GraphiQL to interact and inspect the Backend.AI Manager's GraphQL AP
 5. Run `python -m http.server` command in the directory where `index.html` is located.
 6. Open the page served by the HTTP server in the previous step in your web browser.  
    Enjoy auto-completion and schema introspection of Backend.AI admin API!
-
-For more details about GraphiQL, check out https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql.
 
 
 ## References for newcomers

--- a/docs/_static/css/customTheme.css
+++ b/docs/_static/css/customTheme.css
@@ -7454,89 +7454,88 @@ section {
 } */
 
 pre { line-height: 125%; }
-td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
-span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
-td.linenos .special { color: #767676; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
-span.linenos.special { color: #767676; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
-.highlight .hll { background-color: #ffffcc }
-.highlight {
-  background: #1E1E1E;
-  color: #FFF;
-}
-.highlight .c { color: #8f5902; font-style: italic } /* Comment */
-.highlight .err { color: #a40000; border: 1px solid #ef2929 } /* Error */
-.highlight .g { color: #767676 } /* Generic */
-.highlight .k { color: #51B2E0; font-weight: bold } /* Keyword */
-.highlight .l { color: #767676 } /* Literal */
-.highlight .n { color: #767676 } /* Name */
-.highlight .o { color: #ce5c00; font-weight: bold } /* Operator */
-.highlight .x { color: #767676 } /* Other */
-.highlight .p { color: #767676; font-weight: bold } /* Punctuation */
-.highlight .ch { color: #8f5902; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #8f5902; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #8f5902; font-style: italic } /* Comment.Preproc */
-.highlight .cpf { color: #8f5902; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #03B5E5; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #8f5902; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #a40000 } /* Generic.Deleted */
-.highlight .ge { color: #767676; font-style: italic } /* Generic.Emph */
-.highlight .ges { color: #767676; font-weight: bold; font-style: italic } /* Generic.EmphStrong */
-.highlight .gr { color: #ef2929 } /* Generic.Error */
-.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #767676; font-style: italic } /* Generic.Output */
-.highlight .gp { color: #FF9D00 } /* Generic.Prompt */
-.highlight .gs { color: #767676; font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight .gt { color: #a40000; font-weight: bold } /* Generic.Traceback */
-.highlight .kc { color: #51B2E0; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #51B2E0; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #51B2E0; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #51B2E0; font-weight: bold } /* Keyword.Pseudo */
-.highlight .kr { color: #51B2E0; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #51B2E0; font-weight: bold } /* Keyword.Type */
-.highlight .ld { color: #767676 } /* Literal.Date */
-.highlight .m { color: #0000cf; font-weight: bold } /* Literal.Number */
-.highlight .s { color: #75D100 } /* Literal.String */
-.highlight .na { color: #c4a000 } /* Name.Attribute */
-.highlight .nb { color: #51B2E0 } /* Name.Builtin */
-.highlight .nc { color: #767676 } /* Name.Class */
-.highlight .no { color: #767676 } /* Name.Constant */
-.highlight .nd { color: #5c35cc; font-weight: bold } /* Name.Decorator */
-.highlight .ni { color: #ce5c00 } /* Name.Entity */
-.highlight .ne { color: #cc0000; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #767676 } /* Name.Function */
-.highlight .nl { color: #f57900 } /* Name.Label */
-.highlight .nn { color: #767676 } /* Name.Namespace */
-.highlight .nx { color: #767676 } /* Name.Other */
-.highlight .py { color: #767676 } /* Name.Property */
-.highlight .nt { color: #51B2E0; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #767676 } /* Name.Variable */
-.highlight .ow { color: #51B2E0; font-weight: bold } /* Operator.Word */
-.highlight .pm { color: #767676; font-weight: bold } /* Punctuation.Marker */
-.highlight .w { color: #f8f8f8 } /* Text.Whitespace */
-.highlight .mb { color: #0000cf; font-weight: bold } /* Literal.Number.Bin */
-.highlight .mf { color: #0000cf; font-weight: bold } /* Literal.Number.Float */
-.highlight .mh { color: #0000cf; font-weight: bold } /* Literal.Number.Hex */
-.highlight .mi { color: #0000cf; font-weight: bold } /* Literal.Number.Integer */
-.highlight .mo { color: #0000cf; font-weight: bold } /* Literal.Number.Oct */
-.highlight .sa { color: #75D100 } /* Literal.String.Affix */
-.highlight .sb { color: #75D100 } /* Literal.String.Backtick */
-.highlight .sc { color: #75D100 } /* Literal.String.Char */
-.highlight .dl { color: #75D100 } /* Literal.String.Delimiter */
-.highlight .sd { color: #8f5902; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #75D100 } /* Literal.String.Double */
-.highlight .se { color: #75D100 } /* Literal.String.Escape */
-.highlight .sh { color: #75D100 } /* Literal.String.Heredoc */
-.highlight .si { color: #75D100 } /* Literal.String.Interpol */
-.highlight .sx { color: #75D100 } /* Literal.String.Other */
-.highlight .sr { color: #75D100 } /* Literal.String.Regex */
-.highlight .s1 { color: #75D100 } /* Literal.String.Single */
-.highlight .ss { color: #75D100 } /* Literal.String.Symbol */
-.highlight .bp { color: #3465a4 } /* Name.Builtin.Pseudo */
-.highlight .fm { color: #767676 } /* Name.Function.Magic */
-.highlight .vc { color: #767676 } /* Name.Variable.Class */
-.highlight .vg { color: #767676 } /* Name.Variable.Global */
-.highlight .vi { color: #767676 } /* Name.Variable.Instance */
-.highlight .vm { color: #767676 } /* Name.Variable.Magic */
-.highlight .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */
+td.linenos .normal { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #e6edf3; background-color: #6e7681; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #e6edf3; background-color: #6e7681; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #6e7681 }
+.highlight { background: #0d1117; color: #e6edf3 }
+.highlight .c { color: #8b949e; font-style: italic } /* Comment */
+.highlight .err { color: #f85149 } /* Error */
+.highlight .esc { color: #e6edf3 } /* Escape */
+.highlight .g { color: #e6edf3 } /* Generic */
+.highlight .k { color: #ff7b72 } /* Keyword */
+.highlight .l { color: #a5d6ff } /* Literal */
+.highlight .n { color: #e6edf3 } /* Name */
+.highlight .o { color: #ff7b72; font-weight: bold } /* Operator */
+.highlight .x { color: #e6edf3 } /* Other */
+.highlight .p { color: #e6edf3 } /* Punctuation */
+.highlight .ch { color: #8b949e; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #8b949e; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #8b949e; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #8b949e; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #8b949e; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #8b949e; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #ffa198; background-color: #490202 } /* Generic.Deleted */
+.highlight .ge { color: #e6edf3; font-style: italic } /* Generic.Emph */
+.highlight .ges { color: #e6edf3; font-weight: bold; font-style: italic } /* Generic.EmphStrong */
+.highlight .gr { color: #ffa198 } /* Generic.Error */
+.highlight .gh { color: #79c0ff; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #56d364; background-color: #0f5323 } /* Generic.Inserted */
+.highlight .go { color: #8b949e } /* Generic.Output */
+.highlight .gp { color: #8b949e } /* Generic.Prompt */
+.highlight .gs { color: #e6edf3; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #79c0ff } /* Generic.Subheading */
+.highlight .gt { color: #ff7b72 } /* Generic.Traceback */
+.highlight .g-Underline { color: #e6edf3; text-decoration: underline } /* Generic.Underline */
+.highlight .kc { color: #79c0ff } /* Keyword.Constant */
+.highlight .kd { color: #ff7b72 } /* Keyword.Declaration */
+.highlight .kn { color: #ff7b72 } /* Keyword.Namespace */
+.highlight .kp { color: #79c0ff } /* Keyword.Pseudo */
+.highlight .kr { color: #ff7b72 } /* Keyword.Reserved */
+.highlight .kt { color: #ff7b72 } /* Keyword.Type */
+.highlight .ld { color: #79c0ff } /* Literal.Date */
+.highlight .m { color: #a5d6ff } /* Literal.Number */
+.highlight .s { color: #a5d6ff } /* Literal.String */
+.highlight .na { color: #e6edf3 } /* Name.Attribute */
+.highlight .nb { color: #e6edf3 } /* Name.Builtin */
+.highlight .nc { color: #f0883e; font-weight: bold } /* Name.Class */
+.highlight .no { color: #79c0ff; font-weight: bold } /* Name.Constant */
+.highlight .nd { color: #d2a8ff; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #ffa657 } /* Name.Entity */
+.highlight .ne { color: #f0883e; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #d2a8ff; font-weight: bold } /* Name.Function */
+.highlight .nl { color: #79c0ff; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #ff7b72 } /* Name.Namespace */
+.highlight .nx { color: #e6edf3 } /* Name.Other */
+.highlight .py { color: #79c0ff } /* Name.Property */
+.highlight .nt { color: #7ee787 } /* Name.Tag */
+.highlight .nv { color: #79c0ff } /* Name.Variable */
+.highlight .ow { color: #ff7b72; font-weight: bold } /* Operator.Word */
+.highlight .pm { color: #e6edf3 } /* Punctuation.Marker */
+.highlight .w { color: #6e7681 } /* Text.Whitespace */
+.highlight .mb { color: #a5d6ff } /* Literal.Number.Bin */
+.highlight .mf { color: #a5d6ff } /* Literal.Number.Float */
+.highlight .mh { color: #a5d6ff } /* Literal.Number.Hex */
+.highlight .mi { color: #a5d6ff } /* Literal.Number.Integer */
+.highlight .mo { color: #a5d6ff } /* Literal.Number.Oct */
+.highlight .sa { color: #79c0ff } /* Literal.String.Affix */
+.highlight .sb { color: #a5d6ff } /* Literal.String.Backtick */
+.highlight .sc { color: #a5d6ff } /* Literal.String.Char */
+.highlight .dl { color: #79c0ff } /* Literal.String.Delimiter */
+.highlight .sd { color: #a5d6ff } /* Literal.String.Doc */
+.highlight .s2 { color: #a5d6ff } /* Literal.String.Double */
+.highlight .se { color: #79c0ff } /* Literal.String.Escape */
+.highlight .sh { color: #79c0ff } /* Literal.String.Heredoc */
+.highlight .si { color: #a5d6ff } /* Literal.String.Interpol */
+.highlight .sx { color: #a5d6ff } /* Literal.String.Other */
+.highlight .sr { color: #79c0ff } /* Literal.String.Regex */
+.highlight .s1 { color: #a5d6ff } /* Literal.String.Single */
+.highlight .ss { color: #a5d6ff } /* Literal.String.Symbol */
+.highlight .bp { color: #e6edf3 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #d2a8ff; font-weight: bold } /* Name.Function.Magic */
+.highlight .vc { color: #79c0ff } /* Name.Variable.Class */
+.highlight .vg { color: #79c0ff } /* Name.Variable.Global */
+.highlight .vi { color: #79c0ff } /* Name.Variable.Instance */
+.highlight .vm { color: #79c0ff } /* Name.Variable.Magic */
+.highlight .il { color: #a5d6ff } /* Literal.Number.Integer.Long */

--- a/docs/client/dev/examples.rst
+++ b/docs/client/dev/examples.rst
@@ -115,8 +115,10 @@ Creating and destroying a compute session
 
 
 
-Retrieving the app proxy address to a container application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Accessing Container Applications
+--------------------------------
+
+TODO: Retrieving the app proxy address to a container application
 
 .. code-block:: python
 
@@ -127,11 +129,14 @@ Retrieving the app proxy address to a container application
         print(...)
 
 
-Synchronous-mode execution
---------------------------
+Code Execution via API
+----------------------
 
-Query mode
-~~~~~~~~~~
+Synchronous mode
+~~~~~~~~~~~~~~~~
+
+Snippet execution (query mode)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is the minimal code to execute a code snippet with this client SDK.
 
@@ -172,8 +177,8 @@ but within the timeout, any kernel creation requests with the same ``client_toke
 let Backend.AI cloud to reuse the kernel.
 
 
-Batch mode
-~~~~~~~~~~
+Script execution (batch mode)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You first need to upload the files after creating the session and construct a
 ``opts`` struct.
@@ -216,7 +221,7 @@ You first need to upload the files after creating the session and construct a
 
 
 Handling user inputs
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 Inside the while-loop for ``kern.execute()`` above,
 change the if-block for ``result['status']`` as follows:
@@ -241,7 +246,7 @@ A common gotcha is to miss setting ``mode = "input"``. Be careful!
 
 
 Handling multi-media outputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``handle_media()`` function used above examples would look like:
 
@@ -262,8 +267,8 @@ Currently the following behaviors are well-defined:
   browsers)
 
 
-Asynchronous-mode Execution
----------------------------
+Asynchronous mode
+~~~~~~~~~~~~~~~~~
 
 The async version has all sync-version interfaces as coroutines but comes with additional
 features such as ``stream_execute()`` which streams the execution results via websockets and

--- a/docs/client/dev/examples.rst
+++ b/docs/client/dev/examples.rst
@@ -407,8 +407,10 @@ Starting model service
             1,
             service_name="Llama2-service",
             resources={"cuda.shares": 2, "cpu": 8, "mem": "64g"},
-            open_to_public=False,  # setting this to True will allow service endpoint to accept requests without API token
+            open_to_public=False,
         )
+
+If you set ``open_to_public=True``, the endpoint accepts anonymous traffic without the authentication token (see below).
 
 
 Making request to model service endpoint
@@ -428,5 +430,8 @@ Making request to model service endpoint
         headers = {"Authorization": f"BackendAI {token}"}  # providing token is not required for public model services
         resp = requests.get(f"{endpoint}/v1/models", headers=headers)
 
+The token returned by the ``generate_api_token()`` method is a JSON web token (JWT), which conveys all required information to authenticate the inference request.
+Once generated, it cannot be revoked.  A token may have its own expiration date/time.
+The lifetime of a token is configured by the user who deploys the inference model, and currently there is no intrinsic minimum/maximum limits of the lifetime.
 
 .. versionadded:: 23.09

--- a/docs/client/dev/index.rst
+++ b/docs/client/dev/index.rst
@@ -2,7 +2,7 @@ Developer Guides
 ================
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 3
    :caption: Table of contents
 
    session

--- a/docs/client/dev/session.rst
+++ b/docs/client/dev/session.rst
@@ -1,6 +1,9 @@
 Client Session
 ==============
 
+Client Session Objects
+----------------------
+
 .. module:: ai.backend.client.session
 .. currentmodule:: ai.backend.client.session
 

--- a/docs/client/func/index.rst
+++ b/docs/client/func/index.rst
@@ -5,6 +5,7 @@ High-level Function Reference
    :maxdepth: 1
    :caption: Table of contents
 
+   examples
    admin
    agent
    auth

--- a/docs/client/func/index.rst
+++ b/docs/client/func/index.rst
@@ -5,7 +5,6 @@ High-level Function Reference
    :maxdepth: 1
    :caption: Table of contents
 
-   examples
    admin
    agent
    auth

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,6 @@ import os
 import sys
 from pathlib import Path
 
-import sphinx_rtd_theme
-
 root_path = Path(__file__).parent.parent
 
 on_rtd = os.environ.get("READTHEDOCS") == "True"
@@ -62,6 +60,7 @@ master_doc = "index"
 
 # General information about the project.
 from datetime import date
+
 project = "Backend.AI Documentation"
 copyright = f"2015-{date.today().year}, Lablup Inc."
 author = "Lablup Inc."
@@ -127,10 +126,10 @@ todo_include_todos = False
 numfig = True
 
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/3", None),
-    "multidict": ("https://multidict.readthedocs.io/en/stable/", None),
-    "yarl": ("https://yarl.readthedocs.io/en/stable/", None),
-    "aiohttp": ("https://aiohttp.readthedocs.io/en/stable/", None),
+    "python": ("https://docs.python.org/3", None),
+    "multidict": ("https://multidict.aio-libs.org/en/stable/", None),
+    "yarl": ("https://yarl.aio-libs.org/en/stable/", None),
+    "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
 }
 
 
@@ -242,3 +241,4 @@ html_style = 'css/customTheme.css'
 html_js_files = [
     'js/custom.js',
 ]
+

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1012,13 +1012,13 @@ class ComputeSession(BaseFunction):
         to access AppProxy endpoint.
         """
         body: dict[str, Any] = {"app": app}
-        if not isinstance(port, Undefined):
+        if port is not undefined):
             body["port"] = port
-        if not isinstance(envs, Undefined):
+        if envs is not undefined:
             body["envs"] = json.dumps(envs)
-        if not isinstance(arguments, Undefined):
+        if arguments is not undefined:
             body["arguments"] = json.dumps(arguments)
-        if not isinstance(login_session_token, Undefined):
+        if login_session_token is not undefined:
             body["login_session_token"] = login_session_token
 
         prefix = get_naming(api_session.get().api_version, "path")

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -997,6 +997,39 @@ class ComputeSession(BaseFunction):
         async with rqst.fetch() as resp:
             return await resp.json()
 
+    @api_function
+    async def start_service(
+        self,
+        app: str,
+        *,
+        port: int | Undefined = undefined,
+        envs: dict[str, Any] | Undefined = undefined,
+        arguments: dict[str, Any] | Undefined = undefined,
+        login_session_token: str | Undefined = undefined,
+    ) -> Mapping[str, Any]:
+        """
+        Starts application from Backend.AI session and returns access credentials
+        to access AppProxy endpoint.
+        """
+        body: dict[str, Any] = {"app": app}
+        if not isinstance(port, Undefined):
+            body["port"] = port
+        if not isinstance(envs, Undefined):
+            body["envs"] = json.dumps(envs)
+        if not isinstance(arguments, Undefined):
+            body["arguments"] = json.dumps(arguments)
+        if not isinstance(login_session_token, Undefined):
+            body["login_session_token"] = login_session_token
+
+        prefix = get_naming(api_session.get().api_version, "path")
+        rqst = Request(
+            "POST",
+            f"/{prefix}/{self.name}/start-service",
+        )
+        rqst.set_json(body)
+        async with rqst.fetch() as resp:
+            return await resp.json()
+
     # only supported in AsyncAPISession
     def listen_events(self, scope: Literal["*", "session", "kernel"] = "*") -> SSEContextManager:
         """

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1012,7 +1012,7 @@ class ComputeSession(BaseFunction):
         to access AppProxy endpoint.
         """
         body: dict[str, Any] = {"app": app}
-        if port is not undefined):
+        if port is not undefined:
             body["port"] = port
         if envs is not undefined:
             body["envs"] = json.dumps(envs)


### PR DESCRIPTION
This is a documentation update to expand our client SDK usage scenarios.

It also improves the doc build speed by updating the intersphinx links, and fixes the code-block theme to be more readable using the GitHub Dark style from pygments.

To compliment the updated description of the SDK example for model serving, this PR adds a missing `ComputeSession.start_service()` functional API wrapper.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--1789.org.readthedocs.build/en/1789/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--1789.org.readthedocs.build/ko/1789/

<!-- readthedocs-preview sorna-ko end -->