### PR TITLE
fix: add default group when cil signup and return groups info

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+when user singup at cli-env, add default group when create a user without specifying the project, and return groups when signup at cli

--- a/src/ai/backend/client/cli/admin/user.py
+++ b/src/ai/backend/client/cli/admin/user.py
@@ -255,6 +255,13 @@ def add(
                 allowed_client_ip=allowed_ip,
                 description=description,
                 sudo_session_enabled=sudo_session_enabled,
+                fields=(
+                    user_fields["domain_name"],
+                    user_fields["email"],
+                    user_fields["username"],
+                    user_fields["uuid"],
+                    user_fields["groups"],
+                ),
             )
         except Exception as e:
             ctx.output.print_mutation_error(
@@ -270,6 +277,9 @@ def add(
                 action_name="add",
             )
             sys.exit(ExitCode.FAILURE)
+
+        # preprocessing groups
+        data["user"]["groups"] = " ,".join(item["name"] for item in data["user"]["groups"])
         ctx.output.print_mutation_result(
             data,
             item_name="user",

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -657,10 +657,18 @@ class CreateUser(graphene.Mutation):
             model_store_query = sa.select([groups.c.id]).where(
                 groups.c.type == ProjectType.MODEL_STORE
             )
+            default_query = sa.select([groups.c.id]).where(groups.c.name == "default")
+
             model_store_gid = (await conn.execute(model_store_query)).first()["id"]
-            gids_to_join = [*group_ids, model_store_gid]
+            default_gid = (await conn.execute(default_query)).first()["id"]
+
+            if group_ids:
+                gids_to_join = [*group_ids, model_store_gid]
+            else:
+                gids_to_join = [default_gid, model_store_gid]
 
             # Add user to groups if group_ids parameter is provided.
+            # Or add default group
             if gids_to_join:
                 query = (
                     sa.select([groups.c.id])


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR resolves #1625 by add default-group when signup in cli-env

1. Now when user signup at cil-mode, add default-group
2. When signup at cil-env, it return user's group info

![스크린샷 2024-01-23 오후 4 51 45](https://github.com/lablup/backend.ai/assets/91869302/02401832-c50f-448a-a878-156d01e1ff9c)


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
