### PR TITLE
feat: update manager to utilize network plugin

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,7 @@ Backend.AI Migration Guide
 
 # 24.09 to 24.12
 * `endpoints.desired_session_count` is renamed to `endpoints.replicas`. External components locating the database column directly should be updated accordingly.
+* Etcd config `config/network/overlay` must be moved to `config/plugins/network/overlay`.
 
 # 24.03 to 24.09
 * PostgreSQL version upgraded from 15.1 to 16.3. Before upgrading, create a data dump, and restore the data after the upgrade is complete.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -506,20 +506,20 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         )
 
     async def apply_network(self, cluster_info: ClusterInfo) -> None:
-        if cluster_info["network_name"] == "host":
+        if cluster_info["network_config"].get("network_name") == "host":
             self.container_configs.append({
                 "HostConfig": {
                     "NetworkMode": "host",
                 },
             })
-        elif cluster_info["network_name"] is not None:
+        elif cluster_info["network_config"].get("network_name") is not None:
             self.container_configs.append({
                 "HostConfig": {
-                    "NetworkMode": cluster_info["network_name"],
+                    "NetworkMode": cluster_info["network_config"].get("network_name"),
                 },
                 "NetworkingConfig": {
                     "EndpointsConfig": {
-                        cluster_info["network_name"]: {
+                        cluster_info["network_config"].get("network_name"): {
                             "Aliases": [self.kernel_config["cluster_hostname"]],
                         },
                     },

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1047,7 +1047,7 @@ class ClusterInfo(TypedDict):
     mode: ClusterMode
     size: int
     replicas: Mapping[str, int]  # per-role kernel counts
-    network_name: Optional[str]
+    network_config: Mapping[str, Any]
     ssh_keypair: ClusterSSHKeyPair
     cluster_ssh_port_mapping: Optional[ClusterSSHPortMapping]
 
@@ -1080,6 +1080,7 @@ class KernelCreationResult(TypedDict):
 
 class KernelCreationConfig(TypedDict):
     image: ImageConfig
+    network_id: str
     auto_pull: AutoPullBehavior
     session_type: SessionTypes
     cluster_mode: ClusterMode

--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -81,6 +81,7 @@ async def _handle_gql_common(request: web.Request, params: Any) -> ExecutionResu
         redis_stat=root_ctx.redis_stat,
         redis_image=root_ctx.redis_image,
         redis_live=root_ctx.redis_live,
+        network_plugin_ctx=root_ctx.network_plugin_ctx,
         manager_status=manager_status,
         known_slot_types=known_slot_types,
         background_task_manager=root_ctx.background_task_manager,

--- a/src/ai/backend/manager/api/context.py
+++ b/src/ai/backend/manager/api/context.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import attrs
 
+from ai.backend.manager.plugin.network import NetworkPluginContext
+
 if TYPE_CHECKING:
     from ai.backend.common.bgtask import BackgroundTaskManager
     from ai.backend.common.events import EventDispatcher, EventProducer
@@ -46,6 +48,7 @@ class RootContext(BaseContext):
     idle_checker_host: IdleCheckerHost
     storage_manager: StorageSessionManager
     hook_plugin_ctx: HookPluginContext
+    network_plugin_ctx: NetworkPluginContext
 
     registry: AgentRegistry
     agent_cache: AgentRPCCache

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -214,6 +214,8 @@ type Queries {
 
   """Added in 24.03.0."""
   model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection
+  network(id: UUID!): NetworkNode
+  networks(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): NetworkConnection
 }
 
 """
@@ -1598,6 +1600,37 @@ type ModelCardEdge {
   cursor: String!
 }
 
+type NetworkNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  row_id: UUID
+  name: String
+  ref_name: String
+  project: UUID
+  domain_name: String
+  options: JSONString
+}
+
+type NetworkConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NetworkEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""A Relay edge containing a `Network` and its cursor."""
+type NetworkEdge {
+  """The item at the end of the edge"""
+  node: NetworkNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
 """All available GraphQL mutations."""
 type Mutations {
   modify_agent(id: String!, props: ModifyAgentInput!): ModifyAgent
@@ -1802,6 +1835,9 @@ type Mutations {
 
   """Added in 24.09.0."""
   check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
+  create_network(name: String!, project: UUID!): CreateNetwork
+  modify_network(network_id: UUID!, props: ModifyNetworkInput!): ModifyNetwork
+  delete_network(network_id: UUID!): DeleteNetwork
 }
 
 type ModifyAgent {
@@ -2616,4 +2652,23 @@ type CheckAndTransitStatus {
 input CheckAndTransitStatusInput {
   ids: [GlobalIDField]!
   client_mutation_id: String
+type CreateNetwork {
+  ok: Boolean
+  msg: String
+  network: NetworkNode
+}
+
+type ModifyNetwork {
+  ok: Boolean
+  msg: String
+  network: NetworkNode
+}
+
+input ModifyNetworkInput {
+  name: String!
+}
+
+type DeleteNetwork {
+  ok: Boolean
+  msg: String
 }

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -2655,6 +2655,8 @@ type CheckAndTransitStatus {
 input CheckAndTransitStatusInput {
   ids: [GlobalIDField]!
   client_mutation_id: String
+}
+
 type CreateNetwork {
   ok: Boolean
   msg: String

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -214,7 +214,11 @@ type Queries {
 
   """Added in 24.03.0."""
   model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection
+
+  """Added in 24.12.0."""
   network(id: String!): NetworkNode
+
+  """Added in 24.12.0."""
   networks(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): NetworkConnection
 }
 
@@ -1838,8 +1842,14 @@ type Mutations {
 
   """Added in 24.09.0."""
   check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
+
+  """Added in 24.12.0."""
   create_network(driver: String, name: String!, project_id: UUID!): CreateNetwork
+
+  """Added in 24.12.0."""
   modify_network(network: String!, props: ModifyNetworkInput!): ModifyNetwork
+
+  """Added in 24.12.0."""
   delete_network(network: String!): DeleteNetwork
 }
 

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1604,6 +1604,7 @@ type ModelCardEdge {
   cursor: String!
 }
 
+"""Added in 24.12.0."""
 type NetworkNode implements Node {
   """The ID of the object"""
   id: ID!
@@ -1618,6 +1619,7 @@ type NetworkNode implements Node {
   updated_at: DateTime
 }
 
+"""Added in 24.12.0."""
 type NetworkConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -2667,22 +2669,26 @@ input CheckAndTransitStatusInput {
   client_mutation_id: String
 }
 
+"""Added in 24.12.0."""
 type CreateNetwork {
   ok: Boolean
   msg: String
   network: NetworkNode
 }
 
+"""Added in 24.12.0."""
 type ModifyNetwork {
   ok: Boolean
   msg: String
   network: NetworkNode
 }
 
+"""Added in 24.12.0."""
 input ModifyNetworkInput {
   name: String!
 }
 
+"""Added in 24.12.0."""
 type DeleteNetwork {
   ok: Boolean
   msg: String

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -214,7 +214,7 @@ type Queries {
 
   """Added in 24.03.0."""
   model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection
-  network(id: UUID!): NetworkNode
+  network(id: String!): NetworkNode
   networks(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): NetworkConnection
 }
 
@@ -1606,9 +1606,12 @@ type NetworkNode implements Node {
   row_id: UUID
   name: String
   ref_name: String
+  driver: String
   project: UUID
   domain_name: String
   options: JSONString
+  created_at: DateTime
+  updated_at: DateTime
 }
 
 type NetworkConnection {
@@ -1835,9 +1838,9 @@ type Mutations {
 
   """Added in 24.09.0."""
   check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
-  create_network(name: String!, project: UUID!): CreateNetwork
-  modify_network(network_id: UUID!, props: ModifyNetworkInput!): ModifyNetwork
-  delete_network(network_id: UUID!): DeleteNetwork
+  create_network(driver: String, name: String!, project_id: UUID!): CreateNetwork
+  modify_network(network: String!, props: ModifyNetworkInput!): ModifyNetwork
+  delete_network(network: String!): DeleteNetwork
 }
 
 type ModifyAgent {

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1631,7 +1631,7 @@ type NetworkConnection {
   count: Int
 }
 
-"""A Relay edge containing a `Network` and its cursor."""
+"""Added in 24.12.0. A Relay edge containing a `Network` and its cursor."""
 type NetworkEdge {
   """The item at the end of the edge"""
   node: NetworkNode

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -414,7 +414,8 @@ shared_config_iv = t.Dict({
     t.Key("network", default=_config_defaults["network"]): t.Dict({
         t.Key("inter-container", default=_config_defaults["network"]["inter-container"]): t.Dict({
             t.Key(
-                "default-driver", default=_config_defaults["network"]["inter-container"]["default-driver"]
+                "default-driver",
+                default=_config_defaults["network"]["inter-container"]["default-driver"],
             ): t.Null | t.String,
         }).allow_extra("*"),
         t.Key("subnet", default=_config_defaults["network"]["subnet"]): t.Dict({

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -96,17 +96,20 @@ Alias keys are also URL-quoted in the same way.
          + "cuda"
            - allocation_mode: "discrete"
            ...
+       + network
+         + "overlay"
+           - mtu: 1500  # Maximum Transmission Unit
        + scheduler
          + "fifo"
          + "lifo"
          + "drf"
          ...
      + network
+       + inter-container:
+         - default-driver: "overlay"
        + subnet
          - agent: "0.0.0.0/0"
          - container: "0.0.0.0/0"
-       + overlay
-         - mtu: 1500  # Maximum Transmission Unit
        + rpc
          - keepalive-timeout: 60  # seconds
      + watcher
@@ -330,16 +333,17 @@ _config_defaults: Mapping[str, Any] = {
         },
     },
     "network": {
+        "inter-container": {
+            "default-driver": "overlay",
+        },
         "subnet": {
             "agent": "0.0.0.0/0",
             "container": "0.0.0.0/0",
         },
-        "overlay": {
-            "mtu": "1500",
-        },
     },
     "plugins": {
         "accelerator": {},
+        "network": {},
         "scheduler": {},
         "agent-selector": {},
     },
@@ -408,15 +412,16 @@ shared_config_iv = t.Dict({
         ),
     }).allow_extra("*"),
     t.Key("network", default=_config_defaults["network"]): t.Dict({
+        t.Key("inter-container", default=_config_defaults["network"]["inter-container"]): t.Dict({
+            t.Key(
+                "default-driver", default=_config_defaults["network"]["inter-container"]["default-driver"]
+            ): t.Null | t.String,
+        }).allow_extra("*"),
         t.Key("subnet", default=_config_defaults["network"]["subnet"]): t.Dict({
             t.Key("agent", default=_config_defaults["network"]["subnet"]["agent"]): tx.IPNetwork,
             t.Key(
                 "container", default=_config_defaults["network"]["subnet"]["container"]
             ): tx.IPNetwork,
-        }).allow_extra("*"),
-        t.Key("overlay", default=_config_defaults["network"]["overlay"]): t.Null
-        | t.Dict({
-            t.Key("mtu", default=_config_defaults["network"]["overlay"]["mtu"]): t.ToInt(gte=1),
         }).allow_extra("*"),
     }).allow_extra("*"),
     t.Key("watcher", default=_config_defaults["watcher"]): t.Dict({

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -343,9 +343,9 @@ class Mutations(graphene.ObjectType):
     modify_endpoint = ModifyEndpoint.Field()
 
     check_and_transit_session_status = CheckAndTransitStatus.Field(description="Added in 24.09.0.")
-    create_network = CreateNetwork.Field(description="Added in 24.12.0.")
-    modify_network = ModifyNetwork.Field(description="Added in 24.12.0.")
-    delete_network = DeleteNetwork.Field(description="Added in 24.12.0.")
+    create_network = CreateNetwork.Field()
+    modify_network = ModifyNetwork.Field()
+    delete_network = DeleteNetwork.Field()
 
 
 class Queries(graphene.ObjectType):

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -343,9 +343,9 @@ class Mutations(graphene.ObjectType):
     modify_endpoint = ModifyEndpoint.Field()
 
     check_and_transit_session_status = CheckAndTransitStatus.Field(description="Added in 24.09.0.")
-    create_network = CreateNetwork.Field()
-    modify_network = ModifyNetwork.Field()
-    delete_network = DeleteNetwork.Field()
+    create_network = CreateNetwork.Field(description="Added in 24.12.0.")
+    modify_network = ModifyNetwork.Field(description="Added in 24.12.0.")
+    delete_network = DeleteNetwork.Field(description="Added in 24.12.0.")
 
 
 class Queries(graphene.ObjectType):
@@ -895,10 +895,9 @@ class Queries(graphene.ObjectType):
     model_cards = PaginatedConnectionField(ModelCardConnection, description="Added in 24.03.0.")
 
     network = graphene.Field(
-        NetworkNode,
-        id=graphene.String(required=True),
+        NetworkNode, id=graphene.String(required=True), description="Added in 24.12.0."
     )
-    networks = PaginatedConnectionField(NetworkConnection)
+    networks = PaginatedConnectionField(NetworkConnection, description="Added in 24.12.0.")
 
     @staticmethod
     @privileged_query(UserRole.SUPERADMIN)

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -11,6 +11,8 @@ from graphene.types.inputobjecttype import set_input_object_type_default_value
 from graphql import OperationType, Undefined
 from graphql.type import GraphQLField
 
+from ai.backend.manager.plugin.network import NetworkPluginContext
+
 set_input_object_type_default_value(Undefined)
 
 from ai.backend.common.types import QuotaScopeID, SessionId
@@ -129,6 +131,7 @@ from .kernel import (
     LegacyComputeSessionList,
 )
 from .keypair import CreateKeyPair, DeleteKeyPair, KeyPair, KeyPairList, ModifyKeyPair
+from .network import CreateNetwork, DeleteNetwork, ModifyNetwork, NetworkConnection, NetworkNode
 from .rbac import ProjectScope, ScopeType, SystemScope
 from .rbac.permission_defs import AgentPermission, ComputeSessionPermission, DomainPermission
 from .rbac.permission_defs import VFolderPermission as VFolderRBACPermission
@@ -207,6 +210,7 @@ class GraphQueryContext:
     user: Mapping[str, Any]  # TODO: express using typed dict
     access_key: str
     db: ExtendedAsyncSAEngine
+    network_plugin_ctx: NetworkPluginContext
     redis_stat: RedisConnectionInfo
     redis_live: RedisConnectionInfo
     redis_image: RedisConnectionInfo
@@ -339,6 +343,9 @@ class Mutations(graphene.ObjectType):
     modify_endpoint = ModifyEndpoint.Field()
 
     check_and_transit_session_status = CheckAndTransitStatus.Field(description="Added in 24.09.0.")
+    create_network = CreateNetwork.Field()
+    modify_network = ModifyNetwork.Field()
+    delete_network = DeleteNetwork.Field()
 
 
 class Queries(graphene.ObjectType):
@@ -886,6 +893,12 @@ class Queries(graphene.ObjectType):
         ModelCard, id=graphene.String(required=True), description="Added in 24.03.0."
     )
     model_cards = PaginatedConnectionField(ModelCardConnection, description="Added in 24.03.0.")
+
+    network = graphene.Field(
+        NetworkNode,
+        id=graphene.String(required=True),
+    )
+    networks = PaginatedConnectionField(NetworkConnection)
 
     @staticmethod
     @privileged_query(UserRole.SUPERADMIN)
@@ -2564,6 +2577,38 @@ class Queries(graphene.ObjectType):
         last: int | None = None,
     ) -> ConnectionResolverResult[ModelCard]:
         return await ModelCard.get_connection(
+            info,
+            filter,
+            order,
+            offset,
+            after,
+            first,
+            before,
+            last,
+        )
+
+    @staticmethod
+    async def resolve_network(
+        root: Any,
+        info: graphene.ResolveInfo,
+        id: str,
+    ):
+        return await NetworkNode.get_node(info, id)
+
+    @staticmethod
+    async def resolve_networks(
+        root: Any,
+        info: graphene.ResolveInfo,
+        *,
+        filter: str | None = None,
+        order: str | None = None,
+        offset: int | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        before: str | None = None,
+        last: int | None = None,
+    ) -> ConnectionResolverResult:
+        return await NetworkNode.get_connection(
             info,
             filter,
             order,

--- a/src/ai/backend/manager/models/network.py
+++ b/src/ai/backend/manager/models/network.py
@@ -142,6 +142,8 @@ class NetworkRow(Base):
 
 
 class NetworkNode(graphene.ObjectType):
+    """Added in 24.12.0."""
+
     class Meta:
         interfaces = (AsyncNode,)
 
@@ -294,6 +296,8 @@ class NetworkNode(graphene.ObjectType):
 
 
 class CreateNetwork(graphene.Mutation):
+    """Added in 24.12.0."""
+
     allowed_roles = (UserRole.ADMIN, UserRole.SUPERADMIN)
 
     class Arguments:
@@ -364,10 +368,14 @@ class CreateNetwork(graphene.Mutation):
 
 
 class ModifyNetworkInput(graphene.InputObjectType):
+    """Added in 24.12.0."""
+
     name = graphene.String(required=True)
 
 
 class ModifyNetwork(graphene.Mutation):
+    """Added in 24.12.0."""
+
     allowed_roles = (UserRole.ADMIN, UserRole.SUPERADMIN)
 
     class Arguments:
@@ -420,6 +428,8 @@ class ModifyNetwork(graphene.Mutation):
 
 
 class DeleteNetwork(graphene.Mutation):
+    """Added in 24.12.0."""
+
     allowed_roles = (UserRole.ADMIN, UserRole.SUPERADMIN)
 
     class Arguments:
@@ -468,5 +478,7 @@ class DeleteNetwork(graphene.Mutation):
 
 
 class NetworkConnection(Connection):
+    """Added in 24.12.0."""
+
     class Meta:
         node = NetworkNode

--- a/src/ai/backend/manager/models/network.py
+++ b/src/ai/backend/manager/models/network.py
@@ -482,3 +482,4 @@ class NetworkConnection(Connection):
 
     class Meta:
         node = NetworkNode
+        description = "Added in 24.12.0."

--- a/src/ai/backend/manager/network/overlay.py
+++ b/src/ai/backend/manager/network/overlay.py
@@ -22,7 +22,7 @@ class OverlayNetworkPlugin(AbstractNetworkManagerPlugin):
     def __init__(self, plugin_config: Mapping[str, Any], local_config: Mapping[str, Any]) -> None:
         super().__init__(plugin_config, local_config)
 
-        plugin_config_iv.check(plugin_config)
+        self.plugin_config = plugin_config_iv.check(plugin_config)
 
     async def init(self, context: Any = None) -> None:
         self.docker = aiodocker.Docker()
@@ -33,6 +33,9 @@ class OverlayNetworkPlugin(AbstractNetworkManagerPlugin):
 
     async def cleanup(self) -> None:
         await self.docker.close()
+
+    async def update_plugin_config(self, plugin_config: Mapping[str, Any]) -> None:
+        return await super().update_plugin_config(plugin_config)
 
     async def create_network(
         self, *, identifier: str | None = None, options: dict[str, Any] = {}
@@ -56,8 +59,12 @@ class OverlayNetworkPlugin(AbstractNetworkManagerPlugin):
         await self.docker.networks.create(create_options)
 
         return NetworkInfo(
-            network_id=ident,
-            options={"mode": "overlay", "network_name": network_name},
+            network_id=network_name,
+            options={
+                "mode": "overlay",
+                "network_name": network_name,
+                "network_id": network_name,
+            },
         )
 
     async def destroy_network(self, network_id: str) -> None:

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -813,7 +813,7 @@ async def registry_ctx(mocker):
     mock_event_producer.produce_event = AsyncMock()
     # mocker.object.patch(mocked_etcd, 'get_prefix', AsyncMock(return_value={}))
     hook_plugin_ctx = HookPluginContext(mocked_etcd, {})  # type: ignore
-    hook_plugin_ctx = NetworkPluginContext(mocked_etcd, {})  # type: ignore
+    network_plugin_ctx = NetworkPluginContext(mocked_etcd, {})  # type: ignore
 
     registry = AgentRegistry(
         local_config=mock_local_config,
@@ -827,6 +827,7 @@ async def registry_ctx(mocker):
         event_producer=mock_event_producer,
         storage_manager=None,  # type: ignore
         hook_plugin_ctx=hook_plugin_ctx,
+        network_plugin_ctx=network_plugin_ctx,
         agent_cache=mock_agent_cache,
         manager_public_key=PublicKey(b"GqK]ZYY#h*9jAQbGxSwkeZX3Y*%b+DiY$7ju6sh{"),
         manager_secret_key=SecretKey(b"37KX6]ac^&hcnSaVo=-%eVO9M]ENe8v=BOWF(Sw$"),

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -76,6 +76,7 @@ from ai.backend.manager.models.base import (
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts
 from ai.backend.manager.models.utils import connect_database
+from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.server import build_root_app
 from ai.backend.testutils.bootstrap import (  # noqa: F401
@@ -812,6 +813,7 @@ async def registry_ctx(mocker):
     mock_event_producer.produce_event = AsyncMock()
     # mocker.object.patch(mocked_etcd, 'get_prefix', AsyncMock(return_value={}))
     hook_plugin_ctx = HookPluginContext(mocked_etcd, {})  # type: ignore
+    hook_plugin_ctx = NetworkPluginContext(mocked_etcd, {})  # type: ignore
 
     registry = AgentRegistry(
         local_config=mock_local_config,

--- a/tests/manager/models/test_container_registries.py
+++ b/tests/manager/models/test_container_registries.py
@@ -35,6 +35,7 @@ def get_graphquery_context(database_engine: ExtendedAsyncSAEngine) -> GraphQuery
         user={"domain": "default", "role": "superadmin"},
         access_key="AKIAIOSFODNN7EXAMPLE",
         db=database_engine,  # type: ignore
+        network_plugin_ctx=None,  # type: ignore
         redis_stat=None,  # type: ignore
         redis_image=None,  # type: ignore
         redis_live=None,  # type: ignore

--- a/tests/manager/models/test_container_registry_nodes.py
+++ b/tests/manager/models/test_container_registry_nodes.py
@@ -64,6 +64,7 @@ def get_graphquery_context(database_engine: ExtendedAsyncSAEngine) -> GraphQuery
         storage_manager=None,  # type: ignore
         registry=None,  # type: ignore
         idle_checker_host=None,  # type: ignore
+        network_plugin_ctx=None,  # type: ignore
     )
 
 


### PR DESCRIPTION
This PR encapsulates container network allocation process as a separate plugin architecture. By default, Backend.AI Manager will ship with a default `overlay` plugin, which in previous supported as one and only option when establishing an inter-container network.    

## Operational update
To support multiple architectures, system operators will now have to explicitly specify which network drivers they will use when creating a multi-node session. Check `MIGRATION.md` for more details.

## Creating new plugin
Just like other computational plugins, Backend.AI Manager Network Plugin is based on Backend.AI's plugin architecture. Create a new network class by inheriting `AbstractNetworkManagerPlugin` and implement every abstract methods. Then expose the class with entrypoint `backendai_network_manager_v1`.    
If your plugin requires any customizable field then pour the values under etcd, with keys prefixed as `config/plugins/network/<plugin name>`. The configured items later can be accessed from plugin with `self.plugin_config` variable. 

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2098.org.readthedocs.build/en/2098/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2098.org.readthedocs.build/ko/2098/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2098.org.readthedocs.build/en/2098/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2098.org.readthedocs.build/ko/2098/

<!-- readthedocs-preview sorna-ko end -->