### PR TITLE
fix: Make the event names consistent when reporting already-completed bgtask

### DIFF
--- a/changes/1886.fix.md
+++ b/changes/1886.fix.md
@@ -1,0 +1,1 @@
+Fix inconsistent event names reported when making event source channels for already-completed bgtasks (background tasks), which has caused a stale progress bar UI lingering for bgtask operations that finished too quickly

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -38,7 +38,7 @@ from .types import AgentId, Sentinel
 
 sentinel: Final = Sentinel.TOKEN
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
-TaskResult = Literal["bgtask_started", "bgtask_done", "bgtask_cancelled", "bgtask_failed"]
+TaskStatus = Literal["bgtask_started", "bgtask_done", "bgtask_cancelled", "bgtask_failed"]
 BgtaskEvents: TypeAlias = (
     BgtaskUpdatedEvent | BgtaskDoneEvent | BgtaskCancelledEvent | BgtaskFailedEvent
 )
@@ -168,7 +168,7 @@ class BackgroundTaskManager:
                         "total_progress": task_info["total"],
                         "message": task_info["msg"],
                     }
-                    await resp.send(json.dumps(body), event=f"bgtask_{task_info['status']}")
+                    await resp.send(json.dumps(body), event="bgtask_" + task_info["status"])
                 finally:
                     await resp.send("{}", event="server_close")
             return resp
@@ -252,7 +252,7 @@ class BackgroundTaskManager:
         task_name: str | None,
         **kwargs,
     ) -> None:
-        task_result: TaskResult = "bgtask_started"
+        task_result: TaskStatus = "bgtask_started"
         reporter = ProgressReporter(self.event_producer, task_id)
         message = ""
         event_cls: Type[BgtaskDoneEvent] | Type[BgtaskCancelledEvent] | Type[BgtaskFailedEvent] = (

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -165,7 +165,7 @@ class BackgroundTaskManager:
                         "total_progress": task_info["total"],
                         "message": task_info["msg"],
                     }
-                    await resp.send(json.dumps(body), event=f"task_{task_info['status']}")
+                    await resp.send(json.dumps(body), event=f"bgtask_{task_info['status']}")
                 finally:
                     await resp.send("{}", event="server_close")
             return resp


### PR DESCRIPTION
When the client makes the EventSource channel later than the target bgtask has already finished, the server "simulates" a realtime event using the temporarily stored (up to 24 hours by default) task information from Redis.

The event name must be consistent for both the actual realtime event pushes and postmortem event pushes, for a seamless frontend implementation.

There was a typo missing "bg" in the postmortem event push logic. 😭 So, `bgtask_done` was reported as `task_done`...

This PR fixes this issue and refactors the bgtask module code a little bit more to prevent confusion of future code readers using latest Python conventions (such as `str.removeprefix()`).

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version