### PR TITLE
ci: Treats special characters as regular characters

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -94,13 +94,15 @@ jobs:
         with:
           ref: ${{ matrix.milestone }}
       - name: Cherry-pick
+        env:
+          COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
         run: |
           git config --global user.name "${{ needs.backport-target-branch.outputs.author }}"
           git config --global user.email "${{ needs.backport-target-branch.outputs.author_email }}"
           git fetch origin main --depth=10
           git cherry-pick --strategy=recursive --strategy-option=theirs ${{ needs.backport-target-branch.outputs.latest_commit }}
           git commit \
-            --amend -m '${{ needs.backport-target-branch.outputs.commit_message }}' \
+            --amend -m "${COMMIT_MESSAGE}" \
             --trailer "Backported-from=main (${{ needs.backport-target-branch.outputs.latest_release }})" \
             --trailer "Backported-to=${{ matrix.milestone }}" \
             --trailer "Backport-of=${{ needs.backport-target-branch.outputs.pr_number }}"


### PR DESCRIPTION
In #2247, the string was treated as a single quote to treat special characters such as backticks as regular characters.
However, the ${{ }} syntax in github actions was used to replace the relevant part of the script rather than using a shell string variable, so it did not work properly if the commit_message value included a single quote.
So, change it to use as a shell variable using env so that it operates normally.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
