### PR TITLE
fix: Typo in storage `check_status()` API response

### DIFF
--- a/changes/2523.fix.md
+++ b/changes/2523.fix.md
@@ -1,0 +1,1 @@
+Corrected a typo (`maanger` corrected to `manager`) in the `check_status()` API response of the storage component

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -91,7 +91,7 @@ async def check_status(request: web.Request) -> web.Response:
         return web.json_response(
             {
                 "status": "ok",
-                "type": "maanger-facing",
+                "type": "manager-facing",
                 "storage-proxy": __version__,
             },
         )


### PR DESCRIPTION
This pull request is a follow-up to #1430 and simply corrects a typo in `check_status()` API's response.

| Before | After |
| ------- | ----- |
| ma**an**ger-facing | ma**na**ger-facing |

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
