### PR TITLE
feat: Add manager status report bgtask

### DIFF
--- a/changes/2566.feature.md
+++ b/changes/2566.feature.md
@@ -1,0 +1,1 @@
+Add background task that reports manager DB status.

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -7,7 +7,7 @@ import json
 import logging
 import socket
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Final, FrozenSet, Tuple, cast
+from typing import TYPE_CHECKING, Any, Final, FrozenSet, Optional, Tuple, cast
 
 import aiohttp_cors
 import attrs
@@ -109,7 +109,10 @@ async def detect_status_update(root_ctx: RootContext) -> None:
 
 
 async def report_status_bgtask(root_ctx: RootContext) -> None:
-    interval = cast(float, root_ctx.local_config["manager"]["status-update-interval"])
+    interval = cast(Optional[float], root_ctx.local_config["manager"]["status-update-interval"])
+    if interval is None:
+        # Do not report if interval is not set
+        return
     try:
         while True:
             await asyncio.sleep(interval)

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -111,15 +111,13 @@ async def detect_status_update(root_ctx: RootContext) -> None:
 async def report_status_bgtask(root_ctx: RootContext) -> None:
     interval = cast(Optional[float], root_ctx.local_config["manager"]["status-update-interval"])
     if interval is None:
-        # Do not report if interval is not set
+        # Do not run bgtask if interval is not set
         return
     try:
         while True:
             await asyncio.sleep(interval)
             try:
                 await report_manager_status(root_ctx)
-            except asyncio.CancelledError:
-                raise
             except Exception as e:
                 log.exception(f"Failed to report manager health status (e:{str(e)})")
     except asyncio.CancelledError:

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -290,7 +290,7 @@ manager_local_config_iv = (
             ],
             t.Key("aiomonitor-webui-port", default=49100): t.ToInt[1:65535],
             t.Key("use-experimental-redis-event-dispatcher", default=False): t.ToBool,
-            t.Key("status-update-interval", default=10.0): t.ToFloat[0:],
+            t.Key("status-update-interval", default=None): t.Null | t.ToFloat[0:],
             t.Key("status-lifetime", default=None): t.Null | t.ToFloat[0:],
             t.Key("public-metrics-port", default=None): t.Null | t.ToInt[1:65535],
         }).allow_extra("*"),

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -290,8 +290,8 @@ manager_local_config_iv = (
             ],
             t.Key("aiomonitor-webui-port", default=49100): t.ToInt[1:65535],
             t.Key("use-experimental-redis-event-dispatcher", default=False): t.ToBool,
-            t.Key("status-update-interval", default=None): t.Null | t.ToFloat[0:],
-            t.Key("status-lifetime", default=None): t.Null | t.ToFloat[0:],
+            t.Key("status-update-interval", default=None): t.Null | t.ToFloat[0:],  # second
+            t.Key("status-lifetime", default=None): t.Null | t.ToInt[0:],  # second
             t.Key("public-metrics-port", default=None): t.Null | t.ToInt[1:65535],
         }).allow_extra("*"),
         t.Key("docker-registry"): t.Dict({  # deprecated in v20.09

--- a/src/ai/backend/manager/models/health.py
+++ b/src/ai/backend/manager/models/health.py
@@ -142,7 +142,7 @@ async def _get_connnection_info(root_ctx: RootContext) -> ConnectionInfoOfProces
 
 
 async def report_manager_status(root_ctx: RootContext) -> None:
-    lifetime = cast(Optional[float], root_ctx.local_config["manager"]["status-lifetime"])
+    lifetime = cast(Optional[int], root_ctx.local_config["manager"]["status-lifetime"])
     cxn_info = await _get_connnection_info(root_ctx)
     _data = msgpack.packb(cxn_info.model_dump(mode="json"))
 

--- a/src/ai/backend/manager/models/health.py
+++ b/src/ai/backend/manager/models/health.py
@@ -11,6 +11,7 @@ from pydantic import (
 from redis.asyncio import ConnectionPool
 from sqlalchemy.pool import Pool
 
+from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.types import (
     RedisConnectionInfo,
     RedisHelperConfig,
@@ -26,6 +27,7 @@ __all__: tuple[str, ...] = (
     "get_sqlalchemy_connection_info",
     "get_redis_object_info_list",
     "_get_connnection_info",
+    "report_manager_status",
 )
 
 _sqlalchemy_pool_type_names = (
@@ -40,6 +42,10 @@ _sqlalchemy_pool_type_names = (
 
 
 MANAGER_STATUS_KEY = "manager.status"
+
+
+def _get_connection_status_key(node_id: str, pid: int) -> str:
+    return f"{MANAGER_STATUS_KEY}.{node_id}:{pid}"
 
 
 class SQLAlchemyConnectionInfo(BaseModel):
@@ -132,4 +138,19 @@ async def _get_connnection_info(root_ctx: RootContext) -> ConnectionInfoOfProces
     redis_infos = await get_redis_object_info_list(root_ctx)
     return ConnectionInfoOfProcess(
         node_id=node_id, pid=pid, sqlalchemy_info=sqlalchemy_info, redis_connection_info=redis_infos
+    )
+
+
+async def report_manager_status(root_ctx: RootContext) -> None:
+    lifetime = cast(float | None, root_ctx.local_config["manager"]["status-lifetime"])
+    cxn_info = await _get_connnection_info(root_ctx)
+    _data = msgpack.packb(cxn_info.model_dump(mode="json"))
+
+    await redis_helper.execute(
+        root_ctx.redis_stat,
+        lambda r: r.set(
+            _get_connection_status_key(cxn_info.node_id, cxn_info.pid),
+            _data,
+            ex=lifetime,
+        ),
     )

--- a/src/ai/backend/manager/models/health.py
+++ b/src/ai/backend/manager/models/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import socket
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from pydantic import (
     BaseModel,
@@ -67,11 +67,11 @@ class SQLAlchemyConnectionInfo(BaseModel):
 
 class RedisObjectConnectionInfo(BaseModel):
     name: str
-    num_connections: int | None = Field(
+    num_connections: Optional[int] = Field(
         description="The number of connections in Redis Client's connection pool."
     )
     max_connections: int
-    err_msg: str | None = Field(
+    err_msg: Optional[str] = Field(
         description="Error message occurred when fetch connection info from Redis client objects.",
         default=None,
     )
@@ -142,7 +142,7 @@ async def _get_connnection_info(root_ctx: RootContext) -> ConnectionInfoOfProces
 
 
 async def report_manager_status(root_ctx: RootContext) -> None:
-    lifetime = cast(float | None, root_ctx.local_config["manager"]["status-lifetime"])
+    lifetime = cast(Optional[float], root_ctx.local_config["manager"]["status-lifetime"])
     cxn_info = await _get_connnection_info(root_ctx)
     _data = msgpack.packb(cxn_info.model_dump(mode="json"))
 


### PR DESCRIPTION
Managers report DB connection info to Redis stat DB for every specified interval.
Able to set the interval and lifetime of reports.
Default value of the interval is 30 sec.
Default value of the lifetime of reports is null, which means infinite.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2566.org.readthedocs.build/en/2566/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2566.org.readthedocs.build/ko/2566/

<!-- readthedocs-preview sorna-ko end -->