### PR TITLE
feat: Expose user info to session environment variables

### DIFF
--- a/changes/2043.feature.md
+++ b/changes/2043.feature.md
@@ -1,0 +1,1 @@
+Expose user info to environment variables

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1449,7 +1449,20 @@ class AgentRegistry:
                 Optional[ClusterSSHPortMapping], cluster_ssh_port_mapping
             ),
         )
+
+        async with self.db.begin_readonly_session() as db_sess:
+            uuid, email, username = (
+                await db_sess.execute(
+                    sa.select([UserRow.uuid, UserRow.email, UserRow.username]).where(
+                        UserRow.uuid == scheduled_session.user_uuid
+                    )
+                )
+            ).fetchone()
+
         scheduled_session.environ.update({
+            "BACKENDAI_USER_UUID": str(uuid),
+            "BACKENDAI_USER_EMAIL": email,
+            "BACKENDAI_USER_NAME": username,
             "BACKENDAI_SESSION_ID": str(scheduled_session.id),
             "BACKENDAI_SESSION_NAME": str(scheduled_session.name),
             "BACKENDAI_CLUSTER_SIZE": str(scheduled_session.cluster_size),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

Tested manually.

```
❯ ./backend.ai ssh gPNsIaBh-session
∙ running a temporary sshd proxy at localhost:9922 ...

...

work@main1[gPNsIaBh-session]:~$ env | grep BACKENDAI_
BACKENDAI_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
BACKENDAI_CLUSTER_HOST=main1
BACKENDAI_CLUSTER_IDX=1
BACKENDAI_CLUSTER_SIZE=1
BACKENDAI_CLUSTER_LOCAL_RANK=0
BACKENDAI_CLUSTER_ROLE=main
BACKENDAI_USER_UUID=f38dea23-50fa-42a0-b5ae-338f5f4693f4
BACKENDAI_KERNEL_ID=6bd9443b-def0-41ab-aea3-aa5280c8e1ab
BACKENDAI_PREOPEN_PORTS=
BACKENDAI_SERVICE_PORTS=ipython:pty:3000,jupyter:http:8070,jupyterlab:http:8090
BACKENDAI_CLUSTER_REPLICAS=main:1
BACKENDAI_KERNEL_IMAGE=cr.backend.ai/stable/python:3.9-ubuntu20.04
BACKENDAI_SESSION_NAME=gPNsIaBh-session
BACKENDAI_USER_EMAIL=admin@lablup.com
BACKENDAI_USER_NAME=admin
BACKENDAI_CLUSTER_HOSTS=main1
BACKENDAI_SESSION_ID=95d866b4-16fb-48f1-a260-db8ee1bd1d68

```