### PR TITLE
fix: A minor range calculation bug in #2396

### DIFF
--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -30,13 +30,13 @@ def get_next_tcp_port(num_alloc: int = 1) -> tuple[int, ...]:
     with sync_file_lock(lock_path):
         if port_path.exists():
             port_no = int(port_path.read_text())
-            allocated_ports = tuple(range(port_no, port_no + num_alloc))
-            port_no = PORT_POOL_BASE + (port_no + num_alloc) % PORT_POOL_SIZE
-            port_path.write_text(str(port_no))
         else:
             port_no = PORT_POOL_BASE
-            port_path.write_text(str(port_no))
-            allocated_ports = (port_no,)
+        allocated_ports = tuple(
+            PORT_POOL_BASE + (port_no + i) % PORT_POOL_SIZE for i in range(num_alloc)
+        )
+        port_no = PORT_POOL_BASE + (port_no + num_alloc) % PORT_POOL_SIZE
+        port_path.write_text(str(port_no))
     return allocated_ports
 
 


### PR DESCRIPTION
It's a follow-up to #2396 and #2379.

This PR fixes a minor bug that may affect the local test runners who repeat running tests until the counter reaches the end of the range.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
