### PR TITLE
feat: bring back etcetra on `etcdlock`

### DIFF
--- a/changes/2079.feature.md
+++ b/changes/2079.feature.md
@@ -1,0 +1,1 @@
+Bring back etcetra-backed Etcd as an option for ditributed lock backend

--- a/python.lock
+++ b/python.lock
@@ -45,6 +45,7 @@
 //     "cryptography>=2.8",
 //     "dataclasses-json~=0.5.7",
 //     "etcd-client-py==0.3.0",
+//     "etcetra~=0.1.19",
 //     "faker~=24.7.1",
 //     "graphene~=3.3.0",
 //     "graypy==2.1.0",
@@ -225,73 +226,73 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f3460a92638dce7e47062cf088d6e7663adb135e936cb117be88d5e6c48c9d53",
-              "url": "https://files.pythonhosted.org/packages/1c/fd/8994aa9fe735bca37230cc1439aa0744c53a198244f85abb62db4cd64112/aiohttp-3.9.4-cp312-cp312-musllinux_1_1_x86_64.whl"
+              "hash": "c671dc117c2c21a1ca10c116cfcd6e3e44da7fcde37bf83b2be485ab377b25da",
+              "url": "https://files.pythonhosted.org/packages/5c/f1/f61b397a0eaf01d197e610b0f56935b0002d688f27d73af2882b282fc2f8/aiohttp-3.9.5-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b2feaf1b7031ede1bc0880cec4b0776fd347259a723d625357bb4b82f62687b",
-              "url": "https://files.pythonhosted.org/packages/1d/6c/2da5ba31bfc80d2b6a1851eeba236ec80106970bfc6a69d440b1f51fd677/aiohttp-3.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "edea7d15772ceeb29db4aff55e482d4bcfb6ae160ce144f2682de02f6d693551",
+              "url": "https://files.pythonhosted.org/packages/04/a4/e3679773ea7eb5b37a2c998e25b017cc5349edf6ba2739d1f32855cfb11b/aiohttp-3.9.5.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "dcad56c8d8348e7e468899d2fb3b309b9bc59d94e6db08710555f7436156097f",
-              "url": "https://files.pythonhosted.org/packages/29/3d/9dcbd75e46ee2d1ae05615e926982f72590248cddf5400f860f6b3cc4228/aiohttp-3.9.4-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "18f634d540dd099c262e9f887c8bbacc959847cfe5da7a0e2e1cf3f14dbf2daf",
+              "url": "https://files.pythonhosted.org/packages/0c/ea/8e1bd13e39b3f4c37889b8480f04ed398e07017f5709d66d4e1d0dee39fe/aiohttp-3.9.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d2334e387b2adcc944680bebcf412743f2caf4eeebd550f67249c1c3696be04",
-              "url": "https://files.pythonhosted.org/packages/3f/b4/86e833f70cd4a7c5f86a7c8d5c2e4210637a9c943ac4b8c96a16d92de176/aiohttp-3.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0a158704edf0abcac8ac371fbb54044f3270bdbc93e254a82b6c82be1ef08f3c",
+              "url": "https://files.pythonhosted.org/packages/18/5f/f6428eb55244d44e1c674c8c823ae1567136ac1d2f8b128e194dd4febbe1/aiohttp-3.9.5-cp312-cp312-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d12a244627eba4e9dc52cbf924edef905ddd6cafc6513849b4876076a6f38b0e",
-              "url": "https://files.pythonhosted.org/packages/61/fb/9b32f0b5c7bf1bb53e41951b0965d32e4be243d60dec1c544717902659ed/aiohttp-3.9.4-cp312-cp312-macosx_10_9_x86_64.whl"
+              "hash": "320e8618eda64e19d11bdb3bd04ccc0a816c17eaecb7e4945d01deee2a22f95f",
+              "url": "https://files.pythonhosted.org/packages/2a/ac/7c00027510f42a21c0a905f2472d9afef7ea276573357829bfe8c12883d4/aiohttp-3.9.5-cp312-cp312-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aba80e77c227f4234aa34a5ff2b6ff30c5d6a827a91d22ff6b999de9175d71bd",
-              "url": "https://files.pythonhosted.org/packages/64/fe/9aaff07d02a734a4127a2b903431374e6f74fddcf354b46225fc6e4b0fe1/aiohttp-3.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl"
+              "hash": "393c7aba2b55559ef7ab791c94b44f7482a07bf7640d17b341b79081f5e5cd1a",
+              "url": "https://files.pythonhosted.org/packages/54/8e/72d1ddd6e653b6d4b7b1fece7619287d3319bae10ad3a7f12d956bcc9e96/aiohttp-3.9.5-cp312-cp312-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4870cb049f10d7680c239b55428916d84158798eb8f353e74fa2c98980dcc0b",
-              "url": "https://files.pythonhosted.org/packages/7d/88/2351a70e47d1b4ec944e4db14ecd5e562c756da5eb80b472b34f6c9162aa/aiohttp-3.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "c7a4b7a6cf5b6eb11e109a9755fd4fda7d57395f8c575e166d363b9fc3ec4678",
+              "url": "https://files.pythonhosted.org/packages/5e/25/c6bd6cb160a4dc81f83adbc9bdd6758f01932a6c81a3e4ac707746e7855e/aiohttp-3.9.5-cp312-cp312-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ff71ede6d9a5a58cfb7b6fffc83ab5d4a63138276c771ac91ceaaddf5459644",
-              "url": "https://files.pythonhosted.org/packages/7e/0b/4235b25496c741f4c9f75a94951fbc15c48537349a03448687fb226256ef/aiohttp-3.9.4.tar.gz"
+              "hash": "d153f652a687a8e95ad367a86a61e8d53d528b0530ef382ec5aaf533140ed00f",
+              "url": "https://files.pythonhosted.org/packages/78/28/2080ed3140b7d25c406f77fe2d5776edd9c7a25228f7f905d7058a6e2d61/aiohttp-3.9.5-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c5ff8ff44825736a4065d8544b43b43ee4c6dd1530f3a08e6c0578a813b0aa35",
-              "url": "https://files.pythonhosted.org/packages/8b/93/3dc56fcab9087f36439d12877c30c9b94c57de7082d0ed81317a5c1fe53b/aiohttp-3.9.4-cp312-cp312-macosx_10_9_universal2.whl"
+              "hash": "8c64a6dc3fe5db7b1b4d2b5cb84c4f677768bdc340611eca673afb7cf416ef5a",
+              "url": "https://files.pythonhosted.org/packages/88/31/e55083b026428324cde827c04bdfbc837c131f9d3ee38d28c766614b09ef/aiohttp-3.9.5-cp312-cp312-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fb68dc73bc8ac322d2e392a59a9e396c4f35cb6fdbdd749e139d1d6c985f2527",
-              "url": "https://files.pythonhosted.org/packages/a2/35/9749ef7ca527eb478f4e0c7845b70de1e75ab2329c8ac463cf1d7a2ee398/aiohttp-3.9.4-cp312-cp312-musllinux_1_1_s390x.whl"
+              "hash": "8676e8fd73141ded15ea586de0b7cda1542960a7b9ad89b2b06428e97125d4fa",
+              "url": "https://files.pythonhosted.org/packages/a6/39/ca4fc97af53167ff6c8888a59002b17447bddd8dd474ae0f0e778446cfe7/aiohttp-3.9.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e0198ea897680e480845ec0ffc5a14e8b694e25b3f104f63676d55bf76a82f1a",
-              "url": "https://files.pythonhosted.org/packages/af/f4/3e880364f49977d2ee9e724740fd318c8fc00653cefb5893471f020842c7/aiohttp-3.9.4-cp312-cp312-musllinux_1_1_aarch64.whl"
+              "hash": "82a6a97d9771cb48ae16979c3a3a9a18b600a8505b1115cfe354dfb2054468b4",
+              "url": "https://files.pythonhosted.org/packages/d3/c0/cd9d02e1b9e1b1073c94f7692ffe69067987c4acc0252bbc0c7645360d37/aiohttp-3.9.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f7e69a7fd4b5ce419238388e55abd220336bd32212c673ceabc57ccf3d05b55",
-              "url": "https://files.pythonhosted.org/packages/e1/8f/3998b71747bf3b2dcf73743df6ee7f0fd4162cf7006e0a6b6c14088f154d/aiohttp-3.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "da00da442a0e31f1c69d26d224e1efd3a1ca5bcbf210978a2ca7426dfcae9f58",
+              "url": "https://files.pythonhosted.org/packages/dd/0a/526c8480bd846b9155c624c7e54db94733fc6b381dfd748cc8dd69c994b0/aiohttp-3.9.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e40d2cd22914d67c84824045861a5bb0fb46586b15dfe4f046c7495bf08306b2",
-              "url": "https://files.pythonhosted.org/packages/f8/40/a7ab46aa09db9b68e07b54c85a59615164db1f8aaac00c5a862b82b732b2/aiohttp-3.9.4-cp312-cp312-musllinux_1_1_i686.whl"
+              "hash": "2faa61a904b83142747fc6a6d7ad8fccff898c849123030f8e75d5d967fd4a81",
+              "url": "https://files.pythonhosted.org/packages/e3/f5/e0c216a12b2490cbecd79e9b7671f4e50dfc72e9a52347943aabe6f5bc44/aiohttp-3.9.5-cp312-cp312-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "939393e8c3f0a5bcd33ef7ace67680c318dc2ae406f15e381c0054dd658397de",
-              "url": "https://files.pythonhosted.org/packages/fa/d1/13d90775af7115d97d6fa8815cc1704fabd24080e5a6de0a88ac250e8707/aiohttp-3.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "60cdbd56f4cad9f69c35eaac0fbbdf1f77b0ff9456cebd4902f3dd1cf096464c",
+              "url": "https://files.pythonhosted.org/packages/f2/fb/d65d58230e9ed5cfed886b0c433634bfb14cbe183125e84de909559e29e7/aiohttp-3.9.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             }
           ],
           "project_name": "aiohttp",
