### PR TITLE
fix: `BACKEND_MODEL_NAME` env var overwritten (#2481)

### DIFF
--- a/changes/2481.fix.md
+++ b/changes/2481.fix.md
@@ -1,0 +1,1 @@
+Fix `BACKEND_MODEL_NAME` environment always overwritten to model name specified at model definition

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2276,7 +2276,8 @@ class AbstractAgent(
             model_definition = model_definition_iv.check(raw_definition)
             assert model_definition is not None
             for model in model_definition["models"]:
-                environ["BACKEND_MODEL_NAME"] = model["name"]
+                if "BACKEND_MODEL_NAME" not in environ:
+                    environ["BACKEND_MODEL_NAME"] = model["name"]
                 environ["BACKEND_MODEL_PATH"] = model["model_path"]
                 if service := model.get("service"):
                     overlapping_services = [


### PR DESCRIPTION
This is an auto-generated backport PR of #2481 to the 24.03 release.