### PR TITLE
feat: Add Prometheus-compatible manager stat API

### DIFF
--- a/changes/2567.feature.md
+++ b/changes/2567.feature.md
@@ -1,0 +1,1 @@
+Add manager DB stat API compatible with Prometheus.

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 import socket
+import textwrap
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Final, FrozenSet, Optional, Tuple, cast
 
@@ -20,12 +21,15 @@ from aiotools import aclosing
 from ai.backend.common import redis_helper
 from ai.backend.common import validators as tx
 from ai.backend.common.events import DoPrepareEvent, DoScaleEvent, DoScheduleEvent
+from ai.backend.common.types import PromMetric, PromMetricGroup, PromMetricPrimitive
 from ai.backend.logging import BraceStyleAdapter
 
 from .. import __version__
 from ..defs import DEFAULT_ROLE
 from ..models import AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES, agents, kernels
 from ..models.health import (
+    SQLAlchemyConnectionInfo,
+    get_manager_db_cxn_status,
     report_manager_status,
 )
 from . import ManagerStatus, SchedulerEvent
@@ -295,6 +299,121 @@ async def scheduler_healthcheck(request: web.Request) -> web.Response:
     return web.json_response(scheduler_status)
 
 
+class SQLAlchemyConnectionMetric(PromMetric):
+    def __init__(self, node_id: str, pid: int, val: int) -> None:
+        self.mgr_id = f"{node_id}:{pid}"
+        self.val = val
+
+    def metric_value_string(self, metric_name: str, primitive: PromMetricPrimitive) -> str:
+        return f"""{metric_name}{{mgr_id="{self.mgr_id}"}} {self.val}"""
+
+
+class SQLAlchemyTotalConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_total_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of total connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class SQLAlchemyOpenConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_open_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of open connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class SQLAlchemyClosedConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_closed_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of closed connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class RedisConnectionMetric(PromMetric):
+    def __init__(self, node_id: str, pid: int, redis_obj_name: str, val: int) -> None:
+        self.redis_obj_name = redis_obj_name
+        self.mgr_id = f"{node_id}:{pid}"
+        self.val = val
+
+    def metric_value_string(self, metric_name: str, primitive: PromMetricPrimitive) -> str:
+        return (
+            f"""{metric_name}{{mgr_id="{self.mgr_id}",name="{self.redis_obj_name}"}} {self.val}"""
+        )
+
+
+class RedisConnectionMetricGroup(PromMetricGroup[RedisConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "redis_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of connections in Redis Client's connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+async def get_manager_status_for_prom(request: web.Request) -> web.Response:
+    root_ctx: RootContext = request.app["_root.context"]
+    status = await get_manager_db_cxn_status(root_ctx)
+
+    total_cxn_metrics = []
+    open_cxn_metrics = []
+    closed_cxn_metrics = []
+    redis_cxn_metrics = []
+    for stat in status:
+        sqlalchemy_info = cast(SQLAlchemyConnectionInfo, stat.sqlalchemy_info)
+
+        total_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.total_cxn)
+        )
+        open_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.num_checkedout_cxn)
+        )
+        closed_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.num_checkedin_cxn)
+        )
+
+        for redis_info in stat.redis_connection_info:
+            if (num_cxn := redis_info.num_connections) is not None:
+                redis_cxn_metrics.append(
+                    RedisConnectionMetric(stat.node_id, stat.pid, redis_info.name, num_cxn)
+                )
+
+    metric_string = (
+        SQLAlchemyTotalConnectionMetricGroup(total_cxn_metrics).metric_string(),
+        SQLAlchemyOpenConnectionMetricGroup(open_cxn_metrics).metric_string(),
+        SQLAlchemyClosedConnectionMetricGroup(closed_cxn_metrics).metric_string(),
+        RedisConnectionMetricGroup(redis_cxn_metrics).metric_string(),
+    )
+
+    result = "\n".join(metric_string)
+    return web.Response(text=textwrap.dedent(result))
+
+
 @attrs.define(slots=True, auto_attribs=True, init=False)
 class PrivateContext:
     status_watch_task: asyncio.Task
