### PR TITLE
fix: typo of user queryfilter (#2314)

### DIFF
--- a/changes/2314.fix.md
+++ b/changes/2314.fix.md
@@ -1,0 +1,1 @@
+Corrected an issue where the `resource_policy` field in the user model was incorrectly mapped to `domain_name`.

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -1400,7 +1400,7 @@ class UserNode(graphene.ObjectType):
         "modified_at": ("modified_at", dtparse),
         "domain_name": ("domain_name", None),
         "role": ("role", enum_field_getter(UserRole)),
-        "resource_policy": ("domain_name", None),
+        "resource_policy": ("resource_policy", None),
         "allowed_client_ip": ("allowed_client_ip", None),
         "totp_activated": ("totp_activated", None),
         "totp_activated_at": ("totp_activated_at", dtparse),


### PR DESCRIPTION
This is an auto-generated backport PR of #2314 to the 24.03 release.