### PR TITLE
feat: Implement rate limiter for anonymous clients

### DIFF
--- a/changes/2066.feature.md
+++ b/changes/2066.feature.md
@@ -1,0 +1,1 @@
+Implement `anonymous-ratelimit`

--- a/src/ai/backend/common/networking.py
+++ b/src/ai/backend/common/networking.py
@@ -6,6 +6,7 @@ from contextlib import closing
 from typing import TYPE_CHECKING, Callable, Mapping, Optional, TypeVar
 
 import aiohttp
+from aiohttp import web
 from async_timeout import timeout as _timeout
 
 if TYPE_CHECKING:
@@ -52,3 +53,12 @@ def find_free_port(bind_addr: str = "127.0.0.1") -> int:
         s.bind((bind_addr, 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
+
+
+def get_client_ip(request: web.Request) -> str | None:
+    client_ip = request.headers.get("X-Forwarded-For")
+    if not client_ip and request.transport:
+        client_ip = request.transport.get_extra_info("peername")[0]
+    if not client_ip:
+        client_ip = request.remote
+    return client_ip

--- a/src/ai/backend/manager/api/ratelimit.py
+++ b/src/ai/backend/manager/api/ratelimit.py
@@ -80,13 +80,12 @@ async def rlim_middleware(
         response.headers["X-RateLimit-Window"] = str(_rlim_window)
         return response
     else:
-        ip_address = get_client_ip(request)
-        assert ip_address is not None, "Client IP Address is not provided"
-
         root_ctx: RootContext = app["_root.context"]
         rate_limit = root_ctx.local_config["manager"]["anonymous-ratelimit"]
 
-        if rate_limit is None:
+        ip_address = get_client_ip(request)
+
+        if not ip_address or rate_limit is None:
             # No checks for rate limiting.
             response = await handler(request)
             # Arbitrary number for indicating no rate limiting.

--- a/src/ai/backend/manager/api/ratelimit.py
+++ b/src/ai/backend/manager/api/ratelimit.py
@@ -11,8 +11,9 @@ from aiotools import apartial
 
 from ai.backend.common import redis_helper
 from ai.backend.common.defs import REDIS_RLIM_DB
+from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.common.networking import get_client_ip
 from ai.backend.common.types import RedisConnectionInfo
-from ai.backend.logging import BraceStyleAdapter
 
 from .context import RootContext
 from .exceptions import RateLimitExceeded
@@ -27,19 +28,21 @@ _rlim_window: Final = 60 * 15
 # last-minute and first-minute bursts between the intervals.
 
 _rlim_script = """
-local access_key = KEYS[1]
+local id_type = KEYS[1]
+local id_value = KEYS[2]
+local namespaced_id = id_type .. ":" .. id_value
 local now = tonumber(ARGV[1])
 local window = tonumber(ARGV[2])
 local request_id = tonumber(redis.call('INCR', '__request_id'))
 if request_id >= 1e12 then
     redis.call('SET', '__request_id', 1)
 end
-if redis.call('EXISTS', access_key) == 1 then
-    redis.call('ZREMRANGEBYSCORE', access_key, 0, now - window)
+if redis.call('EXISTS', namespaced_id) == 1 then
+    redis.call('ZREMRANGEBYSCORE', namespaced_id, 0, now - window)
 end
-redis.call('ZADD', access_key, now, tostring(request_id))
-redis.call('EXPIRE', access_key, window)
-return redis.call('ZCARD', access_key)
+redis.call('ZADD', namespaced_id, now, tostring(request_id))
+redis.call('EXPIRE', namespaced_id, window)
+return redis.call('ZCARD', namespaced_id)
 """
 
 
@@ -53,6 +56,7 @@ async def rlim_middleware(
     app_ctx: PrivateContext = app["ratelimit.context"]
     now = Decimal(time.time()).quantize(_time_prec)
     rr = app_ctx.redis_rlim
+
     if request["is_authorized"]:
         rate_limit = request["keypair"]["rate_limit"]
         access_key = request["keypair"]["access_key"]
@@ -60,7 +64,7 @@ async def rlim_middleware(
             rr,
             "ratelimit",
             _rlim_script,
-            [access_key],
+            ["access_key", access_key],
             [str(now), str(_rlim_window)],
         )
         if ret is None:
@@ -76,10 +80,38 @@ async def rlim_middleware(
         response.headers["X-RateLimit-Window"] = str(_rlim_window)
         return response
     else:
-        # No checks for rate limiting for non-authorized queries.
-        response = await handler(request)
-        response.headers["X-RateLimit-Limit"] = "1000"
-        response.headers["X-RateLimit-Remaining"] = "1000"
+        ip_address = get_client_ip(request)
+        assert ip_address is not None, "Client IP Address is not provided"
+
+        root_ctx: RootContext = app["_root.context"]
+        rate_limit = root_ctx.local_config["manager"]["anonymous-ratelimit"]
+
+        if rate_limit is None:
+            # No checks for rate limiting.
+            response = await handler(request)
+            # Arbitrary number for indicating no rate limiting.
+            response.headers["X-RateLimit-Limit"] = "1000"
+            response.headers["X-RateLimit-Remaining"] = "1000"
+        else:
+            ret = await redis_helper.execute_script(
+                rr,
+                "ratelimit",
+                _rlim_script,
+                ["ip", ip_address],
+                [str(now), str(_rlim_window)],
+            )
+            if ret is None:
+                remaining = rate_limit
+            else:
+                rolling_count = int(ret)
+                if rate_limit is not None and rolling_count > rate_limit:
+                    raise RateLimitExceeded
+                remaining = rate_limit - rolling_count
+
+            response = await handler(request)
+            response.headers["X-RateLimit-Limit"] = str(rate_limit)
+            response.headers["X-RateLimit-Remaining"] = str(remaining)
+
         response.headers["X-RateLimit-Window"] = str(_rlim_window)
         return response
 

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -293,6 +293,7 @@ manager_local_config_iv = (
                 "agent-selection-resource-priority",
                 default=["cuda", "rocm", "tpu", "cpu", "mem"],
             ): t.List(t.String),
+            t.Key("anonymous-ratelimit", default=None): t.Null | t.ToInt,
             t.Key("importer-image", default="lablup/importer:manylinux2010"): t.String,
             t.Key("max-wsmsg-size", default=16 * (2**20)): t.ToInt,  # default: 16 MiB
             tx.AliasedKey(["aiomonitor-termui-port", "aiomonitor-port"], default=48100): t.ToInt[

--- a/src/ai/backend/web/auth.py
+++ b/src/ai/backend/web/auth.py
@@ -5,6 +5,7 @@ from aiohttp import web
 
 from ai.backend.client.config import APIConfig
 from ai.backend.client.session import AsyncSession as APISession
+from ai.backend.common.networking import get_client_ip
 from ai.backend.common.web.session import get_session
 
 from . import user_agent
@@ -75,15 +76,6 @@ async def get_anonymous_session(
         skip_sslcert_validation=not config["api"]["ssl_verify"],
     )
     return APISession(config=api_config, proxy_mode=True)
-
-
-def get_client_ip(request: web.Request) -> Optional[str]:
-    client_ip = request.headers.get("X-Forwarded-For")
-    if not client_ip and request.transport:
-        client_ip = request.transport.get_extra_info("peername")[0]
-    if not client_ip:
-        client_ip = request.remote
-    return client_ip
 
 
 def fill_forwarding_hdrs_to_api_session(

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -29,13 +29,12 @@ from ai.backend.client.exceptions import BackendAPIError, BackendClientError
 from ai.backend.client.session import AsyncSession as APISession
 from ai.backend.common import config, redis_helper
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
+from ai.backend.common.networking import get_client_ip
 from ai.backend.common.web.session import (
     extra_config_headers,
     get_session,
     get_time,
 )
-from ai.backend.common.networking import get_client_ip
-from ai.backend.common.web.session import extra_config_headers, get_session
 from ai.backend.common.web.session import setup as setup_session
 from ai.backend.common.web.session.redis_storage import RedisStorage
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -34,12 +34,14 @@ from ai.backend.common.web.session import (
     get_session,
     get_time,
 )
+from ai.backend.common.networking import get_client_ip
+from ai.backend.common.web.session import extra_config_headers, get_session
 from ai.backend.common.web.session import setup as setup_session
 from ai.backend.common.web.session.redis_storage import RedisStorage
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel
 
 from . import __version__, user_agent
-from .auth import fill_forwarding_hdrs_to_api_session, get_client_ip
+from .auth import fill_forwarding_hdrs_to_api_session
 from .config import config_iv
 from .proxy import decrypt_payload, web_handler, web_plugin_handler, websocket_handler
 from .stats import WebStats, track_active_handlers, view_stats


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

# Outline

Resolves https://github.com/lablup/backend.ai/issues/2060.

Introduce the concept of `anonymous-ratelimit` and expand the existing ratelimiter logic to allow for ratelimiting of anonymous users as well.

## Details

### id_type, id_value

For `id_type`, the string `access_key` is used for requests from authenticated clients, and `ip` is used for anonymous users.

| | Value for Authenticated Clients | Value for Anonymous Users |
|-----------|---------------------------------|--------------------------|
| `id_type` | "access_key"                    | "ip_address"                     |

### get_client_ip

The `get_client_ip` function has been moved to the `/common` directory for use in the manager as well.

## Test

Manually tested.

If the ratelimit of an anonymous user exceeds the rlimit, a `RateLimitExceeded` error will be occured from the manager and the client will receive a *429* response.

![2024-08-05_14-06-52](https://github.com/user-attachments/assets/d62a70ca-8e81-42d7-96a5-805a5c1816fa)



---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2076.org.readthedocs.build/en/2076/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2076.org.readthedocs.build/ko/2076/

<!-- readthedocs-preview sorna-ko end -->