### PR TITLE
feat: Enable to configure sync_container_lifecycles task

### DIFF
--- a/changes/2338.fix.md
+++ b/changes/2338.fix.md
@@ -1,0 +1,1 @@
+Add support for configuring `sync_container_lifecycles()` task.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -704,7 +704,13 @@ class AbstractAgent(
         self.timer_tasks.append(aiotools.create_timer(self.heartbeat, heartbeat_interval))
 
         # Prepare auto-cleaning of idle kernels.
-        self.timer_tasks.append(aiotools.create_timer(self.sync_container_lifecycles, 10.0))
+        sync_container_lifecycles_config = self.local_config["agent"]["sync-container-lifecycles"]
+        if sync_container_lifecycles_config["run-task"]:
+            self.timer_tasks.append(
+                aiotools.create_timer(
+                    self.sync_container_lifecycles, sync_container_lifecycles_config["interval"]
+                )
+            )
 
         if abuse_report_path := self.local_config["agent"].get("abuse-report-path"):
             log.info(

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -705,7 +705,7 @@ class AbstractAgent(
 
         # Prepare auto-cleaning of idle kernels.
         sync_container_lifecycles_config = self.local_config["agent"]["sync-container-lifecycles"]
-        if sync_container_lifecycles_config["run-task"]:
+        if sync_container_lifecycles_config["enabled"]:
             self.timer_tasks.append(
                 aiotools.create_timer(
                     self.sync_container_lifecycles, sync_container_lifecycles_config["interval"]

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -128,7 +128,7 @@ default_container_logs_config = {
 }
 
 default_sync_container_lifecycles_config = {
-    "run-task": True,
+    "enabled": True,
     "interval": 10.0,
 }
 
@@ -138,7 +138,7 @@ agent_etcd_config_iv = t.Dict({
         t.Key("chunk-size", default=default_container_logs_config["chunk-size"]): tx.BinarySize(),
     }).allow_extra("*"),
     t.Key("sync-container-lifecycles", default=default_sync_container_lifecycles_config): t.Dict({
-        t.Key("run-task", default=default_sync_container_lifecycles_config["run-task"]): t.ToBool,
+        t.Key("enabled", default=default_sync_container_lifecycles_config["enabled"]): t.ToBool,
         t.Key("interval", default=default_sync_container_lifecycles_config["interval"]): t.ToFloat[
             0:
         ],

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -16,6 +16,11 @@ coredump_defaults = {
     "size-limit": "64M",
 }
 
+default_sync_container_lifecycles_config = {
+    "enabled": True,
+    "interval": 10.0,
+}
+
 agent_local_config_iv = (
     t.Dict({
         t.Key("agent"): t.Dict({
@@ -59,6 +64,16 @@ agent_local_config_iv = (
             t.Key("force-terminate-abusing-containers", default=False): t.ToBool,
             t.Key("kernel-creation-concurrency", default=4): t.ToInt[1:32],
             t.Key("use-experimental-redis-event-dispatcher", default=False): t.ToBool,
+            t.Key(
+                "sync-container-lifecycles", default=default_sync_container_lifecycles_config
+            ): t.Dict({
+                t.Key(
+                    "enabled", default=default_sync_container_lifecycles_config["enabled"]
+                ): t.ToBool,
+                t.Key(
+                    "interval", default=default_sync_container_lifecycles_config["interval"]
+                ): t.ToFloat[0:],
+            }).allow_extra("*"),
         }).allow_extra("*"),
         t.Key("container"): t.Dict({
             t.Key("kernel-uid", default=-1): tx.UserID,
@@ -127,21 +142,10 @@ default_container_logs_config = {
     "chunk-size": "64K",  # used when storing logs to Redis as a side-channel to the event bus
 }
 
-default_sync_container_lifecycles_config = {
-    "enabled": True,
-    "interval": 10.0,
-}
-
 agent_etcd_config_iv = t.Dict({
     t.Key("container-logs", default=default_container_logs_config): t.Dict({
         t.Key("max-length", default=default_container_logs_config["max-length"]): tx.BinarySize(),
         t.Key("chunk-size", default=default_container_logs_config["chunk-size"]): tx.BinarySize(),
-    }).allow_extra("*"),
-    t.Key("sync-container-lifecycles", default=default_sync_container_lifecycles_config): t.Dict({
-        t.Key("enabled", default=default_sync_container_lifecycles_config["enabled"]): t.ToBool,
-        t.Key("interval", default=default_sync_container_lifecycles_config["interval"]): t.ToFloat[
-            0:
-        ],
     }).allow_extra("*"),
 }).allow_extra("*")
 

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -127,10 +127,21 @@ default_container_logs_config = {
     "chunk-size": "64K",  # used when storing logs to Redis as a side-channel to the event bus
 }
 
+default_sync_container_lifecycles_config = {
+    "run-task": True,
+    "interval": 10.0,
+}
+
 agent_etcd_config_iv = t.Dict({
     t.Key("container-logs", default=default_container_logs_config): t.Dict({
         t.Key("max-length", default=default_container_logs_config["max-length"]): tx.BinarySize(),
         t.Key("chunk-size", default=default_container_logs_config["chunk-size"]): tx.BinarySize(),
+    }).allow_extra("*"),
+    t.Key("sync-container-lifecycles", default=default_sync_container_lifecycles_config): t.Dict({
+        t.Key("run-task", default=default_sync_container_lifecycles_config["run-task"]): t.ToBool,
+        t.Key("interval", default=default_sync_container_lifecycles_config["interval"]): t.ToFloat[
+            0:
+        ],
     }).allow_extra("*"),
 }).allow_extra("*")
 


### PR DESCRIPTION
Let's make `sync_container_lifecycles()` task configurable to turn on/off and set the interval seconds.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
