### PR TITLE
ci: Allow required permissions to auto-label-in-issue

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   auto-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/8032135076/job/21958781426
I think actions are failing due to lack of permission in auto-label-in-issue.
