### PR TITLE
fix: halt session creation when invalid resource slot provided

### DIFF
--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import copy
+import decimal
 import itertools
 import logging
 import re
@@ -437,6 +438,22 @@ class AgentRegistry:
                     raise InvalidAPIParameters(
                         "Alias name cannot be set to an existing folder name: " + str(alias_name)
                     )
+
+        if _resources := config["resources"]:
+            available_resource_slots = await self.shared_config.get_resource_slots()
+            unknown_resource_slots = _resources.keys() - available_resource_slots.keys()
+            if (
+                len(unknown_resource_slots) > 0
+            ):  # request contains resource request for unknown accelerator
+                raise InvalidAPIParameters(f"Unknown resource type: {list(unknown_resource_slots)}")
+            interim_value: Dict[str, Any] = _resources
+            mem = _resources.get("mem")
+            try:
+                if isinstance(mem, str) and not mem.isdigit():
+                    interim_value["mem"] = BinarySize.from_str(mem)
+                ResourceSlot.from_json(interim_value)
+            except (decimal.InvalidOperation, ValueError):
+                raise InvalidAPIParameters("Invalid value passed to resource allocation amount")
 
         # Resolve the image reference.
         try:


### PR DESCRIPTION
This PR fixes model service API raising InternalServiceError when `requested_slot` with invalid syntax has been inserted into the `endpoints` table.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
