### PR TITLE
fix: allow bypassing ownership check when admin role user tries to delete folder

### DIFF
--- a/changes/2055.fix.md
+++ b/changes/2055.fix.md
@@ -1,0 +1,1 @@
+Fixes declining vfolder deletion due to ownership check on every user role by adding `allow_privileged_access` argument according to `user_role` value

--- a/changes/2055.fix.md
+++ b/changes/2055.fix.md
@@ -1,1 +1,1 @@
-Fixes declining vfolder deletion due to ownership check on every user role by adding `allow_privileged_access` argument according to `user_role` value
+Fix a buggy restriction on VFolder deletion due to wrong query condition

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -34,11 +34,7 @@ import attrs
 import sqlalchemy as sa
 import trafaret as t
 from aiohttp import web
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    Field,
-)
+from pydantic import AliasChoices, BaseModel, Field
 from sqlalchemy.orm import load_only, selectinload
 
 from ai.backend.common import msgpack, redis_helper
@@ -117,12 +113,7 @@ from .exceptions import (
 )
 from .manager import ALL_ALLOWED, READ_ALLOWED, server_status_required
 from .resource import get_watcher_info
-from .utils import (
-    BaseResponseModel,
-    check_api_params,
-    get_user_scopes,
-    pydantic_params_api_handler,
-)
+from .utils import BaseResponseModel, check_api_params, get_user_scopes, pydantic_params_api_handler
 
 if TYPE_CHECKING:
     from .context import RootContext
@@ -2191,10 +2182,12 @@ async def _delete(
     allowed_vfolder_types: Sequence[str],
     resource_policy: Mapping[str, Any],
 ) -> None:
+    allow_privileged_access = True if user_role == UserRole.SUPERADMIN or UserRole.ADMIN else False
     async with root_ctx.db.begin() as conn:
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,
+            allow_privileged_access=allow_privileged_access,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -34,7 +34,11 @@ import attrs
 import sqlalchemy as sa
 import trafaret as t
 from aiohttp import web
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+)
 from sqlalchemy.orm import load_only, selectinload
 
 from ai.backend.common import msgpack, redis_helper
@@ -113,7 +117,12 @@ from .exceptions import (
 )
 from .manager import ALL_ALLOWED, READ_ALLOWED, server_status_required
 from .resource import get_watcher_info
-from .utils import BaseResponseModel, check_api_params, get_user_scopes, pydantic_params_api_handler
+from .utils import (
+    BaseResponseModel,
+    check_api_params,
+    get_user_scopes,
+    pydantic_params_api_handler,
+)
 
 if TYPE_CHECKING:
     from .context import RootContext

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2191,12 +2191,11 @@ async def _delete(
     allowed_vfolder_types: Sequence[str],
     resource_policy: Mapping[str, Any],
 ) -> None:
-    allow_privileged_access = True if user_role == UserRole.SUPERADMIN or UserRole.ADMIN else False
     async with root_ctx.db.begin() as conn:
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,
-            allow_privileged_access=allow_privileged_access,
+            allow_privileged_access=True,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,
@@ -2427,6 +2426,7 @@ async def delete_from_trash_bin(
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,
+            allow_privileged_access=True,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,
@@ -2497,6 +2497,7 @@ async def purge(request: web.Request, params: PurgeRequestModel) -> web.Response
         entries = await query_accessible_vfolders(
             conn,
             user_uuid,
+            allow_privileged_access=True,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,
@@ -2558,6 +2559,7 @@ async def restore(request: web.Request, params: RestoreRequestModel) -> web.Resp
         restore_targets = await query_accessible_vfolders(
             conn,
             user_uuid,
+            allow_privileged_access=True,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,


### PR DESCRIPTION
> NOTE: This bug has been reported by @agatha197 

This PR fixes delete operation failing issue when owner and user doesn't match by adding `allowe_privileged_access` according to `user_role` argument value only if the value is `SUPERADMIN` or `ADMIN`.  

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
