### PR TITLE
fix: Pass ImageRef.canonical in `commit_session_to_file` (#2134)

### DIFF
--- a/changes/2134.fix.md
+++ b/changes/2134.fix.md
@@ -1,0 +1,1 @@
+Pass ImageRef.canonical in `commit_session_to_file`

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -223,7 +223,7 @@ class DockerKernel(AbstractKernel):
                     else:
                         repo, tag = None, None
                     response: Mapping[str, Any] = await container.commit(
-                        changes=changes,
+                        changes=changes or None,
                         repository=repo,
                         tag=tag,
                         config=config,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3392,10 +3392,15 @@ class AgentRegistry:
         img_path, _, image_name = filtered.partition("/")
         filename = f"{now}_{shortend_sname}_{image_name}.tar.gz"
         filename = filename.replace(":", "-")
+        image_ref = ImageRef(kernel.image, [registry], kernel.architecture)
         async with handle_session_exception(self.db, "commit_session_to_file", session.id):
             async with self.agent_cache.rpc_context(kernel.agent, order_key=kernel.id) as rpc:
                 resp: Mapping[str, Any] = await rpc.call.commit(
-                    str(kernel.id), email, filename=filename, extra_labels=extra_labels
+                    str(kernel.id),
+                    email,
+                    filename=filename,
+                    extra_labels=extra_labels,
+                    canonical=image_ref.canonical,
                 )
         return resp
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2134 to the 24.03 release.