### PR TITLE
chore: Add `requested_slots` field to compute session GQL

### DIFF
--- a/changes/1984.misc.md
+++ b/changes/1984.misc.md
@@ -1,0 +1,1 @@
+Add `requested_slots` field to compute session GQL type.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -523,6 +523,8 @@ type ComputeSession implements Item {
   vfolder_mounts: [String]
   occupying_slots: JSONString
   occupied_slots: JSONString
+
+  """Added in 24.03.0"""
   requested_slots: JSONString
   num_queries: BigInt
   containers: [ComputeContainer]

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -523,6 +523,7 @@ type ComputeSession implements Item {
   vfolder_mounts: [String]
   occupying_slots: JSONString
   occupied_slots: JSONString
+  requested_slots: JSONString
   num_queries: BigInt
   containers: [ComputeContainer]
   dependencies: [ComputeSession]

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -1191,7 +1191,7 @@ class ComputeSession(graphene.ObjectType):
     vfolder_mounts = graphene.List(lambda: graphene.String)
     occupying_slots = graphene.JSONString()
     occupied_slots = graphene.JSONString()  # legacy
-    requested_slots = graphene.JSONString()
+    requested_slots = graphene.JSONString(description="Added in 24.03.0")
 
     # statistics
     num_queries = BigInt()

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -1260,7 +1260,7 @@ class ComputeSession(graphene.ObjectType):
             "service_ports": row.main_kernel.service_ports,
             "mounts": [mount.name for mount in row.vfolder_mounts],
             "vfolder_mounts": row.vfolder_mounts,
-            "requested_slots": row.requested_slots,
+            "requested_slots": row.requested_slots.to_json(),
             # statistics
             "num_queries": row.num_queries,
         }

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -1191,6 +1191,7 @@ class ComputeSession(graphene.ObjectType):
     vfolder_mounts = graphene.List(lambda: graphene.String)
     occupying_slots = graphene.JSONString()
     occupied_slots = graphene.JSONString()  # legacy
+    requested_slots = graphene.JSONString()
 
     # statistics
     num_queries = BigInt()
@@ -1259,6 +1260,7 @@ class ComputeSession(graphene.ObjectType):
             "service_ports": row.main_kernel.service_ports,
             "mounts": [mount.name for mount in row.vfolder_mounts],
             "vfolder_mounts": row.vfolder_mounts,
+            "requested_slots": row.requested_slots,
             # statistics
             "num_queries": row.num_queries,
         }


### PR DESCRIPTION
I forgot to add `requested_slots` field to ComputeSession GQL class in #576..
**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
