### PR TITLE
fix: typing update in CLI decorator function

### DIFF
--- a/src/ai/backend/client/cli/extensions.py
+++ b/src/ai/backend/client/cli/extensions.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import update_wrapper
-from typing import Any, Callable, Mapping, TypeVar, cast
+from typing import Callable, Concatenate, Mapping, ParamSpec, TypeVar
 
 from click import get_current_context
 
@@ -34,11 +34,12 @@ def set_client_config(info: Mapping) -> CLIContext:
     return cli_ctx
 
 
-F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T")
+P = ParamSpec("P")
 
 
-def pass_ctx_obj(f: F) -> F:
-    def new_func(*args, **kwargs):
+def pass_ctx_obj(f: Callable[Concatenate[CLIContext, P], T]) -> Callable[P, T]:
+    def new_func(*args: P.args, **kwargs: P.kwargs) -> T:
         obj = get_current_context().obj
         match obj:
             case CLIContext():
@@ -49,4 +50,4 @@ def pass_ctx_obj(f: F) -> F:
                 raise RuntimeError("Invalid Context from client command")
         return inner
 
-    return update_wrapper(cast(F, new_func), f)
+    return update_wrapper(new_func, f)


### PR DESCRIPTION
follow-up #2147 

Updated mypy found an typing error in main branch
Let's fix it !!
![image](https://github.com/lablup/backend.ai/assets/44239739/4c1b5900-9164-4b52-ae3c-27f2b5ac4a34)


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
