### PR TITLE
hotfix: metric collection not working (#2321)

### DIFF
--- a/changes/2321.fix.md
+++ b/changes/2321.fix.md
@@ -1,0 +1,1 @@
+Fix container metric collection halted on systems with Cgroups v1

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -578,6 +578,7 @@ class MemoryPlugin(AbstractComputePlugin):
                 match version:
                     case "1":
                         mem_cur_bytes = read_sysfs(mem_path / "memory.usage_in_bytes", int)
+                        mem_max_bytes = read_sysfs(mem_path / "memory.limit_in_bytes", int)
 
                         for line in (mem_path / "memory.stat").read_text().splitlines():
                             key, value = line.split(" ")


### PR DESCRIPTION
This is an auto-generated backport PR of #2321 to the 24.03 release.