### PR TITLE
ci: Minimize LFS fetches in CI

### DIFF
--- a/.github/workflows/alembic-head-check.yml
+++ b/.github/workflows/alembic-head-check.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        lfs: false
     - name: Parse versions from config
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)

--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        lfs: false
         token: ${{ secrets.WORKFLOW_PAT }}
 
     - name: Extract Python version from pants.toml

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,10 @@ jobs:
       author: ${{ steps.commit.outputs.author }}
       author_email: ${{ steps.commit.outputs.author_email }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the revision
+        uses: actions/checkout@v4
+        with:
+          lfs: false
       - name: Extract pr_number from commit message
         id: commit
         run: |

--- a/.github/workflows/check-requirement.yml
+++ b/.github/workflows/check-requirement.yml
@@ -7,7 +7,10 @@ jobs:
   check-requirement:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the revision
+        uses: actions/checkout@v4
+        with:
+          lfs: false
       - name: Check if a precompiled binary file exists in dependencies
         run: |
             cat python.lock | grep -v '^//' | jq -r '.locked_resolves[].locked_requirements[]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,8 @@ jobs:
     if: ${{ contains(fromJson('["schedule", "workflow_dispatch"]'), github.event_name) || (!contains(github.event.pull_request.labels.*.name, 'skip:ci') && github.event.pull_request.merged == true) }}
     runs-on: [ubuntu-latest-8-cores]
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout the revision
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Create LFS file hash list

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
+        lfs: false
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
@@ -94,6 +95,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
+        lfs: false
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
@@ -158,16 +160,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
-    - name: Git LFS Pull
-      run: git lfs pull
+        lfs: false
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
@@ -234,14 +227,6 @@ jobs:
       uses: actions/checkout@v4
     - name: Fetch remote tags
       run: git fetch origin 'refs/tags/*:refs/tags/*' -f
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
     - name: Extract Python version from pants.toml
@@ -293,14 +278,6 @@ jobs:
       uses: actions/checkout@v4
     - name: Fetch remote tags
       run: git fetch origin 'refs/tags/*:refs/tags/*' -f
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
     - name: Extract Python version from pants.toml
@@ -515,14 +492,6 @@ jobs:
     steps:
     - name: Check out the revision
       uses: actions/checkout@v4
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
     - name: Git LFS Pull
       run: git lfs pull
     - name: Extract Python version from pants.toml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,8 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout the revision
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Create LFS file hash list

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,18 +6,10 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     steps:
-    - name: Calculate the fetch depth
-      run: |
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-          echo "GIT_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-        else
-          echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
-        fi
-    - name: Checkout the source tree
+    - name: Checkout the revision
       uses: actions/checkout@v4
       with:
         lfs: false
-        fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
     - name: Generate the SBOM report
       uses: CycloneDX/gh-python-generate-sbom@v2
     - name: Upload the SBOM report

--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -20,9 +20,11 @@ jobs:
     steps:
     - name: Get PR's fetch depth
       run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-    - uses: actions/checkout@v4
+    - name: Checkout the revision
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        lfs: false
         fetch-depth: ${{ env.PR_FETCH_DEPTH }}
         sparse-checkout: changes
     - name: Set up Python

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -18,11 +18,13 @@ jobs:
         else
           echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
         fi
-    - uses: actions/checkout@v4
+    - name: Checkout the revision with minimal required history
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
         ref: ${{ github.head_ref }}
         token: ${{ secrets.OCTODOG }}
+        lfs: false
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -185,7 +185,8 @@ def socket_relay_image():
             already_fetched = True
     if not already_fetched:
         subprocess.run(["git", "lfs", "pull", "--include", image_path], check=True, cwd=build_root)
-        pytest.fail("Intentionally failing the test to rerun with the updated LFS files!")
+        # This will trigger 'Filesystem changed during run' in pants and let it retry the test after
+        # interrupting the test via SIGINT.
 
 
 @pytest.fixture

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -15,7 +15,11 @@ from ai.backend.common import validators as tx
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
 from ai.backend.common.logging import LocalLogger
 from ai.backend.common.types import EtcdRedisConfig, HostPortPair
-from ai.backend.testutils.bootstrap import etcd_container, redis_container, sync_file_lock  # noqa: F401
+from ai.backend.testutils.bootstrap import (  # noqa: F401
+    etcd_container,
+    redis_container,
+    sync_file_lock,
+)
 from ai.backend.testutils.pants import get_parallel_slot
 
 

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -174,6 +174,7 @@ def prepare_images():
 def socket_relay_image():
     # Since pulling all LFS files takes too much GitHub storage bandwidth in CI,
     # we fetch the only required image for tests on demand.
+    build_root = os.environ.get("BACKEND_BUILD_ROOT", os.getcwd())
     image_path = (
         f"src/ai/backend/agent/docker/backendai-socket-relay.img.{DEFAULT_IMAGE_ARCH}.tar.gz"
     )
@@ -183,7 +184,8 @@ def socket_relay_image():
         if not head.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
             already_fetched = True
     if not already_fetched:
-        subprocess.run(["git", "lfs", "pull", "--include", image_path], check=True)
+        subprocess.run(["git", "lfs", "pull", "--include", image_path], check=True, cwd=build_root)
+        pytest.fail("Intentionally failing the test to rerun with the updated LFS files!")
 
 
 @pytest.fixture

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -15,7 +15,7 @@ from ai.backend.common import validators as tx
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
 from ai.backend.common.logging import LocalLogger
 from ai.backend.common.types import EtcdRedisConfig, HostPortPair
-from ai.backend.testutils.bootstrap import etcd_container, redis_container  # noqa: F401
+from ai.backend.testutils.bootstrap import etcd_container, redis_container, sync_file_lock  # noqa: F401
 from ai.backend.testutils.pants import get_parallel_slot
 
 
@@ -175,24 +175,27 @@ def socket_relay_image():
     # Since pulling all LFS files takes too much GitHub storage bandwidth in CI,
     # we fetch the only required image for tests on demand.
     build_root = os.environ.get("BACKEND_BUILD_ROOT", os.getcwd())
+    lock_path = Path("~/.cache/bai/testing/lfs-pull.lock").expanduser()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
     image_path = (
         f"src/ai/backend/agent/docker/backendai-socket-relay.img.{DEFAULT_IMAGE_ARCH}.tar.gz"
     )
     already_fetched = False
-    with open(image_path, "rb") as f:
-        head = f.read(256)
-        if not head.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
-            already_fetched = True
-    if not already_fetched:
-        proc = subprocess.Popen(["git", "lfs", "pull", "--include", image_path], cwd=build_root)
-        try:
-            proc.wait()
-        except (KeyboardInterrupt, SystemExit):
-            # This will trigger 'Filesystem changed during run' in pants and let it retry the test
-            # after interrupting the test via SIGINT.
-            # We need to wait until the git command to complete anyway.
-            proc.wait()
-            raise
+    with sync_file_lock(lock_path):
+        with open(image_path, "rb") as f:
+            head = f.read(256)
+            if not head.startswith(b"version https://git-lfs.github.com/spec/v1\n"):
+                already_fetched = True
+        if not already_fetched:
+            proc = subprocess.Popen(["git", "lfs", "pull", "--include", image_path], cwd=build_root)
+            try:
+                proc.wait()
+            except (KeyboardInterrupt, SystemExit):
+                # This will trigger 'Filesystem changed during run' in pants and let it retry the test
+                # after interrupting the test via SIGINT.
+                # We need to wait until the git command to complete anyway.
+                proc.wait()
+                raise
 
 
 @pytest.fixture

--- a/tests/agent/docker/test_agent.py
+++ b/tests/agent/docker/test_agent.py
@@ -9,6 +9,7 @@ import pytest
 from aiodocker.exceptions import DockerError
 
 from ai.backend.agent.docker.agent import DockerAgent
+from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.exception import ImageNotAvailable
 from ai.backend.common.types import AutoPullBehavior
@@ -20,7 +21,7 @@ class DummyEtcd:
 
 
 @pytest.fixture
-async def agent(local_config, test_id, mocker):
+async def agent(local_config, test_id, mocker, socket_relay_image):
     dummy_etcd = DummyEtcd()
     mocked_etcd_get_prefix = AsyncMock(return_value={})
     mocker.patch.object(dummy_etcd, "get_prefix", new=mocked_etcd_get_prefix)
@@ -45,17 +46,7 @@ async def test_init(agent, mocker):
     print(agent)
 
 
-ret = platform.machine().lower()
-aliases = {
-    "arm64": "aarch64",  # macOS with LLVM
-    "amd64": "x86_64",  # Windows/Linux
-    "x64": "x86_64",  # Windows
-    "x32": "x86",  # Windows
-    "i686": "x86",  # Windows
-}
-arch = aliases.get(ret, ret)
-
-imgref = ImageRef("index.docker.io/lablup/lua:5.3-alpine3.8", architecture=arch)
+imgref = ImageRef("index.docker.io/lablup/lua:5.3-alpine3.8", architecture=DEFAULT_IMAGE_ARCH)
 query_digest = "sha256:b000000000000000000000000000000000000000000000000000000000000001"
 digest_matching_image_info = {
     "Id": "sha256:b000000000000000000000000000000000000000000000000000000000000001",

--- a/tests/agent/docker/test_agent.py
+++ b/tests/agent/docker/test_agent.py
@@ -1,4 +1,5 @@
-import platform
+from __future__ import annotations
+
 import secrets
 import signal
 from pickle import PickleError


### PR DESCRIPTION
We have been hitting a rapid increase of LFS storage bandwidth usage recent days.
This PR is an effort to optimize the usage.

It _explicitly disables_ LFS pulling in all per-commit GitHub Actions workflows, leaving LFS pulls only for:
- individual files only when required by selected tests, without caching
- the release/build jobs without caching (as there is no need to cache for such infrequent jobs)
- the integration (once per day, or manually triggered) and coverage tests (run per PR merge) with caching

**Example:**
In the agent tests, let developers use the `socket_relay_image` session-scoped fixture only in required test cases to pull the image tarball stored as LFS files.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
