### PR TITLE
ci: Bump actions/labeler from 4 to 5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,59 +1,65 @@
 require:db-migration:
-- any: ['src/ai/backend/manager/models/alembic/versions/*.py']
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/manager/models/alembic/versions/*.py'
 
 area:docs:
-- any: [
-    'docs/**/*',
-    'src/ai/backend/manager/api/**/*.py',
-    'src/ai/backend/manager/models/gql.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'docs/**/*'
+    - 'src/ai/backend/manager/api/**/*.py'
+    - 'src/ai/backend/manager/models/gql.py'
 
 comp:storage-proxy:
-- any: ['src/ai/backend/storage/**/*.py']
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/storage/**/*.py'
 
 comp:agent:
-- any: [
-    'src/ai/backend/agent/**/*.py',
-    'src/ai/backend/kernel/**/*.py',
-    'src/ai/backend/runner/**/*.py',
-    'src/ai/backend/helpers/**/*.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/agent/**/*.py'
+    - 'src/ai/backend/kernel/**/*.py'
+    - 'src/ai/backend/runner/**/*.py'
+    - 'src/ai/backend/helpers/**/*.py'
 
 comp:manager:
-- any: ['src/ai/backend/manager/**/*.py']
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/manager/**/*.py'
 
 comp:common:
-- any: [
-    'src/ai/backend/common/**/*.py',
-    'src/ai/backend/plugin/**/*.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/common/**/*.py'
+    - 'src/ai/backend/plugin/**/*.py'
 
 comp:client:
-- any: [
-    'src/ai/backend/client/**/*.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/client/**/*.py'
 
 comp:cli:
-- any: [
-    'src/ai/backend/cli/**/*.py',
-    'src/ai/backend/client/cli/**/*.py',
-    'src/ai/backend/manager/cli/**/*.py',
-    'src/ai/backend/agent/cli/**/*.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/cli/**/*.py'
+    - 'src/ai/backend/client/cli/**/*.py'
+    - 'src/ai/backend/manager/cli/**/*.py'
+    - 'src/ai/backend/agent/cli/**/*.py'
 
 comp:webserver:
-- any: [
-    'src/ai/backend/web/**/*.py',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/web/**/*.py'
 
 comp:webui:
-- any: [
-    'src/ai/backend/web/static',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'src/ai/backend/web/static'
 
 comp:installer:
-- any: [
-    'scripts/install-dev.sh',
-    'scripts/delete-dev.sh',
-    'tools/pants-plugins/**/*',
-  ]
+- changed-files:
+  - any-glob-to-any-file:
+    - 'scripts/install-dev.sh'
+    - 'scripts/delete-dev.sh'
+    - 'tools/pants-plugins/**/*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: jsoref/labeler@v0-5.0.0
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: size-label


### PR DESCRIPTION
As the labeler became version v5, its usage has changed.

```
any: match ALL globs against ANY changed path
all: match ALL globs against ALL changed paths
```

From the existing two rules that could be used,

```
any-glob-to-any-file: ANY glob must match against ANY changed file
any-glob-to-all-files: ANY glob must match against ALL changed files
all-globs-to-any-file: ALL globs must match against ANY changed file
all-globs-to-all-files: ALL globs must match against ALL changed files
```

It has been added so that it can be used in 4 ways.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
