### PR TITLE
fix: Ensure that all pending sessions are picked by schedulers

### DIFF
--- a/changes/2155.fix.md
+++ b/changes/2155.fix.md
@@ -1,0 +1,1 @@
+Ensure that all pending sessions are picked by schedulers


### PR DESCRIPTION
Currently, a scheduler fetches one list of all pending session in a given scaling group and it iterates them to schedule pending sessions one by one.
If one of the pending sessions raises `InstanceNotAvailable` or `GenericBadRequest` exceptions (which is normal), the scheduler skips all trailing pending sessions in the list.
The scheduler should keep iterating, not stop scheduling.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version