### PR TITLE
enhance: Apply batch dataloader to statistics fetched from Redis

### DIFF
--- a/changes/2558.enhance.md
+++ b/changes/2558.enhance.md
@@ -1,0 +1,1 @@
+Optimize the query latency when fetching a large number of agents with stat metrics from Redis


### PR DESCRIPTION
Like other SQLAlchemy queries in GraphQL, apply the same dataloader mechanism to batch the Redis queries for stat metric fields of the agent query.

On a simulated 500 node cluster setup, it reduces the latency of the all-agent listing query from 1.62s to 212msec.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
