### PR TITLE
fix: Filter out host permissions of model store

### DIFF
--- a/changes/2117.fix.md
+++ b/changes/2117.fix.md
@@ -1,0 +1,1 @@
+Do not fetch folder host permission of model store when permission check 

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -490,7 +490,7 @@ class CreateGroup(graphene.Mutation):
         _type = ProjectType[props.type]
         data = {
             "name": name,
-            "type": ProjectType[props.type],
+            "type": _type,
             "description": props.description,
             "is_active": props.is_active,
             "domain_name": props.domain_name,

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -487,6 +487,7 @@ class CreateGroup(graphene.Mutation):
         if _rx_slug.search(name) is None:
             raise ValueError("invalid name format. slug format required.")
         graph_ctx: GraphQueryContext = info.context
+        _type = ProjectType[props.type]
         data = {
             "name": name,
             "type": ProjectType[props.type],
@@ -504,7 +505,8 @@ class CreateGroup(graphene.Mutation):
             "total_resource_slots",
             clean_func=lambda v: ResourceSlot.from_user_input(v, None),
         )
-        set_if_set(props, data, "allowed_vfolder_hosts")
+        if _type != ProjectType.MODEL_STORE:
+            set_if_set(props, data, "allowed_vfolder_hosts")
         insert_query = sa.insert(groups).values(data)
         return await simple_db_mutate_returning_item(cls, graph_ctx, insert_query, item_cls=Group)
 

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -642,6 +642,7 @@ async def get_allowed_vfolder_hosts_by_group(
     if group_id is not None:
         query = sa.select([groups.c.allowed_vfolder_hosts]).where(
             (groups.c.domain_name == domain_name)
+            & (groups.c.type != ProjectType.MODEL_STORE)
             & (groups.c.id == group_id)
             & (groups.c.is_active),
         )
@@ -649,7 +650,9 @@ async def get_allowed_vfolder_hosts_by_group(
             allowed_hosts = allowed_hosts | values
     elif domain_admin:
         query = sa.select([groups.c.allowed_vfolder_hosts]).where(
-            (groups.c.domain_name == domain_name) & (groups.c.is_active),
+            (groups.c.domain_name == domain_name)
+            & (groups.c.type != ProjectType.MODEL_STORE)
+            & (groups.c.is_active),
         )
         if rows := (await conn.execute(query)).fetchall():
             for row in rows:

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -689,6 +689,7 @@ async def get_allowed_vfolder_hosts_by_user(
             association_groups_users,
             (
                 (groups.c.id == association_groups_users.c.group_id)
+                & (groups.c.type != ProjectType.MODEL_STORE)
                 & (groups.c.id == group_id)
                 & (association_groups_users.c.user_id == user_uuid)
             ),
@@ -698,6 +699,7 @@ async def get_allowed_vfolder_hosts_by_user(
             association_groups_users,
             (
                 (groups.c.id == association_groups_users.c.group_id)
+                & (groups.c.type != ProjectType.MODEL_STORE)
                 & (association_groups_users.c.user_id == user_uuid)
             ),
         )


### PR DESCRIPTION
"Model store" projects have `allowed_host_permission` values and it is used when determining folder permissions.
We should not use host permission of model stores because it is out of the purpose of the model store project.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)