### PR TITLE
ci: Schema uses the files of the base branch

### DIFF
--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -72,13 +72,13 @@ jobs:
     name: Check Schema
     runs-on: ubuntu-latest
     permissions:
-      contents: read 
+      contents: read
       pull-requests: write
       checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: kamilkisiela/graphql-inspector@release-1717403590269
         with:
-          schema: 'main:src/ai/backend/manager/api/schema.graphql'
+          schema: '${{ github.base_ref }}:src/ai/backend/manager/api/schema.graphql'
           rules: |
             gql-inspector-checker.js


### PR DESCRIPTION
As backport automation was performed, a workflow to verify that the schema was correct became necessary even in previous release branches.
So, previously, the main branch's schema was used as the base file, but now the base branch's schema file is used.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
