### PR TITLE
feature: Pass Root context of manager to plugins

### DIFF
--- a/changes/1829.feature.md
+++ b/changes/1829.feature.md
@@ -1,0 +1,1 @@
+Pass Root context of manager to plugins.

--- a/changes/1829.feature.md
+++ b/changes/1829.feature.md
@@ -1,1 +1,1 @@
-Pass Root context of manager to plugins.
+Pass the root context to the manager plugins so that they can access database connection pools and other globals

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -440,7 +440,7 @@ async def hook_plugin_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     ctx = HookPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     root_ctx.hook_plugin_ctx = ctx
     await ctx.init(
-        context=ctx,
+        context=root_ctx,
         allowlist=root_ctx.local_config["manager"]["allowed-plugins"],
         blocklist=root_ctx.local_config["manager"]["disabled-plugins"],
     )

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -301,6 +301,7 @@ async def webapp_plugin_ctx(root_app: web.Application) -> AsyncIterator[None]:
     root_ctx: RootContext = root_app["_root.context"]
     plugin_ctx = WebappPluginContext(root_ctx.shared_config.etcd, root_ctx.local_config)
     await plugin_ctx.init(
+        context=root_ctx,
         allowlist=root_ctx.local_config["manager"]["allowed-plugins"],
         blocklist=root_ctx.local_config["manager"]["disabled-plugins"],
     )


### PR DESCRIPTION
follow-up #1699 

let's pass a root context to plugins instead of a plugin context for easy accessibility to db

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)