### PR TITLE
fix: Self-execution under SCIE/PEX-based envs (#2226)

### DIFF
--- a/changes/2226.fix.md
+++ b/changes/2226.fix.md
@@ -1,0 +1,1 @@
+Fix `backend.ai ssh` command execution when packaged as SCIE/PEX

--- a/src/ai/backend/client/cli/session/ssh.py
+++ b/src/ai/backend/client/cli/session/ssh.py
@@ -5,13 +5,17 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Final, Iterator, List
+from typing import Iterator, List
 
 from ai.backend.cli.types import ExitCode
 
 from ..pretty import print_fail, print_info
 
-CLI_EXECUTABLE: Final = (sys.executable, "-m", "ai.backend.cli")
+CLI_EXECUTABLE: tuple[str, ...]
+if pex_path := os.environ.get("PEX", None):
+    CLI_EXECUTABLE = (sys.executable, pex_path)
+else:
+    CLI_EXECUTABLE = (sys.executable, "-m", "ai.backend.cli")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This is an auto-generated backport PR of #2226 to the 23.09 release.