### PR TITLE
fix: Hanging tests due to docker-internal races for TCP ports (#2379)

### DIFF
--- a/changes/2379.misc.md
+++ b/changes/2379.misc.md
@@ -1,0 +1,1 @@
+Finally stabilize the hanging tests in our CI due to docker-internal races on TCP port mappings to concurrently spawned fixture containers by introducing monotonically increasing TCP port numbers

--- a/pants.toml
+++ b/pants.toml
@@ -36,7 +36,6 @@ root_patterns = [
     "/",
     "/src",
     "/stubs",
-    "/tests",
     "/tools/pants-plugins",
 ]
 

--- a/scripts/clear-test-containers.sh
+++ b/scripts/clear-test-containers.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+docker ps -a -q --filter 'name=^test-' | xargs -r docker rm -f -v
+docker network ls --filter 'name=^testnet-' --format '{{.ID}}' | xargs -r docker network rm
+rm -rf ~/.cache/bai/testing/*

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -7,15 +7,13 @@ import socket
 import time
 from typing import (
     Any,
-    AsyncIterator,
+    AsyncGenerator,
     Awaitable,
     Callable,
-    Dict,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
-    Tuple,
     Union,
     cast,
 )
@@ -69,7 +67,7 @@ _default_conn_pool_opts: Mapping[str, Any] = {
     # "timeout": 20.0,  # for redis-py 5.0+
 }
 
-_scripts: Dict[str, str] = {}
+_scripts: dict[str, str] = {}
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
@@ -78,7 +76,11 @@ class ConnectionNotAvailable(Exception):
     pass
 
 
-async def subscribe(channel: PubSub, *, reconnect_poll_interval: float = 0.3) -> AsyncIterator[Any]:
+async def subscribe(
+    channel: PubSub,
+    *,
+    reconnect_poll_interval: float = 0.3,
+) -> AsyncGenerator[Any, None]:
     """
     An async-generator wrapper for pub-sub channel subscription.
     It automatically recovers from server shutdowns until explicitly cancelled.
@@ -102,9 +104,9 @@ async def subscribe(channel: PubSub, *, reconnect_poll_interval: float = 0.3) ->
             if message is not None:
                 yield message["data"]
         except (
-            redis.exceptions.ConnectionError,
             MasterNotFoundError,
             SlaveNotFoundError,
+            redis.exceptions.ConnectionError,
             redis.exceptions.ReadOnlyError,
             ConnectionResetError,
             ConnectionNotAvailable,
@@ -113,7 +115,7 @@ async def subscribe(channel: PubSub, *, reconnect_poll_interval: float = 0.3) ->
             await _reset_chan()
             continue
         except redis.exceptions.ResponseError as e:
-            if len(e.args) > 0 and e.args[0].startswith("NOREPLICAS "):
+            if len(e.args) > 0 and e.args[0].upper().startswith("NOREPLICAS "):
                 await asyncio.sleep(reconnect_poll_interval)
                 await _reset_chan()
                 continue
@@ -131,7 +133,7 @@ async def blpop(
     key: str,
     *,
     service_name: Optional[str] = None,
-) -> AsyncIterator[Any]:
+) -> AsyncGenerator[bytes, None]:
     """
     An async-generator wrapper for blpop (blocking left pop).
     It automatically recovers from server shutdowns until explicitly cancelled.
@@ -150,16 +152,16 @@ async def blpop(
                 continue
             yield raw_msg[1]
         except (
-            redis.exceptions.ConnectionError,
             MasterNotFoundError,
             SlaveNotFoundError,
+            redis.exceptions.ConnectionError,
             redis.exceptions.ReadOnlyError,
             ConnectionResetError,
         ):
             await asyncio.sleep(reconnect_poll_interval)
             continue
         except redis.exceptions.ResponseError as e:
-            if e.args[0].startswith("NOREPLICAS "):
+            if e.args[0].upper().startswith("NOREPLICAS "):
                 await asyncio.sleep(reconnect_poll_interval)
                 continue
             raise
@@ -333,7 +335,7 @@ async def read_stream(
     stream_key: str,
     *,
     block_timeout: int = 10_000,  # in msec
-) -> AsyncIterator[Tuple[bytes, bytes]]:
+) -> AsyncGenerator[tuple[bytes, bytes], None]:
     """
     A high-level wrapper for the XREAD command.
     """
@@ -377,7 +379,7 @@ async def read_stream_by_group(
     *,
     autoclaim_idle_timeout: int = 1_000,  # in msec
     block_timeout: int = 10_000,  # in msec
-) -> AsyncIterator[Tuple[bytes, bytes]]:
+) -> AsyncGenerator[tuple[bytes, Any], None]:
     """
     A high-level wrapper for the XREADGROUP command
     combined with XAUTOCLAIM and XGROUP_CREATE.

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -20,23 +20,22 @@ from ai.backend.testutils.pants import get_parallel_slot
 log = logging.getLogger(__spec__.name)  # type: ignore[name-defined]
 
 
-def get_free_port():
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
-
-
-def check_if_port_is_clear(host, port):
-    while True:
-        try:
-            s = socket.create_connection((host, port), timeout=0.3)
-        except (ConnectionRefusedError, TimeoutError):
-            break
+def get_next_tcp_port() -> int:
+    parallel_slot = get_parallel_slot()
+    lock_path = Path(f"~/.cache/bai/testing/port-{parallel_slot}.lock").expanduser()
+    port_path = Path(f"~/.cache/bai/testing/port-{parallel_slot}.txt").expanduser()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with sync_file_lock(lock_path):
+        if port_path.exists():
+            port_no = int(port_path.read_text())
+            port_no += 1
+            port_path.write_text(str(port_no))
         else:
-            time.sleep(0.1)
-            s.close()
-            continue
+            # NOTE: We should set sufficiently large multiplier to the number of all spawned
+            #       containers during tests.
+            port_no = 9200 + parallel_slot * 250
+            port_path.write_text(str(port_no))
+    return port_no
 
 
 @contextlib.contextmanager
@@ -91,9 +90,8 @@ def wait_health_check(container_id):
 @pytest.fixture(scope="session", autouse=False)
 def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
-    etcd_allocated_port = 9600 + get_parallel_slot() * 8 + 0
     random_id = secrets.token_hex(8)
-    check_if_port_is_clear("127.0.0.1", etcd_allocated_port)
+    published_port = get_next_tcp_port()
     proc = subprocess.run(
         [
             "docker",
@@ -104,9 +102,7 @@ def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
             "--name",
             f"test--etcd-slot-{get_parallel_slot()}-{random_id}",
             "-p",
-            f"0.0.0.0:{etcd_allocated_port}:2379",
-            "-p",
-            "0.0.0.0::4001",
+            f"127.0.0.1:{published_port}:2379",
             "--health-cmd",
             "etcdctl endpoint health",
             "--health-interval",
@@ -125,9 +121,9 @@ def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
     container_id = proc.stdout.decode().strip()
     if not container_id:
         raise RuntimeError("etcd_container: failed to create container", proc.stderr.decode())
-    log.info("spawning etcd container on port %d", etcd_allocated_port)
+    log.info("spawning etcd container (parallel slot: %d)", get_parallel_slot())
     wait_health_check(container_id)
-    yield container_id, HostPortPair("127.0.0.1", etcd_allocated_port)
+    yield container_id, HostPortPair("127.0.0.1", published_port)
     subprocess.run(
         [
             "docker",
@@ -143,9 +139,8 @@ def etcd_container() -> Iterator[tuple[str, HostPortPair]]:
 @pytest.fixture(scope="session", autouse=False)
 def redis_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
-    redis_allocated_port = 9600 + get_parallel_slot() * 8 + 1
-    check_if_port_is_clear("127.0.0.1", redis_allocated_port)
     random_id = secrets.token_hex(8)
+    published_port = get_next_tcp_port()
     proc = subprocess.run(
         [
             "docker",
@@ -158,7 +153,7 @@ def redis_container() -> Iterator[tuple[str, HostPortPair]]:
             "--name",
             f"test--redis-slot-{get_parallel_slot()}-{random_id}",
             "-p",
-            f"0.0.0.0:{redis_allocated_port}:6379",
+            f"127.0.0.1:{published_port}:6379",
             # IMPORTANT: We have intentionally omitted the healthcheck here
             # to avoid intermittent failures when pausing/unpausing containers.
             "redis:7-alpine",
@@ -168,11 +163,11 @@ def redis_container() -> Iterator[tuple[str, HostPortPair]]:
     container_id = proc.stdout.decode().strip()
     if not container_id:
         raise RuntimeError("redis_container: failed to create container", proc.stderr.decode())
-    log.info("spawning redis container on port %d", redis_allocated_port)
+    log.info("spawning redis container (parallel slot: %d)", get_parallel_slot())
     while True:
         try:
             with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-                s.connect(("127.0.0.1", redis_allocated_port))
+                s.connect(("127.0.0.1", published_port))
                 s.send(b"*2\r\n$4\r\nPING\r\n$5\r\nhello\r\n")
                 reply = s.recv(128, 0)
                 if not reply.startswith(b"$5\r\nhello\r\n"):
@@ -183,7 +178,7 @@ def redis_container() -> Iterator[tuple[str, HostPortPair]]:
             time.sleep(0.1)
             continue
     time.sleep(0.5)
-    yield container_id, HostPortPair("127.0.0.1", redis_allocated_port)
+    yield container_id, HostPortPair("127.0.0.1", published_port)
     subprocess.run(
         [
             "docker",
@@ -199,9 +194,8 @@ def redis_container() -> Iterator[tuple[str, HostPortPair]]:
 @pytest.fixture(scope="session", autouse=False)
 def postgres_container() -> Iterator[tuple[str, HostPortPair]]:
     # Spawn a single-node etcd container for a testing session.
-    postgres_allocated_port = 9600 + get_parallel_slot() * 8 + 2
-    check_if_port_is_clear("127.0.0.1", postgres_allocated_port)
     random_id = secrets.token_hex(8)
+    published_port = get_next_tcp_port()
     proc = subprocess.run(
         [
             "docker",
@@ -212,7 +206,7 @@ def postgres_container() -> Iterator[tuple[str, HostPortPair]]:
             "--name",
             f"test--postgres-slot-{get_parallel_slot()}-{random_id}",
             "-p",
-            f"0.0.0.0:{postgres_allocated_port}:5432",
+            f"127.0.0.1:{published_port}:5432",
             "-e",
             "POSTGRES_PASSWORD=develove",
             "-e",
@@ -230,9 +224,9 @@ def postgres_container() -> Iterator[tuple[str, HostPortPair]]:
     container_id = proc.stdout.decode().strip()
     if not container_id:
         raise RuntimeError("postgres_container: failed to create container", proc.stderr.decode())
-    log.info("spawning postgres container on port %d", postgres_allocated_port)
+    log.info("spawning postgres container (parallel slot: %d)", get_parallel_slot())
     wait_health_check(container_id)
-    yield container_id, HostPortPair("127.0.0.1", postgres_allocated_port)
+    yield container_id, HostPortPair("127.0.0.1", published_port)
     subprocess.run(
         [
             "docker",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,1 @@
+python_test_utils()

--- a/tests/common/BUILD
+++ b/tests/common/BUILD
@@ -3,6 +3,6 @@ python_test_utils()
 python_tests(
     name="tests",
     overrides={
-        "test_distributed.py": {"timeout": 30},
+        "test_distributed.py": {"timeout": 60},
     },
 )

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -6,7 +6,11 @@ from decimal import Decimal
 import pytest
 
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
-from ai.backend.testutils.bootstrap import etcd_container, redis_container  # noqa: F401
+from ai.backend.testutils.bootstrap import (  # noqa: F401
+    etcd_container,
+    redis_container,
+    sync_file_lock,
+)
 
 
 def pytest_addoption(parser):

--- a/tests/common/redis_helper/BUILD
+++ b/tests/common/redis_helper/BUILD
@@ -7,7 +7,6 @@ resources(
 )
 
 python_test_utils(
-    name="test_utils",
     dependencies=[
         ":redis-cluster-compose",
     ],

--- a/tests/common/redis_helper/docker.py
+++ b/tests/common/redis_helper/docker.py
@@ -9,11 +9,11 @@ from pprint import pprint
 from typing import AsyncIterator, Tuple
 
 import aiohttp
-import async_timeout
 import pytest
 from packaging.version import Version
 from packaging.version import parse as parse_version
 
+from ai.backend.testutils.bootstrap import get_next_tcp_port
 from ai.backend.testutils.pants import get_parallel_slot
 
 from .types import AbstractRedisNode, AbstractRedisSentinelCluster, RedisClusterInfo
@@ -35,10 +35,22 @@ async def check_if_port_is_clear(host, port):
 
 
 class DockerRedisNode(AbstractRedisNode):
-    def __init__(self, node_type: str, port: int, container_id: str) -> None:
+    def __init__(
+        self,
+        node_type: str,
+        port: int,
+        container_id: str,
+        *,
+        verbose: bool = False,
+    ) -> None:
         self.node_type = node_type
         self.port = port
         self.container_id = container_id
+        self.verbose = verbose
+        self._cmd_opts = {}
+        if not self.verbose:
+            self._cmd_opts["stdout"] = asyncio.subprocess.DEVNULL
+            self._cmd_opts["stderr"] = asyncio.subprocess.DEVNULL
 
     @property
     def addr(self) -> Tuple[str, int]:
@@ -50,50 +62,30 @@ class DockerRedisNode(AbstractRedisNode):
     async def pause(self) -> None:
         assert self.container_id is not None
         print(f"Docker container {self.container_id[:12]} is being paused...")
-        p = await simple_run_cmd(
-            ["docker", "pause", self.container_id],
-            # stdout=asyncio.subprocess.DEVNULL,
-            # stderr=asyncio.subprocess.DEVNULL,
-        )
+        p = await simple_run_cmd(["docker", "pause", self.container_id], **self._cmd_opts)
         await p.wait()
         print(f"Docker container {self.container_id[:12]} is paused")
 
     async def unpause(self) -> None:
         assert self.container_id is not None
-        p = await simple_run_cmd(
-            ["docker", "unpause", self.container_id],
-            # stdout=asyncio.subprocess.DEVNULL,
-            # stderr=asyncio.subprocess.DEVNULL,
-        )
+        p = await simple_run_cmd(["docker", "unpause", self.container_id], **self._cmd_opts)
         await p.wait()
         print(f"Docker container {self.container_id[:12]} is unpaused")
 
     async def stop(self, force_kill: bool = False) -> None:
         assert self.container_id is not None
         if force_kill:
-            p = await simple_run_cmd(
-                ["docker", "kill", self.container_id],
-                # stdout=asyncio.subprocess.DEVNULL,
-                # stderr=asyncio.subprocess.DEVNULL,
-            )
+            p = await simple_run_cmd(["docker", "kill", self.container_id], **self._cmd_opts)
             await p.wait()
             print(f"Docker container {self.container_id[:12]} is killed")
         else:
-            p = await simple_run_cmd(
-                ["docker", "stop", self.container_id],
-                # stdout=asyncio.subprocess.DEVNULL,
-                # stderr=asyncio.subprocess.DEVNULL,
-            )
+            p = await simple_run_cmd(["docker", "stop", self.container_id], **self._cmd_opts)
             await p.wait()
             print(f"Docker container {self.container_id[:12]} is terminated")
 
     async def start(self) -> None:
         assert self.container_id is not None
-        p = await simple_run_cmd(
-            ["docker", "start", self.container_id],
-            # stdout=asyncio.subprocess.DEVNULL,
-            # stderr=asyncio.subprocess.DEVNULL,
-        )
+        p = await simple_run_cmd(["docker", "start", self.container_id], **self._cmd_opts)
         await p.wait()
         print(f"Docker container {self.container_id[:12]} started")
 
@@ -156,14 +148,13 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
         compose_cfg_dir = (
             Path.home() / ".cache" / "bai" / "testing" / f"bai-redis-test-{get_parallel_slot()}"
         )
-        base_port = 9200 + get_parallel_slot() * 8
         ports = {
-            "REDIS_MASTER_PORT": base_port,
-            "REDIS_SLAVE1_PORT": base_port + 1,
-            "REDIS_SLAVE2_PORT": base_port + 2,
-            "REDIS_SENTINEL1_PORT": base_port + 3,
-            "REDIS_SENTINEL2_PORT": base_port + 4,
-            "REDIS_SENTINEL3_PORT": base_port + 5,
+            "REDIS_MASTER_PORT": get_next_tcp_port(),
+            "REDIS_SLAVE1_PORT": get_next_tcp_port(),
+            "REDIS_SLAVE2_PORT": get_next_tcp_port(),
+            "REDIS_SENTINEL1_PORT": get_next_tcp_port(),
+            "REDIS_SENTINEL2_PORT": get_next_tcp_port(),
+            "REDIS_SENTINEL3_PORT": get_next_tcp_port(),
         }
         async with asyncio.TaskGroup() as tg:
             for port in ports.values():
@@ -171,25 +162,26 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
         os.environ.update({k: str(v) for k, v in ports.items()})
         os.environ["COMPOSE_PATH"] = str(compose_cfg_dir)
         os.environ["DOCKER_USER"] = f"{os.getuid()}:{os.getgid()}"
+        os.environ["NETWORK_NAME"] = f"testnet-{get_parallel_slot()}-{self.test_case_ns}"
 
         if compose_cfg_dir.exists():
             shutil.rmtree(compose_cfg_dir)
         compose_cfg_dir.mkdir(parents=True)
         for file in template_cfg_files:
             shutil.copy(template_cfg_dir / file, compose_cfg_dir)
-        compose_tpl = (compose_cfg_dir / "sentinel.conf").read_text()
-        compose_tpl = compose_tpl.replace("REDIS_PASSWORD", "develove")
-        compose_tpl = compose_tpl.replace("REDIS_MASTER_HOST", "node01")
-        compose_tpl = compose_tpl.replace("REDIS_MASTER_PORT", str(ports["REDIS_MASTER_PORT"]))
-        sentinel01_cfg = compose_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel01")
+        sentinel_tpl = (compose_cfg_dir / "sentinel.conf").read_text()
+        sentinel_tpl = sentinel_tpl.replace("REDIS_PASSWORD", "develove")
+        sentinel_tpl = sentinel_tpl.replace("REDIS_MASTER_HOST", "node01")
+        sentinel_tpl = sentinel_tpl.replace("REDIS_MASTER_PORT", str(ports["REDIS_MASTER_PORT"]))
+        sentinel01_cfg = sentinel_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel01")
         sentinel01_cfg = sentinel01_cfg.replace(
             "REDIS_SENTINEL_SELF_PORT", str(ports["REDIS_SENTINEL1_PORT"])
         )
-        sentinel02_cfg = compose_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel02")
+        sentinel02_cfg = sentinel_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel02")
         sentinel02_cfg = sentinel02_cfg.replace(
             "REDIS_SENTINEL_SELF_PORT", str(ports["REDIS_SENTINEL2_PORT"])
         )
-        sentinel03_cfg = compose_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel03")
+        sentinel03_cfg = sentinel_tpl.replace("REDIS_SENTINEL_SELF_HOST", "sentinel03")
         sentinel03_cfg = sentinel03_cfg.replace(
             "REDIS_SENTINEL_SELF_PORT", str(ports["REDIS_SENTINEL3_PORT"])
         )
@@ -199,7 +191,7 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
 
         compose_file = compose_cfg_dir / "redis-cluster.yml"
 
-        async with async_timeout.timeout(30.0):
+        async with asyncio.timeout(30.0):
             cmdargs = [
                 *compose_cmd,
                 "-p",
@@ -213,8 +205,6 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                 cmdargs,
                 env=os.environ,
                 cwd=compose_cfg_dir,
-                # stdout=asyncio.subprocess.DEVNULL,
-                # stderr=asyncio.subprocess.DEVNULL,
             )
             await p.wait()
             assert p.returncode == 0, "Compose cluster creation has failed."
@@ -297,12 +287,13 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                 cid_mapping[container["Config"]["Labels"]["com.docker.compose.service"]] = (
                     container["Id"]
                 )
-                print(f"--- logs of {container['Id']} ---")
-                try:
-                    p = await simple_run_cmd(["docker", "logs", container["Id"]])
-                finally:
-                    await p.wait()
-                print("--- end of logs ---")
+                if self.verbose:
+                    print(f"--- logs of {container['Id']} ---")
+                    try:
+                        p = await simple_run_cmd(["docker", "logs", container["Id"]])
+                    finally:
+                        await p.wait()
+                    print("--- end of logs ---")
             print(f"{cids=}")
             print(f"{cid_mapping=}")
 
@@ -317,16 +308,19 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                         "node",
                         ports["REDIS_MASTER_PORT"],
                         cid_mapping["backendai-half-redis-node01"],
+                        verbose=self.verbose,
                     ),
                     DockerRedisNode(
                         "node",
                         ports["REDIS_SLAVE1_PORT"],
                         cid_mapping["backendai-half-redis-node02"],
+                        verbose=self.verbose,
                     ),
                     DockerRedisNode(
                         "node",
                         ports["REDIS_SLAVE2_PORT"],
                         cid_mapping["backendai-half-redis-node03"],
+                        verbose=self.verbose,
                     ),
                 ],
                 sentinel_addrs=[
@@ -339,22 +333,25 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                         "sentinel",
                         ports["REDIS_SENTINEL1_PORT"],
                         cid_mapping["backendai-half-redis-sentinel01"],
+                        verbose=self.verbose,
                     ),
                     DockerRedisNode(
                         "sentinel",
                         ports["REDIS_SENTINEL2_PORT"],
                         cid_mapping["backendai-half-redis-sentinel02"],
+                        verbose=self.verbose,
                     ),
                     DockerRedisNode(
                         "sentinel",
                         ports["REDIS_SENTINEL3_PORT"],
                         cid_mapping["backendai-half-redis-sentinel03"],
+                        verbose=self.verbose,
                     ),
                 ],
             )
         finally:
             await asyncio.sleep(0.2)
-            async with async_timeout.timeout(30.0):
+            async with asyncio.timeout(30.0):
                 p = await simple_run_cmd(
                     [
                         *compose_cmd,
@@ -370,7 +367,9 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                     stderr=asyncio.subprocess.DEVNULL,
                 )
                 await p.wait()
-            await asyncio.sleep(0.2)
+            async with asyncio.TaskGroup() as tg:
+                for port in ports.values():
+                    tg.create_task(check_if_port_is_clear("127.0.0.1", port))
 
 
 async def main():

--- a/tests/common/redis_helper/redis-cluster.yml
+++ b/tests/common/redis_helper/redis-cluster.yml
@@ -127,3 +127,4 @@ services:
 
 networks:
   testnet:
+    name: ${NETWORK_NAME:-testnet}

--- a/tests/common/redis_helper/test_list.py
+++ b/tests/common/redis_helper/test_list.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import traceback
 from typing import List, Tuple
 
-import aiotools
 import pytest
 from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
@@ -30,7 +30,7 @@ async def test_blist(redis_container: tuple[str, HostPortPair], disruption_metho
 
     async def pop(r: RedisConnectionInfo, key: str) -> None:
         try:
-            async with aiotools.aclosing(
+            async with contextlib.aclosing(
                 redis_helper.blpop(r, key),
             ) as agen:
                 async for raw_msg in agen:
@@ -114,7 +114,7 @@ async def test_blist_with_retrying_rpush(
 
     async def pop(r: RedisConnectionInfo, key: str) -> None:
         try:
-            async with aiotools.aclosing(
+            async with contextlib.aclosing(
                 redis_helper.blpop(r, key),
             ) as agen:
                 async for raw_msg in agen:

--- a/tests/common/redis_helper/types.py
+++ b/tests/common/redis_helper/types.py
@@ -16,11 +16,20 @@ class RedisClusterInfo:
 
 
 class AbstractRedisSentinelCluster(metaclass=ABCMeta):
-    def __init__(self, test_ns: str, test_case_ns: str, password: str, service_name: str) -> None:
+    def __init__(
+        self,
+        test_ns: str,
+        test_case_ns: str,
+        password: str,
+        service_name: str,
+        *,
+        verbose: bool = False,
+    ) -> None:
         self.test_ns = test_ns
         self.test_case_ns = test_case_ns
         self.password = password
         self.service_name = service_name
+        self.verbose = verbose
 
     @contextlib.asynccontextmanager
     @abstractmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+
+from ai.backend.testutils.bootstrap import sync_file_lock
+from ai.backend.testutils.pants import get_parallel_slot
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_tcp_port_range():
+    parallel_slot = get_parallel_slot()
+    lock_path = Path(f"~/.cache/bai/testing/port-{parallel_slot}.lock").expanduser()
+    port_path = Path(f"~/.cache/bai/testing/port-{parallel_slot}.txt").expanduser()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    print("init_tcp_port_range: enter")
+    with sync_file_lock(lock_path):
+        if port_path.exists():
+            port_path.unlink()
+    try:
+        yield
+    finally:
+        with sync_file_lock(lock_path):
+            if port_path.exists():
+                port_path.unlink()
+        print("init_tcp_port_range: exit")

--- a/tests/manager/BUILD
+++ b/tests/manager/BUILD
@@ -1,5 +1,4 @@
 python_test_utils(
-    name="test_utils",
     sources=[
         "conftest.py",
         "model_factory.py",


### PR DESCRIPTION
This is an auto-generated backport PR of #2379 to the 24.03 release.