### PR TITLE
ci: Change package manager from npm to pnpm (#2436)

### DIFF
--- a/changes/2436.fix.md
+++ b/changes/2436.fix.md
@@ -1,0 +1,1 @@
+Update the install-dev scripts to use `pnpm` instead of `npm` to speed up installation and resolve some peculiar version resolution issues related to esbuild.

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -620,7 +620,7 @@ install_editable_webui() {
     echo "PROXYBASEHOST=localhost" >> .env
     echo "PROXYBASEPORT=${WSPROXY_PORT}" >> .env
   fi
-  npm i
+  pnpm i
   make compile
   make compile_wsproxy
   cd ../../../..

--- a/src/ai/backend/install/dev.py
+++ b/src/ai/backend/install/dev.py
@@ -107,7 +107,7 @@ async def install_editable_webui(ctx: Context) -> None:
       echo "PROXYBASEHOST=localhost" >> .env
       echo "PROXYBASEPORT=${WSPROXY_PORT}" >> .env
     fi
-    npm i
+    pnpm i
     make compile
     make compile_wsproxy
     cd ../../../..


### PR DESCRIPTION
This is an auto-generated backport PR of #2436 to the 23.09 release.