### PR TITLE
fix: disallow mounting  VFolders via extra_mounts on model service (#2237)

### DIFF
--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1798,7 +1798,9 @@ input ModifyEndpointInput {
   model_definition_path: String
   open_to_public: Boolean
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4. MODEL type VFolders are not allowed to be attached to model service session with this option.
+  """
   extra_mounts: [ExtraMountInput]
 }
 

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -283,7 +283,10 @@ class ServiceConfigModel(BaseModel):
     extra_mounts: Annotated[
         dict[uuid.UUID, MountOptionModel],
         Field(
-            description="Specifications about extra VFolders mounted to model service session",
+            description=(
+                "Specifications about extra VFolders mounted to model service session. "
+                "MODEL type VFolders are not allowed to be attached to model service session with this option."
+            ),
             default={},
         ),
     ]

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -30,6 +30,7 @@ from ai.backend.common.types import (
     SessionTypes,
     VFolderID,
     VFolderMount,
+    VFolderUsageMode,
 )
 from ai.backend.manager.defs import DEFAULT_CHUNK_SIZE, SERVICE_MAX_RETRIES
 from ai.backend.manager.models.gql_relay import AsyncNode
@@ -574,6 +575,10 @@ class ModelServicePredicateChecker:
                 raise InvalidAPIParameters(
                     "extra_mounts.mount_destination conflicts with model_mount_destination config. Make sure not to shadow value defined at model_mount_destination as a mount destination of extra VFolders."
                 )
+            if vfolder.usage_mode == VFolderUsageMode.MODEL:
+                raise InvalidAPIParameters(
+                    "MODEL type VFolders cannot be added as a part of extra_mounts folder"
+                )
 
         return vfolder_mounts
 
@@ -1005,7 +1010,10 @@ class ModifyEndpointInput(graphene.InputObjectType):
     resource_group = graphene.String()
     model_definition_path = graphene.String(description="Added in 24.03.4.")
     open_to_public = graphene.Boolean()
-    extra_mounts = graphene.List(ExtraMountInput, description="Added in 24.03.4.")
+    extra_mounts = graphene.List(
+        ExtraMountInput,
+        description="Added in 24.03.4. MODEL type VFolders are not allowed to be attached to model service session with this option.",
+    )
 
 
 class ModifyEndpoint(graphene.Mutation):


### PR DESCRIPTION
This is an auto-generated backport PR of #2237 to the 24.03 release.