### PR TITLE
fix: Check null value of user mutation by `Undefined` (#2506)

### DIFF
--- a/changes/2506.fix.md
+++ b/changes/2506.fix.md
@@ -1,0 +1,1 @@
+Check null value of user mutation by `Undefined` sentinel value rather than `None`.

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -737,12 +737,13 @@ class ModifyUser(graphene.Mutation):
         set_if_set(props, data, "resource_policy")
         set_if_set(props, data, "sudo_session_enabled")
         set_if_set(props, data, "main_access_key")
+        set_if_set(props, data, "is_active")
         if data.get("password") is None:
             data.pop("password", None)
         if not data and not props.group_ids:
             return cls(ok=False, msg="nothing to update", user=None)
-        if data.get("status") is None and props.is_active is not None:
-            data["status"] = UserStatus.ACTIVE if props.is_active else UserStatus.INACTIVE
+        if data.get("status") is None and data.get("is_active") is not None:
+            data["status"] = UserStatus.ACTIVE if data["is_active"] else UserStatus.INACTIVE
 
         if data.get("password") is not None:
             data["password_changed_at"] = sa.func.now()


### PR DESCRIPTION
This is an auto-generated backport PR of #2506 to the 24.03 release.