### PR TITLE
fix: `ai.backend.service-ports` container label syntax broken (#2288)

### DIFF
--- a/changes/2288.fix.md
+++ b/changes/2288.fix.md
@@ -1,0 +1,1 @@
+Fix `ai.backend.service-ports` label syntax broken when image does not expose built-in service port

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -827,7 +827,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         service_ports_label += image_labels.get("ai.backend.service-ports", "").split(",")
         service_ports_label += [f"{port_no}:preopen:{port_no}" for port_no in preopen_ports]
 
-        container_config["Labels"]["ai.backend.service-ports"] = ",".join(service_ports_label)
+        container_config["Labels"]["ai.backend.service-ports"] = ",".join([
+            label for label in service_ports_label if label
+        ])
         update_nested_dict(container_config, self.computer_docker_args)
         kernel_name = f"kernel.{self.image_ref.name.split('/')[-1]}.{self.kernel_id}"
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2288 to the 24.03 release.