### PR TITLE
ci: Bump auto-label-in-issue from 1.6.0 to 1.7.0

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: 'Auto Label'
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [labeled, unlabeled, opened, synchronize, reopened, edited]
 
 permissions:
   issues: write
@@ -12,4 +12,4 @@ jobs:
   auto-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: lablup/auto-label-in-issue@1.6.0
+      - uses: lablup/auto-label-in-issue@1.7.0


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/8438248840?pr=1758
Fixed a simple error that occurred because the code that outputs the milestone was faster than the if condition that checks if the milestone exists.
https://github.com/lablup/auto-label-in-issue/commit/c383a01c513347b9dfba7909f0f30ab53591fd05