### PR TITLE
fix: agent heartbeat not handled when agent reports image with invalid ame (#2516)

### DIFF
--- a/changes/2516.fix.md
+++ b/changes/2516.fix.md
@@ -1,0 +1,1 @@
+Fix hearbeat processing failing when agent reports image with its name not compilant to Backend.AI's naming rule

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1215,6 +1215,15 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 for repo_tag in image["RepoTags"]:
                     if repo_tag.endswith("<none>"):
                         continue
+                    try:
+                        ImageRef(repo_tag, ["*"])
+                    except ValueError:
+                        log.warn(
+                            "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored.",
+                            repo_tag,
+                        )
+                        continue
+
                     img_detail = await docker.images.inspect(repo_tag)
                     labels = img_detail["Config"]["Labels"]
                     if labels is None or "ai.backend.kernelspec" not in labels:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3056,8 +3056,12 @@ class AgentRegistry:
             async def _pipe_builder(r: Redis):
                 pipe = r.pipeline()
                 for image in loaded_images:
-                    image_ref = ImageRef(image[0], known_registries, agent_info["architecture"])
-                    await pipe.sadd(image_ref.canonical, agent_id)
+                    try:
+                        image_ref = ImageRef(image[0], known_registries, agent_info["architecture"])
+                        await pipe.sadd(image_ref.canonical, agent_id)
+                    except ValueError:
+                        # Skip opaque (non-Backend.AI) image.
+                        continue
                 return pipe
 
             await redis_helper.execute(self.redis_image, _pipe_builder)


### PR DESCRIPTION
This is an auto-generated backport PR of #2516 to the 24.03 release.