@@ -307,7 +308,7 @@
             "yarl<2.0,>=1.0"
           ],
           "requires_python": ">=3.8",
-          "version": "3.9.4"
+          "version": "3.9.5"
         },
         {
           "artifacts": [
@@ -946,48 +947,48 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "33cf93f6de5176f1188c923f4de1ae149ed723b89ed12e434f2b2f628491769e",
-              "url": "https://files.pythonhosted.org/packages/58/7c/cd68102950769f630af7239251f8f875f2dad91f991b0538147f2e64421c/boto3-1.34.83-py3-none-any.whl"
+              "hash": "db7bbb1c6059e99b74dcf634e497b04addcac4c527ae2b2696e47c39eccc6c50",
+              "url": "https://files.pythonhosted.org/packages/4b/bb/f3a77166e1917b4269f13752edbabbd8aa022a442f51e4779247fb9a1253/boto3-1.34.92-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9733ce811bd82feab506ad9309e375a79cabe8c6149061971c17754ce8997551",
-              "url": "https://files.pythonhosted.org/packages/46/6d/8f361c95d4f948dae469a3072cf998f62300ca3bc1a311c1c029a2793313/boto3-1.34.83.tar.gz"
+              "hash": "684cba753d64978a486e8ea9645d53de0d4e3b4a3ab1495b26bd04b9541cea2d",
+              "url": "https://files.pythonhosted.org/packages/c5/d2/57a90069ab4de1780a16d1a670c14098a417b676ab14724402a32feb695a/boto3-1.34.92.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.35.0,>=1.34.83",
+            "botocore<1.35.0,>=1.34.92",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.11.0,>=0.10.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.34.83"
+          "version": "1.34.92"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0a3fbbe018416aeefa8978454fb0b8129adbaf556647b72269bf02e4bf1f4161",
-              "url": "https://files.pythonhosted.org/packages/0b/82/43e4e861fc883ec52e289aca674910e114399f39157b4d3b429d980f07f4/botocore-1.34.83-py3-none-any.whl"
+              "hash": "4211a22a1f6c6935e70cbb84c2cd93b29f9723eaf5036d59748dd104f389a681",
+              "url": "https://files.pythonhosted.org/packages/c4/58/c25d117142140b65f0782bc066b4b52a84454075e4e575bf37d1c7fb0ad9/botocore-1.34.92-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0f302aa76283d4df62b4fbb6d3d20115c1a8957fc02171257fc93904d69d5636",
-              "url": "https://files.pythonhosted.org/packages/0c/b8/6d1ec4802de76d21851784ca2b1d26575f193c31ebd194a196d08dac0d0d/botocore-1.34.83.tar.gz"
+              "hash": "d1ca4886271f184445ec737cd2e752498648cca383887c5a37b2e01c8ab94039",
+              "url": "https://files.pythonhosted.org/packages/d5/d0/e263194220495a7a61cad619100db16128bd0a3ab1ea73f1e540905ca29a/botocore-1.34.92.tar.gz"
             }
           ],
           "project_name": "botocore",
           "requires_dists": [
-            "awscrt==0.19.19; extra == \"crt\"",
+            "awscrt==0.20.9; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "python-dateutil<3.0.0,>=2.1",
             "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\"",
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.34.83"
+          "version": "1.34.92"
         },
         {
           "artifacts": [
@@ -1479,6 +1480,40 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "ffe055d931e00011b546f89c5c029e3f76f3915fe0590ec32c647f9ab81117d2",
+              "url": "https://files.pythonhosted.org/packages/59/81/09edbe1d18117d4805a81f0feda005b2afe308feaccd0efab99893add0fd/etcetra-0.1.19-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb8f710e54c3b6d6f85d219ea89e73edaa3916677966c7f72430381a28619a46",
+              "url": "https://files.pythonhosted.org/packages/65/f1/558889a8bebdae7cc62e67625da481dbe9c6fab5bf51251573bb939bf833/etcetra-0.1.19.tar.gz"
+            }
+          ],
+          "project_name": "etcetra",
+          "requires_dists": [
+            "codecov; extra == \"test\"",
+            "flake8-commas>=2.1; extra == \"lint\"",
+            "flake8>=4.0.1; extra == \"lint\"",
+            "grpcio-tools==1.62.2",
+            "grpcio==1.62.2",
+            "mypy>=1.4.1; extra == \"typecheck\"",
+            "protobuf~=4.25.3",
+            "pytest-asyncio~=0.16.0; extra == \"test\"",
+            "pytest-cov>=2.11; extra == \"test\"",
+            "pytest-mock>=3.5.0; extra == \"test\"",
+            "pytest~=6.2.5; extra == \"test\"",
+            "twine>=3.4.1; extra == \"build\"",
+            "types-protobuf; extra == \"typecheck\"",
+            "types-setuptools; extra == \"typecheck\"",
+            "wheel>=0.36.2; extra == \"build\""
+          ],
+          "requires_python": ">=3.10",
+          "version": "0.1.19"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "73f2bd886e8ce751e660c7d37a6c0a128aab5e1551359335bb79cfea0f4fabfc",
               "url": "https://files.pythonhosted.org/packages/72/04/b5290fc71cad85eadd86d24ad21dd70e76a98a073db6c1c7a925df7ba037/Faker-24.7.1-py3-none-any.whl"
             },
