### PR TITLE
fix: Delete vfolders in own DB context when purge user

### DIFF
--- a/changes/2001.fix.md
+++ b/changes/2001.fix.md
@@ -1,0 +1,1 @@
+Delete vfolders in own DB context when purge users.


### PR DESCRIPTION
`PurgeUser.mutate()` deletes user related DB records, such as key pairs and vfolders.
When a vfolder is being deleted through `PurgeUser.delete_vfolder()`,  the method opens own DB connection while the process is already in a DB connection context. It could raise error like below.
```
File "/backend.ai/src/ai/backend/manager/models/user.py", line 996, in _pre_func
    await cls.delete_keypairs(conn, graph_ctx.redis_stat, user_uuid)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/src/ai/backend/manager/models/user.py", line 1300, in delete_keypairs
    ak_rows = await conn.execute(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/ext/asyncio/engine.py", line 453, in execute
    result = await greenlet_spawn(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 126, in greenlet_spawn
    result = context.throw(*sys.exc_info())
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2138, in _handle_dbapi_exception
    util.raise_(exc_info[1], with_traceback=exc_info[2])
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 479, in execute
    self._adapt_connection.await_(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 68, in await_only
    return current.driver.switch(awaitable)
      ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 121, in greenlet_spawn
    value = await result
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 454, in _prepare_and_execute
    self._handle_exception(error)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 389, in _handle_exception
    self._adapt_connection._handle_exception(error)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 684, in _handle_exception
    raise error
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 418, in _prepare_and_execute
    prepared_stmt, attributes = await adapt_connection._prepare(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 660, in _prepare
    prepared_stmt = await self._connection.prepare(operation)
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/asyncpg/connection.py", line 636, in prepare
    return await self._prepare(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/asyncpg/connection.py", line 654, in _prepare
    stmt = await self._get_statement(
    ^^^^^^^^^^^^^^^^^
  File "/backend.ai/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/asyncpg/connection.py", line 433, in _get_statement
    statement = await self._protocol.prepare(
    ^^^^^^^^^^^^^^^^^
  File "asyncpg/protocol/protocol.pyx", line 166, in prepare
    return await waiter
    ^^^^^^^^^^^^^^^^^
  File "asyncpg/protocol/protocol.pyx", line 156, in asyncpg.protocol.protocol.BaseProtocol.prepare
    self._prepare_and_describe(stmt_name, query)  # network op
    ^^^^^^^^^^^^^^^^^
  File "asyncpg/protocol/coreproto.pyx", line 899, in asyncpg.protocol.protocol.CoreProtocol._prepare_and_describe
    self._set_state(PROTOCOL_PREPARE)
    ^^^^^^^^^^^^^^^^^
  File "asyncpg/protocol/coreproto.pyx", line 789, in asyncpg.protocol.protocol.CoreProtocol._set_state
    raise apg_exc.InternalClientError(
    ^^^^^^^^^^^^^^^^^
asyncpg.exceptions._base.InternalClientError: cannot switch to state 11; another operation (2) is in progress
Collapse
```
Let's run `delete_vfolder()` in own context.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation