### PR TITLE
chore: Allow `pydantic.BaseModel` as API handler return schema

### DIFF
--- a/1987.misc.md
+++ b/1987.misc.md
@@ -1,0 +1,1 @@
+Allow `pydantic.BaseModel` as an API function return type.

--- a/1987.misc.md
+++ b/1987.misc.md
@@ -1,1 +1,1 @@
-Allow `pydantic.BaseModel` as an API function return type.
+Allow `pydantic.BaseModel` as the API function return type.

--- a/1987.misc.md
+++ b/1987.misc.md
@@ -1,1 +1,0 @@
-Allow `pydantic.BaseModel` as the API function return type.

--- a/changes/1987.misc.md
+++ b/changes/1987.misc.md
@@ -1,0 +1,1 @@
+Allow `pydantic.BaseModel` as the API handler return schema.

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -214,12 +214,12 @@ def check_api_params(
 
 
 class BaseResponseModel(BaseModel):
-    status: Annotated[int, Field(strict=True, ge=100, lt=600)] = 200
+    status: Annotated[int, Field(strict=True, exclude=True, ge=100, lt=600)] = 200
 
 
 TParamModel = TypeVar("TParamModel", bound=BaseModel)
 TQueryModel = TypeVar("TQueryModel", bound=BaseModel)
-TResponseModel = TypeVar("TResponseModel", bound=BaseResponseModel)
+TResponseModel = TypeVar("TResponseModel", bound=BaseModel)
 
 TPydanticResponse: TypeAlias = TResponseModel | list
 THandlerFuncWithoutParam: TypeAlias = Callable[
@@ -231,11 +231,13 @@ THandlerFuncWithParam: TypeAlias = Callable[
 
 
 def ensure_stream_response_type(
-    response: BaseResponseModel | list[TResponseModel] | web.StreamResponse,
+    response: BaseResponseModel | BaseModel | list[TResponseModel] | web.StreamResponse,
 ) -> web.StreamResponse:
     match response:
         case BaseResponseModel(status=status):
             return web.json_response(response.model_dump(mode="json"), status=status)
+        case BaseModel():
+            return web.json_response(response.model_dump(mode="json"))
         case list():
             return web.json_response(TypeAdapter(type(response)).dump_python(response, mode="json"))
         case web.StreamResponse():


### PR DESCRIPTION
in #1927, I disallowed all `pydantic.BaseModel` as an API response and it is forced to return only `BaseResponseModel` now.
But it undermines API functions compatibility. let's allow `pydantic.BaseModel`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)