### PR TITLE
feat: Impl Resource sync interface in agent side

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1138,7 +1138,11 @@ class AbstractAgent(
                                 ),
                             )
                     # Notify cleanup waiters after all state updates.
-                    if kernel_obj is not None and kernel_obj.clean_event is not None:
+                    if (
+                        kernel_obj is not None
+                        and kernel_obj.clean_event is not None
+                        and not kernel_obj.clean_event.done()
+                    ):
                         kernel_obj.clean_event.set_result(None)
                     if ev.done_future is not None and not ev.done_future.done():
                         ev.done_future.set_result(None)

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1263,3 +1263,29 @@ MODEL_SERVICE_RUNTIME_PROFILES: Mapping[RuntimeVariant, ModelServiceProfile] = {
     ),
     RuntimeVariant.CMD: ModelServiceProfile(name="Predefined Image Command"),
 }
+
+
+@dataclass
+class KernelStatusCollection(JSONSerializableMixin):
+    KernelTerminationInfo = tuple[KernelId, str]
+
+    actual_existing_kernels: list[KernelId]
+    actual_terminating_kernels: list[KernelTerminationInfo]
+    actual_terminated_kernels: list[KernelTerminationInfo]
+
+    def to_json(self) -> dict[str, list[KernelId]]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_json(cls, obj: Mapping[str, Any]) -> KernelStatusCollection:
+        return cls(**cls.as_trafaret().check(obj))
+
+    @classmethod
+    def as_trafaret(cls) -> t.Trafaret:
+        from . import validators as tx
+
+        return t.Dict({
+            t.Key("actual_existing_kernels"): tx.ToList(tx.UUID),
+            t.Key("actual_terminating_kernels"): tx.ToList(t.Tuple(t.String, t.String)),
+            t.Key("actual_terminated_kernels"): tx.ToList(t.Tuple(t.String, t.String)),
+        })

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -711,6 +711,19 @@ class ToSet(t.Trafaret):
             self._failure("value must be Iterable")
 
 
+class ToList(t.List):
+    def check_common(self, value: Any) -> None:
+        return super().check_common(self.check_and_return(value))  # type: ignore[misc]
+
+    def check_and_return(self, value: Any) -> list:
+        try:
+            return list(value)
+        except TypeError:
+            self._failure(
+                f"Cannot parse {type(value)} to list. value must be Iterable", value=value
+            )
+
+
 class Delay(t.Trafaret):
     """
     Convert a float or a tuple of 2 floats into a random generated float value


### PR DESCRIPTION
Agents's sync-and-get-kernels() API
The API that synchronizes agent's kernels to kernel information specified by API parameters (preparing_kernels, pulling_kernels, running_kernels, terminating_kernels). It assumes that the kernel information given by the parameter is the "truth".
If any of kernel information mismatch between kernel_registry and running_kernels(or terminating_kernels), agent injects termination event to terminate the kernel.

sync-and-get-kernels() API returns actual { running, terminating, terminated } kernels (which is not used for now). actual_terminated_kernels contains terminated kernels specified as running_kernels by API parameter.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version