### PR TITLE
fix: Update Pants installation path from `~/bin` to `~/.local/bin`

### DIFF
--- a/changes/1806.fix.md
+++ b/changes/1806.fix.md
@@ -1,0 +1,1 @@
+For dev installer, Change Pants install directory

--- a/changes/1806.fix.md
+++ b/changes/1806.fix.md
@@ -1,1 +1,1 @@
-For dev installer, Change Pants install directory
+Update the default PATH where the `pants` executable is installed in `install-dev.sh`

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -576,8 +576,8 @@ bootstrap_pants() {
       curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh > /tmp/get-pants.sh
       bash /tmp/get-pants.sh
       if ! command -v pants &> /dev/null ; then
-        $sudo ln -s $HOME/bin/pants /usr/local/bin/pants
-        show_note "Symlinked $HOME/bin/pants from /usr/local/bin/pants as we could not find it from PATH..."
+        $sudo ln -s $HOME/.local/bin/pants /usr/local/bin/pants
+        show_note "Symlinked $HOME/.local/bin/pants from /usr/local/bin/pants as we could not find it from PATH..."
       fi
       ;;
     esac


### PR DESCRIPTION
resolves #1751

due to the [recent changes in pants install script](https://github.com/pantsbuild/setup/pull/144), the install directory of pants changed to ~/.local/bin

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Installer updates