### PR TITLE
docs: add the manager's RPC client certificate entry to the guide

### DIFF
--- a/changes/2052.doc.md
+++ b/changes/2052.doc.md
@@ -1,1 +1,1 @@
-docs: add the manager's RPC client certificate entry on "install from package" document
+Updated the package installation documentation to include instructions on adding the manager's RPC key pair.

--- a/changes/2052.doc.md
+++ b/changes/2052.doc.md
@@ -1,0 +1,1 @@
+docs: add the manager's RPC client certificate entry on "install from package" document

--- a/changes/2052.doc.md
+++ b/changes/2052.doc.md
@@ -1,1 +1,1 @@
-Updated the package installation documentation to include instructions on adding the manager's RPC key pair.
+Update the package installation documentation to include instructions on adding the manager's RPC key pair.

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -18,8 +18,8 @@ If you want to install a specific version:
 
    $ pip install -U backend.ai-manager==${BACKEND_PKG_VERSION}
 
-You may need to generate an RPC keypair for the first setup. This key pair is used for authentication and encryption in our manager-to-agent RPC connections.
-Even if you don't intend to encrypt the RPC channel, the key pair should still be present.
+You may need to generate an RPC keypair for the first setup. This keypair is used for authentication and encryption in our manager-to-agent RPC connections.
+Even if you don't want to encrypt the RPC channel, you still need to have a keypair.
 
 
 .. code-block:: console
@@ -32,7 +32,7 @@ Even if you don't intend to encrypt the RPC channel, the key pair should still b
     Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager.key)
     Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager.key_secret)
 
-You generated an RPC keypair for the manager. The public key is stored in ``fixtures/manager.key`` and the secret key is stored in ``fixtures/manager.key_secret``.
+You have generated an RPC keypair for the manager. The public key is stored in ``fixtures/manager.key`` and the secret key is stored in ``fixtures/manager.key_secret``.
 
 Local configuration
 -------------------

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -66,8 +66,8 @@ would be:
    ssl-enabled = false
 
    heartbeat-timeout = 40.0
-   rpc-auth-manager-keypair = "/home/bai/manager/fixtures/manager.key_secret"
-   pid-file = "/home/bai/manager/manager.pid"
+   rpc-auth-manager-keypair = "fixtures/manager.key_secret"
+   pid-file = "manager.pid"
    disabled-plugins = []
    hide-agents = true
    # event-loop = "asyncio"

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -200,7 +200,7 @@ issuing SQL statement directly inside the PostgreSQL container:
 .. code-block:: console
 
    $ vfolder_host_val='{"bai-m1:local": ["create-vfolder", "modify-vfolder", "delete-vfolder", "mount-in-session", "upload-file", "download-file", "invite-others", "set-user-specific-permission"]}'
-   $ docker compose -f halfstack/postgres-cluster-default exec -it backendai-half-db psql -U postgres -d backend \
+   $ docker compose -f "$HOME/halfstack/postgres-cluster-default" exec -it backendai-half-db psql -U postgres -d backend \
          -c "UPDATE domains SET allowed_vfolder_hosts = '${vfolder_host_val}' WHERE name = 'default';"
 
 

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -18,17 +18,21 @@ If you want to install a specific version:
 
    $ pip install -U backend.ai-manager==${BACKEND_PKG_VERSION}
 
-For the first time, you need to generate rpc keypair. This keypair is used for authentication and encryption to our manager-to-agent RPC connections.
+You may need to generate an RPC keypair for the first setup. This key pair is used for authentication and encryption in our manager-to-agent RPC connections.
+Even if you don't intend to encrypt the RPC channel, the key pair should still be present.
+
 
 .. code-block:: console
 
    $ cd "${HOME}/manager"
-   $ mkdir -p fixtures/manager
-   $ backend.ai mgr generate-rpc-keypair fixtures/manager 'manager'
+   $ mkdir fixtures
+   $ backend.ai mgr generate-rpc-keypair fixtures 'manager'
 
    2024-04-23 12:06:31.913 INFO ai.backend.manager.cli [21024] Generating a RPC keypair...
-    Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager/manager.key)
-    Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager/manager.key_secret)
+    Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager.key)
+    Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager.key_secret)
+
+You generated an RPC keypair for the manager. The public key is stored in ``fixtures/manager.key`` and the secret key is stored in ``fixtures/manager.key_secret``.
 
 Local configuration
 -------------------
@@ -61,8 +65,8 @@ would be:
    # group = "bai"
    ssl-enabled = false
 
