### PR TITLE
fix: Malfunctions in compute container resolvers

### DIFF
--- a/changes/2012.fix.md
+++ b/changes/2012.fix.md
@@ -1,0 +1,1 @@
+Fix `compute_container` GraphQL query resolver functions.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -161,6 +161,9 @@ type ComputeContainer implements Item {
   idx: Int
   role: String
   hostname: String
+
+  """Added in 24.03.1."""
+  kernel_id: UUID
   cluster_idx: Int
   local_rank: Int
   cluster_role: String

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1747,15 +1747,23 @@ class Queries(graphene.ObjectType):
     async def resolve_compute_container(
         root: Any,
         info: graphene.ResolveInfo,
-        container_id: str,
+        id: str,
+        *,
+        domain_name: str | None = None,
+        access_key: AccessKey | None = None,
     ) -> ComputeContainer:
         # We need to check the group membership of the designated kernel,
         # but practically a user cannot guess the IDs of kernels launched
         # by other users and in other groups.
         # Let's just protect the domain/user boundary here.
         graph_ctx: GraphQueryContext = info.context
-        loader = graph_ctx.dataloader_manager.get_loader(graph_ctx, "ComputeContainer.detail")
-        return await loader.load(container_id)
+        loader = graph_ctx.dataloader_manager.get_loader(
+            graph_ctx,
+            "ComputeContainer.detail",
+            domain_name=domain_name,
+            access_key=access_key,
+        )
+        return await loader.load(id)
 
     @staticmethod
     @scoped_query(autofill_user=False, user_key="access_key")

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -792,6 +792,7 @@ class ComputeContainer(graphene.ObjectType):
     idx = graphene.Int()  # legacy
     role = graphene.String()  # legacy
     hostname = graphene.String()  # legacy
+    kernel_id = graphene.UUID(description="Added in 24.03.1.")
     cluster_idx = graphene.Int()
     local_rank = graphene.Int()
     cluster_role = graphene.String()
@@ -839,6 +840,7 @@ class ComputeContainer(graphene.ObjectType):
         return {
             # identity
             "id": row.id,
+            "kernel_id": row.id,
             "idx": row.cluster_idx,
             "role": row.cluster_role,
             "hostname": row.cluster_hostname,
@@ -1004,8 +1006,8 @@ class ComputeContainer(graphene.ObjectType):
             query = qoparser.append_ordering(query, order)
         else:
             query = query.order_by(*DEFAULT_KERNEL_ORDERING)
-        async with ctx.db.begin_readonly_session() as conn:
-            return [cls.from_row(ctx, r) async for r in (await conn.stream(query))]
+        async with ctx.db.begin_readonly_session() as db_session:
+            return [cls.from_row(ctx, r) async for r in (await db_session.stream_scalars(query))]
 
     @classmethod
     async def batch_load_by_session(


### PR DESCRIPTION
- Add "id", "domain_name" and "access_key" parameters to `resolve_compute_container()` because `scoped_query()` decorator calls resolver functions with those arguments.
- `ComputeContainer.load_slice()` should parse rows in db `stream_scalars()`, not in `stream()`
- Add `kernel_id` field to ComputeContainer Graphene schema

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
