### PR TITLE
docs: Update invocation of the pants command

### DIFF
--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -188,7 +188,7 @@ Similarly, you can export all virtualenvs at once:
 
 .. code-block:: console
 
-    $ python -c 'import tomllib,pathlib;print("\n".join(tomllib.loads(pathlib.Path("pants.toml").read_text())["python"]["resolves"].keys()))' | sed 's/^/--resolve=/' | xargs ./pants export
+    $ python -c 'import tomllib,pathlib;print("\n".join(tomllib.loads(pathlib.Path("pants.toml").read_text())["python"]["resolves"].keys()))' | sed 's/^/--resolve=/' | xargs pants export
 
 Then configure your IDEs/editors to use
 ``dist/export/python/virtualenvs/python-default/PYTHON_VERSION/bin/python`` as the
@@ -718,19 +718,19 @@ Making a new release
 * Push the commit and tag.  The GitHub Actions workflow will build the packages
   and publish them to PyPI.
 
-* When making a new major release, snapshot of prior release's final DB migration history 
-  should be dumped. This will later help to fill out missing gaps of DB revisions when 
+* When making a new major release, snapshot of prior release's final DB migration history
+  should be dumped. This will later help to fill out missing gaps of DB revisions when
   upgrading outdated cluster. The output then should be committed to **next** major release.
 
   .. code-block:: console
-    
+
       $ ./backend.ai mgr schema dump-history > src/ai/backend/manager/models/alembic/revision_history/<version>.json
 
   Suppose you are trying to create both fresh baked 24.09.0 and good old 24.03.10 releases.
   In such cases you should first make a release of version 24.03.10, move back to latest branch, and then
   execute code snippet above with `<version>` set as `24.03.10`, and release 24.09.0 including the dump.
 
-  To make workflow above effective, be aware that backporting DB revisions to older major releases will no longer 
+  To make workflow above effective, be aware that backporting DB revisions to older major releases will no longer
   be permitted after major release version is switched.
 
 Backporting to legacy per-pkg repositories

--- a/pants.toml
+++ b/pants.toml
@@ -51,7 +51,7 @@ enable_resolves = true
 #   - Regenerate lockfiles
 #   - pyproject.toml: [tool.mypy].python_executable
 # * Let other developers do:
-#   - Run `./pants export` again
+#   - Run `pants export` again
 #   - Update their local IDE/editor's interpreter path configurations
 interpreter_constraints = ["CPython==3.12.2"]
 tailor_pex_binary_targets = false

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -7,5 +7,5 @@ Run `./scripts/install-plugin.sh {github-owner}/{repo-name}`.
 The plugin code will be cloned into `./plugins/{repo-name}` and it will be installed
 as an editable package inside the Pants exported unified virtualenv.
 
-Note that whenever you run `./pants export` again, you need to run
+Note that whenever you run `pants export` again, you need to run
 `./scripts/reinstall-plugins.sh` again to redo editable installation.


### PR DESCRIPTION
`./pants` is deprecated and we should use `pants` by installing it via brew or manually downloaded `scie`-based executable.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2046.org.readthedocs.build/en/2046/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2046.org.readthedocs.build/ko/2046/

<!-- readthedocs-preview sorna-ko end -->