### PR TITLE
fix: Restrict GraphQL query to `user_nodes` field to require `superadmin` privilege (#2401)

### DIFF
--- a/changes/2401.fix.md
+++ b/changes/2401.fix.md
@@ -1,0 +1,1 @@
+Restrict GraphQL query to `user_nodes` field to require `superadmin` privilege

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1305,6 +1305,7 @@ class Queries(graphene.ObjectType):
     ):
         return await UserNode.get_node(info, id)
 
+    @privileged_query(UserRole.SUPERADMIN)
     async def resolve_user_nodes(
         root: Any,
         info: graphene.ResolveInfo,


### PR DESCRIPTION
This is an auto-generated backport PR of #2401 to the 24.03 release.