### PR TITLE
fix: Make GPFS plugin reliable

### DIFF
--- a/changes/2144.fix.md
+++ b/changes/2144.fix.md
@@ -1,0 +1,1 @@
+Handle fileset-already-exists response of `create-filset` API request and make sure to wait between all GPFS job polling iterations

--- a/src/ai/backend/storage/gpfs/gpfs_client.py
+++ b/src/ai/backend/storage/gpfs/gpfs_client.py
@@ -135,13 +135,16 @@ class GPFSAPIClient:
                 stop=stop_after_attempt(100),
                 retry=retry_if_exception_type(web.HTTPNotFound),
             ):
-                job = await self.get_job(job_to_wait.jobId)
-                if job.status == GPFSJobStatus.COMPLETED:
-                    return
-                elif job.status == GPFSJobStatus.FAILED:
-                    raise GPFSJobFailedError(job.result.to_json() if job.result is not None else "")
-                elif job.status == GPFSJobStatus.CANCELLED:
-                    raise GPFSJobCancelledError
+                with attempt:
+                    job = await self.get_job(job_to_wait.jobId)
+                    if job.status == GPFSJobStatus.COMPLETED:
+                        return
+                    elif job.status == GPFSJobStatus.FAILED:
+                        raise GPFSJobFailedError(
+                            job.result.to_json() if job.result is not None else ""
+                        )
+                    elif job.status == GPFSJobStatus.CANCELLED:
+                        raise GPFSJobCancelledError
 
     @contextlib.asynccontextmanager
     async def _build_session(self) -> AsyncIterator[aiohttp.ClientSession]:
@@ -283,26 +286,23 @@ class GPFSAPIClient:
         if path is not None:
             body["path"] = path.as_posix()
 
-        async def handler(response: aiohttp.ClientResponse) -> aiohttp.ClientResponse:
-            match response.status:
-                case 200 | 201 | 202:
-                    pass
-                case 409:
-                    log.warning(f"GPFS fileset already exists. Skip create. (name: {fileset_name})")
-                case _:
-                    raise ExternalError(
-                        f"Cannot create GPFS fileset. status code: {response.status}"
-                    )
-            return response
-
         async with self._build_session() as sess:
             response = await self._build_request(
                 sess,
                 "POST",
                 f"/filesystems/{fs_name}/filesets",
                 body,
-                err_handler=handler,
             )
+            match response.status:
+                case 200 | 201 | 202:
+                    pass
+                case 409:
+                    log.warning(f"GPFS fileset already exists. Skip create. (name: {fileset_name})")
+                    return
+                case _:
+                    raise ExternalError(
+                        f"Cannot create GPFS fileset. status code: {response.status}"
+                    )
             data = await response.json()
             await self._wait_for_job_done([GPFSJob.from_dict(x) for x in data["jobs"]])
 


### PR DESCRIPTION
- Place retrying codes into async-attempt context so that it can actually wait for `wait_for` seconds.
- Skip waiting `create_fileset` job when the given fileset already exists

Tested on real GPFS API server

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)