### PR TITLE
add: parameter `kernel_id` for fetching container log from agent by kernel_id

### DIFF
--- a/changes/2363.feature.md
+++ b/changes/2363.feature.md
@@ -1,0 +1,1 @@
+Add parameter `kernel_id` for fetching container log from agent by kernel_id not just main container

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -216,6 +216,10 @@ class MainKernelNotFound(ObjectNotFound):
     object_name = "main kernel"
 
 
+class KernelNotFound(ObjectNotFound):
+    object_name = "kernel"
+
+
 class EndpointNotFound(ObjectNotFound):
     object_name = "endpoint"
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2739,14 +2739,22 @@ class AgentRegistry:
     async def get_logs_from_agent(
         self,
         session: SessionRow,
+        kernel_id: uuid.UUID | None,
     ) -> str:
         async with handle_session_exception(self.db, "get_logs_from_agent", session.id):
+            agent_by_kernel_id = (
+                session.get_kernel_by_id(kernel_id).agent
+                if kernel_id
+                else session.main_kernel.agent
+            )
             async with self.agent_cache.rpc_context(
-                session.main_kernel.agent,
+                agent_id=agent_by_kernel_id,
                 invoke_timeout=30,
                 order_key=session.main_kernel.id,
             ) as rpc:
-                reply = await rpc.call.get_logs(str(session.main_kernel.id))
+                reply = await rpc.call.get_logs(
+                    str(kernel_id if kernel_id else session.main_kernel.id)
+                )
                 return reply["logs"]
 
     async def increment_session_usage(


### PR DESCRIPTION
This PR adds `kernel_id` as optional parameter on fetching container log from agent(s) by its id.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2363.org.readthedocs.build/en/2363/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2363.org.readthedocs.build/ko/2363/

<!-- readthedocs-preview sorna-ko end -->