### PR TITLE
feat: UNIX socket server to report agent status

### DIFF
--- a/changes/2038.feature.md
+++ b/changes/2038.feature.md
@@ -1,0 +1,1 @@
+Allow agent to report its internal registry snapshot via UNIX domain socket server 


### PR DESCRIPTION
This PR allows agent to host a UNIX domain socket which produces up-to-date snapshot of agent's `kernel_registry` and `computers` property. By exposing these informations admins should be able to monitor discrepancies of accelerator allocation status between agent and manager easier. The server can be accessed by `nc` ing socket file (e.g. `nc -U /tmp/backend.ai/ipc/agent-registry-snapshot.sock`).

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
