### PR TITLE
fix: make `metadata` field of model definition optional

### DIFF
--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -104,7 +104,7 @@ model_definition_iv = t.Dict({
                     t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
                 }),
             }),
-            t.Key("metadata"): t.Null
+            t.Key("metadata", default=None): t.Null
             | t.Dict({
                 t.Key("author", default=None): t.Null | t.String(allow_blank=True),
                 t.Key("title", default=None): t.Null | t.String(allow_blank=True),


### PR DESCRIPTION
Follow-up PR of #1749. This PR adds a default value of `metadata` config schema so that it can really be treated as an optional value.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue