### PR TITLE
feature: Set `pool-recycle` config to prevent using closed connection

### DIFF
--- a/changes/1877.feature.md
+++ b/changes/1877.feature.md
@@ -1,0 +1,1 @@
+Add `pool-recycle` config to drop and replace timed-out connections.

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -11,6 +11,7 @@ addr = { host = "localhost", port = 8100 }
 name = "backend"
 user = "postgres"
 password = "develove"
+pool-recycle = 50
 
 
 [manager]

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -26,6 +26,12 @@ password = "DB_PASSWORD"                    # env: BACKEND_DB_PASSWORD
 # (See https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_size)
 # pool-size = 8
 
+# This setting causes the pool to recycle connections after the given number of seconds has passed.
+# Default is -1, which means infinite. 
+# https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_recycle
+# https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle
+# pool-recycle = -1
+
 # The maximum allowed overflow of the connection pool
 # (See https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.max_overflow)
 # max-overflow = 64

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -243,6 +243,7 @@ manager_local_config_iv = (
             t.Key("user"): t.String,
             t.Key("password"): t.String,
             t.Key("pool-size", default=8): t.ToInt[1:],  # type: ignore
+            t.Key("pool-recycle", default=-1): t.ToFloat[-1:],  # -1 is infinite
             t.Key("max-overflow", default=64): t.ToInt[-1:],  # -1 is infinite  # type: ignore
         }),
         t.Key("manager"): t.Dict({

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -198,6 +198,7 @@ async def connect_database(
         url,
         connect_args=pgsql_connect_opts,
         pool_size=local_config["db"]["pool-size"],
+        pool_recycle=local_config["db"]["pool-recycle"],
         max_overflow=local_config["db"]["max-overflow"],
         json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
         isolation_level=isolation_level,

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -176,6 +176,7 @@ def local_config(
             "user": "postgres",
             "password": "develove",
             "pool-size": 8,
+            "pool-recycle": -1,
             "max-overflow": 64,
         },
         "manager": {


### PR DESCRIPTION
"connection is closed" `DBAPIError` can occur if we set timeout for connections. This is because the pools of SQLAlchemy is not fully synced with real connections.
Let's set `pool-recycle` config to replace timeout connections
- https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_recycle
- https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle
- https://community.fly.io/t/postgresql-connection-is-closed-error-after-a-few-minutes-of-activity/4768
- https://github.com/sqlalchemy/sqlalchemy/discussions/7657

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
