### PR TITLE
fix: add watcher.py back to agent wheel

### DIFF
--- a/changes/1880.fix.md
+++ b/changes/1880.fix.md
@@ -1,0 +1,1 @@
+Bring `watcher.py` back to Backend.AI Agent wheel

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -2,7 +2,9 @@ python_sources(
     name="src",
     sources=[
         "*.py",
-        "!watcher.py",
+# FIXME: remove watcher.py from agent artifact after we settle down
+# binary-based agent watcher deployments
+#        "!watcher.py",
     ],
     dependencies=[
         "src/ai/backend/cli:src",  # not auto-inferred

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -2,9 +2,9 @@ python_sources(
     name="src",
     sources=[
         "*.py",
-# FIXME: remove watcher.py from agent artifact after we settle down
-# binary-based agent watcher deployments
-#        "!watcher.py",
+        # FIXME: remove watcher.py from agent artifact after we settle down
+        # binary-based agent watcher deployments
+        # "!watcher.py",
     ],
     dependencies=[
         "src/ai/backend/cli:src",  # not auto-inferred


### PR DESCRIPTION
This PR updates agent's `BUILD` file in order to include `watcher.py` back to agent wheel. `watcher.py`, a source code of our agent watcher, is set to be split out from Backend.AI Agent distribution artifact and be served as a standalone binary. Since majority of deployed Backend.AI clusters are relying on current Backend.AI Agent watcher distribution mechanism, we decided that until we polish our deployment policies to reflect those changes it is better to keep `watcher.py` into agent distribution artifact.
**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
