### PR TITLE
feat: collect zombie routes automatically

### DIFF
--- a/changes/2229.feature.md
+++ b/changes/2229.feature.md
@@ -1,0 +1,1 @@
+Clear zombie routes automatically

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1404,6 +1404,26 @@ class SchedulerDispatcher(aobject):
         routes_to_destroy = []
         endpoints_to_expand: dict[EndpointRow, Any] = {}
         endpoints_to_mark_terminated: set[EndpointRow] = set()
+        async with self.db.begin_session() as session:
+            query = (
+                sa.select(RoutingRow)
+                .join(
+                    RoutingRow.session_row.and_(
+                        SessionRow.status.in_((SessionStatus.TERMINATED, SessionStatus.CANCELLED))
+                    )
+                )
+                .where(RoutingRow.status == RouteStatus.PROVISIONING)
+                .options(selectinload(RoutingRow.session_row))
+            )
+            result = await session.execute(query)
+            zombie_routes = result.scalars().all()
+            if len(zombie_routes) > 0:
+                query = sa.delete(RoutingRow).where(
+                    RoutingRow.id.in_([r.id for r in zombie_routes])
+                )
+                result = await session.execute(query)
+                log.info("Cleared {} zombie routes", result.rowcount)
+
         async with self.db.begin_readonly_session() as session:
             endpoints = await EndpointRow.list(
                 session,

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1412,7 +1412,7 @@ class SchedulerDispatcher(aobject):
                         SessionRow.status.in_((SessionStatus.TERMINATED, SessionStatus.CANCELLED))
                     )
                 )
-                .where(RoutingRow.status == RouteStatus.PROVISIONING)
+                .where(RoutingRow.status.in_((RouteStatus.PROVISIONING, RouteStatus.TERMINATING)))
                 .options(selectinload(RoutingRow.session_row))
             )
             result = await session.execute(query)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR adds an extra logic to `scale_services()` scheduler, which inspects existence of zombie routes (routes not removed despite upstream session already in dead status) and automatically clears it before starting route scheduling.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
