### PR TITLE
fix: Wrong success check of vfolder cli integration test

### DIFF
--- a/src/ai/backend/test/cli_integration/user/test_vfolder.py
+++ b/src/ai/backend/test/cli_integration/user/test_vfolder.py
@@ -159,17 +159,21 @@ def test_mkdir_vfolder(run_user: ClientRunnerFunc):
     # Create directory in the vfolder
     with closing(run_user(["vfolder", "mkdir", vfolder_name, dir_paths[0]])) as p:
         p.expect(EOF)
-        assert "Done." in p.before.decode(), "Directory creation failed."
+        assert "Successfully created" in p.before.decode(), "Directory creation failed."
 
     # Create already existing directory with exist-ok option
     with closing(run_user(["vfolder", "mkdir", "-e", vfolder_name, dir_paths[0]])) as p:
         p.expect(EOF)
-        assert "Done." in p.before.decode(), "Exist-ok option does not work properly."
+        assert (
+            "Successfully created" in p.before.decode()
+        ), "Exist-ok option does not work properly."
 
     # Test whether the parent directory is created automatically
     with closing(run_user(["vfolder", "mkdir", "-p", vfolder_name, dir_paths[1]])) as p:
         p.expect(EOF)
-        assert "Done." in p.before.decode(), "The parent directory is not created automatically."
+        assert (
+            "Successfully created" in p.before.decode()
+        ), "The parent directory is not created automatically."
 
 
 @pytest.mark.dependency(


### PR DESCRIPTION
follow-up #1778 

Many of cli integration test codes check success by asserting output messages.
Some CLI output message changed in #1803 and we need to update the test codes. 

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Update of end-to-end CLI integration tests in `ai.backend.test`