### PR TITLE
fix: Exclude utilization checks for unallocated resources

### DIFF
--- a/changes/1820.fix.md
+++ b/changes/1820.fix.md
@@ -1,0 +1,1 @@
+Exclude unallocated resources from kernel idle utilization checks.

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -889,16 +889,16 @@ class UtilizationIdleChecker(BaseIdleChecker):
 
         # Merge same type of (exclusive) resources as a unique resource with the values added.
         # Example: {cuda.device: 0, cuda.shares: 0.5} -> {cuda: 0.5}.
-        unique_res_map: DefaultDict[str, Any] = defaultdict(Decimal)
-        for k, v in occupied_slots.items():
-            unique_key = k.split(".")[0]
-            unique_res_map[unique_key] += v
+        unique_res_map: DefaultDict[str, Decimal] = defaultdict(Decimal)
+        for slot_name, alloc in occupied_slots.items():
+            unique_key = slot_name.split(".")[0]
+            unique_res_map[unique_key] += alloc
 
         # Do not take into account unallocated resources. For example, do not garbage collect
         # a session without GPU even if cuda_util is configured in resource-thresholds.
-        for slot in unique_res_map:
-            if unique_res_map[slot] == 0:
-                unavailable_resources.update(self.slot_resource_map[slot])
+        for slot_prefix, resources in self.slot_resource_map.items():
+            if unique_res_map.get(slot_prefix, 0) == 0:
+                unavailable_resources.update(resources)
 
         # Get current utilization data from all containers of the session.
         if kernel["cluster_size"] > 1:


### PR DESCRIPTION
resolves https://github.com/lablup/giftbox/issues/592

When sessions(or kernels) are created without allocating cuda or any other devices, the value of `kernel.occupied_slots` field would be like below.
```
{'cpu': Decimal('1'), 'mem': Decimal('335544320')}
```
If we set thresholds of resources which are not in `kernel.occupied_slots` field to util checker, the checker determines the utilization with default `0` value resource. Example values below.
```
# utilization of a kernel
{'cpu': Decimal('1'), 'mem': Decimal('335544320'), 'cuda': 0}

# thresholds
{'cpu': Decimal('1'), 'mem': Decimal('10'), 'cuda': 2}
```

In this PR, util checker does not determine utilization of resources that is not in `kernel.occupied_slots` value.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
