### PR TITLE
feat: Enable robust DB connection handling

### DIFF
--- a/changes/1991.enhance.md
+++ b/changes/1991.enhance.md
@@ -1,0 +1,1 @@
+Enable robust DB connection handling by allowing `pool-pre-ping` setting.

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -12,7 +12,7 @@ name = "backend"
 user = "postgres"
 password = "develove"
 pool-recycle = 50
-pool-pre-ping = true
+pool-pre-ping = false
 
 
 [manager]

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -12,6 +12,7 @@ name = "backend"
 user = "postgres"
 password = "develove"
 pool-recycle = 50
+pool-pre-ping = true
 
 
 [manager]

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -37,6 +37,12 @@ password = "DB_PASSWORD"                    # env: BACKEND_DB_PASSWORD
 # https://docs.sqlalchemy.org/en/14/core/pooling.html#setting-pool-recycle
 # pool-recycle = -1
 
+# This setting eliminates DB error due to stale pooled connections by ping at the start of each connection pool checkout.
+# It adds a small overhead to the connection checkout process.
+# https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic
+# Default is false.
+# pool-pre-ping = false
+
 # The maximum allowed overflow of the connection pool
 # (See https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.max_overflow)
 # max-overflow = 64

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -245,6 +245,7 @@ manager_local_config_iv = (
             t.Key("password"): t.String,
             t.Key("pool-size", default=8): t.ToInt[1:],  # type: ignore
             t.Key("pool-recycle", default=-1): t.ToFloat[-1:],  # -1 is infinite
+            t.Key("pool-pre-ping", default=False): t.ToBool,
             t.Key("max-overflow", default=64): t.ToInt[-1:],  # -1 is infinite  # type: ignore
             t.Key("lock-conn-timeout", default=0): t.ToFloat[0:],  # 0 is infinite
         }),

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -215,6 +215,7 @@ async def connect_database(
         connect_args=pgsql_connect_opts,
         pool_size=local_config["db"]["pool-size"],
         pool_recycle=local_config["db"]["pool-recycle"],
+        pool_pre_ping=local_config["db"]["pool-pre-ping"],
         max_overflow=local_config["db"]["max-overflow"],
         json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
         isolation_level=isolation_level,

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -183,6 +183,7 @@ def local_config(
             "password": "develove",
             "pool-size": 8,
             "pool-recycle": -1,
+            "pool-pre-ping": False,
             "max-overflow": 64,
             "lock-conn-timeout": 0,
         },


### PR DESCRIPTION
Considering situations such as DB HA settings, there may be many situations where DB processes are restarted. Optimistic connection pool handling(pool-recycle, #1877) does not fully cope with these frequent DB restarts, so we introduce pessimistic DB connection pool handling, `pool-pre-ping`.

`pool-pre-ping` setting eliminates DB error due to stale pooled connections by ping at the start of each connection pool checkout.
It adds a small overhead to the connection checkout process.

ref: https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
