### PR TITLE
ci: Update the regex and list of the PR title prefix checker

### DIFF
--- a/.github/workflows/pr-prefix.yml
+++ b/.github/workflows/pr-prefix.yml
@@ -10,18 +10,21 @@ jobs:
     steps:
       - name: Check PR title prefix
         run: |
-          if echo "${{ github.event.pull_request.title }}" | tr ':' '\n' | head -n 1 | grep -qE 'feat|fix|docs|refactor|ci|chore(\([^)]+\)|$)';
+          if echo "${{ github.event.pull_request.title }}" | tr ':' '\n' | head -n 1 | grep -qE '^(feat|fix|docs?|refactor|ci|chore(\([^)]+\))?|deps)$';
           then
             echo "PR title is valid."
           else
             echo "PR title is invalid."
             echo "Use the title prefixes like:"
-            echo "  feat: (for new features and functionality)"
-            echo "  fix: (for bug fixes and revisions on how things work)"
-            echo "  docs: (for docs, docstring, and comment changes)"
-            echo "  refactor: (for refactoring and revisions on how things are related)"
-            echo "  ci: (for changes related to CI/CD workflows)"
-            echo "  chore(...): (for changes related to repo/build configs, dependencies, etc.)"
+            echo "  feat:       (for new features and functionality)"
+            echo "  fix:        (for bug fixes and revisions on how things work)"
+            echo "  doc:        (for docs, docstring, and comment changes)"
+            echo "  docs:       (for docs, docstring, and comment changes)"
+            echo "  refactor:   (for refactoring and revisions on how things are related)"
+            echo "  ci:         (for changes related to CI/CD workflows)"
+            echo "  chore:      (for changes related to repo/build configs, tool dependencies, etc.)"
+            echo "  chore(...): (for changes related to repo/build configs, tool dependencies, etc.)"
+            echo "  deps:       (for changes related to upstream dependencies, etc.)"
             echo "following the conventional commit style."
             exit 1
           fi


### PR DESCRIPTION
This PR updates the PR title prefix checker as follows:

- Allow `chore:` in addition to the `chore(...):` pattern.
- Allow `deps:`.
- Allow `doc:` in addition to `docs:`.
- Align inner indentation of the error message for better readability.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
