### PR TITLE
fix: pre-commit hook raising false alarm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ ignore = ["E203","E731","E501"]
 [tool.ruff.isort]
 known-first-party = ["ai.backend"]
 known-local-folder = ["src"]
+known-third-party = ["alembic"]
 split-on-trailing-comma = true
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ignore = ["E203","E731","E501"]
 [tool.ruff.isort]
 known-first-party = ["ai.backend"]
 known-local-folder = ["src"]
-known-third-party = ["alembic"]
+known-third-party = ["alembic", "redis"]
 split-on-trailing-comma = true
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
Follow-up PR of #1998. This PR explicitly marks `alembic` as a third party package on ruff's isort config to avoid ruff from think that the package pretending to be a first-party one. Those confusion is caused by our `ai.backend.manager.models.alembic` package having identical name with the third-party `alembic`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
