### PR TITLE
ci: Check whether the branch actually exists

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -50,9 +50,17 @@ jobs:
           milestones=$(gh api /repos/:owner/:repo/milestones --jq '.[].title')
           echo $milestones
 
+          # Remove Backlog from the backport target branch
           milestones=($milestones)
           for i in "${!milestones[@]}"; do
             if [[ "${milestones[$i]}" == "Backlog" ]]; then
+              unset 'milestones[$i]'
+            fi
+          done
+          echo "${milestones[@]}"
+
+          for i in "${milestones[@]}"; do
+            if ! git branch -r | grep -q "^origin/$i\$"; then
               unset 'milestones[$i]'
             fi
           done


### PR DESCRIPTION
To resolve the difference between the milestone and the actually managed Release branch, first check whether the branch actually exists in the milestone list and add it to the backport target.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version