### PR TITLE
chore: add option to query not-owned customized images

### DIFF
--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -46,7 +46,10 @@ type Queries {
   images(is_installed: Boolean, is_operation: Boolean): [Image]
 
   """Added in 24.03.1"""
-  customized_images: [ImageNode]
+  customized_images(
+    """Added in 24.03.4"""
+    owned_only: Boolean
+  ): [ImageNode]
   user(domain_name: String, email: String): User
   user_from_uuid(domain_name: String, user_id: ID): User
   users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User]


### PR DESCRIPTION
follow-up #1973 

Add an option to enable admins to query customized images that created from other users
Option is `owned_only`
```gql
query CustomizedImages {
    customized_images(owned_only: false) {
        id
        name
    }
}
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)