### PR TITLE
ci: Skip typecheck & test when adding Graphite merge-queue labels

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -79,7 +79,7 @@ jobs:
 
 
   typecheck:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name) && github.event.pull_request.merged == false }}
     runs-on: ubuntu-latest
     steps:
     - name: Calculate the fetch depth
@@ -142,7 +142,7 @@ jobs:
 
 
   test:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == false }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name) && github.event.pull_request.merged == false }}
     runs-on: [ubuntu-latest-8-cores]
     steps:
     - name: Calculate the fetch depth


### PR DESCRIPTION
Previously, GitHub has triggered the typecheck and test workflows when adding `flow:merge-queue` and `flow:hotfix` labels to add the PR to the Graphite merge-queue.
This is a duplicated check as the merge-queue itself will run the CI again.

Let's skip those workflows when just adding those `flow:*` labels.

This PR is a follow up of #2261, which did it for the lint and other required workflows.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
