### PR TITLE
feat: Support GitHub Container Registry

### DIFF
--- a/changes/2341.feature.md
+++ b/changes/2341.feature.md
@@ -1,0 +1,1 @@
+Support GitHub Container Registry

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -29,9 +29,9 @@ def get_container_registry_cls(registry_info: Mapping[str, Any]) -> Type[BaseCon
 
         cr_cls = HarborRegistry_v2
     elif registry_type == "github":
-        from .github import GitHubRegistry_v2
+        from .github import GitHubRegistry
 
-        cr_cls = GitHubRegistry_v2
+        cr_cls = GitHubRegistry
     elif registry_type == "local":
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -28,6 +28,10 @@ def get_container_registry_cls(registry_info: Mapping[str, Any]) -> Type[BaseCon
         from .harbor import HarborRegistry_v2
 
         cr_cls = HarborRegistry_v2
+    elif registry_type == "github":
+        from .github import GitHubRegistry_v2
+
+        cr_cls = GitHubRegistry_v2
     elif registry_type == "local":
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -292,7 +292,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         manifest: Mapping[str, Any],
         rqst_args: Mapping[str, Any],
         image: str,
-    ) -> Mapping[str, Any]:
+    ) -> dict[str, Any]:
         """
         Extracts informations from
         [Docker iamge manifest](https://github.com/openshift/docker-distribution/blob/master/docs/spec/manifest-v2-2.md#example-image-manifest)

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -217,7 +217,6 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         image: str,
         tag: str,
     ) -> None:
-        manifests = {}
         async with concurrency_sema.get():
             rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST_LIST
             async with sess.get(
@@ -230,63 +229,192 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 content_type = resp.headers["Content-Type"]
                 resp.raise_for_status()
                 resp_json = await resp.json()
-                match content_type:
-                    # TODO: Support `self.MEDIA_TYPE_DOCKER_MANIFEST`
-                    case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
-                        manifest_list = resp_json["manifests"]
-                        request_type = self.MEDIA_TYPE_DOCKER_MANIFEST
-                    case self.MEDIA_TYPE_OCI_INDEX:
-                        manifest_list = [
-                            item
-                            for item in resp_json["manifests"]
-                            if "annotations" not in item  # skip attestation manifests
-                        ]
-                        request_type = self.MEDIA_TYPE_OCI_MANIFEST
-                    case _:
-                        log.warn("Unknown content type: {}", content_type)
-                        raise RuntimeError(
-                            "The registry does not support the standard way of "
-                            "listing multiarch images."
-                        )
-            rqst_args["headers"]["Accept"] = request_type
-            for manifest in manifest_list:
-                platform_arg = (
-                    f"{manifest['platform']['os']}/{manifest['platform']['architecture']}"
-                )
-                if variant := manifest["platform"].get("variant", None):
-                    platform_arg += f"/{variant}"
-                architecture = manifest["platform"]["architecture"]
-                architecture = arch_name_aliases.get(architecture, architecture)
-                async with sess.get(
-                    self.registry_url / f"v2/{image}/manifests/{manifest['digest']}", **rqst_args
-                ) as resp:
-                    data = await resp.json()
-                config_digest = data["config"]["digest"]
-                size_bytes = sum(layer["size"] for layer in data["layers"]) + data["config"]["size"]
-                async with sess.get(
-                    self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
-                ) as resp:
-                    resp.raise_for_status()
-                    data = json.loads(await resp.read())
-                labels = {}
-                # we should favor `config` instead of `container_config` since `config` can contain additional datas
-                # set when commiting image via `--change` flag
-                if _config_labels := data.get("config", {}).get("Labels"):
-                    labels = _config_labels
-                elif _container_config_labels := data.get("container_config", {}).get("Labels"):
-                    labels = _container_config_labels
 
-                if not labels:
-                    log.warning(
-                        "Labels section not found on image {}:{}/{}", image, tag, architecture
-                    )
+                async with aiotools.TaskGroup() as tg:
+                    match content_type:
+                        case self.MEDIA_TYPE_DOCKER_MANIFEST:
+                            await self._process_docker_v2_image(
+                                tg, sess, rqst_args, image, tag, resp_json
+                            )
+                        case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
+                            await self._process_docker_v2_multiplatform_image(
+                                tg, sess, rqst_args, image, tag, resp_json
+                            )
+                        case self.MEDIA_TYPE_OCI_INDEX:
+                            await self._process_oci_index(
+                                tg, sess, rqst_args, image, tag, resp_json
+                            )
+                        case _:
+                            log.warn("Unknown content type: {}", content_type)
+                            raise RuntimeError(
+                                "The registry does not support the standard way of "
+                                "listing multiarch images."
+                            )
 
-                manifests[architecture] = {
+    async def _process_oci_index(
+        self,
+        tg: aiotools.TaskGroup,
+        sess: aiohttp.ClientSession,
+        rqst_args: Mapping[str, Any],
+        image: str,
+        tag: str,
+        image_info: Mapping[str, Any],
+    ) -> None:
+        manifests = {}
+        manifest_list = [
+            item
+            for item in image_info["manifests"]
+            if "annotations" not in item  # skip attestation manifests
+        ]
+        rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_OCI_MANIFEST
+
+        for manifest in manifest_list:
+            platform_arg = f"{manifest['platform']['os']}/{manifest['platform']['architecture']}"
+            if variant := manifest["platform"].get("variant", None):
+                platform_arg += f"/{variant}"
+            architecture = manifest["platform"]["architecture"]
+            architecture = arch_name_aliases.get(architecture, architecture)
+
+            async with sess.get(
+                self.registry_url / f"v2/{image}/manifests/{manifest['digest']}", **rqst_args
+            ) as resp:
+                data = await resp.json()
+            config_digest = data["config"]["digest"]
+            size_bytes = sum(layer["size"] for layer in data["layers"]) + data["config"]["size"]
+
+            async with sess.get(
+                self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
+            ) as resp:
+                resp.raise_for_status()
+                data = json.loads(await resp.read())
+            labels = {}
+            # we should favor `config` instead of `container_config` since `config` can contain additional datas
+            # set when commiting image via `--change` flag
+            if _config_labels := data.get("config", {}).get("Labels"):
+                labels = _config_labels
+            elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+                labels = _container_config_labels
+
+            if not labels:
+                log.warning("Labels section not found on image {}:{}/{}", image, tag, architecture)
+
+            manifests[architecture] = {
+                "size": size_bytes,
+                "labels": labels,
+                "digest": config_digest,
+            }
+        await self._read_manifest(image, tag, manifests)
+
+    async def _process_docker_v2_multiplatform_image(
+        self,
+        tg: aiotools.TaskGroup,
+        sess: aiohttp.ClientSession,
+        rqst_args: Mapping[str, Any],
+        image: str,
+        tag: str,
+        image_info: Mapping[str, Any],
+    ) -> None:
+        manifests = {}
+        manifest_list = image_info["manifests"]
+        rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
+
+        for manifest in manifest_list:
+            platform_arg = f"{manifest['platform']['os']}/{manifest['platform']['architecture']}"
+            if variant := manifest["platform"].get("variant", None):
+                platform_arg += f"/{variant}"
+            architecture = manifest["platform"]["architecture"]
+            architecture = arch_name_aliases.get(architecture, architecture)
+
+            async with sess.get(
+                self.registry_url / f"v2/{image}/manifests/{manifest['digest']}", **rqst_args
+            ) as resp:
+                data = await resp.json()
+            config_digest = data["config"]["digest"]
+            size_bytes = sum(layer["size"] for layer in data["layers"]) + data["config"]["size"]
+
+            async with sess.get(
+                self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
+            ) as resp:
+                resp.raise_for_status()
+                data = json.loads(await resp.read())
+            labels = {}
+            # we should favor `config` instead of `container_config` since `config` can contain additional datas
+            # set when commiting image via `--change` flag
+            if _config_labels := data.get("config", {}).get("Labels"):
+                labels = _config_labels
+            elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+                labels = _container_config_labels
+
+            if not labels:
+                log.warning("Labels section not found on image {}:{}/{}", image, tag, architecture)
+
+            manifests[architecture] = {
+                "size": size_bytes,
+                "labels": labels,
+                "digest": config_digest,
+            }
+        await self._read_manifest(image, tag, manifests)
+
+    async def _process_docker_v2_image(
+        self,
+        tg: aiotools.TaskGroup,
+        sess: aiohttp.ClientSession,
+        rqst_args: Mapping[str, Any],
+        image: str,
+        tag: str,
+        image_info: Mapping[str, Any],
+    ) -> None:
+        config_digest = image_info["config"]["digest"]
+        rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
+
+        async with sess.get(
+            self.registry_url / f"v2/{image}/blobs/{config_digest}",
+            **rqst_args,
+        ) as resp:
+            resp.raise_for_status()
+            blob_data = json.loads(await resp.read())
+
+        manifest_os = blob_data["os"]
+        manifest_arch = blob_data["architecture"]
+        architecture = arch_name_aliases.get(manifest_arch, manifest_arch)
+        manifest_variant = blob_data.get("variant", None)
+
+        platform_arg = f"{manifest_os}/{manifest_arch}"
+        if manifest_variant:
+            platform_arg += f"/{manifest_variant}"
+
+        size_bytes = (
+            sum(layer["size"] for layer in image_info["layers"]) + image_info["config"]["size"]
+        )
+
+        async with sess.get(
+            self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
+        ) as resp:
+            resp.raise_for_status()
+            data = json.loads(await resp.read())
+        labels = {}
+
+        # we should favor `config` instead of `container_config` since `config` can contain additional datas
+        # set when commiting image via `--change` flag
+        if _config_labels := data.get("config", {}).get("Labels"):
+            labels = _config_labels
+        elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+            labels = _container_config_labels
+
+        if not labels:
+            log.warning("Labels section not found on image {}:{}/{}", image, tag, architecture)
+
+        await self._read_manifest(
+            image,
+            tag,
+            {
+                architecture: {
                     "size": size_bytes,
                     "labels": labels,
                     "digest": config_digest,
                 }
-            await self._read_manifest(image, tag, manifests)
+            },
+        )
 
     async def _read_manifest(
         self,

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -231,6 +231,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 resp.raise_for_status()
                 resp_json = await resp.json()
                 match content_type:
+                    # TODO: Support `self.MEDIA_TYPE_DOCKER_MANIFEST`
                     case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                         manifest_list = resp_json["manifests"]
                         request_type = self.MEDIA_TYPE_DOCKER_MANIFEST

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -12,7 +12,7 @@ from .base import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
-class GitHubRegistry_v2(BaseContainerRegistry):
+class GitHubRegistry(BaseContainerRegistry):
     async def fetch_repositories(
         self,
         sess: aiohttp.ClientSession,

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -20,7 +20,7 @@ class GitHubRegistry_v2(BaseContainerRegistry):
         name, access_token, type_ = (
             self.registry_info["username"],
             self.registry_info["password"],
-            self.registry_info["name_type"],
+            self.registry_info["entity_type"],
         )
 
         base_url = f"https://api.github.com/{type_}/{name}/packages"

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -1,0 +1,158 @@
+import asyncio
+import json
+import logging
+from typing import AsyncIterator, Optional, cast
+
+import aiohttp
+import aiotools
+import yarl
+
+from ai.backend.common.bgtask import ProgressReporter
+from ai.backend.common.logging import BraceStyleAdapter
+
+from .base import (
+    BaseContainerRegistry,
+    all_updates,
+    concurrency_sema,
+    progress_reporter,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+class GitHubRegistry_v2(BaseContainerRegistry):
+    async def fetch_repositories(
+        self,
+        sess: aiohttp.ClientSession,
+    ) -> AsyncIterator[str]:
+        name, type_, access_token = (
+            self.registry_info["name"],
+            self.registry_info["name_type"],
+            self.registry_info["token"],
+        )
+
+        base_url = f"https://api.github.com/{type_}/{name}/packages"
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+        page = 1
+
+        while True:
+            async with sess.get(
+                base_url,
+                headers=headers,
+                params={"package_type": "container", "per_page": 30, "page": page},
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    for repo in data:
+                        yield repo["name"]
+                    if "next" in response.links:
+                        page += 1
+                    else:
+                        break
+                else:
+                    print(f"Failed to fetch repositories: {response.status}")
+                    break
+
+    async def get_ghcr_token(self, image: str):
+        url = f"https://ghcr.io/token?scope=repository:{image}:pull"
+        auth = aiohttp.BasicAuth(
+            login=self.registry_info["name"], password=self.registry_info["token"]
+        )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, auth=auth) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data["token"]
+                else:
+                    raise Exception("Failed to get token")
+
+    async def rescan_single_registry(
+        self,
+        reporter: ProgressReporter | None = None,
+    ) -> None:
+        log.info("rescan_single_registry()")
+        all_updates_token = all_updates.set({})
+        concurrency_sema.set(asyncio.Semaphore(self.max_concurrency_per_registry))
+        progress_reporter.set(reporter)
+        try:
+            username = self.registry_info["name"]
+            if username is not None:
+                self.credentials["username"] = username
+            password = self.registry_info["token"]
+            if password is not None:
+                self.credentials["password"] = password
+            async with self.prepare_client_session() as (url, client_session):
+                self.registry_url = url
+                async with aiotools.TaskGroup() as tg:
+                    async for image in self.fetch_repositories(client_session):
+                        tg.create_task(
+                            self._scan_image(
+                                client_session, f"{self.registry_info["name"]}/{image}"
+                            )
+                        )
+            await self.commit_rescan_result()
+        finally:
+            all_updates.reset(all_updates_token)
+
+    async def _scan_image(
+        self,
+        sess: aiohttp.ClientSession,
+        image: str,
+    ) -> None:
+        log.info("_scan_image()")
+
+        ghcr_token = await self.get_ghcr_token(
+            image,
+        )
+
+        tags = []
+        tag_list_url: Optional[yarl.URL]
+        tag_list_url = (self.registry_url / f"v2/{image}/tags/list").with_query(
+            {"n": "10"},
+        )
+        rqst_args = {"headers": {"Authorization": f"Bearer {ghcr_token}"}}
+
+        while tag_list_url is not None:
+            async with sess.get(tag_list_url, allow_redirects=False, **rqst_args) as resp:
+                data = json.loads(await resp.read())
+
+                if "tags" in data:
+                    # sometimes there are dangling image names in the hub.
+                    tags.extend(data["tags"])
+                tag_list_url = None
+                next_page_link = resp.links.get("next")
+                if next_page_link:
+                    next_page_url = cast(yarl.URL, next_page_link["url"])
+                    tag_list_url = self.registry_url.with_path(next_page_url.path).with_query(
+                        next_page_url.query
+                    )
+
+        if (reporter := progress_reporter.get()) is not None:
+            reporter.total_progress += len(tags)
+
+        async with aiotools.TaskGroup() as tg:
+            for tag in tags:
+                tg.create_task(self._scan_tag(sess, rqst_args, image, tag))
+
+    # async def _scan_tag(self, sess: aiohttp.ClientSession, image: str):
+    #     url = f"https://ghcr.io/v2/{image}/tags/list"
+    #     headers = {'Authorization': f'Bearer {token}'}
+    #     async with aiohttp.ClientSession() as session:
+    #         async with session.get(url, headers=headers) as response:
+    #             if response.status == 200:
+    #                 data = await response.json()
+    #                 return data
+    #             else:
+    #                 print('response.status', response.status)
+    #                 print("Failed to fetch tags")
+    #                 return {}
+
+    # async def _scan_image(self):
+    #     pass
+
+    # async def _read_manifest(self):
+    #     pass

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -1,20 +1,12 @@
-import asyncio
-import json
 import logging
-from typing import AsyncIterator, Optional, cast
+from typing import AsyncIterator
 
 import aiohttp
-import aiotools
-import yarl
 
-from ai.backend.common.bgtask import ProgressReporter
 from ai.backend.common.logging import BraceStyleAdapter
 
 from .base import (
     BaseContainerRegistry,
-    all_updates,
-    concurrency_sema,
-    progress_reporter,
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
@@ -25,13 +17,14 @@ class GitHubRegistry_v2(BaseContainerRegistry):
         self,
         sess: aiohttp.ClientSession,
     ) -> AsyncIterator[str]:
-        name, type_, access_token = (
-            self.registry_info["name"],
+        name, access_token, type_ = (
+            self.registry_info["username"],
+            self.registry_info["password"],
             self.registry_info["name_type"],
-            self.registry_info["token"],
         )
 
         base_url = f"https://api.github.com/{type_}/{name}/packages"
+
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Accept": "application/vnd.github.v3+json",
@@ -47,112 +40,12 @@ class GitHubRegistry_v2(BaseContainerRegistry):
                 if response.status == 200:
                     data = await response.json()
                     for repo in data:
-                        yield repo["name"]
+                        yield f"{self.registry_info["username"]}/{repo["name"]}"
                     if "next" in response.links:
                         page += 1
                     else:
                         break
                 else:
-                    print(f"Failed to fetch repositories: {response.status}")
-                    break
-
-    async def get_ghcr_token(self, image: str):
-        url = f"https://ghcr.io/token?scope=repository:{image}:pull"
-        auth = aiohttp.BasicAuth(
-            login=self.registry_info["name"], password=self.registry_info["token"]
-        )
-
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, auth=auth) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    return data["token"]
-                else:
-                    raise Exception("Failed to get token")
-
-    async def rescan_single_registry(
-        self,
-        reporter: ProgressReporter | None = None,
-    ) -> None:
-        log.info("rescan_single_registry()")
-        all_updates_token = all_updates.set({})
-        concurrency_sema.set(asyncio.Semaphore(self.max_concurrency_per_registry))
-        progress_reporter.set(reporter)
-        try:
-            username = self.registry_info["name"]
-            if username is not None:
-                self.credentials["username"] = username
-            password = self.registry_info["token"]
-            if password is not None:
-                self.credentials["password"] = password
-            async with self.prepare_client_session() as (url, client_session):
-                self.registry_url = url
-                async with aiotools.TaskGroup() as tg:
-                    async for image in self.fetch_repositories(client_session):
-                        tg.create_task(
-                            self._scan_image(
-                                client_session, f"{self.registry_info["name"]}/{image}"
-                            )
-                        )
-            await self.commit_rescan_result()
-        finally:
-            all_updates.reset(all_updates_token)
-
-    async def _scan_image(
-        self,
-        sess: aiohttp.ClientSession,
-        image: str,
-    ) -> None:
-        log.info("_scan_image()")
-
-        ghcr_token = await self.get_ghcr_token(
-            image,
-        )
-
-        tags = []
-        tag_list_url: Optional[yarl.URL]
-        tag_list_url = (self.registry_url / f"v2/{image}/tags/list").with_query(
-            {"n": "10"},
-        )
-        rqst_args = {"headers": {"Authorization": f"Bearer {ghcr_token}"}}
-
-        while tag_list_url is not None:
-            async with sess.get(tag_list_url, allow_redirects=False, **rqst_args) as resp:
-                data = json.loads(await resp.read())
-
-                if "tags" in data:
-                    # sometimes there are dangling image names in the hub.
-                    tags.extend(data["tags"])
-                tag_list_url = None
-                next_page_link = resp.links.get("next")
-                if next_page_link:
-                    next_page_url = cast(yarl.URL, next_page_link["url"])
-                    tag_list_url = self.registry_url.with_path(next_page_url.path).with_query(
-                        next_page_url.query
+                    raise RuntimeError(
+                        f"Failed to fetch repositories! {response.status} error occured."
                     )
-
-        if (reporter := progress_reporter.get()) is not None:
-            reporter.total_progress += len(tags)
-
-        async with aiotools.TaskGroup() as tg:
-            for tag in tags:
-                tg.create_task(self._scan_tag(sess, rqst_args, image, tag))
-
-    # async def _scan_tag(self, sess: aiohttp.ClientSession, image: str):
-    #     url = f"https://ghcr.io/v2/{image}/tags/list"
-    #     headers = {'Authorization': f'Bearer {token}'}
-    #     async with aiohttp.ClientSession() as session:
-    #         async with session.get(url, headers=headers) as response:
-    #             if response.status == 200:
-    #                 data = await response.json()
-    #                 return data
-    #             else:
-    #                 print('response.status', response.status)
-    #                 print("Failed to fetch tags")
-    #                 return {}
-
-    # async def _scan_image(self):
-    #     pass
-
-    # async def _read_manifest(self):
-    #     pass

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -243,15 +243,15 @@ class HarborRegistry_v2(BaseContainerRegistry):
                             match image_info["manifest_media_type"]:
                                 case self.MEDIA_TYPE_OCI_INDEX:
                                     await self._process_oci_index(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                                     await self._process_docker_v2_multiplatform_image(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case self.MEDIA_TYPE_DOCKER_MANIFEST:
                                     await self._process_docker_v2_image(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case _ as media_type:
                                     raise RuntimeError(
@@ -292,15 +292,19 @@ class HarborRegistry_v2(BaseContainerRegistry):
             resp.raise_for_status()
             resp_json = await resp.json()
             async with aiotools.TaskGroup() as tg:
+                tag = resp_json["tags"][0]["name"]
+
                 match resp_json["manifest_media_type"]:
                     case self.MEDIA_TYPE_OCI_INDEX:
-                        await self._process_oci_index(tg, sess, rqst_args, image, resp_json)
+                        await self._process_oci_index(tg, sess, rqst_args, image, tag, resp_json)
                     case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                         await self._process_docker_v2_multiplatform_image(
-                            tg, sess, rqst_args, image, resp_json
+                            tg, sess, rqst_args, image, tag, resp_json
                         )
                     case self.MEDIA_TYPE_DOCKER_MANIFEST:
-                        await self._process_docker_v2_image(tg, sess, rqst_args, image, resp_json)
+                        await self._process_docker_v2_image(
+                            tg, sess, rqst_args, image, tag, resp_json
+                        )
                     case _ as media_type:
                         raise RuntimeError(f"Unsupported artifact media-type: {media_type}")
 
@@ -310,6 +314,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -317,7 +322,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             rqst_args["headers"] = {}
         rqst_args["headers"].update({"Accept": "application/vnd.oci.image.manifest.v1+json"})
         digests: list[tuple[str, str]] = []
-        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
@@ -335,7 +339,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                         rqst_args,
                         image,
                         digest=digest,
-                        tag=tag_name,
+                        tag=tag,
                         architecture=architecture,
                     )
                 )
@@ -346,6 +350,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -355,7 +360,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             "Accept": "application/vnd.docker.distribution.manifest.v2+json"
         })
         digests: list[tuple[str, str]] = []
-        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
@@ -373,7 +377,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                         rqst_args,
                         image,
                         digest=digest,
-                        tag=tag_name,
+                        tag=tag,
                         architecture=architecture,
                     )
                 )
@@ -384,6 +388,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -394,14 +399,13 @@ class HarborRegistry_v2(BaseContainerRegistry):
         })
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
-        tag_name = image_info["tags"][0]["name"]
         async with aiotools.TaskGroup() as tg:
             tg.create_task(
                 self._harbor_scan_tag_single_arch(
                     sess,
                     rqst_args,
                     image,
-                    tag=tag_name,
+                    tag,
                 )
             )
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix #2337.

# Overview of the changes

## `base.py`'s `_scan_tag` update for handling `MEDIA_TYPE_DOCKER_MANIFEST`

In the existing code, only `MEDIA_TYPE_DOCKER_MANIFEST_LIST` and `MEDIA_TYPE_OCI_INDEX` types were handled in `_scan_tag`, so a runtime error occurred when `MEDIA_TYPE_DOCKER_MANIFEST` type was passed as `content_type`.

However, in `harbor.py`, handling based on `manifest_media_type` is processed by separate functions such as `_process_oci_index` and `_process_docker_v2_multiplatform_image`, so handling for `MEDIA_TYPE_DOCKER_MANIFEST` has been added by extracting these functions with the same signatures.

Adding handling for the `MEDIA_TYPE_DOCKER_MANIFEST` type (`_process_docker_v2_image`) seems not to be specific only to ghcr, so it was added to `base.py`.

# Test

Manually tested it using the following methods.

In this PR, the `cr.backend.ai/stable/python:3.9-ubuntu20.04` image is used as a placeholder for testing.

## Prerequisite

1. Tag and push the `cr.backend.ai/stable/python` image to your GitHub package for testing.

```
❯ docker tag cr.backend.ai/stable/python:3.9-ubuntu20.04 ghcr.io/<github_username>/python:3.9-ubuntu20.04
❯ docker push ghcr.io/<github_username>/python:3.9-ubuntu20.04
```

2. Enter the following command for putting the necessary key-values in `etcd`.

```
❯ ./backend.ai mgr etcd put config/docker/registry/ghcr.io "https://ghcr.io"; \
./backend.ai mgr etcd put config/docker/registry/ghcr.io/type "github"; \
./backend.ai mgr etcd put config/docker/registry/ghcr.io/entity_type "users"; \
./backend.ai mgr etcd put config/docker/registry/ghcr.io/username "<github_username>"; \
./backend.ai mgr etcd put config/docker/registry/ghcr.io/password "<github_PAT>"
```
> [!NOTE]  
The `entity_type` should be either "users" or "orgs".

3. Insert the following value into the `container_registry` column of the `groups` table.

```
{
	"registry": "ghcr.io",
	"project": "<github_username>"
}
```

4. Add `ghcr.io` value to `allowed_docker_registries` column of `domains` table using below command

```
❯ ./backend.ai admin domain update default --allowed-docker-registries=ghcr.io
```

## Test scenarios

Verify that the container registry added in this PR is functioning based on several scenarios.

If there are additional scenarios that need testing, please leave a comment.

### 1. Image Rescan

Image rescanning should work through the following command.

```
❯ ./backend.ai mgr image rescan ghcr.io
```

###  2. Create a session from the pulled image

Run a session using the downloaded image.

```
❯ ./backend.ai session create ghcr.io/<github_username>/python:3.9-ubuntu20.04
```

### 3. Commit the changes and push it to the container registry.

For committing a session, it is necessary to assume that the your "GitHub ID" is included in `config/docker/registry/ghcr.io/project` in etcd.

Enter the key value using the following command.

```
❯ ./backend.ai mgr etcd put config/docker/registry/ghcr.io/project "<github_username>"
```

Commit the changes using the `convert-to-image` command and push them to the container registry.

```
❯ ./backend.ai session convert-to-image <session_id> test_imgname

∙ Request to commit Session(name or id: ce592e27-b90a-4859-92b1-360fdd6d8464)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.02it/s]
✓ Session export process completed.
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue