### PR TITLE
fix: Do null check on `total_resource_slots` value (#2509)

### DIFF
--- a/changes/2509.fix.md
+++ b/changes/2509.fix.md
@@ -1,0 +1,1 @@
+Do null check on `groups.total_resource_slots` and `domains.total_resource_slots` value.

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -125,7 +125,9 @@ class Domain(graphene.ObjectType):
             is_active=row["is_active"],
             created_at=row["created_at"],
             modified_at=row["modified_at"],
-            total_resource_slots=row["total_resource_slots"].to_json(),
+            total_resource_slots=row["total_resource_slots"].to_json()
+            if row["total_resource_slots"] is not None
+            else {},
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
             allowed_docker_registries=row["allowed_docker_registries"],
             integration_id=row["integration_id"],

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -298,7 +298,9 @@ class Group(graphene.ObjectType):
             created_at=row["created_at"],
             modified_at=row["modified_at"],
             domain_name=row["domain_name"],
-            total_resource_slots=row["total_resource_slots"].to_json(),
+            total_resource_slots=row["total_resource_slots"].to_json()
+            if row["total_resource_slots"] is not None
+            else {},
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
             integration_id=row["integration_id"],
             resource_policy=row["resource_policy"],


### PR DESCRIPTION
This is an auto-generated backport PR of #2509 to the 24.03 release.