### PR TITLE
ci: Modify artifact name to avoid duplication

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -292,7 +292,7 @@ jobs:
     - name: Upload local-proxy binaries
       uses: actions/upload-artifact@v4
       with:
-        name: local-proxy
+        name: ${{ matrix.os }}-local-proxy
         path: dist-local-proxy/*
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v5-scie-pants
@@ -311,12 +311,12 @@ jobs:
     - name: Upload scies
       uses: actions/upload-artifact@v4
       with:
-        name: scies-${{ matrix.os }}
+        name: ${{ matrix.os }}-scies
         path: dist/*
     - name: Upload pants log
       uses: actions/upload-artifact@v4
       with:
-        name: pants.deploy.log
+        name: ${{ matirx.os }}-pants.deploy.log
         path: .pants.d/workdir/pants.log
       if: always()  # We want the log even on failures.
 


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/8709104568/job/23888120282
Starting from artifact@v4, artifacts with duplicate names are not allowed.
So, we add the OS name of each matrix running in parallel to make it unique.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
