### PR TITLE
feature: update `delete-dev.sh` to remove DB volumes by default

### DIFF
--- a/changes/1852.feature.md
+++ b/changes/1852.feature.md
@@ -1,0 +1,1 @@
+Change default to remove all volumes when execute delete-dev.sh and add "--skip-db" option to skip to remove volumes

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -34,6 +34,8 @@ usage() {
   echo "  ${LWHITE}--skip-containers${NC}  Skip removal of docker resources (default: false)"
   echo ""
   echo "  ${LWHITE}--skip-venvs${NC}       Skip removal of temporary virtualenvs (default: false)"
+  echo ""
+  echo "  ${LWHITE}--skip-db${NC}       Skip removal of volume resources (default: false)"
 }
 
 show_error() {
@@ -100,12 +102,14 @@ fi
 INSTALL_PATH="./backend.ai-dev"
 REMOVE_VENVS=1
 REMOVE_CONTAINERS=1
+REMOVE_DB=1
 
 while [ $# -gt 0 ]; do
   case $1 in
     -h | --help)           usage; exit 1 ;;
     --skip-venvs)          REMOVE_VENVS=0 ;;
     --skip-containers)     REMOVE_CONTAINERS=0 ;;
+    --skip-db)             REMOVE_DB=0 ;;
     *)
       echo "Unknown option: $1"
       echo "Run '$0 --help' for usage."
@@ -132,6 +136,11 @@ if [ $REMOVE_CONTAINERS -eq 1 ]; then
   fi
 else
   show_info "Skipped removal of Docker containers."
+fi
+
+if [ $REMOVE_DB -eq 1 ]; then
+  show_info "Removing data volumes..."
+  sudo rm -rf volumes
 fi
 
 echo ""

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -35,7 +35,7 @@ usage() {
   echo ""
   echo "  ${LWHITE}--skip-venvs${NC}       Skip removal of temporary virtualenvs (default: false)"
   echo ""
-  echo "  ${LWHITE}--skip-db${NC}       Skip removal of volume resources (default: false)"
+  echo "  ${LWHITE}--skip-db${NC}          Skip removal of volume resources (default: false)"
 }
 
 show_error() {
@@ -140,7 +140,7 @@ fi
 
 if [ $REMOVE_DB -eq 1 ]; then
   show_info "Removing data volumes..."
-  sudo rm -rf volumes
+  rm -rf volumes
 fi
 
 echo ""


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR resolves #1802 by adding option "--skip-db".

1. User can delete all data volumes with no option.
`./scripts/delete-dev.sh`
2. User can skip to delete all data volumes with "--skip-db" option.
`./scripts/install-dev.sh --skip-db`
3. User can get help through the --help command.
`./scripts/install-dev.sh --help`
and then,
  ```
  USAGE
    ./scripts/delete-dev.sh [OPTIONS]
  
  OPTIONS
    -h, --help         Show this help and exit
  
    --skip-containers  Skip removal of docker resources (default: false)
  
    --skip-venvs       Skip removal of temporary virtualenvs (default: false)
  
    --skip-db       Skip removal of volume resources (default: false)
  ```
**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
