### PR TITLE
feat: update selected_route method and add scenario tests

### DIFF
--- a/src/ai/backend/wsproxy/proxy/backend/http.py
+++ b/src/ai/backend/wsproxy/proxy/backend/http.py
@@ -44,8 +44,8 @@ class HTTPBackend(AbstractBackend):
                 ranges.append(ratio_sum)
             rand = random.random() * ranges[-1]
             for i in range(len(ranges)):
-                ceiling = ranges[0]
-                if (i == 0 and rand < ceiling) or (ranges[i - 1] <= rand and rand < ceiling):
+                ceiling = ranges[i]
+                if rand < ceiling:
                     selected_route = routes[i]
                     break
             else:

--- a/tests/wsproxy/BUILD
+++ b/tests/wsproxy/BUILD
@@ -1,0 +1,3 @@
+python_test_utils()
+
+python_tests(name="tests")

--- a/tests/wsproxy/proxy/backend/BUILD
+++ b/tests/wsproxy/proxy/backend/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/wsproxy/proxy/backend/test_http.py
+++ b/tests/wsproxy/proxy/backend/test_http.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import MagicMock
+from ai.backend.wsproxy.proxy.backend.http import HTTPBackend
+from ai.backend.wsproxy.types import RouteInfo
+import uuid
+from ai.backend.wsproxy.exceptions import WorkerNotAvailable
+import random
+
+
+class TestHTTPBackend(unittest.TestCase):
+
+    def setUp(self):
+        self.backend = HTTPBackend(
+            root_context=MagicMock(),
+            circuit=MagicMock(),
+            routes=self._create_routes()
+        )
+
+    def _create_routes(self):
+        return [
+            RouteInfo(
+                session_id=uuid.uuid4(),
+                session_name=None,
+                kernel_host='localhost',
+                kernel_port=8080,
+                protocol="http",
+                traffic_ratio=0.5
+            ),
+            RouteInfo(
+                session_id=uuid.uuid4(),
+                session_name=None,
+                kernel_host='localhost',
+                kernel_port=8081,
+                protocol="http",
+                traffic_ratio=0.3
+            ),
+            RouteInfo(
+                session_id=uuid.uuid4(),
+                session_name=None,
+                kernel_host='localhost',
+                kernel_port=8082,
+                protocol="http",
+                traffic_ratio=0.2
+            )
+        ]
+
+    def test_no_routes(self):
+        self.backend.routes = []
+        with self.assertRaises(WorkerNotAvailable):
+            self.backend.selected_route
+
+    def test_single_route_zero_traffic(self):
+        self.backend.routes = [
+            RouteInfo(
+                session_id=uuid.uuid4(),
+                session_name=None,
+                kernel_host='localhost',
+                kernel_port=8082,
+                protocol="http",
+                traffic_ratio=0
+            )
+        ]
+        with self.assertRaises(WorkerNotAvailable):
+            self.backend.selected_route
+
+    def test_multiple_routes(self):
+        test_cases = [
+            (0.1, 0.2),
+            (0.4, 0.3),
+            (0.9, 0.5)
+        ]
+
+        for random_value, expected_ratio in test_cases:
+            random.random = MagicMock(return_value=random_value)
+            route = self.backend.selected_route
+            self.assertEqual(route.traffic_ratio, expected_ratio)

--- a/tests/wsproxy/proxy/backend/test_http.py
+++ b/tests/wsproxy/proxy/backend/test_http.py
@@ -1,76 +1,111 @@
+import random
 import unittest
+import uuid
 from unittest.mock import MagicMock
+
+from ai.backend.wsproxy.exceptions import WorkerNotAvailable
 from ai.backend.wsproxy.proxy.backend.http import HTTPBackend
 from ai.backend.wsproxy.types import RouteInfo
-import uuid
-from ai.backend.wsproxy.exceptions import WorkerNotAvailable
-import random
 
 
 class TestHTTPBackend(unittest.TestCase):
-
     def setUp(self):
+        """Set up the HTTPBackend with predefined routes for testing."""
         self.backend = HTTPBackend(
-            root_context=MagicMock(),
-            circuit=MagicMock(),
-            routes=self._create_routes()
+            root_context=MagicMock(), circuit=MagicMock(), routes=self._create_routes()
         )
 
     def _create_routes(self):
