### PR TITLE
fix: handle DB serialization error when transaction begins

### DIFF
--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -271,13 +271,13 @@ async def execute_with_txn_retry(
             retry=retry_if_exception_type(TryAgain),
         ):
             with attempt:
-                async with begin_trx(bind=connection) as session_or_conn:
-                    try:
+                try:
+                    async with begin_trx(bind=connection) as session_or_conn:
                         result = await txn_func(session_or_conn)
-                    except DBAPIError as e:
-                        if is_db_retry_error(e):
-                            raise TryAgain
-                        raise
+                except DBAPIError as e:
+                    if is_db_retry_error(e):
+                        raise TryAgain
+                    raise
     except RetryError:
         raise asyncio.TimeoutError(
             f"DB serialization failed after {max_attempts} retry transactions"


### PR DESCRIPTION
follow-up #2088 

When handling DB serialization error in `ai.backend.manager.models.utils.execute_with_txn_retry()`, the handling context should include the `async with begin_trx(bind=connection) as session_or_conn: ...` line since `SerializationError` occurs in `begin_trx()`.

### Example error stack
```
File "/Users/sh/bai-dev/src/ai/backend/manager/models/utils.py", line 274, in execute_with_txn_retry
    async with begin_trx(bind=connection) as session_or_conn:
  File "/Users/sh/.pyenv/versions/3.12.2/lib/python3.12/contextlib.py", line 217, in __aexit__
    await anext(self.gen)
  File "/Users/sh/bai-dev/src/ai/backend/manager/models/utils.py", line 171, in begin_session
    async with _begin_session(bind) as sess:
  File "/Users/sh/.pyenv/versions/3.12.2/lib/python3.12/contextlib.py", line 217, in __aexit__
    await anext(self.gen)
  File "/Users/sh/bai-dev/src/ai/backend/manager/models/utils.py", line 164, in _begin_session
    await session.commit()
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/ext/asyncio/session.py", line 585, in commit
    return await greenlet_spawn(self.sync_session.commit)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 128, in greenlet_spawn
    result = context.switch(value)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 1454, in commit
    self._transaction.commit(_to_root=self.future)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 832, in commit
    self._prepare_impl()
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 811, in _prepare_impl
    self.session.flush()
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3449, in flush
    self._flush(objects)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3588, in _flush
    with util.safe_reraise():
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3549, in _flush
    flush_context.execute()
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/persistence.py", line 237, in save_obj
    _emit_update_statements(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/orm/persistence.py", line 1001, in _emit_update_statements
    c = connection._execute_20(
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
    util.raise_(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 479, in execute
    self._adapt_connection.await_(
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 68, in await_only
    return current.driver.switch(awaitable)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 121, in greenlet_spawn
    value = await result
            ^^^^^^^^^^^^
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 454, in _prepare_and_execute
    self._handle_exception(error)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 389, in _handle_exception
    self._adapt_connection._handle_exception(error)
  File "/Users/sh/bai-dev/dist/export/python/virtualenvs/python-default/3.12.2/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 682, in _handle_exception
    raise translated_error from error
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.SerializationError'>: could not serialize access due to concurrent update
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)