### PR TITLE
feat: allow modifying model service env var

### DIFF
--- a/changes/2255.feature.md
+++ b/changes/2255.feature.md
@@ -1,0 +1,1 @@
+Allow modifying model service session's environment variable setup

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1802,6 +1802,9 @@ input ModifyEndpointInput {
   Added in 24.03.4. MODEL type VFolders are not allowed to be attached to model service session with this option.
   """
   extra_mounts: [ExtraMountInput]
+
+  """Added in 24.03.5."""
+  environ: JSONString
 }
 
 input ImageRefType {

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1014,6 +1014,7 @@ class ModifyEndpointInput(graphene.InputObjectType):
         ExtraMountInput,
         description="Added in 24.03.4. MODEL type VFolders are not allowed to be attached to model service session with this option.",
     )
+    environ = graphene.JSONString(description="Added in 24.03.5.")
 
 
 class ModifyEndpoint(graphene.Mutation):
@@ -1073,6 +1074,9 @@ class ModifyEndpoint(graphene.Mutation):
 
                 if (_newval := props.model_definition_path) and _newval is not Undefined:
                     endpoint_row.model_definition_path = _newval
+
+                if (_newval := props.environ) and _newval is not Undefined:
+                    endpoint_row.environ = _newval
 
                 if (
                     _newval := props.desired_session_count


### PR DESCRIPTION
This PR updates `ModifyEndpoint` mutation to allow altering environment variable definition of model service session.
**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
