### PR TITLE
docs: Remove scripts not needed for webui update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Backend.AI
 ![Wheels](https://img.shields.io/pypi/wheel/backend.ai-manager.svg)
 [![Gitter](https://badges.gitter.im/lablup/backend.ai.svg)](https://gitter.im/lablup/backend.ai)
 
-Backend.AI is a streamlined, container-based computing cluster platform 
-that hosts popular computing/ML frameworks and diverse programming languages, 
+Backend.AI is a streamlined, container-based computing cluster platform
+that hosts popular computing/ML frameworks and diverse programming languages,
 with pluggable heterogeneous accelerator support including CUDA GPU, ROCm GPU, TPU, IPU and other NPUs.
 
 It allocates and isolates the underlying computing resources for multi-tenant
@@ -175,7 +175,6 @@ and basic administration tasks.
 
 **Synchronizing the static Backend.AI WebUI version:**
 ```console
-$ git remote add webui-package https://github.com/lablup/backend.ai-app  # first time only
 $ scripts/download-webui-release.sh <target version to download>
 ```
 

--- a/scripts/download-webui-release.sh
+++ b/scripts/download-webui-release.sh
@@ -1,9 +1,19 @@
 #! /bin/sh
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <webui-version>"
+    exit 1
+fi
+
 BASE_PATH=$(cd "$(dirname "$0")"/.. && pwd)
 TARGET_VERSION=$1
 
 cd $BASE_PATH/src/ai/backend/web
-curl -sL https://github.com/lablup/backend.ai-webui/releases/download/v$TARGET_VERSION/backend.ai-webui-bundle-$TARGET_VERSION.zip > /tmp/bai-webui.zip
+curl --fail -sL https://github.com/lablup/backend.ai-webui/releases/download/v$TARGET_VERSION/backend.ai-webui-bundle-$TARGET_VERSION.zip > /tmp/bai-webui.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to download the webui bundle."
+    exit 1
+fi
 rm -rf static
 mkdir static
 cd static


### PR DESCRIPTION
https://github.com/lablup/backend.ai/commit/a24796ddbe4abf166572f3c116da6b62354248b1
As the method of updating the built webui file has been changed to downloading the distribution from the subtree, there is no need to add backend.ai-app remotely.

Additionally, exception handling logic for the script has been added.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2131.org.readthedocs.build/en/2131/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2131.org.readthedocs.build/ko/2131/

<!-- readthedocs-preview sorna-ko end -->