### PR TITLE
ci: Change lfs to use actions/cache in test job

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -160,7 +160,7 @@ jobs:
     - name: Create LFS file hash list
       run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
     - name: Restore LFS cache
-      uses: maxnowack/local-cache@v1
+      uses: actions/cache@v4
       id: lfs-cache
       with:
           path: .git/lfs


### PR DESCRIPTION
![image](https://github.com/lablup/backend.ai/assets/31057849/41a2e35e-9477-4b49-8bd8-0dcc8c51a261)

The test job was running on the github hosted runner, but the lfs cache was set to use local-cache, so the cache was not being used at all.
This issue causes a lot of github lfs traffic and causes a lot of charges.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
