### PR TITLE
fix: Allow vfolders in delete-pending status to be deleted forever (#2431)

### DIFF
--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -230,8 +230,9 @@ vfolder_status_map: Final[dict[VFolderStatusSet, set[VFolderOperationStatus]]] =
     VFolderStatusSet.DELETABLE: {
         VFolderOperationStatus.READY,
     },
-    # if DELETABLE access status is requested, only DELETE_COMPLETE operation status is accepted.
+    # if DELETABLE access status is requested, DELETE_PENDING, DELETE_COMPLETE operation status is accepted.
     VFolderStatusSet.PURGABLE: {
+        VFolderOperationStatus.DELETE_PENDING,
         VFolderOperationStatus.DELETE_COMPLETE,
     },
     VFolderStatusSet.RECOVERABLE: {


### PR DESCRIPTION
This is an auto-generated backport PR of #2431 to the 24.03 release.