### PR TITLE
ci: Explicitly adding permissions because the default permissions have changed

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:
+permissions:
+  contents: write
 
 jobs:
   pr-number-assign:


### PR DESCRIPTION
As you upgrade to GitHub enterprise plan, the default permissions for actions change, so you must explicitly write the permissions required for the workflow.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
