### PR TITLE
feat: Add `row_id`, `type` and `container_registry` fields to GroupNode GQL schema

### DIFF
--- a/changes/2409.feature.md
+++ b/changes/2409.feature.md
@@ -1,0 +1,1 @@
+Added the `row_id`, `type` and `container_registry` fields to the `GroupNode` class in the `group.py` file. These fields were introduced in version 24.03.7.

--- a/changes/2409.feature.md
+++ b/changes/2409.feature.md
@@ -1,1 +1,1 @@
-Added the `row_id`, `type` and `container_registry` fields to the `GroupNode` class in the `group.py` file. These fields were introduced in version 24.03.7.
+Add `row_id`, `type` and `container_registry` fields to the `GroupNode` GQL schema.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -321,6 +321,12 @@ type GroupNode implements Node {
   allowed_vfolder_hosts: JSONString
   integration_id: String
   resource_policy: String
+
+  """Added in 24.03.7."""
+  type: String
+
+  """Added in 24.03.7."""
+  container_registry: JSONString
   scaling_groups: [String]
   user_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): UserConnection
 }

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -311,6 +311,9 @@ type Domain {
 type GroupNode implements Node {
   """The ID of the object"""
   id: ID!
+
+  """Added in 24.03.7. The undecoded id value stored in DB."""
+  row_id: UUID
   name: String
   description: String
   is_active: Boolean

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -325,7 +325,7 @@ type GroupNode implements Node {
   integration_id: String
   resource_policy: String
 
-  """Added in 24.03.7."""
+  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
   type: String
 
   """Added in 24.03.7."""

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -822,7 +822,7 @@ class GroupNode(graphene.ObjectType):
     allowed_vfolder_hosts = graphene.JSONString()
     integration_id = graphene.String()
     resource_policy = graphene.String()
-    type = graphene.String(description="Added in 24.03.7.")
+    type = graphene.String(description=f"Added in 24.03.7. One of {[t.name for t in ProjectType]}.")
     container_registry = graphene.JSONString(description="Added in 24.03.7.")
     scaling_groups = graphene.List(
         lambda: graphene.String,

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -811,6 +811,7 @@ class GroupNode(graphene.ObjectType):
     class Meta:
         interfaces = (AsyncNode,)
 
+    row_id = graphene.UUID(description="Added in 24.03.7. The undecoded id value stored in DB.")
     name = graphene.String()
     description = graphene.String()
     is_active = graphene.Boolean()
@@ -821,6 +822,8 @@ class GroupNode(graphene.ObjectType):
     allowed_vfolder_hosts = graphene.JSONString()
     integration_id = graphene.String()
     resource_policy = graphene.String()
+    type = graphene.String(description="Added in 24.03.7.")
+    container_registry = graphene.JSONString(description="Added in 24.03.7.")
     scaling_groups = graphene.List(
         lambda: graphene.String,
     )
@@ -833,16 +836,19 @@ class GroupNode(graphene.ObjectType):
     def from_row(cls, row: GroupRow) -> GroupNode:
         return cls(
             id=row.id,
+            row_id=row.id,
             name=row.name,
             description=row.description,
             is_active=row.is_active,
             created_at=row.created_at,
             modified_at=row.modified_at,
             domain_name=row.domain_name,
-            total_resource_slots=row.total_resource_slots or {},
-            allowed_vfolder_hosts=row.allowed_vfolder_hosts or {},
+            total_resource_slots=row.total_resource_slots.to_json() or {},
+            allowed_vfolder_hosts=row.allowed_vfolder_hosts.to_json() or {},
             integration_id=row.integration_id,
             resource_policy=row.resource_policy,
+            type=row.type.name,
+            container_registry=row.container_registry,
         )
 
     async def resolve_scaling_groups(self, info: graphene.ResolveInfo) -> Sequence[ScalingGroup]:


### PR DESCRIPTION
### TL;DR

Added the `row_id`, `type` and `container_registry` fields to the `GroupNode` class in the `group.py` file. These fields were introduced in version 24.03.7.

### What changed?

Added three new fields to GroupNode class: `row_id`, `type`, and `container_registry`. Also updated `schema.graphql` and methods in `group.py` to reflect these changes.
### How to test?

Verify that the new fields are properly integrated and can be accessed as expected through the GraphQL queries.
### Why make this change?

These fields provide more detailed information about the group and have been introduced in the latest version 24.03.7 to improve the system's functionality.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
