### PR TITLE
ci: Add missing codecov token and skip LFS pulls in coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,6 +54,9 @@ jobs:
         pants test --use-coverage tests:: -- -m 'not integration' -v
     - name: Upload coverage report
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
     - name: Upload pants log
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,16 +18,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 2
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
-    - name: Git LFS Pull
-      run: git lfs pull
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)


### PR DESCRIPTION
Add the missing codecove.io auth token, and let it skip explicit LFS pulls as `pants test :: -- -m 'not integration'` pulls individual LFS files only when required.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
