### PR TITLE
feat: update CLI to be aware of `model_definition_path` parameter

### DIFF
--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -248,6 +248,12 @@ def info(ctx: CLIContext, service_name_or_id: str):
     help="Set the owner of the target session explicitly.",
 )
 @click.option(
+    "--model-definition-path",
+    metavar="PATH",
+    default=None,
+    help="Relative path to model definition file. Defaults to `model-definition.yaml`.",
+)
+@click.option(
     "--public",
     "--expose-to-public",
     is_flag=True,
@@ -279,6 +285,7 @@ def create(
     architecture: Optional[str],
     scaling_group: Optional[str],
     owner: Optional[str],
+    model_definition_path: Optional[str],
     public: bool,
 ):
     """
@@ -309,6 +316,7 @@ def create(
         "architecture": architecture,
         "scaling_group": scaling_group,
         "expose_to_public": public,
+        "model_definition_path": model_definition_path,
     }
     if model_mount_destination:
         body["model_mount_destination"] = model_mount_destination

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -111,6 +111,7 @@ class Service(BaseFunction):
         architecture: Optional[str] = DEFAULT_IMAGE_ARCH,
         scaling_group: Optional[str] = None,
         owner_access_key: Optional[str] = None,
+        model_definition_path: Optional[str] = None,
         expose_to_public=False,
     ) -> Any:
         """
@@ -138,6 +139,7 @@ class Service(BaseFunction):
         :param tag: An optional string to annotate extra information.
         :param owner: An optional access key that owns the created session. (Only
             available to administrators)
+        :param model_definition_path: Relative path to model definition file. Defaults to `model-definition.yaml`.
         :param expose_to_public: Visibility of API Endpoint which serves inference workload.
             If set to true, no authentication will be required to access the endpoint.
 
@@ -181,6 +183,7 @@ class Service(BaseFunction):
             "scaling_group": scaling_group,
             "resources": resources,
             "resource_opts": resource_opts,
+            "model_definition_path": model_definition_path,
         }
         if model_version:
             model_config["model_version"] = model_version


### PR DESCRIPTION
This PR updates Backend.AI Client so that users can customize `model_definition_path` value when using Python SDK.