### PR TITLE
feat: Add session status checker API

### DIFF
--- a/changes/2312.feature.md
+++ b/changes/2312.feature.md
@@ -1,0 +1,1 @@
+Add session status check & update API.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1406,9 +1406,6 @@ type Mutations {
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
-
-  """Added in 24.09.0."""
-  check_and_transit_session_status(session_ids: [UUID]!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -2133,9 +2130,4 @@ input ExtraMountInput {
   Added in 24.03.4. Set permission of this mount. Should be one of (ro,rw,wd). Default is null
   """
   permission: String
-}
-
-"""Added in 24.09.0."""
-type CheckAndTransitStatus {
-  sessions: [ComputeSessionNode]
 }

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1406,6 +1406,9 @@ type Mutations {
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
+
+  """Added in 24.09.0."""
+  check_and_transit_session_status(session_ids: [UUID]!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -2130,4 +2133,9 @@ input ExtraMountInput {
   Added in 24.03.4. Set permission of this mount. Should be one of (ro,rw,wd). Default is null
   """
   permission: String
+}
+
+"""Added in 24.09.0."""
+type CheckAndTransitStatus {
+  sessions: [ComputeSessionNode]
 }

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -254,6 +254,40 @@ class ComputeSessionNode(graphene.ObjectType):
         return result
 
     @classmethod
+    async def parse_status_only(
+        cls,
+        info: graphene.ResolveInfo,
+        row: SessionRow,
+    ) -> ComputeSessionNode:
+        status_history = row.status_history or {}
+        raw_scheduled_at = status_history.get(SessionStatus.SCHEDULED.name)
+        return cls(
+            # identity
+            id=row.id,
+            row_id=row.id,
+            name=row.name,
+            # status
+            status=row.status.name,
+            status_changed=row.status_changed,
+            status_info=row.status_info,
+            status_data=row.status_data,
+            status_history=status_history,
+            created_at=row.created_at,
+            starts_at=row.starts_at,
+            terminated_at=row.terminated_at,
+            scheduled_at=datetime.fromisoformat(raw_scheduled_at)
+            if raw_scheduled_at is not None
+            else None,
+            result=row.result.name,
+            # resources
+            agent_ids=row.agent_ids,
+            scaling_group=row.scaling_group_name,
+            vfolder_mounts=row.vfolder_mounts,
+            occupied_slots=row.occupying_slots.to_json(),
+            requested_slots=row.requested_slots.to_json(),
+        )
+
+    @classmethod
     async def get_accessible_node(
         cls,
         info: graphene.ResolveInfo,


### PR DESCRIPTION
Add GQL mutation and `POST /session/_/transit-status` API to check and update the status of session

### Request 
```
curl --location --request POST 'MANAGER_ADDR/session/_/transit-status' \
--header 'Content-Type: application/json' \
--data '{
    "id": "SESSION_ID"
}'
```

### Response
```json
{"session_status": "RUNNING"}
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2312.org.readthedocs.build/en/2312/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2312.org.readthedocs.build/ko/2312/

<!-- readthedocs-preview sorna-ko end -->