### PR TITLE
fix: `check-docker.py` script not working

### DIFF
--- a/scripts/check-docker.py
+++ b/scripts/check-docker.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import base64
 import functools
 import hashlib
@@ -7,10 +8,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import quote
 
-import requests
-import requests_unixsocket
+import aiohttp
 
 log = functools.partial(print, file=sys.stderr)
 run = subprocess.run
@@ -42,19 +41,22 @@ def simple_hash(data: bytes) -> str:
     return base64.b64encode(h.digest()[:12], altchars=b"._").decode()
 
 
-def detect_snap_docker():
+async def detect_snap_docker():
     if not Path("/run/snapd.socket").is_socket():
         return None
-    with requests.get("http+unix://%2Frun%2Fsnapd.socket/v2/snaps?names=docker") as r:
-        if r.status_code != 200:
-            raise RuntimeError("Failed to query Snapd package information")
-        response_data = r.json()
-        for pkg_data in response_data["result"]:
-            if pkg_data["name"] == "docker":
-                return pkg_data["version"]
+    async with aiohttp.ClientSession(connector=aiohttp.UnixConnector("/run/snapd.socket")) as sess:
+        async with sess.get("http://localhost/v2/snaps?names=docker") as r:
+            try:
+                r.raise_for_status()
+            except:
+                raise RuntimeError("Failed to query Snapd package information")
+            response_data = await r.json()
+            for pkg_data in response_data["result"]:
+                if pkg_data["name"] == "docker":
+                    return pkg_data["version"]
 
 
-def detect_system_docker():
+async def detect_system_docker():
     sock_paths = [
         Path("/run/docker.sock"),  # Linux default
         Path("/var/run/docker.sock"),  # macOS default
@@ -68,12 +70,14 @@ def detect_system_docker():
             break
     else:
         return None
-    encoded_sock_path = quote(bytes(sock_path), safe="")
-    with requests.get(f"http+unix://{encoded_sock_path}/version") as r:
-        if r.status_code != 200:
-            raise RuntimeError("Failed to query the Docker daemon API")
-        response_data = r.json()
-        return response_data["Version"]
+    async with aiohttp.ClientSession(connector=aiohttp.UnixConnector(sock_path.as_posix())) as sess:
+        async with sess.get("http://localhost/version") as r:
+            try:
+                r.raise_for_status()
+            except:
+                raise RuntimeError("Failed to query Snapd package information")
+            response_data = await r.json()
+            return response_data["Version"]
 
 
 def fail_with_snap_docker_refresh_request():
@@ -94,15 +98,13 @@ def fail_with_compose_install_request():
     sys.exit(1)
 
 
-def main():
-    requests_unixsocket.monkeypatch()
-
+async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--get-preferred-pants-local-exec-root", action="store_true", default=False)
     args = parser.parse_args()
 
     if args.get_preferred_pants_local_exec_root:
-        docker_version = detect_snap_docker()
+        docker_version = await detect_snap_docker()
         build_root_path = get_build_root()
         build_root_name = build_root_path.name
         build_root_hash = simple_hash(os.fsencode(build_root_path))
@@ -114,13 +116,13 @@ def main():
             print(f"/tmp/{build_root_name}-{build_root_hash}-pants")
         return
 
-    docker_version = detect_snap_docker()
+    docker_version = await detect_snap_docker()
     if docker_version is not None:
         log(f"Detected Docker installation: Snap package ({docker_version})")
         if parse_version(docker_version) < (20, 10, 15):
             fail_with_snap_docker_refresh_request()
     else:
-        docker_version = detect_system_docker()
+        docker_version = await detect_system_docker()
         if docker_version is not None:
             log(f"Detected Docker installation: System package ({docker_version})")
         else:
@@ -145,4 +147,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -641,7 +641,7 @@ show_info "Checking prerequisites and script dependencies..."
 install_script_deps
 $bpython -m ensurepip --upgrade
 # FIXME: Remove urllib3<2.0 requirement after docker/docker-py#3113 is resolved
-$bpython -m pip --disable-pip-version-check install -q -U 'urllib3<2.0' requests requests-unixsocket
+$bpython -m pip --disable-pip-version-check install -q -U 'urllib3<2.0' aiohttp
 if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
   $docker_sudo $bpython scripts/check-docker.py
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR resolves `install-dev.sh` script failing due to recent changes in `requests` library by lifting up dependencies to `requests` and instead benefiting from `aiohttp`'s native Unix Domain Socket connector feature.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
