### PR TITLE
feat: expose email of model service owner

### DIFF
--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 from typing import TYPE_CHECKING, Any, Iterable, Tuple
 
 import aiohttp_cors
@@ -96,6 +97,7 @@ async def _handle_gql_common(request: web.Request, params: Any) -> ExecutionResu
             else:
                 errmsg = {"message": str(e)}
             log.error("ADMIN.GQL Exception: {}", errmsg)
+            log.debug("{}", "".join(traceback.format_exception(e)))
     return result
 
 

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -147,6 +147,12 @@ class EndpointRow(Base):
     routings = relationship("RoutingRow", back_populates="endpoint_row")
     tokens = relationship("EndpointTokenRow", back_populates="endpoint_row")
     image_row = relationship("ImageRow", back_populates="endpoints")
+    created_user_row = relationship(
+        "UserRow", back_populates="created_endpoints", foreign_keys="EndpointRow.created_user"
+    )
+    session_owner_row = relationship(
+        "UserRow", back_populates="owned_endpoints", foreign_keys="EndpointRow.session_owner"
+    )
 
     def __init__(
         self,
@@ -368,8 +374,16 @@ class Endpoint(graphene.ObjectType):
     url = graphene.String()
     model = graphene.UUID()
     model_mount_destiation = graphene.String()
-    created_user = graphene.UUID()
-    session_owner = graphene.UUID()
+    created_user = graphene.UUID(
+        deprecation_reason="Deprecated since 23.09.8; use `created_user_id`"
+    )
+    created_user_email = graphene.String(description="Added at 23.09.8")
+    created_user_id = graphene.UUID(description="Added at 23.09.8")
+    session_owner = graphene.UUID(
+        deprecation_reason="Deprecated since 23.09.8; use `session_owner_id`"
+    )
+    session_owner_email = graphene.String(description="Added at 23.09.8")
+    session_owner_id = graphene.UUID(description="Added at 23.09.8")
     tag = graphene.String()
     startup_command = graphene.String()
     bootstrap_script = graphene.String()
@@ -410,7 +424,11 @@ class Endpoint(graphene.ObjectType):
             model=row.model,
             model_mount_destiation=row.model_mount_destiation,
             created_user=row.created_user,
+            created_user_id=row.created_user,
+            created_user_email=row.created_user_row.email,
             session_owner=row.session_owner,
+            session_owner_id=row.session_owner,
+            session_owner_email=row.session_owner_row.email,
             tag=row.tag,
             startup_command=row.startup_command,
             bootstrap_script=row.bootstrap_script,
@@ -477,6 +495,8 @@ class Endpoint(graphene.ObjectType):
             .offset(offset)
             .options(selectinload(EndpointRow.image_row))
             .options(selectinload(EndpointRow.routings))
+            .options(selectinload(EndpointRow.created_user_row))
+            .options(selectinload(EndpointRow.session_owner_row))
             .order_by(sa.desc(EndpointRow.created_at))
             .filter(
                 EndpointRow.lifecycle_stage.in_([

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -174,6 +174,13 @@ class UserRow(Base):
     resource_policy_row = relationship("UserResourcePolicyRow", back_populates="users")
     keypairs = relationship("KeyPairRow", back_populates="user_row", foreign_keys="KeyPairRow.user")
 
+    created_endpoints = relationship(
+        "EndpointRow", back_populates="created_user_row", foreign_keys="EndpointRow.created_user"
+    )
+    owned_endpoints = relationship(
+        "EndpointRow", back_populates="session_owner_row", foreign_keys="EndpointRow.session_owner"
+    )
+
     main_keypair = relationship("KeyPairRow", foreign_keys=users.c.main_access_key)
 
 


### PR DESCRIPTION
This PR updates `Endpoint` GQL model to make available to query email address of both model service creator and model session owner.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue