### PR TITLE
fix: set all resource policies' `allowed_roles` to superadmin and admin.

### DIFF
--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -328,7 +328,10 @@ class ModifyKeyPairResourcePolicyInput(graphene.InputObjectType):
 
 
 class CreateKeyPairResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -367,7 +370,10 @@ class CreateKeyPairResourcePolicy(graphene.Mutation):
 
 
 class ModifyKeyPairResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -412,7 +418,10 @@ class ModifyKeyPairResourcePolicy(graphene.Mutation):
 
 
 class DeleteKeyPairResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -553,7 +562,10 @@ class ModifyUserResourcePolicyInput(graphene.InputObjectType):
 
 
 class CreateUserResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -595,7 +607,10 @@ class CreateUserResourcePolicy(graphene.Mutation):
 
 
 class ModifyUserResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -624,7 +639,10 @@ class ModifyUserResourcePolicy(graphene.Mutation):
 
 
 class DeleteUserResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -749,7 +767,10 @@ class ModifyProjectResourcePolicyInput(graphene.InputObjectType):
 
 
 class CreateProjectResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -789,7 +810,10 @@ class CreateProjectResourcePolicy(graphene.Mutation):
 
 
 class ModifyProjectResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)
@@ -818,7 +842,10 @@ class ModifyProjectResourcePolicy(graphene.Mutation):
 
 
 class DeleteProjectResourcePolicy(graphene.Mutation):
-    allowed_roles = (UserRole.SUPERADMIN,)
+    allowed_roles = (
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+    )
 
     class Arguments:
         name = graphene.String(required=True)


### PR DESCRIPTION
Modify the `allowed_roles` to allow creation, reading, update, and deletion of resource policies for both superadmin and **admin** within their respective domains.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
