### PR TITLE
chore(deps): bump actions/setup-python from 4 to 5 (#1981)

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -25,7 +25,7 @@ jobs:
         echo "PANTS_CONFIG_FILES=pants.ci.toml" >> $GITHUB_ENV
         echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
     - name: Set up Python as Runtime
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PROJECT_PYTHON_VERSION }}
     - name: Set up remote cache backend (if applicable)


### PR DESCRIPTION
This is an auto-generated backport PR of #1981 to the 24.03 release.