### PR TITLE
ci: PR that has already been merged will not run ci

### DIFF
--- a/.github/workflows/alembic-head-check.yml
+++ b/.github/workflows/alembic-head-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-multiple-heads:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'require:db-migration') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'require:db-migration') && github.event.pull_request.merged == false }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
     runs-on: arc-runner-set
     steps:
     - name: Calculate the fetch depth
@@ -81,7 +81,7 @@ jobs:
 
 
   typecheck:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
     runs-on: arc-runner-set
     steps:
     - name: Calculate the fetch depth
@@ -144,7 +144,7 @@ jobs:
 
 
   test:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
     runs-on: [ubuntu-latest-8-cores]
     steps:
     - name: Calculate the fetch depth

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   docs-preview-links-:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'area:docs') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'area:docs') && github.event.pull_request.merged == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Make a link to the doc preview build (en)

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pr-number-assign:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') && github.event.pull_request.number != null }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') && github.event.pull_request.number != null && github.event.pull_request.merged == false }}
     uses: ./.github/workflows/pr-number-assign.yml
     secrets:
       WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
These workflows were triggered not only by branch changes such as commits, but also by label changes in pr, so they could be executed even after pr was merged.
However, since CI for already merged pr is meaningless, it saves resources by not executing it.