### PR TITLE
fix: `admin mgr agent info` is returning an incorrect value

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1382,12 +1382,10 @@ class AbstractAgent(
             except Exception as e:
                 return key, e
 
-        keys = []
         for key, plugin in self.computers.items():
-            keys.append(key)
             tasks.append(_get(key, plugin.instance))
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        for key, result in zip(keys, results):
+        for key, result in results:
             match result:
                 case NotImplementedError():
                     continue

--- a/src/ai/backend/manager/cli/agent.py
+++ b/src/ai/backend/manager/cli/agent.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pprint import pprint
 from typing import TYPE_CHECKING
 
 import click
@@ -80,9 +79,12 @@ def ping(cli_ctx: CLIContext, agent_id: str, alembic_config: str, timeout: float
                 AgentId(agent_id),
                 invoke_timeout=timeout,
             ) as rpc:
-                result = await rpc.call.gather_hwinfo()
-                print(f"Retrieved ag:{agent_id} hardware information as a health check:")
-                pprint(result)
+                result = await rpc.call.ping("pong")
+                print(f"Received response from ag:{agent_id}: {result}")
+                # TODO: When get_node_hwinfo() of CPUPlugin and MemoryPlugin are implemented, use the code below.
+                # result = await rpc.call.gather_hwinfo()
+                # print(f"Retrieved ag:{agent_id} hardware information as a health check:")
+                # pprint(result)
         except asyncio.TimeoutError:
             log.error("Timeout occurred while reading the response from ag:{}", agent_id)
         except Exception:


### PR DESCRIPTION
Because results contain key values, delete keys that are not needed.
Modify mgr agent ping, which uses get_node_hwinfo(), which has not been implemented yet, to use ping().
It will be replaced when get_node_hwinfo() is implemented in the future.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
