### PR TITLE
ci: Change package manager from npm to pnpm

### DIFF
--- a/changes/2436.fix.md
+++ b/changes/2436.fix.md
@@ -1,0 +1,1 @@
+Update the install-dev scripts to use `pnpm` instead of `npm` to speed up installation and resolve some peculiar version resolution issues related to esbuild.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -620,7 +620,7 @@ install_editable_webui() {
     echo "PROXYBASEHOST=localhost" >> .env
     echo "PROXYBASEPORT=${WSPROXY_PORT}" >> .env
   fi
-  npm i
+  pnpm i
   make compile
   cd ../../../..
 }

--- a/src/ai/backend/install/dev.py
+++ b/src/ai/backend/install/dev.py
@@ -107,7 +107,7 @@ async def install_editable_webui(ctx: Context) -> None:
       echo "PROXYBASEHOST=localhost" >> .env
       echo "PROXYBASEPORT=${WSPROXY_PORT}" >> .env
     fi
-    npm i
+    pnpm i
     make compile
     make compile_wsproxy
     cd ../../../..


### PR DESCRIPTION
https://github.com/lablup/backend.ai-webui/pull/2515
If the above pr is applied, webui will use pnpm as the package manager from now on.
So, in the webui build script part, we also use pnpm.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
