### PR TITLE
fix: alembic migration failing when primary key does not exist

### DIFF
--- a/changes/1963.fix.md
+++ b/changes/1963.fix.md
@@ -1,0 +1,1 @@
+Fix `caf54fcc17ab` migration to drop a primary key only if it exists and in `589c764a18f1` migration, add missing table arguments.

--- a/src/ai/backend/manager/models/alembic/versions/589c764a18f1_change_endpoint_to_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/589c764a18f1_change_endpoint_to_nullable.py
@@ -54,6 +54,7 @@ def downgrade():
     endpoint_tokens = sa.Table(
         "endpoint_tokens",
         metadata,
+        sa.Column("id", GUID, primary_key=True),
         sa.Column(
             "endpoint", GUID, sa.ForeignKey("endpoints.id", ondelete="SET NULL"), nullable=True
         ),
@@ -61,6 +62,8 @@ def downgrade():
     )
     endpoints = sa.Table(
         "endpoints",
+        metadata,
+        sa.Column("id", GUID, primary_key=True),
         sa.Column("model", GUID, sa.ForeignKey("vfolders.id", ondelete="SET NULL"), nullable=True),
         extend_existing=True,
     )

--- a/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
@@ -1,5 +1,7 @@
 """add_id_columns_to_association_tables
 
+Adds ID column to select tables and replaces its Primary Key from pair of data columns to newly created ID column
+
 Revision ID: caf54fcc17ab
 Revises: 8b2ec7e3d22a
 Create Date: 2024-01-03 21:39:50.558724
@@ -9,7 +11,7 @@ Create Date: 2024-01-03 21:39:50.558724
 import sqlalchemy as sa
 from alembic import op
 
-from ai.backend.manager.models.base import GUID, metadata
+from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "caf54fcc17ab"
@@ -36,88 +38,19 @@ def upgrade():
         sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
     )
 
-    association_groups_users = sa.Table(
-        "association_groups_users",
-        metadata,
-        sa.Column(
-            "user_id",
-            GUID,
-            sa.ForeignKey("users.uuid", onupdate="CASCADE", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column(
-            "group_id",
-            GUID,
-            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        extend_existing=True,
-    )
+    def drop_existing_pk(table: str) -> None:
+        try:
+            # based on age of our constraint naming convention (ai.backend.manager.models.base)
+            # it is safe to assume that every primary key has pk_{table} as its name
+            op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS pk_{table}")
+        except sa.exc.ProgrammingError:
+            # Skip dropping if the table has no primary key
+            pass
 
-    sgroups_for_domains = sa.Table(
-        "sgroups_for_domains",
-        metadata,
-        sa.Column(
-            "scaling_group",
-            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        sa.Column(
-            "domain",
-            sa.ForeignKey("domains.name", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        extend_existing=True,
-    )
-
-    sgroups_for_groups = sa.Table(
-        "sgroups_for_groups",
-        metadata,
-        sa.Column(
-            "scaling_group",
-            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        sa.Column(
-            "group",
-            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        extend_existing=True,
-    )
-
-    sgroups_for_keypairs = sa.Table(
-        "sgroups_for_keypairs",
-        metadata,
-        sa.Column(
-            "scaling_group",
-            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        sa.Column(
-            "access_key",
-            sa.ForeignKey("keypairs.access_key", onupdate="CASCADE", ondelete="CASCADE"),
-            index=True,
-            nullable=False,
-        ),
-        extend_existing=True,
-    )
-
-    def drop_existing_pk(table: sa.sql.schema.Table) -> None:
-        for const in table.constraints:
-            if isinstance(const, sa.PrimaryKeyConstraint):
-                op.drop_constraint(const.name, table.name, type_="primary")
-                break
-
-    drop_existing_pk(association_groups_users)
-    drop_existing_pk(sgroups_for_domains)
-    drop_existing_pk(sgroups_for_groups)
-    drop_existing_pk(sgroups_for_keypairs)
+    drop_existing_pk("association_groups_users")
+    drop_existing_pk("sgroups_for_domains")
+    drop_existing_pk("sgroups_for_groups")
+    drop_existing_pk("sgroups_for_keypairs")
 
     op.create_primary_key("pk_association_groups_users", "association_groups_users", ["id"])
     op.create_primary_key("pk_sgroups_for_domains", "sgroups_for_domains", ["id"])

--- a/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
@@ -9,7 +9,7 @@ Create Date: 2024-01-03 21:39:50.558724
 import sqlalchemy as sa
 from alembic import op
 
-from ai.backend.manager.models.base import GUID
+from ai.backend.manager.models.base import GUID, metadata
 
 # revision identifiers, used by Alembic.
 revision = "caf54fcc17ab"
@@ -36,17 +36,112 @@ def upgrade():
         sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
     )
 
-    def drop_existing_pk(idx: str, table: str):
-        try:
-            op.drop_constraint(idx, table, type_="primary")
-        except sa.exc.ProgrammingError:
-            # Skip dropping if the table has no primary key
-            pass
+    association_groups_users = sa.Table(
+        "association_groups_users",
+        metadata,
+        sa.Column(
+            "id",
+            GUID,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            GUID,
+            sa.ForeignKey("users.uuid", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "group_id",
+            GUID,
+            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id", "group_id", name="uq_association_user_id_group_id"),
+        extend_existing=True,
+    )
 
-    drop_existing_pk("pk_association_groups_users", "association_groups_users")
-    drop_existing_pk("pk_sgroups_for_domains", "sgroups_for_domains")
-    drop_existing_pk("pk_sgroups_for_groups", "sgroups_for_groups")
-    drop_existing_pk("pk_sgroups_for_keypairs", "sgroups_for_keypairs")
+    sgroups_for_domains = sa.Table(
+        "sgroups_for_domains",
+        metadata,
+        sa.Column(
+            "id",
+            GUID,
+            nullable=False,
+        ),
+        sa.Column(
+            "scaling_group",
+            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "domain",
+            sa.ForeignKey("domains.name", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("scaling_group", "domain", name="uq_sgroup_domain"),
+        extend_existing=True,
+    )
+
+    sgroups_for_groups = sa.Table(
+        "sgroups_for_groups",
+        metadata,
+        sa.Column(
+            "id",
+            GUID,
+            nullable=False,
+        ),
+        sa.Column(
+            "scaling_group",
+            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "group",
+            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("scaling_group", "group", name="uq_sgroup_ugroup"),
+        extend_existing=True,
+    )
+
+    sgroups_for_keypairs = sa.Table(
+        "sgroups_for_keypairs",
+        metadata,
+        sa.Column(
+            "id",
+            GUID,
+            nullable=False,
+        ),
+        sa.Column(
+            "scaling_group",
+            sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "access_key",
+            sa.ForeignKey("keypairs.access_key", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("scaling_group", "access_key", name="uq_sgroup_akey"),
+        extend_existing=True,
+    )
+
+    def drop_existing_pk(table: sa.sql.schema.Table) -> None:
+        for const in table.constraints:
+            if isinstance(const, sa.PrimaryKeyConstraint):
+                op.drop_constraint(const.name, table.name, type_="primary")
+                break
+
+    drop_existing_pk(association_groups_users)
+    drop_existing_pk(sgroups_for_domains)
+    drop_existing_pk(sgroups_for_groups)
+    drop_existing_pk(sgroups_for_keypairs)
 
     op.create_primary_key("pk_association_groups_users", "association_groups_users", ["id"])
     op.create_primary_key("pk_sgroups_for_domains", "sgroups_for_domains", ["id"])

--- a/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
@@ -40,11 +40,6 @@ def upgrade():
         "association_groups_users",
         metadata,
         sa.Column(
-            "id",
-            GUID,
-            nullable=False,
-        ),
-        sa.Column(
             "user_id",
             GUID,
             sa.ForeignKey("users.uuid", onupdate="CASCADE", ondelete="CASCADE"),
@@ -62,11 +57,6 @@ def upgrade():
     sgroups_for_domains = sa.Table(
         "sgroups_for_domains",
         metadata,
-        sa.Column(
-            "id",
-            GUID,
-            nullable=False,
-        ),
         sa.Column(
             "scaling_group",
             sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
@@ -86,11 +76,6 @@ def upgrade():
         "sgroups_for_groups",
         metadata,
         sa.Column(
-            "id",
-            GUID,
-            nullable=False,
-        ),
-        sa.Column(
             "scaling_group",
             sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),
             index=True,
@@ -108,11 +93,6 @@ def upgrade():
     sgroups_for_keypairs = sa.Table(
         "sgroups_for_keypairs",
         metadata,
-        sa.Column(
-            "id",
-            GUID,
-            nullable=False,
-        ),
         sa.Column(
             "scaling_group",
             sa.ForeignKey("scaling_groups.name", onupdate="CASCADE", ondelete="CASCADE"),

--- a/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/caf54fcc17ab_add_id_columns_to_association_tables.py
@@ -56,7 +56,6 @@ def upgrade():
             sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.UniqueConstraint("user_id", "group_id", name="uq_association_user_id_group_id"),
         extend_existing=True,
     )
 
@@ -80,7 +79,6 @@ def upgrade():
             index=True,
             nullable=False,
         ),
-        sa.UniqueConstraint("scaling_group", "domain", name="uq_sgroup_domain"),
         extend_existing=True,
     )
 
@@ -104,7 +102,6 @@ def upgrade():
             index=True,
             nullable=False,
         ),
-        sa.UniqueConstraint("scaling_group", "group", name="uq_sgroup_ugroup"),
         extend_existing=True,
     )
 
@@ -128,7 +125,6 @@ def upgrade():
             index=True,
             nullable=False,
         ),
-        sa.UniqueConstraint("scaling_group", "access_key", name="uq_sgroup_akey"),
         extend_existing=True,
     )
 


### PR DESCRIPTION
follow up #1935 and #1818

- When dropping primary keys, check if the table has any primary key
- Add some missing Table arguments in `589c764a18f1` alembic downgrade.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version