### PR TITLE
refactor: Reorganize scope and roles in RBAC interface

### DIFF
--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -205,6 +205,10 @@ class GroupNotFound(ObjectNotFound):
     object_name = "user group (or project)"
 
 
+class UserNotFound(ObjectNotFound):
+    object_name = "user"
+
+
 class ScalingGroupNotFound(ObjectNotFound):
     object_name = "scaling group"
 

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -94,12 +94,6 @@ __all__: Sequence[str] = (
 MAXIMUM_DOTFILE_SIZE = 64 * 1024  # 61 KiB
 
 
-class UserRoleInProject(enum.StrEnum):
-    ADMIN = enum.auto()  # TODO: impl project admin
-    USER = enum.auto()  # UserRole.USER is associated as user
-    NONE = enum.auto()
-
-
 association_groups_users = sa.Table(
     "association_groups_users",
     mapper_registry.metadata,

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -441,16 +441,16 @@ class AbstractPermissionContextBuilder(
         cls,
         roles: Iterable[ScopedUserRole],
     ) -> frozenset[PermissionType]:
-        result = set()
+        result: frozenset[PermissionType] = frozenset()
         for role in roles:
             result |= await cls.calculate_permission_by_role(role)
-        return frozenset(result)
+        return result
 
     @classmethod
     async def calculate_permission_by_role(
         cls,
         role: ScopedUserRole,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         # This forces to implement a get_permission() method for each Built-in role.
         match role:
             case ScopedUserRole.OWNER:
@@ -468,33 +468,33 @@ class AbstractPermissionContextBuilder(
     @abstractmethod
     async def _permission_for_owner(
         cls,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         pass
 
     @classmethod
     @abstractmethod
     async def _permission_for_admin(
         cls,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         pass
 
     @classmethod
     @abstractmethod
     async def _permission_for_monitor(
         cls,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         pass
 
     @classmethod
     @abstractmethod
     async def _permission_for_contributor(
         cls,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         pass
 
     @classmethod
     @abstractmethod
     async def _permission_for_member(
         cls,
-    ) -> set[PermissionType]:
+    ) -> frozenset[PermissionType]:
         pass

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 import enum
 import uuid
 from abc import ABCMeta, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, cast
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import load_only
+from sqlalchemy.orm import load_only, selectinload, with_loader_criteria
 
-from ..group import AssocGroupUserRow, GroupRow, UserRoleInProject
-from ..user import UserRole
+from ..domain import DomainRow
+from ..group import AssocGroupUserRow, GroupRow
+from ..user import UserRole, UserRow
+from .exceptions import InvalidScope
 
 if TYPE_CHECKING:
     from ..utils import ExtendedAsyncSAEngine
@@ -39,7 +41,17 @@ class BasePermission(enum.StrEnum):
 PermissionType = TypeVar("PermissionType", bound=BasePermission)
 
 
-ProjectContext = Mapping[uuid.UUID, UserRoleInProject]
+class ScopedUserRole(enum.StrEnum):
+    OWNER = enum.auto()
+    ADMIN = enum.auto()
+    MONITOR = enum.auto()
+    CONTRIBUTOR = enum.auto()  # User is part of a specific scope and has read(or some additional permissions) to objects that the scope has.
+    MEMBER = (
+        enum.auto()
+    )  # User is part of a specific scope and has NO PERMISSION to objects that the scope has.
+
+
+_EMPTY_FSET: frozenset = frozenset()
 
 
 @dataclass
@@ -50,82 +62,206 @@ class ClientContext:
     user_id: uuid.UUID
     user_role: UserRole
 
-    _domain_project_ctx: Mapping[str, ProjectContext] | None = field(init=False, default=None)
+    async def _calculate_role_in_scope_for_suadmin(
+        self, db_session: AsyncSession, scope: BaseScope
+    ) -> frozenset[ScopedUserRole]:
+        match scope:
+            case DomainScope(domain_name):
+                stmt = (
+                    sa.select(DomainRow)
+                    .where(DomainRow.name == domain_name)
+                    .options(load_only(DomainRow.name))
+                )
+                domain_row = cast(DomainRow | None, await db_session.scalar(stmt))
+                if domain_row is not None:
+                    return frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+            case ProjectScope(project_id):
+                stmt = (
+                    sa.select(GroupRow)
+                    .where(GroupRow.id == project_id)
+                    .options(load_only(GroupRow.id))
+                )
+                project_row = cast(GroupRow | None, await db_session.scalar(stmt))
+                if project_row is None:
+                    return _EMPTY_FSET
+                if project_row is not None:
+                    return frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+            case UserScope(user_id):
+                if self.user_id == user_id:
+                    return frozenset([ScopedUserRole.OWNER])
+                stmt = (
+                    sa.select(UserRow)
+                    .where(UserRow.uuid == user_id)
+                    .options(load_only(UserRow.uuid))
+                )
+                user_row = cast(UserRow | None, await db_session.scalar(stmt))
+                if user_row is not None:
+                    return frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+            case _:
+                raise InvalidScope(f"invalid scope `{scope}`")
 
-    async def get_accessible_projects_in_domain(
-        self, db_session: AsyncSession, domain_name: str
-    ) -> ProjectContext | None:
-        match self.user_role:
-            case UserRole.SUPERADMIN | UserRole.MONITOR:
-                if self._domain_project_ctx is None:
-                    self._domain_project_ctx = {}
-                if domain_name not in self._domain_project_ctx:
-                    stmt = (
-                        sa.select(GroupRow)
-                        .where(GroupRow.domain_name == domain_name)
-                        .options(load_only(GroupRow.id))
+    async def _calculate_role_in_scope_for_monitor(
+        self, db_session: AsyncSession, scope: BaseScope
+    ) -> frozenset[ScopedUserRole]:
+        match scope:
+            case DomainScope(domain_name):
+                stmt = (
+                    sa.select(DomainRow)
+                    .where(DomainRow.name == domain_name)
+                    .options(load_only(DomainRow.name))
+                )
+                domain_row = cast(DomainRow | None, await db_session.scalar(stmt))
+                if domain_row is not None:
+                    return frozenset([ScopedUserRole.MONITOR])
+                else:
+                    return _EMPTY_FSET
+            case ProjectScope(project_id):
+                stmt = (
+                    sa.select(GroupRow)
+                    .where(GroupRow.id == project_id)
+                    .options(
+                        load_only(GroupRow.id, GroupRow.domain_name),
+                        selectinload(GroupRow.users),
+                        with_loader_criteria(
+                            AssocGroupUserRow, AssocGroupUserRow.user_id == self.user_id
+                        ),
                     )
-                    self._domain_project_ctx = {
-                        **self._domain_project_ctx,
-                        domain_name: {
-                            row.id: UserRoleInProject.ADMIN
-                            for row in await db_session.scalars(stmt)
-                        },
-                    }
-            case UserRole.ADMIN | UserRole.USER:
-                _project_ctx = await self._get_or_init_project_ctx(db_session)
-                self._domain_project_ctx = {self.domain_name: _project_ctx}
-        return self._domain_project_ctx.get(domain_name)
+                )
+                project_row = cast(GroupRow | None, await db_session.scalar(stmt))
+                if project_row is None:
+                    return _EMPTY_FSET
+                if project_row.domain_name == self.domain_name:
+                    result = frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+                if project_row.users:
+                    result = frozenset([*result, ScopedUserRole.CONTRIBUTOR])
+                return result
+            case UserScope(user_id):
+                if self.user_id == user_id:
+                    return frozenset([ScopedUserRole.OWNER])
+                stmt = (
+                    sa.select(UserRow)
+                    .where(UserRow.uuid == user_id)
+                    .options(load_only(UserRow.uuid))
+                )
+                user_row = cast(UserRow | None, await db_session.scalar(stmt))
+                if user_row is not None:
+                    return frozenset([ScopedUserRole.MONITOR])
+                else:
+                    return _EMPTY_FSET
+            case _:
+                raise InvalidScope(f"invalid scope `{scope}`")
 
-    async def get_user_role_in_project(
-        self, db_session: AsyncSession, project_id: uuid.UUID
-    ) -> UserRoleInProject:
-        match self.user_role:
-            case UserRole.SUPERADMIN | UserRole.MONITOR:
-                return UserRoleInProject.ADMIN
-            case UserRole.ADMIN | UserRole.USER:
-                _project_ctx = await self._get_or_init_project_ctx(db_session)
-                return _project_ctx.get(project_id, UserRoleInProject.NONE)
+    async def _calculate_role_in_scope_for_admin(
+        self, db_session: AsyncSession, scope: BaseScope
+    ) -> frozenset[ScopedUserRole]:
+        match scope:
+            case DomainScope(domain_name):
+                if self.domain_name == domain_name:
+                    return frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+            case ProjectScope(project_id):
+                stmt = (
+                    sa.select(GroupRow)
+                    .where(GroupRow.id == project_id)
+                    .options(
+                        load_only(GroupRow.id, GroupRow.domain_name),
+                        selectinload(GroupRow.users),
+                        with_loader_criteria(
+                            AssocGroupUserRow, AssocGroupUserRow.user_id == self.user_id
+                        ),
+                    )
+                )
+                project_row = cast(GroupRow | None, await db_session.scalar(stmt))
+                if project_row is None:
+                    return _EMPTY_FSET
 
-    async def _get_or_init_project_ctx(self, db_session: AsyncSession) -> ProjectContext:
-        match self.user_role:
-            case UserRole.SUPERADMIN | UserRole.MONITOR:
-                # Superadmins and monitors can access to ALL projects in the system.
-                # Let's not fetch all project data from DB.
-                return {}
-            case UserRole.ADMIN:
-                if (
-                    self._domain_project_ctx is None
-                    or self.domain_name not in self._domain_project_ctx
-                ):
-                    stmt = (
-                        sa.select(GroupRow)
-                        .where(GroupRow.domain_name == self.domain_name)
-                        .options(load_only(GroupRow.id))
+                if project_row.domain_name == self.domain_name:
+                    result = frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+                if project_row.users:
+                    result = frozenset([*result, ScopedUserRole.CONTRIBUTOR])
+                return result
+            case UserScope(user_id):
+                if self.user_id == user_id:
+                    return frozenset([ScopedUserRole.OWNER])
+                stmt = (
+                    sa.select(UserRow)
+                    .where(UserRow.uuid == user_id)
+                    .options(load_only(UserRow.domain_name))
+                )
+                user_row = cast(UserRow | None, await db_session.scalar(stmt))
+                if user_row is None:
+                    return _EMPTY_FSET
+
+                if user_row.domain_name == self.domain_name:
+                    return frozenset([ScopedUserRole.ADMIN])
+                else:
+                    return _EMPTY_FSET
+            case _:
+                raise InvalidScope(f"invalid scope `{scope}`")
+
+    async def _calculate_role_in_scope_for_user(
+        self, db_session: AsyncSession, scope: BaseScope
+    ) -> frozenset[ScopedUserRole]:
+        match scope:
+            case DomainScope(domain_name):
+                if self.domain_name == domain_name:
+                    return frozenset([ScopedUserRole.MEMBER])
+                else:
+                    return _EMPTY_FSET
+            case ProjectScope(project_id):
+                stmt = (
+                    sa.select(AssocGroupUserRow)
+                    .where(
+                        (AssocGroupUserRow.user_id == self.user_id)
+                        & (AssocGroupUserRow.group_id == project_id)
                     )
-                    _project_ctx = {
-                        row.id: UserRoleInProject.ADMIN for row in await db_session.scalars(stmt)
-                    }
-                    self._domain_project_ctx = {self.domain_name: _project_ctx}
-                return self._domain_project_ctx[self.domain_name]
-            case UserRole.USER:
-                if (
-                    self._domain_project_ctx is None
-                    or self.domain_name not in self._domain_project_ctx
-                ):
-                    stmt = (
-                        sa.select(AssocGroupUserRow)
-                        .select_from(sa.join(AssocGroupUserRow, GroupRow))
-                        .where(
-                            (AssocGroupUserRow.user_id == self.user_id)
-                            & (GroupRow.domain_name == self.domain_name)
-                        )
-                    )
-                    _project_ctx = {
-                        row.id: UserRoleInProject.USER for row in await db_session.scalars(stmt)
-                    }
-                    self._domain_project_ctx = {self.domain_name: _project_ctx}
-                return self._domain_project_ctx[self.domain_name]
+                    .options(load_only(AssocGroupUserRow.user_id))
+                )
+                assoc_row = cast(AssocGroupUserRow | None, await db_session.scalar(stmt))
+                if assoc_row is not None:
+                    return frozenset([ScopedUserRole.CONTRIBUTOR])
+                else:
+                    return _EMPTY_FSET
+            case UserScope(user_id):
+                if self.user_id == user_id:
+                    return frozenset([ScopedUserRole.OWNER])
+                else:
+                    return _EMPTY_FSET
+            case _:
+                raise InvalidScope(f"invalid scope `{scope}`")
+
+    async def get_roles_in_scope(
+        self,
+        scope: BaseScope,
+        db_session: AsyncSession | None = None,
+    ) -> frozenset[ScopedUserRole]:
+        async def _calculate_role(db_session: AsyncSession) -> frozenset[ScopedUserRole]:
+            match self.user_role:
+                case UserRole.SUPERADMIN:
+                    return await self._calculate_role_in_scope_for_suadmin(db_session, scope)
+                case UserRole.MONITOR:
+                    return await self._calculate_role_in_scope_for_monitor(db_session, scope)
+                case UserRole.ADMIN:
+                    return await self._calculate_role_in_scope_for_admin(db_session, scope)
+                case UserRole.USER:
+                    return await self._calculate_role_in_scope_for_user(db_session, scope)
+
+        if db_session is None:
+            async with self.db.begin_readonly_session() as _db_session:
+                return await _calculate_role(_db_session)
+        else:
+            return await _calculate_role(db_session)
 
 
 class BaseScope(metaclass=ABCMeta):
@@ -245,6 +381,31 @@ class AbstractPermissionContext(
             if permission_to_include in permissions
         }
 
+    @classmethod
+    def merge(cls, src: Self, trgt: Self) -> Self:
+        def _merge_map(
+            src: Mapping[Any, frozenset[PermissionType]],
+            trgt: Mapping[Any, frozenset[PermissionType]],
+        ) -> dict[Any, frozenset[PermissionType]]:
+            val = {}
+            for key in {*src.keys(), *trgt.keys()}:
+                val[key] = src.get(key, frozenset()) | trgt.get(key, frozenset())
+            return val
+
+        return cls(
+            _merge_map(src.user_id_to_permission_map, trgt.user_id_to_permission_map),
+            _merge_map(src.project_id_to_permission_map, trgt.project_id_to_permission_map),
+            _merge_map(src.domain_name_to_permission_map, trgt.domain_name_to_permission_map),
+            _merge_map(
+                src.object_id_to_additional_permission_map,
+                trgt.object_id_to_additional_permission_map,
+            ),
+            _merge_map(
+                src.object_id_to_overriding_permission_map,
+                trgt.object_id_to_overriding_permission_map,
+            ),
+        )
+
     @abstractmethod
     async def build_query(self) -> sa.sql.Select | None:
         pass
@@ -263,46 +424,75 @@ PermissionContextType = TypeVar("PermissionContextType", bound=AbstractPermissio
 class AbstractPermissionContextBuilder(
     Generic[PermissionType, PermissionContextType], metaclass=ABCMeta
 ):
-    async def build(
+    async def filter_by_permission_of_customized_role(
         self,
         ctx: ClientContext,
         target_scope: BaseScope,
         *,
-        permission: PermissionType | None = None,
-    ) -> PermissionContextType:
-        match target_scope:
-            case UserScope(user_id=user_id):
-                result = await self._build_in_user_scope(ctx, user_id)
-            case ProjectScope(project_id=project_id):
-                result = await self._build_in_project_scope(ctx, project_id)
-            case DomainScope(domain_name=domain_name):
-                result = await self._build_in_domain_scope(ctx, domain_name)
-            case _:
-                raise RuntimeError(f"invalid scope `{target_scope}`")
-        if permission is not None:
-            result.filter_by_permission(permission)
-        return result
+        permissions: frozenset[PermissionType],
+    ) -> frozenset[PermissionType]:
+        # TODO: materialize customized roles
+        return permissions
 
+    @classmethod
+    async def calculate_permission_by_roles(
+        cls,
+        roles: Iterable[ScopedUserRole],
+    ) -> frozenset[PermissionType]:
+        result = set()
+        for role in roles:
+            result |= await cls.calculate_permission_by_role(role)
+        return frozenset(result)
+
+    @classmethod
+    async def calculate_permission_by_role(
+        cls,
+        role: ScopedUserRole,
+    ) -> set[PermissionType]:
+        # This forces to implement a get_permission() method for each Built-in role.
+        match role:
+            case ScopedUserRole.OWNER:
+                return await cls._permission_for_owner()
+            case ScopedUserRole.ADMIN:
+                return await cls._permission_for_admin()
+            case ScopedUserRole.MONITOR:
+                return await cls._permission_for_monitor()
+            case ScopedUserRole.CONTRIBUTOR:
+                return await cls._permission_for_contributor()
+            case ScopedUserRole.MEMBER:
+                return await cls._permission_for_member()
+
+    @classmethod
     @abstractmethod
-    async def _build_in_user_scope(
-        self,
-        ctx: ClientContext,
-        user_id: uuid.UUID,
-    ) -> PermissionContextType:
+    async def _permission_for_owner(
+        cls,
+    ) -> set[PermissionType]:
         pass
 
+    @classmethod
     @abstractmethod
-    async def _build_in_project_scope(
-        self,
-        ctx: ClientContext,
-        project_id: uuid.UUID,
-    ) -> PermissionContextType:
+    async def _permission_for_admin(
+        cls,
+    ) -> set[PermissionType]:
         pass
 
+    @classmethod
     @abstractmethod
-    async def _build_in_domain_scope(
-        self,
-        ctx: ClientContext,
-        domain_name: str,
-    ) -> PermissionContextType:
+    async def _permission_for_monitor(
+        cls,
+    ) -> set[PermissionType]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def _permission_for_contributor(
+        cls,
+    ) -> set[PermissionType]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def _permission_for_member(
+        cls,
+    ) -> set[PermissionType]:
         pass

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -281,17 +281,19 @@ class DomainScope(BaseScope):
 @dataclass(frozen=True)
 class ProjectScope(BaseScope):
     project_id: uuid.UUID
+    domain_name: str | None = None
 
     def __str__(self) -> str:
-        return f"Project(id: {self.project_id})"
+        return f"Project(id: {self.project_id}, domain: {self.domain_name}])"
 
 
 @dataclass(frozen=True)
 class UserScope(BaseScope):
     user_id: uuid.UUID
+    domain_name: str | None = None
 
     def __str__(self) -> str:
-        return f"User(id: {self.user_id})"
+        return f"User(id: {self.user_id}, domain: {self.domain_name})"
 
 
 # Extra scope is to address some scopes that contain specific object types

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -413,9 +413,9 @@ class AbstractPermissionContext(
         pass
 
     @abstractmethod
-    async def calculate_final_permission(self, acl_obj: ObjectType) -> frozenset[PermissionType]:
+    async def calculate_final_permission(self, rbac_obj: ObjectType) -> frozenset[PermissionType]:
         """
-        Calculate the final permissions applied to the given  object based on the fields in this class.
+        Calculate the final permissions applied to the given object based on the fields in this class.
         """
         pass
 

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -426,15 +426,13 @@ PermissionContextType = TypeVar("PermissionContextType", bound=AbstractPermissio
 class AbstractPermissionContextBuilder(
     Generic[PermissionType, PermissionContextType], metaclass=ABCMeta
 ):
-    async def filter_by_permission_of_customized_role(
+    async def apply_customized_role(
         self,
         ctx: ClientContext,
         target_scope: BaseScope,
-        *,
-        permissions: frozenset[PermissionType],
     ) -> frozenset[PermissionType]:
         # TODO: materialize customized roles
-        return permissions
+        raise NotImplementedError
 
     @classmethod
     async def calculate_permission_by_roles(

--- a/src/ai/backend/manager/models/rbac/exceptions.py
+++ b/src/ai/backend/manager/models/rbac/exceptions.py
@@ -2,5 +2,9 @@ class RBACException(Exception):
     pass
 
 
+class InvalidScope(RBACException):
+    pass
+
+
 class NotEnoughPermission(RBACException):
     pass

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -727,17 +727,19 @@ WhereClauseType: TypeAlias = (
 )
 # TypeAlias is deprecated since 3.12
 
-OWNER_PERMISSIONS: set[VFolderRBACPermission] = set([perm for perm in VFolderRBACPermission])
-ADMIN_PERMISSIONS: set[VFolderRBACPermission] = set([
+OWNER_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
+    perm for perm in VFolderRBACPermission
+])
+ADMIN_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
     VFolderRBACPermission.READ_ATTRIBUTE,
     VFolderRBACPermission.UPDATE_ATTRIBUTE,
     VFolderRBACPermission.DELETE_VFOLDER,
 ])
-MONITOR_PERMISSIONS: set[VFolderRBACPermission] = set([
+MONITOR_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
     VFolderRBACPermission.READ_ATTRIBUTE,
     VFolderRBACPermission.UPDATE_ATTRIBUTE,
 ])
-CONTRIBUTOR_PERMISSIONS: set[VFolderRBACPermission] = set([
+CONTRIBUTOR_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
     VFolderRBACPermission.READ_ATTRIBUTE,
     VFolderRBACPermission.READ_CONTENT,
     VFolderRBACPermission.WRITE_CONTENT,
@@ -746,26 +748,7 @@ CONTRIBUTOR_PERMISSIONS: set[VFolderRBACPermission] = set([
     VFolderRBACPermission.MOUNT_RW,
     VFolderRBACPermission.MOUNT_WD,
 ])
-MEMBER_PERMISSIONS: set[VFolderRBACPermission] = set()
-ADMIN_PERMISSIONS_ON_OTHER_USER_INVITED_FOLDERS: frozenset[VFolderRBACPermission] = frozenset([
-    VFolderRBACPermission.READ_ATTRIBUTE,
-])  # Admins are allowed to READ folders that other users are invited to.
-USER_PERMISSIONS_ON_PROJECT_FOLDERS: frozenset[VFolderRBACPermission] = frozenset([
-    VFolderRBACPermission.READ_ATTRIBUTE,
-    VFolderRBACPermission.READ_CONTENT,
-    VFolderRBACPermission.WRITE_CONTENT,
-    VFolderRBACPermission.DELETE_CONTENT,
-    VFolderRBACPermission.MOUNT_RO,
-    VFolderRBACPermission.MOUNT_RW,
-    VFolderRBACPermission.MOUNT_WD,
-])
-# `ADMIN_PERMISSIONS_ON_PROJECT_FOLDERS == OWNER_PERMISSIONS` is true
-# but it doesn't mean that admins are the owner of the project folders.
-ADMIN_PERMISSIONS_ON_PROJECT_FOLDERS: frozenset[VFolderRBACPermission] = frozenset(
-    ADMIN_PERMISSIONS
-    | USER_PERMISSIONS_ON_PROJECT_FOLDERS
-    | {VFolderRBACPermission.CLONE, VFolderRBACPermission.ASSIGN_PERMISSION_TO_OTHERS}
-)
+MEMBER_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset()
 
 # TODO: Change type of `vfolder_permissions.permission` to VFolderRBACPermission
 PERMISSION_TO_RBAC_PERMISSION_MAP: Mapping[VFolderPermission, frozenset[VFolderRBACPermission]] = {
@@ -1012,31 +995,31 @@ class PermissionContextBuilder(
     @classmethod
     async def _permission_for_owner(
         cls,
-    ) -> set[VFolderRBACPermission]:
+    ) -> frozenset[VFolderRBACPermission]:
         return OWNER_PERMISSIONS
 
     @classmethod
     async def _permission_for_admin(
         cls,
-    ) -> set[VFolderRBACPermission]:
+    ) -> frozenset[VFolderRBACPermission]:
         return ADMIN_PERMISSIONS
 
     @classmethod
     async def _permission_for_monitor(
         cls,
-    ) -> set[VFolderRBACPermission]:
+    ) -> frozenset[VFolderRBACPermission]:
         return MONITOR_PERMISSIONS
 
     @classmethod
     async def _permission_for_contributor(
         cls,
-    ) -> set[VFolderRBACPermission]:
+    ) -> frozenset[VFolderRBACPermission]:
         return CONTRIBUTOR_PERMISSIONS
 
     @classmethod
     async def _permission_for_member(
         cls,
-    ) -> set[VFolderRBACPermission]:
+    ) -> frozenset[VFolderRBACPermission]:
         return MEMBER_PERMISSIONS
 
 

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -844,9 +844,9 @@ class PermissionContext(AbstractPermissionContext[VFolderRBACPermission, VFolder
         return sa.select(VFolderRow).where(cond)
 
     async def calculate_final_permission(
-        self, acl_obj: VFolderRow
+        self, rbac_obj: VFolderRow
     ) -> frozenset[VFolderRBACPermission]:
-        vfolder_row = acl_obj
+        vfolder_row = rbac_obj
         vfolder_id = cast(uuid.UUID, vfolder_row.id)
         if (
             overriding_perm := self.object_id_to_overriding_permission_map.get(vfolder_id)


### PR DESCRIPTION
## Define `ScopedUserRole`
Users have one or many roles {Owner, Admin, Monitor, Contributor, Member} in a scope.
`Contributor` is a role that user has if the user is part of a specific scope and has read(or some additional permissions) to objects that the scope has. e.g. project user has a Contributor role in the project and the user can mount folders of the project.
`Member` is a role that user has if the user is part of a specific scope and has **NO PERMISSION** to objects that the scope has. e.g. domain user has a Member role in the domain and the user cannot read, write or mount folders of the domain.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2504.org.readthedocs.build/en/2504/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2504.org.readthedocs.build/ko/2504/

<!-- readthedocs-preview sorna-ko end -->