### PR TITLE
fix: model service route status incorrectly displayed

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fix `endpoint.routings` GQL field showing routing ID instead of status enum


### PR DESCRIPTION
This PR fixes `endpoint.routings` GQL query displaying routing ID instead of its status. This PR also adds new `DEGRADED` status among currently available Endpoint status, which represents a portion of model service sessions not behaving correctly.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
