### PR TITLE
chore: Add `vfolders.domain_name` and `vfolder_permissions.id`

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/d7df3baf3779_add_vfolders_domain_name.py
+++ b/src/ai/backend/manager/models/alembic/versions/d7df3baf3779_add_vfolders_domain_name.py
@@ -1,7 +1,7 @@
 """add vfolders domain name
 
 Revision ID: d7df3baf3779
-Revises: f56a82d0ac9f
+Revises: 5d92c9cc930c
 Create Date: 2024-06-11 16:39:26.648608
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = "d7df3baf3779"
-down_revision = "f56a82d0ac9f"
+down_revision = "5d92c9cc930c"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/d7df3baf3779_add_vfolders_domain_name.py
+++ b/src/ai/backend/manager/models/alembic/versions/d7df3baf3779_add_vfolders_domain_name.py
@@ -1,0 +1,43 @@
+"""add vfolders domain name
+
+Revision ID: d7df3baf3779
+Revises: f56a82d0ac9f
+Create Date: 2024-06-11 16:39:26.648608
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "d7df3baf3779"
+down_revision = "f56a82d0ac9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    op.add_column("vfolders", sa.Column("domain_name", sa.String(length=64), nullable=True))
+
+    conn.execute(
+        text(
+            """\
+        UPDATE vfolders
+        SET domain_name = COALESCE(
+            (SELECT domain_name FROM users WHERE vfolders.user = users.uuid),
+            (SELECT domain_name FROM groups WHERE vfolders.group = groups.id)
+        )
+        WHERE domain_name IS NULL;
+    """
+        )
+    )
+
+    op.alter_column("vfolders", column_name="domain_name", nullable=False)
+    op.create_index(op.f("ix_vfolders_domain_name"), "vfolders", ["domain_name"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_vfolders_domain_name"), table_name="vfolders")
+    op.drop_column("vfolders", "domain_name")

--- a/src/ai/backend/manager/models/alembic/versions/fdb2dcdb8811_add_vfolder_permissions_id.py
+++ b/src/ai/backend/manager/models/alembic/versions/fdb2dcdb8811_add_vfolder_permissions_id.py
@@ -1,0 +1,31 @@
+"""add vfolder_permissions id
+
+Revision ID: fdb2dcdb8811
+Revises: d7df3baf3779
+Create Date: 2024-06-11 16:40:45.267761
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "fdb2dcdb8811"
+down_revision = "d7df3baf3779"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "vfolder_permissions",
+        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
+    )
+    op.create_primary_key("pk_vfolder_permissions", "vfolder_permissions", ["id"])
+
+
+def downgrade():
+    op.drop_constraint("pk_vfolder_permissions", "vfolder_permissions", type_="primary")
+    op.drop_column("vfolder_permissions", "id")

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -297,6 +297,7 @@ vfolders = sa.Table(
     IDColumn("id"),
     # host will be '' if vFolder is unmanaged
     sa.Column("host", sa.String(length=128), nullable=False, index=True),
+    sa.Column("domain_name", sa.String(length=64), nullable=False, index=True),
     sa.Column("quota_scope_id", QuotaScopeIDType, nullable=False),
     sa.Column("name", sa.String(length=64), nullable=False, index=True),
     sa.Column(
@@ -404,6 +405,7 @@ vfolder_invitations = sa.Table(
 vfolder_permissions = sa.Table(
     "vfolder_permissions",
     metadata,
+    IDColumn(),
     sa.Column("permission", EnumValueType(VFolderPermission), default=VFolderPermission.READ_WRITE),
     sa.Column(
         "vfolder",
@@ -413,6 +415,10 @@ vfolder_permissions = sa.Table(
     ),
     sa.Column("user", GUID, sa.ForeignKey("users.uuid"), nullable=False),
 )
+
+
+class VFolderPermissionRow(Base):
+    __table__ = vfolder_permissions
 
 
 class VFolderRow(Base):


### PR DESCRIPTION
Since we cannot move or migrate existing vfolders to other domain, let's add `domain_name` column to vfolders table.
And I added `vfolder_permissions.id` column for easy query

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version