### PR TITLE
fix: GQL Relay node query builder does not have `queryfilter_fieldspec` and `queryorder_colmap`

### DIFF
--- a/changes/1916.fix.md
+++ b/changes/1916.fix.md
@@ -1,0 +1,1 @@
+Fix GQL Relay node resolver to parse `filter` and `order` argument into SQL query properly.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -1324,6 +1324,8 @@ def _build_sql_stmt_from_sql_arg(
 
     if offset is not None:
         stmt = stmt.offset(offset)
+    for cond in conditions:
+        stmt = stmt.where(cond)
     return stmt, conditions
 
 

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -1233,8 +1233,8 @@ def _build_sql_stmt_from_connection_args(
     info: graphene.ResolveInfo,
     orm_class,
     id_column: sa.Column,
-    filter_expr: str | None = None,
-    order_expr: str | None = None,
+    filter_expr: FilterExprArg | None = None,
+    order_expr: OrderExprArg | None = None,
     *,
     connection_args: ConnectionArgs,
 ) -> tuple[sa.sql.Select, list[WhereClauseType]]:
@@ -1247,8 +1247,8 @@ def _build_sql_stmt_from_connection_args(
     id_ordering_item: OrderingItem = OrderingItem(id_column, OrderDirection.ASC)
     ordering_item_list: list[OrderingItem] = []
     if order_expr is not None:
-        parser = QueryOrderParser()
-        ordering_item_list = parser.parse_order(orm_class, order_expr)
+        parser = order_expr.parser
+        ordering_item_list = parser.parse_order(orm_class, order_expr.expr)
 
     # Apply SQL order_by
     match pagination_order:
@@ -1287,8 +1287,8 @@ def _build_sql_stmt_from_connection_args(
         stmt = stmt.limit(requested_page_size + 1)
 
     if filter_expr is not None:
-        condition_parser = QueryFilterParser()
-        conditions.append(condition_parser.parse_filter(orm_class, filter_expr))
+        condition_parser = filter_expr.parser
+        conditions.append(condition_parser.parse_filter(orm_class, filter_expr.expr))
 
     for cond in conditions:
         stmt = stmt.where(cond)
@@ -1299,8 +1299,8 @@ def _build_sql_stmt_from_sql_arg(
     info: graphene.ResolveInfo,
     orm_class,
     id_column: sa.Column,
-    filter_expr: str | None = None,
-    order_expr: str | None = None,
+    filter_expr: FilterExprArg | None = None,
+    order_expr: OrderExprArg | None = None,
     *,
     limit: int | None = None,
     offset: int | None = None,
@@ -1309,16 +1309,15 @@ def _build_sql_stmt_from_sql_arg(
     conditions: list[WhereClauseType] = []
 
     if order_expr is not None:
-        parser = QueryOrderParser()
-        stmt = parser.append_ordering(stmt, order_expr)
+        parser = order_expr.parser
+        stmt = parser.append_ordering(stmt, order_expr.expr)
 
     # default order_by id column
     stmt = stmt.order_by(id_column.asc())
 
     if filter_expr is not None:
-        condition_parser = QueryFilterParser()
-        # stmt = condition_parser.append_filter(stmt, filter_expr)
-        conditions.append(condition_parser.parse_filter(orm_class, filter_expr))
+        condition_parser = filter_expr.parser
+        conditions.append(condition_parser.parse_filter(orm_class, filter_expr.expr))
 
     if limit is not None:
         stmt = stmt.limit(limit)
@@ -1336,12 +1335,22 @@ class GraphQLConnectionSQLInfo(NamedTuple):
     requested_page_size: int | None
 
 
+class FilterExprArg(NamedTuple):
+    expr: str
+    parser: QueryFilterParser
+
+
+class OrderExprArg(NamedTuple):
+    expr: str
+    parser: QueryOrderParser
+
+
 def generate_sql_info_for_gql_connection(
     info: graphene.ResolveInfo,
     orm_class,
     id_column: sa.Column,
-    filter_expr: str | None = None,
-    order_expr: str | None = None,
+    filter_expr: FilterExprArg | None = None,
+    order_expr: OrderExprArg | None = None,
     offset: int | None = None,
     after: str | None = None,
     first: int | None = None,

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -36,7 +36,9 @@ from .base import (
     GUID,
     Base,
     EnumValueType,
+    FilterExprArg,
     IDColumn,
+    OrderExprArg,
     PaginatedConnectionField,
     ResourceSlotColumn,
     VFolderHostPermissionColumn,
@@ -54,6 +56,8 @@ from .gql_relay import (
     Connection,
     ConnectionResolverResult,
 )
+from .minilang.ordering import QueryOrderParser
+from .minilang.queryfilter import QueryFilterParser
 from .storage import StorageSessionManager
 from .user import ModifyUserInput, UserConnection, UserNode, UserRole
 from .utils import ExtendedAsyncSAEngine, execute_with_retry
@@ -830,6 +834,16 @@ class GroupNode(graphene.ObjectType):
         from .user import UserRow
 
         graph_ctx: GraphQueryContext = info.context
+        _filter_arg = (
+            FilterExprArg(filter, QueryFilterParser(UserNode._queryfilter_fieldspec))
+            if filter is not None
+            else None
+        )
+        _order_expr = (
+            OrderExprArg(order, QueryOrderParser(UserNode._queryorder_colmap))
+            if order is not None
+            else None
+        )
         (
             query,
             conditions,
@@ -840,8 +854,8 @@ class GroupNode(graphene.ObjectType):
             info,
             UserRow,
             UserRow.uuid,
-            filter,
-            order,
+            _filter_arg,
+            _order_expr,
             offset,
             after=after,
             first=first,
@@ -884,6 +898,12 @@ class GroupNode(graphene.ObjectType):
         last: int | None = None,
     ) -> ConnectionResolverResult:
         graph_ctx: GraphQueryContext = info.context
+        _filter_arg = (
+            FilterExprArg(filter_expr, QueryFilterParser()) if filter_expr is not None else None
+        )
+        _order_expr = (
+            OrderExprArg(order_expr, QueryOrderParser()) if order_expr is not None else None
+        )
         (
             query,
             conditions,
@@ -894,8 +914,8 @@ class GroupNode(graphene.ObjectType):
             info,
             GroupRow,
             GroupRow.id,
-            filter_expr,
-            order_expr,
+            _filter_arg,
+            _order_expr,
             offset,
             after=after,
             first=first,

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -31,9 +31,11 @@ from ..defs import DEFAULT_KEYPAIR_RATE_LIMIT, DEFAULT_KEYPAIR_RESOURCE_POLICY_N
 from .base import (
     Base,
     EnumValueType,
+    FilterExprArg,
     IDColumn,
     IPColumn,
     Item,
+    OrderExprArg,
     PaginatedList,
     batch_multiresult,
     batch_result,
@@ -1376,6 +1378,48 @@ class UserNode(graphene.ObjectType):
             user_row = (await db_session.scalars(query)).first()
             return cls.from_row(user_row)
 
+    _queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
+        "uuid": ("uuid", None),
+        "username": ("username", None),
+        "email": ("email", None),
+        "need_password_change": ("need_password_change", None),
+        "full_name": ("full_name", None),
+        "description": ("description", None),
+        "is_active": ("is_active", None),
+        "status": ("status", enum_field_getter(UserStatus)),
+        "status_info": ("status_info", None),
+        "created_at": ("created_at", dtparse),
+        "modified_at": ("modified_at", dtparse),
+        "domain_name": ("domain_name", None),
+        "role": ("role", enum_field_getter(UserRole)),
+        "resource_policy": ("domain_name", None),
+        "allowed_client_ip": ("allowed_client_ip", None),
+        "totp_activated": ("totp_activated", None),
+        "totp_activated_at": ("totp_activated_at", dtparse),
+        "sudo_session_enabled": ("sudo_session_enabled", None),
+        "main_access_key": ("main_access_key", None),
+    }
+
+    _queryorder_colmap: Mapping[str, OrderSpecItem] = {
+        "uuid": ("uuid", None),
+        "username": ("username", None),
+        "email": ("email", None),
+        "need_password_change": ("need_password_change", None),
+        "full_name": ("full_name", None),
+        "is_active": ("is_active", None),
+        "status": ("status", None),
+        "status_info": ("status_info", None),
+        "created_at": ("created_at", None),
+        "modified_at": ("modified_at", None),
+        "domain_name": ("domain_name", None),
+        "role": ("role", None),
+        "resource_policy": ("resource_policy", None),
+        "totp_activated": ("totp_activated", None),
+        "totp_activated_at": ("totp_activated_at", None),
+        "sudo_session_enabled": ("sudo_session_enabled", None),
+        "main_access_key": ("main_access_key", None),
+    }
+
     @classmethod
     async def get_connection(
         cls,
@@ -1389,6 +1433,16 @@ class UserNode(graphene.ObjectType):
         last: int | None = None,
     ) -> ConnectionResolverResult:
         graph_ctx: GraphQueryContext = info.context
+        _filter_arg = (
+            FilterExprArg(filter_expr, QueryFilterParser(cls._queryfilter_fieldspec))
+            if filter_expr is not None
+            else None
+        )
+        _order_expr = (
+            OrderExprArg(order_expr, QueryOrderParser(cls._queryorder_colmap))
+            if order_expr is not None
+            else None
+        )
         (
             query,
             conditions,
@@ -1399,8 +1453,8 @@ class UserNode(graphene.ObjectType):
             info,
             UserRow,
             UserRow.uuid,
-            filter_expr,
-            order_expr,
+            _filter_arg,
+            _order_expr,
             offset,
             after=after,
             first=first,

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -51,8 +51,10 @@ from .base import (
     Base,
     BigInt,
     EnumValueType,
+    FilterExprArg,
     IDColumn,
     Item,
+    OrderExprArg,
     PaginatedList,
     QuotaScopeIDType,
     batch_multiresult,
@@ -1854,6 +1856,62 @@ class ModelCard(graphene.ObjectType):
         )
     )
 
+    _queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
+        "id": ("vfolders_id", uuid.UUID),
+        "host": ("vfolders_host", None),
+        "quota_scope_id": ("vfolders_quota_scope_id", None),
+        "name": ("vfolders_name", None),
+        "group": ("vfolders_group", uuid.UUID),
+        "group_name": ("groups_name", None),
+        "user": ("vfolders_user", uuid.UUID),
+        "user_email": ("users_email", None),
+        "creator": ("vfolders_creator", None),
+        "unmanaged_path": ("vfolders_unmanaged_path", None),
+        "usage_mode": (
+            "vfolders_usage_mode",
+            enum_field_getter(VFolderUsageMode),
+        ),
+        "permission": (
+            "vfolders_permission",
+            enum_field_getter(VFolderPermission),
+        ),
+        "ownership_type": (
+            "vfolders_ownership_type",
+            enum_field_getter(VFolderOwnershipType),
+        ),
+        "max_files": ("vfolders_max_files", None),
+        "max_size": ("vfolders_max_size", None),
+        "created_at": ("vfolders_created_at", dtparse),
+        "last_used": ("vfolders_last_used", dtparse),
+        "cloneable": ("vfolders_cloneable", None),
+        "status": (
+            "vfolders_status",
+            enum_field_getter(VFolderOperationStatus),
+        ),
+    }
+
+    _queryorder_colmap: Mapping[str, OrderSpecItem] = {
+        "id": ("vfolders_id", None),
+        "host": ("vfolders_host", None),
+        "quota_scope_id": ("vfolders_quota_scope_id", None),
+        "name": ("vfolders_name", None),
+        "group": ("vfolders_group", None),
+        "group_name": ("groups_name", None),
+        "user": ("vfolders_user", None),
+        "user_email": ("users_email", None),
+        "creator": ("vfolders_creator", None),
+        "usage_mode": ("vfolders_usage_mode", None),
+        "permission": ("vfolders_permission", None),
+        "ownership_type": ("vfolders_ownership_type", None),
+        "max_files": ("vfolders_max_files", None),
+        "max_size": ("vfolders_max_size", None),
+        "created_at": ("vfolders_created_at", None),
+        "last_used": ("vfolders_last_used", None),
+        "cloneable": ("vfolders_cloneable", None),
+        "status": ("vfolders_status", None),
+        "cur_size": ("vfolders_cur_size", None),
+    }
+
     def resolve_created_at(
         self,
         info: graphene.ResolveInfo,
@@ -2033,6 +2091,16 @@ class ModelCard(graphene.ObjectType):
         last: int | None = None,
     ) -> ConnectionResolverResult:
         graph_ctx: GraphQueryContext = info.context
+        _filter_arg = (
+            FilterExprArg(filter_expr, QueryFilterParser(cls._queryfilter_fieldspec))
+            if filter_expr is not None
+            else None
+        )
+        _order_expr = (
+            OrderExprArg(order_expr, QueryOrderParser(cls._queryorder_colmap))
+            if order_expr is not None
+            else None
+        )
         (
             query,
             conditions,
@@ -2043,8 +2111,8 @@ class ModelCard(graphene.ObjectType):
             info,
             VFolderRow,
             VFolderRow.id,
-            filter_expr,
-            order_expr,
+            _filter_arg,
+            _order_expr,
             offset,
             after=after,
             first=first,


### PR DESCRIPTION
follow-up #1719
resolves #1923

Clients cannot query relay nodes with "filter" and "order" argument properly.
Add `queryfilter_fieldspec` and `queryorder_colmap` as Relay node class variable and initiate `QueryFilterParser` or `QueryOrderParser` with them.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)