### PR TITLE
fix: Add missing `main_access_key` in fixture

### DIFF
--- a/fixtures/manager/example-keypairs.json
+++ b/fixtures/manager/example-keypairs.json
@@ -80,7 +80,8 @@
             "status_info": "admin-requested",
             "domain_name": "default",
             "resource_policy": "default",
-            "role": "superadmin"
+            "role": "superadmin",
+            "main_access_key": "AKIAIOSFODNN7EXAMPLE"
         },
         {
             "uuid": "4f13d193-f646-425a-a340-270c4d2b9860",
@@ -94,7 +95,8 @@
             "status_info": "admin-requested",
             "domain_name": "default",
             "resource_policy": "default",
-            "role": "admin"
+            "role": "admin",
+            "main_access_key": "AKIAHUKCHDEZGEXAMPLE"
         },
         {
             "uuid": "dfa9da54-4b28-432f-be29-c0d680c7a412",
@@ -108,7 +110,8 @@
             "status_info": "admin-requested",
             "domain_name": "default",
             "resource_policy": "default",
-            "role": "user"
+            "role": "user",
+            "main_access_key": "AKIANABBDUSEREXAMPLE"
         },
         {
             "uuid": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
@@ -122,7 +125,8 @@
             "status_info": "admin-requested",
             "domain_name": "default",
             "resource_policy": "default",
-            "role": "user"
+            "role": "user",
+            "main_access_key": "AKIANATWOUSEREXAMPLE"
         },
         {
             "uuid": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
@@ -136,7 +140,8 @@
             "status_info": "admin-requested",
             "domain_name": "default",
             "resource_policy": "default",
-            "role": "monitor"
+            "role": "monitor",
+            "main_access_key": "AKIANAMONITOREXAMPLE"
         }
     ],
     "association_groups_users": [


### PR DESCRIPTION
follow up: #1761 

`main_access_key` was not added in dev fixture.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)