### PR TITLE
fix: Modify help text for delete and purge domain

### DIFF
--- a/src/ai/backend/client/cli/admin/domain.py
+++ b/src/ai/backend/client/cli/admin/domain.py
@@ -228,7 +228,7 @@ def update(
 @click.argument("name", type=str, metavar="NAME")
 def delete(ctx: CLIContext, name: str) -> None:
     """
-    Inactive an existing domain.
+    Deletes an existing domain. This action only deletes the primary record and might leave behind some associated data or metadata that can be manually cleaned up or ignored. Ideal for removing items that may be re-created or restored.
 
     NAME: Name of a domain to inactive.
     """
@@ -262,7 +262,7 @@ def delete(ctx: CLIContext, name: str) -> None:
 @click.argument("name", type=str, metavar="NAME")
 def purge(ctx: CLIContext, name: str) -> None:
     """
-    Delete an existing domain.
+    Purges an existing domain. This action is irreversible and should be used when you need to ensure that no trace of the resource remains.
 
     NAME: Name of a domain to delete.
     """

--- a/src/ai/backend/client/func/domain.py
+++ b/src/ai/backend/client/func/domain.py
@@ -183,7 +183,7 @@ class Domain(BaseFunction):
     @classmethod
     async def delete(cls, name: str):
         """
-        Inactivates an existing domain.
+        Deletes an existing domain. This action only deletes the primary record and might leave behind some associated data or metadata that can be manually cleaned up or ignored. Ideal for removing items that may be re-created or restored.
         """
         query = textwrap.dedent(
             """\
@@ -202,7 +202,7 @@ class Domain(BaseFunction):
     @classmethod
     async def purge(cls, name: str):
         """
-        Deletes an existing domain.
+        Purges an existing domain. This action is irreversible and should be used when you need to ensure that no trace of the resource remains.
         """
         query = textwrap.dedent(
             """\


### PR DESCRIPTION
Domain's purge help text explains delete.
Of course, delete and purge are words used with similar meanings, but there is a command called domain delete, which can confuse users.
```
Delete the given virtual folder.
Purge the given virtual folder.
```
I modified it by referring to the vfolder delete and purge help phrases above.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