+        """Create a list of RouteInfo objects with different traffic ratios."""
         return [
             RouteInfo(
                 session_id=uuid.uuid4(),
                 session_name=None,
-                kernel_host='localhost',
-                kernel_port=8080,
+                kernel_host="localhost",
+                kernel_port=30729,
                 protocol="http",
-                traffic_ratio=0.5
+                traffic_ratio=0.5,
             ),
             RouteInfo(
                 session_id=uuid.uuid4(),
                 session_name=None,
-                kernel_host='localhost',
-                kernel_port=8081,
+                kernel_host="localhost",
+                kernel_port=30730,
                 protocol="http",
-                traffic_ratio=0.3
+                traffic_ratio=0.3,
             ),
             RouteInfo(
                 session_id=uuid.uuid4(),
                 session_name=None,
-                kernel_host='localhost',
-                kernel_port=8082,
+                kernel_host="localhost",
+                kernel_port=30731,
                 protocol="http",
-                traffic_ratio=0.2
-            )
+                traffic_ratio=0.2,
+            ),
         ]
 
     def test_no_routes(self):
+        """Test that WorkerNotAvailable is raised when there are no routes."""
         self.backend.routes = []
         with self.assertRaises(WorkerNotAvailable):
             self.backend.selected_route
 
     def test_single_route_zero_traffic(self):
+        """Test that WorkerNotAvailable is raised when the only route has zero traffic ratio."""
         self.backend.routes = [
             RouteInfo(
                 session_id=uuid.uuid4(),
                 session_name=None,
-                kernel_host='localhost',
-                kernel_port=8082,
+                kernel_host="localhost",
+                kernel_port=8080,
                 protocol="http",
-                traffic_ratio=0
+                traffic_ratio=0,
             )
         ]
         with self.assertRaises(WorkerNotAvailable):
             self.backend.selected_route
 
     def test_multiple_routes(self):
+        """
+        Test that the correct route is selected based on the random value.
+
+        This test covers different ranges:
+        - 0-20% selects the last route with 20% traffic ratio
+        - 20-50% selects the middle route with 30% traffic ratio
+        - 50-100% selects the first route with 50% traffic ratio
+        """
         test_cases = [
-            (0.1, 0.2),
-            (0.4, 0.3),
-            (0.9, 0.5)
+            {
+                "random_value": 0.1,
+                "expected_ratio": 0.2,
+                "description": "Selects the last route with 20% traffic ratio (0-20% range)",
+            },
+            {
+                "random_value": 0.25,
+                "expected_ratio": 0.3,
+                "description": "Selects the middle route with 30% traffic ratio (20-50% range)",
+            },
+            {
+                "random_value": 0.6,
+                "expected_ratio": 0.5,
+                "description": "Selects the first route with 50% traffic ratio (50-100% range)",
+            },
+            {
+                "random_value": 0.49,
+                "expected_ratio": 0.3,
+                "description": "Edge case that selects the middle route at the upper boundary of 20-50% range",
+            },
+            {
+                "random_value": 0.99,
+                "expected_ratio": 0.5,
+                "description": "Edge case that selects the first route at the upper boundary of 50-100% range",
+            },
         ]
 
-        for random_value, expected_ratio in test_cases:
-            random.random = MagicMock(return_value=random_value)
-            route = self.backend.selected_route
-            self.assertEqual(route.traffic_ratio, expected_ratio)
+        for case in test_cases:
+            with self.subTest(case=case):
+                random.random = MagicMock(return_value=case["random_value"])
+                route = self.backend.selected_route
+                self.assertEqual(
+                    route.traffic_ratio, case["expected_ratio"], msg=case["description"]
+                )


### PR DESCRIPTION
### Background
```python
for ... # Original code
    ceiling = ranges[0]
    if (i == 0 and rand < ceiling) or (ranges[i - 1] <= rand and rand < ceiling):
        selected_route = routes[i]
        break
else:
	...
```
[was intended to distribute traffic based on traffic_ratio.](https://github.com/lablup/backend.ai/blob/9140bed4d7ae578709152cb128c24fa8b1832dc5/src/ai/backend/wsproxy/proxy/backend/http.py#L28C5-L53C30) However, ceiling = ranges[0] was fixed, causing an issue where, for example, if ranges[0] = 0.4 and rand = 0.5, the code would always fall into the else clause, selecting the last route regardless of other ratios.


### Changes 
1. **Refactored `selected_route` Method:**

2. **Added Comprehensive Scenario Tests:**


## **Checklist:** 


- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation