### PR TITLE
fix: Delete quota scope when deleting vfolder

### DIFF
--- a/changes/2525.fix.md
+++ b/changes/2525.fix.md
@@ -1,0 +1,1 @@
+Delete quota scope when deleting vfolder.

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -399,6 +399,8 @@ class BaseVolume(AbstractVolume):
     async def delete_vfolder(self, vfid: VFolderID) -> None:
         vfpath = self.mangle_vfpath(vfid)
         await self.fsop_model.delete_tree(vfpath)
+        if (qsid := vfid.quota_scope_id) is not None:
+            await self.quota_model.delete_quota_scope(qsid)
         for p in [vfpath, vfpath.parent, vfpath.parent.parent]:
             try:
                 await aiofiles.os.rmdir(p)

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -398,7 +398,7 @@ class BaseVolume(AbstractVolume):
     @final
     async def delete_vfolder(self, vfid: VFolderID) -> None:
         if (qsid := vfid.quota_scope_id) is not None:
-            # Delete files and directories before deleting vfolder
+            # Delete files and directories before deleting quota
             # otherwise `delete_quota_scope()` raises NotEmptyError.
             paths = [
                 PurePosixPath(dir_.path)


### PR DESCRIPTION
There are a few storage backends that require deleting quota scope before deleting a path of a vfolder, such as GPFS.
Let's call `AbstractQuotaModel.delete_quota_scope()` when deleting vfolder.

> [!NOTE]
> Calling `AbstractQuotaModel.delete_quota_scope()` raises `NotEmptyError` if the vfolder is not empty. We should empty the folder before deleting quota scope.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)