### PR TITLE
fix: `BACKEND_MODEL_NAME` env var overwritten (#2481)

### DIFF
--- a/changes/2481.fix.md
+++ b/changes/2481.fix.md
@@ -1,0 +1,1 @@
+Fix `BACKEND_MODEL_NAME` environment always overwritten to model name specified at model definition


### PR DESCRIPTION
This is an auto-generated backport PR of #2481 to the 23.09 release.