### PR TITLE
ci: Add missing codecov token and skip LFS pulls in coverage test (#2495)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,16 +18,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 2
-    - name: Create LFS file hash list
-      run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
-    - name: Restore LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
-    - name: Git LFS Pull
-      run: git lfs pull
     - name: Extract Python version from pants.toml
       run: |
         PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
@@ -53,7 +43,10 @@ jobs:
         grep -q "127.0.0.1 node03" /etc/hosts || echo "127.0.0.1 node03" | sudo tee -a /etc/hosts
         pants test --use-coverage tests:: -- -m 'not integration' -v
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
     - name: Upload pants log
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This is an auto-generated backport PR of #2495 to the 24.03 release.