### PR TITLE
fix: drop existing primary keys of association tables

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
@@ -36,6 +36,18 @@ def upgrade():
         sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
     )
 
+    def drop_existing_pk(idx: str, table: str):
+        try:
+            op.drop_constraint(idx, table, type_="primary")
+        except sa.exc.ProgrammingError:
+            # Skip dropping if the table has no primary key
+            pass
+
+    drop_existing_pk("pk_association_groups_users", "association_groups_users")
+    drop_existing_pk("pk_sgroups_for_domains", "sgroups_for_domains")
+    drop_existing_pk("pk_sgroups_for_groups", "sgroups_for_groups")
+    drop_existing_pk("pk_sgroups_for_keypairs", "sgroups_for_keypairs")
+
     op.create_primary_key("pk_association_groups_users", "association_groups_users", ["id"])
     op.create_primary_key("pk_sgroups_for_domains", "sgroups_for_domains", ["id"])
     op.create_primary_key("pk_sgroups_for_groups", "sgroups_for_groups", ["id"])
@@ -52,3 +64,14 @@ def downgrade():
     op.drop_column("sgroups_for_groups", "id")
     op.drop_column("sgroups_for_domains", "id")
     op.drop_column("association_groups_users", "id")
+
+    op.create_primary_key(
+        "pk_association_groups_users", "association_groups_users", ["user_id", "group_id"]
+    )
+    op.create_primary_key(
+        "pk_sgroups_for_domains", "sgroups_for_domains", ["scaling_group", "domain"]
+    )
+    op.create_primary_key("pk_sgroups_for_groups", "sgroups_for_groups", ["scaling_group", "group"])
+    op.create_primary_key(
+        "pk_sgroups_for_keypairs", "sgroups_for_keypairs", ["scaling_group", "access_key"]
+    )


### PR DESCRIPTION
follow-up #1818 

There could be mismatch between alembic migrations and real DB. I mistakenly write alembic scripts to delete primary keys from association tables in #576, but usually alembic does not delete the pk.

Since the primary keys remain in some DBs and don't remain in others, let's sync it in this patch by dropping existing pk in association tables and restore them when downgrade alembic

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options