### PR TITLE
ci: Upgrade version of auto-label-in-issue action

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,11 +4,8 @@ on:
   pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
-permissions:
-  pull-requests: write
-
 jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: lablup/auto-label-in-issue@1.4.0
+      - uses: lablup/auto-label-in-issue@1.6.0


### PR DESCRIPTION
Now auto-label-in-issue reflects not only the label but also the issue's milestone in the PR.