### PR TITLE
ci: Bump graphql-inspector from 4.0.2 to 5.0.6

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -68,9 +68,13 @@ jobs:
     needs: graphql-updated
     name: Check Schema
     runs-on: ubuntu-latest
+    permissions:
+      contents: read 
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: kamilkisiela/graphql-inspector@release-1689086705050
+      - uses: kamilkisiela/graphql-inspector@release-1717403590269
         with:
           schema: 'main:src/ai/backend/manager/api/schema.graphql'
           rules: |


### PR DESCRIPTION
follow-up #2265
Due to node.js v16 deprecated, upgraded to a version using node.js v20

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
