### PR TITLE
fix: Allow GraphQL query to non-installed images (#2250)

### DIFF
--- a/changes/2250.fix.md
+++ b/changes/2250.fix.md
@@ -1,0 +1,1 @@
+Fix GraphQL to support query to non-installed images

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1130,7 +1130,7 @@ class Queries(graphene.ObjectType):
         root: Any,
         info: graphene.ResolveInfo,
         *,
-        is_installed=None,
+        is_installed: bool | None = None,
         is_operation=False,
         image_filters: list[str] | None = None,
     ) -> Sequence[Image]:
@@ -1173,7 +1173,7 @@ class Queries(graphene.ObjectType):
         else:
             raise InvalidAPIParameters("Unknown client role")
         if is_installed is not None:
-            items = [item for item in items if item.installed]
+            items = [item for item in items if item.installed == is_installed]
         return items
 
     @staticmethod


### PR DESCRIPTION
This is an auto-generated backport PR of #2250 to the 24.03 release.