@@ -339,6 +458,8 @@ def create_app(
     cors.add(app.router.add_route("POST", "/scheduler/operation", perform_scheduler_ops))
     cors.add(app.router.add_route("POST", "/scheduler/trigger", scheduler_trigger))
     cors.add(app.router.add_route("GET", "/scheduler/status", scheduler_healthcheck))
+    prom_resource = cors.add(app.router.add_resource("/prom"))
+    cors.add(prom_resource.add_route("GET", get_manager_status_for_prom))
     app.on_startup.append(init)
     app.on_shutdown.append(shutdown)
     return app, []

--- a/src/ai/backend/manager/public_api/health.py
+++ b/src/ai/backend/manager/public_api/health.py
@@ -1,24 +1,5 @@
 from __future__ import annotations
 
-<<<<<<< HEAD
-import logging
-
-from aiohttp import web
-
-from ai.backend.common.logging import BraceStyleAdapter
-
-from .types import CORSOptions
-
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
-
-
-async def init(app: web.Application) -> None:
-    pass
-
-
-async def shutdown(app: web.Application) -> None:
-    pass
-=======
 import asyncio
 import logging
 import textwrap
@@ -192,16 +173,10 @@ async def shutdown(app: web.Application) -> None:
         await asyncio.sleep(0)
         if not app_ctx.db_status_report_task.done():
             await app_ctx.db_status_report_task
->>>>>>> 38656cb96 (feat: Add manager stat API that compatible with Prometheus)
 
 
 def create_app(default_cors_options: CORSOptions):
     app = web.Application()
-<<<<<<< HEAD
-    app["prefix"] = "health"
-    app.on_startup.append(init)
-    app.on_shutdown.append(shutdown)
-=======
     app["health.context"] = PrivateContext()
     app["prefix"] = "health"
     app.on_startup.append(init)
@@ -209,5 +184,4 @@ def create_app(default_cors_options: CORSOptions):
     cors = aiohttp_cors.setup(app, defaults=default_cors_options)
     prom_resource = cors.add(app.router.add_resource("/prom"))
     cors.add(prom_resource.add_route("GET", get_manager_status_for_prom))
->>>>>>> 38656cb96 (feat: Add manager stat API that compatible with Prometheus)
     return app, []

--- a/src/ai/backend/manager/public_api/health.py
+++ b/src/ai/backend/manager/public_api/health.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+<<<<<<< HEAD
 import logging
 
 from aiohttp import web
@@ -17,11 +18,196 @@ async def init(app: web.Application) -> None:
 
 async def shutdown(app: web.Application) -> None:
     pass
+=======
+import asyncio
+import logging
+import textwrap
+from typing import TYPE_CHECKING, cast
+
+import aiohttp_cors
+import attrs
+from aiohttp import web
+
+from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.common.types import PromMetric, PromMetricGroup, PromMetricPrimitive
+
+from ..models.health import (
+    SQLAlchemyConnectionInfo,
+    get_manager_db_cxn_status,
+    report_manager_status,
+)
+from .types import CORSOptions
+
+if TYPE_CHECKING:
+    from ..api.context import RootContext
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+async def report_status_bgtask(root_ctx: RootContext) -> None:
+    interval = cast(float, root_ctx.local_config["manager"]["status-update-interval"])
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await report_manager_status(root_ctx)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                log.exception(f"Failed to report manager health status (e:{str(e)})")
+    except asyncio.CancelledError:
+        pass
+
+
+class SQLAlchemyConnectionMetric(PromMetric):
+    def __init__(self, node_id: str, pid: int, val: int) -> None:
+        self.mgr_id = f"{node_id}:{pid}"
+        self.val = val
+
+    def metric_value_string(self, metric_name: str, primitive: PromMetricPrimitive) -> str:
+        return f"""{metric_name}{{mgr_id="{self.mgr_id}"}} {self.val}"""
+
+
+class SQLAlchemyTotalConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_total_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of total connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class SQLAlchemyOpenConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_open_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of open connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class SQLAlchemyClosedConnectionMetricGroup(PromMetricGroup[SQLAlchemyConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "sqlalchemy_closed_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of closed connections in SQLAlchemy connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+class RedisConnectionMetric(PromMetric):
+    def __init__(self, node_id: str, pid: int, redis_obj_name: str, val: int) -> None:
+        self.redis_obj_name = redis_obj_name
+        self.mgr_id = f"{node_id}:{pid}"
+        self.val = val
+
+    def metric_value_string(self, metric_name: str, primitive: PromMetricPrimitive) -> str:
+        return (
+            f"""{metric_name}{{mgr_id="{self.mgr_id}",name="{self.redis_obj_name}"}} {self.val}"""
+        )
+
+
+class RedisConnectionMetricGroup(PromMetricGroup[RedisConnectionMetric]):
+    @property
+    def metric_name(self) -> str:
+        return "redis_connection"
+
+    @property
+    def description(self) -> str:
+        return "The number of connections in Redis Client's connection pool."
+
+    @property
+    def metric_primitive(self) -> PromMetricPrimitive:
+        return PromMetricPrimitive.gauge
+
+
+async def get_manager_status_for_prom(request: web.Request) -> web.Response:
+    root_ctx: RootContext = request.app["_root.context"]
+    status = await get_manager_db_cxn_status(root_ctx)
+
+    total_cxn_metrics = []
+    open_cxn_metrics = []
+    closed_cxn_metrics = []
+    redis_cxn_metrics = []
+    for stat in status:
+        sqlalchemy_info = cast(SQLAlchemyConnectionInfo, stat.sqlalchemy_info)
+
+        total_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.total_cxn)
+        )
+        open_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.num_checkedout_cxn)
+        )
+        closed_cxn_metrics.append(
+            SQLAlchemyConnectionMetric(stat.node_id, stat.pid, sqlalchemy_info.num_checkedin_cxn)
+        )
+
+        for redis_info in stat.redis_connection_info:
+            if (num_cxn := redis_info.num_connections) is not None:
+                redis_cxn_metrics.append(
+                    RedisConnectionMetric(stat.node_id, stat.pid, redis_info.name, num_cxn)
+                )
+
+    metric_string = (
+        SQLAlchemyTotalConnectionMetricGroup(total_cxn_metrics).metric_string(),
+        SQLAlchemyOpenConnectionMetricGroup(open_cxn_metrics).metric_string(),
+        SQLAlchemyClosedConnectionMetricGroup(closed_cxn_metrics).metric_string(),
+        RedisConnectionMetricGroup(redis_cxn_metrics).metric_string(),
+    )
+
+    result = "\n".join(metric_string)
+    return web.Response(text=textwrap.dedent(result))
+
+
+@attrs.define(slots=True, auto_attribs=True, init=False)
+class PrivateContext:
+    db_status_report_task: asyncio.Task
+
+
+async def init(app: web.Application) -> None:
+    root_ctx: RootContext = app["_root.context"]
+    app_ctx: PrivateContext = app["health.context"]
+    app_ctx.db_status_report_task = asyncio.create_task(report_status_bgtask(root_ctx))
+
+
+async def shutdown(app: web.Application) -> None:
+    app_ctx: PrivateContext = app["health.context"]
+    if app_ctx.db_status_report_task is not None:
+        app_ctx.db_status_report_task.cancel()
+        await asyncio.sleep(0)
+        if not app_ctx.db_status_report_task.done():
+            await app_ctx.db_status_report_task
+>>>>>>> 38656cb96 (feat: Add manager stat API that compatible with Prometheus)
 
 
 def create_app(default_cors_options: CORSOptions):
     app = web.Application()
