### PR TITLE
ci: Grant write permission required for actions

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   graphql-updated:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Calculate the fetch depth
       run: |


### PR DESCRIPTION
Same as #2265, the default value of actions permission is changed to explicitly add write permission.
<img width="1045" alt="CleanShot 2024-06-16 at 14 35 38@2x" src="https://github.com/lablup/backend.ai/assets/31057849/aa756a42-1338-414e-a76d-bec1b398386a">


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
