### PR TITLE
fix: Rewrite the vfolder status migration in #1892

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/7ff52ff68bfc_detail_vfolder_deletion_status.py
+++ b/src/ai/backend/manager/models/alembic/versions/7ff52ff68bfc_detail_vfolder_deletion_status.py
@@ -10,10 +10,7 @@ import enum
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.sql import text
-
-from ai.backend.manager.models.base import EnumValueType, IDColumn, metadata
 
 # revision identifiers, used by Alembic.
 revision = "7ff52ff68bfc"
@@ -22,194 +19,112 @@ branch_labels = None
 depends_on = None
 
 
-BATCH_SIZE = 100
-
-ENUM_NAME = "vfolderoperationstatus"
-
-
-class VFolderOperationStatus(enum.StrEnum):
-    # New enum values
-    DELETE_PENDING = "delete-pending"  # vfolder is in trash bin
-    DELETE_COMPLETE = "delete-complete"  # vfolder is deleted permanently, only DB row remains
-    DELETE_ERROR = "delete-error"
-
-    # Legacy enum values
-    LEGACY_DELETE_COMPLETE = "deleted-complete"
-    PURGE_ONGOING = "purge-ongoing"
-
-    # Original enum values
-    DELETE_ONGOING = "delete-ongoing"  # vfolder is being deleted in storage
+class OldVFolderOperationStatus(enum.StrEnum):
+    READY = "ready"
+    PERFORMING = "performing"
+    CLONING = "cloning"
+    MOUNTED = "mounted"
     ERROR = "error"
-
-
-vfolders = sa.Table(
-    "vfolders",
-    metadata,
-    IDColumn("id"),
-    sa.Column(
-        "status",
-        EnumValueType(VFolderOperationStatus),
-        nullable=False,
-    ),
-    sa.Column("status_history", pgsql.JSONB(), nullable=True, default=sa.null()),
-    extend_existing=True,
-)
-
-
-def add_enum(enum_val: VFolderOperationStatus) -> None:
-    op.execute(f"ALTER TYPE {ENUM_NAME} ADD VALUE IF NOT EXISTS '{str(enum_val)}'")
-
-
-def delete_enum(enum_val: VFolderOperationStatus) -> None:
-    op.execute(
-        text(
-            f"""DELETE FROM pg_enum
-        WHERE enumlabel = '{str(enum_val)}'
-        AND enumtypid = (
-            SELECT oid FROM pg_type WHERE typname = '{ENUM_NAME}'
-        )"""
-        )
-    )
-
-
-def update_legacy_to_new(
-    conn,
-    vfolder_t,
-    legacy_enum: VFolderOperationStatus,
-    new_enum: VFolderOperationStatus,
-    *,
-    legacy_enum_name: str | None = None,
-    new_enum_name: str | None = None,
-) -> None:
-    _legacy_enum_name = legacy_enum_name or legacy_enum.name
-    _new_enum_name = new_enum_name or new_enum.name
-
-    while True:
-        stmt = (
-            sa.select([vfolder_t.c.id])
-            .where(
-                (vfolder_t.c.status == legacy_enum)
-                | (vfolder_t.c.status_history.has_key(_legacy_enum_name))
-            )
-            .limit(BATCH_SIZE)
-        )
-        result = conn.execute(stmt).fetchall()
-        vfolder_ids = [vf[0] for vf in result]
-
-        if not vfolder_ids:
-            break
-
-        # Update `status`
-        update_status = (
-            sa.update(vfolder_t)
-            .values({"status": new_enum})
-            .where((vfolder_t.c.id.in_(vfolder_ids)) & (vfolder_t.c.status == legacy_enum))
-        )
-        conn.execute(update_status)
-
-        # Update `status_history`
-        update_status_history = (
-            sa.update(vfolder_t)
-            .values({
-                "status_history": sa.func.jsonb_build_object(
-                    _new_enum_name, vfolder_t.c.status_history.op("->>")(_legacy_enum_name)
-                )
-                + vfolder_t.c.status_history.op("-")(_legacy_enum_name)
-            })
-            .where(
-                (vfolder_t.c.id.in_(vfolder_ids))
-                & (vfolder_t.c.status_history.has_key(_legacy_enum_name))
-            )
-        )
-        conn.execute(update_status_history)
+    DELETE_ONGOING = "delete-ongoing"  # vfolder is being deleted
+    DELETE_COMPLETE = "deleted-complete"  # vfolder is deleted
+    PURGE_ONGOING = "purge-ongoing"  # vfolder is being removed permanently
 
 
 def upgrade() -> None:
     conn = op.get_bind()
