### PR TITLE
fix: ignore request body of certain request methods (#2483)

### DIFF
--- a/changes/2483.fix.md
+++ b/changes/2483.fix.md
@@ -1,0 +1,1 @@
+Fix GET requests with queryparams defined in API spec occasionally throwing 400 Bad Request error

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -163,7 +163,7 @@ def check_api_params(
             body: str = ""
             try:
                 body_exists = request.can_read_body
-                if body_exists:
+                if body_exists and request.method not in ("GET", "DELETE", "HEAD"):
                     body = await request.text()
                     if request.content_type == "text/yaml":
                         orig_params = yaml.load(body, Loader=yaml.BaseLoader)


### PR DESCRIPTION
This is an auto-generated backport PR of #2483 to the 23.09 release.