+<<<<<<< HEAD
     app["prefix"] = "health"
     app.on_startup.append(init)
     app.on_shutdown.append(shutdown)
+=======
+    app["health.context"] = PrivateContext()
+    app["prefix"] = "health"
+    app.on_startup.append(init)
+    app.on_shutdown.append(shutdown)
+    cors = aiohttp_cors.setup(app, defaults=default_cors_options)
+    prom_resource = cors.add(app.router.add_resource("/prom"))
+    cors.add(prom_resource.add_route("GET", get_manager_status_for_prom))
+>>>>>>> 38656cb96 (feat: Add manager stat API that compatible with Prometheus)
     return app, []

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -190,7 +190,7 @@ global_subapp_pkgs: Final[list[str]] = [
     ".logs",
 ]
 
-global_subapp_pkgs_for_public_metrics_app: Final[list[str]] = [".health"]
+global_subapp_pkgs_for_public_metrics_app: Final[tuple[str, ...]] = (".health",)
 
 EVENT_DISPATCHER_CONSUMER_GROUP: Final = "manager"
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -53,7 +53,7 @@ from ai.backend.common.events_experimental import EventDispatcher as Experimenta
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.plugin.hook import ALL_COMPLETED, PASSED, HookPluginContext
 from ai.backend.common.plugin.monitor import INCREMENT
