### PR TITLE
fix: Typo in 714c119 using f-string (follow-up of follow-up of #1938)

### DIFF
--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -68,7 +68,7 @@ async def _negotiate_api_version(
                 )
             if server_version < MIN_API_VERSION:
                 warnings.warn(
-                    "The server is too old ({server_version}) and does not meet the minimum API version"
+                    f"The server is too old ({server_version}) and does not meet the minimum API version"
                     f" requirement: v{MIN_API_VERSION[0]}.{MIN_API_VERSION[1]}\nPlease upgrade"
                     " the server or downgrade/reinstall the client SDK with the same"
                     " major.minor release of the server.",


### PR DESCRIPTION
This PR is a follow-up to 714c1191c4634bcd2c9d21ba3fc764f40a5a1f36 to supply missing "f-string".

https://github.com/lablup/backend.ai/blob/9e56e5449acc8aefabcfa6aa4612b317bae9a2ec/src/ai/backend/client/session.py#L68-L74

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
