### PR TITLE
fix: Wrong image name extraction logic

### DIFF
--- a/changes/2391.fix.md
+++ b/changes/2391.fix.md
@@ -1,0 +1,1 @@
+Fix wrong image name extraction logic

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1088,7 +1088,7 @@ async def convert_session_to_image(
         await reporter.update(message="Commit started")
         try:
             if "/" in base_image_ref.name:
-                new_name = base_image_ref.name.split("/", maxsplit=1)[1]
+                new_name = base_image_ref.name.split("/")[-1]
             else:
                 # for cases where project name is not specified (e.g. redis, nginx, ...)
                 new_name = base_image_ref.name


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Existing code appears to assume the image name format is `<registry URL>/<namespace>/<image>`

https://github.com/lablup/backend.ai/blob/f16b76e81e357b2bd55da3b1dc7aa01b5eeccd26/src/ai/backend/manager/api/session.py#L1091-L1103

If the image name format is `<registry URL>/<namespace>/<project>/<image>`, this logic incorrectly extracts the image name.

For example,

```
>>> base_image_ref = "jopemachine/ghcr-test/python"
>>> new_name = base_image_ref.split("/", maxsplit=1)[1]
>>> new_name 
'ghcr-test/python'  # <project>/<image> 
```

new_name includes not only the image name but also the project name.

As a result, in the logic that assigns `new_canonical`, the project name is included twice.

(like `ghcr.io/jopemachine/ghcr-test/ghcr-test/python:3.9-ubuntu20.04`)

---

Ref: #2341.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2391.org.readthedocs.build/en/2391/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2391.org.readthedocs.build/ko/2391/

<!-- readthedocs-preview sorna-ko end -->