### PR TITLE
ci: Remove no longer used LFS files (#2485)

### DIFF
--- a/src/ai/backend/web/assets/backend.ai-local-proxy-linux-arm64.zip
+++ b/src/ai/backend/web/assets/backend.ai-local-proxy-linux-arm64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ec1f94cabf4133c82d30d24c93711674bf806a46c99cc856749374bc83908a2
-size 19446202

--- a/src/ai/backend/web/assets/backend.ai-local-proxy-linux-x64.zip
+++ b/src/ai/backend/web/assets/backend.ai-local-proxy-linux-x64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6714bffa86c446a904af15189c36ece6e88fa83b60fb0e28183385869b643581
-size 19625388

--- a/src/ai/backend/web/assets/backend.ai-local-proxy-macos-arm64.zip
+++ b/src/ai/backend/web/assets/backend.ai-local-proxy-macos-arm64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a06272796d0b29d0647d0624d30d3afd7e8ced0d853f22ec62f0a0a4ee445db
-size 18547501

--- a/src/ai/backend/web/assets/backend.ai-local-proxy-macos-x64.zip
+++ b/src/ai/backend/web/assets/backend.ai-local-proxy-macos-x64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9aa7eef0852dfbe96ec98e53bbd4ce924733db42ef100df4161d3b70b49ba73
-size 20006720


### PR DESCRIPTION
This is an auto-generated backport PR of #2485 to the 24.03 release.