### PR TITLE
docs: remove docker compose top-level element 'version'

### DIFF
--- a/changes/2035.doc.md
+++ b/changes/2035.doc.md
@@ -1,0 +1,1 @@
+Remove deprecated `version` from the docker compose YAML templates in package installation docs.

--- a/docs/install/install-from-package/prepare-cache-service.rst
+++ b/docs/install/install-from-package/prepare-cache-service.rst
@@ -11,7 +11,6 @@ refer
 
 .. code-block:: yaml
 
-   version: "3"
    x-base: &base
       logging:
          driver: "json-file"

--- a/docs/install/install-from-package/prepare-config-service.rst
+++ b/docs/install/install-from-package/prepare-config-service.rst
@@ -11,7 +11,6 @@ refer
 
 .. code-block:: yaml
 
-   version: "3"
    x-base: &base
       logging:
          driver: "json-file"

--- a/docs/install/install-from-package/prepare-database.rst
+++ b/docs/install/install-from-package/prepare-database.rst
@@ -11,7 +11,6 @@ refer
 
 .. code-block:: yaml
 
-   version: "3"
    x-base: &base
       logging:
          driver: "json-file"


### PR DESCRIPTION
Docker compose 'version' element has been deprecated and shows up with an obsoleted error.

On the install from Package guide, remove docker compose top-level element 'version'

Following the document https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element , The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative.

As a result, On the install from Package documents need to remove deprecated top-level version element.

Fixed https://github.com/lablup/backend.ai/issues/2034

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ v ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2035.org.readthedocs.build/en/2035/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2035.org.readthedocs.build/ko/2035/

<!-- readthedocs-preview sorna-ko end -->