### PR TITLE
fix: Wrong usage of dataloader in GQL group resolver

### DIFF
--- a/changes/2056.fix.md
+++ b/changes/2056.fix.md
@@ -1,0 +1,1 @@
+Fix wrong usage of dataloader in GQL group resolver.

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -916,7 +916,9 @@ class Queries(graphene.ObjectType):
                 ctx,
                 "Group.by_user",
             )
-            client_groups = await loader.load(client_user_id, type=[ProjectType[t] for t in type])
+            client_groups = [
+                group for group in await loader.load(client_user_id) if group.type in type
+            ]
             if group.id not in (g.id for g in client_groups):
                 raise InsufficientPrivilege
         else:


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2056.org.readthedocs.build/en/2056/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2056.org.readthedocs.build/ko/2056/

<!-- readthedocs-preview sorna-ko end -->