### PR TITLE
ci: Bump gh-python-generate-sbom from v1 to v2

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,7 +27,7 @@ jobs:
         gha-cache-key: pants-cache-main-1-sbom-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
-    - uses: CycloneDX/gh-python-generate-sbom@v1.0.1
+    - uses: CycloneDX/gh-python-generate-sbom@v2
     - name: Upload SBOM report
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/7406811894?pr=1138
This is a change to resolve the node12 deprecated warning in the actions log above.
