### PR TITLE
feature: add vfolder_mounts client output field

### DIFF
--- a/changes/1811.feature.md
+++ b/changes/1811.feature.md
@@ -1,0 +1,1 @@
+Add `vfolder_mounts` field to session field of client's output.

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -184,6 +184,7 @@ session_fields = FieldSet([
     FieldSpec("scaling_group"),
     FieldSpec("service_ports", formatter=nested_dict_formatter),
     FieldSpec("mounts"),
+    FieldSpec("vfolder_mounts"),
     FieldSpec("occupying_slots", formatter=resource_slot_formatter),
     FieldSpec(
         "containers",


### PR DESCRIPTION
Add `vfolder_mounts` field to session field of client's output to enable query the mount field.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] API server-client counterparts (e.g., manager API -> client SDK)
