### PR TITLE
fix: Keypair double-count across multiple projects

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fix double-count issue caused by keypairs belonging to multiple projects

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -339,7 +339,7 @@ class KeyPair(graphene.ObjectType):
             .join(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
             .join(groups, association_groups_users.c.group_id == groups.c.id)
         )
-        query = sa.select([sa.func.count()]).select_from(j)
+        query = sa.select([sa.func.count()]).group_by(keypairs.c.access_key).select_from(j)
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)
         if email is not None:
@@ -351,7 +351,7 @@ class KeyPair(graphene.ObjectType):
             query = qfparser.append_filter(query, filter)
         async with graph_ctx.db.begin_readonly() as conn:
             result = await conn.execute(query)
-            return result.scalar()
+            return len(result.all())
 
     @classmethod
     async def load_slice(


### PR DESCRIPTION
This PR is a follow-up to #1749 and fixes double-count in keypairs across multiple projects.

This occurred when attempting to list keypairs using the command:

```sh
$ backend.ai admin keypair list
```

However, the command got stuck in an infinite loop. After investigating the code below:
https://github.com/lablup/backend.ai/blob/a4149f26bae3ff510ecf54e1b355f60b8206b481/src/ai/backend/client/output/console.py#L130-L139
I observed that `fetch_func()` returned an empty list (`len(result.items) == 0`). Despite having only 6 keypairs, `result.total_count` was 12, indicating duplication.

Further investigation revealed that `Keypair.load_count()` did not aggregate the results, leading to the duplication issue.

https://github.com/lablup/backend.ai/blob/7c2ab43d5f4787caf29631d7ee4c3599ca2dfc4a/src/ai/backend/manager/models/keypair.py#L324-L342

![image](https://github.com/lablup/backend.ai/assets/14137676/b25af979-4a1a-4087-8592-ad7ad856056a)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
