### PR TITLE
fix: Init Redis connection pool with appropriate connection opts

### DIFF
--- a/changes/2574.fix.md
+++ b/changes/2574.fix.md
@@ -1,0 +1,1 @@
+Initialize Redis connection pool objects with specified connection opts rather than ignoring them.

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -529,8 +529,8 @@ def get_redis_object(
                 connection_pool=ConnectionPool.from_url(
                     str(url),
                     **conn_pool_opts,
+                    **conn_opts,
                 ),
-                **conn_opts,
                 auto_close_connection_pool=True,
             ),
             sentinel=None,

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -531,6 +531,7 @@ def get_redis_object(
                     **conn_pool_opts,
                     **conn_opts,
                 ),
+                **conn_opts,
                 auto_close_connection_pool=True,
             ),
             sentinel=None,


### PR DESCRIPTION
As I checked [how Redis client gets initialized](https://github.com/redis/redis-py/blob/4.5/redis/asyncio/client.py#L195), it passes keyword arguments to its connection pool only when it has to initialize new connection pool object.
As we pass connection pool object to Redis client, we should pass the connection options to connection pool's `from_url()`.

refs:
https://github.com/redis/redis-py/blob/4.5/redis/asyncio/connection.py#L1247
https://github.com/redis/redis-py/blob/4.5/redis/asyncio/connection.py#L1290-L1295

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version