### PR TITLE
fix: Immediately move vfolders to trash bin when purging user

### DIFF
--- a/changes/2404.enhance.md
+++ b/changes/2404.enhance.md
@@ -1,0 +1,1 @@
+Remove database-level foreign key constraints in `vfolders.{user,group}` columns to decouple the timing of vfolder deletion and user/group deletion.

--- a/changes/2405.enhance.md
+++ b/changes/2405.enhance.md
@@ -1,0 +1,1 @@
+Just move the vfolders to the trash bin when purging a user instead of initiating storage-level deletion, making it an immediately completed action

--- a/src/ai/backend/manager/models/alembic/versions/59a622c31820_remove_foreign_key_in_vfolders_user_and_project.py
+++ b/src/ai/backend/manager/models/alembic/versions/59a622c31820_remove_foreign_key_in_vfolders_user_and_project.py
@@ -1,0 +1,38 @@
+"""Remove foreign key constraint from vfolders to users and projects
+
+Revision ID: 59a622c31820
+Revises: fdb2dcdb8811
+Create Date: 2024-07-08 22:54:20.762521
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "59a622c31820"
+down_revision = "fdb2dcdb8811"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("fk_vfolders_user_users", "vfolders", type_="foreignkey")
+    op.drop_constraint("fk_vfolders_group_groups", "vfolders", type_="foreignkey")
+    op.drop_constraint("ck_vfolders_ownership_type_match_with_user_or_group", "vfolders")
+    op.drop_constraint("ck_vfolders_either_one_of_user_or_group", "vfolders")
+
+
+def downgrade():
+    op.create_foreign_key("fk_vfolders_group_groups", "vfolders", "groups", ["group"], ["id"])
+    op.create_foreign_key("fk_vfolders_user_users", "vfolders", "users", ["user"], ["uuid"])
+    op.create_check_constraint(
+        "ck_vfolders_ownership_type_match_with_user_or_group",
+        "vfolders",
+        "(ownership_type = 'user' AND \"user\" IS NOT NULL) OR "
+        "(ownership_type = 'group' AND \"group\" IS NOT NULL)",
+    )
+    op.create_check_constraint(
+        "ck_vfolders_either_one_of_user_or_group",
+        "vfolders",
+        '("user" IS NULL AND "group" IS NOT NULL) OR ("user" IS NOT NULL AND "group" IS NULL)',
+    )

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -197,7 +197,11 @@ class GroupRow(Base):
     users = relationship("AssocGroupUserRow", back_populates="group")
     resource_policy_row = relationship("ProjectResourcePolicyRow", back_populates="projects")
     kernels = relationship("KernelRow", back_populates="group_row")
-    vfolder_row = relationship("VFolderRow", back_populates="group_row")
+    vfolder_rows = relationship(
+        "VFolderRow",
+        back_populates="group_row",
+        primaryjoin="GroupRow.id == foreign(VFolderRow.group)",
+    )
 
 
 def _build_group_query(cond: sa.sql.BinaryExpression, domain_name: str) -> sa.sql.Select:

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -186,7 +186,11 @@ class UserRow(Base):
 
     main_keypair = relationship("KeyPairRow", foreign_keys=users.c.main_access_key)
 
-    vfolder_row = relationship("VFolderRow", back_populates="user_row")
+    vfolder_rows = relationship(
+        "VFolderRow",
+        back_populates="user_row",
+        primaryjoin="UserRow.uuid == foreign(VFolderRow.user)",
+    )
 
 
 class UserGroup(graphene.ObjectType):


### PR DESCRIPTION
refs #2376

Move all vfolders when purging a user, instead of triggering immediate storage-level deletion.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
