### PR TITLE
fix: Let GQL images resolver filter out image objects correctly

### DIFF
--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -715,10 +715,11 @@ class Image(graphene.ObjectType):
         if not filters:
             return True
 
+        result = False
         for label in self.labels:
             if ImageLoadFilter.OPERATIONAL in filters:
                 if label.key == "ai.backend.features" and "operation" in label.value:
-                    return True
+                    result = True
             else:
                 if label.key == "ai.backend.features" and "operation" in label.value:
                     return False
@@ -726,16 +727,16 @@ class Image(graphene.ObjectType):
             if ImageLoadFilter.CUSTOMIZED in filters:
                 if label.key == "ai.backend.customized-image.owner":
                     if label.value == f"user:{ctx.user['uuid']}":
-                        return True
+                        result = True
                     else:
                         return False
             if ImageLoadFilter.CUSTOMIZED_GLOBAL in filters:
                 if label.key == "ai.backend.customized-image.owner":
                     if user_role == UserRole.SUPERADMIN:
-                        return True
+                        result = True
                     else:
                         return False
-        return False
+        return result
         #     match label.key:
         #         case "ai.backend.features" if "operation" in label.value and ImageLoadFilter.OPERATIONAL not in filters:
         #             return False

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -729,6 +729,11 @@ class Image(graphene.ObjectType):
                     else:
                         return False
                 case "ai.backend.customized-image.owner":
+                    if (
+                        ImageLoadFilter.CUSTOMIZED not in filters
+                        and ImageLoadFilter.CUSTOMIZED_GLOBAL not in filters
+                    ):
+                        return False
                     if ImageLoadFilter.CUSTOMIZED in filters:
                         if label.value == f"user:{ctx.user['uuid']}":
                             is_valid = True

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -712,27 +712,50 @@ class Image(graphene.ObjectType):
     ) -> bool:
         user_role = ctx.user["role"]
 
+        if not filters:
+            return True
+
         for label in self.labels:
-            match label.key:
-                case "ai.backend.features" if "operation" in label.value and ImageLoadFilter.OPERATIONAL not in filters:
+            if ImageLoadFilter.OPERATIONAL in filters:
+                if label.key == "ai.backend.features" and "operation" in label.value:
+                    return True
+            else:
+                if label.key == "ai.backend.features" and "operation" in label.value:
                     return False
-                case "ai.backend.customized-image.owner":
-                    if (
-                        (
-                            ImageLoadFilter.CUSTOMIZED not in filters
-                            and ImageLoadFilter.CUSTOMIZED_GLOBAL not in filters
-                        )
-                        or (
-                            ImageLoadFilter.CUSTOMIZED_GLOBAL in filters
-                            and user_role != UserRole.SUPERADMIN
-                        )
-                        or (
-                            ImageLoadFilter.CUSTOMIZED in filters
-                            and label.value != f"user:{ctx.user['uuid']}"
-                        )
-                    ):
+
+            if ImageLoadFilter.CUSTOMIZED in filters:
+                if label.key == "ai.backend.customized-image.owner":
+                    if label.value == f"user:{ctx.user['uuid']}":
+                        return True
+                    else:
                         return False
-        return True
+            if ImageLoadFilter.CUSTOMIZED_GLOBAL in filters:
+                if label.key == "ai.backend.customized-image.owner":
+                    if user_role == UserRole.SUPERADMIN:
+                        return True
+                    else:
+                        return False
+        return False
+        #     match label.key:
+        #         case "ai.backend.features" if "operation" in label.value and ImageLoadFilter.OPERATIONAL not in filters:
+        #             return False
+        #         case "ai.backend.customized-image.owner":
+        #             if (
+        #                 (
+        #                     ImageLoadFilter.CUSTOMIZED not in filters
+        #                     and ImageLoadFilter.CUSTOMIZED_GLOBAL not in filters
+        #                 )
+        #                 or (
+        #                     ImageLoadFilter.CUSTOMIZED_GLOBAL in filters
+        #                     and user_role != UserRole.SUPERADMIN
+        #                 )
+        #                 or (
+        #                     ImageLoadFilter.CUSTOMIZED in filters
+        #                     and label.value != f"user:{ctx.user['uuid']}"
+        #                 )
+        #             ):
+        #                 return False
+        # return True
 
 
 class ImageNode(graphene.ObjectType):

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -718,8 +718,8 @@ class Image(graphene.ObjectType):
         if not filters:
             return True
 
-        # If the image filtered out by any of its labels, return False early.
-        # If the image is not filtered and is determiend to be balid by any of its labels, `is_valid = True`.
+        # If the image filtered by any of its labels, return False early.
+        # If the image is not filtered and is determiend to be valid by any of its labels, `is_valid = True`.
         is_valid = False
         for label in self.labels:
             match label.key:

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -722,25 +722,23 @@ class Image(graphene.ObjectType):
         # If the image is not filtered and is determiend to be balid by any of its labels, `is_valid = True`.
         is_valid = False
         for label in self.labels:
-            if ImageLoadFilter.OPERATIONAL in filters:
-                if label.key == "ai.backend.features" and "operation" in label.value:
-                    is_valid = True
-            else:
-                if label.key == "ai.backend.features" and "operation" in label.value:
-                    return False
-
-            if ImageLoadFilter.CUSTOMIZED in filters:
-                if label.key == "ai.backend.customized-image.owner":
-                    if label.value == f"user:{ctx.user['uuid']}":
+            match label.key:
+                case "ai.backend.features" if "operation" in label.value:
+                    if ImageLoadFilter.OPERATIONAL in filters:
                         is_valid = True
                     else:
                         return False
-            if ImageLoadFilter.CUSTOMIZED_GLOBAL in filters:
-                if label.key == "ai.backend.customized-image.owner":
-                    if user_role == UserRole.SUPERADMIN:
-                        is_valid = True
-                    else:
-                        return False
+                case "ai.backend.customized-image.owner":
+                    if ImageLoadFilter.CUSTOMIZED in filters:
+                        if label.value == f"user:{ctx.user['uuid']}":
+                            is_valid = True
+                        else:
+                            return False
+                    if ImageLoadFilter.CUSTOMIZED_GLOBAL in filters:
+                        if user_role == UserRole.SUPERADMIN:
+                            is_valid = True
+                        else:
+                            return False
         return is_valid
 
 


### PR DESCRIPTION
follow-up #1973 #2136

If superadmins request GQL images query with `filters=["customized"]` parameter, the resolver does not filter out images without any of `operation` or `customized` labels, and it returns all types of images.
Let's fix it

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)