### PR TITLE
fix: model server started on every kernels (#2124)

### DIFF
--- a/changes/2124.fix.md
+++ b/changes/2124.fix.md
@@ -1,0 +1,1 @@
+Fix model server starting on every kernels (including sub role kernels) on multi container infernce session

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2094,7 +2094,7 @@ class AbstractAgent(
                     "attached_devices": attached_devices,
                 }
 
-                if model_definition:
+                if ctx.kernel_config["cluster_role"] in ("main", "master") and model_definition:
                     for model in model_definition["models"]:
                         asyncio.create_task(
                             self.start_and_monitor_model_service_health(kernel_obj, model)


### PR DESCRIPTION
This is an auto-generated backport PR of #2124 to the 24.03 release.