### PR TITLE
fix: Allow GraphQL query to non-installed images

### DIFF
--- a/changes/2250.fix.md
+++ b/changes/2250.fix.md
@@ -1,0 +1,1 @@
+Fix GraphQL to support query to non-installed images

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1130,7 +1130,7 @@ class Queries(graphene.ObjectType):
         root: Any,
         info: graphene.ResolveInfo,
         *,
-        is_installed=None,
+        is_installed: bool | None = None,
         is_operation=False,
         image_filters: list[str] | None = None,
     ) -> Sequence[Image]:
@@ -1173,7 +1173,7 @@ class Queries(graphene.ObjectType):
         else:
             raise InvalidAPIParameters("Unknown client role")
         if is_installed is not None:
-            items = [item for item in items if item.installed]
+            items = [item for item in items if item.installed == is_installed]
         return items
 
     @staticmethod


### PR DESCRIPTION
This pull request is a follow-up of #2136.

It has been observed that the `images(is_installed: Boolean)` GraphQL queries would fail to query `images(is_installed: false)` due to:
https://github.com/lablup/backend.ai/blob/05da1590095a61677402211cc84e74a07340b276/src/ai/backend/manager/models/gql.py#L1175-L1176

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2250.org.readthedocs.build/en/2250/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2250.org.readthedocs.build/ko/2250/

<!-- readthedocs-preview sorna-ko end -->