### PR TITLE
fix: Utilize `ExtendedJSONEncoder` for error logging to handle `UUID` extra data

### DIFF
--- a/changes/2415.fix.md
+++ b/changes/2415.fix.md
@@ -1,0 +1,1 @@
+Utilize `ExtendedJSONEncoder` for error logging to handle `UUID` objects in `extra_data`

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Mapping, Optional, Union, cast
 
 from aiohttp import web
 
+from ai.backend.common.json import ExtendedJSONEncoder
 from ai.backend.common.plugin.hook import HookResult
 
 from ..exceptions import AgentError
@@ -48,7 +49,7 @@ class BackendError(web.HTTPError):
             body["msg"] = extra_msg
         if extra_data is not None:
             body["data"] = extra_data
-        self.body = json.dumps(body).encode()
+        self.body = json.dumps(body, cls=ExtendedJSONEncoder).encode()
 
     def __str__(self):
         lines = []


### PR DESCRIPTION
This pull request fixes potential errors caused by invalid attempt to serialize `UUID` object.

| Before | After |
| ------- | ----- |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xO1yT8FVVJioYjE5byZ6/213d9a20-e93e-4436-ab35-9dfa5174a053.png) | <img width="613" alt="스크린샷 2024-07-10 오후 4 38 20" src="https://github.com/lablup/backend.ai/assets/14137676/e2ee265c-b18c-4a52-8549-f1fe3c40ed7e"> |

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2415.org.readthedocs.build/en/2415/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2415.org.readthedocs.build/ko/2415/

<!-- readthedocs-preview sorna-ko end -->