### PR TITLE
ci: Missing string in backticks in commit message of backport PR

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -95,7 +95,7 @@ jobs:
           git fetch origin main --depth=2
           git cherry-pick --strategy=recursive --strategy-option=theirs ${{ needs.backport-target-branch.outputs.latest_commit }}
           git commit \
-            --amend -m "${{ needs.backport-target-branch.outputs.commit_message }}" \
+            --amend -m '${{ needs.backport-target-branch.outputs.commit_message }}' \
             --trailer "Backported-from=main (${{ needs.backport-target-branch.outputs.latest_release }})" \
             --trailer "Backported-to=${{ matrix.milestone }}" \
             --trailer "Backport-of=${{ needs.backport-target-branch.outputs.pr_number }}"
@@ -107,13 +107,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - id: commit_message
         run: |
-          commit_header=$(echo "${{ needs.backport-target-branch.outputs.commit_message }}" | head -n 1)
+          commit_header=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | head -n 1)
           echo "commit_header=$commit_header" >> $GITHUB_OUTPUT
-          commit_body=$(echo "${{ needs.backport-target-branch.outputs.commit_message }}" | awk '/^$/{p++;next} p==1')
+          commit_body=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | awk '/^$/{p++;next} p==1')
           echo "commit_body<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_body" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          commit_footer=$(echo "${{ needs.backport-target-branch.outputs.commit_message }}" | awk '/^$/{p++;next} p==2')
+          commit_footer=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | awk '/^$/{p++;next} p==2')
           echo "commit_footer<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_footer" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION

<img width="1044" alt="CleanShot 2024-06-03 at 15 50 57@2x" src="https://github.com/lablup/backend.ai/assets/31057849/897e83e6-98c9-4aac-b56e-83950b8391d4">
If commit_message contains special characters in the shell string, such as backticks, there is a problem in that it is not processed as is.
Changed the string to be treated as a single quote and treated as all characters.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