@@ -1774,6 +1809,108 @@
           ],
           "requires_python": ">=3.7",
           "version": "3.0.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "17708db5b11b966373e21519c4c73e5a750555f02fde82276ea2a267077c68ad",
+              "url": "https://files.pythonhosted.org/packages/1b/ca/6531616cca14aec55d840f1332adb83ebac06daf46880634469a8fffcbe6/grpcio-1.62.2-cp312-cp312-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c77618071d96b7a8be2c10701a98537823b9c65ba256c0b9067e0594cdbd954d",
+              "url": "https://files.pythonhosted.org/packages/04/7a/cb869ec6d7f634c0153b4a38ae25bb33699b9307ea17f8cb22b609a46605/grpcio-1.62.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "65034473fc09628a02fb85f26e73885cf1ed39ebd9cf270247b38689ff5942c5",
+              "url": "https://files.pythonhosted.org/packages/40/bd/acdcb5f9166b4e43b56feb1b863403547b87ef8582b7ba0109e65c766f5f/grpcio-1.62.2-cp312-cp312-linux_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2c1771d0ee3cf72d69bb5e82c6a82f27fbd504c8c782575eddb7839729fbaad",
+              "url": "https://files.pythonhosted.org/packages/5d/b2/14286af1774e02336b2e32bb6bb84fc75936b3be0648b5b60f84cdde3a25/grpcio-1.62.2-cp312-cp312-macosx_10_10_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "262cda97efdabb20853d3b5a4c546a535347c14b64c017f628ca0cc7fa780cc6",
+              "url": "https://files.pythonhosted.org/packages/7f/53/31c57c5527496352f31174a9ed7962374501449178769599dee0555ffd26/grpcio-1.62.2-cp312-cp312-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "404d3b4b6b142b99ba1cff0b2177d26b623101ea2ce51c25ef6e53d9d0d87bcc",
+              "url": "https://files.pythonhosted.org/packages/89/7c/1412c5a39b59c3e8a72cd4f46d29450486c48746ab831c9750eb42d770e9/grpcio-1.62.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c5ffeb269f10cedb4f33142b89a061acda9f672fd1357331dbfd043422c94e9e",
+              "url": "https://files.pythonhosted.org/packages/b4/9a/13573112aa127fc1f1334c2aa22e95aefa5634f05d06f228b25a22f30863/grpcio-1.62.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3abe6838196da518863b5d549938ce3159d809218936851b395b09cad9b5d64a",
+              "url": "https://files.pythonhosted.org/packages/bb/47/b097ac8848be12e63c7d6baf935ddae9f1251a98a0713b5e45461a14cb93/grpcio-1.62.2-cp312-cp312-manylinux_2_17_aarch64.whl"
+            }
+          ],
+          "project_name": "grpcio",
+          "requires_dists": [
+            "grpcio-tools>=1.62.2; extra == \"protobuf\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "1.62.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "462e0ab8dd7c7b70bfd6e3195eebc177549ede5cf3189814850c76f9a340d7ce",
+              "url": "https://files.pythonhosted.org/packages/2d/38/b2d64e17cdf91c49f809153a5c6a17625719706461fa100aa3ab390653b0/grpcio_tools-1.62.2-cp312-cp312-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9be84ff6d47fd61462be7523b49d7ba01adf67ce4e1447eae37721ab32464dd8",
+              "url": "https://files.pythonhosted.org/packages/44/28/41057eab5f14f418d9852c9ff3e71a70cb060ec7df71acd9534182139d3d/grpcio_tools-1.62.2-cp312-cp312-macosx_10_10_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04c607029ae3660fb1624ed273811ffe09d57d84287d37e63b5b802a35897329",
+              "url": "https://files.pythonhosted.org/packages/46/b4/e37db5a4b018568fc7b6dad6f95b2e36ed2f256f4e42f98f4bb294b85954/grpcio_tools-1.62.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "10cc3321704ecd17c93cf68c99c35467a8a97ffaaed53207e9b2da6ae0308ee1",
+              "url": "https://files.pythonhosted.org/packages/4f/48/c6ca99947db7fb70533fd72072fd82915bcad7564c2039e0e2d8143e6656/grpcio_tools-1.62.2-cp312-cp312-linux_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5fd5e1582b678e6b941ee5f5809340be5e0724691df5299aae8226640f94e18f",
+              "url": "https://files.pythonhosted.org/packages/b1/09/dfb87373a34bf6ce3261d65f8fb102a163c850c72a3e84902777ed44aa1d/grpcio-tools-1.62.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d82f681c9a9d933a9d8068e8e382977768e7779ddb8870fa0cf918d8250d1532",
+              "url": "https://files.pythonhosted.org/packages/bb/71/3af2c44dc891b4b7d0f0f3f63b157e4b400cb0d2dce225532b01be5470f3/grpcio_tools-1.62.2-cp312-cp312-manylinux_2_17_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8214820990d01b52845f9fbcb92d2b7384a0c321b303e3ac614c219dc7d1d3af",
+              "url": "https://files.pythonhosted.org/packages/cf/5d/7894aafb27232030628e1ba014bb107c6742771e3f70b9bd3780febdc2f5/grpcio_tools-1.62.2-cp312-cp312-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "72b61332f1b439c14cbd3815174a8f1d35067a02047c32decd406b3a09bb9890",
+              "url": "https://files.pythonhosted.org/packages/ed/84/9b573774b692d2d60cc93d2b87ea98c9814658ea4f371e8d518375cd7abc/grpcio_tools-1.62.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            }
+          ],
+          "project_name": "grpcio-tools",
+          "requires_dists": [
+            "grpcio>=1.62.2",
+            "protobuf<5.0dev,>=4.21.6",
+            "setuptools"
+          ],
+          "requires_python": ">=3.7",
+          "version": "1.62.2"
         },
         {
           "artifacts": [
@@ -2710,13 +2847,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
-              "url": "https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl"
+              "hash": "17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1",
+              "url": "https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768",
-              "url": "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz"
+              "hash": "031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf",
+              "url": "https://files.pythonhosted.org/packages/b2/e4/2856bf61e54d7e3a03dd00d0c1b5fa86e6081e8f262eb91befbe64d20937/platformdirs-4.2.1.tar.gz"
             }
           ],
           "project_name": "platformdirs",
