### PR TITLE
refactor: fetch all containers eagerly when sync containers

### DIFF
--- a/changes/2263.enhance.md
+++ b/changes/2263.enhance.md
@@ -1,0 +1,1 @@
+Fetch all containers eagerly when matching agent's registry to containers.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1259,10 +1259,17 @@ class AbstractAgent(
         own_kernels: dict[KernelId, ContainerId] = {}
         terminated_kernels = {}
 
+        _containers = await self.enumerate_containers(DEAD_STATUS_SET | ACTIVE_STATUS_SET)
+
         async with self.registry_lock:
             try:
                 # Check if: there are dead containers
-                for kernel_id, container in await self.enumerate_containers(DEAD_STATUS_SET):
+                dead_containers = [
+                    (kid, container)
+                    for kid, container in _containers
+                    if container.status in DEAD_STATUS_SET
+                ]
+                for kernel_id, container in dead_containers:
                     if (
                         kernel_id in self.restarting_kernels
                         or kernel_id in self.terminating_kernels
@@ -1281,7 +1288,12 @@ class AbstractAgent(
                         LifecycleEvent.CLEAN,
                         KernelLifecycleEventReason.SELF_TERMINATED,
                     )
-                for kernel_id, container in await self.enumerate_containers(ACTIVE_STATUS_SET):
+                alive_containers = [
+                    (kid, container)
+                    for kid, container in _containers
+                    if container.status in ACTIVE_STATUS_SET
+                ]
+                for kernel_id, container in alive_containers:
                     alive_kernels[kernel_id] = container.id
                     session_id = SessionId(UUID(container.labels["ai.backend.session-id"]))
                     kernel_session_map[kernel_id] = session_id


### PR DESCRIPTION
`AbstractAgent.enumerate_containers()` fetches containers whose status matches with `status` parameter.
Currently, `sync_container_lifecycles()` fetches containers twice by setting different status option.
Let's fetch containers all at once.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
