### PR TITLE
ci: Grant pull request write permission to backport job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -84,6 +84,8 @@ jobs:
     needs: backport-target-branch
     strategy:
       matrix: ${{ fromJson(needs.backport-target-branch.outputs.matrix) }}
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d0ba2860-516d-45f9-a21f-1578f2691e0d)
Similar to #2285, the default permissions of GITHUB_TOKEN have been reduced and the necessary permissions are granted directly in the workflow.
Add the pull-requests wirte permission to write a comment indicating that actions-bot must manually backport when backport fails.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
