### PR TITLE
fix: CLI `agent info` related bugs

### DIFF
--- a/changes/1934.fix.md
+++ b/changes/1934.fix.md
@@ -1,0 +1,1 @@
+Fix CLI `agent info` related issues by replacing `HardwareMetadata` to `dict` when class check and adding parameter to default metric value formatter.

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -248,7 +248,7 @@ class CUDAPlugin(AbstractComputePlugin):
         return [
             NodeMeasurement(
                 MetricKey("cuda_mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_node=Measurement(Decimal(mem_used_total), Decimal(mem_avail_total)),
@@ -256,7 +256,7 @@ class CUDAPlugin(AbstractComputePlugin):
             ),
             NodeMeasurement(
                 MetricKey("cuda_util"),
-                MetricTypes.USAGE,
+                MetricTypes.UTILIZATION,
                 unit_hint="percent",
                 stats_filter=frozenset({"avg", "max"}),
                 per_node=Measurement(Decimal(util_total), Decimal(dev_count * 100)),

--- a/src/ai/backend/accelerator/mock/plugin.py
+++ b/src/ai/backend/accelerator/mock/plugin.py
@@ -412,7 +412,7 @@ class MockPlugin(AbstractComputePlugin):
         return [
             NodeMeasurement(
                 MetricKey(f"{self.key}_mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_node=Measurement(Decimal(mem_used_total), Decimal(mem_avail_total)),
@@ -420,7 +420,7 @@ class MockPlugin(AbstractComputePlugin):
             ),
             NodeMeasurement(
                 MetricKey(f"{self.key}_util"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="percent",
                 stats_filter=frozenset({"avg", "max"}),
                 per_node=Measurement(Decimal(util_total), Decimal(dev_count * 100)),
@@ -428,7 +428,7 @@ class MockPlugin(AbstractComputePlugin):
             ),
             NodeMeasurement(
                 MetricKey(f"{self.key}_power"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="Watts",
                 stats_filter=frozenset({"avg", "max"}),
                 per_node=Measurement(Decimal(power_usage_total), Decimal(power_max_total)),
@@ -436,7 +436,7 @@ class MockPlugin(AbstractComputePlugin):
             ),
             NodeMeasurement(
                 MetricKey(f"{self.key}_temperature"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="Celsius",
                 stats_filter=frozenset({"avg", "max"}),
                 per_node=Measurement(
@@ -508,7 +508,7 @@ class MockPlugin(AbstractComputePlugin):
         return [
             ContainerMeasurement(
                 MetricKey(f"{self.key}_mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_container={
@@ -521,7 +521,7 @@ class MockPlugin(AbstractComputePlugin):
             ),
             ContainerMeasurement(
                 MetricKey(f"{self.key}_util"),
-                MetricTypes.USAGE,
+                MetricTypes.UTILIZATION,
                 unit_hint="percent",
                 stats_filter=frozenset({"avg", "max"}),
                 per_container={

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1395,7 +1395,7 @@ class AbstractAgent(
                         "status_info": str(result),
                         "metadata": {},
                     }
-                case HardwareMetadata():
+                case dict():  # HardwareMetadata
                     hwinfo[device_name] = result
         return hwinfo
 

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -270,7 +270,7 @@ class CPUPlugin(AbstractComputePlugin):
             ),
             ContainerMeasurement(
                 MetricKey("cpu_used"),
-                MetricTypes.USAGE,
+                MetricTypes.ACCUMULATION,
                 unit_hint="msec",
                 per_container=per_container_cpu_used,
             ),
@@ -336,7 +336,7 @@ class CPUPlugin(AbstractComputePlugin):
             ),
             ProcessMeasurement(
                 MetricKey("cpu_used"),
-                MetricTypes.USAGE,
+                MetricTypes.ACCUMULATION,
                 unit_hint="msec",
                 per_process=per_process_cpu_used,
             ),
@@ -512,7 +512,7 @@ class MemoryPlugin(AbstractComputePlugin):
         return [
             NodeMeasurement(
                 MetricKey("mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_node=Measurement(total_mem_used_bytes, total_mem_capacity_bytes),
@@ -522,7 +522,7 @@ class MemoryPlugin(AbstractComputePlugin):
             ),
             NodeMeasurement(
                 MetricKey("disk"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 per_node=Measurement(total_disk_usage, total_disk_capacity),
                 per_device=per_disk_stat,
@@ -714,21 +714,21 @@ class MemoryPlugin(AbstractComputePlugin):
         return [
             ContainerMeasurement(
                 MetricKey("mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_container=per_container_mem_used_bytes,
             ),
             ContainerMeasurement(
                 MetricKey("io_read"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"rate"}),
                 per_container=per_container_io_read_bytes,
             ),
             ContainerMeasurement(
                 MetricKey("io_write"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"rate"}),
                 per_container=per_container_io_write_bytes,
@@ -749,7 +749,7 @@ class MemoryPlugin(AbstractComputePlugin):
             ),
             ContainerMeasurement(
                 MetricKey("io_scratch_size"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_container=per_container_io_scratch_size,
@@ -817,21 +817,21 @@ class MemoryPlugin(AbstractComputePlugin):
         return [
             ProcessMeasurement(
                 MetricKey("mem"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"max"}),
                 per_process=per_process_mem_used_bytes,
             ),
             ProcessMeasurement(
                 MetricKey("io_read"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"rate"}),
                 per_process=per_process_io_read_bytes,
             ),
             ProcessMeasurement(
                 MetricKey("io_write"),
-                MetricTypes.USAGE,
+                MetricTypes.GAUGE,
                 unit_hint="bytes",
                 stats_filter=frozenset({"rate"}),
                 per_process=per_process_io_write_bytes,

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -82,12 +82,39 @@ class StatModes(enum.Enum):
 
 
 class MetricTypes(enum.Enum):
-    USAGE = 0  # for instant snapshot (e.g., used memory bytes, used cpu msec)
-    RATE = 1  # for rate of increase (e.g., I/O bps)
-    UTILIZATION = (
-        2  # for ratio of resource occupation time per measurement interval (e.g., CPU util)
-    )
-    ACCUMULATED = 3  # for accumulated value (e.g., total number of events)
+    """
+    Specifies the type of a metric value.
+
+    Currently this DOES NOT affect calculation and processing of the metric,
+    but serves as a metadata for code readers.
+    The actual calculation and formatting is controlled by :meth:`Metric.current_hook()`,
+    :attr:`Metric.unit_hint` and :attr:`Metric.stats_filter`.
+    """
+
+    GAUGE = 0
+    """
+    Represents a instantly measured occupancy value.
+    (e.g., used space as bytes, occupied amount as the number of items or a bandwidth)
+    """
+    USAGE = 0
+    """
+    This is same to GAUGE, but just kept for backward compatibility of compute plugins.
+    """
+    RATE = 1
+    """
+    Represents a rate of changes calculated from underlying gauge/accumulation values
+    (e.g., I/O bps calculated from RX/TX accum.bytes)
+    """
+    UTILIZATION = 2
+    """
+    Represents a ratio of resource occupation time per each measurement interval
+    (e.g., CPU utilization)
+    """
+    ACCUMULATION = 3
+    """
+    Represents an accumulated value
+    (e.g., total number of events, total period of occupation)
+    """
 
 
 @attrs.define(auto_attribs=True, slots=True)
@@ -345,7 +372,6 @@ class StatContext:
                     else:
                         self.node_metrics[metric_key].update(node_measure.per_node)
                     # update per-device metric
-                    # NOTE: device IDs are defined by each metric keys.
                     for dev_id, measure in node_measure.per_device.items():
                         if metric_key not in self.device_metrics:
                             self.device_metrics[metric_key] = {}

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -93,7 +93,7 @@ class MetricTypes(enum.Enum):
 
     GAUGE = 0
     """
-    Represents a instantly measured occupancy value.
+    Represents an instantly measured occupancy value.
     (e.g., used space as bytes, occupied amount as the number of items or a bandwidth)
     """
     USAGE = 0

--- a/src/ai/backend/client/cli/session/execute.py
+++ b/src/ai/backend/client/cli/session/execute.py
@@ -191,20 +191,20 @@ def format_stats(stats):
         max_fraction_len = 0
         for key, metric in stats.items():
             unit = metric["unit_hint"]
-            if unit == "bytes":
-                val = metric.get("stats.max", metric["current"])
-                val = naturalsize(val, binary=True)
-                val, unit = val.rsplit(" ", maxsplit=1)
-                val = "{:,}".format(Decimal(val))
-            elif unit == "msec":
-                val = "{:,}".format(Decimal(metric["current"]))
-                unit = "msec"
-            elif unit == "percent":
-                val = metric["pct"]
-                unit = "%"
-            else:
-                val = metric["current"]
-                unit = ""
+            match unit:
+                case "bytes":
+                    val = metric.get("stats.max", metric["current"])
+                    val = naturalsize(val, binary=True)
+                    val, unit = val.rsplit(" ", maxsplit=1)
+                    val = "{:,}".format(Decimal(val))
+                case "msec" | "usec" | "sec":
+                    val = "{:,}".format(Decimal(metric["current"]))
+                case "percent" | "pct" | "%":
+                    val = metric["pct"]
+                    unit = "%"
+                case _:
+                    val = metric["current"]
+                    unit = ""
             if val is None:
                 continue
             ip, _, fp = val.partition(".")

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -176,6 +176,7 @@ class AgentStatFormatter(OutputFormatter):
         except TypeError:
             return ""
 
+        percent_formatter = lambda metric, _: "{} %".format(metric["pct"])
         value_formatters: Mapping[str, Callable[[MetricValue, bool], str]] = {
             "bytes": lambda metric, binary: "{} / {}".format(
                 humanize.naturalsize(int(metric["current"]), binary=binary, gnu=binary),
@@ -191,19 +192,20 @@ class AgentStatFormatter(OutputFormatter):
             "bps": lambda metric, _: "{}/s".format(
                 humanize.naturalsize(float(metric["current"])),
             ),
-            "pct": lambda metric, _: "{} %".format(
-                metric["pct"],
-            ),
+            "pct": percent_formatter,
+            "percent": percent_formatter,
+            "%": percent_formatter,
         }
 
         def format_value(metric: MetricValue, binary: bool) -> str:
+            unit_hint = metric["unit_hint"]
             formatter = value_formatters.get(
-                metric["unit_hint"],
+                unit_hint,
                 # a fallback implementation
                 lambda m, _: "{} / {} {}".format(
                     m["current"],
                     m["capacity"] if m["capacity"] is not None else "(unknown)",
-                    m["unit_hint"],
+                    "" if unit_hint == "count" else unit_hint,
                 ),
             )
             return formatter(metric, binary)

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -199,9 +199,10 @@ class AgentStatFormatter(OutputFormatter):
         def format_value(metric: MetricValue, binary: bool) -> str:
             formatter = value_formatters.get(
                 metric["unit_hint"],
+                # a fallback implementation
                 lambda m, _: "{} / {} {}".format(
                     m["current"],
-                    m["capacity"],
+                    m["capacity"] if m["capacity"] is not None else "(unknown)",
                     m["unit_hint"],
                 ),
             )

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -193,7 +193,7 @@ class AgentStatFormatter(OutputFormatter):
         def format_value(metric, binary):
             formatter = value_formatters.get(
                 metric["unit_hint"],
-                lambda m: "{} / {} {}".format(
+                lambda m, _: "{} / {} {}".format(
                     m["current"],
                     m["capacity"],
                     m["unit_hint"],

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -204,7 +204,7 @@ class AgentStatFormatter(OutputFormatter):
                 # a fallback implementation
                 lambda m, _: "{} / {} {}".format(
                     m["current"],
-                    m["capacity"] if m["capacity"] is not None else "(unknown)",
+                    "(unknown)" if m["capacity"] is None else m["capacity"],
                     "" if unit_hint == "count" else unit_hint,
                 ),
             )

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -324,7 +324,7 @@ MetricValue = TypedDict(
     {
         "current": str,
         "capacity": Optional[str],
-        "pct": Optional[str],
+        "pct": str,
         "unit_hint": str,
         "stats.min": str,
         "stats.max": str,
@@ -332,8 +332,8 @@ MetricValue = TypedDict(
         "stats.avg": str,
         "stats.diff": str,
         "stats.rate": str,
+        "stats.version": Optional[str],
     },
-    total=False,
 )
 
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -332,7 +332,7 @@ MetricValue = TypedDict(
         "stats.avg": str,
         "stats.diff": str,
         "stats.rate": str,
-        "stats.version": Optional[str],
+        "stats.version": Optional[int],
     },
 )
 


### PR DESCRIPTION
related to #1793 

* Replace `HardwareMetadata` to `dict` when class check because `TypedDict` does not support such functionality
* Add a missing parameter to default metric value formatter in the Client SDK's output framework.
  - Also make it detectable via static type checks by improving type annotations.
* Refine and clarify the description of `MetricTypes`, with fixes of the `cuda_open` and `mock` plugin metric types.
  - Rename `MetricTypes.USAGE` to `MetricTypes.GAUGE` to distinguish better from `MetricTypes.ACCUMULATION`.
  - This renaming does not affect existing compute plugins:
    - `MetricTypes.USAGE` is preserved for backward compatibility and evaluated as the same to `MetricTypes.GAUGE`.
    - `metric.type` attribute does not change the processing/display of metric values at all. Frontend formatters use `unit_hint` as the primary key.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)