### PR TITLE
fix: add omitted fetch func on delete trash request on client vfolder module

### DIFF
--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -292,7 +292,8 @@ class VFolder(BaseFunction):
         rqst.set_json({
             "id": self.id.hex,
         })
-        return {}
+        async with rqst.fetch():
+            return {}
 
     @api_function
     async def rename(self, new_name):


### PR DESCRIPTION
This PR fixes no responds when deleting vfolder from trash-bin (temporally deleted) originated from omitted fetching request from client to manager.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