@@ -2724,6 +2861,7 @@
             "appdirs==1.4.4; extra == \"test\"",
             "covdefaults>=2.3; extra == \"test\"",
             "furo>=2023.9.10; extra == \"docs\"",
+            "mypy>=1.8; extra == \"type\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4.1; extra == \"test\"",
             "pytest-mock>=3.12; extra == \"test\"",
@@ -2732,19 +2870,19 @@
             "sphinx>=7.2.6; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "4.2.0"
+          "version": "4.2.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-              "url": "https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl"
+              "hash": "44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669",
+              "url": "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be",
-              "url": "https://files.pythonhosted.org/packages/54/c6/43f9d44d92aed815e781ca25ba8c174257e27253a94630d21be8725a2b59/pluggy-1.4.0.tar.gz"
+              "hash": "2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+              "url": "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz"
             }
           ],
           "project_name": "pluggy",
@@ -2755,7 +2893,7 @@
             "tox; extra == \"dev\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.4.0"
+          "version": "1.5.0"
         },
         {
           "artifacts": [
@@ -2776,6 +2914,39 @@
           ],
           "requires_python": ">=3.7.0",
           "version": "3.0.43"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9",
+              "url": "https://files.pythonhosted.org/packages/f4/d5/db585a5e8d64af6b384c7b3a63da13df2ff86933e486ba78431736c67c25/protobuf-4.25.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d",
+              "url": "https://files.pythonhosted.org/packages/15/db/7f731524fe0e56c6b2eb57d05b55d3badd80ef7d1f1ed59db191b2fdd8ab/protobuf-4.25.3-cp37-abi3-manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c",
+              "url": "https://files.pythonhosted.org/packages/5e/d8/65adb47d921ce828ba319d6587aa8758da022de509c3862a70177a958844/protobuf-4.25.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019",
+              "url": "https://files.pythonhosted.org/packages/d8/82/aefe901174b5a618daee511ddd00342193c1b545e3cd6a2cd6df9ba452b5/protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c",
+              "url": "https://files.pythonhosted.org/packages/f3/bf/26deba06a4c910a85f78245cac7698f67cedd7efe00d04f6b3e1b3506a59/protobuf-4.25.3-cp37-abi3-macosx_10_9_universal2.whl"
+            }
+          ],
+          "project_name": "protobuf",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "4.25.3"
         },
         {
           "artifacts": [
@@ -3590,13 +3761,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c",
-              "url": "https://files.pythonhosted.org/packages/92/e1/1c8bb3420105e70bdf357d57dd5567202b4ef8d27f810e98bb962d950834/setuptools-69.2.0-py3-none-any.whl"
+              "hash": "c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32",
+              "url": "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e",
-              "url": "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
+              "hash": "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987",
+              "url": "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -3620,26 +3791,25 @@
             "packaging>=23.2; extra == \"testing-integration\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
+            "pytest!=8.1.1,>=6; extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=2.2; extra == \"testing\"",
             "pytest-home>=0.5; extra == \"testing\"",
-            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-mypy; extra == \"testing\"",
             "pytest-perf; sys_platform != \"cygwin\" and extra == \"testing\"",
             "pytest-ruff>=0.2.1; sys_platform != \"cygwin\" and extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest-xdist>=3; extra == \"testing\"",
             "pytest; extra == \"testing-integration\"",
-            "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
             "sphinx-lint; extra == \"docs\"",
             "sphinx-notfound-page<2,>=1; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx<7.2.5; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
@@ -3651,7 +3821,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.8",
-          "version": "69.2.0"
+          "version": "69.5.1"
         },
         {
           "artifacts": [
@@ -3968,13 +4138,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fcdf85684a772ddeba87db2f398ce00b40ff550d1528c03c14dbf6a02003cd80",
-              "url": "https://files.pythonhosted.org/packages/7c/c4/366a09036c07f46eb8c9b2af39c97f502ef24f11f2a6e4d763655d9f2708/traitlets-5.14.2-py3-none-any.whl"
+              "hash": "b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f",
+              "url": "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8cdd83c040dab7d1dee822678e5f5d100b514f7b72b01615b26fc5718916fdf9",
-              "url": "https://files.pythonhosted.org/packages/4f/97/d957b3a5f6da825cbbb6a02e584bcab769ea2c2a9ad67a9cc25b4bbafb30/traitlets-5.14.2.tar.gz"
+              "hash": "9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7",
+              "url": "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz"
             }
           ],
           "project_name": "traitlets",
@@ -3986,11 +4156,11 @@
             "pydata-sphinx-theme; extra == \"docs\"",
             "pytest-mock; extra == \"test\"",
             "pytest-mypy-testing; extra == \"test\"",
-            "pytest<8.1,>=7.0; extra == \"test\"",
+            "pytest<8.2,>=7.0; extra == \"test\"",
             "sphinx; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "5.14.2"
+          "version": "5.14.3"
         },
         {
           "artifacts": [
@@ -4076,6 +4246,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "a363e5ea54a4eb6a4a105d800685fde596bc318089b025b27dee09849fe41ff0",
+              "url": "https://files.pythonhosted.org/packages/69/7a/98f5d2493a652cec05d3b09be59202d202004a41fca9c70d224782611365/types_cffi-1.16.0.20240331-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b8b20d23a2b89cfed5f8c5bc53b0cb8677c3aac6d970dbc771e28b9c698f5dee",
+              "url": "https://files.pythonhosted.org/packages/91/c8/81e5699160b91f0f91eea852d84035c412bfb4b3a29389701044400ab379/types-cffi-1.16.0.20240331.tar.gz"
+            }
+          ],
+          "project_name": "types-cffi",
+          "requires_dists": [
+            "types-setuptools"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.16.0.20240331"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "60a1e21e8296979db32f9374d8a239af4cb541ff66447bb915d8ad398f9c63b2",
               "url": "https://files.pythonhosted.org/packages/b7/b0/e79d84748f1d34304f13191424348a719c3febaa3493835370fe9528e1e6/types_Jinja2-2.11.9-py3-none-any.whl"
             },
