### PR TITLE
feat: Make distributed-lock backends configurable

### DIFF
--- a/changes/2080.feature.md
+++ b/changes/2080.feature.md
@@ -1,0 +1,1 @@
+Enable distribute-lock configuration

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -133,7 +133,7 @@ agent-selection-resource-priority = ["cuda", "rocm", "tpu", "cpu", "mem"]
 # Choose the implementation of distributed lock.
 # "filelock" is the simplest one when the manager is deployed on only one node.
 # "pg_advisory" uses PostgreSQL's session-level advisory lock.
-# "redlock" uses Redis-based distributed lock (Redlock) -- currently not supported.
+# "redlock" uses Redis-based distributed lock (Redlock).
 # "etcd" uses etcd-based distributed lock via etcd-client-py.
 # distributed-lock = "pg_advisory"
 

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -4,10 +4,12 @@ import abc
 import asyncio
 import fcntl
 import logging
+from collections.abc import Mapping
 from io import IOBase
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
+import trafaret as t
 from etcd_client import Client as EtcdClient
 from etcd_client import Communicator as EtcdCommunicator
 from etcd_client import EtcdLockOption
@@ -36,6 +38,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 
 
 class AbstractDistributedLock(metaclass=abc.ABCMeta):
+    default_config: ClassVar[Mapping[str, Any]] = {}
+    config_iv: ClassVar[t.Trafaret] = t.Dict().allow_extra("*")
+
     def __init__(self, *, lifetime: Optional[float] = None) -> None:
         assert lifetime is None or lifetime >= 0.0
         self._lifetime = lifetime
@@ -207,7 +212,14 @@ class RedisLock(AbstractDistributedLock):
     _lock: Optional[AsyncRedisLock]
 
     default_timeout = 9600
-    default_lock_acquire_pause = 1.0
+    default_lock_retry_interval = 1.0
+
+    default_config: ClassVar[Mapping[str, Any]] = {
+        "lock_retry_interval": default_lock_retry_interval
+    }
+    config_iv: ClassVar[t.Trafaret] = t.Dict({
+        t.Key("lock_retry_interval", default=None): t.Null | t.ToFloat[0:],
+    }).allow_extra("*")
 
     def __init__(
         self,
@@ -217,14 +229,18 @@ class RedisLock(AbstractDistributedLock):
         timeout: Optional[float] = None,
         lifetime: Optional[float] = None,
         debug: bool = False,
-        lock_acquire_pause: Optional[float] = None,
+        lock_retry_interval: Optional[float] = None,
     ):
         super().__init__(lifetime=lifetime)
         self.lock_name = lock_name
         self._redis = redis.client
         self._timeout = timeout if timeout is not None else self.default_timeout
         self._debug = debug
-        self._lock_acquire_pause = lock_acquire_pause or self.default_lock_acquire_pause
+        self._lock_retry_interval = (
+            lock_retry_interval
+            if lock_retry_interval is not None
+            else self.default_lock_retry_interval
+        )
 
     async def __aenter__(self) -> None:
         self._lock = AsyncRedisLock(
@@ -233,7 +249,7 @@ class RedisLock(AbstractDistributedLock):
             blocking_timeout=self._timeout,
             timeout=self._lifetime,
             thread_local=False,
-            sleep=self._lock_acquire_pause,
+            sleep=self._lock_retry_interval,
         )
         try:
             await self._lock.__aenter__()

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -209,6 +209,7 @@ from ai.backend.common.defs import DEFAULT_FILE_IO_TIMEOUT
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.etcd_etcetra import AsyncEtcd as EtcetraAsyncEtcd
 from ai.backend.common.identity import get_instance_id
+from ai.backend.common.lock import EtcdLock, FileLock, RedisLock
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import (
     HostPortPair,
@@ -223,6 +224,7 @@ from ..manager.defs import INTRINSIC_SLOTS
 from .api import ManagerStatus
 from .api.exceptions import ObjectNotFound, ServerMisconfiguredError
 from .models.session import SessionStatus
+from .pglock import PgAdvisoryLock
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
@@ -276,6 +278,12 @@ manager_local_config_iv = (
                 "etcd",
                 "etcetra",
             ),
+            t.Key(
+                "pg-advisory-config", default=PgAdvisoryLock.default_config
+            ): PgAdvisoryLock.config_iv,
+            t.Key("filelock-config", default=FileLock.default_config): FileLock.config_iv,
+            t.Key("redlock-config", default=RedisLock.default_config): RedisLock.config_iv,
+            t.Key("etcdlock-config", default=EtcdLock.default_config): EtcdLock.config_iv,
             t.Key("pid-file", default=os.devnull): tx.Path(
                 type="file",
                 allow_nonexisting=True,

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -733,10 +733,13 @@ def init_lock_factory(root_ctx: RootContext) -> DistributedLockFactory:
         case "redlock":
             from ai.backend.common.lock import RedisLock
 
+            redlock_config = root_ctx.local_config["manager"]["redlock-config"]
+
             return lambda lock_id, lifetime_hint: RedisLock(
                 str(lock_id),
                 root_ctx.redis_lock,
                 lifetime=min(lifetime_hint * 2, lifetime_hint + 30),
+                lock_retry_interval=redlock_config["lock_retry_interval"],
             )
         case "etcd":
             from ai.backend.common.lock import EtcdLock


### PR DESCRIPTION
Some distribute locks need detail configuration.
Let's enable it with config validation backward compatibility.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version