### PR TITLE
fix: Disable krunner's user site to avoid potential conflicts with user-installed packages

### DIFF
--- a/changes/1962.fix.md
+++ b/changes/1962.fix.md
@@ -1,0 +1,1 @@
+Explicitly disable the user-site package detection in the krunner python commands to avoid potential conflicts with user-installed packages in `.local` directories

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1920,6 +1920,7 @@ class AbstractAgent(
                     krunner_opts.append("--debug")
                 cmdargs += [
                     "/opt/backend.ai/bin/python",
+                    "-s",
                     "-m",
                     "ai.backend.kernel",
                     *krunner_opts,

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -32,8 +32,9 @@ import janus
 import msgpack
 import zmq
 from async_timeout import timeout
-from jupyter_client import AsyncKernelClient, AsyncKernelManager
+from jupyter_client.asynchronous.client import AsyncKernelClient
 from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.manager import AsyncKernelManager
 
 from .compat import current_loop
 from .intrinsic import (

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -37,7 +37,7 @@ if [ $USER_ID -eq 0 ]; then
   fi
 
   # Extract dotfiles
-  /opt/backend.ai/bin/python /opt/kernel/extract_dotfiles.py
+  /opt/backend.ai/bin/python -s /opt/kernel/extract_dotfiles.py
 
   # Start ssh-agent if it is available
   if command -v ssh-agent > /dev/null; then
@@ -47,7 +47,7 @@ if [ $USER_ID -eq 0 ]; then
 
   echo "Generate random alpha-numeric password"
   if [ ! -f "$HOME/.password" ]; then
-    /opt/backend.ai/bin/python /opt/kernel/fantompass.py > "$HOME/.password"
+    /opt/backend.ai/bin/python -s /opt/kernel/fantompass.py > "$HOME/.password"
     export ALPHA_NUMERIC_VAL=$(cat $HOME/.password)
     chmod 0644 "$HOME/.password"
     echo "work:$ALPHA_NUMERIC_VAL" | chpasswd
@@ -114,7 +114,7 @@ else
   chown $USER_ID:$GROUP_ID /opt/kernel/agent.sock
 
   # Extract dotfiles
-  /opt/kernel/su-exec $USER_ID:$GROUP_ID /opt/backend.ai/bin/python /opt/kernel/extract_dotfiles.py
+  /opt/kernel/su-exec $USER_ID:$GROUP_ID /opt/backend.ai/bin/python -s /opt/kernel/extract_dotfiles.py
 
   # Start ssh-agent if it is available
   if command -v ssh-agent > /dev/null; then
@@ -129,7 +129,7 @@ else
 
   echo "Generate random alpha-numeric password"
   if [ ! -f "$HOME/.password" ]; then
-    /opt/kernel/su-exec $USER_ID:$GROUP_ID  /opt/backend.ai/bin/python /opt/kernel/fantompass.py > "$HOME/.password"
+    /opt/kernel/su-exec $USER_ID:$GROUP_ID /opt/backend.ai/bin/python -s /opt/kernel/fantompass.py > "$HOME/.password"
     export ALPHA_NUMERIC_VAL=$(cat $HOME/.password)
     chmod 0644 "$HOME/.password"
     echo "$USER_NAME:$ALPHA_NUMERIC_VAL" | chpasswd


### PR DESCRIPTION
resolves #1959

This PR disables the user-site functionality for the krunner python commands to improve security and potential conflicts with the user-installed packages that may override some packages in the krunner.

Though, it does not disable it for the user-executed service-port apps that use the container's own Python runtime such as Jupyter notebooks (both the frontend server and the kernel processes). This is why I've put `-s` options individually instead of setting the `PYTHONNOUSERSITE=1` environment variable which may propagate to all sub-processes.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
