### PR TITLE
fix: typos in install and concepts docs

### DIFF
--- a/docs/concepts/computing.rst
+++ b/docs/concepts/computing.rst
@@ -27,7 +27,7 @@ Kernel roles in a cluster session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In a cluster session with multiple kernels, each kernel has a role.
-By default, the first container takes the "main" role while others takes the "sub" role.
+By default, the first container takes the "main" role while others take the "sub" role.
 All kernels are given unique hostnames like "main1", "sub1", "sub2", ..., and "subN" (the cluster size is N+1 in this case).
 A non-cluster session has one "main1" kernel only.
 
@@ -91,7 +91,7 @@ Interactive compute session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Interactive compute sessions are used to run various interactive applications and development tools,
-such as Jupyter Notebooks, web-based terminals, and etc.
+such as Jupyter Notebooks, web-based terminals, etc.
 It is expected that the users control their lifecycles (e.g., terminating them)
 while Backend.AI offers configuration knobs for the administrators to set idle timeouts with various criteria.
 

--- a/docs/concepts/configuration.rst
+++ b/docs/concepts/configuration.rst
@@ -16,7 +16,7 @@ Local config
 ^^^^^^^^^^^^
 
 Each service component has a `TOML <https://toml.io/en/>`_-based local configuration.
-It defines node-specific configurations such as the agent name, the resource group where it belongs, specific system limits, the IP address and the TCP port(s) to bind their service traffic, and etc.
+It defines node-specific configurations such as the agent name, the resource group where it belongs, specific system limits, the IP address and the TCP port(s) to bind their service traffic, etc.
 
 The configuration files are named after the service components, like ``manager.toml``, ``agent.toml``, and ``storage-proxy.toml``.
 The search paths are: the current working directory, ``~/.config/backend.ai``, and ``/etc/backend.ai``.