-from ai.backend.common.types import AgentSelectionStrategy
+from ai.backend.common.types import AgentSelectionStrategy, HostPortPair
 from ai.backend.common.utils import env_info
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel
 
@@ -940,7 +940,7 @@ async def server_main(
 
             runner = web.AppRunner(root_app, keepalive_timeout=30.0)
             await runner.setup()
-            service_addr = root_ctx.local_config["manager"]["service-addr"]
+            service_addr = cast(HostPortPair, root_ctx.local_config["manager"]["service-addr"])
             site = web.TCPSite(
                 runner,
                 str(service_addr.host),
@@ -967,6 +967,9 @@ async def server_main(
                     reuse_port=True,
                 )
                 await _site.start()
+                log.info(
+                    f"started handling public metric API requests at {service_addr.host}:{public_metrics_port}"
+                )
 
             if os.geteuid() == 0:
                 uid = root_ctx.local_config["manager"]["user"]


### PR DESCRIPTION
resolves #2522

`GET /manager/prom` API returns Prometheus-compatible text.
Here is an example response.
```
HELP sqlalchemy_total_connection The number of total connections in SQLAlchemy connection pool.
TYPE sqlalchemy_total_connection gauge
sqlalchemy_total_connection{mgr_id="i-SH-macbook.local:51809"} 1

HELP sqlalchemy_open_connection The number of open connections in SQLAlchemy connection pool.
TYPE sqlalchemy_open_connection gauge
sqlalchemy_open_connection{mgr_id="i-SH-macbook.local:51809"} 1

HELP sqlalchemy_closed_connection The number of closed connections in SQLAlchemy connection pool.
TYPE sqlalchemy_closed_connection gauge
sqlalchemy_closed_connection{mgr_id="i-SH-macbook.local:51809"} 0

HELP redis_connection The number of connections in Redis Client's connection pool.
TYPE redis_connection gauge
redis_connection{mgr_id="i-SH-macbook.local:51809",name="live"} 2
redis_connection{mgr_id="i-SH-macbook.local:51809",name="stat"} 1
redis_connection{mgr_id="i-SH-macbook.local:51809",name="image"} 1
redis_connection{mgr_id="i-SH-macbook.local:51809",name="stream"} 1
redis_connection{mgr_id="i-SH-macbook.local:51809",name="lock"} 4
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2567.org.readthedocs.build/en/2567/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2567.org.readthedocs.build/ko/2567/

<!-- readthedocs-preview sorna-ko end -->