### PR TITLE
feat: Add `row_id`, `type` and `container_registry` fields to GroupNode GQL schema (#2409)

### DIFF
--- a/changes/2409.feature.md
+++ b/changes/2409.feature.md
@@ -1,0 +1,1 @@
+Add `row_id`, `type` and `container_registry` fields to the `GroupNode` GQL schema.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -311,6 +311,9 @@ type Domain {
 type GroupNode implements Node {
   """The ID of the object"""
   id: ID!
+
+  """Added in 24.03.7. The undecoded id value stored in DB."""
+  row_id: UUID
   name: String
   description: String
   is_active: Boolean
@@ -321,6 +324,12 @@ type GroupNode implements Node {
   allowed_vfolder_hosts: JSONString
   integration_id: String
   resource_policy: String
+
+  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
+  type: String
+
+  """Added in 24.03.7."""
+  container_registry: JSONString
   scaling_groups: [String]
   user_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): UserConnection
 }

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -807,6 +807,7 @@ class GroupNode(graphene.ObjectType):
     class Meta:
         interfaces = (AsyncNode,)
 
+    row_id = graphene.UUID(description="Added in 24.03.7. The undecoded id value stored in DB.")
     name = graphene.String()
     description = graphene.String()
     is_active = graphene.Boolean()
@@ -817,6 +818,8 @@ class GroupNode(graphene.ObjectType):
     allowed_vfolder_hosts = graphene.JSONString()
     integration_id = graphene.String()
     resource_policy = graphene.String()
+    type = graphene.String(description=f"Added in 24.03.7. One of {[t.name for t in ProjectType]}.")
+    container_registry = graphene.JSONString(description="Added in 24.03.7.")
     scaling_groups = graphene.List(
         lambda: graphene.String,
     )
@@ -829,16 +832,19 @@ class GroupNode(graphene.ObjectType):
     def from_row(cls, row: GroupRow) -> GroupNode:
         return cls(
             id=row.id,
+            row_id=row.id,
             name=row.name,
             description=row.description,
             is_active=row.is_active,
             created_at=row.created_at,
             modified_at=row.modified_at,
             domain_name=row.domain_name,
-            total_resource_slots=row.total_resource_slots or {},
-            allowed_vfolder_hosts=row.allowed_vfolder_hosts or {},
+            total_resource_slots=row.total_resource_slots.to_json() or {},
+            allowed_vfolder_hosts=row.allowed_vfolder_hosts.to_json() or {},
             integration_id=row.integration_id,
             resource_policy=row.resource_policy,
+            type=row.type.name,
+            container_registry=row.container_registry,
         )
 
     async def resolve_scaling_groups(self, info: graphene.ResolveInfo) -> Sequence[ScalingGroup]:


### PR DESCRIPTION
This is an auto-generated backport PR of #2409 to the 24.03 release.