### PR TITLE
feat: Add missing fields of keypair resource policy (#2146)

### DIFF
--- a/changes/2146.feature.md
+++ b/changes/2146.feature.md
@@ -1,0 +1,1 @@
+Added missing fields for `keypair_resource_policy` in client-py, models, etc.

--- a/src/ai/backend/client/cli/admin/resource_policy.py
+++ b/src/ai/backend/client/cli/admin/resource_policy.py
@@ -121,6 +121,18 @@ def list(ctx: CLIContext) -> None:
         ' --vfolder-host-perms=\'{"HOST_NAME": ["create-vfolder", "modify-vfolder"]}\')'
     ),
 )
+@click.option(
+    "--max-pending-session-count",
+    type=int,
+    default=None,
+    help="Number of maximum pending sessions.",
+)
+@click.option(
+    "--max-pending-session-resource-slots",
+    type=str,
+    default=None,
+    help="Set maximum resource slots for pending sessions.",
+)
 def add(
     ctx: CLIContext,
     name: str,
@@ -132,6 +144,8 @@ def add(
     max_containers_per_session: int,
     idle_timeout: int,
     vfolder_host_perms: str,  # JSON string
+    max_pending_session_count: int,
+    max_pending_session_resource_slots: str,  # JSON string
 ) -> None:
     """
     Add a new keypair resource policy.
@@ -150,6 +164,8 @@ def add(
                 max_containers_per_session=max_containers_per_session,
                 idle_timeout=idle_timeout,
                 vfolder_host_perms=vfolder_host_perms,
+                max_pending_session_count=max_pending_session_count,
+                max_pending_session_resource_slots=max_pending_session_resource_slots,
             )
         except Exception as e:
             ctx.output.print_mutation_error(
@@ -228,6 +244,18 @@ def add(
         ' --vfolder-host-perms=\'{"HOST_NAME": ["create-vfolder", "modify-vfolder"]}\')'
     ),
 )
+@click.option(
+    "--max-pending-session-count",
+    type=OptionalType(int),
+    default=undefined,
+    help="Number of maximum pending sessions.",
+)
+@click.option(
+    "--max-pending-session-resource-slots",
+    type=OptionalType(str),
+    default=undefined,
+    help="Set maximum resource slots for pending sessions.",
+)
 def update(
     ctx: CLIContext,
     name: str,
@@ -239,6 +267,8 @@ def update(
     max_containers_per_session: int | Undefined,
     idle_timeout: int | Undefined,
     vfolder_host_perms: str | Undefined,  # JSON string
+    max_pending_session_count: int | Undefined,
+    max_pending_session_resource_slots: str | Undefined,  # JSON string
 ) -> None:
     """
     Update an existing keypair resource policy.
@@ -257,6 +287,8 @@ def update(
                 max_containers_per_session=max_containers_per_session,
                 idle_timeout=idle_timeout,
                 vfolder_host_perms=vfolder_host_perms,
+                max_pending_session_count=max_pending_session_count,
+                max_pending_session_resource_slots=max_pending_session_resource_slots,
             )
         except Exception as e:
             ctx.output.print_mutation_error(

--- a/src/ai/backend/client/func/keypair_resource_policy.py
+++ b/src/ai/backend/client/func/keypair_resource_policy.py
@@ -17,6 +17,10 @@ _default_list_fields = (
     keypair_resource_policy_fields["idle_timeout"],
     keypair_resource_policy_fields["max_containers_per_session"],
     keypair_resource_policy_fields["allowed_vfolder_hosts"],
+    keypair_resource_policy_fields["max_session_lifetime"],
+    keypair_resource_policy_fields["max_pending_session_count"],
+    keypair_resource_policy_fields["max_pending_session_resource_slots"],
+    keypair_resource_policy_fields["max_concurrent_sftp_sessions"],
 )
 
 _default_detail_fields = (
@@ -27,6 +31,10 @@ _default_detail_fields = (
     keypair_resource_policy_fields["idle_timeout"],
     keypair_resource_policy_fields["max_containers_per_session"],
     keypair_resource_policy_fields["allowed_vfolder_hosts"],
+    keypair_resource_policy_fields["max_session_lifetime"],
+    keypair_resource_policy_fields["max_pending_session_count"],
+    keypair_resource_policy_fields["max_pending_session_resource_slots"],
+    keypair_resource_policy_fields["max_concurrent_sftp_sessions"],
 )
 
 
@@ -52,6 +60,8 @@ class KeypairResourcePolicy(BaseFunction):
         max_containers_per_session: int,
         idle_timeout: int,
         vfolder_host_perms: str | Undefined = undefined,
+        max_pending_session_count: int | Undefined = undefined,
+        max_pending_session_resource_slots: str | Undefined = undefined,
         fields: Iterable[FieldSpec | str] | None = None,
     ) -> dict:
         """
@@ -78,6 +88,8 @@ class KeypairResourcePolicy(BaseFunction):
             "max_containers_per_session": max_containers_per_session,
             "idle_timeout": idle_timeout,
             "allowed_vfolder_hosts": vfolder_host_perms,
+            "max_pending_session_count": max_pending_session_count,
+            "max_pending_session_resource_slots": max_pending_session_resource_slots,
         }
         set_if_set(inputs, "allowed_vfolder_hosts", vfolder_host_perms)
         variables = {
@@ -101,6 +113,8 @@ class KeypairResourcePolicy(BaseFunction):
         idle_timeout: int | Undefined = undefined,
         total_resource_slots: str | Undefined = undefined,
         vfolder_host_perms: str | Undefined = undefined,
+        max_pending_session_count: int | Undefined = undefined,
+        max_pending_session_resource_slots: str | Undefined = undefined,
     ) -> dict:
         """
         Updates an existing keypair resource policy with the given options.
@@ -119,6 +133,8 @@ class KeypairResourcePolicy(BaseFunction):
         set_if_set(inputs, "max_containers_per_session", max_containers_per_session)
         set_if_set(inputs, "idle_timeout", idle_timeout)
         set_if_set(inputs, "allowed_vfolder_hosts", vfolder_host_perms)
+        set_if_set(inputs, "max_pending_session_count", max_pending_session_count)
+        set_if_set(inputs, "max_pending_session_resource_slots", max_pending_session_resource_slots)
         variables = {
             "name": name,
             "input": inputs,

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -136,10 +136,14 @@ keypair_resource_policy_fields = FieldSet([
     FieldSpec("name"),
     FieldSpec("created_at"),
     FieldSpec("total_resource_slots"),
+    FieldSpec("max_session_lifetime"),
     FieldSpec("max_concurrent_sessions"),  # formerly concurrency_limit
     FieldSpec("idle_timeout"),
     FieldSpec("max_containers_per_session"),
     FieldSpec("allowed_vfolder_hosts"),
+    FieldSpec("max_pending_session_count"),
+    FieldSpec("max_pending_session_resource_slots"),
+    FieldSpec("max_concurrent_sftp_sessions"),
 ])
 
 

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -603,6 +603,9 @@ type KeyPairResourcePolicy {
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
   max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
 
+  """Added in 23.03.3."""
+  max_concurrent_sftp_sessions: Int
+
   """Added in 24.03.4."""
   max_pending_session_count: Int
 

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -159,6 +159,7 @@ class KeyPairResourcePolicy(graphene.ObjectType):
     max_vfolder_count = graphene.Int(deprecation_reason="Deprecated since 23.09.4.")
     max_vfolder_size = BigInt(deprecation_reason="Deprecated since 23.09.4.")
     max_quota_scope_size = BigInt(deprecation_reason="Deprecated since 23.09.6.")
+    max_concurrent_sftp_sessions = graphene.Int(description="Added in 23.03.3.")
     max_pending_session_count = graphene.Int(description="Added in 24.03.4.")
     max_pending_session_resource_slots = graphene.JSONString(description="Added in 24.03.4.")
 
@@ -182,6 +183,7 @@ class KeyPairResourcePolicy(graphene.ObjectType):
             total_resource_slots=row["total_resource_slots"].to_json(),
             max_session_lifetime=row["max_session_lifetime"],
             max_concurrent_sessions=row["max_concurrent_sessions"],
+            max_concurrent_sftp_sessions=row["max_concurrent_sftp_sessions"],
             max_containers_per_session=row["max_containers_per_session"],
             idle_timeout=row["idle_timeout"],
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
@@ -375,7 +377,7 @@ class CreateKeyPairResourcePolicy(graphene.Mutation):
             props,
             data,
             "max_pending_session_resource_slots",
-            clean_func=lambda v: ResourceSlot.from_user_input(v, None),
+            clean_func=lambda v: ResourceSlot.from_user_input(v, None) if v is not None else None,
         )
         insert_query = sa.insert(keypair_resource_policies).values(data)
         return await simple_db_mutate_returning_item(


### PR DESCRIPTION
This is an auto-generated backport PR of #2146 to the 24.03 release.