### PR TITLE
fix: import graphql ast node correctly (#2202)

### DIFF
--- a/changes/2203.fix.md
+++ b/changes/2203.fix.md
@@ -1,0 +1,1 @@
+Fix error when query or mutate GraphQL using `BigInt` field type

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -41,7 +41,7 @@ from aiotools import apartial
 from graphene.types import Scalar
 from graphene.types.scalars import MAX_INT, MIN_INT
 from graphql import Undefined
-from graphql.language import ast  # pants: no-infer-dep
+from graphql.language.ast import IntValueNode
 from sqlalchemy.dialects.postgresql import ARRAY, CIDR, ENUM, JSONB, UUID
 from sqlalchemy.engine.result import Result
 from sqlalchemy.engine.row import Row
@@ -732,7 +732,7 @@ class BigInt(Scalar):
 
     @staticmethod
     def parse_literal(node):
-        if isinstance(node, ast.IntValue):
+        if isinstance(node, IntValueNode):
             num = int(node.value)
             if not (SAFE_MIN_INT <= num <= SAFE_MAX_INT):
                 raise ValueError("Cannot parse integer out of the safe range.")


### PR DESCRIPTION
This is an auto-generated backport PR of #2202 to the 24.03 release.