### PR TITLE
ci: Makes if conditions written in multi-line work properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
 
   lint:
-    if: >
+    if: |
       !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,11 @@ jobs:
 
 
   lint:
-    if: |
-      ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci')
-        && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-        && github.event.pull_request.merged == false
-        && needs.optimize-ci.outputs.skip == false
-      }}
+    if: >
+      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.merged == false
+      && needs.optimize-ci.outputs.skip == false
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
 
   lint:
     if: |
-      ${{ !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true) }}
-      && ${{ !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name) }}
-      && ${{ github.event.pull_request.merged == false }}
+      !(
+        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        || needs.optimize-ci.outputs.skip == true
+      )
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.merged == false
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on:
   push:
+    branches:
+      - 'main'
+      - '[0-9][0-9].0[39]'
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
 
   lint:
     if: >
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false
-      && needs.optimize-ci.outputs.skip == false
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,10 @@ jobs:
 
   check-alembic-migrations:
     if: |
-      ${{ contains(github.event.pull_request.labels.*.name, 'require:db-migration')
-        && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-        && github.event.pull_request.merged == false
-        && needs.optimize-ci.outputs.skip == false
-      }}
+      contains(github.event.pull_request.labels.*.name, 'require:db-migration')
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.merged == false
+      && needs.optimize-ci.outputs.skip == false
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:
@@ -130,11 +129,12 @@ jobs:
 
   typecheck:
     if: |
-      ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci')
-        && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-        && github.event.pull_request.merged == false
-        && needs.optimize-ci.outputs.skip == false
-      }}
+      !(
+        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        || needs.optimize-ci.outputs.skip == true
+      )
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.merged == false
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:
@@ -201,11 +201,10 @@ jobs:
 
   test:
     if: |
-      ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci')
-        && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-        && github.event.pull_request.merged == false
-        && needs.optimize-ci.outputs.skip == false
-      }}
+      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.merged == false
+      && needs.optimize-ci.outputs.skip == false
     needs: [optimize-ci]
     runs-on: [ubuntu-latest-8-cores]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
 
   lint:
-    if: |
+    if: >
       !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     if: |
       !(
         contains(github.event.pull_request.labels.*.name, 'skip:ci')
-        && needs.optimize-ci.outputs.skip == true
+        || needs.optimize-ci.outputs.skip == true
       )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
 
 
   lint:
-    if: >
-      !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
+    if: |
+      ${{ !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-      && github.event.pull_request.merged == false
+      && github.event.pull_request.merged == false }}
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
 
   lint:
     if: |
-      ${{ !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true)
-      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
-      && github.event.pull_request.merged == false }}
+      ${{ !(contains(github.event.pull_request.labels.*.name, 'skip:ci') || needs.optimize-ci.outputs.skip == true) }}
+      && ${{ !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name) }}
+      && ${{ github.event.pull_request.merged == false }}
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,12 @@ jobs:
 
   test:
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      !(
+        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        && needs.optimize-ci.outputs.skip == true
+      )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false
-      && needs.optimize-ci.outputs.skip == false
     needs: [optimize-ci]
     runs-on: [ubuntu-latest-8-cores]
     steps:


### PR DESCRIPTION
Refactored the syntax with multiple if conditions to multi-line in #2499 to make the code more readable.
However, when using `${{ }}` as multi-line in github actions does not work correctly.
To use a grammar like `!` in an if condition, it would conflict with the existing keyword in YAML, so originally the `${{ }}` grammar, but using multi-line grammars like `|` or `>` is fine because all subsequent values are treated as literal.

To make sure it is labeled skip:ci, the kind of event must be pull_request.
So the ci is not being skipped in the case of ci fired by push trigger, and it is not merged in the case of required.
And there is also a problem that if you push a commit to the pr branch, the pull_request trigger and push trigger occur at the same time, so the ci is performed twice.
So we make sure that the push trigger is only executed on the main branch and release branch, which performs the commit directly without PR.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
