### PR TITLE
feature: enhanced PostgreSQL connection mgmt

### DIFF
--- a/tests/manager/models/test_dbutils.py
+++ b/tests/manager/models/test_dbutils.py
@@ -1,8 +1,10 @@
+import asyncio
+
 import aiotools
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.manager.models.utils import execute_with_retry
+from ai.backend.manager.models.utils import execute_with_retry, execute_with_txn_retry
 
 
 @pytest.mark.asyncio
@@ -43,3 +45,53 @@ async def test_execute_with_retry():
 
         ret = await execute_with_retry(txn_func_temporary_serialization_failure)
         assert ret == 1234
+
+
+@pytest.mark.asyncio
+async def test_execute_with_trx_retry(database_engine):
+    class DummyDBError(Exception):
+        def __init__(self, pgcode):
+            self.pgcode = pgcode
+
+    async def txn_func_generic_failure(db_session):
+        raise sa.exc.IntegrityError("DUMMY_SQL", params=None, orig=DummyDBError("999"))
+
+    async def txn_func_generic_failure_2(db_session):
+        raise ZeroDivisionError("oops")
+
+    async def txn_func_permanent_serialization_failure(db_session):
+        raise sa.exc.DBAPIError("DUMMY_SQL", params=None, orig=DummyDBError("40001"))
+
+    _fail_count = 0
+
+    async def txn_func_temporary_serialization_failure(db_session):
+        nonlocal _fail_count
+        _fail_count += 1
+        if _fail_count == 5:
+            return 1234
+        raise sa.exc.DBAPIError("DUMMY_SQL", params=None, orig=DummyDBError("40001"))
+
+    with pytest.raises(sa.exc.IntegrityError):
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_generic_failure, database_engine.begin_session, conn
+            )
+
+    with pytest.raises(ZeroDivisionError):
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_generic_failure_2, database_engine.begin_session, conn
+            )
+
+    with pytest.raises(asyncio.TimeoutError) as e:
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_permanent_serialization_failure, database_engine.begin_session, conn
+            )
+    assert "serialization failed" in e.value.args[0].lower()
+
+    async with database_engine.connect() as conn:
+        ret = await execute_with_txn_retry(
+            txn_func_temporary_serialization_failure, database_engine.begin_session, conn
+        )
+    assert ret == 1234


### PR DESCRIPTION
This is a stacked PR migrated from #1817

Improve PostgreSQL connection management.
The point is replacing connection retry function `execute_with_retry()` to transaction retry function `execute_with_txn_retry()`.

## Connection and transaction management
`sqlalchemy.Connection` object and `sqlalchemy.Engine` object can open DB transactions.
We can open multiple transactions in a single DB connection by calling `Connection.begin()` while calling `Engine.begin()` opens a new DB connection for every transaction.

Currently Backend.AI Manager opens a new DB connection for every DB transaction and it can cause connection burden especially when it runs `models.utils.execute_with_retry()` which retries entire DB connection.

Let's decrease the connection burden by managing a lifecycle of `Connection`s and retry DB transaction within a connection.

- https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.begin
- https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine.connect


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation