### PR TITLE
feat: expose `model_definition_filename` field to API responses (#2065)

### DIFF
--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -849,6 +849,9 @@ type Endpoint implements Item {
   resource_slots: JSONString
   url: String
   model: UUID
+
+  """Added at 24.03.3"""
+  model_definition_path: String
   model_mount_destiation: String @deprecated(reason: "Deprecated since 24.03.4; use `model_mount_destination` instead")
 
   """Added in 24.03.4."""
@@ -1769,6 +1772,9 @@ input ModifyEndpointInput {
   image: ImageRefType
   name: String
   resource_group: String
+
+  """Added at 24.03.3"""
+  model_definition_path: String
   open_to_public: Boolean
 
   """Added in 24.03.4."""

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -202,6 +202,9 @@ class ServeInfoModel(BaseResponseModel):
     desired_session_count: NonNegativeInt = Field(
         description="Number of identical inference sessions."
     )
+    model_definition_path: str | None = Field(
+        description="Path to the the model definition file. If not set, Backend.AI will look for model-definition.yml or model-definition.yaml by default."
+    )
     active_routes: list[RouteInfoModel] = Field(
         description="Information of routes which are bound with healthy sessions."
     )
@@ -246,6 +249,7 @@ async def get_info(request: web.Request) -> ServeInfoModel:
         model_id=endpoint.model,
         extra_mounts=[m.vfid.folder_id for m in endpoint.extra_mounts],
         name=endpoint.name,
+        model_definition_path=endpoint.model_definition_path,
         desired_session_count=endpoint.desired_session_count,
         active_routes=[
             RouteInfoModel(route_id=r.id, session_id=r.session, traffic_ratio=r.traffic_ratio)
@@ -589,6 +593,7 @@ async def create(request: web.Request, params: NewServiceRequestModel) -> ServeI
         model_id=endpoint.model,
         extra_mounts=[m.vfid.folder_id for m in endpoint.extra_mounts],
         name=params.service_name,
+        model_definition_path=validation_result.model_definition_path,
         desired_session_count=params.desired_session_count,
         active_routes=[],
         service_endpoint=None,

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -689,6 +689,7 @@ class Endpoint(graphene.ObjectType):
     resource_slots = graphene.JSONString()
     url = graphene.String()
     model = graphene.UUID()
+    model_definition_path = graphene.String(description="Added at 24.03.3")
     model_vfolder = VirtualFolderNode()
     model_mount_destiation = graphene.String(
         deprecation_reason="Deprecated since 24.03.4; use `model_mount_destination` instead"
@@ -744,6 +745,7 @@ class Endpoint(graphene.ObjectType):
             resource_slots=row.resource_slots.to_json(),
             url=row.url,
             model=row.model,
+            model_definition_path=row.model_definition_path,
             model_mount_destiation=row.model_mount_destination,
             model_mount_destination=row.model_mount_destination,
             created_user=row.created_user,
@@ -993,6 +995,7 @@ class ModifyEndpointInput(graphene.InputObjectType):
     image = ImageRefType()
     name = graphene.String()
     resource_group = graphene.String()
+    model_definition_path = graphene.String(description="Added at 24.03.3")
     open_to_public = graphene.Boolean()
     extra_mounts = graphene.List(ExtraMountInput, description="Added in 24.03.4.")
 
@@ -1051,6 +1054,9 @@ class ModifyEndpoint(graphene.Mutation):
 
                 if (_newval := props.cluster_size) and _newval is not Undefined:
                     endpoint_row.cluster_size = _newval
+
+                if (_newval := props.model_definition_path) and _newval is not Undefined:
+                    endpoint_row.model_definition_path = _newval
 
                 if (
                     _newval := props.desired_session_count
@@ -1134,7 +1140,7 @@ class ModifyEndpoint(graphene.Mutation):
                 await ModelServicePredicateChecker.validate_model_definition(
                     graph_ctx.storage_manager,
                     endpoint_row.model_row,
-                    None,
+                    endpoint_row.model_definition_path,
                 )
 
                 # from AgentRegistry.handle_route_creation()


### PR DESCRIPTION
This is an auto-generated backport PR of #2065 to the 24.03 release.