### PR TITLE
ci: octodog performs graphql schema dump commit (#2344)

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
+        ref: ${{ github.head_ref }}
+        token: ${{ secrets.OCTODOG }}
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)


### PR DESCRIPTION
This is an auto-generated backport PR of #2344 to the 24.03 release.