### PR TITLE
refactor: Handle container start error in separate try-catch context (#2316)

### DIFF
--- a/changes/2316.misc.md
+++ b/changes/2316.misc.md
@@ -1,0 +1,1 @@
+Handle container creation exception and start exception in separate try-except contexts.


### PR DESCRIPTION
This is an auto-generated backport PR of #2316 to the 24.03 release.