### PR TITLE
fix: improve stability of `untag_image_from_registry` mutation (#2289)

### DIFF
--- a/changes/2289.fix.md
+++ b/changes/2289.fix.md
@@ -1,0 +1,1 @@
+Improve stability of `untag_image_from_registry` mutation


### PR DESCRIPTION
This is an auto-generated backport PR of #2289 to the 24.03 release.