### PR TITLE
ci: Fix if condition not working properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
         release_version=$(awk -F'.' '{print $1"."$2}' <<< "${{ github.ref_name }}")
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update stable installer shorten URL
-      if: ${{ !env.IS_PRERELEASE }} && ${{ vars.STABLE_RELEASE }} == ${{ steps.extract_stable_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ !env.IS_PRERELEASE && vars.STABLE_RELEASE == steps.extract_stable_release_version.outputs.RELEASE_VERSION }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-stable-macos-aarch64' \
@@ -508,7 +508,7 @@ jobs:
         release_version=$(git branch -r | grep -E 'origin/[0-9]{2}\.[0-9]{2}$' | awk -F'/' '{print $2}' | sort -V | tail -n 1)
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update edge installer shorten URL
-      if: ${{ github.ref_name }} == ${{ steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ github.ref_name == steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-edge-macos-aarch64' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,21 @@ jobs:
 
   optimize-ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       skip: ${{ steps.check_skip.outputs.skip }}
     steps:
       - name: Optimize CI
+        if: ${{ github.event_name == 'pull_request' }}
         id: check_skip
         uses: withgraphite/graphite-ci-action@main
-        if: ${{ github.event_name == 'pull_request' }}
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+      - name: labeler
+        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'syncrhonize'
+        uses: lablup/auto-labeler@main # actions/labeler, lablup/size-label-action, lablup/auto-label-in-issue
 
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,8 +548,9 @@ jobs:
     needs: [make-final-release]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: windows-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+
     steps:
     - name: Check out the revision
       uses: actions/checkout@v4
@@ -595,3 +596,5 @@ jobs:
     - name: Upload conda-pack to GitHub release
       run: |
         gh release upload ${{ github.ref_name }} backend.ai-client-${{ github.ref_name }}-windows-conda.zip
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, labeling automation and CI are triggered and run separately.
This can cause timing issues because the ci is optimizing based on the label.
Use `needs` in one workflow to ensure ordering.

Also, you can manage multiple labeling-related automation actions in a single composite action.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
