### PR TITLE
ci: Fix if condition not working properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
         release_version=$(awk -F'.' '{print $1"."$2}' <<< "${{ github.ref_name }}")
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update stable installer shorten URL
-      if: ${{ !env.IS_PRERELEASE }} && ${{ vars.STABLE_RELEASE }} == ${{ steps.extract_stable_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ !env.IS_PRERELEASE && vars.STABLE_RELEASE == steps.extract_stable_release_version.outputs.RELEASE_VERSION }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-stable-macos-aarch64' \
@@ -508,7 +508,7 @@ jobs:
         release_version=$(git branch -r | grep -E 'origin/[0-9]{2}\.[0-9]{2}$' | awk -F'/' '{print $2}' | sort -V | tail -n 1)
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update edge installer shorten URL
-      if: ${{ github.ref_name }} == ${{ steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ github.ref_name == steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-edge-macos-aarch64' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,8 +548,9 @@ jobs:
     needs: [make-final-release]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: windows-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+
     steps:
     - name: Check out the revision
       uses: actions/checkout@v4
@@ -595,3 +596,5 @@ jobs:
     - name: Upload conda-pack to GitHub release
       run: |
         gh release upload ${{ github.ref_name }} backend.ai-client-${{ github.ref_name }}-windows-conda.zip
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- ${{ }} syntax does not skip the step as intended when used in a split syntax.
If the ${{ }} statement in the if condition to wrap the whole thing.

- As a follow-up to #2265, we added additional permissions for uploading releases.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
