### PR TITLE
fix: missing eager load to `aliases` row (#2239)

### DIFF
--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -1029,7 +1029,7 @@ class UntagImageFromRegistry(graphene.Mutation):
         client_role = ctx.user["role"]
 
         async with ctx.db.begin_readonly_session() as session:
-            image_row = await ImageRow.get(session, _image_id)
+            image_row = await ImageRow.get(session, _image_id, load_aliases=True)
             if not image_row:
                 raise ImageNotFound
             if client_role != UserRole.SUPERADMIN:

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -988,7 +988,7 @@ class ComputeContainer(graphene.ObjectType):
             .where(KernelRow.session_id == session_id)
             .limit(limit)
             .offset(offset)
-            .options(selectinload(KernelRow.image_row))
+            .options(selectinload(KernelRow.image_row).options(selectinload(ImageRow.aliases)))
         )
         if cluster_role is not None:
             query = query.where(KernelRow.cluster_role == cluster_role)


### PR DESCRIPTION
This is an auto-generated backport PR of #2239 to the 24.03 release.