@@ -4114,21 +4304,22 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6e8e8bfad34924067333232c93f7fc4b369856d8bea0d5c9d1808cb290ab1972",
-              "url": "https://files.pythonhosted.org/packages/7d/7d/06b1d678521cebeab11cc0fb02986c901de783a40befcc32076bbe7fe278/types_pyOpenSSL-24.0.0.20240311-py3-none-any.whl"
+              "hash": "f51a156835555dd2a1f025621e8c4fbe7493470331afeef96884d1d29bf3a473",
+              "url": "https://files.pythonhosted.org/packages/b6/7b/555c69a26d733c5254657d4a9fc4b3ec3ed13c73336f06c68ebd352258d0/types_pyOpenSSL-24.1.0.20240425-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bca00cfc4e7ef9c5d2663c6a1c068c35798e59670595439f6296e7ba3d58083",
-              "url": "https://files.pythonhosted.org/packages/0b/27/4112745fb4f44d89c3260fc683fae69b2bb2c724e1e1994c3e24f21d24e8/types-pyOpenSSL-24.0.0.20240311.tar.gz"
+              "hash": "0a7e82626c1983dc8dc59292bf20654a51c3c3881bcbb9b337c1da6e32f0204e",
+              "url": "https://files.pythonhosted.org/packages/ba/99/0ef33ca243dc4a9306ed7c976dd2d8563e3cf89371456d575f5b13f7dc68/types-pyOpenSSL-24.1.0.20240425.tar.gz"
             }
           ],
           "project_name": "types-pyopenssl",
           "requires_dists": [
-            "cryptography>=35.0.0"
+            "cryptography>=35.0.0",
+            "types-cffi"
           ],
           "requires_python": ">=3.8",
-          "version": "24.0.0.20240311"
+          "version": "24.1.0.20240425"
         },
         {
           "artifacts": [
@@ -4170,13 +4361,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a3b92760c49a034827a0c3825206728df4e61e981c1324099d4414335af4f52f",
-              "url": "https://files.pythonhosted.org/packages/a7/f9/9944b2480301c553c95dfd8b225c82ece5f3bf0756d9b97d678166c4491d/types_redis-4.6.0.20240409-py3-none-any.whl"
+              "hash": "ac5bc19e8f5997b9e76ad5d9cf15d0392d9f28cf5fc7746ea4a64b989c45c6a8",
+              "url": "https://files.pythonhosted.org/packages/82/79/9de458746a7907f7bd2e96ff7ee1538aa9066683d1276d4494f2b8c7678b/types_redis-4.6.0.20240425-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce217c279581d769df992c5b76d61c65425b0a679626048e633e643868eb881b",
-              "url": "https://files.pythonhosted.org/packages/6f/48/2f3ec8681c3ad9e9d21d4db16056caf9cda023f2df0b773f39f82d91efa0/types-redis-4.6.0.20240409.tar.gz"
+              "hash": "9402a10ee931d241fdfcc04592ebf7a661d7bb92a8dea631279f0d8acbcf3a22",
+              "url": "https://files.pythonhosted.org/packages/15/a9/5ba198edeccefe7c3e6e620f4737f56814309201c8dfad184590dcc3cb0a/types-redis-4.6.0.20240425.tar.gz"
             }
           ],
           "project_name": "types-redis",
@@ -4185,43 +4376,43 @@
             "types-pyOpenSSL"
           ],
           "requires_python": ">=3.8",
-          "version": "4.6.0.20240409"
+          "version": "4.6.0.20240425"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cf91ff7c87ab7bf0625c3f0d4d90427c9da68561f3b0feab77977aaf0bbf7531",
-              "url": "https://files.pythonhosted.org/packages/1f/22/904934a3344fa5f332ecab887003f3f033c1272432a4af877007b75b0bd3/types_setuptools-69.2.0.20240317-py3-none-any.whl"
+              "hash": "a4381e041510755a6c9210e26ad55b1629bc10237aeb9cb8b6bd24996b73db48",
+              "url": "https://files.pythonhosted.org/packages/c3/00/3413afcbbf152442034ffeec6ca66f48939926ee50aa9a22ee8a39e26050/types_setuptools-69.5.0.20240423-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b607c4c48842ef3ee49dc0c7fe9c1bad75700b071e1018bb4d7e3ac492d47048",
-              "url": "https://files.pythonhosted.org/packages/2d/06/0de7b539346aaa8758b3c80375c4841dc2764ef92c5e743f1ebe9789da54/types-setuptools-69.2.0.20240317.tar.gz"
+              "hash": "a7ba908f1746c4337d13f027fa0f4a5bcad6d1d92048219ba792b3295c58586d",
+              "url": "https://files.pythonhosted.org/packages/12/c7/10593c47ad543413eaf25bba1979a3c5a4bf3f42e505dd28869c618a764c/types-setuptools-69.5.0.20240423.tar.gz"
             }
           ],
           "project_name": "types-setuptools",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "69.2.0.20240317"
+          "version": "69.5.0.20240423"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "abc0377990d38e9b37b3333dd115ec960ca9788d78f3d9c7eb3f778cfc6c925c",
-              "url": "https://files.pythonhosted.org/packages/f8/2e/92578323e36deeb7baf82ad1612a49dfe5ed0882b44e8ddbe18cfdfd5534/types_six-1.16.21.20240311-py3-none-any.whl"
+              "hash": "1e924f823cdc2142670c942527f71b49912e6954b3b85388cd0cc1259ad4bfcf",
+              "url": "https://files.pythonhosted.org/packages/ab/a5/ba68e41d7070fbcdbb359ad4c57aa455d6b07348d468214f643097f47d0a/types_six-1.16.21.20240425-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b5a117193ba0dc7a66507925e95e140b2af52731402cdd71ef9f2a4348e01f60",
-              "url": "https://files.pythonhosted.org/packages/b4/f1/53abd134a8838c6046b433cbe426aa51ccc70237cd196dfca735d7000984/types-six-1.16.21.20240311.tar.gz"
+              "hash": "378f8baa5b693e4f8a284e8f7b0b34c682210848900816788e19ee4712de8f59",
+              "url": "https://files.pythonhosted.org/packages/04/b8/34a12ef6b1f046590fc5f8ab15b5756a39f4edea1fe7b7a84ab6a7859c01/types-six-1.16.21.20240425.tar.gz"
             }
           ],
           "project_name": "types-six",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "1.16.21.20240311"
