### PR TITLE
fix: Fill vfolder user and group field

### DIFF
--- a/changes/1837.fix.md
+++ b/changes/1837.fix.md
@@ -1,0 +1,1 @@
+Fix `vfolder_list` GQL query not returning `user_email` and `groups_name` field

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -1123,15 +1123,21 @@ class VirtualFolder(graphene.ObjectType):
         if row is None:
             return None
 
+        def _get_field(name: str) -> Any:
+            try:
+                return row[name]
+            except sa.exc.NoSuchColumnError:
+                return None
+
         return cls(
             id=row["id"],
             host=row["host"],
             quota_scope_id=row["quota_scope_id"],
             name=row["name"],
             user=row["user"],
-            user_email=row["users_email"] if "users_email" in row else None,
+            user_email=_get_field("users_email"),
             group=row["group"],
-            group_name=row["groups_name"] if "groups_name" in row else None,
+            group_name=_get_field("groups_name"),
             creator=row["creator"],
             unmanaged_path=row["unmanaged_path"],
             usage_mode=row["usage_mode"],


### PR DESCRIPTION


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
