### PR TITLE
fix: invalid container memory capacity reported (#2291)

### DIFF
--- a/changes/2291.fix.md
+++ b/changes/2291.fix.md
@@ -1,0 +1,1 @@
+Invalid container memory capacity reported


### PR DESCRIPTION
This is an auto-generated backport PR of #2291 to the 24.03 release.