### PR TITLE
hotfix: invalid enum string set as fallback value (#2318)

### DIFF
--- a/changes/2318.fix.md
+++ b/changes/2318.fix.md
@@ -1,0 +1,1 @@
+Fix model service sessions created before 24.03.5 failing to spawn

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1842,7 +1842,7 @@ class AbstractAgent(
                 if kernel_config["session_type"] == SessionTypes.INFERENCE:
                     model_definition = await self.load_model_definition(
                         RuntimeVariant(
-                            (kernel_config["internal_data"] or {}).get("runtime_variant", "CUSTOM")
+                            (kernel_config["internal_data"] or {}).get("runtime_variant", "custom")
                         ),
                         model_folders,
                         environ,


### PR DESCRIPTION
This is an auto-generated backport PR of #2318 to the 24.03 release.