### PR TITLE
fix: sync agent's kernel-registry to actual container periodically

### DIFF
--- a/changes/2179.fix.md
+++ b/changes/2179.fix.md
@@ -1,0 +1,1 @@
+Sync agent's kernel registry with the actual container through periodic loop.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1084,6 +1084,10 @@ class AbstractAgent(
                         await kernel_obj.close()
                 finally:
                     self.terminating_kernels.discard(ev.kernel_id)
+                    try:
+                        del self.kernel_registry[ev.kernel_id]
+                    except KeyError:
+                        pass
                     if restart_tracker := self.restarting_kernels.get(ev.kernel_id, None):
                         restart_tracker.destroy_event.set()
                     else:


### PR DESCRIPTION
### Intro
The status information of the container is divided into three types in BackendAI system: DB on the manager side, agent's kernel registry, and actual container. This PR is about agent's kernel registry and actual container.

### Problem
In the current implementation, kernel data is inserted and removed from the agent's kernel registry in the task of creating and destroying containers. In the case of a container creation, when any unhandled error occurs, the kernel data inserted into the kernel registry is removed. Such removing is not reliable and any other unpredictable errors can cause mismatch between kernel registry and actual container state.
So, let's sync kernel registry to the actual container state in a periodic loop.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version