### PR TITLE
ci: Set fetch-depth to calculate prev_tag

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -411,6 +411,8 @@ jobs:
     environment: deploy-to-pypi
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Fetch remote tags
       run: git fetch origin 'refs/tags/*:refs/tags/*' -f
     - name: Extract Python version from pants.toml

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -411,8 +411,6 @@ jobs:
     environment: deploy-to-pypi
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Fetch remote tags
       run: git fetch origin 'refs/tags/*:refs/tags/*' -f
     - name: Extract Python version from pants.toml

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -16,7 +16,7 @@ def get_tag():
 
 def get_prev_tag():
     tag = get_tag()
-    p = subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'git://github.com/{os.environ["GITHUB_REPOSITORY"]}.git', '.git-tmp'], capture_output=True)
+    subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'git://github.com/{os.environ["GITHUB_REPOSITORY"]}.git', '.git-tmp'])
     p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', tag + '^'], capture_output=True, cwd='.git-tmp')
     prev_tag = p.stdout.decode().strip()
     return prev_tag

--- a/scripts/extract-release-changelog.py
+++ b/scripts/extract-release-changelog.py
@@ -16,9 +16,9 @@ def get_tag():
 
 def get_prev_tag():
     tag = get_tag()
-    p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', tag + '^'], capture_output=True)
+    p = subprocess.run(['git', 'clone', '--filter=blob:none', '--no-checkout', f'git://github.com/{os.environ["GITHUB_REPOSITORY"]}.git', '.git-tmp'], capture_output=True)
+    p = subprocess.run(['git', 'describe', '--abbrev=0', '--tags', tag + '^'], capture_output=True, cwd='.git-tmp')
     prev_tag = p.stdout.decode().strip()
-
     return prev_tag
 
 def main():


### PR DESCRIPTION
<img width="523" alt="CleanShot 2024-02-07 at 03 56 06@2x" src="https://github.com/lablup/backend.ai/assets/31057849/395d3715-1008-4425-b4bc-39e2856287a6">

The prev_tag calculation was not performed properly after #1520.
The reason is that by default, only one commit log is fetched in actions/checkout, so prev_tag could not be calculated.