### PR TITLE
fix: Allow passing HTTP status code via pydantic-based response models

### DIFF
--- a/changes/1927.fix.md
+++ b/changes/1927.fix.md
@@ -1,1 +1,1 @@
-Enable to pass HTTP status code from Pydantic response model.
+Allow passing HTTP status codes via the pydantic-based API response model objects

--- a/changes/1927.fix.md
+++ b/changes/1927.fix.md
@@ -1,0 +1,1 @@
+Enable to pass HTTP status code from Pydantic response model.

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -60,6 +60,7 @@ from .manager import ALL_ALLOWED, READ_ALLOWED, server_status_required
 from .session import query_userinfo
 from .types import CORSOptions, WebMiddleware
 from .utils import (
+    BaseResponseModel,
     get_access_key_scopes,
     get_user_uuid_scopes,
     pydantic_params_api_handler,
@@ -93,7 +94,7 @@ class ListServeRequestModel(BaseModel):
     name: str | None = Field(default=None)
 
 
-class SuccessResponseModel(BaseModel):
+class SuccessResponseModel(BaseResponseModel):
     success: bool = Field(default=True)
 
 
@@ -173,7 +174,7 @@ class RouteInfoModel(BaseModel):
     traffic_ratio: NonNegativeFloat
 
 
-class ServeInfoModel(BaseModel):
+class ServeInfoModel(BaseResponseModel):
     endpoint_id: uuid.UUID = Field(description="Unique ID referencing the model service.")
     name: str = Field(description="Name of the model service.")
     desired_session_count: NonNegativeInt = Field(
@@ -613,7 +614,7 @@ class ScaleRequestModel(BaseModel):
     to: int = Field(description="Ideal number of inference sessions")
 
 
-class ScaleResponseModel(BaseModel):
+class ScaleResponseModel(BaseResponseModel):
     current_route_count: int
     target_count: int
 
@@ -759,7 +760,7 @@ class TokenRequestModel(BaseModel):
     )
 
 
-class TokenResponseModel(BaseModel):
+class TokenResponseModel(BaseResponseModel):
     token: str
 
 
@@ -840,7 +841,7 @@ class ErrorInfoModel(BaseModel):
     error: dict[str, Any]
 
 
-class ErrorListResponseModel(BaseModel):
+class ErrorListResponseModel(BaseResponseModel):
     errors: list[ErrorInfoModel]
     retries: int
 

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -234,7 +234,7 @@ def ensure_stream_response_type(
     response: TResponseModel | list | TAnyResponse,
 ) -> web.StreamResponse:
     match response:
-        case BaseResponseModel(status):
+        case BaseResponseModel(status=status):
             return web.json_response(response.model_dump(mode="json"), status=status)
         case list():
             return web.json_response(

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -214,7 +214,7 @@ def check_api_params(
 
 
 class BaseResponseModel(BaseModel):
-    status: Annotated[int, Field(strict=True, gt=0)] = 200
+    status: Annotated[int, Field(strict=True, ge=100, lt=600)] = 200
 
 
 TParamModel = TypeVar("TParamModel", bound=BaseModel)
@@ -231,15 +231,13 @@ THandlerFuncWithParam: TypeAlias = Callable[
 
 
 def ensure_stream_response_type(
-    response: BaseResponseModel | list | web.StreamResponse,
+    response: BaseResponseModel | list[TResponseModel] | web.StreamResponse,
 ) -> web.StreamResponse:
     match response:
         case BaseResponseModel(status=status):
             return web.json_response(response.model_dump(mode="json"), status=status)
         case list():
-            return web.json_response(
-                TypeAdapter(list[BaseResponseModel]).dump_python(response, mode="json")
-            )
+            return web.json_response(TypeAdapter(type(response)).dump_python(response, mode="json"))
         case web.StreamResponse():
             return response
         case _:

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -32,7 +32,7 @@ from typing import (
 import sqlalchemy as sa
 import trafaret as t
 import yaml
-from aiohttp import web, web_response
+from aiohttp import web
 from aiohttp.typedefs import Handler
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
@@ -231,16 +231,16 @@ THandlerFuncWithParam: TypeAlias = Callable[
 
 
 def ensure_stream_response_type(
-    response: TResponseModel | list | TAnyResponse,
+    response: BaseResponseModel | list | web.StreamResponse,
 ) -> web.StreamResponse:
     match response:
         case BaseResponseModel(status=status):
             return web.json_response(response.model_dump(mode="json"), status=status)
         case list():
             return web.json_response(
-                TypeAdapter(list[TResponseModel]).dump_python(response, mode="json")
+                TypeAdapter(list[BaseResponseModel]).dump_python(response, mode="json")
             )
-        case web_response.StreamResponse():
+        case web.StreamResponse():
             return response
         case _:
             raise RuntimeError(f"Unsupported response type ({type(response)})")

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -115,6 +115,7 @@ from .exceptions import (
 from .manager import ALL_ALLOWED, READ_ALLOWED, server_status_required
 from .resource import get_watcher_info
 from .utils import (
+    BaseResponseModel,
     check_api_params,
     get_user_scopes,
     pydantic_params_api_handler,
@@ -129,9 +130,8 @@ VFolderRow: TypeAlias = Mapping[str, Any]
 P = ParamSpec("P")
 
 
-class SuccessResponseModel(BaseModel):
+class SuccessResponseModel(BaseResponseModel):
     success: bool = Field(default=True)
-    status: int = Field(default=200)
 
 
 async def ensure_vfolder_status(
@@ -2320,7 +2320,7 @@ class IDRequestModel(BaseModel):
     )
 
 
-class CompactVFolderInfoModel(BaseModel):
+class CompactVFolderInfoModel(BaseResponseModel):
     id: uuid.UUID = Field(description="Unique ID referencing the vfolder.")
     name: str = Field(description="Name of the vfolder.")
 


### PR DESCRIPTION
Currently, `web.Response` parsed from pydantic model cannot pass **HTTP status**.
For example, I cannot return web.Response with status code 204, it is always 200.
Let's add status code parameter to response model


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
