### PR TITLE
fix: Add missing `commit_session_to_file` to `OP_EXC` (#2127)

### DIFF
--- a/changes/2127.fix.md
+++ b/changes/2127.fix.md
@@ -1,0 +1,1 @@
+Add missing `commit_session_to_file` to `OP_EXC`

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -190,6 +190,7 @@ OP_EXC = {
     "get_logs_from_agent": KernelExecutionFailed,
     "refresh_session": KernelExecutionFailed,
     "commit_session": KernelExecutionFailed,
+    "commit_session_to_file": KernelExecutionFailed,
 }
 
 

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -177,6 +177,7 @@ OP_EXC = {
     "get_logs_from_agent": KernelExecutionFailed,
     "refresh_session": KernelExecutionFailed,
     "commit_session": KernelExecutionFailed,
+    "commit_session_to_file": KernelExecutionFailed,
     "trigger_batch_execution": KernelExecutionFailed,
 }
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2127 to the 24.03 release.