### PR TITLE
fix: function default argument from a mutable object to None

### DIFF
--- a/changes/1986.fix.md
+++ b/changes/1986.fix.md
@@ -1,0 +1,1 @@
+Change function default arguments from mutable object to `None`.

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -923,7 +923,7 @@ class SessionRow(Base):
         allow_stale: bool = False,
         for_update: bool = False,
         kernel_loading_strategy: KernelLoadingStrategy = KernelLoadingStrategy.NONE,
-        eager_loading_op: list[Any] = [],
+        eager_loading_op: list[Any] | None = None,
     ) -> SessionRow:
         """
         Retrieve the session information by session's UUID,
@@ -939,9 +939,10 @@ class SessionRow(Base):
         :param kernel_loading_strategy: Determines JOIN strategy of `kernels` relation when fetching session rows.
         :param eager_loading_op: Extra loading operators to be passed directly to `match_sessions()` API.
         """
+        _eager_loading_op = eager_loading_op or []
         match kernel_loading_strategy:
             case KernelLoadingStrategy.ALL_KERNELS:
-                eager_loading_op.extend([
+                _eager_loading_op.extend([
                     noload("*"),
                     selectinload(SessionRow.kernels).options(
                         noload("*"),
@@ -951,7 +952,7 @@ class SessionRow(Base):
             case KernelLoadingStrategy.MAIN_KERNEL_ONLY:
                 kernel_rel = SessionRow.kernels
                 kernel_rel.and_(KernelRow.cluster_role == DEFAULT_ROLE)
-                eager_loading_op.extend([
+                _eager_loading_op.extend([
                     noload("*"),
                     selectinload(kernel_rel).options(
                         noload("*"),
@@ -965,7 +966,7 @@ class SessionRow(Base):
             access_key,
             allow_stale=allow_stale,
             for_update=for_update,
-            eager_loading_op=eager_loading_op,
+            eager_loading_op=_eager_loading_op,
         )
         if not session_list:
             raise SessionNotFound(f"Session (id={session_name_or_id}) does not exist.")
@@ -992,11 +993,12 @@ class SessionRow(Base):
         allow_stale: bool = False,
         for_update: bool = False,
         kernel_loading_strategy=KernelLoadingStrategy.NONE,
-        eager_loading_op: list[Any] = [],
+        eager_loading_op: list[Any] | None = None,
     ) -> Iterable[SessionRow]:
+        _eager_loading_op = eager_loading_op or []
         match kernel_loading_strategy:
             case KernelLoadingStrategy.ALL_KERNELS:
-                eager_loading_op.extend([
+                _eager_loading_op.extend([
                     noload("*"),
                     selectinload(SessionRow.kernels).options(
                         noload("*"),
@@ -1006,7 +1008,7 @@ class SessionRow(Base):
             case KernelLoadingStrategy.MAIN_KERNEL_ONLY:
                 kernel_rel = SessionRow.kernels
                 kernel_rel.and_(KernelRow.cluster_role == DEFAULT_ROLE)
-                eager_loading_op.extend([
+                _eager_loading_op.extend([
                     noload("*"),
                     selectinload(kernel_rel).options(
                         noload("*"),
@@ -1020,7 +1022,7 @@ class SessionRow(Base):
             access_key,
             allow_stale=allow_stale,
             for_update=for_update,
-            eager_loading_op=eager_loading_op,
+            eager_loading_op=_eager_loading_op,
         )
         try:
             return session_list


### PR DESCRIPTION
follow-up #1396 

function default arguments should never be a mutable object such as `list` or `dict`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version