### PR TITLE
fix: Correctly register and deregister terminating kernels

### DIFF
--- a/changes/2157.fix.md
+++ b/changes/2157.fix.md
@@ -1,0 +1,1 @@
+Correctly register and deregister Agent's terminating kernels

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1017,12 +1017,12 @@ class AbstractAgent(
                             ev.done_future.set_result(None)
                         return
                 else:
-                    self.terminating_kernels.add(ev.kernel_id)
                     kernel_obj.stats_enabled = False
                     kernel_obj.termination_reason = ev.reason
                     if kernel_obj.runner is not None:
                         await kernel_obj.runner.close()
                     kernel_obj.clean_event = ev.done_future
+                self.terminating_kernels.add(ev.kernel_id)
                 try:
                     await self.destroy_kernel(ev.kernel_id, ev.container_id)
                 except Exception as e:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1043,6 +1043,8 @@ class AbstractAgent(
                             ),
                         )
                     else:
+                        # Items in `terminating_kernels` are deleted only in _handle_clean_event()
+                        # Should delete the kernel_id that will not be cleaned
                         self.terminating_kernels.discard(ev.kernel_id)
         except asyncio.CancelledError:
             pass


### PR DESCRIPTION
`Agent` registers kernel ids to its `terminating_kernels` so that it can track kernels under "terminate" lifecycle.
There are some holes that kernel ids cannot be deleted from the `terminating_kernels`, which block destroying or cleaning the kernels by `sync_container_lifecycle` task.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