+          "version": "1.16.21.20240425"
         },
         {
           "artifacts": [
@@ -4406,25 +4597,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f4c3d22fec12a2461427a29957ff07d35098ee2d976d3ba244e688b8b4057588",
-              "url": "https://files.pythonhosted.org/packages/1e/70/1e88138a9afbed1d37093b85f0bebc3011623c4f47c166431599fe9d6c93/websocket_client-1.7.0-py3-none-any.whl"
+              "hash": "17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526",
+              "url": "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10e511ea3a8c744631d3bd77e61eb17ed09304c413ad42cf6ddfa4c7787e8fe6",
-              "url": "https://files.pythonhosted.org/packages/20/07/2a94288afc0f6c9434d6709c5320ee21eaedb2f463ede25ed9cf6feff330/websocket-client-1.7.0.tar.gz"
+              "hash": "3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da",
+              "url": "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz"
             }
           ],
           "project_name": "websocket-client",
           "requires_dists": [
             "Sphinx>=6.0; extra == \"docs\"",
+            "myst-parser>=2.0.0; extra == \"docs\"",
             "python-socks; extra == \"optional\"",
             "sphinx-rtd-theme>=1.1.0; extra == \"docs\"",
             "websockets; extra == \"test\"",
             "wsaccel; extra == \"optional\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.7.0"
+          "version": "1.8.0"
         },
         {
           "artifacts": [
@@ -4578,6 +4770,7 @@
     "cryptography>=2.8",
     "dataclasses-json~=0.5.7",
     "etcd-client-py==0.3.0",
+    "etcetra~=0.1.19",
     "faker~=24.7.1",
     "graphene~=3.3.0",
     "graypy==2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ coloredlogs~=15.0
 colorama>=0.4.4
 cryptography>=2.8
 dataclasses-json~=0.5.7
+etcetra~=0.1.19
 faker~=24.7.1
 graphene~=3.3.0
 graypy==2.1.0

--- a/src/ai/backend/common/etcd_etcetra.py
+++ b/src/ai/backend/common/etcd_etcetra.py
@@ -1,0 +1,534 @@
+"""
+An asynchronous client wrapper for etcd v3 API.
+
+It uses the etcd3 library using a thread pool executor.
+We plan to migrate to aioetcd3 library but it requires more work to get maturity.
+Fortunately, etcd3's watchers are not blocking because they are implemented
+using callbacks in separate threads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from collections import ChainMap, namedtuple
+from typing import (
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    ParamSpec,
+    Tuple,
+    TypeAlias,
+    TypeVar,
+    Union,
+    cast,
+)
+from urllib.parse import quote as _quote
+from urllib.parse import unquote
+
+import grpc  # pants: no-infer-dep (etcetra)
+import trafaret as t
+from etcetra import EtcdCommunicator, WatchEvent
+from etcetra.client import EtcdClient, EtcdTransactionAction
+from etcetra.types import CompareKey, EtcdCredential
+from etcetra.types import HostPortPair as EtcetraHostPortPair
+
+from .etcd import ConfigScopes
+from .logging_utils import BraceStyleAdapter
+from .types import HostPortPair, QueueSentinel
+
+__all__ = (
+    "quote",
+    "unquote",
+    "AsyncEtcd",
+)
+
+Event = namedtuple("Event", "key event value")
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+quote = functools.partial(_quote, safe="")
+
+
+def make_dict_from_pairs(key_prefix, pairs, path_sep="/"):
+    result = {}
+    len_prefix = len(key_prefix)
+    if isinstance(pairs, dict):
+        iterator = pairs.items()
+    else:
+        iterator = pairs
+    for k, v in iterator:
+        if not k.startswith(key_prefix):
+            continue
+        subkey = k[len_prefix:]
+        if subkey.startswith(path_sep):
+            subkey = subkey[1:]
+        path_components = subkey.split("/")
+        parent = result
+        for p in path_components[:-1]:
+            p = unquote(p)
+            if p not in parent:
+                parent[p] = {}
+            if p in parent and not isinstance(parent[p], dict):
+                root = parent[p]
+                parent[p] = {"": root}
+            parent = parent[p]
+        parent[unquote(path_components[-1])] = v
+    return result
+
+
+def _slash(v: str):
+    return v.rstrip("/") + "/" if len(v) > 0 else ""
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+GetPrefixValue: TypeAlias = "Mapping[str, GetPrefixValue | Optional[str]]"
+NestedStrKeyedMapping: TypeAlias = "Mapping[str, str | NestedStrKeyedMapping]"
+NestedStrKeyedDict: TypeAlias = "dict[str, str | NestedStrKeyedDict]"
+
+
+class AsyncEtcd:
+    etcd: EtcdClient
+
+    _creds: Optional[EtcdCredential]
+
+    def __init__(
+        self,
+        addr: HostPortPair | EtcetraHostPortPair,
+        namespace: str,
+        scope_prefix_map: Mapping[ConfigScopes, str],
+        *,
+        credentials: dict[str, str] | None = None,
+        encoding: str = "utf-8",
+        watch_reconnect_intvl: float = 0.5,
+    ) -> None:
+        self.scope_prefix_map = t.Dict({
+            t.Key(ConfigScopes.GLOBAL): t.String(allow_blank=True),
+            t.Key(ConfigScopes.SGROUP, optional=True): t.String,
+            t.Key(ConfigScopes.NODE, optional=True): t.String,
+        }).check(scope_prefix_map)
+        if credentials is not None:
+            self._creds = EtcdCredential(credentials["user"], credentials["password"])
+        else:
+            self._creds = None
+
+        self.ns = namespace
+        log.info('using etcd cluster from {} with namespace "{}"', addr, namespace)
+        self.encoding = encoding
+        self.watch_reconnect_intvl = watch_reconnect_intvl
+        self.etcd = EtcdClient(
+            EtcetraHostPortPair(str(addr.host), addr.port),
+            credentials=self._creds,
+            encoding=self.encoding,
+        )
+
+    async def close(self):
+        pass  # for backward compatibility
+
+    def _mangle_key(self, k: str) -> str:
+        if k.startswith("/"):
+            k = k[1:]
+        return f"/sorna/{self.ns}/{k}"
+
+    def _demangle_key(self, k: Union[bytes, str]) -> str:
+        if isinstance(k, bytes):
+            k = k.decode(self.encoding)
+        prefix = f"/sorna/{self.ns}/"
+        if k.startswith(prefix):
+            k = k[len(prefix) :]
+        return k
+
+    def _merge_scope_prefix_map(
+        self,
+        override: Mapping[ConfigScopes, str] = None,
+    ) -> Mapping[ConfigScopes, str]:
+        """
+        This stub ensures immutable usage of the ChainMap because ChainMap does *not*
+        have the immutable version in typeshed.
+        (ref: https://github.com/python/typeshed/issues/6042)
+        """
+        return ChainMap(cast(MutableMapping, override) or {}, self.scope_prefix_map)
+
+    async def put(
+        self,
+        key: str,
+        val: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        """
+        Put a single key-value pair to the etcd.
+
+        :param key: The key. This must be quoted by the caller as needed.
+        :param val: The value.
+        :param scope: The config scope for putting the values.
+        :param scope_prefix_map: The scope map used to mangle the prefix for the config scope.
+        :return:
+        """
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        mangled_key = self._mangle_key(f"{_slash(scope_prefix)}{key}")
+        async with self.etcd.connect() as communicator:
+            await communicator.put(mangled_key, str(val))
+
+    async def put_prefix(
+        self,
+        key: str,
+        dict_obj: NestedStrKeyedMapping,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        """
+        Put a nested dict object under the given key prefix.
+        All keys in the dict object are automatically quoted to avoid conflicts with the path separator.
+
+        :param key: Prefix to put the given data. This must be quoted by the caller as needed.
+        :param dict_obj: Nested dictionary representing the data.
+        :param scope: The config scope for putting the values.
+        :param scope_prefix_map: The scope map used to mangle the prefix for the config scope.
+        :return:
+        """
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        flattened_dict: NestedStrKeyedDict = {}
+
+        def _flatten(prefix: str, inner_dict: NestedStrKeyedDict) -> None:
+            for k, v in inner_dict.items():
+                if k == "":
+                    flattened_key = prefix
+                else:
+                    flattened_key = prefix + "/" + quote(k)
+                if isinstance(v, dict):
+                    _flatten(flattened_key, v)
+                else:
+                    flattened_dict[flattened_key] = v
+
+        _flatten(key, cast(NestedStrKeyedDict, dict_obj))
+
+        def _txn(action: EtcdTransactionAction):
+            for k, v in flattened_dict.items():
+                action.put(self._mangle_key(f"{_slash(scope_prefix)}{k}"), str(v))
+
+        async with self.etcd.connect() as communicator:
+            await communicator.txn(_txn)
+
+    async def put_dict(
+        self,
+        flattened_dict_obj: Mapping[str, str],
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        """
+        Put a flattened key-value pairs into the etcd.
+        Since the given dict must be a flattened one, its keys must be quoted as needed by the caller.
+        For new codes, ``put_prefix()`` is recommended.
+
+        :param dict_obj: Flattened key-value pairs to put.
+        :param scope: The config scope for putting the values.
+        :param scope_prefix_map: The scope map used to mangle the prefix for the config scope.
+        :return:
+        """
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+
+        def _pipe(txn: EtcdTransactionAction):
+            for k, v in flattened_dict_obj.items():
+                txn.put(self._mangle_key(f"{_slash(scope_prefix)}{k}"), str(v))
+
+        async with self.etcd.connect() as communicator:
+            await communicator.txn(_pipe)
+
+    async def get(
+        self,
+        key: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.MERGED,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ) -> Optional[str]:
+        """
+        Get a single key from the etcd.
+        Returns ``None`` if the key does not exist.
+        The returned value may be an empty string if the value is a zero-length string.
+
+        :param key: The key. This must be quoted by the caller as needed.
+        :param scope: The config scope to get the value.
+        :param scope_prefix_map: The scope map used to mangle the prefix for the config scope.
+        :return:
+        """
+
+        _scope_prefix_map = self._merge_scope_prefix_map(scope_prefix_map)
+        if scope == ConfigScopes.MERGED or scope == ConfigScopes.NODE:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+            p = _scope_prefix_map.get(ConfigScopes.SGROUP)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+            p = _scope_prefix_map.get(ConfigScopes.NODE)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+        elif scope == ConfigScopes.SGROUP:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+            p = _scope_prefix_map.get(ConfigScopes.SGROUP)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+        elif scope == ConfigScopes.GLOBAL:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+        else:
+            raise ValueError("Invalid scope prefix value")
+
+        async with self.etcd.connect() as communicator:
+            for scope_prefix in scope_prefixes:
+                value = await communicator.get(self._mangle_key(f"{_slash(scope_prefix)}{key}"))
+                if value is not None:
+                    return value
+        return None
+
+    async def get_prefix(
+        self,
+        key_prefix: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.MERGED,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ) -> GetPrefixValue:
+        """
+        Retrieves all key-value pairs under the given key prefix as a nested dictionary.
+        All dictionary keys are automatically unquoted.
+        If a key has a value while it is also used as path prefix for other keys,
+        the value directly referenced by the key itself is included as a value in a dictionary
+        with the empty-string key.
+
+        For instance, when the etcd database has the following key-value pairs:
+
+        .. code-block::
+
+           myprefix/mydata = abc
+           myprefix/mydata/x = 1
+           myprefix/mydata/y = 2
+           myprefix/mykey = def
+
+        ``get_prefix("myprefix")`` returns the following dictionary:
+
+        .. code-block::
+
+           {
+             "mydata": {
+               "": "abc",
+               "x": "1",
+               "y": "2",
+             },
+             "mykey": "def",
+           }
+
+        :param key_prefix: The key. This must be quoted by the caller as needed.
+        :param scope: The config scope to get the value.
+        :param scope_prefix_map: The scope map used to mangle the prefix for the config scope.
+        :return:
+        """
+
+        _scope_prefix_map = self._merge_scope_prefix_map(scope_prefix_map)
+        if scope == ConfigScopes.MERGED or scope == ConfigScopes.NODE:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+            p = _scope_prefix_map.get(ConfigScopes.SGROUP)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+            p = _scope_prefix_map.get(ConfigScopes.NODE)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+        elif scope == ConfigScopes.SGROUP:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+            p = _scope_prefix_map.get(ConfigScopes.SGROUP)
+            if p is not None:
+                scope_prefixes.insert(0, p)
+        elif scope == ConfigScopes.GLOBAL:
+            scope_prefixes = [_scope_prefix_map[ConfigScopes.GLOBAL]]
+        else:
+            raise ValueError("Invalid scope prefix value")
+        pair_sets: List[List[Mapping | Tuple]] = []
+        async with self.etcd.connect() as communicator:
+            for scope_prefix in scope_prefixes:
+                mangled_key_prefix = self._mangle_key(f"{_slash(scope_prefix)}{key_prefix}")
+                values = await communicator.get_prefix(mangled_key_prefix)
+                pair_sets.append([(self._demangle_key(k), v) for k, v in values.items()])
+
+        configs = [
+            make_dict_from_pairs(f"{_slash(scope_prefix)}{key_prefix}", pairs, "/")
+            for scope_prefix, pairs in zip(scope_prefixes, pair_sets)
+        ]
+        return ChainMap(*configs)
+
+    # for legacy
+    get_prefix_dict = get_prefix
+
+    async def replace(
+        self,
+        key: str,
+        initial_val: str,
+        new_val: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ) -> bool:
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        mangled_key = self._mangle_key(f"{_slash(scope_prefix)}{key}")
+
+        def _txn(success: EtcdTransactionAction, _):
+            success.put(mangled_key, new_val)
+
+        async with self.etcd.connect() as communicator:
+            _, success = await communicator.txn_compare(
+                [
+                    CompareKey(mangled_key).value == initial_val,
+                ],
+                _txn,
+            )
+            return success
+
+    async def delete(
+        self,
+        key: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        mangled_key = self._mangle_key(f"{_slash(scope_prefix)}{key}")
+        async with self.etcd.connect() as communicator:
+            await communicator.delete(mangled_key)
+
+    async def delete_multi(
+        self,
+        keys: Iterable[str],
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        async with self.etcd.connect() as communicator:
+
+            def _txn(action: EtcdTransactionAction):
+                for k in keys:
+                    action.delete(self._mangle_key(f"{_slash(scope_prefix)}{k}"))
+
+            await communicator.txn(_txn)
+
+    async def delete_prefix(
+        self,
+        key_prefix: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+    ):
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        mangled_key_prefix = self._mangle_key(f"{_slash(scope_prefix)}{key_prefix}")
+        async with self.etcd.connect() as communicator:
+            await communicator.delete_prefix(mangled_key_prefix)
+
+    async def _watch_impl(
+        self,
+        iterator_factory: Callable[[EtcdCommunicator], AsyncIterator[WatchEvent]],
+        scope_prefix_len: int,
+        once: bool,
+        cleanup_event: Optional[asyncio.Event] = None,
+        wait_timeout: Optional[float] = None,
+    ) -> AsyncGenerator[Union[QueueSentinel, Event], None]:
+        try:
+            async with self.etcd.connect() as communicator:
+                iterator = iterator_factory(communicator)
+                async for ev in iterator:
+                    if wait_timeout is not None:
+                        try:
+                            ev = await asyncio.wait_for(iterator.__anext__(), wait_timeout)
+                        except asyncio.TimeoutError:
+                            pass
+                    yield Event(ev.key[scope_prefix_len:], ev.event, ev.value)
+                    if once:
+                        return
+        finally:
+            if cleanup_event:
+                cleanup_event.set()
+
+    async def watch(
+        self,
+        key: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+        once: bool = False,
+        ready_event: asyncio.Event = None,
+        cleanup_event: asyncio.Event = None,
+        wait_timeout: float = None,
+    ) -> AsyncGenerator[Union[QueueSentinel, Event], None]:
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        scope_prefix_len = len(self._mangle_key(f"{_slash(scope_prefix)}"))
+        mangled_key = self._mangle_key(f"{_slash(scope_prefix)}{key}")
+        ended_without_error = False
+
+        while not ended_without_error:
+            try:
+                async for ev in self._watch_impl(
+                    lambda communicator: communicator.watch(
+                        mangled_key,
+                        ready_event=ready_event,
+                    ),
+                    scope_prefix_len,
+                    once,
+                    cleanup_event=cleanup_event,
+                    wait_timeout=wait_timeout,
+                ):
+                    yield ev
+                ended_without_error = True
+            except grpc.aio.AioRpcError as e:
+                if e.code() == grpc.StatusCode.UNAVAILABLE:
+                    log.warning("watch(): error while connecting to Etcd server, retrying...")
+                    await asyncio.sleep(self.watch_reconnect_intvl)
+                    ended_without_error = False
+                else:
+                    raise
+
+    async def watch_prefix(
+        self,
+        key_prefix: str,
+        *,
+        scope: ConfigScopes = ConfigScopes.GLOBAL,
+        scope_prefix_map: Mapping[ConfigScopes, str] = None,
+        once: bool = False,
+        ready_event: asyncio.Event = None,
+        cleanup_event: asyncio.Event = None,
+        wait_timeout: float = None,
+    ) -> AsyncGenerator[Union[QueueSentinel, Event], None]:
+        scope_prefix = self._merge_scope_prefix_map(scope_prefix_map)[scope]
+        scope_prefix_len = len(self._mangle_key(f"{_slash(scope_prefix)}"))
+        mangled_key_prefix = self._mangle_key(f"{_slash(scope_prefix)}{key_prefix}")
+        ended_without_error = False
+
+        while not ended_without_error:
+            try:
+                async for ev in self._watch_impl(
+                    lambda communicator: communicator.watch_prefix(
+                        mangled_key_prefix,
+                        ready_event=ready_event,
+                    ),
+                    scope_prefix_len,
+                    once,
+                    cleanup_event=cleanup_event,
+                    wait_timeout=wait_timeout,
+                ):
+                    yield ev
+                ended_without_error = True
+            except grpc.aio.AioRpcError as e:
+                if e.code() == grpc.StatusCode.UNAVAILABLE:
+                    log.warning(
+                        "watch_prefix(): error while connecting to Etcd server, retrying..."
+                    )
+                    await asyncio.sleep(self.watch_reconnect_intvl)
+                    ended_without_error = False
+                else:
+                    raise e

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -207,6 +207,7 @@ from ai.backend.common import config
 from ai.backend.common import validators as tx
 from ai.backend.common.defs import DEFAULT_FILE_IO_TIMEOUT
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
+from ai.backend.common.etcd_etcetra import AsyncEtcd as EtcetraAsyncEtcd
 from ai.backend.common.identity import get_instance_id
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
@@ -590,6 +591,9 @@ class SharedConfig(AbstractConfig):
             # TODO: provide a way to specify other scope prefixes
         }
         self.etcd = AsyncEtcd(etcd_addr, namespace, scope_prefix_map, credentials=credentials)
+        self.etcetra_etcd = EtcetraAsyncEtcd(
+            etcd_addr, namespace, scope_prefix_map, credentials=credentials
+        )
 
     async def close(self) -> None:
         await self.etcd.close()

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -270,7 +270,11 @@ manager_local_config_iv = (
             t.Key("ssl-privkey", default=None): t.Null | tx.Path(type="file"),
             t.Key("event-loop", default="asyncio"): t.Enum("asyncio", "uvloop"),
             t.Key("distributed-lock", default="pg_advisory"): t.Enum(
-                "filelock", "pg_advisory", "redlock", "etcd"
+                "filelock",
+                "pg_advisory",
+                "redlock",
+                "etcd",
+                "etcetra",
             ),
             t.Key("pid-file", default=os.devnull): tx.Path(
                 type="file",

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -746,6 +746,14 @@ def init_lock_factory(root_ctx: RootContext) -> DistributedLockFactory:
                 root_ctx.shared_config.etcd,
                 lifetime=min(lifetime_hint * 2, lifetime_hint + 30),
             )
+        case "etcetra":
+            from ai.backend.common.lock import EtcetraLock
+
+            return lambda lock_id, lifetime_hint: EtcetraLock(
+                str(lock_id),
+                root_ctx.shared_config.etcetra_etcd,
+                lifetime=min(lifetime_hint * 2, lifetime_hint + 30),
+            )
         case other:
             raise ValueError(f"Invalid lock backend: {other}")
 


### PR DESCRIPTION
This PR brings back `etcetra` flavored `AsyncEtcd` implementation so that the client can remain as an option for our lock backend. These changes are temporary painkillers and should be reverted once `etcd-client-py` gets mature enough to rely on.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version