### PR TITLE
fix: pydantic raising 500 when response includes UUID

### DIFF
--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -230,9 +230,11 @@ def ensure_stream_response_type(
 ) -> web.StreamResponse:
     match response:
         case BaseModel():
-            return web.json_response(response.model_dump())
+            return web.json_response(response.model_dump(mode="json"))
         case list():
-            return web.json_response(TypeAdapter(list[TResponseModel]).dump_python(response))
+            return web.json_response(
+                TypeAdapter(list[TResponseModel]).dump_python(response, mode="json")
+            )
         case web_response.StreamResponse():
             return response
         case _:


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
Follow-up PR of #1804. Resolves Pydantic raising `TypeError` when response includes UUID object.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
