### PR TITLE
refactor: Replace `vfolder`'s `status_history`'s type `map` with `list`

### DIFF
--- a/changes/2111.feature.md
+++ b/changes/2111.feature.md
@@ -1,0 +1,1 @@
+Change the type of `vfolders.status_history` from a mapping of status and timestamps to a list of log entries containing status and timestamps, to preserve the log entries.

--- a/src/ai/backend/manager/models/alembic/versions/786be66ef4e5_replace_vfolders_status_history_s_type_.py
+++ b/src/ai/backend/manager/models/alembic/versions/786be66ef4e5_replace_vfolders_status_history_s_type_.py
@@ -1,0 +1,67 @@
+"""Replace vfolders status_history's type map with list
+
+Revision ID: 786be66ef4e5
+Revises: 8c8e90aebacd
+Create Date: 2024-05-07 05:10:23.799723
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "786be66ef4e5"
+down_revision = "8c8e90aebacd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        WITH data AS (
+            SELECT id,
+                (jsonb_each(status_history)).key AS status,
+                (jsonb_each(status_history)).value AS timestamp
+            FROM vfolders
+        )
+        UPDATE vfolders
+        SET status_history = (
+            SELECT jsonb_agg(
+                jsonb_build_object('status', status, 'timestamp', timestamp)
+            )
+            FROM data
+            WHERE data.id = vfolders.id
+        );
+    """
+    )
+
+    op.execute("UPDATE vfolders SET status_history = '[]'::jsonb WHERE status_history IS NULL;")
+    op.alter_column(
+        "vfolders",
+        "status_history",
+        nullable=False,
+        default=[],
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        WITH data AS (
+            SELECT id,
+                jsonb_object_agg(
+                    elem->>'status', elem->>'timestamp'
+                ) AS new_status_history
+            FROM vfolders,
+            jsonb_array_elements(status_history) AS elem
+            GROUP BY id
+        )
+        UPDATE vfolders
+        SET status_history = data.new_status_history
+        FROM data
+        WHERE data.id = vfolders.id;
+    """
+    )
+
+    op.alter_column("vfolders", "status_history", nullable=True, default=None)
+    op.execute("UPDATE vfolders SET status_history = NULL WHERE status_history = '[]'::jsonb;")


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially resolves #767.

The current implementation saves only the most recent timestamp whenever status information in status_history is updated, and all previous information is deleted.

This PR prevents the loss of timestamp information by changing the data structure of vfolders' status_history to **List**.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue