### PR TITLE
ci: Modified to operate even in deprecation reason changed situations

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -58,7 +58,7 @@ jobs:
         echo "name=$author_name" >> $GITHUB_OUTPUT
         echo "email=$author_email" >> $GITHUB_OUTPUT
     - name: Make commit message for changing change log file
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_author: ${{ steps.get_author_info.outputs.name }} <${{ steps.get_author_info.outputs.email }}>
         commit_message: 'chore: update GraphQL schema dump'
@@ -73,4 +73,4 @@ jobs:
         with:
           schema: 'main:src/ai/backend/manager/api/schema.graphql'
           rules: |
-            custom-rule.js
+            gql-inspector-checker.js

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -1,7 +1,8 @@
 module.exports = (props) => {
   const { changes, newSchema, oldSchema } = props;
   return changes.map((change) => {
-    // console.log(change);
+    const deprecateNotationRegex = /Deprecated since (\d{2}\.\d{2}.\d{1})/;
+    const addNotationRegex = /Added in (\d{2}\.\d{2}.\d{1})/;
     if (
       [
         "FIELD_DEPRECATION_REASON_ADDED",
@@ -10,14 +11,13 @@ module.exports = (props) => {
       change.criticality.level !== "BREAKING"
     ) {
       const newReason =
-        change.meta?.addedDeprecationReason || change.meta?.newDeprecationReason;
-      const regex = /Deprecated since (\d{2}\.\d{2}.\d{1})/;
-      if (!newReason.match(regex)) {
+        change.meta?.addedDeprecationReason ?? change.meta?.newDeprecationReason;
+      if (newReason && !newReason.match(deprecateNotationRegex)) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X"';
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X."';
         change.message =
-          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X", ' +
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X.", ' +
           change.message;
       }
     } else if (
@@ -28,12 +28,12 @@ module.exports = (props) => {
       const description = newSchema.getTypeMap()[typeName].getFields()[
         fieldName
       ].astNode.description?.value;
-      if (!description || !description.match(/Added in (\d{2}\.\d{2}.\d{1})/)) {
+      if (!description || (description && !description.match(addNotationRegex))) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'New fields must include a description with a version number in the format "Added in XX.XX.X"';
+          'New fields must include a description with a version number in the format "Added in XX.XX.X."';
         change.message =
-          'New fields must include a description with a version number in the format "Added in XX.XX.X", ' +
+          'New fields must include a description with a version number in the format "Added in XX.XX.X.", ' +
           change.message;
       }
     } else if (
@@ -43,12 +43,12 @@ module.exports = (props) => {
       const typeName = change.path.split(".")[0];
       const description =
         newSchema.getTypeMap()[typeName].astNode.description?.value;
-      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+      if (!description || (description && !description.match(addNotationRegex))) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'New types must include a description with a version number in the format "since XX.XX"';
+          'New types must include a description with a version number in the format "Added in XX.XX.X."';
         change.message =
-          'New types must include a description with a version number in the format "XX.XX", ' +
+          'New types must include a description with a version number in the format "Added in XX.XX.X.", ' +
           change.message;
       }
     } else if (
@@ -63,12 +63,12 @@ module.exports = (props) => {
         (arg) => arg.name === argumentName
       )?.description;
 
-      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+      if (!description || (description && !description.match(addNotationRegex))) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'New arguments must include a description with a version number in the format "since XX.XX"';
+          'New arguments must include a description with a version number in the format "Added in XX.XX.X."';
         change.message =
-          'New arguments must include a description with a version number in the format "XX.XX", ' +
+          'New arguments must include a description with a version number in the format "XX.XX.X.", ' +
           change.message;
       }
     }

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -10,7 +10,7 @@ module.exports = (props) => {
       change.criticality.level !== "BREAKING"
     ) {
       const newReason =
-        change.meta?.addedDeprecationReason || change.meta.newDeprecationReason;
+        change.meta?.addedDeprecationReason || change.meta?.newDeprecationReason;
       const regex = /Deprecated since (\d{2}\.\d{2}.\d{1})/;
       if (!newReason.match(regex)) {
         change.criticality.level = "BREAKING";

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -10,7 +10,7 @@ module.exports = (props) => {
       change.criticality.level !== "BREAKING"
     ) {
       const newReason =
-        change.meta.addedDeprecationReason || change.meta.newDeprecationReason;
+        change.meta.addedDeprecationReason ?? change.meta.newDeprecationReason;
       const regex = /Deprecated since (\d{2}\.\d{2})/;
       if (!newReason.match(regex)) {
         change.criticality.level = "BREAKING";

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -11,13 +11,13 @@ module.exports = (props) => {
     ) {
       const newReason =
         change.meta?.addedDeprecationReason || change.meta.newDeprecationReason;
-      const regex = /Deprecated since (\d{2}\.\d{2})/;
+      const regex = /Deprecated since (\d{2}\.\d{2}.\d{1})/;
       if (!newReason.match(regex)) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'Deprecation reason must include a version number in the format "Deprecated since XX.XX"';
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X"';
         change.message =
-          'Deprecation reason must include a version number in the format "Deprecated since XX.XX", ' +
+          'Deprecation reason must include a version number in the format "Deprecated since XX.XX.X", ' +
           change.message;
       }
     } else if (
@@ -28,12 +28,12 @@ module.exports = (props) => {
       const description = newSchema.getTypeMap()[typeName].getFields()[
         fieldName
       ].astNode.description?.value;
-      if (!description || !description.match(/since (\d{2}\.\d{2})/)) {
+      if (!description || !description.match(/Added in (\d{2}\.\d{2}.\d{1})/)) {
         change.criticality.level = "BREAKING";
         change.criticality.reason =
-          'New fields must include a description with a version number in the format "since XX.XX"';
+          'New fields must include a description with a version number in the format "Added in XX.XX.X"';
         change.message =
-          'New fields must include a description with a version number in the format "XX.XX", ' +
+          'New fields must include a description with a version number in the format "Added in XX.XX.X", ' +
           change.message;
       }
     } else if (

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -68,7 +68,7 @@ module.exports = (props) => {
         change.criticality.reason =
           'New arguments must include a description with a version number in the format "Added in XX.XX.X."';
         change.message =
-          'New arguments must include a description with a version number in the format "XX.XX.X.", ' +
+          'New arguments must include a description with a version number in the format "Added in XX.XX.X.", ' +
           change.message;
       }
     }

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -10,7 +10,7 @@ module.exports = (props) => {
       change.criticality.level !== "BREAKING"
     ) {
       const newReason =
-        change.meta.addedDeprecationReason ?? change.meta.newDeprecationReason;
+        change.meta?.addedDeprecationReason || change.meta.newDeprecationReason;
       const regex = /Deprecated since (\d{2}\.\d{2})/;
       if (!newReason.match(regex)) {
         change.criticality.level = "BREAKING";


### PR DESCRIPTION
- https://github.com/lablup/backend.ai/actions/runs/8564982449?pr=1993
'||' The part that could not handle undefined because it operates as an operator is '??' Modify to use operators.
- Upgrade stefanzweifel/git-auto-commit-action@v4 using node 16 version to v5 version.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