-   heartbeat-timeout = 30.0
-   rpc-auth-manager-keypair = "/home/bai/manager/fixtures/manager/manager.key_secret"
+   heartbeat-timeout = 40.0
+   rpc-auth-manager-keypair = "/home/bai/manager/fixtures/manager.key_secret"
    pid-file = "/home/bai/manager/manager.pid"
    disabled-plugins = []
    hide-agents = true
@@ -195,7 +199,7 @@ issuing SQL statement directly inside the PostgreSQL container:
 .. code-block:: console
 
    $ vfolder_host_val='{"bai-m1:local": ["create-vfolder", "modify-vfolder", "delete-vfolder", "mount-in-session", "upload-file", "download-file", "invite-others", "set-user-specific-permission"]}'
-   $ docker exec -it bai-backendai-pg-active-1 psql -U postgres -d backend \
+   $ docker exec -it $(docker ps | grep backendai-pg | awk '{print $1}') psql -U postgres -d backend \
          -c "UPDATE domains SET allowed_vfolder_hosts = '${vfolder_host_val}' WHERE name = 'default';"
 
 

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -18,7 +18,8 @@ If you want to install a specific version:
 
    $ pip install -U backend.ai-manager==${BACKEND_PKG_VERSION}
 
-You may need to generate an RPC keypair for the first setup. This keypair is used for authentication and encryption in our manager-to-agent RPC connections.
+You must generate an RPC keypair for the first-time setup.
+This keypair is used for authentication and encryption in our manager-to-agent RPC connections.
 Even if you don't want to encrypt the RPC channel, you still need to have a keypair.
 
 
@@ -27,12 +28,12 @@ Even if you don't want to encrypt the RPC channel, you still need to have a keyp
    $ cd "${HOME}/manager"
    $ mkdir fixtures
    $ backend.ai mgr generate-rpc-keypair fixtures 'manager'
-
    2024-04-23 12:06:31.913 INFO ai.backend.manager.cli [21024] Generating a RPC keypair...
-    Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager.key)
-    Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager.key_secret)
+   Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager.key)
+   Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager.key_secret)
 
-You have generated an RPC keypair for the manager. The public key is stored in ``fixtures/manager.key`` and the secret key is stored in ``fixtures/manager.key_secret``.
+You have generated an RPC keypair for the manager.
+The public key is stored in ``fixtures/manager.key`` and the secret key is stored in ``fixtures/manager.key_secret``.
 
 Local configuration
 -------------------
@@ -199,7 +200,7 @@ issuing SQL statement directly inside the PostgreSQL container:
 .. code-block:: console
 
    $ vfolder_host_val='{"bai-m1:local": ["create-vfolder", "modify-vfolder", "delete-vfolder", "mount-in-session", "upload-file", "download-file", "invite-others", "set-user-specific-permission"]}'
-   $ docker exec -it $(docker ps | grep backendai-pg | awk '{print $1}') psql -U postgres -d backend \
+   $ docker compose -f halfstack/postgres-cluster-default exec -it backendai-half-db psql -U postgres -d backend \
          -c "UPDATE domains SET allowed_vfolder_hosts = '${vfolder_host_val}' WHERE name = 'default';"
 
 

--- a/docs/install/install-from-package/install-manager.rst
+++ b/docs/install/install-from-package/install-manager.rst
@@ -18,6 +18,17 @@ If you want to install a specific version:
 
    $ pip install -U backend.ai-manager==${BACKEND_PKG_VERSION}
 
+For the first time, you need to generate rpc keypair. This keypair is used for authentication and encryption to our manager-to-agent RPC connections.
+
+.. code-block:: console
+
+   $ cd "${HOME}/manager"
+   $ mkdir -p fixtures/manager
+   $ backend.ai mgr generate-rpc-keypair fixtures/manager 'manager'
+
+   2024-04-23 12:06:31.913 INFO ai.backend.manager.cli [21024] Generating a RPC keypair...
+    Public Key: >B-mF}N{WygT92d&=Kceix$7cWzg!dT])rIc39=S (stored at fixtures/manager/manager.key)
+    Secret Key: g.4&?*b&0#oRRC9?DMO[SUXikjKZ7nYj!bzFJN92 (stored at fixtures/manager/manager.key_secret)
 
 Local configuration
 -------------------
@@ -51,6 +62,7 @@ would be:
    ssl-enabled = false
 
    heartbeat-timeout = 30.0
+   rpc-auth-manager-keypair = "/home/bai/manager/fixtures/manager/manager.key_secret"
    pid-file = "/home/bai/manager/manager.pid"
    disabled-plugins = []
    hide-agents = true

