### PR TITLE
fix: Utilize `ExtendedJSONEncoder` for error logging to handle `UUID` extra data (#2415)

### DIFF
--- a/changes/2415.fix.md
+++ b/changes/2415.fix.md
@@ -1,0 +1,1 @@
+Utilize `ExtendedJSONEncoder` for error logging to handle `UUID` objects in `extra_data`

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Mapping, Optional, Union, cast
 
 from aiohttp import web
 
+from ai.backend.common.json import ExtendedJSONEncoder
 from ai.backend.common.plugin.hook import HookResult
 
 from ..exceptions import AgentError
@@ -48,7 +49,7 @@ class BackendError(web.HTTPError):
             body["msg"] = extra_msg
         if extra_data is not None:
             body["data"] = extra_data
-        self.body = json.dumps(body).encode()
+        self.body = json.dumps(body, cls=ExtendedJSONEncoder).encode()
 
     def __str__(self):
         lines = []


### PR DESCRIPTION
This is an auto-generated backport PR of #2415 to the 24.03 release.