### PR TITLE
fix: SSH not working between kernels started with customized image (#2290)

### DIFF
--- a/changes/2290.fix.md
+++ b/changes/2290.fix.md
@@ -1,0 +1,1 @@
+SSH not working between kernels started with customized image

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -207,7 +207,10 @@ class DockerKernel(AbstractKernel):
                         config = {"ContainerSpec": {}}
 
                     container = docker.containers.container(container_id)
-                    changes: list[str] = []
+                    changes: list[str] = [
+                        "RUN rm -rf /tmp/*",
+                    ]
+
                     for label_name, label_value in extra_labels.items():
                         changes.append(f"LABEL {label_name}={label_value}")
                     if canonical:

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -11,6 +12,8 @@ log = BraceStyleAdapter(logging.getLogger())
 
 
 async def init_sshd_service(child_env):
+    if Path("/tmp/dropbear").is_dir():
+        shutil.rmtree("/tmp/dropbear")
     Path("/tmp/dropbear").mkdir(parents=True, exist_ok=True)
     auth_path = Path("/home/work/.ssh/authorized_keys")
     if not auth_path.is_file():


### PR DESCRIPTION
This is an auto-generated backport PR of #2290 to the 24.03 release.