--- a/docs/install/install-from-package/prepare-cache-service.rst
+++ b/docs/install/install-from-package/prepare-cache-service.rst
@@ -1,12 +1,10 @@
-Prepare Cache Service
+Prepare Redis Service
 =====================
 
-Backend.AI makes use of Redis as its main cache service. Launch the service
-using docker compose by generating the file
-``$HOME/halfstack/redis-cluster-default/docker-compose.yaml`` and populating it with the
-following YAML. Feel free to adjust the volume paths and port settings. Please
-refer
-`the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
+Backend.AI makes use of Redis as the message queue (event bus) and the cache backend.
+Launch the service using docker compose by generating the file ``$HOME/halfstack/redis-cluster-default/docker-compose.yaml`` and populating it with the following YAML.
+Feel free to adjust the volume paths and port settings.
+Please refer `the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
 (it's a symbolic link so follow the filename in it) if needed.
 
 .. code-block:: yaml
@@ -19,7 +17,7 @@ refer
             max-size: "10m"
 
    services:
-      backendai-halfstack-redis:
+      backendai-half-redis:
          <<: *base
          image: redis:6.2-alpine
          restart: unless-stopped

--- a/docs/install/install-from-package/prepare-config-service.rst
+++ b/docs/install/install-from-package/prepare-config-service.rst
@@ -1,12 +1,10 @@
 Prepare Config Service
 ======================
 
-Backend.AI makes use of Etcd as its main config service. Launch the service
-using docker compose by generating the file
-``$HOME/halfstack/etcd-cluster-default/docker-compose.yaml`` and populating it with the
-following YAML. Feel free to adjust the volume paths and port settings. Please
-refer
-`the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
+Backend.AI makes use of Etcd as the distributed configuration store.
+Launch the service using docker compose by generating the file ``$HOME/halfstack/etcd-cluster-default/docker-compose.yaml`` and populating it with the following YAML.
+Feel free to adjust the volume paths and port settings.
+Please refer `the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
 (it's a symbolic link so follow the filename in it) if needed.
 
 .. code-block:: yaml
@@ -19,7 +17,7 @@ refer
             max-size: "10m"
 
    services:
-      backendai-halfstack-etcd:
+      backendai-half-etcd:
          <<: *base
          image: quay.io/coreos/etcd:v3.4.15
          restart: unless-stopped
@@ -53,8 +51,8 @@ refer
    networks:
       half_stack:
 
-Execute the following command to start the service container. The project
-``${USER}`` is added for operational convenience.
+Execute the following command to start the service container.
+The project ``${USER}`` is added for operational convenience.
 
 .. code-block:: console
 

--- a/docs/install/install-from-package/prepare-database.rst
+++ b/docs/install/install-from-package/prepare-database.rst
@@ -1,12 +1,10 @@
 Prepare Database
 ================
 
-Backend.AI makes use of PostgreSQL as its main database. Launch the service
-using docker compose by generating the file
-``$HOME/halfstack/postgres-cluster-default/docker-compose.yaml`` and populating it with the
-following YAML. Feel free to adjust the volume paths and port settings. Please
-refer
-`the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
+Backend.AI makes use of PostgreSQL as the main database to store user information, access control policies, and persistent states of the system such as agent and container tracking registry.
+Launch the service using docker compose by generating the file ``$HOME/halfstack/postgres-cluster-default/docker-compose.yaml`` and populating it with the following YAML.
+Feel free to adjust the volume paths and port settings.
+Please refer `the latest configuration <https://github.com/lablup/backend.ai/blob/main/docker-compose.halfstack-main.yml>`_
 (it's a symbolic link so follow the filename in it) if needed.
 
 .. code-block:: yaml
@@ -19,7 +17,7 @@ refer
             max-size: "10m"
 
    services:
-      backendai-pg-active:
+      backendai-half-db:
          <<: *base
          image: postgres:16.3-alpine
          restart: unless-stopped
@@ -52,8 +50,8 @@ refer
    networks:
        half_stack:
 
-Execute the following command to start the service container. The project
-``${USER}`` is added for operational convenience.
+Execute the following command to start the service container.
+The project ``${USER}`` is added for operational convenience.
 
 .. code-block:: console
 


### PR DESCRIPTION
To add the manager's RPC client certificate entry to the guide.

Following the merged PR #887 , manager.toml config file's rpc-auth-manager-keypair filed is always required, even when no agents require authentication and encryption.

As a result, add the manager's RPC client certificate entry to the guide.

fix https://github.com/lablup/backend.ai/issues/2044

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2052.org.readthedocs.build/en/2052/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2052.org.readthedocs.build/ko/2052/

<!-- readthedocs-preview sorna-ko end -->