### PR TITLE
chore: Allow 'DELETE' method for vfolder delete-from-trash API

### DIFF
--- a/changes/2092.misc.md
+++ b/changes/2092.misc.md
@@ -1,0 +1,1 @@
+Allow `DELETE` method for vfolder delete-from-trash API

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3501,6 +3501,7 @@ def create_app(default_cors_options):
     cors.add(add_route("POST", r"/purge", purge))
     cors.add(add_route("POST", r"/restore-from-trash-bin", restore))
     cors.add(add_route("POST", r"/delete-from-trash-bin", delete_from_trash_bin))
+    cors.add(add_route("DELETE", r"/_/delete-from-trash-bin", delete_from_trash_bin))
     cors.add(add_route("GET", r"/invitations/list-sent", list_sent_invitations))
     cors.add(add_route("GET", r"/invitations/list_sent", list_sent_invitations))  # legacy underbar
     cors.add(add_route("POST", r"/invitations/update/{inv_id}", update_invitation))


### PR DESCRIPTION
Currently only `POST` method is used for vfolder delete-from-trash API.
Let's allow `DELETE` method for easy usage.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2082.org.readthedocs.build/en/2082/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2082.org.readthedocs.build/ko/2082/

<!-- readthedocs-preview sorna-ko end -->