### PR TITLE
fix: `pants fmt` command not working

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -7,6 +7,7 @@ backend_packages = [
     "pants.backend.shell",
     "pants.backend.experimental.python",
     "pants.backend.experimental.python.lint.ruff.check",
+    "pants.backend.experimental.python.lint.ruff.format",
     "pants.backend.experimental.visibility",
     "pants.backend.plugin_development",
     # "ruff_preview",  # a vendored backport of the pants 2.20's lint plugin

--- a/src/ai/backend/common/logging.py
+++ b/src/ai/backend/common/logging.py
@@ -202,14 +202,7 @@ class LogstashHandler(logging.Handler):
 class GELFTLSHandler(graypy.GELFTLSHandler):
     ssl_ctx: ssl.SSLContext
 
-    def __init__(
-        self,
-        host,
-        port=12204,
-        validate=False,
-        ca_certs=None,
-        **kwargs
-    ):
+    def __init__(self, host, port=12204, validate=False, ca_certs=None, **kwargs):
         """Initialize the GELFTLSHandler
 
         :param host: GELF TLS input host.
@@ -241,7 +234,8 @@ class GELFTLSHandler(graypy.GELFTLSHandler):
             plain_socket.settimeout(timeout)
 
         wrapped_socket = self.ssl_ctx.wrap_socket(
-            plain_socket, server_hostname=self.host,
+            plain_socket,
+            server_hostname=self.host,
         )
         wrapped_socket.connect((self.host, self.port))
 


### PR DESCRIPTION
Follow-up of #1998. This PR appends new `pants.backend.experimental.python.lint.ruff.format` package to our `pants.toml` (ref: https://github.com/pantsbuild/pants/pull/20555) to make `pants fmt ::` command work again.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue