### PR TITLE
fix: invalid concurrency calculation logic (#2175)

### DIFF
--- a/changes/2175.fix.md
+++ b/changes/2175.fix.md
@@ -1,0 +1,1 @@
+Fix wrong per-user concurrency calculation logic


### PR DESCRIPTION
This is an auto-generated backport PR of #2175 to the 24.03 release.