### PR TITLE
fix: enqueue session with `use_host_network` field

### DIFF
--- a/changes/1873.fix.md
+++ b/changes/1873.fix.md
@@ -1,1 +1,1 @@
-Insert the `use_host_network` field along the scaling_group to which the session belongs.
+Enqueue session with `use_host_network` field along the scaling_group to which the session belongs.

--- a/changes/1873.fix.md
+++ b/changes/1873.fix.md
@@ -1,0 +1,1 @@
+Insert the `use_host_network` field along the scaling_group to which the session belongs.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -991,6 +991,7 @@ class AgentRegistry:
             "callback_url": callback_url,
             "occupying_slots": ResourceSlot(),
             "vfolder_mounts": vfolder_mounts,
+            "use_host_network": use_host_network,
         }
 
         kernel_shared_data = {


### PR DESCRIPTION
Insert `sessions` rows with valid `use_host_network` field.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version