### PR TITLE
feat: Allow self-ssh in single-node single-container compute sessions

### DIFF
--- a/changes/2032.feature.md
+++ b/changes/2032.feature.md
@@ -1,0 +1,1 @@
+Allow self-ssh in single-node single-container compute sessions.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1055,7 +1055,7 @@ class ClusterInfo(TypedDict):
     size: int
     replicas: Mapping[str, int]  # per-role kernel counts
     network_name: Optional[str]
-    ssh_keypair: Optional[ClusterSSHKeyPair]
+    ssh_keypair: ClusterSSHKeyPair
     cluster_ssh_port_mapping: Optional[ClusterSSHPortMapping]
 
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1444,11 +1444,7 @@ class AgentRegistry:
             size=scheduled_session.cluster_size,
             replicas=replicas,
             network_name=network_name,
-            ssh_keypair=(
-                await self.create_cluster_ssh_keypair()
-                if scheduled_session.cluster_size > 1
-                else None
-            ),
+            ssh_keypair=await self.create_cluster_ssh_keypair(),
             cluster_ssh_port_mapping=cast(
                 Optional[ClusterSSHPortMapping], cluster_ssh_port_mapping
             ),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation

Fixed #2031.

## How to test

Tested manually according to the following procedure.
If there is anything I missed, please let me know.

1. Create a single cluster session
2. Check the environment variables `BACKENDAI_CLUSTER_REPLICAS`, `BACKENDAI_CLUSTER_HOSTS`.
3. Check `~/.ssh/config` file.
4. Confirm if it is possible to connect using the `ssh main1` command.

```
❯ ./backend.ai session create cr.backend.ai/stable/python:3.9-ubuntu20.04
...

❯ cat ~/.ssh/config
Host main*
        Port 2200
        StrictHostKeyChecking no
        IdentityFile /home/config/ssh/id_cluster

❯ ./backend.ai ssh pysdk-arnoldjohn
∙ running a temporary sshd proxy at localhost:9922 ...
work@main1[pysdk-arnoldjohn]:~$ env | grep BACKEND
BACKENDAI_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
BACKENDAI_CLUSTER_HOST=main1
BACKENDAI_CLUSTER_IDX=1
BACKENDAI_CLUSTER_SIZE=1
BACKENDAI_CLUSTER_LOCAL_RANK=0
BACKENDAI_CLUSTER_ROLE=main
BACKENDAI_KERNEL_ID=57ecc01f-2e39-473f-a572-f8e80e42b6fb
BACKENDAI_PREOPEN_PORTS=
BACKENDAI_SERVICE_PORTS=ipython:pty:3000,jupyter:http:8070,jupyterlab:http:8090
BACKENDAI_CLUSTER_REPLICAS=main:1
BACKENDAI_KERNEL_IMAGE=cr.backend.ai/stable/python:3.9-ubuntu20.04
BACKENDAI_SESSION_NAME=pysdk-arnoldjohn
BACKENDAI_CLUSTER_HOSTS=main1
BACKENDAI_SESSION_ID=3ee8afde-ca5d-4bbc-af48-d2c64ec6048d
...

work@main1[pysdk-arnoldjohn]:/home/config/ssh$ ssh main1
Warning: Permanently added '[main1]:2200,[172.17.0.2]:2200' (RSA) to the list of known hosts.
work@main1[pysdk-arnoldjohn]:~$
```
