### PR TITLE
refactor: Handle container start error in separate try-catch context

### DIFF
--- a/changes/2316.misc.md
+++ b/changes/2316.misc.md
@@ -1,0 +1,1 @@
+Handle container creation exception and start exception in separate try-except contexts.


### PR DESCRIPTION
### Fix
- Separate the exception context of `container.create()` and `container.start()` to handle them granularly.

### Refactor
- Scratch clean codes to `clean_scratch()`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version