### PR TITLE
fix: Skip waiting cancelled task to shutdown agent properly (#2392)

### DIFF
--- a/changes/2392.fix.md
+++ b/changes/2392.fix.md
@@ -1,0 +1,1 @@
+Shutdown agent properly by removing a code that waits a cancelled task.

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -404,7 +404,9 @@ class AgentRPCServer(aobject):
         # Stop receiving further requests.
         await self.rpc_server.__aexit__(*exc_info)
         self.debug_server_task.cancel()
-        await self.debug_server_task
+        await asyncio.sleep(0)
+        if not self.debug_server_task.done():
+            await self.debug_server_task
         await self.agent.shutdown(self._stop_signal)
         await self.stats_monitor.cleanup()
         await self.error_monitor.cleanup()


### PR DESCRIPTION
This is an auto-generated backport PR of #2392 to the 24.03 release.