### PR TITLE
fix: Resource usage wrong calculation

### DIFF
--- a/changes/2062.fix.md
+++ b/changes/2062.fix.md
@@ -1,0 +1,1 @@
+Fix wrong calculation of resource usage

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -103,7 +103,7 @@ class ResourceUsage:
         }
 
     def copy(self) -> ResourceUsage:
-        return attrs.evolve(self, nfs={*self.nfs})
+        return attrs.evolve(self, nfs={*self.nfs}, device_type={*self.device_type})
 
 
 def to_str(val: Any) -> Optional[str]:

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -478,7 +478,7 @@ def parse_resource_usage(
         disk_used=int(nmget(last_stat, "io_scratch_size/stats.max", 0, "/")),
         io_read=int(nmget(last_stat, "io_read.current", 0)),
         io_write=int(nmget(last_stat, "io_write.current", 0)),
-        device_type=device_type,
+        device_type={*device_type},
         smp=float(smp),
         gpu_mem_allocated=float(gpu_mem_allocated),
         gpu_allocated=float(gpu_allocated),

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -267,7 +267,10 @@ class KernelResourceUsage(BaseResourceUsageGroup):
             session_row=usage_group.session_row,
             kernel_row=usage_group.kernel_row,
             agent=usage_group.kernel_row.agent,
-            **usage_group.to_map(),
+            **{
+                **usage_group.to_map(),
+                "total_usage": ResourceUsage(),
+            },
         )
 
     def register_resource_group(
@@ -315,7 +318,10 @@ class SessionResourceUsage(BaseResourceUsageGroup):
         return cls(
             project_row=usage_group.project_row,
             session_row=usage_group.session_row,
-            **usage_group.to_map(),
+            **{
+                **usage_group.to_map(),
+                "total_usage": ResourceUsage(),
+            },
         )
 
     def register_resource_group(self, other: BaseResourceUsageGroup) -> bool:
@@ -381,6 +387,7 @@ class ProjectResourceUsage(BaseResourceUsageGroup):
             "cluster_mode": None,
             "scheduled_at": None,
             "terminated_at": None,
+            "total_usage": ResourceUsage(),
         }
         return cls(
             project_row=usage_group.project_row,

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -316,6 +316,8 @@ class SessionResourceUsage(BaseResourceUsageGroup):
         )
 
     def register_resource_group(self, other: BaseResourceUsageGroup) -> bool:
+        if other.session_id != self.session_id:
+            return False
         if other.kernel_id is None:
             return False
         if other.kernel_id in self.child_usage_group:
@@ -385,6 +387,8 @@ class ProjectResourceUsage(BaseResourceUsageGroup):
         )
 
     def register_resource_group(self, other: BaseResourceUsageGroup) -> bool:
+        if other.project_id != self.project_id:
+            return False
         if other.session_id is None:
             return False
         if other.session_id not in self.child_usage_group:

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -103,7 +103,7 @@ class ResourceUsage:
         }
 
     def copy(self) -> ResourceUsage:
-        return attrs.evolve(self)
+        return attrs.evolve(self, nfs={*self.nfs})
 
 
 def to_str(val: Any) -> Optional[str]:
@@ -468,7 +468,7 @@ def parse_resource_usage(
 
     return ResourceUsage(
         agent_ids={kernel.agent},
-        nfs=nfs,
+        nfs={*nfs},
         cpu_allocated=float(kernel.occupied_slots.get("cpu", 0)),
         cpu_used=float(nmget(last_stat, "cpu_used.current", 0)),
         mem_allocated=int(kernel.occupied_slots.get("mem", 0)),


### PR DESCRIPTION
Currently resource usage APIs calculates all project/session/kernel resource in a wrong way.
1. We did not deep-copy `ResourceUsage` objects when we register it to project/session/kernel resource usage and that causes referenced fields of `ResourceUsage` are shared with unrelated project/session usages. e.g. kernel-1 has `nfs={"/vfroot/foo"}` and kernel-2 has `nfs={"/vfroot/bar"}` but the usage API results kernel-1 has `nfs={"/vfroot/foo", "/vfroot/bar"}`.
2. `total_usage` is doubled or tripled in project/session resource usages because `total_usage` is initiated when it is registered as a child resource group and project/session resource usages add the `total_usage` again after initiate a child resource group. Let's initiate child resource usages with "zero" ResourceUsage.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)