### PR TITLE
chore: migrate `subprocess.call()` usages to `.run()` (#2023)

### DIFF
--- a/src/ai/backend/helpers/package.py
+++ b/src/ai/backend/helpers/package.py
@@ -35,7 +35,7 @@ def install(pkgname, force_install=False):
     if force_install:
         cmdargs.append("-I")
     cmdargs.append(pkgname)
-    subprocess.call(cmdargs)
+    subprocess.run(cmdargs)
     sys.stdout.flush()
 
     # Ensure the user site directory to be in sys.path

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -128,7 +128,7 @@ def dbshell(cli_ctx: CLIContext, container_name, psql_help, psql_args):
             ),
             *psql_args,
         ]
-        subprocess.call(cmd)
+        subprocess.run(cmd)
         return
     # Use the container to start the psql client command
     log.info(f"using the db container {container_name} ...")
@@ -145,7 +145,7 @@ def dbshell(cli_ctx: CLIContext, container_name, psql_help, psql_args):
         local_config["db"]["name"],
         *psql_args,
     ]
-    subprocess.call(cmd)
+    subprocess.run(cmd)
 
 
 @main.command()


### PR DESCRIPTION
This is an auto-generated backport PR of #2023 to the 23.09 release.