### PR TITLE
refactor: Enhance typing of some modules

### DIFF
--- a/src/ai/backend/accelerator/mock/defs.py
+++ b/src/ai/backend/accelerator/mock/defs.py
@@ -1,6 +1,6 @@
 import enum
 
 
-class AllocationModes(str, enum.Enum):
+class AllocationModes(enum.StrEnum):
     DISCRETE = "discrete"
     FRACTIONAL = "fractional"

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -868,15 +868,15 @@ async def server_main(
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
 def main(
     cli_ctx: click.Context,
     config_path: Path,
-    log_level: str,
+    log_level: LogSeverity,
     debug: bool = False,
 ) -> int:
     """Start the agent service as a foreground process."""
@@ -907,10 +907,10 @@ def main(
     config.override_with_env(raw_cfg, ("container", "scratch-root"), "BACKEND_SCRATCH_ROOT")
 
     if debug:
-        log_level = "DEBUG"
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
+        log_level = LogSeverity.DEBUG
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogSeverity.DEBUG)
+    config.override_key(raw_cfg, ("logging", "level"), log_level)
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/agent/types.py
+++ b/src/ai/backend/agent/types.py
@@ -11,7 +11,7 @@ from ai.backend.common.events import KernelLifecycleEventReason
 from ai.backend.common.types import ContainerId, KernelId, MountTypes, SessionId
 
 
-class AgentBackend(enum.Enum):
+class AgentBackend(enum.StrEnum):
     # The list of importable backend names under "ai.backend.agent" pkg namespace.
     DOCKER = "docker"
     KUBERNETES = "kubernetes"
@@ -45,7 +45,7 @@ class AgentEventData:
     data: dict[str, Any]
 
 
-class ContainerStatus(str, enum.Enum):
+class ContainerStatus(enum.StrEnum):
     RUNNING = "running"
     RESTARTING = "restarting"
     PAUSED = "paused"
@@ -64,7 +64,7 @@ class Container:
     backend_obj: Any  # used to keep the backend-specific data
 
 
-class LifecycleEvent(int, enum.Enum):
+class LifecycleEvent(enum.IntEnum):
     DESTROY = 0
     CLEAN = 1
     START = 2

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -332,12 +332,17 @@ async def watcher_server(loop, pidx, args):
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
-def main(ctx: click.Context, config_path: str, log_level: str, debug: bool) -> None:
+def main(
+    ctx: click.Context,
+    config_path: str,
+    log_level: LogSeverity,
+    debug: bool,
+) -> None:
     watcher_config_iv = (
         t.Dict({
             t.Key("watcher"): t.Dict({
@@ -370,10 +375,10 @@ def main(ctx: click.Context, config_path: str, log_level: str, debug: bool) -> N
         raw_cfg, ("watcher", "service-addr", "port"), "BACKEND_WATCHER_SERVICE_PORT"
     )
     if debug:
-        log_level = "DEBUG"
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
+        log_level = LogSeverity.DEBUG
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogSeverity.DEBUG)
+    config.override_key(raw_cfg, ("logging", "level"), log_level)
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     try:
         cfg = config.check(raw_cfg, watcher_config_iv)

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -11,6 +11,7 @@ from ai.backend.client.cli.session.execute import prepare_env_arg, prepare_resou
 from ai.backend.client.compat import asyncio_run
 from ai.backend.client.session import AsyncSession, Session
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
+from ai.backend.common.types import ClusterMode
 
 from ..output.fields import routing_fields, service_fields
 from ..output.types import FieldSpec
@@ -181,8 +182,8 @@ def info(ctx: CLIContext, service_name_or_id: str):
 @click.option(
     "--cluster-mode",
     metavar="MODE",
-    type=click.Choice(["single-node", "multi-node"]),
-    default="single-node",
+    type=click.Choice([*ClusterMode], case_sensitive=False),
+    default=ClusterMode.SINGLE_NODE,
     help="The mode of clustering.",
 )
 @click.option("-d", "--domain", type=str, default="default")
@@ -369,8 +370,8 @@ def create(
 @click.option(
     "--cluster-mode",
     metavar="MODE",
-    type=click.Choice(["single-node", "multi-node"]),
-    default="single-node",
+    type=click.Choice([*ClusterMode], case_sensitive=False),
+    default=ClusterMode.SINGLE_NODE,
     help="The mode of clustering.",
 )
 @click.option("-d", "--domain", type=str, default="default")

--- a/src/ai/backend/client/cli/session/args.py
+++ b/src/ai/backend/client/cli/session/args.py
@@ -2,6 +2,8 @@ from typing import Any, Callable
 
 import click
 
+from ai.backend.common.types import SessionTypes
+
 START_OPTION = [
     click.option(
         "-t",
@@ -16,8 +18,8 @@ START_OPTION = [
     click.option(
         "--type",
         metavar="SESSTYPE",
-        type=click.Choice(["batch", "interactive"]),
-        default="interactive",
+        type=click.Choice([*SessionTypes], case_sensitive=False),
+        default=SessionTypes.INTERACTIVE,
         help="Either batch or interactive",
     ),
     click.option(

--- a/src/ai/backend/client/cli/session/execute.py
+++ b/src/ai/backend/client/cli/session/execute.py
@@ -20,6 +20,7 @@ from ai.backend.cli.main import main
 from ai.backend.cli.params import CommaSeparatedListType, RangeExprOptionType
 from ai.backend.cli.types import ExitCode
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
+from ai.backend.common.types import ClusterMode
 
 from ...compat import asyncio_run, current_loop
 from ...config import local_cache_path
@@ -346,8 +347,8 @@ def prepare_mount_arg(
 @click.option(
     "--cluster-mode",
     metavar="MODE",
-    type=click.Choice(["single-node", "multi-node"]),
-    default="single-node",
+    type=click.Choice([*ClusterMode], case_sensitive=False),
+    default=ClusterMode.SINGLE_NODE,
     help="The mode of clustering.",
 )
 @click.option(
@@ -409,7 +410,7 @@ def run(
     scaling_group,  # click_start_option
     resources,  # click_start_option
     cluster_size,  # click_start_option
-    cluster_mode,
+    cluster_mode: ClusterMode,
     resource_opts,  # click_start_option
     architecture,
     domain,  # click_start_option

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -26,6 +26,7 @@ from ai.backend.cli.main import main
 from ai.backend.cli.params import CommaSeparatedListType, OptionalType
 from ai.backend.cli.types import ExitCode, Undefined, undefined
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
+from ai.backend.common.types import ClusterMode
 
 from ...compat import asyncio_run
 from ...exceptions import BackendAPIError
@@ -97,8 +98,8 @@ def _create_cmd(docs: str = None):
     @click.option(
         "--cluster-mode",
         metavar="MODE",
-        type=click.Choice(["single-node", "multi-node"]),
-        default="single-node",
+        type=click.Choice([*ClusterMode], case_sensitive=False),
+        default=ClusterMode.SINGLE_NODE,
         help="The mode of clustering.",
     )
     @click.option("--preopen", default=None, type=list_expr, help="Pre-open service ports")

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -16,7 +16,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Union,
     cast,
 )
 from uuid import UUID
@@ -29,7 +28,7 @@ from tqdm import tqdm
 from ai.backend.client.output.fields import session_fields
 from ai.backend.client.output.types import FieldSpec, PaginatedResult
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
-from ai.backend.common.types import SessionTypes
+from ai.backend.common.types import ClusterMode, SessionTypes
 
 from ...cli.types import Undefined, undefined
 from ..compat import current_loop
@@ -182,7 +181,7 @@ class ComputeSession(BaseFunction):
         resources: Mapping[str, str | int] = None,
         resource_opts: Mapping[str, str | int] = None,
         cluster_size: int = 1,
-        cluster_mode: Literal["single-node", "multi-node"] = "single-node",
+        cluster_mode: ClusterMode = ClusterMode.SINGLE_NODE,
         domain_name: str = None,
         group_name: str = None,
         bootstrap_script: str = None,
@@ -348,21 +347,21 @@ class ComputeSession(BaseFunction):
         *,
         name: str | Undefined = undefined,
         type_: str | Undefined = undefined,
-        starts_at: str = None,
+        starts_at: str | None = None,  # not included in templates
         enqueue_only: bool | Undefined = undefined,
         max_wait: int | Undefined = undefined,
-        dependencies: Sequence[str] = None,  # cannot be stored in templates
+        dependencies: Sequence[str] | None = None,  # cannot be stored in templates
         callback_url: str | Undefined = undefined,
         no_reuse: bool | Undefined = undefined,
         image: str | Undefined = undefined,
-        mounts: Union[List[str], Undefined] = undefined,
-        mount_map: Union[Mapping[str, str], Undefined] = undefined,
-        envs: Union[Mapping[str, str], Undefined] = undefined,
+        mounts: List[str] | Undefined = undefined,
+        mount_map: Mapping[str, str] | Undefined = undefined,
+        envs: Mapping[str, str] | Undefined = undefined,
         startup_command: str | Undefined = undefined,
-        resources: Union[Mapping[str, str | int], Undefined] = undefined,
-        resource_opts: Union[Mapping[str, str | int], Undefined] = undefined,
+        resources: Mapping[str, str | int] | Undefined = undefined,
+        resource_opts: Mapping[str, str | int] | Undefined = undefined,
         cluster_size: int | Undefined = undefined,
-        cluster_mode: Union[Literal["single-node", "multi-node"], Undefined] = undefined,
+        cluster_mode: ClusterMode | Undefined = undefined,
         domain_name: str | Undefined = undefined,
         group_name: str | Undefined = undefined,
         bootstrap_script: str | Undefined = undefined,
@@ -1207,7 +1206,7 @@ class InferenceSession(BaseFunction):
         resources: Optional[Mapping[str, str]] = None,
         resource_opts: Optional[Mapping[str, str]] = None,
         cluster_size: int = 1,
-        cluster_mode: Literal["single-node", "multi-node"] = "single-node",
+        cluster_mode: ClusterMode = ClusterMode.SINGLE_NODE,
         domain_name: Optional[str] = None,
         group_name: Optional[str] = None,
         bootstrap_script: Optional[str] = None,
@@ -1244,7 +1243,7 @@ class InferenceSession(BaseFunction):
         resources: Mapping[str, int] | Undefined = undefined,
         resource_opts: Mapping[str, int] | Undefined = undefined,
         cluster_size: int | Undefined = undefined,
-        cluster_mode: Literal["single-node", "multi-node"] | Undefined = undefined,
+        cluster_mode: ClusterMode | Undefined = undefined,
         domain_name: str | Undefined = undefined,
         group_name: str | Undefined = undefined,
         bootstrap_script: str | Undefined = undefined,

--- a/src/ai/backend/client/func/user.py
+++ b/src/ai/backend/client/func/user.py
@@ -58,7 +58,7 @@ _default_detail_fields = (
 )
 
 
-class UserRole(str, enum.Enum):
+class UserRole(enum.StrEnum):
     """
     The role (privilege level) of users.
     """
@@ -69,7 +69,7 @@ class UserRole(str, enum.Enum):
     MONITOR = "monitor"
 
 
-class UserStatus(enum.Enum):
+class UserStatus(enum.StrEnum):
     """
     The detailed status of users to represent the signup process and account lifecycles.
     """

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -206,7 +206,7 @@ class DoAgentResourceCheckEvent(AbstractEvent):
         )
 
 
-class KernelLifecycleEventReason(str, enum.Enum):
+class KernelLifecycleEventReason(enum.StrEnum):
     AGENT_TERMINATION = "agent-termination"
     ALREADY_TERMINATED = "already-terminated"
     ANOMALY_DETECTED = "anomaly-detected"
@@ -238,6 +238,8 @@ class KernelLifecycleEventReason(str, enum.Enum):
 
     @classmethod
     def from_value(cls, value: Optional[str]) -> Optional[KernelLifecycleEventReason]:
+        if value is None:
+            return None
         try:
             return cls(value)
         except ValueError:

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -223,7 +223,7 @@ AccessKey = NewType("AccessKey", str)
 SecretKey = NewType("SecretKey", str)
 
 
-class AbstractPermission(str, enum.Enum):
+class AbstractPermission(enum.StrEnum):
     """
     Abstract enum type for permissions
     """
@@ -244,15 +244,15 @@ class VFolderHostPermission(AbstractPermission):
     SET_USER_PERM = "set-user-specific-permission"  # override permission of group-type vfolder
 
 
-class LogSeverity(str, enum.Enum):
-    CRITICAL = "critical"
-    ERROR = "error"
-    WARNING = "warning"
-    INFO = "info"
-    DEBUG = "debug"
+class LogSeverity(enum.StrEnum):
+    CRITICAL = "CRITICAL"
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
 
 
-class SlotTypes(str, enum.Enum):
+class SlotTypes(enum.StrEnum):
     COUNT = "count"
     BYTES = "bytes"
     UNIQUE = "unique"
@@ -264,42 +264,42 @@ class HardwareMetadata(TypedDict):
     metadata: Dict[str, str]
 
 
-class AutoPullBehavior(str, enum.Enum):
+class AutoPullBehavior(enum.StrEnum):
     DIGEST = "digest"
     TAG = "tag"
     NONE = "none"
 
 
-class ServicePortProtocols(str, enum.Enum):
+class ServicePortProtocols(enum.StrEnum):
     HTTP = "http"
     TCP = "tcp"
     PREOPEN = "preopen"
     INTERNAL = "internal"
 
 
-class SessionTypes(str, enum.Enum):
+class SessionTypes(enum.StrEnum):
     INTERACTIVE = "interactive"
     BATCH = "batch"
     INFERENCE = "inference"
 
 
-class SessionResult(str, enum.Enum):
+class SessionResult(enum.StrEnum):
     UNDEFINED = "undefined"
     SUCCESS = "success"
     FAILURE = "failure"
 
 
-class ClusterMode(str, enum.Enum):
+class ClusterMode(enum.StrEnum):
     SINGLE_NODE = "single-node"
     MULTI_NODE = "multi-node"
 
 
-class CommitStatus(str, enum.Enum):
+class CommitStatus(enum.StrEnum):
     READY = "ready"
     ONGOING = "ongoing"
 
 
-class AbuseReportValue(str, enum.Enum):
+class AbuseReportValue(enum.StrEnum):
     DETECTED = "detected"
     CLEANING = "cleaning"
 
@@ -342,12 +342,12 @@ class IntrinsicSlotNames(enum.Enum):
     MEMORY = SlotName("mem")
 
 
-class DefaultForUnspecified(str, enum.Enum):
+class DefaultForUnspecified(enum.StrEnum):
     LIMITED = "LIMITED"
     UNLIMITED = "UNLIMITED"
 
 
-class HandlerForUnknownSlotName(str, enum.Enum):
+class HandlerForUnknownSlotName(enum.StrEnum):
     DROP = "drop"
     ERROR = "error"
 
@@ -355,7 +355,7 @@ class HandlerForUnknownSlotName(str, enum.Enum):
 Quantum = Decimal("0.000")
 
 
-class MountPermission(str, enum.Enum):
+class MountPermission(enum.StrEnum):
     READ_ONLY = "ro"
     READ_WRITE = "rw"
     RW_DELETE = "wd"
@@ -364,7 +364,7 @@ class MountPermission(str, enum.Enum):
 MountPermissionLiteral = Literal["ro", "rw", "wd"]
 
 
-class MountTypes(str, enum.Enum):
+class MountTypes(enum.StrEnum):
     VOLUME = "volume"
     BIND = "bind"
     TMPFS = "tmpfs"
@@ -863,7 +863,7 @@ class VFolderID:
         return self.quota_scope_id == other.quota_scope_id and self.folder_id == other.folder_id
 
 
-class VFolderUsageMode(str, enum.Enum):
+class VFolderUsageMode(enum.StrEnum):
     """
     Usage mode of virtual folder.
 

--- a/src/ai/backend/manager/api/__init__.py
+++ b/src/ai/backend/manager/api/__init__.py
@@ -1,14 +1,14 @@
 import enum
 
 
-class ManagerStatus(str, enum.Enum):
+class ManagerStatus(enum.StrEnum):
     TERMINATED = "terminated"  # deprecated
     PREPARING = "preparing"  # deprecated
     RUNNING = "running"
     FROZEN = "frozen"
 
 
-class SchedulerEvent(str, enum.Enum):
+class SchedulerEvent(enum.StrEnum):
     SCHEDULE = "schedule"
     PREPARE = "prepare"
     SCALE_SERVICES = "scale_services"

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -46,15 +46,15 @@ log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.cli"))
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
 def main(
     ctx: click.Context,
     config_path: pathlib.Path,
-    log_level: str,
+    log_level: LogSeverity,
     debug: bool,
 ) -> None:
     """

--- a/src/ai/backend/manager/cli/context.py
+++ b/src/ai/backend/manager/cli/context.py
@@ -15,7 +15,7 @@ from ai.backend.common.defs import REDIS_IMAGE_DB, REDIS_LIVE_DB, REDIS_STAT_DB,
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.exception import ConfigurationError
 from ai.backend.common.logging import AbstractLogger, LocalLogger
-from ai.backend.common.types import RedisConnectionInfo
+from ai.backend.common.types import LogSeverity, RedisConnectionInfo
 
 from ..config import LocalConfig, SharedConfig
 from ..config import load as load_config
@@ -25,7 +25,7 @@ class CLIContext:
     _local_config: LocalConfig | None
     _logger: AbstractLogger
 
-    def __init__(self, config_path: Path, log_level: str) -> None:
+    def __init__(self, config_path: Path, log_level: LogSeverity) -> None:
         self.config_path = config_path
         self.log_level = log_level
         self._local_config = None

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -211,6 +211,7 @@ from ai.backend.common.identity import get_instance_id
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     HostPortPair,
+    LogSeverity,
     RoundRobinState,
     SlotName,
     SlotTypes,
@@ -504,7 +505,10 @@ class LocalConfig(AbstractConfig):
         raise NotImplementedError
 
 
-def load(config_path: Optional[Path] = None, log_level: str = "INFO") -> LocalConfig:
+def load(
+    config_path: Optional[Path] = None,
+    log_level: LogSeverity = LogSeverity.INFO,
+) -> LocalConfig:
     # Determine where to read configuration.
     raw_cfg, cfg_src_path = config.read_from_file(config_path, "manager")
 
@@ -535,10 +539,10 @@ def load(config_path: Optional[Path] = None, log_level: str = "INFO") -> LocalCo
         raw_cfg, ("docker-registry", "ssl-verify"), "BACKEND_SKIP_SSLCERT_VALIDATION"
     )
 
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level.upper())
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogSeverity.DEBUG)
+    config.override_key(raw_cfg, ("logging", "level"), log_level)
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -163,7 +163,7 @@ class ThresholdOperator(enum.Enum):
     OR = "or"
 
 
-class RemainingTimeType(str, enum.Enum):
+class RemainingTimeType(enum.StrEnum):
     GRACE_PERIOD = "grace_period"
     EXPIRE_AFTER = "expire_after"
 

--- a/src/ai/backend/manager/models/alembic/versions/308bcecec5c2_add_groups_type.py
+++ b/src/ai/backend/manager/models/alembic/versions/308bcecec5c2_add_groups_type.py
@@ -27,7 +27,7 @@ metadata = sa.MetaData(naming_convention=convention)
 MAXIMUM_DOTFILE_SIZE = 64 * 1024  # 61 KiB
 
 
-class ProjectType(str, enum.Enum):
+class ProjectType(enum.StrEnum):
     GENERAL = "general"
     MODEL_STORE = "model-store"
 
@@ -107,7 +107,7 @@ association_groups_users = sa.Table(
 )
 
 
-projecttype_choices = list(map(lambda v: v.value, ProjectType))
+projecttype_choices = list(map(str, ProjectType))
 projecttype = postgresql.ENUM(
     *projecttype_choices,
     name="projecttype",

--- a/src/ai/backend/manager/models/alembic/versions/529113b08c2c_add_vfolder_type_column.py
+++ b/src/ai/backend/manager/models/alembic/versions/529113b08c2c_add_vfolder_type_column.py
@@ -24,16 +24,16 @@ down_revision = "c481d3dc6c7d"
 branch_labels = None
 depends_on = None
 
-vfperm_choices = list(map(lambda v: v.value, VFolderPermission))
+vfperm_choices = list(map(str, VFolderPermission))
 # vfolderpermission type should already be defined.
 
-vfusagemode_choices = list(map(lambda v: v.value, VFolderUsageMode))
+vfusagemode_choices = list(map(str, VFolderUsageMode))
 vfolderusagemode = postgresql.ENUM(
     *vfusagemode_choices,
     name="vfolderusagemode",
 )
 
-vfownershiptype_choices = list(map(lambda v: v.value, VFolderOwnershipType))
+vfownershiptype_choices = list(map(str, VFolderOwnershipType))
 vfolderownershiptype = postgresql.ENUM(
     *vfownershiptype_choices,
     name="vfolderownershiptype",

--- a/src/ai/backend/manager/models/alembic/versions/6f5fe19894b7_vfolder_invitation_state_to_enum_type.py
+++ b/src/ai/backend/manager/models/alembic/versions/6f5fe19894b7_vfolder_invitation_state_to_enum_type.py
@@ -18,7 +18,7 @@ down_revision = "48ab2dfefba9"
 branch_labels = None
 depends_on = None
 
-vfinvs_choices = list(map(lambda v: v.value, VFolderInvitationState))
+vfinvs_choices = list(map(str, VFolderInvitationState))
 vfolderinvitationstate = postgresql.ENUM(
     *vfinvs_choices,
     name="vfolderinvitationstate",

--- a/src/ai/backend/manager/models/alembic/versions/819c2b3830a9_add_user_model.py
+++ b/src/ai/backend/manager/models/alembic/versions/819c2b3830a9_add_user_model.py
@@ -30,7 +30,7 @@ branch_labels = None
 depends_on = None
 
 
-userrole_choices = list(map(lambda v: v.value, UserRole))
+userrole_choices = list(map(str, UserRole))
 userrole = postgresql.ENUM(*userrole_choices, name="userrole")
 
 

--- a/src/ai/backend/manager/models/alembic/versions/a1fd4e7b7782_enumerate_vfolder_perms.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1fd4e7b7782_enumerate_vfolder_perms.py
@@ -19,7 +19,7 @@ branch_labels = None
 depends_on = None
 
 # NOTE: VFolderPermission is EnumValueType
-vfperm_choices = list(map(lambda v: v.value, VFolderPermission))
+vfperm_choices = list(map(str, VFolderPermission))
 vfolderpermission = postgresql.ENUM(
     *vfperm_choices,
     name="vfolderpermission",

--- a/src/ai/backend/manager/models/alembic/versions/d3f8c74bf148_user_main_keypair.py
+++ b/src/ai/backend/manager/models/alembic/versions/d3f8c74bf148_user_main_keypair.py
@@ -31,7 +31,7 @@ Base = mapper_registry.generate_base()
 PAGE_SIZE = 100
 
 
-class UserRole(str, enum.Enum):
+class UserRole(enum.StrEnum):
     """
     User's role.
     """

--- a/src/ai/backend/manager/models/alembic/versions/dbc1e053b880_add_keypair_resource_policy.py
+++ b/src/ai/backend/manager/models/alembic/versions/dbc1e053b880_add_keypair_resource_policy.py
@@ -20,7 +20,7 @@ branch_labels = None
 depends_on = None
 
 
-default_for_unspecified_choices = list(map(lambda v: v.name, DefaultForUnspecified))
+default_for_unspecified_choices = [*map(str, DefaultForUnspecified)]
 default_for_unspecified = postgresql.ENUM(
     *default_for_unspecified_choices,
     name="default_for_unspecified",

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -22,6 +22,7 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
+    Self,
     Sequence,
     Type,
     TypeVar,
@@ -77,6 +78,8 @@ from .minilang.ordering import OrderDirection, OrderingItem, QueryOrderParser
 from .minilang.queryfilter import QueryFilterParser, WhereClauseType
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine.interfaces import Dialect
+
     from .gql import GraphQueryContext
     from .user import UserRole
 
@@ -117,7 +120,10 @@ class FixtureOpModes(enum.StrEnum):
     UPDATE = "update"
 
 
-class EnumType(TypeDecorator, SchemaType):
+T_Enum = TypeVar("T_Enum", bound=enum.Enum)
+
+
+class EnumType(TypeDecorator, SchemaType, Generic[T_Enum]):
     """
     A stripped-down version of Spoqa's sqlalchemy-enum34.
     It also handles postgres-specific enum type creation.
@@ -128,8 +134,7 @@ class EnumType(TypeDecorator, SchemaType):
     impl = ENUM
     cache_ok = True
 
-    def __init__(self, enum_cls, **opts):
-        assert issubclass(enum_cls, enum.Enum)
+    def __init__(self, enum_cls: type[T_Enum], **opts) -> None:
         if "name" not in opts:
             opts["name"] = enum_cls.__name__.lower()
         self._opts = opts
@@ -137,13 +142,21 @@ class EnumType(TypeDecorator, SchemaType):
         super().__init__(*enums, **opts)
         self._enum_cls = enum_cls
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(
+        self,
+        value: Optional[T_Enum],
+        dialect: Dialect,
+    ) -> Optional[str]:
         return value.name if value else None
 
-    def process_result_value(self, value: str, dialect):
+    def process_result_value(
+        self,
+        value: str,
+        dialect: Dialect,
+    ) -> Optional[T_Enum]:
         return self._enum_cls[value] if value else None
 
-    def copy(self):
+    def copy(self, **kw) -> type[Self]:
         return EnumType(self._enum_cls, **self._opts)
 
     @property
@@ -151,7 +164,7 @@ class EnumType(TypeDecorator, SchemaType):
         return self._enum_class
 
 
-class EnumValueType(TypeDecorator, SchemaType):
+class EnumValueType(TypeDecorator, SchemaType, Generic[T_Enum]):
     """
     A stripped-down version of Spoqa's sqlalchemy-enum34.
     It also handles postgres-specific enum type creation.
@@ -162,8 +175,7 @@ class EnumValueType(TypeDecorator, SchemaType):
     impl = ENUM
     cache_ok = True
 
-    def __init__(self, enum_cls, **opts):
-        assert issubclass(enum_cls, enum.Enum)
+    def __init__(self, enum_cls: type[T_Enum], **opts) -> None:
         if "name" not in opts:
             opts["name"] = enum_cls.__name__.lower()
         self._opts = opts
@@ -171,17 +183,25 @@ class EnumValueType(TypeDecorator, SchemaType):
         super().__init__(*enums, **opts)
         self._enum_cls = enum_cls
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(
+        self,
+        value: Optional[T_Enum],
+        dialect: Dialect,
+    ) -> Optional[str]:
         return value.value if value else None
 
-    def process_result_value(self, value: str, dialect):
+    def process_result_value(
+        self,
+        value: str,
+        dialect: Dialect,
+    ) -> Optional[T_Enum]:
         return self._enum_cls(value) if value else None
 
-    def copy(self):
+    def copy(self, **kw) -> type[Self]:
         return EnumValueType(self._enum_cls, **self._opts)
 
     @property
-    def python_type(self):
+    def python_type(self) -> T_Enum:
         return self._enum_class
 
 
@@ -203,13 +223,21 @@ class CurvePublicKeyColumn(TypeDecorator):
     def load_dialect_impl(self, dialect):
         return dialect.type_descriptor(sa.String(40))
 
-    def process_bind_param(self, value: Optional[PublicKey], dialect) -> Optional[str]:
+    def process_bind_param(
+        self,
+        value: Optional[PublicKey],
+        dialect: Dialect,
+    ) -> Optional[str]:
         return value.decode("ascii") if value else None
 
-    def process_result_value(self, raw_value: str | None, dialect) -> Optional[PublicKey]:
-        if raw_value is None:
+    def process_result_value(
+        self,
+        value: str | None,
+        dialect: Dialect,
+    ) -> Optional[PublicKey]:
+        if value is None:
             return None
-        return PublicKey(raw_value.encode("ascii"))
+        return PublicKey(value.encode("ascii"))
 
 
 class QuotaScopeIDType(TypeDecorator):
@@ -223,11 +251,19 @@ class QuotaScopeIDType(TypeDecorator):
     def load_dialect_impl(self, dialect):
         return dialect.type_descriptor(sa.String(64))
 
-    def process_bind_param(self, value: Optional[QuotaScopeID], dialect) -> Optional[str]:
+    def process_bind_param(
+        self,
+        value: Optional[QuotaScopeID],
+        dialect: Dialect,
+    ) -> Optional[str]:
         return str(value) if value else None
 
-    def process_result_value(self, raw_value: str, dialect) -> QuotaScopeID:
-        return QuotaScopeID.parse(raw_value)
+    def process_result_value(
+        self,
+        value: Optional[str],
+        dialect: Dialect,
+    ) -> Optional[QuotaScopeID]:
+        return QuotaScopeID.parse(value) if value else None
 
 
 class ResourceSlotColumn(TypeDecorator):
@@ -239,15 +275,21 @@ class ResourceSlotColumn(TypeDecorator):
     cache_ok = True
 
     def process_bind_param(
-        self, value: Union[Mapping, ResourceSlot, None], dialect
-    ) -> Optional[Mapping]:
+        self,
+        value: Optional[ResourceSlot],
+        dialect: Dialect,
+    ) -> Optional[Mapping[str, str]]:
         if value is None:
             return None
         if isinstance(value, ResourceSlot):
             return value.to_json()
         return value
 
-    def process_result_value(self, value: dict[str, str] | None, dialect) -> ResourceSlot | None:
+    def process_result_value(
+        self,
+        value: Optional[dict[str, str]],
+        dialect: Dialect,
+    ) -> Optional[ResourceSlot]:
         if value is None:
             return None
         try:
@@ -255,9 +297,6 @@ class ResourceSlotColumn(TypeDecorator):
         except ArithmeticError:
             # for legacy-compat scenario
             return ResourceSlot.from_user_input(value, None)
-
-    def copy(self):
-        return ResourceSlotColumn()
 
 
 class StructuredJSONColumn(TypeDecorator):
@@ -272,13 +311,17 @@ class StructuredJSONColumn(TypeDecorator):
         super().__init__()
         self._schema = schema
 
-    def load_dialect_impl(self, dialect):
+    def load_dialect_impl(self, dialect: Dialect):
         if dialect.name == "sqlite":
             return dialect.type_descriptor(sa.JSON)
         else:
             return super().load_dialect_impl(dialect)
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(
+        self,
+        value: Optional[Any],
+        dialect: Dialect,
+    ) -> Optional[Any]:
         if value is None:
             return self._schema.check({})
         try:
@@ -290,12 +333,16 @@ class StructuredJSONColumn(TypeDecorator):
             )
         return value
 
-    def process_result_value(self, raw_value, dialect):
-        if raw_value is None:
+    def process_result_value(
+        self,
+        value: Optional[Any],
+        dialect: Dialect,
+    ) -> Optional[Any]:
+        if value is None:
             return self._schema.check({})
-        return self._schema.check(raw_value)
+        return self._schema.check(value)
 
-    def copy(self):
+    def copy(self, **kw) -> type[Self]:
         return StructuredJSONColumn(self._schema)
 
 
@@ -314,10 +361,10 @@ class StructuredJSONObjectColumn(TypeDecorator):
     def process_bind_param(self, value, dialect):
         return self._schema.to_json(value)
 
-    def process_result_value(self, raw_value, dialect):
-        return self._schema.from_json(raw_value)
+    def process_result_value(self, value, dialect):
+        return self._schema.from_json(value)
 
-    def copy(self):
+    def copy(self, **kw) -> type[Self]:
         return StructuredJSONObjectColumn(self._schema)
 
 
@@ -337,12 +384,12 @@ class StructuredJSONObjectListColumn(TypeDecorator):
     def process_bind_param(self, value, dialect):
         return [self._schema.to_json(item) for item in value]
 
-    def process_result_value(self, raw_value, dialect):
-        if raw_value is None:
+    def process_result_value(self, value, dialect):
+        if value is None:
             return []
-        return [self._schema.from_json(item) for item in raw_value]
+        return [self._schema.from_json(item) for item in value]
 
-    def copy(self):
+    def copy(self, **kw) -> type[Self]:
         return StructuredJSONObjectListColumn(self._schema)
 
 
@@ -354,12 +401,10 @@ class URLColumn(TypeDecorator):
     impl = sa.types.UnicodeText
     cache_ok = True
 
-    def process_bind_param(self, value, dialect):
-        if isinstance(value, yarl.URL):
-            return str(value)
-        return value
+    def process_bind_param(self, value: Optional[yarl.URL], dialect: Dialect) -> Optional[str]:
+        return str(value)
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(self, value: Optional[str], dialect: Dialect) -> Optional[yarl.URL]:
         if value is None:
             return None
         if value is not None:
@@ -402,16 +447,20 @@ class PermissionListColumn(TypeDecorator):
         self._perm_type = perm_type
 
     @overload
-    def process_bind_param(self, value: Sequence[AbstractPermission], dialect) -> List[str]: ...
+    def process_bind_param(
+        self, value: Sequence[AbstractPermission], dialect: Dialect
+    ) -> List[str]: ...
 
     @overload
-    def process_bind_param(self, value: Sequence[str], dialect) -> List[str]: ...
+    def process_bind_param(self, value: Sequence[str], dialect: Dialect) -> List[str]: ...
 
     @overload
-    def process_bind_param(self, value: None, dialect) -> List[str]: ...
+    def process_bind_param(self, value: None, dialect: Dialect) -> List[str]: ...
 
     def process_bind_param(
-        self, value: Sequence[AbstractPermission] | Sequence[str] | None, dialect
+        self,
+        value: Sequence[AbstractPermission] | Sequence[str] | None,
+        dialect: Dialect,
     ) -> List[str]:
         if value is None:
             return []
@@ -420,7 +469,11 @@ class PermissionListColumn(TypeDecorator):
         except ValueError:
             raise InvalidAPIParameters(f"Invalid value for binding to {self._perm_type}")
 
-    def process_result_value(self, value: Sequence[str] | None, dialect) -> set[AbstractPermission]:
+    def process_result_value(
+        self,
+        value: Sequence[str] | None,
+        dialect: Dialect,
+    ) -> set[AbstractPermission]:
         if value is None:
             return set()
         return set(self._perm_type(perm) for perm in value)
@@ -435,7 +488,11 @@ class VFolderHostPermissionColumn(TypeDecorator):
     cache_ok = True
     perm_col = PermissionListColumn(VFolderHostPermission)
 
-    def process_bind_param(self, value: Mapping[str, Any] | None, dialect) -> Mapping[str, Any]:
+    def process_bind_param(
+        self,
+        value: Mapping[str, Any] | None,
+        dialect: Dialect,
+    ) -> Mapping[str, Any]:
         if value is None:
             return {}
         return {
@@ -443,7 +500,9 @@ class VFolderHostPermissionColumn(TypeDecorator):
         }
 
     def process_result_value(
-        self, value: Mapping[str, Any] | None, dialect
+        self,
+        value: Mapping[str, Any] | None,
+        dialect: Dialect,
     ) -> VFolderHostPermissionMap:
         if value is None:
             return VFolderHostPermissionMap()

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -510,7 +510,7 @@ async def _match_sessions_by_name(
     return result.scalars().all()
 
 
-class SessionOp(str, enum.Enum):
+class SessionOp(enum.StrEnum):
     CREATE = "create_session"
     DESTROY = "destroy_session"
     RESTART = "restart_session"
@@ -523,7 +523,7 @@ class SessionOp(str, enum.Enum):
     GET_AGENT_LOGS = "get_logs_from_agent"
 
 
-class KernelLoadingStrategy(str, enum.Enum):
+class KernelLoadingStrategy(enum.StrEnum):
     ALL_KERNELS = "all"
     MAIN_KERNEL_ONLY = "main"
     NONE = "none"

--- a/src/ai/backend/manager/models/session_template.py
+++ b/src/ai/backend/manager/models/session_template.py
@@ -25,7 +25,7 @@ __all__: Sequence[str] = (
 )
 
 
-class TemplateType(str, enum.Enum):
+class TemplateType(enum.StrEnum):
     TASK = "task"
     CLUSTER = "cluster"
 

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -82,7 +82,7 @@ class PasswordColumn(TypeDecorator):
         return _hash_password(value)
 
 
-class UserRole(str, enum.Enum):
+class UserRole(enum.StrEnum):
     """
     User's role.
     """
@@ -93,7 +93,7 @@ class UserRole(str, enum.Enum):
     MONITOR = "monitor"
 
 
-class UserStatus(str, enum.Enum):
+class UserStatus(enum.StrEnum):
     """
     User account status.
     """

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -111,7 +111,7 @@ __all__: Sequence[str] = (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
-class VFolderOwnershipType(str, enum.Enum):
+class VFolderOwnershipType(enum.StrEnum):
     """
     Ownership type of virtual folder.
     """
@@ -120,7 +120,7 @@ class VFolderOwnershipType(str, enum.Enum):
     GROUP = "group"
 
 
-class VFolderPermission(str, enum.Enum):
+class VFolderPermission(enum.StrEnum):
     """
     Permissions for a virtual folder given to a specific access key.
     RW_DELETE includes READ_WRITE and READ_WRITE includes READ_ONLY.
@@ -139,7 +139,7 @@ class VFolderPermissionValidator(t.Trafaret):
         return VFolderPermission(value)
 
 
-class VFolderInvitationState(str, enum.Enum):
+class VFolderInvitationState(enum.StrEnum):
     """
     Virtual Folder invitation state.
     """

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -952,16 +952,21 @@ async def server_main_logwrapper(
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
-def main(ctx: click.Context, config_path: Path, log_level: str, debug: bool = False) -> None:
+def main(
+    ctx: click.Context,
+    config_path: Path,
+    log_level: LogSeverity,
+    debug: bool = False,
+) -> None:
     """
     Start the manager service as a foreground process.
     """
-    cfg = load_config(config_path, "DEBUG" if debug else log_level)
+    cfg = load_config(config_path, LogSeverity.DEBUG if debug else log_level)
 
     if ctx.invoked_subcommand is None:
         cfg["manager"]["pid-file"].write_text(str(os.getpid()))

--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -153,7 +153,8 @@ class AbstractFSOpModel(metaclass=ABCMeta):
     def scan_tree(
         self,
         path: Path,
-        recursive=False,
+        *,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
         """
         Iterates over all files within the given path recursively.
@@ -320,7 +321,11 @@ class AbstractVolume(metaclass=ABCMeta):
 
     @abstractmethod
     def scandir(
-        self, vfid: VFolderID, relpath: PurePosixPath, recursive=True
+        self,
+        vfid: VFolderID,
+        relpath: PurePosixPath,
+        *,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
         pass
 
@@ -404,6 +409,7 @@ class AbstractVolume(metaclass=ABCMeta):
         self,
         vfid: VFolderID,
         relpaths: Sequence[PurePosixPath],
+        *,
         recursive: bool = False,
     ) -> None:
         pass

--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -86,7 +86,7 @@ class AbstractQuotaModel(metaclass=ABCMeta):
     async def update_quota_scope(
         self,
         quota_scope_id: QuotaScopeID,
-        options: QuotaConfig,
+        config: QuotaConfig,
     ) -> None:
         """
         Update the quota option of the given quota scope.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -216,7 +216,7 @@ async def download(request: web.Request) -> web.StreamResponse:
 async def download_directory_as_archive(
     request: web.Request,
     file_path: Path,
-    zip_filename: str = None,
+    zip_filename: str | None = None,
 ) -> web.StreamResponse:
     """
     Serve a directory as a zip archive on the fly.

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -1021,7 +1021,7 @@ async def delete_files(request: web.Request) -> web.Response:
                 await volume.delete_files(
                     params["vfid"],
                     params["relpaths"],
-                    params["recursive"],
+                    recursive=params["recursive"],
                 )
         return web.json_response(
             {

--- a/src/ai/backend/storage/cephfs/__init__.py
+++ b/src/ai/backend/storage/cephfs/__init__.py
@@ -87,24 +87,24 @@ class CephDirQuotaModel(BaseQuotaModel):
 
 
 class CephFSOpModel(BaseFSOpModel):
-    async def scan_tree_usage(self, target_path: Path) -> TreeUsage:
+    async def scan_tree_usage(self, path: Path) -> TreeUsage:
         loop = asyncio.get_running_loop()
         raw_reports = await loop.run_in_executor(
             None,
             lambda: (
-                os.getxattr(target_path, "ceph.dir.rentries"),  # type: ignore[attr-defined]
-                os.getxattr(target_path, "ceph.dir.rbytes"),  # type: ignore[attr-defined]
+                os.getxattr(path, "ceph.dir.rentries"),  # type: ignore[attr-defined]
+                os.getxattr(path, "ceph.dir.rbytes"),  # type: ignore[attr-defined]
             ),
         )
         file_count = int(raw_reports[0].strip().decode())
         used_bytes = int(raw_reports[1].strip().decode())
         return TreeUsage(file_count=file_count, used_bytes=used_bytes)
 
-    async def scan_tree_size(self, target_path: Path) -> BinarySize:
+    async def scan_tree_size(self, path: Path) -> BinarySize:
         loop = asyncio.get_running_loop()
         raw_report = await loop.run_in_executor(
             None,
-            lambda: os.getxattr(target_path, "ceph.dir.rbytes"),  # type: ignore[attr-defined]
+            lambda: os.getxattr(path, "ceph.dir.rbytes"),  # type: ignore[attr-defined]
         )
         return BinarySize(raw_report.strip().decode())
 

--- a/src/ai/backend/storage/gpfs/types.py
+++ b/src/ai/backend/storage/gpfs/types.py
@@ -173,7 +173,7 @@ class GPFSJobRequest(DataClassJsonMixin):
     data: Optional[Any] = None
 
 
-class GPFSJobStatus(str, enum.Enum):
+class GPFSJobStatus(enum.StrEnum):
     RUNNING = "RUNNING"
     CANCELLING = "CANCELLING"
     CANCELLED = "CANCELLED"
@@ -193,7 +193,7 @@ class GPFSJob(DataClassJsonMixin):
     pids: Optional[List[int]] = None
 
 
-class GPFSQuotaType(str, enum.Enum):
+class GPFSQuotaType(enum.StrEnum):
     FILESET = "FILESET"
     USER = "USR"
     GROUP = "GRP"

--- a/src/ai/backend/storage/netapp/__init__.py
+++ b/src/ai/backend/storage/netapp/__init__.py
@@ -212,10 +212,11 @@ class XCPFSOpModel(BaseFSOpModel):
 
     def scan_tree(
         self,
-        target_path: Path,
-        recursive=False,
+        path: Path,
+        *,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
-        target_relpath = target_path.relative_to(self.mount_path)
+        target_relpath = path.relative_to(self.mount_path)
         nfspath = f"{self.netapp_nfs_host}:{self.nas_path}/{target_relpath}"
         # Use a custom formatting
         scan_cmd = [
@@ -263,7 +264,7 @@ class XCPFSOpModel(BaseFSOpModel):
                     if entry_type == DirEntryType.SYMLINK:
                         try:
                             symlink_dst = Path(item_abspath).resolve()
-                            symlink_dst = symlink_dst.relative_to(target_path)
+                            symlink_dst = symlink_dst.relative_to(path)
                         except (ValueError, RuntimeError):
                             pass
                         else:
@@ -319,9 +320,9 @@ class XCPFSOpModel(BaseFSOpModel):
 
     async def scan_tree_usage(
         self,
-        target_path: Path,
+        path: Path,
     ) -> TreeUsage:
-        target_relpath = target_path.relative_to(self.mount_path)
+        target_relpath = path.relative_to(self.mount_path)
         nfspath = f"{self.netapp_nfs_host}:{self.nas_path}/{target_relpath}"
         total_size = 0
         total_count = 0
@@ -367,9 +368,9 @@ class XCPFSOpModel(BaseFSOpModel):
 
     async def scan_tree_size(
         self,
-        target_path: Path,
+        path: Path,
     ) -> BinarySize:
-        usage = await self.scan_tree_usage(target_path)
+        usage = await self.scan_tree_usage(path)
         return BinarySize(usage.used_bytes)
 
 

--- a/src/ai/backend/storage/purestorage/__init__.py
+++ b/src/ai/backend/storage/purestorage/__init__.py
@@ -54,10 +54,11 @@ class RapidFileToolsFSOpModel(BaseFSOpModel):
 
     def scan_tree(
         self,
-        target_path: Path,
-        recursive=False,
+        path: Path,
+        *,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
-        raw_target_path = os.fsencode(target_path)
+        raw_target_path = os.fsencode(path)
 
         async def _aiter() -> AsyncIterator[DirEntry]:
             proc = await asyncio.create_subprocess_exec(

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -232,15 +232,15 @@ async def server_main(
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
 def main(
     cli_ctx: click.Context,
     config_path: Path,
-    log_level: str,
+    log_level: LogSeverity,
     debug: bool = False,
 ) -> int:
     """Start the storage-proxy service as a foreground process."""
@@ -254,10 +254,10 @@ def main(
         print(pformat(e.invalid_data), file=sys.stderr)
         raise click.Abort()
     if debug:
-        log_level = "DEBUG"
-    override_key(local_config, ("debug", "enabled"), log_level == "DEBUG")
-    override_key(local_config, ("logging", "level"), log_level.upper())
-    override_key(local_config, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
+        log_level = LogSeverity.DEBUG
+    override_key(local_config, ("debug", "enabled"), log_level == LogSeverity.DEBUG)
+    override_key(local_config, ("logging", "level"), log_level)
+    override_key(local_config, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     multiprocessing.set_start_method("spawn")
 

--- a/src/ai/backend/storage/vast/__init__.py
+++ b/src/ai/backend/storage/vast/__init__.py
@@ -101,7 +101,11 @@ class VASTQuotaModel(BaseQuotaModel):
                 raise ExternalError(str(e))
             await self._set_vast_quota_id(quota_scope_id, quota.id)
 
-    async def update_quota_scope(self, quota_scope_id: QuotaScopeID, config: QuotaConfig) -> None:
+    async def update_quota_scope(
+        self,
+        quota_scope_id: QuotaScopeID,
+        config: QuotaConfig,
+    ) -> None:
         vast_quota_id = await self._get_vast_quota_id(quota_scope_id)
         if vast_quota_id is None:
             raise QuotaScopeNotFoundError

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -232,17 +232,18 @@ class BaseFSOpModel(AbstractFSOpModel):
 
     def scan_tree(
         self,
-        target_path: Path,
+        path: Path,
+        *,
         recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
         q: janus.Queue[Sentinel | DirEntry] = janus.Queue()
         loop = asyncio.get_running_loop()
 
-        def _scandir(target_path: Path, q: janus._SyncQueueProxy[Sentinel | DirEntry]) -> None:
+        def _scandir(path: Path, q: janus._SyncQueueProxy[Sentinel | DirEntry]) -> None:
             count = 0
             limit = self.scandir_limit
             next_paths: deque[Path] = deque()
-            next_paths.append(target_path)
+            next_paths.append(path)
             while next_paths:
                 next_path = next_paths.popleft()
                 with os.scandir(next_path) as scanner:
@@ -258,7 +259,7 @@ class BaseFSOpModel(AbstractFSOpModel):
                                 entry_type = DirEntryType.SYMLINK
                                 try:
                                     symlink_dst = Path(entry).resolve()
-                                    symlink_dst = symlink_dst.relative_to(target_path)
+                                    symlink_dst = symlink_dst.relative_to(path)
                                 except (ValueError, RuntimeError):
                                     # ValueError and ELOOP
                                     pass
@@ -270,7 +271,7 @@ class BaseFSOpModel(AbstractFSOpModel):
                             continue
                         item = DirEntry(
                             name=entry.name,
-                            path=Path(entry.path).relative_to(target_path),
+                            path=Path(entry.path).relative_to(path),
                             type=entry_type,
                             stat=Stat(
                                 size=entry_stat.st_size,
@@ -288,7 +289,7 @@ class BaseFSOpModel(AbstractFSOpModel):
 
         async def _scan_task(q: janus.Queue[Sentinel | DirEntry]) -> None:
             try:
-                await loop.run_in_executor(None, _scandir, target_path, q.sync_q)
+                await loop.run_in_executor(None, _scandir, path, q.sync_q)
             finally:
                 await q.async_q.put(SENTINEL)
 
@@ -313,17 +314,17 @@ class BaseFSOpModel(AbstractFSOpModel):
 
     async def scan_tree_usage(
         self,
-        target_path: Path,
+        path: Path,
     ) -> TreeUsage:
         total_size = 0
         total_count = 0
         start_time = time.monotonic()
         _timeout = 30
 
-        def _calc_usage(target_path: Path) -> None:
+        def _calc_usage(path: Path) -> None:
             nonlocal total_size, total_count
             next_paths: deque[Path] = deque()
-            next_paths.append(target_path)
+            next_paths.append(path)
             while next_paths:
                 next_path = next_paths.popleft()
                 with os.scandir(next_path) as scanner:  # type: ignore
@@ -344,7 +345,7 @@ class BaseFSOpModel(AbstractFSOpModel):
 
         loop = asyncio.get_running_loop()
         try:
-            await loop.run_in_executor(None, _calc_usage, target_path)
+            await loop.run_in_executor(None, _calc_usage, path)
         except TimeoutError:
             # -1 indicates "too many"
             total_size = -1
@@ -353,9 +354,9 @@ class BaseFSOpModel(AbstractFSOpModel):
 
     async def scan_tree_size(
         self,
-        target_path: Path,
+        path: Path,
     ) -> BinarySize:
-        info = await run(["du", "-hs", target_path])
+        info = await run(["du", "-hs", path])
         used_bytes, _ = info.split()
         return BinarySize.finite_from_str(used_bytes)
 
@@ -489,7 +490,11 @@ class BaseVolume(AbstractVolume):
 
     @final
     def scandir(
-        self, vfid: VFolderID, relpath: PurePosixPath, recursive=True
+        self,
+        vfid: VFolderID,
+        relpath: PurePosixPath,
+        *,
+        recursive: bool = True,
     ) -> AsyncIterator[DirEntry]:
         target_path = self.sanitize_vfpath(vfid, relpath)
         return self.fsop_model.scan_tree(target_path, recursive=recursive)
@@ -664,6 +669,7 @@ class BaseVolume(AbstractVolume):
         self,
         vfid: VFolderID,
         relpaths: Sequence[PurePosixPath],
+        *,
         recursive: bool = False,
     ) -> None:
         target_paths = [self.sanitize_vfpath(vfid, p) for p in relpaths]

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -102,7 +102,7 @@ class BaseQuotaModel(AbstractQuotaModel):
     async def update_quota_scope(
         self,
         quota_scope_id: QuotaScopeID,
-        options: QuotaConfig,
+        config: QuotaConfig,
     ) -> None:
         # This is a no-op.
         pass

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -726,15 +726,15 @@ async def server_main(
 )
 @click.option(
     "--log-level",
-    type=click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogSeverity], case_sensitive=False),
+    default=LogSeverity.INFO,
     help="Set the logging verbosity level",
 )
 @click.pass_context
 def main(
     ctx: click.Context,
     config_path: Path,
-    log_level: str,
+    log_level: LogSeverity,
     debug: bool,
 ) -> None:
     """Start the webui host service as a foreground process."""
@@ -742,10 +742,10 @@ def main(
     raw_cfg = tomli.loads(Path(config_path).read_text(encoding="utf-8"))
 
     if debug:
-        log_level = "DEBUG"
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
+        log_level = LogSeverity.DEBUG
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogSeverity.DEBUG)
+    config.override_key(raw_cfg, ("logging", "level"), log_level)
+    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     cfg = config.check(raw_cfg, config_iv)
 

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -39,7 +39,7 @@ from ai.backend.common.auth import PublicKey, SecretKey
 from ai.backend.common.config import ConfigurationError, etcd_config_iv, redis_config_iv
 from ai.backend.common.logging import LocalLogger
 from ai.backend.common.plugin.hook import HookPluginContext
-from ai.backend.common.types import HostPortPair
+from ai.backend.common.types import HostPortPair, LogSeverity
 from ai.backend.manager.api.context import RootContext
 from ai.backend.manager.api.types import CleanupContext
 from ai.backend.manager.cli.context import CLIContext
@@ -237,7 +237,7 @@ def etcd_fixture(
     redis_addr = local_config["redis"]["addr"]
     cli_ctx = CLIContext(
         config_path=Path.cwd() / "dummy-manager.toml",
-        log_level="DEBUG",
+        log_level=LogSeverity.DEBUG,
     )
     cli_ctx._local_config = local_config  # override the lazy-loaded config
     with tempfile.NamedTemporaryFile(mode="w", suffix=".etcd.json") as f:


### PR DESCRIPTION
* refactor: Enhance typing of the `ai.backend.manager.models.base` module
* refactor: Make typing/arg-names consistent in the `ai.backend.storage` package
  - `recursive` is now an explicitly keyword-only argument.
  - The default value of `recursive` is now consistent between the concrete implementation classes and the abstract base class.
  - `options: QuotaConfig` is now consistently `config: QuotaConfig`.
  - `target_path` arguments in the concrete classes are renamed to `path` to silence pyright warning about mismatch with argument names in the base classes.
* refactor: Use `enum.{IntEnum,StrEnum}` when possible
  - https://docs.python.org/3/library/enum.html#enum.IntEnum
  - https://docs.python.org/3/library/enum.html#enum.StrEnum
  - They can be serialized via `json.dumps()` as their values without any extra conversion.
  - In Click command handlers:  
    `click.Choice([*LogSeverity.__members__.keys()], case_sensitive=False)`  
    → `click.Choice([*LogSeverity], case_sensitive=False)`
    - Click preserves the enum type when processing case-insensitive match.
  - In alembic migrations:  
    `list(map(lambda v: v.value, VFolderPermission))`  
    → `list(map(str, VFolderPermission))`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
