### PR TITLE
docs: resize only on footer text in ads popup

### DIFF
--- a/changes/1967.doc.md
+++ b/changes/1967.doc.md
@@ -1,0 +1,1 @@
+Only resize font-size of footer text in ethical ads not in title of content in documentation

--- a/docs/_static/css/customTheme.css
+++ b/docs/_static/css/customTheme.css
@@ -7541,6 +7541,6 @@ span.linenos.special { color: #e6edf3; background-color: #6e7681; padding-left: 
 .highlight .il { color: #a5d6ff } /* Literal.Number.Integer.Long */
 
 /* DO NOT REMOVE THIS - customizing ads comment in ethical ads */
-.ethical-rtd .ethical-sidebar, a {
+div.ethical-callout > * > * > a {
   font-size: small;
 }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Related: #1965 
This PR fixes font resizing in ads footer, not in contents titles.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--1967.org.readthedocs.build/en/1967/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--1967.org.readthedocs.build/ko/1967/

<!-- readthedocs-preview sorna-ko end -->