### PR TITLE
hotfix: Resolve cycle in alembic migration versions

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/c5ed277b7f7b_change_main_access_key_ondelete_to_set_.py
+++ b/src/ai/backend/manager/models/alembic/versions/c5ed277b7f7b_change_main_access_key_ondelete_to_set_.py
@@ -1,7 +1,7 @@
 """change_main_access_key_ondelete_to_set_null
 
 Revision ID: c5ed277b7f7b
-Revises: 8b2ec7e3d22a
+Revises: d3f8c74bf148
 Create Date: 2024-01-11 15:37:24.097596
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c5ed277b7f7b"
-down_revision = "8b2ec7e3d22a"
+down_revision = "d3f8c74bf148"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This PR is a follow-up of e9b81fc190f79da478783a0573f53947c0268b69.

Two alembic migration scripts* c5ed277b7f7b by #1775 and 8b2ec7e3d22a by #1835) have dependencies on each other.

https://github.com/lablup/backend.ai/blob/e9b81fc190f79da478783a0573f53947c0268b69/src/ai/backend/manager/models/alembic/versions/c5ed277b7f7b_change_main_access_key_ondelete_to_set_.py#L12-L13

https://github.com/lablup/backend.ai/blob/e9b81fc190f79da478783a0573f53947c0268b69/src/ai/backend/manager/models/alembic/versions/8b2ec7e3d22a_remove_unique_constraint_of_endpoint_url.py#L12-L13

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