--- a/docs/concepts/monitoring.rst
+++ b/docs/concepts/monitoring.rst
@@ -8,9 +8,9 @@ Dashboard (Enterprise only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Backend.AI Dashboard is an add-on service that displays various real-time and historical performance metrics.
-The metrics include the number of sessions, cluster power usage, GPU utilization, and etc.
+The metrics include the number of sessions, cluster power usage, GPU utilization, etc.
 
 Alerts (Enterprise only)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Administrators may configure automatic alerts based on several thrsholds on the monitored metrics, via an external messaging service like emails and SMS.
+Administrators may configure automatic alerts based on several thresholds on the monitored metrics, via an external messaging service like emails and SMS.

--- a/docs/concepts/services.rst
+++ b/docs/concepts/services.rst
@@ -11,9 +11,9 @@ Manager and Webserver
 ^^^^^^^^^^^^^^^^^^^^^
 :raw-html-m2r:`<span style="background-color:#fafafa;border:1px solid #ccc;display:inline-block;width:16px;height:16px;margin:0;padding:0;"></span>`
 
-Backend.AI manager is the central governor of the cluster.
+Backend.AI manager is the central governor of  the cluster.
 It accepts user requests, creates/destroys the sessions, and routes code execution requests to appropriate agents and sessions.
-It also collects the output of sessions and responds the users with them.
+It also collects the output of sessions and responds to the users with them.
 
 Backend.AI agent is a small daemon installed onto individual worker servers to control them.
 It manages and monitors the lifecycle of kernel containers, and also mediates the input/output of sessions.
@@ -37,7 +37,7 @@ It provides the central place to set the networking and firewall policy for the 
 It has two operation modes:
 
 * Port mapping: Individual app instances are mapped with a TCP port taken from a pre-configured range of TCP port range.
-* Wildecard subdomain: Individual app instances are mapped with a system-generated subdomain under the given top-level domain.
+* Wildcard subdomain: Individual app instances are mapped with a system-generated subdomain under the given top-level domain.
 
 Depending on the session type and application launch configurations, it may require an authenticated HTTP session for HTTP-based applications.
 For instance, you may enforce authentication for interactive development apps like Jupyter while allow anonymous access for AI model service APIs.
@@ -53,7 +53,7 @@ FastTrack (Enterprise only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Backend.AI FastTrack is an add-on service running on top of the manager that features a slick GUI to design and run pipelines of computation tasks.
-It makes it easier to monitor the progress of various MLOps pipelines running concurrently, and allows sharing of such pielines in portable ways.
+It makes it easier to monitor the progress of various MLOps pipelines running concurrently, and allows sharing of such pipelines in portable ways.
 
 Resource Management
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/concepts/storage.rst
+++ b/docs/concepts/storage.rst
@@ -56,7 +56,7 @@ Auto-mount vfolders
 ^^^^^^^^^^^^^^^^^^^
 
 If a user-owned vfolder's name starts with a dot, it is automatically mounted at ``/home/work`` for all sessions created by the user.
-A good usecase is ``.config`` and ``.local`` directories to keep your local configurations and user-installed packages (e.g., ``pip install --user``) persistent across all your sessions.
+A good use case is ``.config`` and ``.local`` directories to keep your local configurations and user-installed packages (e.g., ``pip install --user``) persistent across all your sessions.
 
 
 Quota scopes
@@ -76,7 +76,7 @@ Storage with per-directory quota
    :width: 80%
    :align: center
 
-   Quota scopes and vfolders with storage solutions supporting per-directry quota
+   Quota scopes and vfolders with storage solutions supporting per-directory quota
 
 For each storage volume, each user and project has their own dedicated quota scope directories as shown in :numref:`vfolder-dir-quota`.
 The storage solution must support per-directory quota, at least for a single-level (like NetApp's QTree).

--- a/docs/install/env-wsl2.rst
+++ b/docs/install/env-wsl2.rst
@@ -31,7 +31,7 @@ Configuration of WSL
 
 3. Run ``wsl --shutdown`` in a PowerShell prompt to restart the WSL distribution to ensure your ``wsl.conf`` updates applied.
 
-4. Enter the WSL shell again. If it is applied, your path must appears like ``/c/some/path`` instead of ``/mnt/c/some/path``.
+4. Enter the WSL shell again. If it is applied, your path must appear like ``/c/some/path`` instead of ``/mnt/c/some/path``.
 
 5. Run ``sudo mount --make-rshared /`` in the WSL shell. Otherwise, your container creation from Backend.AI will fail with an error message like ``aiodocker.exceptions.DockerError: DockerError(500, 'path is mounted on /d but it is not a shared mount.')``.
 

--- a/docs/install/install-from-package.rst
+++ b/docs/install/install-from-package.rst
@@ -32,7 +32,7 @@ modules. Some of the major components are:
   statically built JavaScript via Webserver. Or, it also offers desktop
   applications for many operating systems and architectures.
 
-Most components can be installed in a single management node except Agent,
+Most components can be installed on a single management node except Agent,
 which is usually installed on dedicated computing nodes (often GPU servers).
 However, this is not a rule and Agent can also be installed on the management
 node.

--- a/docs/install/install-from-source.rst
+++ b/docs/install/install-from-source.rst
@@ -97,4 +97,4 @@ Configuring Overlay Networks for Multi-node Training (Optional)
 Currently the cross-node inter-container overlay routing is controlled via Docker Swarm's overlay networks.
 In the manager, you need to `create a Swarm <https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/>`_.
 In the agent nodes, you need to `join the Swarm <https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/>`_.
-Then restart all manager and agent daemons to make it working.
+Then restart all manager and agent daemons to make it work.

--- a/docs/install/install-on-clouds.rst
+++ b/docs/install/install-on-clouds.rst
@@ -6,7 +6,7 @@ The minimal instance configuration:
 * 1x SSL certificate with a private key for your own domain (for production)
 * 1x manager instance (e.g., t3.xlarge on AWS)
 
-  - For HA setup, you many replicate multiple manager instances running in different availability zones and put a load balancer in front of them.
+  - For HA setup, you may replicate multiple manager instances running in different availability zones and put a load balancer in front of them.
 
 * Nx agent instances (e.g., t3.medium / p2.xlarge on AWS -- for minimal testing)
 

--- a/docs/install/upgrade-existing-cluster.rst
+++ b/docs/install/upgrade-existing-cluster.rst
@@ -18,7 +18,7 @@ Performing minor upgrade
 A minor upgrade means upgrading a Backend.AI cluster while keeping the major version same (e.g. 24.03.0 to 24.03.1).
 Usually changes for minor upgrades are meant for fixing critical bugs rather than introducing new features.
 In general there should be only trivial changes between minor versions that won't affect how users interact with the software.
-To plan the upgrade, first check following facts:
+To plan the upgrade, first check the following facts:
 
 * Read every bit of the release changelog.
 
@@ -31,7 +31,7 @@ To plan the upgrade, first check following facts:
   As it is mentioned at the beginning it is best to maintain database schema as concrete, but in rare situations it is
   inevitable to alter it.
 
-* Make sure every mission critical workloads are shut down when performing a rolling upgrade.
+* Make sure every mission critical workloads are shut down before performing a rolling upgrade.
 
 
 Upgrading Backend.AI Manager
@@ -39,7 +39,7 @@ Upgrading Backend.AI Manager
 
 1. Stop the manager process running at server.
 2. Upgrade the Python package by executing ``pip install -U backend.ai-manager==<target version>``.
-3. Match databse schema with latest by executing ``alembic upgrade head``.
+3. Match database schema with latest by executing ``alembic upgrade head``.
 4. Restart the process.
 
 
@@ -65,7 +65,7 @@ A major upgrade involves significant feature additions and structural changes.
 DO NOT perform rolling upgrades in any cases.
 Please make sure to shutdown every workload of the cluster and notify users of a relatively prolonged downtime.
 
-To plan the upgrade, first check following facts:
+To plan the upgrade, first check the following facts:
 
 * Upgrade the Backend.AI cluster to the very latest minor version of the prior release before starting major version upgrade.
 
@@ -96,7 +96,7 @@ Upgrading Backend.AI Manager
 
 1. Stop the manager process running at server.
 2. Upgrade the Python package by executing ``pip install -U backend.ai-manager==<target version>``.
-3. Match databse schema with latest by executing ``alembic upgrade head``.
+3. Match database schema with the latest by executing ``alembic upgrade head``.
 4. Fill out any missing DB revisions by executing ``backend.ai mgr schema apply-mission-revisions <version number of previous Backend.AI software>``.
 5. Start the process again.
 


### PR DESCRIPTION
This PR corrects several typos in the install and concepts sections of the documentation.

In addition to correcting typos, I made changes to improve clarity:


> Make sure every mission critical workloads are shut down **`when`** performing a rolling upgrade.
> -> 
> Make sure every mission critical workloads are shut down **`before`** performing a rolling upgrade.
> 

Please double-check the changes for accuracy.