### PR TITLE
fix: Query inconsistencies and mistakes in the vfolder share/change-ownership API handlers

### DIFF
--- a/changes/1850.fix.md
+++ b/changes/1850.fix.md
@@ -1,1 +1,1 @@
-fix query in function `share()` to make valid query and `change_vfolder_options()` to eliminate inconsistency between select and update clause  
+Fix mistakes on SQL queries in the manager's vfolder share API handler when checking target user's status and inconsistent where clauses in the vfolder ownership change API

--- a/changes/1850.fix.md
+++ b/changes/1850.fix.md
@@ -1,0 +1,1 @@
+fix query in function `share()` to make valid query and `change_vfolder_options()` to eliminate inconsistency between select and update clause  

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2026,7 +2026,7 @@ async def share(request: web.Request, params: Any) -> web.Response:
                 (users.c.email.in_(params["emails"]))
                 & (users.c.email != request["user"]["email"])
                 & (agus.c.group_id == vf_info["group"])
-                & (users.c.status == ACTIVE_USER_STATUSES),
+                & (users.c.status.in_(ACTIVE_USER_STATUSES)),
             )
         )
         result = await conn.execute(query)
@@ -2045,7 +2045,7 @@ async def share(request: web.Request, params: Any) -> web.Response:
 
         # Do not share to users who have already been shared the folder.
         query = (
-            sa.select([vfolder_permissions.c.user])
+            sa.select([vfolder_permissions])
             .select_from(vfolder_permissions)
             .where(
                 (vfolder_permissions.c.user.in_(users_to_share))
@@ -3212,7 +3212,12 @@ async def change_vfolder_ownership(request: web.Request, params: Any) -> web.Res
     )
     async with root_ctx.db.begin_readonly() as conn:
         query = (
-            sa.select([vfolders.c.host]).select_from(vfolders).where(vfolders.c.id == vfolder_id)
+            sa.select([vfolders.c.host])
+            .select_from(vfolders)
+            .where(
+                (vfolders.c.id == vfolder_id)
+                & (vfolders.c.ownership_type == VFolderOwnershipType.USER)
+            )
         )
         folder_host = await conn.scalar(query)
     if folder_host not in allowed_hosts_by_user:


### PR DESCRIPTION
fix of vfolder query while making audit_logs

1. share
  `ACTIVE_USER_STATUSES` is tuple so fixed operator from `==` to `in`
   
2. chage_vfolder_options
  there was inconsistency between update and select statement which look for folder to update
