### PR TITLE
fix: Check null value of user mutation by `Undefined`

### DIFF
--- a/changes/2506.fix.md
+++ b/changes/2506.fix.md
@@ -1,0 +1,1 @@
+Check null value of user mutation by `Undefined` sentinel value rather than `None`.

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -744,6 +744,9 @@ class ModifyUser(graphene.Mutation):
         if data.get("status") is None and props.is_active is not Undefined:
             data["status"] = UserStatus.ACTIVE if props.is_active else UserStatus.INACTIVE
 
+        if data.get("password") is not None:
+            data["password_changed_at"] = sa.func.now()
+
         main_access_key: str | None = data.get("main_access_key")
         user_update_data: Dict[str, Any] = {}
         prev_domain_name: str

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -737,12 +737,13 @@ class ModifyUser(graphene.Mutation):
         set_if_set(props, data, "resource_policy")
         set_if_set(props, data, "sudo_session_enabled")
         set_if_set(props, data, "main_access_key")
+        set_if_set(props, data, "is_active")
         if data.get("password") is None:
             data.pop("password", None)
         if not data and not props.group_ids:
             return cls(ok=False, msg="nothing to update", user=None)
-        if data.get("status") is None and props.is_active is not Undefined:
-            data["status"] = UserStatus.ACTIVE if props.is_active else UserStatus.INACTIVE
+        if data.get("status") is None and data.get("is_active") is not None:
+            data["status"] = UserStatus.ACTIVE if data["is_active"] else UserStatus.INACTIVE
 
         if data.get("password") is not None:
             data["password_changed_at"] = sa.func.now()

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -741,11 +741,8 @@ class ModifyUser(graphene.Mutation):
             data.pop("password", None)
         if not data and not props.group_ids:
             return cls(ok=False, msg="nothing to update", user=None)
-        if data.get("status") is None and props.is_active is not None:
+        if data.get("status") is None and props.is_active is not Undefined:
             data["status"] = UserStatus.ACTIVE if props.is_active else UserStatus.INACTIVE
-
-        if data.get("password") is not None:
-            data["password_changed_at"] = sa.func.now()
 
         main_access_key: str | None = data.get("main_access_key")
         user_update_data: Dict[str, Any] = {}


### PR DESCRIPTION
`modify_user` mutation checks `is_active` input value.
All input values that client does not specify get `Undefined` sentinel value rather than `None`.
Let's correct this check logic.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)