### PR TITLE
fix: Handle user creation failure when model-store does not exists (#2160)

### DIFF
--- a/changes/2160.fix.md
+++ b/changes/2160.fix.md
@@ -1,0 +1,1 @@
+Fix user creation error when any model-store does not exists.

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Sequence, cast
 from uuid import UUID, uuid4
 
 import aiotools
@@ -662,8 +662,13 @@ class CreateUser(graphene.Mutation):
             model_store_query = sa.select([groups.c.id]).where(
                 groups.c.type == ProjectType.MODEL_STORE
             )
-            model_store_gid = (await conn.execute(model_store_query)).first()["id"]
-            gids_to_join = [*group_ids, model_store_gid]
+            model_store_project = cast(
+                dict[str, Any] | None, (await conn.execute(model_store_query)).first()
+            )
+            if model_store_project is not None:
+                gids_to_join = [*group_ids, model_store_project["id"]]
+            else:
+                gids_to_join = group_ids
 
             # Add user to groups if group_ids parameter is provided.
             if gids_to_join:


### PR DESCRIPTION
This is an auto-generated backport PR of #2160 to the 24.03 release.