### PR TITLE
feature: apply enhanced postgres cnx mgmt to registry and scheduler modules

### DIFF
--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -11,6 +11,7 @@ addr = { host = "localhost", port = 8100 }
 name = "backend"
 user = "postgres"
 password = "develove"
+conn-timeout = 0
 pool-recycle = 50
 pool-pre-ping = false
 

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -26,6 +26,11 @@ password = "DB_PASSWORD"                    # env: BACKEND_DB_PASSWORD
 # (See https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_size)
 # pool-size = 8
 
+# The connection's lifetime
+# Any connection made from ExtendedAsyncEngine will close after `conn-timeout` seconds
+# Default is 0, which means infinite
+# conn-timeout = 30
+
 # The connections for lock lifetime
 # Distribution locks wait for `lock-conn-timeout` seconds and lock context should finish within this time.
 # Default is 0, which means infinite

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -27,7 +27,7 @@ password = "DB_PASSWORD"                    # env: BACKEND_DB_PASSWORD
 # pool-size = 8
 
 # The connection's lifetime
-# Any connection made from ExtendedAsyncEngine will close after `conn-timeout` seconds
+# Any connection made in `ai.backend.manager.models.utils.ExtendedAsyncEngine` will close after `conn-timeout` seconds
 # Default is 0, which means infinite
 # conn-timeout = 30
 

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -250,6 +250,7 @@ manager_local_config_iv = (
             t.Key("pool-recycle", default=-1): t.ToFloat[-1:],  # -1 is infinite
             t.Key("pool-pre-ping", default=False): t.ToBool,
             t.Key("max-overflow", default=64): t.ToInt[-1:],  # -1 is infinite  # type: ignore
+            t.Key("conn-timeout", default=0): t.ToFloat[0:],  # 0 is infinite
             t.Key("lock-conn-timeout", default=0): t.ToFloat[0:],  # 0 is infinite
         }),
         t.Key("manager"): t.Dict({

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -245,8 +245,8 @@ async def execute_with_txn_retry(
 ) -> TQueryResult: ...
 
 
-# Setting "type ignore" here becuase Mypy does not recognize any types from `sqlalchemy`
-# it just assume all sqlalchemy's types are `Any` including `SASession` and `SAConnection`.
+# Setting "type ignore" here becuase Mypy deduces all fields and attributes in `sqlalchemy` module to `Any` type
+# including `SASession` and `SAConnection`.
 @overload
 async def execute_with_txn_retry(  # type: ignore[misc]
     txn_func: Callable[[SAConnection], Awaitable[TQueryResult]],
@@ -255,7 +255,7 @@ async def execute_with_txn_retry(  # type: ignore[misc]
 ) -> TQueryResult: ...
 
 
-# TODO: Allow only `SASession` parameter, remove type overloading and remove `begin_trx` after migrate Core APIs to ORM.
+# TODO: Allow `SASession` parameter only, remove type overloading and remove `begin_trx` after migrating Core APIs to ORM APIs.
 async def execute_with_txn_retry(
     txn_func: Callable[[SASession], Awaitable[TQueryResult]]
     | Callable[[SAConnection], Awaitable[TQueryResult]],
@@ -266,7 +266,7 @@ async def execute_with_txn_retry(
     """
     Execute DB related function by retrying transaction in a given connection.
 
-    Used to resolve Postgres Serialization error that require transaction retry.
+    The transaction retry resolves Postgres's Serialization error.
     Reference: https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
     """
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -44,7 +44,7 @@ from dateutil.parser import isoparse
 from dateutil.tz import tzutc
 from redis.asyncio import Redis
 from sqlalchemy.exc import DBAPIError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import load_only, noload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 from yarl import URL
@@ -166,10 +166,9 @@ from .models import (
 )
 from .models.utils import (
     ExtendedAsyncSAEngine,
-    execute_with_retry,
+    execute_with_txn_retry,
     is_db_retry_error,
     reenter_txn,
-    reenter_txn_session,
     sql_json_merge,
 )
 from .types import UserScope
@@ -358,12 +357,12 @@ class AgentRegistry:
                 yield row
 
     async def update_instance(self, inst_id, updated_fields):
-        async def _update() -> None:
-            async with self.db.begin() as conn:
-                query = sa.update(agents).values(**updated_fields).where(agents.c.id == inst_id)
-                await conn.execute(query)
+        async def _update(conn: SAConnection) -> None:
+            query = sa.update(agents).values(**updated_fields).where(agents.c.id == inst_id)
+            await conn.execute(query)
 
-        await execute_with_retry(_update)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_update, self.db.begin, conn)
 
     async def gather_agent_hwinfo(self, instance_id: AgentId) -> Mapping[str, HardwareMetadata]:
         agent = await self.get_instance(instance_id, agents.c.addr)
@@ -1223,55 +1222,53 @@ class AgentRegistry:
         session_data["images"] = session_images
         try:
 
-            async def _enqueue() -> None:
-                async with self.db.begin_session() as db_sess:
-                    matched_dependency_session_ids = []
-                    if dependency_sessions:
-                        for dependency_id in dependency_sessions:
-                            try:
-                                match_info = await SessionRow.get_session(
-                                    db_sess,
-                                    dependency_id,
-                                    access_key,
-                                    allow_stale=True,
-                                )
-                            except SessionNotFound:
-                                raise InvalidAPIParameters(
-                                    "Unknown session ID or name in the dependency list",
-                                    extra_data={"session_ref": dependency_id},
-                                )
-                            else:
-                                matched_dependency_session_ids.append(match_info.id)
+            async def _enqueue(db_sess: SASession) -> None:
+                matched_dependency_session_ids = []
+                if dependency_sessions:
+                    for dependency_id in dependency_sessions:
+                        try:
+                            match_info = await SessionRow.get_session(
+                                db_sess,
+                                dependency_id,
+                                access_key,
+                                allow_stale=True,
+                            )
+                        except SessionNotFound:
+                            raise InvalidAPIParameters(
+                                "Unknown session ID or name in the dependency list",
+                                extra_data={"session_ref": dependency_id},
+                            )
+                        else:
+                            matched_dependency_session_ids.append(match_info.id)
 
-                    if sudo_session_enabled:
-                        environ["SUDO_SESSION_ENABLED"] = "1"
+                if sudo_session_enabled:
+                    environ["SUDO_SESSION_ENABLED"] = "1"
 
-                    session_data["environ"] = environ
-                    session_data["requested_slots"] = session_requested_slots
-                    session = SessionRow(**session_data)
-                    kernels = [KernelRow(**kernel) for kernel in kernel_data]
-                    db_sess.add(session)
-                    db_sess.add_all(kernels)
-                    await db_sess.flush()
+                session_data["environ"] = environ
+                session_data["requested_slots"] = session_requested_slots
+                session = SessionRow(**session_data)
+                kernels = [KernelRow(**kernel) for kernel in kernel_data]
+                db_sess.add(session)
+                db_sess.add_all(kernels)
+                await db_sess.flush()
 
-                    if matched_dependency_session_ids:
-                        dependency_rows = [
-                            SessionDependencyRow(session_id=session_id, depends_on=depend_id)
-                            for depend_id in matched_dependency_session_ids
-                        ]
-                        db_sess.add_all(dependency_rows)
+                if matched_dependency_session_ids:
+                    dependency_rows = [
+                        SessionDependencyRow(session_id=session_id, depends_on=depend_id)
+                        for depend_id in matched_dependency_session_ids
+                    ]
+                    db_sess.add_all(dependency_rows)
 
-            await execute_with_retry(_enqueue)
+            async def _post_enqueue(db_sess: SASession) -> None:
+                if route_id:
+                    routing_row = await RoutingRow.get(db_sess, route_id)
+                    routing_row.session = session_id
 
-            async def _post_enqueue() -> None:
-                async with self.db.begin_session() as db_sess:
-                    if route_id:
-                        routing_row = await RoutingRow.get(db_sess, route_id)
-                        routing_row.session = session_id
+                await db_sess.commit()
 
-                    await db_sess.commit()
-
-            await execute_with_retry(_post_enqueue)
+            async with self.db.connect() as conn:
+                await execute_with_txn_retry(_enqueue, self.db.begin_session, conn)
+                await execute_with_txn_retry(_post_enqueue, self.db.begin_session, conn)
         except DBAPIError as e:
             if getattr(e.orig, "pgcode", None) == "23503":
                 match = re.search(r"Key \(agent\)=\((?P<agent>[^)]+)\)", repr(e.orig))
@@ -1643,20 +1640,20 @@ class AgentRegistry:
         assert agent_alloc_ctx.agent_id is not None
         assert scheduled_session.id is not None
 
-        async def _update_kernel() -> None:
-            async with self.db.begin_session() as db_sess:
-                kernel_query = (
-                    sa.update(KernelRow)
-                    .where(KernelRow.id.in_([binding.kernel.id for binding in items]))
-                    .values(
-                        agent=agent_alloc_ctx.agent_id,
-                        agent_addr=agent_alloc_ctx.agent_addr,
-                        scaling_group=agent_alloc_ctx.scaling_group,
-                    )
+        async def _update_kernel(db_sess: SASession) -> None:
+            kernel_query = (
+                sa.update(KernelRow)
+                .where(KernelRow.id.in_([binding.kernel.id for binding in items]))
+                .values(
+                    agent=agent_alloc_ctx.agent_id,
+                    agent_addr=agent_alloc_ctx.agent_addr,
+                    scaling_group=agent_alloc_ctx.scaling_group,
                 )
-                await db_sess.execute(kernel_query)
+            )
+            await db_sess.execute(kernel_query)
 
-        await execute_with_retry(_update_kernel)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_update_kernel, self.db.begin_session, conn)
 
         async with self.agent_cache.rpc_context(
             agent_alloc_ctx.agent_id,
@@ -1739,32 +1736,32 @@ class AgentRegistry:
                 for binding in items:
                     kernel_id = binding.kernel.id
 
-                    async def _update_failure() -> None:
-                        async with self.db.begin_session() as db_sess:
-                            now = datetime.now(tzutc())
-                            query = (
-                                sa.update(KernelRow)
-                                .where(KernelRow.id == kernel_id)
-                                .values(
-                                    status=KernelStatus.ERROR,
-                                    status_info=f"other-error ({ex!r})",
-                                    status_changed=now,
-                                    terminated_at=now,
-                                    status_history=sql_json_merge(
-                                        KernelRow.status_history,
-                                        (),
-                                        {
-                                            KernelStatus.ERROR.name: (
-                                                now.isoformat()
-                                            ),  # ["PULLING", "PREPARING"]
-                                        },
-                                    ),
-                                    status_data=convert_to_status_data(ex, self.debug),
-                                )
+                    async def _update_failure(db_sess: SASession) -> None:
+                        now = datetime.now(tzutc())
+                        query = (
+                            sa.update(KernelRow)
+                            .where(KernelRow.id == kernel_id)
+                            .values(
+                                status=KernelStatus.ERROR,
+                                status_info=f"other-error ({ex!r})",
+                                status_changed=now,
+                                terminated_at=now,
+                                status_history=sql_json_merge(
+                                    KernelRow.status_history,
+                                    (),
+                                    {
+                                        KernelStatus.ERROR.name: (
+                                            now.isoformat()
+                                        ),  # ["PULLING", "PREPARING"]
+                                    },
+                                ),
+                                status_data=convert_to_status_data(ex, self.debug),
                             )
-                            await db_sess.execute(query)
+                        )
+                        await db_sess.execute(query)
 
-                    await execute_with_retry(_update_failure)
+                    async with self.db.connect() as conn:
+                        await execute_with_txn_retry(_update_failure, self.db.begin_session, conn)
                 raise
 
     async def create_cluster_ssh_keypair(self) -> ClusterSSHKeyPair:
@@ -1788,97 +1785,81 @@ class AgentRegistry:
             "public_key": public_key.decode("utf-8"),
         }
 
-    async def get_user_occupancy(self, user_id, *, db_sess=None):
+    async def get_user_occupancy(self, user_id, *, db_sess: SASession) -> ResourceSlot:
         known_slot_types = await self.shared_config.get_resource_slots()
 
-        async def _query() -> ResourceSlot:
-            async with reenter_txn_session(self.db, db_sess) as _sess:
-                query = sa.select(KernelRow.occupied_slots).where(
-                    (KernelRow.user_uuid == user_id)
-                    & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                    & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
-                )
-                zero = ResourceSlot()
-                user_occupied = sum(
-                    [row.occupied_slots async for row in (await _sess.stream(query))], zero
-                )
-                # drop no-longer used slot types
-                user_occupied = ResourceSlot({
-                    key: val for key, val in user_occupied.items() if key in known_slot_types
-                })
-                return user_occupied
+        query = sa.select(KernelRow.occupied_slots).where(
+            (KernelRow.user_uuid == user_id)
+            & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+            & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
+        )
+        zero = ResourceSlot()
+        user_occupied = sum(
+            [row.occupied_slots async for row in (await db_sess.stream(query))], zero
+        )
+        # drop no-longer used slot types
+        user_occupied = ResourceSlot({
+            key: val for key, val in user_occupied.items() if key in known_slot_types
+        })
+        return user_occupied
 
-        return await execute_with_retry(_query)
-
-    async def get_keypair_occupancy(self, access_key, *, db_sess=None):
+    async def get_keypair_occupancy(self, access_key, *, db_sess: SASession) -> ResourceSlot:
         known_slot_types = await self.shared_config.get_resource_slots()
 
-        async def _query() -> ResourceSlot:
-            async with reenter_txn_session(self.db, db_sess) as _sess:
-                query = sa.select(KernelRow.occupied_slots).where(
-                    (KernelRow.access_key == access_key)
-                    & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                    & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
-                )
-                zero = ResourceSlot()
-                key_occupied = sum(
-                    [row.occupied_slots async for row in (await _sess.stream(query))], zero
-                )
-                # drop no-longer used slot types
-                drops = [k for k in key_occupied.keys() if k not in known_slot_types]
-                for k in drops:
-                    del key_occupied[k]
-                return key_occupied
+        query = sa.select(KernelRow.occupied_slots).where(
+            (KernelRow.access_key == access_key)
+            & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+            & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
+        )
+        zero = ResourceSlot()
+        key_occupied = sum(
+            [row.occupied_slots async for row in (await db_sess.stream(query))], zero
+        )
+        # drop no-longer used slot types
+        drops = [k for k in key_occupied.keys() if k not in known_slot_types]
+        for k in drops:
+            del key_occupied[k]
+        return key_occupied
 
-        return await execute_with_retry(_query)
-
-    async def get_domain_occupancy(self, domain_name, *, db_sess=None):
+    async def get_domain_occupancy(self, domain_name, *, db_sess: SASession) -> ResourceSlot:
         # TODO: store domain occupied_slots in Redis?
         known_slot_types = await self.shared_config.get_resource_slots()
 
-        async def _query() -> ResourceSlot:
-            async with reenter_txn_session(self.db, db_sess) as _sess:
-                query = sa.select(KernelRow.occupied_slots).where(
-                    (KernelRow.domain_name == domain_name)
-                    & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                    & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
-                )
-                zero = ResourceSlot()
-                key_occupied = sum(
-                    [row.occupied_slots async for row in (await _sess.stream(query))],
-                    zero,
-                )
-                # drop no-longer used slot types
-                drops = [k for k in key_occupied.keys() if k not in known_slot_types]
-                for k in drops:
-                    del key_occupied[k]
-                return key_occupied
+        query = sa.select(KernelRow.occupied_slots).where(
+            (KernelRow.domain_name == domain_name)
+            & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+            & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
+        )
+        zero = ResourceSlot()
+        key_occupied = sum(
+            [row.occupied_slots async for row in (await db_sess.stream(query))],
+            zero,
+        )
+        # drop no-longer used slot types
+        drops = [k for k in key_occupied.keys() if k not in known_slot_types]
+        for k in drops:
+            del key_occupied[k]
+        return key_occupied
 
-        return await execute_with_retry(_query)
-
-    async def get_group_occupancy(self, group_id, *, db_sess=None):
+    async def get_group_occupancy(self, group_id, *, db_sess: SASession) -> ResourceSlot:
         # TODO: store domain occupied_slots in Redis?
         known_slot_types = await self.shared_config.get_resource_slots()
 
-        async def _query() -> ResourceSlot:
-            async with reenter_txn_session(self.db, db_sess) as _sess:
-                query = sa.select(KernelRow.occupied_slots).where(
-                    (KernelRow.group_id == group_id)
-                    & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                    & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
-                )
-                zero = ResourceSlot()
-                key_occupied = sum(
-                    [row.occupied_slots async for row in (await _sess.stream(query))],
-                    zero,
-                )
-                # drop no-longer used slot types
-                drops = [k for k in key_occupied.keys() if k not in known_slot_types]
-                for k in drops:
-                    del key_occupied[k]
-                return key_occupied
-
-        return await execute_with_retry(_query)
+        query = sa.select(KernelRow.occupied_slots).where(
+            (KernelRow.group_id == group_id)
+            & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+            & (KernelRow.role.not_in(PRIVATE_KERNEL_ROLES)),
+        )
+        zero = ResourceSlot()
+        key_occupied = sum(
+            [row.occupied_slots async for row in (await db_sess.stream(query))],
+            zero,
+        )
+        # drop no-longer used slot types
+        drops = [k for k in key_occupied.keys() if k not in known_slot_types]
+        for k in drops:
+            del key_occupied[k]
+        return key_occupied
 
     async def update_scaling_group(self, id, scaling_group) -> None:
         agent = await self.get_instance(id, agents.c.addr)
@@ -1919,24 +1900,24 @@ class AgentRegistry:
             if actual_allocated_slots != requested_slots:
                 log.debug("calibrating resource slot usage for agent {}", agent_id)
 
-                async def _update_agent_resource() -> None:
-                    async with self.db.begin_session() as db_sess:
-                        select_query = sa.select(AgentRow.occupied_slots).where(
-                            AgentRow.id == agent_id
+                async def _update_agent_resource(db_sess: SASession) -> None:
+                    select_query = sa.select(AgentRow.occupied_slots).where(AgentRow.id == agent_id)
+                    result = await db_sess.execute(select_query)
+                    occupied_slots: ResourceSlot = result.scalar()
+                    diff = actual_allocated_slots - requested_slots
+                    update_query = (
+                        sa.update(AgentRow)
+                        .values(
+                            occupied_slots=ResourceSlot.from_json(occupied_slots) + diff,
                         )
-                        result = await db_sess.execute(select_query)
-                        occupied_slots: ResourceSlot = result.scalar()
-                        diff = actual_allocated_slots - requested_slots
-                        update_query = (
-                            sa.update(AgentRow)
-                            .values(
-                                occupied_slots=ResourceSlot.from_json(occupied_slots) + diff,
-                            )
-                            .where(AgentRow.id == agent_id)
-                        )
-                        await db_sess.execute(update_query)
+                        .where(AgentRow.id == agent_id)
+                    )
+                    await db_sess.execute(update_query)
 
-                await execute_with_retry(_update_agent_resource)
+                async with self.db.connect() as conn:
+                    await execute_with_txn_retry(
+                        _update_agent_resource, self.db.begin_session, conn
+                    )
 
     async def recalc_resource_usage(self, do_fullscan: bool = False) -> None:
         concurrency_used_per_key: MutableMapping[str, set] = defaultdict(
@@ -1946,77 +1927,76 @@ class AgentRegistry:
             set
         )  # key: access_key, value: set of session_id
 
-        async def _recalc() -> None:
+        async def _recalc(db_sess: SASession) -> None:
             occupied_slots_per_agent: MutableMapping[str, ResourceSlot] = defaultdict(
                 lambda: ResourceSlot({"cpu": 0, "mem": 0})
             )
 
-            async with self.db.begin_session() as db_sess:
-                # Query running containers and calculate concurrency_used per AK and
-                # occupied_slots per agent.
-                session_query = (
-                    sa.select(SessionRow)
-                    .where(
-                        (
-                            SessionRow.status.in_({
-                                *AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES,
-                                *USER_RESOURCE_OCCUPYING_SESSION_STATUSES,
-                            })
-                        )
-                    )
-                    .options(
-                        load_only(SessionRow.id, SessionRow.access_key, SessionRow.status),
-                        selectinload(SessionRow.kernels).options(
-                            load_only(KernelRow.agent, KernelRow.role, KernelRow.occupied_slots)
-                        ),
+            # Query running containers and calculate concurrency_used per AK and
+            # occupied_slots per agent.
+            session_query = (
+                sa.select(SessionRow)
+                .where(
+                    (
+                        SessionRow.status.in_({
+                            *AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES,
+                            *USER_RESOURCE_OCCUPYING_SESSION_STATUSES,
+                        })
                     )
                 )
-                async for session_row in await db_sess.stream_scalars(session_query):
-                    session_row = cast(SessionRow, session_row)
-                    for kernel in session_row.kernels:
-                        session_status = cast(SessionStatus, session_row.status)
-                        if session_status in AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES:
-                            occupied_slots_per_agent[kernel.agent] += ResourceSlot(
-                                kernel.occupied_slots
-                            )
-                        if session_status in USER_RESOURCE_OCCUPYING_SESSION_STATUSES:
-                            if kernel.role in PRIVATE_KERNEL_ROLES:
-                                sftp_concurrency_used_per_key[session_row.access_key].add(
-                                    session_row.id
-                                )
-                            else:
-                                concurrency_used_per_key[session_row.access_key].add(session_row.id)
-
-                if len(occupied_slots_per_agent) > 0:
-                    # Update occupied_slots for agents with running containers.
-                    await db_sess.execute(
-                        (
-                            sa.update(AgentRow)
-                            .where(AgentRow.id == sa.bindparam("agent_id"))
-                            .values(occupied_slots=sa.bindparam("occupied_slots"))
-                        ),
-                        [
-                            {"agent_id": aid, "occupied_slots": slots}
-                            for aid, slots in occupied_slots_per_agent.items()
-                        ],
-                    )
-                    await db_sess.execute(
-                        (
-                            sa.update(AgentRow)
-                            .values(occupied_slots=ResourceSlot({}))
-                            .where(AgentRow.status == AgentStatus.ALIVE)
-                            .where(sa.not_(AgentRow.id.in_(occupied_slots_per_agent.keys())))
+                .options(
+                    load_only(SessionRow.id, SessionRow.access_key, SessionRow.status),
+                    selectinload(SessionRow.kernels).options(
+                        load_only(KernelRow.agent, KernelRow.role, KernelRow.occupied_slots)
+                    ),
+                )
+            )
+            async for session_row in await db_sess.stream_scalars(session_query):
+                for kernel in session_row.kernels:
+                    session_status = cast(SessionStatus, session_row.status)
+                    if session_status in AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES:
+                        occupied_slots_per_agent[kernel.agent] += ResourceSlot(
+                            kernel.occupied_slots
                         )
-                    )
-                else:
-                    query = (
+                    if session_status in USER_RESOURCE_OCCUPYING_SESSION_STATUSES:
+                        if kernel.role in PRIVATE_KERNEL_ROLES:
+                            sftp_concurrency_used_per_key[session_row.access_key].add(
+                                session_row.id
+                            )
+                        else:
+                            concurrency_used_per_key[session_row.access_key].add(session_row.id)
+
+            if len(occupied_slots_per_agent) > 0:
+                # Update occupied_slots for agents with running containers.
+                await db_sess.execute(
+                    (
+                        sa.update(AgentRow)
+                        .where(AgentRow.id == sa.bindparam("agent_id"))
+                        .values(occupied_slots=sa.bindparam("occupied_slots"))
+                    ),
+                    [
+                        {"agent_id": aid, "occupied_slots": slots}
+                        for aid, slots in occupied_slots_per_agent.items()
+                    ],
+                )
+                await db_sess.execute(
+                    (
                         sa.update(AgentRow)
                         .values(occupied_slots=ResourceSlot({}))
                         .where(AgentRow.status == AgentStatus.ALIVE)
+                        .where(sa.not_(AgentRow.id.in_(occupied_slots_per_agent.keys())))
                     )
-                    await db_sess.execute(query)
+                )
+            else:
+                query = (
+                    sa.update(AgentRow)
+                    .values(occupied_slots=ResourceSlot({}))
+                    .where(AgentRow.status == AgentStatus.ALIVE)
+                )
+                await db_sess.execute(query)
 
-        await execute_with_retry(_recalc)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_recalc, self.db.begin_session, conn)
 
         # Update keypair resource usage for keypairs with running containers.
         kp_key = "keypair.concurrency_used"
@@ -2287,32 +2267,31 @@ class AgentRegistry:
                             else:
                                 to_be_terminated.append(kernel)
 
-                            async def _update() -> None:
+                            async def _update(db_sess: SASession) -> None:
                                 kern_stat = await redis_helper.execute(
                                     self.redis_stat,
                                     lambda r: r.get(str(kernel.id)),
                                 )
-                                async with self.db.begin_session() as db_sess:
-                                    values = {
-                                        "status": KernelStatus.TERMINATED,
-                                        "status_info": reason,
-                                        "status_changed": now,
-                                        "terminated_at": now,
-                                        "status_history": sql_json_merge(
-                                            KernelRow.status_history,
-                                            (),
-                                            {
-                                                KernelStatus.TERMINATED.name: now.isoformat(),
-                                            },
-                                        ),
-                                    }
-                                    if kern_stat:
-                                        values["last_stat"] = msgpack.unpackb(kern_stat)
-                                    await db_sess.execute(
-                                        sa.update(KernelRow)
-                                        .values(**values)
-                                        .where(KernelRow.id == kernel.id),
-                                    )
+                                values = {
+                                    "status": KernelStatus.TERMINATED,
+                                    "status_info": reason,
+                                    "status_changed": now,
+                                    "terminated_at": now,
+                                    "status_history": sql_json_merge(
+                                        KernelRow.status_history,
+                                        (),
+                                        {
+                                            KernelStatus.TERMINATED.name: now.isoformat(),
+                                        },
+                                    ),
+                                }
+                                if kern_stat:
+                                    values["last_stat"] = msgpack.unpackb(kern_stat)
+                                await db_sess.execute(
+                                    sa.update(KernelRow)
+                                    .values(**values)
+                                    .where(KernelRow.id == kernel.id),
+                                )
 
                             if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
@@ -2329,35 +2308,35 @@ class AgentRegistry:
                                     ),
                                 )
 
-                            await execute_with_retry(_update)
+                            async with self.db.connect() as conn:
+                                await execute_with_txn_retry(_update, self.db.begin_session, conn)
                             await self.event_producer.produce_event(
                                 KernelTerminatedEvent(kernel.id, target_session.id, reason),
                             )
                         case _:
 
-                            async def _update() -> None:
-                                async with self.db.begin_session() as db_sess:
-                                    values = {
-                                        "status": KernelStatus.TERMINATING,
-                                        "status_info": reason,
-                                        "status_changed": now,
-                                        "status_data": {
-                                            "kernel": {"exit_code": None},
-                                            "session": {"status": "terminating"},
+                            async def _update(db_sess: SASession) -> None:
+                                values = {
+                                    "status": KernelStatus.TERMINATING,
+                                    "status_info": reason,
+                                    "status_changed": now,
+                                    "status_data": {
+                                        "kernel": {"exit_code": None},
+                                        "session": {"status": "terminating"},
+                                    },
+                                    "status_history": sql_json_merge(
+                                        KernelRow.status_history,
+                                        (),
+                                        {
+                                            KernelStatus.TERMINATING.name: now.isoformat(),
                                         },
-                                        "status_history": sql_json_merge(
-                                            KernelRow.status_history,
-                                            (),
-                                            {
-                                                KernelStatus.TERMINATING.name: now.isoformat(),
-                                            },
-                                        ),
-                                    }
-                                    await db_sess.execute(
-                                        sa.update(KernelRow)
-                                        .values(**values)
-                                        .where(KernelRow.id == kernel.id),
-                                    )
+                                    ),
+                                }
+                                await db_sess.execute(
+                                    sa.update(KernelRow)
+                                    .values(**values)
+                                    .where(KernelRow.id == kernel.id),
+                                )
 
                             if kernel.cluster_role == DEFAULT_ROLE:
                                 # The main session is terminated;
@@ -2374,7 +2353,8 @@ class AgentRegistry:
                                     ),
                                 )
 
-                            await execute_with_retry(_update)
+                            async with self.db.connect() as conn:
+                                await execute_with_txn_retry(_update, self.db.begin_session, conn)
                             await self.event_producer.produce_event(
                                 KernelTerminatingEvent(kernel.id, target_session.id, reason),
                             )
@@ -2450,27 +2430,26 @@ class AgentRegistry:
         self,
         session_id: SessionId,
     ) -> None:
-        async def _fetch_session() -> Row:
-            async with self.db.begin_readonly() as conn:
-                query = (
-                    sa.select([
-                        kernels.c.session_id,
-                        kernels.c.cluster_mode,
-                        kernels.c.cluster_size,
-                        kernels.c.agent,
-                        kernels.c.agent_addr,
-                        kernels.c.use_host_network,
-                    ])
-                    .select_from(kernels)
-                    .where(
-                        (kernels.c.session_id == session_id)
-                        & (kernels.c.cluster_role == DEFAULT_ROLE)
-                    )
+        async def _fetch_session(conn: SAConnection) -> Row:
+            query = (
+                sa.select([
+                    kernels.c.session_id,
+                    kernels.c.cluster_mode,
+                    kernels.c.cluster_size,
+                    kernels.c.agent,
+                    kernels.c.agent_addr,
+                    kernels.c.use_host_network,
+                ])
+                .select_from(kernels)
+                .where(
+                    (kernels.c.session_id == session_id) & (kernels.c.cluster_role == DEFAULT_ROLE)
                 )
-                result = await conn.execute(query)
-                return result.first()
+            )
+            result = await conn.execute(query)
+            return result.first()
 
-        session = await execute_with_retry(_fetch_session)
+        async with self.db.connect() as conn:
+            session = await execute_with_txn_retry(_fetch_session, self.db.begin, conn)
         if session is None:
             return
         # Get the main container's agent info
@@ -2509,25 +2488,25 @@ class AgentRegistry:
     ) -> None:
         log.warning("restart_session({})", session.id)
 
-        async def _restarting_session() -> None:
-            async with self.db.begin_session() as db_sess:
-                query = (
-                    sa.update(SessionRow)
-                    .values(
-                        status=SessionStatus.RESTARTING,
-                        status_history=sql_json_merge(
-                            SessionRow.status_history,
-                            (),
-                            {
-                                SessionStatus.RESTARTING.name: datetime.now(tzutc()).isoformat(),
-                            },
-                        ),
-                    )
-                    .where(SessionRow.id == session.id)
+        async def _restarting_session(db_sess: SASession) -> None:
+            query = (
+                sa.update(SessionRow)
+                .values(
+                    status=SessionStatus.RESTARTING,
+                    status_history=sql_json_merge(
+                        SessionRow.status_history,
+                        (),
+                        {
+                            SessionStatus.RESTARTING.name: datetime.now(tzutc()).isoformat(),
+                        },
+                    ),
                 )
-                await db_sess.execute(query)
+                .where(SessionRow.id == session.id)
+            )
+            await db_sess.execute(query)
 
-        await execute_with_retry(_restarting_session)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_restarting_session, self.db.begin_session, conn)
 
         kernel_list = session.kernels
 
@@ -2778,125 +2757,125 @@ class AgentRegistry:
             )
 
             # Check and update status of the agent record in DB
-            async def _update() -> None:
+            async def _update(conn: SAConnection) -> None:
                 nonlocal instance_rejoin
-                async with self.db.begin() as conn:
-                    fetch_query = (
-                        sa.select([
-                            agents.c.status,
-                            agents.c.addr,
-                            agents.c.public_host,
-                            agents.c.public_key,
-                            agents.c.scaling_group,
-                            agents.c.available_slots,
-                            agents.c.version,
-                            agents.c.compute_plugins,
-                            agents.c.architecture,
-                            agents.c.auto_terminate_abusing_kernel,
-                        ])
-                        .select_from(agents)
-                        .where(agents.c.id == agent_id)
-                        .with_for_update()
-                    )
-                    result = await conn.execute(fetch_query)
-                    row = result.first()
+                fetch_query = (
+                    sa.select([
+                        agents.c.status,
+                        agents.c.addr,
+                        agents.c.public_host,
+                        agents.c.public_key,
+                        agents.c.scaling_group,
+                        agents.c.available_slots,
+                        agents.c.version,
+                        agents.c.compute_plugins,
+                        agents.c.architecture,
+                        agents.c.auto_terminate_abusing_kernel,
+                    ])
+                    .select_from(agents)
+                    .where(agents.c.id == agent_id)
+                    .with_for_update()
+                )
+                result = await conn.execute(fetch_query)
+                row = result.first()
 
-                    if row is None or row["status"] is None:
-                        # new agent detected!
-                        log.info("instance_lifecycle: agent {0} joined (via heartbeat)!", agent_id)
-                        await self.shared_config.update_resource_slots(slot_key_and_units)
+                if row is None or row["status"] is None:
+                    # new agent detected!
+                    log.info("instance_lifecycle: agent {0} joined (via heartbeat)!", agent_id)
+                    await self.shared_config.update_resource_slots(slot_key_and_units)
+                    self.agent_cache.update(
+                        agent_id,
+                        current_addr,
+                        agent_info["public_key"],
+                    )
+                    insert_query = sa.insert(agents).values({
+                        "id": agent_id,
+                        "status": AgentStatus.ALIVE,
+                        "region": agent_info["region"],
+                        "scaling_group": sgroup,
+                        "available_slots": available_slots,
+                        "occupied_slots": {},
+                        "addr": agent_info["addr"],
+                        "public_host": agent_info["public_host"],
+                        "public_key": agent_info["public_key"],
+                        "first_contact": now,
+                        "lost_at": sa.null(),
+                        "version": agent_info["version"],
+                        "compute_plugins": agent_info["compute_plugins"],
+                        "architecture": agent_info.get("architecture", "x86_64"),
+                        "auto_terminate_abusing_kernel": auto_terminate_abusing_kernel,
+                    })
+                    result = await conn.execute(insert_query)
+                    assert result.rowcount == 1
+                elif row["status"] == AgentStatus.ALIVE:
+                    updates = {}
+                    invalidate_agent_cache = False
+                    if row["available_slots"] != available_slots:
+                        updates["available_slots"] = available_slots
+                    if row["scaling_group"] != sgroup:
+                        updates["scaling_group"] = sgroup
+                    if row["addr"] != current_addr:
+                        updates["addr"] = current_addr
+                        invalidate_agent_cache = True
+                    if row["public_host"] != agent_info["public_host"]:
+                        updates["public_host"] = agent_info["public_host"]
+                    if row["public_key"] != agent_info["public_key"]:
+                        updates["public_key"] = agent_info["public_key"]
+                        invalidate_agent_cache = True
+                    if row["version"] != agent_info["version"]:
+                        updates["version"] = agent_info["version"]
+                    if row["compute_plugins"] != agent_info["compute_plugins"]:
+                        updates["compute_plugins"] = agent_info["compute_plugins"]
+                    if row["architecture"] != agent_info["architecture"]:
+                        updates["architecture"] = agent_info["architecture"]
+                    if row["auto_terminate_abusing_kernel"] != auto_terminate_abusing_kernel:
+                        updates["auto_terminate_abusing_kernel"] = auto_terminate_abusing_kernel
+                    # occupied_slots are updated when kernels starts/terminates
+                    if invalidate_agent_cache:
                         self.agent_cache.update(
                             agent_id,
                             current_addr,
                             agent_info["public_key"],
                         )
-                        insert_query = sa.insert(agents).values({
-                            "id": agent_id,
+                    if updates:
+                        await self.shared_config.update_resource_slots(slot_key_and_units)
+                        update_query = (
+                            sa.update(agents).values(updates).where(agents.c.id == agent_id)
+                        )
+                        await conn.execute(update_query)
+                elif row["status"] in (AgentStatus.LOST, AgentStatus.TERMINATED):
+                    await self.shared_config.update_resource_slots(slot_key_and_units)
+                    instance_rejoin = True
+                    self.agent_cache.update(
+                        agent_id,
+                        current_addr,
+                        agent_info["public_key"],
+                    )
+                    update_query = (
+                        sa.update(agents)
+                        .values({
                             "status": AgentStatus.ALIVE,
                             "region": agent_info["region"],
                             "scaling_group": sgroup,
-                            "available_slots": available_slots,
-                            "occupied_slots": {},
                             "addr": agent_info["addr"],
                             "public_host": agent_info["public_host"],
                             "public_key": agent_info["public_key"],
-                            "first_contact": now,
                             "lost_at": sa.null(),
+                            "available_slots": available_slots,
                             "version": agent_info["version"],
                             "compute_plugins": agent_info["compute_plugins"],
-                            "architecture": agent_info.get("architecture", "x86_64"),
+                            "architecture": agent_info["architecture"],
                             "auto_terminate_abusing_kernel": auto_terminate_abusing_kernel,
                         })
-                        result = await conn.execute(insert_query)
-                        assert result.rowcount == 1
-                    elif row["status"] == AgentStatus.ALIVE:
-                        updates = {}
-                        invalidate_agent_cache = False
-                        if row["available_slots"] != available_slots:
-                            updates["available_slots"] = available_slots
-                        if row["scaling_group"] != sgroup:
-                            updates["scaling_group"] = sgroup
-                        if row["addr"] != current_addr:
-                            updates["addr"] = current_addr
-                            invalidate_agent_cache = True
-                        if row["public_host"] != agent_info["public_host"]:
-                            updates["public_host"] = agent_info["public_host"]
-                        if row["public_key"] != agent_info["public_key"]:
-                            updates["public_key"] = agent_info["public_key"]
-                            invalidate_agent_cache = True
-                        if row["version"] != agent_info["version"]:
-                            updates["version"] = agent_info["version"]
-                        if row["compute_plugins"] != agent_info["compute_plugins"]:
-                            updates["compute_plugins"] = agent_info["compute_plugins"]
-                        if row["architecture"] != agent_info["architecture"]:
-                            updates["architecture"] = agent_info["architecture"]
-                        if row["auto_terminate_abusing_kernel"] != auto_terminate_abusing_kernel:
-                            updates["auto_terminate_abusing_kernel"] = auto_terminate_abusing_kernel
-                        # occupied_slots are updated when kernels starts/terminates
-                        if invalidate_agent_cache:
-                            self.agent_cache.update(
-                                agent_id,
-                                current_addr,
-                                agent_info["public_key"],
-                            )
-                        if updates:
-                            await self.shared_config.update_resource_slots(slot_key_and_units)
-                            update_query = (
-                                sa.update(agents).values(updates).where(agents.c.id == agent_id)
-                            )
-                            await conn.execute(update_query)
-                    elif row["status"] in (AgentStatus.LOST, AgentStatus.TERMINATED):
-                        await self.shared_config.update_resource_slots(slot_key_and_units)
-                        instance_rejoin = True
-                        self.agent_cache.update(
-                            agent_id,
-                            current_addr,
-                            agent_info["public_key"],
-                        )
-                        update_query = (
-                            sa.update(agents)
-                            .values({
-                                "status": AgentStatus.ALIVE,
-                                "region": agent_info["region"],
-                                "scaling_group": sgroup,
-                                "addr": agent_info["addr"],
-                                "public_host": agent_info["public_host"],
-                                "public_key": agent_info["public_key"],
-                                "lost_at": sa.null(),
-                                "available_slots": available_slots,
-                                "version": agent_info["version"],
-                                "compute_plugins": agent_info["compute_plugins"],
-                                "architecture": agent_info["architecture"],
-                                "auto_terminate_abusing_kernel": auto_terminate_abusing_kernel,
-                            })
-                            .where(agents.c.id == agent_id)
-                        )
-                        await conn.execute(update_query)
-                    else:
-                        log.error("should not reach here! {0}", type(row["status"]))
+                        .where(agents.c.id == agent_id)
+                    )
+                    await conn.execute(update_query)
+                else:
+                    log.error("should not reach here! {0}", type(row["status"]))
 
             try:
-                await execute_with_retry(_update)
+                async with self.db.connect() as conn:
+                    await execute_with_txn_retry(_update, self.db.begin, conn)
             except sa.exc.IntegrityError:
                 log.error("Scaling group named [{}] does not exist.", sgroup)
                 return
@@ -2934,41 +2913,41 @@ class AgentRegistry:
                 await pipe.srem(imgname, agent_id)
             return pipe
 
-        async def _update() -> None:
-            async with self.db.begin() as conn:
-                fetch_query = (
-                    sa.select([
-                        agents.c.status,
-                        agents.c.addr,
-                    ])
-                    .select_from(agents)
-                    .where(agents.c.id == agent_id)
-                    .with_for_update()
-                )
-                result = await conn.execute(fetch_query)
-                row = result.first()
-                prev_status = row["status"]
-                if prev_status in (None, AgentStatus.LOST, AgentStatus.TERMINATED):
-                    return
+        async def _update(conn: SAConnection) -> None:
+            fetch_query = (
+                sa.select([
+                    agents.c.status,
+                    agents.c.addr,
+                ])
+                .select_from(agents)
+                .where(agents.c.id == agent_id)
+                .with_for_update()
+            )
+            result = await conn.execute(fetch_query)
+            row = result.first()
+            prev_status = row["status"]
+            if prev_status in (None, AgentStatus.LOST, AgentStatus.TERMINATED):
+                return
 
-                if status == AgentStatus.LOST:
-                    log.warning("agent {0} heartbeat timeout detected.", agent_id)
-                elif status == AgentStatus.TERMINATED:
-                    log.info("agent {0} has terminated.", agent_id)
-                now = datetime.now(tzutc())
-                update_query = (
-                    sa.update(agents)
-                    .values({
-                        "status": status,
-                        "status_changed": now,
-                        "lost_at": now,
-                    })
-                    .where(agents.c.id == agent_id)
-                )
-                await conn.execute(update_query)
+            if status == AgentStatus.LOST:
+                log.warning("agent {0} heartbeat timeout detected.", agent_id)
+            elif status == AgentStatus.TERMINATED:
+                log.info("agent {0} has terminated.", agent_id)
+            now = datetime.now(tzutc())
+            update_query = (
+                sa.update(agents)
+                .values({
+                    "status": status,
+                    "status_changed": now,
+                    "lost_at": now,
+                })
+                .where(agents.c.id == agent_id)
+            )
+            await conn.execute(update_query)
 
         await redis_helper.execute(self.redis_image, _pipe_builder)
-        await execute_with_retry(_update)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_update, self.db.begin, conn)
 
     async def sync_kernel_stats(
         self,
@@ -2988,23 +2967,23 @@ class AgentRegistry:
             else:
                 per_kernel_updates[kernel_id] = msgpack.unpackb(kern_stat)
 
-        async def _update():
-            async with self.db.begin() as conn:
-                update_query = (
-                    sa.update(kernels)
-                    .where(kernels.c.id == sa.bindparam("kernel_id"))
-                    .values({kernels.c.last_stat: sa.bindparam("last_stat")})
-                )
-                params = []
-                for kernel_id, updates in per_kernel_updates.items():
-                    params.append({
-                        "kernel_id": kernel_id,
-                        "last_stat": updates,
-                    })
-                await conn.execute(update_query, params)
+        async def _update(conn: SAConnection):
+            update_query = (
+                sa.update(kernels)
+                .where(kernels.c.id == sa.bindparam("kernel_id"))
+                .values({kernels.c.last_stat: sa.bindparam("last_stat")})
+            )
+            params = []
+            for kernel_id, updates in per_kernel_updates.items():
+                params.append({
+                    "kernel_id": kernel_id,
+                    "last_stat": updates,
+                })
+            await conn.execute(update_query, params)
 
         if per_kernel_updates:
-            await execute_with_retry(_update)
+            async with self.db.connect() as conn:
+                await execute_with_txn_retry(_update, self.db.begin, conn)
 
     async def sync_agent_kernel_registry(self, agent_id: AgentId) -> None:
         """
@@ -3054,68 +3033,68 @@ class AgentRegistry:
             lambda r: r.get(str(kernel_id)),
         )
 
-        async def _update_kernel() -> tuple[AccessKey, AgentId] | None:
-            async with self.db.begin_session() as db_sess:
-                # Check the current status.
-                select_query = (
-                    sa.select(
-                        KernelRow.access_key,
-                        KernelRow.agent,
-                        KernelRow.status,
-                        KernelRow.occupied_slots,
-                        KernelRow.session_id,
-                    )
-                    .where(KernelRow.id == kernel_id)
-                    .with_for_update()
+        async def _update_kernel(db_sess: SASession) -> tuple[AccessKey, AgentId] | None:
+            # Check the current status.
+            select_query = (
+                sa.select(
+                    KernelRow.access_key,
+                    KernelRow.agent,
+                    KernelRow.status,
+                    KernelRow.occupied_slots,
+                    KernelRow.session_id,
                 )
-                result = await db_sess.execute(select_query)
-                kernel = result.first()
-                if kernel is None or kernel.status in (
-                    KernelStatus.CANCELLED,
-                    KernelStatus.TERMINATED,
-                    KernelStatus.RESTARTING,
-                ):
-                    # Skip if non-existent, already terminated, or restarting.
-                    return None
+                .where(KernelRow.id == kernel_id)
+                .with_for_update()
+            )
+            result = await db_sess.execute(select_query)
+            kernel = result.first()
+            if kernel is None or kernel.status in (
+                KernelStatus.CANCELLED,
+                KernelStatus.TERMINATED,
+                KernelStatus.RESTARTING,
+            ):
+                # Skip if non-existent, already terminated, or restarting.
+                return None
 
-                # Change the status to TERMINATED.
-                # (we don't delete the row for later logging and billing)
-                now = datetime.now(tzutc())
-                values = {
-                    "status": KernelStatus.TERMINATED,
-                    "status_info": reason,
-                    "status_changed": now,
-                    "status_data": sql_json_merge(
-                        KernelRow.status_data,
-                        ("kernel",),
-                        {"exit_code": exit_code},
-                    ),
-                    "status_history": sql_json_merge(
-                        KernelRow.status_history,
-                        (),
-                        {
-                            KernelStatus.TERMINATED.name: now.isoformat(),
-                        },
-                    ),
-                    "terminated_at": now,
-                }
-                if kern_stat:
-                    values["last_stat"] = msgpack.unpackb(kern_stat)
-                update_query = (
-                    sa.update(KernelRow).values(**values).where(KernelRow.id == kernel_id)
-                )
-                await db_sess.execute(update_query)
-                return kernel.access_key, kernel.agent
+            # Change the status to TERMINATED.
+            # (we don't delete the row for later logging and billing)
+            now = datetime.now(tzutc())
+            values = {
+                "status": KernelStatus.TERMINATED,
+                "status_info": reason,
+                "status_changed": now,
+                "status_data": sql_json_merge(
+                    KernelRow.status_data,
+                    ("kernel",),
+                    {"exit_code": exit_code},
+                ),
+                "status_history": sql_json_merge(
+                    KernelRow.status_history,
+                    (),
+                    {
+                        KernelStatus.TERMINATED.name: now.isoformat(),
+                    },
+                ),
+                "terminated_at": now,
+            }
+            if kern_stat:
+                values["last_stat"] = msgpack.unpackb(kern_stat)
+            update_query = sa.update(KernelRow).values(**values).where(KernelRow.id == kernel_id)
+            await db_sess.execute(update_query)
+            return kernel.access_key, kernel.agent
 
-        result = await execute_with_retry(_update_kernel)
+        async with self.db.connect() as conn:
+            result = await execute_with_txn_retry(
+                _update_kernel,
+                self.db.begin_session,
+                conn,
+            )
+            if result is None:
+                return
 
-        if result is None:
-            return
+            access_key, agent = result
 
-        access_key, agent = result
-
-        async def _recalc() -> None:
-            async with self.db.begin() as conn:
+            async def _recalc(conn: SAConnection) -> None:
                 log.debug(
                     "recalculate concurrency used in kernel termination (ak: {})",
                     access_key,
@@ -3127,7 +3106,7 @@ class AgentRegistry:
                 )
                 await recalc_agent_resource_occupancy(conn, agent)
 
-        await execute_with_retry(_recalc)
+            await execute_with_txn_retry(_recalc, self.db.begin, conn)
 
         # Perform statistics sync in a separate transaction block, since
         # it may take a while to fetch stats from Redis.
@@ -3296,7 +3275,7 @@ class AgentRegistry:
         }
 
     async def update_appproxy_endpoint_routes(
-        self, db_sess: AsyncSession, endpoint: EndpointRow, active_routes: list[RoutingRow]
+        self, db_sess: SASession, endpoint: EndpointRow, active_routes: list[RoutingRow]
     ) -> None:
         target_sessions = await SessionRow.list_sessions(
             db_sess,
@@ -3364,7 +3343,7 @@ class AgentRegistry:
                     )
                     await db_sess.execute(query)
 
-    async def delete_appproxy_endpoint(self, db_sess: AsyncSession, endpoint: EndpointRow) -> None:
+    async def delete_appproxy_endpoint(self, db_sess: SASession, endpoint: EndpointRow) -> None:
         query = (
             sa.select([scaling_groups.c.wsproxy_addr, scaling_groups.c.wsproxy_api_token])
             .select_from(scaling_groups)
@@ -3507,8 +3486,9 @@ async def handle_model_service_status_update(
     event: ModelServiceStatusEvent,
 ) -> None:
     log.info("HANDLE_MODEL_SERVICE_STATUS_UPDATE (source:{}, event:{})", source, event)
-    try:
-        async with context.db.begin_readonly_session() as db_sess:
+
+    async def _update(db_sess: SASession):
+        try:
             session = await SessionRow.get_session(
                 db_sess,
                 event.session_id,
@@ -3516,41 +3496,39 @@ async def handle_model_service_status_update(
                 kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
             )
             route = await RoutingRow.get_by_session(db_sess, session.id, load_endpoint=True)
-    except SessionNotFound:
-        return
-    except NoResultFound:
-        return
+        except SessionNotFound:
+            return
+        except NoResultFound:
+            return
+        data: dict[str, Any] = {}
+        match event.new_status:
+            case ModelServiceStatus.HEALTHY:
+                data["status"] = RouteStatus.HEALTHY
+            case ModelServiceStatus.UNHEALTHY:
+                data["status"] = RouteStatus.UNHEALTHY
+        query = sa.update(RoutingRow).values(data).where(RoutingRow.id == route.id)
+        await db_sess.execute(query)
 
-    async def _update():
-        async with context.db.begin_session() as db_sess:
-            data: dict[str, Any] = {}
-            match event.new_status:
-                case ModelServiceStatus.HEALTHY:
-                    data["status"] = RouteStatus.HEALTHY
-                case ModelServiceStatus.UNHEALTHY:
-                    data["status"] = RouteStatus.UNHEALTHY
-            query = sa.update(RoutingRow).values(data).where(RoutingRow.id == route.id)
-            await db_sess.execute(query)
+        query = sa.select(RoutingRow).where(
+            (RoutingRow.endpoint == route.endpoint) & (RoutingRow.status == RouteStatus.HEALTHY)
+        )
+        result = await db_sess.execute(query)
+        latest_routes = result.fetchall()
+        latest_routes = await RoutingRow.list(
+            db_sess, route.endpoint, status_filter=[RouteStatus.HEALTHY]
+        )
 
-            query = sa.select(RoutingRow).where(
-                (RoutingRow.endpoint == route.endpoint) & (RoutingRow.status == RouteStatus.HEALTHY)
+        try:
+            await context.update_appproxy_endpoint_routes(
+                db_sess, route.endpoint_row, latest_routes
             )
-            result = await db_sess.execute(query)
-            latest_routes = result.fetchall()
-            latest_routes = await RoutingRow.list(
-                db_sess, route.endpoint, status_filter=[RouteStatus.HEALTHY]
-            )
+        except Exception as e:
+            if is_db_retry_error(e):
+                raise
+            log.exception("failed to communicate with AppProxy endpoint:")
 
-            try:
-                await context.update_appproxy_endpoint_routes(
-                    db_sess, route.endpoint_row, latest_routes
-                )
-            except Exception as e:
-                if is_db_retry_error(e):
-                    raise
-                log.exception("failed to communicate with AppProxy endpoint:")
-
-    await execute_with_retry(_update)
+    async with context.db.connect() as conn:
+        await execute_with_txn_retry(_update, context.db.begin_session, conn)
 
 
 async def invoke_session_callback(
@@ -3585,12 +3563,13 @@ async def invoke_session_callback(
         # Update routing status
         # TODO: Check session health
         if session.session_type == SessionTypes.INFERENCE:
-
-            async def _update() -> None:
-                new_routes: list[RoutingRow]
-                async with context.db.begin_session() as db_sess:
+            async with context.db.connect() as conn:
+                async with context.db.begin_readonly_session(bind=conn) as db_sess:
                     route = await RoutingRow.get_by_session(db_sess, session.id, load_endpoint=True)
                     endpoint = await EndpointRow.get(db_sess, route.endpoint, load_routes=True)
+
+                async def _update(db_sess: SASession) -> None:
+                    new_routes: list[RoutingRow]
                     if isinstance(event, SessionCancelledEvent):
                         update_data: dict[str, Any] = {"status": RouteStatus.FAILED_TO_START}
                         if "error" in session.status_data:
@@ -3667,13 +3646,7 @@ async def invoke_session_callback(
                                 )
                         await db_sess.commit()
 
-            await execute_with_retry(_update)
-
-            async def _clear_error() -> None:
-                async with context.db.begin_session() as db_sess:
-                    route = await RoutingRow.get_by_session(db_sess, session.id, load_endpoint=True)
-                    endpoint = await EndpointRow.get(db_sess, route.endpoint, load_routes=True)
-
+                async def _clear_error(db_sess: SASession) -> None:
                     query = sa.select([sa.func.count("*")]).where(
                         (RoutingRow.endpoint == endpoint.id)
                         & (RoutingRow.status == RouteStatus.HEALTHY)
@@ -3692,7 +3665,8 @@ async def invoke_session_callback(
                         )
                         await db_sess.execute(query)
 
-            await execute_with_retry(_clear_error)
+                await execute_with_txn_retry(_update, context.db.begin_session, conn)
+                await execute_with_txn_retry(_clear_error, context.db.begin_session, conn)
     except NoResultFound:
         pass  # Cases when we try to create a inference session for validation (/services/_/try API)
     except Exception:
@@ -3874,23 +3848,23 @@ async def handle_route_creation(
             ],
         }
 
-        async def _update():
-            async with context.db.begin_session() as db_sess:
+        async def _update(db_sess: SASession):
+            query = (
+                sa.update(RoutingRow)
+                .values({"status": RouteStatus.FAILED_TO_START, "error_data": error_data})
+                .where(RoutingRow.id == event.route_id)
+            )
+            await db_sess.execute(query)
+            if endpoint:
                 query = (
-                    sa.update(RoutingRow)
-                    .values({"status": RouteStatus.FAILED_TO_START, "error_data": error_data})
-                    .where(RoutingRow.id == event.route_id)
+                    sa.update(EndpointRow)
+                    .values({"retries": endpoint.retries + 1})
+                    .where(EndpointRow.id == endpoint.id)
                 )
                 await db_sess.execute(query)
-                if endpoint:
-                    query = (
-                        sa.update(EndpointRow)
-                        .values({"retries": endpoint.retries + 1})
-                        .where(EndpointRow.id == endpoint.id)
-                    )
-                    await db_sess.execute(query)
 
-        await execute_with_retry(_update)
+        async with context.db.connect() as conn:
+            await execute_with_txn_retry(_update, context.db.begin_session, conn)
 
 
 async def handle_check_agent_resource(
@@ -3994,16 +3968,16 @@ async def handle_kernel_log(
         try:
             log_data = log_buffer.getvalue()
 
-            async def _update_log() -> None:
-                async with context.db.begin() as conn:
-                    update_query = (
-                        sa.update(kernels)
-                        .values(container_log=log_data)
-                        .where(kernels.c.id == event.kernel_id)
-                    )
-                    await conn.execute(update_query)
+            async def _update_log(conn: SAConnection) -> None:
+                update_query = (
+                    sa.update(kernels)
+                    .values(container_log=log_data)
+                    .where(kernels.c.id == event.kernel_id)
+                )
+                await conn.execute(update_query)
 
-            await execute_with_retry(_update_log)
+            async with context.db.connect() as conn:
+                await execute_with_txn_retry(_update_log, context.db.begin, conn)
         finally:
             # Clear the log data from Redis when done.
             await redis_helper.execute(

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -29,6 +29,7 @@ from dateutil.tz import tzutc
 from redis.asyncio import Redis
 from redis.asyncio.client import Pipeline as RedisPipeline
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import noload, selectinload
 
@@ -87,7 +88,7 @@ from ..models import (
     recalc_concurrency_used,
 )
 from ..models.utils import ExtendedAsyncSAEngine as SAEngine
-from ..models.utils import execute_with_retry, sql_json_increment, sql_json_merge
+from ..models.utils import execute_with_txn_retry, sql_json_increment, sql_json_merge
 from .predicates import (
     check_concurrency,
     check_dependencies,
@@ -404,11 +405,11 @@ class SchedulerDispatcher(aobject):
         if cancelled_sessions:
             session_ids = [item.id for item in cancelled_sessions]
 
-            async def _update():
-                async with self.db.begin_session() as db_sess:
-                    await _apply_cancellation(db_sess, session_ids)
+            async def _update(db_sess: SASession):
+                await _apply_cancellation(db_sess, session_ids)
 
-            await execute_with_retry(_update)
+            async with self.db.connect() as conn:
+                await execute_with_txn_retry(_update, self.db.begin_session, conn)
             for item in cancelled_sessions:
                 await self.event_producer.produce_event(
                     SessionCancelledEvent(
@@ -460,55 +461,59 @@ class SchedulerDispatcher(aobject):
             _log_args.set(log_args)
             log.debug(log_fmt + "try-scheduling", *log_args)
 
-            async def _check_predicates() -> List[Tuple[str, Union[Exception, PredicateResult]]]:
+            async def _check_predicates(
+                db_sess: SASession,
+            ) -> List[Tuple[str, Union[Exception, PredicateResult]]]:
                 check_results: List[Tuple[str, Union[Exception, PredicateResult]]] = []
-                async with self.db.begin_session() as db_sess:
-                    predicates: list[Tuple[str, Awaitable[PredicateResult]]] = [
+                predicates: list[Tuple[str, Awaitable[PredicateResult]]] = [
+                    (
+                        "reserved_time",
+                        check_reserved_batch_session(db_sess, sched_ctx, sess_ctx),
+                    ),
+                    ("dependencies", check_dependencies(db_sess, sched_ctx, sess_ctx)),
+                    ("concurrency", check_concurrency(db_sess, sched_ctx, sess_ctx)),
+                ]
+                if not sess_ctx.is_private:
+                    predicates += [
                         (
-                            "reserved_time",
-                            check_reserved_batch_session(db_sess, sched_ctx, sess_ctx),
+                            "pending_session_resource_limit",
+                            check_pending_session_resource_limit(db_sess, sched_ctx, sess_ctx),
                         ),
-                        ("dependencies", check_dependencies(db_sess, sched_ctx, sess_ctx)),
-                        ("concurrency", check_concurrency(db_sess, sched_ctx, sess_ctx)),
+                        (
+                            "pending_session_count_limit",
+                            check_pending_session_count_limit(db_sess, sched_ctx, sess_ctx),
+                        ),
+                        (
+                            "keypair_resource_limit",
+                            check_keypair_resource_limit(db_sess, sched_ctx, sess_ctx),
+                        ),
+                        (
+                            "user_resource_limit",
+                            check_user_resource_limit(db_sess, sched_ctx, sess_ctx),
+                        ),
+                        (
+                            "user_group_resource_limit",
+                            check_group_resource_limit(db_sess, sched_ctx, sess_ctx),
+                        ),
+                        (
+                            "domain_resource_limit",
+                            check_domain_resource_limit(db_sess, sched_ctx, sess_ctx),
+                        ),
                     ]
-                    if not sess_ctx.is_private:
-                        predicates += [
-                            (
-                                "pending_session_resource_limit",
-                                check_pending_session_resource_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                            (
-                                "pending_session_count_limit",
-                                check_pending_session_count_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                            (
-                                "keypair_resource_limit",
-                                check_keypair_resource_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                            (
-                                "user_resource_limit",
-                                check_user_resource_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                            (
-                                "user_group_resource_limit",
-                                check_group_resource_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                            (
-                                "domain_resource_limit",
-                                check_domain_resource_limit(db_sess, sched_ctx, sess_ctx),
-                            ),
-                        ]
-                    for predicate_name, check_coro in predicates:
-                        try:
-                            check_results.append((predicate_name, await check_coro))
-                        except DBAPIError:
-                            raise
-                        except Exception as e:
-                            log.exception(log_fmt + "predicate-error", *log_args)
-                            check_results.append((predicate_name, e))
+                for predicate_name, check_coro in predicates:
+                    try:
+                        check_results.append((predicate_name, await check_coro))
+                    except DBAPIError:
+                        raise
+                    except Exception as e:
+                        log.exception(log_fmt + "predicate-error", *log_args)
+                        check_results.append((predicate_name, e))
                 return check_results
 
-            check_results = await execute_with_retry(_check_predicates)
+            async with self.db.connect() as conn:
+                check_results = await execute_with_txn_retry(
+                    _check_predicates, self.db.begin_session, conn
+                )
             failed_predicates = []
             passed_predicates = []
             for predicate_name, result in check_results:
@@ -528,18 +533,20 @@ class SchedulerDispatcher(aobject):
                         "msg": result.message or "",
                     })
 
-            async def _check_predicates_hook() -> HookResult:
-                async with self.db.begin_readonly_session() as db_sess:
-                    return await self.registry.hook_plugin_ctx.dispatch(
-                        "PREDICATE",
-                        (
-                            db_sess,
-                            sched_ctx,
-                            sess_ctx,
-                        ),
-                    )
+            async def _check_predicates_hook(db_sess: SASession) -> HookResult:
+                return await self.registry.hook_plugin_ctx.dispatch(
+                    "PREDICATE",
+                    (
+                        db_sess,
+                        sched_ctx,
+                        sess_ctx,
+                    ),
+                )
 
-            hook_result = await execute_with_retry(_check_predicates_hook)
+            async with self.db.connect() as conn:
+                hook_result = await execute_with_txn_retry(
+                    _check_predicates_hook, self.db.begin_session, conn
+                )
             match hook_result.src_plugin:
                 case str():
                     hook_name = hook_result.src_plugin
@@ -566,70 +573,74 @@ class SchedulerDispatcher(aobject):
             if failed_predicates:
                 log.debug(log_fmt + "predicate-checks-failed (temporary)", *log_args)
 
-                async def _cancel_failed_system_session() -> None:
-                    async with self.db.begin_session() as db_sess:
-                        await _rollback_predicate_mutations(
-                            db_sess,
-                            sched_ctx,
-                            sess_ctx,
+                async def _cancel_failed_system_session(db_sess: SASession) -> None:
+                    await _rollback_predicate_mutations(
+                        db_sess,
+                        sched_ctx,
+                        sess_ctx,
+                    )
+                    query = (
+                        sa.update(SessionRow)
+                        .values(
+                            status_info="predicate-checks-failed",
+                            status_data=sql_json_increment(
+                                SessionRow.status_data,
+                                ("scheduler", "retries"),
+                                parent_updates=status_update_data,
+                            ),
                         )
-                        query = (
-                            sa.update(SessionRow)
-                            .values(
-                                status_info="predicate-checks-failed",
-                                status_data=sql_json_increment(
-                                    SessionRow.status_data,
-                                    ("scheduler", "retries"),
-                                    parent_updates=status_update_data,
-                                ),
+                        .where(SessionRow.id == sess_ctx.id)
+                    )
+                    await db_sess.execute(query)
+                    if sess_ctx.is_private:
+                        await _apply_cancellation(db_sess, [sess_ctx.id])
+                        await self.event_producer.produce_event(
+                            SessionCancelledEvent(
+                                sess_ctx.id,
+                                sess_ctx.creation_id,
+                                reason=KernelLifecycleEventReason.PENDING_TIMEOUT,
                             )
-                            .where(SessionRow.id == sess_ctx.id)
                         )
-                        await db_sess.execute(query)
-                        if sess_ctx.is_private:
-                            await _apply_cancellation(db_sess, [sess_ctx.id])
-                            await self.event_producer.produce_event(
-                                SessionCancelledEvent(
-                                    sess_ctx.id,
-                                    sess_ctx.creation_id,
-                                    reason=KernelLifecycleEventReason.PENDING_TIMEOUT,
-                                )
-                            )
 
-                await execute_with_retry(_cancel_failed_system_session)
+                async with self.db.connect() as conn:
+                    await execute_with_txn_retry(
+                        _cancel_failed_system_session, self.db.begin_session, conn
+                    )
                 # Predicate failures are *NOT* permanent errors.
                 # We need to retry the scheduling afterwards.
                 continue
             else:
 
-                async def _update_session_status_data() -> None:
-                    async with self.db.begin_session() as db_sess:
-                        kernel_query = (
-                            sa.update(KernelRow)
-                            .where(KernelRow.session_id == sess_ctx.id)
-                            .values(
-                                status_data=sql_json_merge(
-                                    KernelRow.status_data,
-                                    ("scheduler",),
-                                    obj=status_update_data,
-                                ),
-                            )
+                async def _update_session_status_data(db_sess: SASession) -> None:
+                    kernel_query = (
+                        sa.update(KernelRow)
+                        .where(KernelRow.session_id == sess_ctx.id)
+                        .values(
+                            status_data=sql_json_merge(
+                                KernelRow.status_data,
+                                ("scheduler",),
+                                obj=status_update_data,
+                            ),
                         )
-                        await db_sess.execute(kernel_query)
-                        session_query = (
-                            sa.update(SessionRow)
-                            .where(SessionRow.id == sess_ctx.id)
-                            .values(
-                                status_data=sql_json_merge(
-                                    SessionRow.status_data,
-                                    ("scheduler",),
-                                    obj=status_update_data,
-                                ),
-                            )
+                    )
+                    await db_sess.execute(kernel_query)
+                    session_query = (
+                        sa.update(SessionRow)
+                        .where(SessionRow.id == sess_ctx.id)
+                        .values(
+                            status_data=sql_json_merge(
+                                SessionRow.status_data,
+                                ("scheduler",),
+                                obj=status_update_data,
+                            ),
                         )
-                        await db_sess.execute(session_query)
+                    )
+                    await db_sess.execute(session_query)
 
-                await execute_with_retry(_update_session_status_data)
+                async with self.db.connect() as conn:
+                    await execute_with_txn_retry(
+                        _update_session_status_data, self.db.begin_session, conn
+                    )
 
             async with self.db.begin_readonly_session() as db_sess:
                 schedulable_sess = await SessionRow.get_session_by_id(
@@ -887,31 +898,35 @@ class SchedulerDispatcher(aobject):
         except InstanceNotAvailable as sched_failure:
             log.debug(log_fmt + "no-available-instances", *log_args)
 
-            async def _update_sched_failure(exc: InstanceNotAvailable) -> None:
-                async with self.db.begin_session() as kernel_db_sess:
-                    await _rollback_predicate_mutations(
-                        kernel_db_sess,
-                        sched_ctx,
-                        sess_ctx,
+            async def _update_sched_failure(
+                exc: InstanceNotAvailable, kernel_db_sess: SASession
+            ) -> None:
+                await _rollback_predicate_mutations(
+                    kernel_db_sess,
+                    sched_ctx,
+                    sess_ctx,
+                )
+                query = (
+                    sa.update(SessionRow)
+                    .values(
+                        status_info="no-available-instances",
+                        status_data=sql_json_increment(
+                            SessionRow.status_data,
+                            ("scheduler", "retries"),
+                            parent_updates={
+                                "last_try": datetime.now(tzutc()).isoformat(),
+                                "msg": exc.extra_msg,
+                            },
+                        ),
                     )
-                    query = (
-                        sa.update(SessionRow)
-                        .values(
-                            status_info="no-available-instances",
-                            status_data=sql_json_increment(
-                                SessionRow.status_data,
-                                ("scheduler", "retries"),
-                                parent_updates={
-                                    "last_try": datetime.now(tzutc()).isoformat(),
-                                    "msg": exc.extra_msg,
-                                },
-                            ),
-                        )
-                        .where(SessionRow.id == sess_ctx.id)
-                    )
-                    await kernel_db_sess.execute(query)
+                    .where(SessionRow.id == sess_ctx.id)
+                )
+                await kernel_db_sess.execute(query)
 
-            await execute_with_retry(partial(_update_sched_failure, sched_failure))
+            async with self.db.connect() as conn:
+                await execute_with_txn_retry(
+                    partial(_update_sched_failure, sched_failure), self.db.begin_session, conn
+                )
             raise
         except Exception as e:
             log.exception(
@@ -920,76 +935,76 @@ class SchedulerDispatcher(aobject):
             )
             exc_data = convert_to_status_data(e, self.local_config["debug"]["enabled"])
 
-            async def _update_generic_failure() -> None:
-                async with self.db.begin_session() as kernel_db_sess:
-                    await _rollback_predicate_mutations(
-                        kernel_db_sess,
-                        sched_ctx,
-                        sess_ctx,
-                    )
-                    query = (
-                        sa.update(SessionRow)
-                        .values(
-                            status_info="scheduler-error",
-                            status_data=exc_data,
-                        )
-                        .where(SessionRow.id == sess_ctx.id)
-                    )
-                    await kernel_db_sess.execute(query)
-
-            await execute_with_retry(_update_generic_failure)
-            raise
-
-        async def _finalize_scheduled() -> None:
-            agent_ids: list[AgentId] = []
-            async with self.db.begin_session() as db_sess:
-                now = datetime.now(tzutc())
-                for kernel in sess_ctx.kernels:
-                    kernel_query = (
-                        sa.update(KernelRow)
-                        .values(
-                            agent=agent_alloc_ctx.agent_id,
-                            agent_addr=agent_alloc_ctx.agent_addr,
-                            scaling_group=sgroup_name,
-                            status=KernelStatus.SCHEDULED,
-                            status_info="scheduled",
-                            status_data={},
-                            status_changed=now,
-                            status_history=sql_json_merge(
-                                KernelRow.status_history,
-                                (),
-                                {
-                                    KernelStatus.SCHEDULED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(KernelRow.id == kernel.id)
-                    )
-                    await db_sess.execute(kernel_query)
-                if agent_alloc_ctx.agent_id is not None:
-                    agent_ids.append(agent_alloc_ctx.agent_id)
-
-                session_query = (
+            async def _update_generic_failure(kernel_db_sess: SASession) -> None:
+                await _rollback_predicate_mutations(
+                    kernel_db_sess,
+                    sched_ctx,
+                    sess_ctx,
+                )
+                query = (
                     sa.update(SessionRow)
                     .values(
-                        scaling_group_name=sgroup_name,
-                        agent_ids=agent_ids,
-                        status=SessionStatus.SCHEDULED,
-                        status_info="scheduled",
-                        status_data={},
-                        status_history=sql_json_merge(
-                            SessionRow.status_history,
-                            (),
-                            {
-                                SessionStatus.SCHEDULED.name: now.isoformat(),
-                            },
-                        ),
+                        status_info="scheduler-error",
+                        status_data=exc_data,
                     )
                     .where(SessionRow.id == sess_ctx.id)
                 )
-                await db_sess.execute(session_query)
+                await kernel_db_sess.execute(query)
 
-        await execute_with_retry(_finalize_scheduled)
+            async with self.db.connect() as conn:
+                await execute_with_txn_retry(_update_generic_failure, self.db.begin_session, conn)
+            raise
+
+        async def _finalize_scheduled(db_sess: SASession) -> None:
+            agent_ids: list[AgentId] = []
+            now = datetime.now(tzutc())
+            for kernel in sess_ctx.kernels:
+                kernel_query = (
+                    sa.update(KernelRow)
+                    .values(
+                        agent=agent_alloc_ctx.agent_id,
+                        agent_addr=agent_alloc_ctx.agent_addr,
+                        scaling_group=sgroup_name,
+                        status=KernelStatus.SCHEDULED,
+                        status_info="scheduled",
+                        status_data={},
+                        status_changed=now,
+                        status_history=sql_json_merge(
+                            KernelRow.status_history,
+                            (),
+                            {
+                                KernelStatus.SCHEDULED.name: now.isoformat(),
+                            },
+                        ),
+                    )
+                    .where(KernelRow.id == kernel.id)
+                )
+                await db_sess.execute(kernel_query)
+            if agent_alloc_ctx.agent_id is not None:
+                agent_ids.append(agent_alloc_ctx.agent_id)
+
+            session_query = (
+                sa.update(SessionRow)
+                .values(
+                    scaling_group_name=sgroup_name,
+                    agent_ids=agent_ids,
+                    status=SessionStatus.SCHEDULED,
+                    status_info="scheduled",
+                    status_data={},
+                    status_history=sql_json_merge(
+                        SessionRow.status_history,
+                        (),
+                        {
+                            SessionStatus.SCHEDULED.name: now.isoformat(),
+                        },
+                    ),
+                )
+                .where(SessionRow.id == sess_ctx.id)
+            )
+            await db_sess.execute(session_query)
+
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_finalize_scheduled, self.db.begin_session, conn)
         await self.registry.event_producer.produce_event(
             SessionScheduledEvent(sess_ctx.id, sess_ctx.creation_id),
         )
@@ -1097,52 +1112,54 @@ class SchedulerDispatcher(aobject):
                             )
                     assert agent_id is not None
 
-                    async def _reserve() -> None:
-                        nonlocal agent_alloc_ctx, candidate_agents
-                        async with agent_db_sess.begin_nested():
-                            agent_alloc_ctx = await _reserve_agent(
-                                sched_ctx,
-                                agent_db_sess,
-                                sgroup_name,
-                                agent_id,
-                                kernel.requested_slots,
-                                extra_conds=agent_query_extra_conds,
-                            )
-                            # Update the agent data to schedule the next kernel in the session
-                            candidate_agents = await list_schedulable_agents_by_sgroup(
-                                agent_db_sess,
-                                sgroup_name,
-                            )
+                    agent_alloc_ctx = await _reserve_agent(
+                        sched_ctx,
+                        agent_db_sess,
+                        sgroup_name,
+                        agent_id,
+                        kernel.requested_slots,
+                        extra_conds=agent_query_extra_conds,
+                    )
+                    # Update the agent data to schedule the next kernel in the session
+                    candidate_agents = await list_schedulable_agents_by_sgroup(
+                        agent_db_sess,
+                        sgroup_name,
+                    )
 
-                    await execute_with_retry(_reserve)
                 except InstanceNotAvailable as sched_failure:
                     log.debug(log_fmt + "no-available-instances", *log_args)
 
-                    async def _update_sched_failure(exc: InstanceNotAvailable) -> None:
-                        async with self.db.begin_session() as agent_db_sess:
-                            await _rollback_predicate_mutations(
-                                agent_db_sess,
-                                sched_ctx,
-                                sess_ctx,
+                    async def _update_sched_failure(
+                        exc: InstanceNotAvailable, agent_db_sess: SASession
+                    ) -> None:
+                        await _rollback_predicate_mutations(
+                            agent_db_sess,
+                            sched_ctx,
+                            sess_ctx,
+                        )
+                        query = (
+                            sa.update(KernelRow)
+                            .values(
+                                status_info="no-available-instances",
+                                status_data=sql_json_increment(
+                                    KernelRow.status_data,
+                                    ("scheduler", "retries"),
+                                    parent_updates={
+                                        "last_try": datetime.now(tzutc()).isoformat(),
+                                        "msg": exc.extra_msg,
+                                    },
+                                ),
                             )
-                            query = (
-                                sa.update(KernelRow)
-                                .values(
-                                    status_info="no-available-instances",
-                                    status_data=sql_json_increment(
-                                        KernelRow.status_data,
-                                        ("scheduler", "retries"),
-                                        parent_updates={
-                                            "last_try": datetime.now(tzutc()).isoformat(),
-                                            "msg": exc.extra_msg,
-                                        },
-                                    ),
-                                )
-                                .where(KernelRow.id == kernel.id)
-                            )
-                            await agent_db_sess.execute(query)
+                            .where(KernelRow.id == kernel.id)
+                        )
+                        await agent_db_sess.execute(query)
 
-                    await execute_with_retry(partial(_update_sched_failure, sched_failure))
+                    async with self.db.connect() as conn:
+                        await execute_with_txn_retry(
+                            partial(_update_sched_failure, sched_failure),
+                            self.db.begin_session,
+                            conn,
+                        )
                     raise
                 except Exception as e:
                     log.exception(
@@ -1151,24 +1168,26 @@ class SchedulerDispatcher(aobject):
                     )
                     exc_data = convert_to_status_data(e, self.local_config["debug"]["enabled"])
 
-                    async def _update_generic_failure() -> None:
-                        async with self.db.begin_session() as kernel_db_sess:
-                            await _rollback_predicate_mutations(
-                                kernel_db_sess,
-                                sched_ctx,
-                                sess_ctx,
+                    async def _update_generic_failure(kernel_db_sess: SASession) -> None:
+                        await _rollback_predicate_mutations(
+                            kernel_db_sess,
+                            sched_ctx,
+                            sess_ctx,
+                        )
+                        query = (
+                            sa.update(KernelRow)
+                            .values(
+                                status_info="scheduler-error",
+                                status_data=exc_data,
                             )
-                            query = (
-                                sa.update(KernelRow)
-                                .values(
-                                    status_info="scheduler-error",
-                                    status_data=exc_data,
-                                )
-                                .where(KernelRow.id == kernel.id)
-                            )
-                            await kernel_db_sess.execute(query)
+                            .where(KernelRow.id == kernel.id)
+                        )
+                        await kernel_db_sess.execute(query)
 
-                    await execute_with_retry(_update_generic_failure)
+                    async with self.db.connect() as conn:
+                        await execute_with_txn_retry(
+                            _update_generic_failure, self.db.begin_session, conn
+                        )
                     raise
                 else:
                     assert agent_alloc_ctx is not None
@@ -1177,57 +1196,57 @@ class SchedulerDispatcher(aobject):
         assert len(kernel_agent_bindings) == len(sess_ctx.kernels)
         # Proceed to PREPARING only when all kernels are successfully scheduled.
 
-        async def _finalize_scheduled() -> None:
+        async def _finalize_scheduled(db_sess: SASession) -> None:
             agent_ids: list[AgentId] = []
-            async with self.db.begin_session() as db_sess:
-                for binding in kernel_agent_bindings:
-                    now = datetime.now(tzutc())
-                    kernel_query = (
-                        sa.update(KernelRow)
-                        .values(
-                            agent=binding.agent_alloc_ctx.agent_id,
-                            agent_addr=binding.agent_alloc_ctx.agent_addr,
-                            scaling_group=sgroup_name,
-                            status=KernelStatus.SCHEDULED,
-                            status_info="scheduled",
-                            status_data={},
-                            status_changed=now,
-                            status_history=sql_json_merge(
-                                KernelRow.status_history,
-                                (),
-                                {
-                                    KernelStatus.SCHEDULED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(KernelRow.id == binding.kernel.id)
-                    )
-                    await db_sess.execute(kernel_query)
-                    if binding.agent_alloc_ctx.agent_id is not None:
-                        agent_ids.append(binding.agent_alloc_ctx.agent_id)
-
-                session_query = (
-                    sa.update(SessionRow)
+            for binding in kernel_agent_bindings:
+                now = datetime.now(tzutc())
+                kernel_query = (
+                    sa.update(KernelRow)
                     .values(
-                        scaling_group_name=sgroup_name,
-                        agent_ids=agent_ids,
-                        status=SessionStatus.SCHEDULED,
+                        agent=binding.agent_alloc_ctx.agent_id,
+                        agent_addr=binding.agent_alloc_ctx.agent_addr,
+                        scaling_group=sgroup_name,
+                        status=KernelStatus.SCHEDULED,
                         status_info="scheduled",
                         status_data={},
-                        # status_changed=now,
+                        status_changed=now,
                         status_history=sql_json_merge(
-                            SessionRow.status_history,
+                            KernelRow.status_history,
                             (),
                             {
-                                SessionStatus.SCHEDULED.name: now.isoformat(),
+                                KernelStatus.SCHEDULED.name: now.isoformat(),
                             },
                         ),
                     )
-                    .where(SessionRow.id == sess_ctx.id)
+                    .where(KernelRow.id == binding.kernel.id)
                 )
-                await db_sess.execute(session_query)
+                await db_sess.execute(kernel_query)
+                if binding.agent_alloc_ctx.agent_id is not None:
+                    agent_ids.append(binding.agent_alloc_ctx.agent_id)
 
-        await execute_with_retry(_finalize_scheduled)
+            session_query = (
+                sa.update(SessionRow)
+                .values(
+                    scaling_group_name=sgroup_name,
+                    agent_ids=agent_ids,
+                    status=SessionStatus.SCHEDULED,
+                    status_info="scheduled",
+                    status_data={},
+                    # status_changed=now,
+                    status_history=sql_json_merge(
+                        SessionRow.status_history,
+                        (),
+                        {
+                            SessionStatus.SCHEDULED.name: now.isoformat(),
+                        },
+                    ),
+                )
+                .where(SessionRow.id == sess_ctx.id)
+            )
+            await db_sess.execute(session_query)
+
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_finalize_scheduled, self.db.begin_session, conn)
         await self.registry.event_producer.produce_event(
             SessionScheduledEvent(sess_ctx.id, sess_ctx.creation_id),
         )
@@ -1272,63 +1291,65 @@ class SchedulerDispatcher(aobject):
             async with self.lock_factory(LockID.LOCKID_PREPARE, 600):
                 now = datetime.now(tzutc())
 
-                async def _mark_session_preparing() -> Sequence[SessionRow]:
-                    async with self.db.begin_session() as db_sess:
-                        update_query = (
-                            sa.update(KernelRow)
-                            .values(
-                                status=KernelStatus.PREPARING,
-                                status_changed=now,
-                                status_info="",
-                                status_data={},
-                                status_history=sql_json_merge(
-                                    KernelRow.status_history,
-                                    (),
-                                    {
-                                        KernelStatus.PREPARING.name: now.isoformat(),
-                                    },
-                                ),
-                            )
-                            .where(
-                                (KernelRow.status == KernelStatus.SCHEDULED),
-                            )
+                async def _mark_session_preparing(db_sess: SASession) -> Sequence[SessionRow]:
+                    update_query = (
+                        sa.update(KernelRow)
+                        .values(
+                            status=KernelStatus.PREPARING,
+                            status_changed=now,
+                            status_info="",
+                            status_data={},
+                            status_history=sql_json_merge(
+                                KernelRow.status_history,
+                                (),
+                                {
+                                    KernelStatus.PREPARING.name: now.isoformat(),
+                                },
+                            ),
                         )
-                        await db_sess.execute(update_query)
-                        update_sess_query = (
-                            sa.update(SessionRow)
-                            .values(
-                                status=SessionStatus.PREPARING,
-                                # status_changed=now,
-                                status_info="",
-                                status_data={},
-                                status_history=sql_json_merge(
-                                    SessionRow.status_history,
-                                    (),
-                                    {
-                                        SessionStatus.PREPARING.name: now.isoformat(),
-                                    },
-                                ),
-                            )
-                            .where(SessionRow.status == SessionStatus.SCHEDULED)
-                            .returning(SessionRow.id)
+                        .where(
+                            (KernelRow.status == KernelStatus.SCHEDULED),
                         )
-                        rows = (await db_sess.execute(update_sess_query)).fetchall()
-                        if len(rows) == 0:
-                            return []
-                        target_session_ids = [r["id"] for r in rows]
-                        select_query = (
-                            sa.select(SessionRow)
-                            .where(SessionRow.id.in_(target_session_ids))
-                            .options(
-                                noload("*"),
-                                selectinload(SessionRow.kernels).noload("*"),
-                            )
+                    )
+                    await db_sess.execute(update_query)
+                    update_sess_query = (
+                        sa.update(SessionRow)
+                        .values(
+                            status=SessionStatus.PREPARING,
+                            # status_changed=now,
+                            status_info="",
+                            status_data={},
+                            status_history=sql_json_merge(
+                                SessionRow.status_history,
+                                (),
+                                {
+                                    SessionStatus.PREPARING.name: now.isoformat(),
+                                },
+                            ),
                         )
-                        result = await db_sess.execute(select_query)
-                        return result.scalars().all()
+                        .where(SessionRow.status == SessionStatus.SCHEDULED)
+                        .returning(SessionRow.id)
+                    )
+                    rows = (await db_sess.execute(update_sess_query)).fetchall()
+                    if len(rows) == 0:
+                        return []
+                    target_session_ids = [r["id"] for r in rows]
+                    select_query = (
+                        sa.select(SessionRow)
+                        .where(SessionRow.id.in_(target_session_ids))
+                        .options(
+                            noload("*"),
+                            selectinload(SessionRow.kernels).noload("*"),
+                        )
+                    )
+                    result = await db_sess.execute(select_query)
+                    return result.scalars().all()
 
                 scheduled_sessions: Sequence[SessionRow]
-                scheduled_sessions = await execute_with_retry(_mark_session_preparing)
+                async with self.db.connect() as conn:
+                    scheduled_sessions = await execute_with_txn_retry(
+                        _mark_session_preparing, self.db.begin_session, conn
+                    )
                 log.debug("prepare(): preparing {} session(s)", len(scheduled_sessions))
                 async with (
                     async_timeout.timeout(delay=50.0),
@@ -1544,23 +1565,21 @@ class SchedulerDispatcher(aobject):
             ),
         )
 
-        async def _delete():
-            async with self.db.begin_session() as db_sess:
-                query = (
-                    sa.update(EndpointRow)
-                    .values({
-                        "destroyed_at": sa.func.now(),
-                        "lifecycle_stage": EndpointLifecycle.DESTROYED,
-                    })
-                    .where(EndpointRow.id.in_([e.id for e in endpoints_to_mark_terminated]))
-                )
-                await db_sess.execute(query)
-                query = sa.delete(RoutingRow).where(
-                    RoutingRow.session.in_(already_destroyed_sessions)
-                )
-                await db_sess.execute(query)
+        async def _delete(db_sess: SASession):
+            query = (
+                sa.update(EndpointRow)
+                .values({
+                    "destroyed_at": sa.func.now(),
+                    "lifecycle_stage": EndpointLifecycle.DESTROYED,
+                })
+                .where(EndpointRow.id.in_([e.id for e in endpoints_to_mark_terminated]))
+            )
+            await db_sess.execute(query)
+            query = sa.delete(RoutingRow).where(RoutingRow.session.in_(already_destroyed_sessions))
+            await db_sess.execute(query)
 
-        await execute_with_retry(_delete)
+        async with self.db.connect() as conn:
+            await execute_with_txn_retry(_delete, self.db.begin_session, conn)
 
         async with self.db.begin_readonly_session() as db_sess:
             for endpoint in endpoints_to_mark_terminated:
@@ -1592,55 +1611,55 @@ class SchedulerDispatcher(aobject):
             # TODO: instead of instantly cancelling upon exception, we could mark it as
             #       SCHEDULED and retry within some limit using status_data.
 
-            async def _mark_session_cancelled() -> None:
-                async with self.db.begin() as db_conn:
-                    affected_agents = set(k.agent for k in session.kernels)
-                    await _rollback_predicate_mutations(db_conn, sched_ctx, session)
-                    now = datetime.now(tzutc())
-                    update_query = (
-                        sa.update(KernelRow)
-                        .values(
-                            status=KernelStatus.CANCELLED,
-                            status_changed=now,
-                            status_info="failed-to-start",
-                            status_data=status_data,
-                            terminated_at=now,
-                            status_history=sql_json_merge(
-                                KernelRow.status_history,
-                                (),
-                                {
-                                    KernelStatus.CANCELLED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(KernelRow.session_id == session.id)
+            async def _mark_session_cancelled(db_conn: SAConnection) -> None:
+                affected_agents = set(k.agent for k in session.kernels)
+                await _rollback_predicate_mutations(db_conn, sched_ctx, session)
+                now = datetime.now(tzutc())
+                update_query = (
+                    sa.update(KernelRow)
+                    .values(
+                        status=KernelStatus.CANCELLED,
+                        status_changed=now,
+                        status_info="failed-to-start",
+                        status_data=status_data,
+                        terminated_at=now,
+                        status_history=sql_json_merge(
+                            KernelRow.status_history,
+                            (),
+                            {
+                                KernelStatus.CANCELLED.name: now.isoformat(),
+                            },
+                        ),
                     )
-                    await SASession(db_conn).execute(update_query)
-                    update_sess_query = (
-                        sa.update(SessionRow)
-                        .values(
-                            status=SessionStatus.CANCELLED,
-                            # status_changed=now,
-                            status_info="failed-to-start",
-                            status_data=status_data,
-                            terminated_at=now,
-                            status_history=sql_json_merge(
-                                SessionRow.status_history,
-                                (),
-                                {
-                                    SessionStatus.CANCELLED.name: now.isoformat(),
-                                },
-                            ),
-                        )
-                        .where(SessionRow.id == session.id)
+                    .where(KernelRow.session_id == session.id)
+                )
+                await SASession(db_conn).execute(update_query)
+                update_sess_query = (
+                    sa.update(SessionRow)
+                    .values(
+                        status=SessionStatus.CANCELLED,
+                        # status_changed=now,
+                        status_info="failed-to-start",
+                        status_data=status_data,
+                        terminated_at=now,
+                        status_history=sql_json_merge(
+                            SessionRow.status_history,
+                            (),
+                            {
+                                SessionStatus.CANCELLED.name: now.isoformat(),
+                            },
+                        ),
                     )
-                    await SASession(db_conn).execute(update_sess_query)
-                    for agent_id in affected_agents:
-                        await recalc_agent_resource_occupancy(db_conn, agent_id)
+                    .where(SessionRow.id == session.id)
+                )
+                await SASession(db_conn).execute(update_sess_query)
+                for agent_id in affected_agents:
+                    await recalc_agent_resource_occupancy(db_conn, agent_id)
 
             log.debug(log_fmt + "cleanup-start-failure: begin", *log_args)
             try:
-                await execute_with_retry(_mark_session_cancelled)
+                async with self.db.connect() as conn:
+                    await execute_with_txn_retry(_mark_session_cancelled, self.db.begin, conn)
                 await self.registry.event_producer.produce_event(
                     SessionCancelledEvent(
                         session.id,

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -21,7 +21,6 @@ from ..models import (
     UserRow,
 )
 from ..models.session import SessionStatus
-from ..models.utils import execute_with_retry
 from .types import PredicateResult, SchedulingContext
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.scheduler"))
@@ -68,21 +67,19 @@ async def check_concurrency(
     sched_ctx: SchedulingContext,
     sess_ctx: SessionRow,
 ) -> PredicateResult:
-    async def _get_max_concurrent_sessions() -> int:
-        resouce_policy_q = sa.select(KeyPairRow.resource_policy).where(
-            KeyPairRow.access_key == sess_ctx.access_key
-        )
-        if sess_ctx.is_private:
-            concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sftp_sessions
-        else:
-            concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sessions
-        select_query = sa.select(concurrent_session_column).where(
-            KeyPairResourcePolicyRow.name == resouce_policy_q.scalar_subquery()
-        )
-        result = await db_sess.execute(select_query)
-        return result.scalar()
+    resouce_policy_q = sa.select(KeyPairRow.resource_policy).where(
+        KeyPairRow.access_key == sess_ctx.access_key
+    )
+    if sess_ctx.is_private:
+        concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sftp_sessions
+    else:
+        concurrent_session_column = KeyPairResourcePolicyRow.max_concurrent_sessions
+    select_query = sa.select(concurrent_session_column).where(
+        KeyPairResourcePolicyRow.name == resouce_policy_q.scalar_subquery()
+    )
+    result = await db_sess.execute(select_query)
 
-    max_concurrent_sessions = await execute_with_retry(_get_max_concurrent_sessions)
+    max_concurrent_sessions = result.scalar()
     if sess_ctx.is_private:
         redis_key = f"keypair.sftp_concurrency_used.{sess_ctx.access_key}"
     else:

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -181,6 +181,7 @@ def local_config(
             "name": test_db,
             "user": "postgres",
             "password": "develove",
+            "conn-timeout": 0,
             "pool-size": 8,
             "pool-recycle": -1,
             "pool-pre-ping": False,

--- a/tests/manager/models/test_dbutils.py
+++ b/tests/manager/models/test_dbutils.py
@@ -1,8 +1,10 @@
+import asyncio
+
 import aiotools
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.manager.models.utils import execute_with_retry
+from ai.backend.manager.models.utils import execute_with_retry, execute_with_txn_retry
 
 
 @pytest.mark.asyncio
@@ -43,3 +45,53 @@ async def test_execute_with_retry():
 
         ret = await execute_with_retry(txn_func_temporary_serialization_failure)
         assert ret == 1234
+
+
+@pytest.mark.asyncio
+async def test_execute_with_trx_retry(database_engine):
+    class DummyDBError(Exception):
+        def __init__(self, pgcode):
+            self.pgcode = pgcode
+
+    async def txn_func_generic_failure(db_session):
+        raise sa.exc.IntegrityError("DUMMY_SQL", params=None, orig=DummyDBError("999"))
+
+    async def txn_func_generic_failure_2(db_session):
+        raise ZeroDivisionError("oops")
+
+    async def txn_func_permanent_serialization_failure(db_session):
+        raise sa.exc.DBAPIError("DUMMY_SQL", params=None, orig=DummyDBError("40001"))
+
+    _fail_count = 0
+
+    async def txn_func_temporary_serialization_failure(db_session):
+        nonlocal _fail_count
+        _fail_count += 1
+        if _fail_count == 5:
+            return 1234
+        raise sa.exc.DBAPIError("DUMMY_SQL", params=None, orig=DummyDBError("40001"))
+
+    with pytest.raises(sa.exc.IntegrityError):
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_generic_failure, database_engine.begin_session, conn
+            )
+
+    with pytest.raises(ZeroDivisionError):
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_generic_failure_2, database_engine.begin_session, conn
+            )
+
+    with pytest.raises(asyncio.TimeoutError) as e:
+        async with database_engine.connect() as conn:
+            await execute_with_txn_retry(
+                txn_func_permanent_serialization_failure, database_engine.begin_session, conn
+            )
+    assert "serialization failed" in e.value.args[0].lower()
+
+    async with database_engine.connect() as conn:
+        ret = await execute_with_txn_retry(
+            txn_func_temporary_serialization_failure, database_engine.begin_session, conn
+        )
+    assert ret == 1234


### PR DESCRIPTION
Improve PostgreSQL connection management.
Replace `execute_with_retry` to `execute_with_txn_retry` in registry and scheduler module.

### Notice
Some of the code that retries DB calls through the `execute_with_retry()` API has been modified to prevent further retries because the DB calls will not be retried as intended.
- `get_*_occupancy()` APIs do not retry DB calls anymore because `execute_with_retry()` retries only when `SerializationError` occurs, which requires retry the entire transaction, not rolling back to `CHECKPOINT`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)