### PR TITLE
fix: `customized_images` GQL Query returning every images

### DIFF
--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1117,7 +1117,13 @@ class Queries(graphene.ObjectType):
             )
         else:
             raise InvalidAPIParameters("Unknown client role")
-        return [ImageNode.from_legacy_image(i) for i in items]
+        return [
+            ImageNode.from_legacy_image(i)
+            for i in items
+            # access scope to each customized image has already been
+            # evaluated at Image.load_all()
+            if "ai.backend.customized-image.owner" in i.raw_labels
+        ]
 
     @staticmethod
     async def resolve_images(

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -527,6 +527,9 @@ class Image(graphene.ObjectType):
     # legacy field
     hash = graphene.String()
 
+    # internal attributes
+    raw_labels: dict[str, Any]
+
     @classmethod
     def populate_row(
         cls,
@@ -536,7 +539,7 @@ class Image(graphene.ObjectType):
     ) -> Image:
         is_superadmin = ctx.user["role"] == UserRole.SUPERADMIN
         hide_agents = False if is_superadmin else ctx.local_config["manager"]["hide-agents"]
-        return cls(
+        ret = cls(
             id=row.id,
             name=row.image,
             humanized_name=row.image,
@@ -562,6 +565,8 @@ class Image(graphene.ObjectType):
             # legacy
             hash=row.config_digest,
         )
+        ret.raw_labels = row.labels
+        return ret
 
     @classmethod
     async def from_row(


### PR DESCRIPTION
Follow-up PR of #2136. `customized_images` should return customized images only.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue