### PR TITLE
fix: Initialization of kernel-level usage aggregation in the resource usage API

### DIFF
--- a/changes/2102.fix.md
+++ b/changes/2102.fix.md
@@ -1,1 +1,1 @@
-Fix initialization of zero values in the resource usage API's kernel-level usage aggregation
+Fix initialization of the resource usage API's kernel-level usage aggregation

--- a/changes/2102.fix.md
+++ b/changes/2102.fix.md
@@ -1,1 +1,1 @@
-Fix zeroed KernelResourceUsage.total_usage field to initiate it to valid values
+Fix initialization of zero values in the resource usage API's kernel-level usage aggregation

--- a/changes/2102.fix.md
+++ b/changes/2102.fix.md
@@ -1,0 +1,1 @@
+Fix zeroed KernelResourceUsage.total_usage field to initiate it to valid values

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -267,10 +267,7 @@ class KernelResourceUsage(BaseResourceUsageGroup):
             session_row=usage_group.session_row,
             kernel_row=usage_group.kernel_row,
             agent=usage_group.kernel_row.agent,
-            **{
-                **usage_group.to_map(),
-                "total_usage": ResourceUsage(),
-            },
+            **usage_group.to_map(),
         )
 
     def register_resource_group(


### PR DESCRIPTION
follow-up #2062, #962
`KernelResourceUsage.total_usage` field is empty currently
Let's not initiate its `total_usage` field with 0(or null) values.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)