### PR TITLE
feat: Add oraclelinux9.0 binaries

### DIFF
--- a/changes/2231.feature.md
+++ b/changes/2231.feature.md
@@ -1,0 +1,1 @@
+Add support for oraclelinux 9 to the build scripts under the `./scripts/agent` and include according binaries.

--- a/scripts/agent/build-dropbear.sh
+++ b/scripts/agent/build-dropbear.sh
@@ -2,7 +2,7 @@
 set -e
 
 arch=$(uname -m)
-distros=("ubuntu18.04" "ubuntu20.04" "ubuntu22.04" "alpine3.8")
+distros=("ubuntu18.04" "ubuntu20.04" "ubuntu22.04" "alpine3.8" "oraclelinux9.0")
 
 ubuntu1804_builder_dockerfile=$(cat <<'EOF'
 FROM ubuntu:18.04
@@ -29,6 +29,14 @@ alpine_builder_dockerfile=$(cat <<'EOF'
 FROM alpine:3.8
 RUN apk add --no-cache make gcc musl-dev
 RUN apk add --no-cache autoconf automake zlib-dev
+EOF
+)
+oraclelinux9_builder_dockerfile=$(cat <<'EOF'
+FROM oraclelinux:9
+
+RUN dnf install -y make gcc automake autoconf dnf-plugins-core
+RUN dnf config-manager --set-enabled ol9_codeready_builder
+RUN dnf install -y zlib-static glibc-static libxcrypt-static
 EOF
 )
 
@@ -67,6 +75,7 @@ echo "$ubuntu1804_builder_dockerfile" > "$SCRIPT_DIR/dropbear-builder.ubuntu18.0
 echo "$ubuntu2004_builder_dockerfile" > "$SCRIPT_DIR/dropbear-builder.ubuntu20.04.dockerfile"
 echo "$ubuntu2204_builder_dockerfile" > "$SCRIPT_DIR/dropbear-builder.ubuntu22.04.dockerfile"
 echo "$alpine_builder_dockerfile" > "$SCRIPT_DIR/dropbear-builder.alpine3.8.dockerfile"
+echo "$oraclelinux9_builder_dockerfile" > "$SCRIPT_DIR/dropbear-builder.oraclelinux9.0.dockerfile"
 
 for distro in "${distros[@]}"; do
   docker build -t dropbear-builder:$distro \

--- a/scripts/agent/build-suexec.sh
+++ b/scripts/agent/build-suexec.sh
@@ -3,7 +3,7 @@ set -e
 
 arch=$(uname -m)
 # distros=("ubuntu16.04" "ubuntu18.04" "ubuntu20.04" "centos7.6" "alpine3.8")
-distros=("ubuntu16.04")
+distros=("oraclelinux9.0")
 
 if [ $arch = "arm64" ]; then
   arch="aarch64"
@@ -42,6 +42,12 @@ RUN apk add --no-cache make gcc musl-dev
 EOF
 )
 
+oraclelinux9_builder_dockerfile=$(cat <<'EOF'
+FROM oraclelinux:9
+RUN dnf install -y make gcc glibc-devel
+EOF
+)
+
 build_script=$(cat <<'EOF'
 #! /bin/sh
 set -e
@@ -62,6 +68,7 @@ echo "$ubuntu1804_builder_dockerfile" > "$SCRIPT_DIR/suexec-builder.ubuntu18.04.
 echo "$ubuntu2004_builder_dockerfile" > "$SCRIPT_DIR/suexec-builder.ubuntu20.04.dockerfile"
 echo "$centos_builder_dockerfile" > "$SCRIPT_DIR/suexec-builder.centos7.6.dockerfile"
 echo "$alpine_builder_dockerfile" > "$SCRIPT_DIR/suexec-builder.alpine3.8.dockerfile"
+echo "$oraclelinux9_builder_dockerfile" > "$SCRIPT_DIR/suexec-builder.oraclelinux9.0.dockerfile"
 
 for distro in "${distros[@]}"; do
   docker build -t suexec-builder:$distro \

--- a/scripts/agent/build-tmux.sh
+++ b/scripts/agent/build-tmux.sh
@@ -2,7 +2,7 @@
 set -e
 
 arch=$(uname -m)
-distros=("glibc" "musl")
+distros=("glibc" "musl" "oraclelinux9.0")
 
 glibc_builder_dockerfile=$(cat <<'EOF'
 FROM ubuntu:22.04
@@ -17,6 +17,15 @@ musl_builder_dockerfile=$(cat <<'EOF'
 FROM alpine:3.8
 RUN apk add --no-cache make gcc g++ musl-dev file bison flex
 RUN apk add --no-cache pkgconfig
+EOF
+)
+
+oraclelinux9_builder_dockerfile=$(cat <<'EOF'
+FROM oraclelinux:9
+
+RUN dnf install -y make gcc automake autoconf dnf-plugins-core
+RUN dnf config-manager --set-enabled ol9_codeready_builder
+RUN dnf install -y zlib-static glibc-static libxcrypt-static
 EOF
 )
 
@@ -61,6 +70,7 @@ echo "$build_script" > "$temp_dir/build.sh"
 chmod +x $temp_dir/*.sh
 echo "$glibc_builder_dockerfile" > "$SCRIPT_DIR/tmux-builder.glibc.dockerfile"
 echo "$musl_builder_dockerfile" > "$SCRIPT_DIR/tmux-builder.musl.dockerfile"
+echo "$oraclelinux9_builder_dockerfile" > "$SCRIPT_DIR/tmux-builder.oraclelinux9.0.dockerfile"
 
 for distro in "${distros[@]}"; do
   docker build -t tmux-builder:$distro \

--- a/src/ai/backend/runner/dropbear.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/dropbear.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6787b5904ad002a20e29f21c48ed869bea6c7acd03a52cd340d4c37d148a4ee0
+size 2001760

--- a/src/ai/backend/runner/dropbearconvert.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/dropbearconvert.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49b677548b09a6982692bd696e2ab9a367c2b8b76ae193de55257c38502005be
+size 1419136

--- a/src/ai/backend/runner/dropbearkey.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/dropbearkey.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec68998271ab7bffab22093ee40b523b3451b6114dc772094f7495bd9c07338b
+size 1405904

--- a/src/ai/backend/runner/scp.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/scp.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f35173d337e8674f3627ff7d54446fb4490b843f230c2caf6721fc76323a745
+size 3246648

--- a/src/ai/backend/runner/sftp-server.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/sftp-server.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:479337cd735a58ebe76c07cf544f6dd31c90c3789098c76b66ccda324b70abf3
+size 3289000

--- a/src/ai/backend/runner/su-exec.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/su-exec.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:835c45daaa32c946824751d359fc5da417fda2c7416c6a26bac2f2e9fe08a57a
+size 22448

--- a/src/ai/backend/runner/tmux.oraclelinux9.0.x86_64.bin
+++ b/src/ai/backend/runner/tmux.oraclelinux9.0.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f535098ad332a8488dd14a0f2683c2c0baf594894c10ad8b399f12dcb2cef02d
+size 2840928


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix https://github.com/lablup/giftbox/issues/677.

## Notes

### zlib upgrade

It appears that ZLIB 1.2.11 is no longer distributed. 
Therefore, the `build-sftpserver.sh` for oraclelinux 9.0 was built with ZLIB version 1.3.1. 
But this PR does not include binary updates for other distributions.

---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue