### PR TITLE
ci: Add the label of the original PR to the backport PR

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,6 +16,7 @@ jobs:
       latest_release: ${{ steps.commit.outputs.latest_release }}
       author: ${{ steps.commit.outputs.author }}
       author_email: ${{ steps.commit.outputs.author_email }}
+      labels: ${{ steps.commit.outputs.labels }}
     steps:
       - name: Checkout the revision
         uses: actions/checkout@v4
@@ -38,6 +39,10 @@ jobs:
           echo "author=$author" >> $GITHUB_OUTPUT
           author_email=$(git show -s --format=%ae $latest_commit)
           echo "author_email=$author_email" >> $GITHUB_OUTPUT
+          labels=$(gh pr view $pr_number --json labels | jq -r '.labels[].name')
+          echo "labels<<EOF" >> $GITHUB_OUTPUT
+          echo "$labels" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Check if this is a merged pr commit
         run: |
           if [[ -z "${{ steps.commit.outputs.pr_number }}" ]]; then
@@ -132,10 +137,10 @@ jobs:
           body: "This is an auto-generated backport PR of #${{ needs.backport-target-branch.outputs.pr_number }} to the ${{ matrix.milestone }} release."
           branch: "backport/${{ needs.backport-target-branch.outputs.pr_number }}-to-${{ matrix.milestone }}"
           base: ${{ matrix.milestone }}
-          labels: backport
+          labels: |
+            backport
+            ${{ needs.backport-target-branch.outputs.labels }}
           assignees: ${{ needs.backport-target-branch.outputs.author }}
-      - run: |
-          gh pr view ${{ needs.backport-target-branch.outputs.pr_number }} --json labels | jq -r '.labels[].name' | xargs -I {} gh pr edit ${{ steps.pr.outputs.pull-request-number }} --add-label {}
       - id: pr_id
         run: |
           pr_id=$(gh api graphql -f query='


### PR DESCRIPTION
close #2158 
In #2159, the label of the existing PR was added, but it was not working until now due to lack of permissions.
By adding a label when creating a pull-request, solve permission issues and prevent race problems between the CI and label states that occur when adding a label after creating a pull-request.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
