### PR TITLE
chore(ci): Temporarily replace self-hosted arc runners with github-hosted runners

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   lint:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
     - name: Calculate the fetch depth
       run: |
@@ -82,7 +82,7 @@ jobs:
 
   typecheck:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
     - name: Calculate the fetch depth
       run: |


### PR DESCRIPTION
There are some networking issues from our self-hosted ARC runners to GitHub.
Until the issue is resolved, let's use GitHub-hosted standard runners.