### PR TITLE
ci: Bump graphql-inspector from 4.0.2 to 5.0.6 (#2267)

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -69,9 +69,13 @@ jobs:
     needs: graphql-updated
     name: Check Schema
     runs-on: ubuntu-latest
+    permissions:
+      contents: read 
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
-      - uses: kamilkisiela/graphql-inspector@release-1689086705050
+      - uses: kamilkisiela/graphql-inspector@release-1717403590269
         with:
           schema: 'main:src/ai/backend/manager/api/schema.graphql'
           rules: |


### PR DESCRIPTION
Backported-from: main (24.09)
Backported-to: 24.03
Backport-of: 2267