-
-    add_enum(VFolderOperationStatus.DELETE_PENDING)
-    add_enum(VFolderOperationStatus.DELETE_COMPLETE)
-    add_enum(VFolderOperationStatus.DELETE_ERROR)
-    conn.commit()
-
-    vfolders = sa.Table(
-        "vfolders",
-        metadata,
-        IDColumn("id"),
-        sa.Column(
-            "status",
-            EnumValueType(VFolderOperationStatus),
-            nullable=False,
-        ),
-        sa.Column("status_history", pgsql.JSONB(), nullable=True, default=sa.null()),
-        extend_existing=True,
+    # Relax the colum type from enum to varchar(64).
+    conn.execute(
+        text("ALTER TABLE vfolders ALTER COLUMN status TYPE varchar(64) USING status::text;")
     )
-
-    update_legacy_to_new(
-        conn, vfolders, VFolderOperationStatus.PURGE_ONGOING, VFolderOperationStatus.DELETE_ONGOING
+    conn.execute(text("ALTER TABLE vfolders ALTER COLUMN status SET DEFAULT 'ready';"))
+    conn.execute(
+        text(
+            """\
+        UPDATE vfolders
+        SET status = CASE
+            WHEN status = 'deleted-complete' THEN 'delete-pending'
+            WHEN status = 'purge-ongoing' THEN 'delete-ongoing'
+            WHEN status = 'error' THEN 'delete-error'
+            ELSE status
+        END,
+        status_history = (
+            SELECT jsonb_object_agg(new_key, value)
+            FROM (
+                SELECT
+                    CASE
+                        WHEN key = 'deleted-complete' THEN 'delete-pending'
+                        WHEN key = 'purge-ongoing' THEN 'delete-ongoing'
+                        WHEN key = 'error' THEN 'delete-error'
+                        ELSE key
+                    END AS new_key,
+                    value
+                FROM jsonb_each(status_history)
+            ) AS subquery
+        );
+    """
+        )
     )
-    update_legacy_to_new(
-        conn,
-        vfolders,
-        VFolderOperationStatus.LEGACY_DELETE_COMPLETE,
-        VFolderOperationStatus.DELETE_PENDING,
-        legacy_enum_name="DELETE_COMPLETE",
-    )
-
-    delete_enum(VFolderOperationStatus.LEGACY_DELETE_COMPLETE)
-    delete_enum(VFolderOperationStatus.PURGE_ONGOING)
-
+    conn.execute(text("DROP TYPE vfolderoperationstatus;"))
     op.add_column(
-        "vfolders", sa.Column("status_changed", sa.DateTime(timezone=True), nullable=True)
+        "vfolders",
+        sa.Column(
+            "status_changed",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
     )
     op.create_index(
-        op.f("ix_vfolders_status_changed"), "vfolders", ["status_changed"], unique=False
+        op.f("ix_vfolders_status_changed"),
+        "vfolders",
+        ["status_changed"],
+        unique=False,
     )
-    conn.commit()
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-
-    add_enum(VFolderOperationStatus.LEGACY_DELETE_COMPLETE)
-    add_enum(VFolderOperationStatus.PURGE_ONGOING)
-    conn.commit()
-
-    vfolders = sa.Table(
-        "vfolders",
-        metadata,
-        IDColumn("id"),
-        sa.Column(
-            "status",
-            EnumValueType(VFolderOperationStatus),
-            nullable=False,
-        ),
-        sa.Column("status_history", pgsql.JSONB(), nullable=True, default=sa.null()),
-        extend_existing=True,
+    conn.execute(
+        text(
+            """\
+        UPDATE vfolders
+        SET status = CASE
+            WHEN status = 'delete-pending' THEN 'deleted-complete'
+            WHEN status = 'delete-complete' THEN 'purge-ongoing'
+            WHEN status = 'delete-ongoing' THEN 'purge-ongoing'
+            WHEN status = 'delete-error' THEN 'error'
+            ELSE status
+        END,
+        status_history = (
+            SELECT jsonb_object_agg(new_key, value)
+            FROM (
+                SELECT
+                    CASE
+                        WHEN key = 'delete-pending' THEN 'deleted-complete'
+                        WHEN key = 'delete-complete' THEN 'purge-ongoing'
+                        WHEN key = 'delete-ongoing' THEN 'purge-ongoing'
+                        WHEN key = 'delete-error' THEN 'error'
+                        ELSE key
+                    END AS new_key,
+                    value
+                FROM jsonb_each(status_history)
+            ) AS subquery
+        );
+    """
+        )
     )
-
-    update_legacy_to_new(
-        conn, vfolders, VFolderOperationStatus.DELETE_COMPLETE, VFolderOperationStatus.PURGE_ONGOING
-    )  # `deleted` vfolders are not in DB rows in this downgraded version
-    update_legacy_to_new(
-        conn, vfolders, VFolderOperationStatus.DELETE_ONGOING, VFolderOperationStatus.PURGE_ONGOING
+    conn.execute(
+        text(
+            "CREATE TYPE vfolderoperationstatus AS ENUM (%s)"
+            % (",".join(f"'{choice.value}'" for choice in OldVFolderOperationStatus))
+        )
     )
-    update_legacy_to_new(
-        conn, vfolders, VFolderOperationStatus.DELETE_ERROR, VFolderOperationStatus.ERROR
+    conn.execute(text("ALTER TABLE vfolders ALTER COLUMN status DROP DEFAULT;"))
+    conn.execute(
+        text(
+            "ALTER TABLE vfolders ALTER COLUMN status TYPE vfolderoperationstatus "
+            "USING status::vfolderoperationstatus;"
+        )
     )
-    update_legacy_to_new(
-        conn,
-        vfolders,
-        VFolderOperationStatus.DELETE_PENDING,
-        VFolderOperationStatus.LEGACY_DELETE_COMPLETE,
-        new_enum_name="DELETE_COMPLETE",
-    )
-
-    delete_enum(VFolderOperationStatus.DELETE_PENDING)
-    delete_enum(VFolderOperationStatus.DELETE_COMPLETE)
-    delete_enum(VFolderOperationStatus.DELETE_ERROR)
-
+    conn.execute(text("ALTER TABLE vfolders ALTER COLUMN status SET DEFAULT 'ready';"))
     op.drop_index(op.f("ix_vfolders_status_changed"), table_name="vfolders")
     op.drop_column("vfolders", "status_changed")
-
-    conn.commit()

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -57,6 +57,7 @@ from .base import (
     OrderExprArg,
     PaginatedList,
     QuotaScopeIDType,
+    StrEnumType,
     batch_multiresult,
     generate_sql_info_for_gql_connection,
     metadata,
@@ -253,9 +254,9 @@ vfolders = sa.Table(
     sa.Column("cloneable", sa.Boolean, default=False, nullable=False),
     sa.Column(
         "status",
-        EnumValueType(VFolderOperationStatus),
+        StrEnumType(VFolderOperationStatus),
         default=VFolderOperationStatus.READY,
-        server_default=VFolderOperationStatus.READY.value,
+        server_default=VFolderOperationStatus.READY,
         nullable=False,
     ),
     # status_history records the most recent status changes for each status
@@ -1207,7 +1208,7 @@ class VirtualFolder(graphene.ObjectType):
         "cloneable": ("vfolders_cloneable", None),
         "status": (
             "vfolders_status",
-            enum_field_getter(VFolderOperationStatus),
+            lambda s: VFolderOperationStatus(s),
         ),
     }
 


### PR DESCRIPTION
The migration in #1892 requires a manual `alembic stamp` command after running the `alembic upgrade` command. This will break many developers and fieldops members.

This PR migrates the `vfolders.status` enum column to a VARCHAR(64) column to avoid complex enum value substitution and simplify the migration process.

* fix: Rewrite the vfolder status migration
  - Remove errorneous commit during alembic migration scripts
  - Use jsonb functions to convert the key names in the `status_history` column at once
* refactor: Add `models.base.StrEnumType` for stringified enum columns

> [!WARNING]
> You must downgrade the existing migration first BEFORE applying this PR's commit with a manual stamping afterwards,
> and then upgrade again AFTER applying this PR's commit (no longer manual stamping required).
>
> ```shell
> git pull  # checkout the main branch after this PR is merged
> git checkout 29e940b659e61410d0007de1cd30691b65929cf7  # the parent commit of this PR's merge commit
> ./py -m alembic downgrade -1
> ./py -m alembic stamp a5319bfc7d7c
> git checkout main
> ./py -m alembic upgrade head
> ```
>
> If you haven't applied the PR commit [f5a8bbf](https://github.com/lablup/backend.ai/commit/f5a8bbf608a35c4f0cb82225d8a783449d4076ea) from #1892, you may just simple run the upgrade.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
