### PR TITLE
chore: Upgrade pants to 2.19.1

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -52,8 +52,6 @@ jobs:
         cache-lmdb-store: 'true'
     - name: Check BUILD files
       run: pants tailor --check update-build-files --check '::'
-    - name: Check forbidden cross imports
-      run: pants dependencies '::'
     - name: Lint
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.19.0"
+pants_version = "2.19.1"
 pythonpath = ["%(buildroot)s/tools/pants-plugins"]
 backend_packages = [
     "pants.backend.python",


### PR DESCRIPTION
refs https://github.com/pantsbuild/pants/releases/tag/release_2.19.1

- **chore(repo): Upgrade pants to 2.19.1**
- **chore(ci): `pants lint` now includes the visibility check**

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version