### PR TITLE
feat: Support GitLab Container Registry

### DIFF
--- a/changes/2348.feature.md
+++ b/changes/2348.feature.md
@@ -1,0 +1,1 @@
+Support GitLab Container Registry

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -32,6 +32,10 @@ def get_container_registry_cls(registry_info: Mapping[str, Any]) -> Type[BaseCon
         from .github import GitHubRegistry
 
         cr_cls = GitHubRegistry
+    elif registry_type == "gitlab":
+        from .gitlab import GitLabRegistry_v2
+
+        cr_cls = GitLabRegistry_v2
     elif registry_type == "local":
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -33,9 +33,9 @@ def get_container_registry_cls(registry_info: Mapping[str, Any]) -> Type[BaseCon
 
         cr_cls = GitHubRegistry
     elif registry_type == "gitlab":
-        from .gitlab import GitLabRegistry_v2
+        from .gitlab import GitLabRegistry
 
-        cr_cls = GitLabRegistry_v2
+        cr_cls = GitLabRegistry
     elif registry_type == "local":
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -1,0 +1,50 @@
+import logging
+import urllib.parse
+from typing import AsyncIterator
+
+import aiohttp
+
+from ai.backend.common.logging import BraceStyleAdapter
+
+from .base import (
+    BaseContainerRegistry,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+class GitLabRegistry_v2(BaseContainerRegistry):
+    async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
+        access_token, gitlab_project = (
+            self.registry_info["password"],
+            self.registry_info["gitlab_project"],
+        )
+        encoded_project_id = urllib.parse.quote(gitlab_project, safe="")
+
+        base_url = f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
+
+        headers = {
+            "Accept": "application/json",
+            "PRIVATE-TOKEN": access_token,
+        }
+        page = 1
+
+        while True:
+            async with sess.get(
+                base_url,
+                headers=headers,
+                params={"per_page": 30, "page": page, "membership": "true"},
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+
+                    for repo in data:
+                        yield repo["path"]
+                    if "next" in response.headers.get("Link", ""):
+                        page += 1
+                    else:
+                        break
+                else:
+                    raise RuntimeError(
+                        f"Failed to fetch repositories! {response.status} error occurred."
+                    )

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -21,33 +21,36 @@ class GitLabRegistry_v2(BaseContainerRegistry):
             self.registry_info["gitlab_project"],
         )
 
-        encoded_project_id = urllib.parse.quote(f"{name}/{gitlab_project}", safe="")
-        repo_list_url = (
-            f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
-        )
+        projects = gitlab_project.split(",")
 
-        headers = {
-            "Accept": "application/json",
-            "PRIVATE-TOKEN": access_token,
-        }
-        page = 1
+        for project in projects:
+            encoded_project_id = urllib.parse.quote(f"{name}/{project}", safe="")
+            repo_list_url = (
+                f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
+            )
 
-        while True:
-            async with sess.get(
-                repo_list_url,
-                headers=headers,
-                params={"per_page": 30, "page": page},
-            ) as response:
-                if response.status == 200:
-                    data = await response.json()
+            headers = {
+                "Accept": "application/json",
+                "PRIVATE-TOKEN": access_token,
+            }
+            page = 1
 
-                    for repo in data:
-                        yield repo["path"]
-                    if "next" in response.headers.get("Link", ""):
-                        page += 1
+            while True:
+                async with sess.get(
+                    repo_list_url,
+                    headers=headers,
+                    params={"per_page": 30, "page": page},
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+
+                        for repo in data:
+                            yield repo["path"]
+                        if "next" in response.headers.get("Link", ""):
+                            page += 1
+                        else:
+                            break
                     else:
-                        break
-                else:
-                    raise RuntimeError(
-                        f"Failed to fetch repositories! {response.status} error occurred."
-                    )
+                        raise RuntimeError(
+                            f"Failed to fetch repositories for project {project}! {response.status} error occurred."
+                        )

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -13,7 +13,7 @@ from .base import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
-class GitLabRegistry_v2(BaseContainerRegistry):
+class GitLabRegistry(BaseContainerRegistry):
     async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
         name, access_token, gitlab_project = (
             self.registry_info["username"],

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -15,14 +15,15 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 
 class GitLabRegistry_v2(BaseContainerRegistry):
     async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
-        access_token, gitlab_project = (
+        name, access_token, gitlab_project = (
+            self.registry_info["username"],
             self.registry_info["password"],
             self.registry_info["gitlab_project"],
         )
 
-        encoded_project = urllib.parse.quote(gitlab_project, safe="")
+        encoded_project_id = urllib.parse.quote(f"{name}/{gitlab_project}", safe="")
         repo_list_url = (
-            f"https://gitlab.com/api/v4/projects/{encoded_project}/registry/repositories"
+            f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
         )
 
         headers = {

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -19,9 +19,11 @@ class GitLabRegistry_v2(BaseContainerRegistry):
             self.registry_info["password"],
             self.registry_info["gitlab_project"],
         )
-        encoded_project_id = urllib.parse.quote(gitlab_project, safe="")
 
-        base_url = f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
+        encoded_project = urllib.parse.quote(gitlab_project, safe="")
+        repo_list_url = (
+            f"https://gitlab.com/api/v4/projects/{encoded_project}/registry/repositories"
+        )
 
         headers = {
             "Accept": "application/json",
@@ -31,9 +33,9 @@ class GitLabRegistry_v2(BaseContainerRegistry):
 
         while True:
             async with sess.get(
-                base_url,
+                repo_list_url,
                 headers=headers,
-                params={"per_page": 30, "page": page, "membership": "true"},
+                params={"per_page": 30, "page": page},
             ) as response:
                 if response.status == 200:
                     data = await response.json()


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix #2337.

# Test

Manually tested it using the following methods.

In this PR, the `cr.backend.ai/stable/python:3.9-ubuntu20.04` image is used as a placeholder for testing.

## Prerequisite

> Note: The example given refers to GitLab Hosted Registry, but it also works in an on-premises environment.

1. Tag and push the `cr.backend.ai/stable/python` image to your GitLab package for testing.

```
❯ docker tag cr.backend.ai/stable/python:3.9-ubuntu20.04 registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
❯ docker push registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
```

2. Enter the following command for putting the necessary key-values in `etcd`.

```
❯ ./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com "https://registry.gitlab.com"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/type "gitlab"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/gitlab_url "https://gitlab.com"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/project "<gitlab_username>"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/gitlab_project "<project_name>"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/username "<gitlab_username>"; \
./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/password "<gitlab_PAT>"
```

3. Insert the following value into the `container_registry` column of the `groups` table.

```
{
	"registry": "registry.gitlab.com",
	"project": "<gitlab_username>"
}
```

4. Add `registry.gitlab.com` value to `allowed_docker_registries` column of `domains` table using below command

```
❯ ./backend.ai admin domain update default --allowed-docker-registries=registry.gitlab.com
```

## Test scenarios

Verify that the container registry added in this PR is functioning based on several scenarios.

If there are additional scenarios that need testing, please leave a comment.

### 1. Image Rescan

Image rescanning should work through the following command.

```
❯ ./backend.ai mgr image rescan registry.gitlab.com
```

###  2. Create a session from the pulled image

Run a session using the downloaded image.

```
❯ ./backend.ai session create registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
```

### 3. Commit the changes and push it to the container registry.

For committing a session, it is necessary to assume that the your "GitLab ID" is included in `config/docker/registry/registry.gitlab.com` in etcd.

Enter the key value using the following command.

```
❯ ./backend.ai mgr etcd put config/docker/registry/registry.gitlab.com/project "<gitlab_username>"
```

Commit the changes using the `convert-to-image` command and push them to the container registry.

```
❯ ./backend.ai session convert-to-image <session_id> test_imgname

∙ Request to commit Session(name or id: ce592e27-b90a-4859-92b1-360fdd6d8464)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.02it/s]
✓ Session export process completed.
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue