### PR TITLE
ci: octodog performs graphql schema dump commit

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
         ref: ${{ github.head_ref }}
+        token: ${{ secrets.OCTODOG }}
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)


### PR DESCRIPTION
By default, events performed by github-actions-bot do not trigger other actions.
So, after the graphql action was executed, there was a problem where prs could not be merged because the action was not triggered.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
