### PR TITLE
docs: add helper message for the allowed_session_types

### DIFF
--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -100,7 +100,7 @@ def list(ctx: CLIContext) -> None:
     default="{}",
     help="""
         Set scheduler options as a JSON string.
-        For 'allowed_session_types', if the key does not exist, the values 'interactive' and 'batch' are set.
+        If the 'allowed_session_types' key is not specified, the policy defaults to accept both 'interactive' and 'batch'.
         """,
 )
 @click.option(
@@ -212,7 +212,7 @@ def add(
     default=undefined,
     help="""
         Set scheduler options as a JSON string.
-        For 'allowed_session_types', if the key does not exist, the values 'interactive' and 'batch' are set.
+        If the 'allowed_session_types' key is not specified, the policy defaults to accept both 'interactive' and 'batch'.
         """,
 )
 @click.option(

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -98,7 +98,10 @@ def list(ctx: CLIContext) -> None:
     "--scheduler-opts",
     type=JSONParamType(),
     default="{}",
-    help="Set scheduler options as a JSON string.",
+    help="""
+        Set scheduler options as a JSON string.
+        For 'allowed_session_types', if the key does not exist, the values 'interactive' and 'batch' are set.
+        """,
 )
 @click.option(
     "--use-host-network",
@@ -207,7 +210,10 @@ def add(
     "--scheduler-opts",
     type=OptionalType(JSONParamType),
     default=undefined,
-    help="Set scheduler options as a JSON string.",
+    help="""
+        Set scheduler options as a JSON string.
+        For 'allowed_session_types', if the key does not exist, the values 'interactive' and 'batch' are set.
+        """,
 )
 @click.option(
     "--use-host-network",


### PR DESCRIPTION
This PR resolves #1293 by adding helper message for the `allowed_session_types` in create and modify commands of scaling group.
The commands work well even without `allowed_session_types`, but since `allowed_session_types` is set to the default values of `interactive` and `batch`, it may not operate as intended by the user. 
Therefore, a helper message has been added.