### PR TITLE
ci: Bump action-gh-release from v1 to v2 (#2303)

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -449,7 +449,7 @@ jobs:
         name: SBOM report
         path: dist
     - name: Release to GitHub
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         body_path: "CHANGELOG_RELEASE.md"
         prerelease: ${{ env.IS_PRERELEASE }}


### PR DESCRIPTION
This is an auto-generated backport PR of #2303 to the 23.09 release.