### PR TITLE
fix: Netapp `create_qtree` timing issue

### DIFF
--- a/changes/2170.fix.md
+++ b/changes/2170.fix.md
@@ -1,0 +1,1 @@
+Wait for real quota scope directory creation after Netapp `create_qtree()` call

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -357,7 +357,10 @@ async def create_vfolder(request: web.Request) -> web.Response:
                 await volume.quota_model.create_quota_scope(
                     params["vfid"].quota_scope_id, options=options
                 )
-                await volume.create_vfolder(params["vfid"])
+                try:
+                    await volume.create_vfolder(params["vfid"])
+                except QuotaScopeNotFoundError:
+                    raise ExternalError("Failed to create vfolder due to quota scope not found.")
             return web.Response(status=204)
 
 


### PR DESCRIPTION
There might be a slight delay between qtree-creation-job success response and the directory creation.
Let's poll after `create_qtree`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version