### PR TITLE
fix: Init Redis connection pool with appropriate connection opts (#2574)

### DIFF
--- a/changes/2574.fix.md
+++ b/changes/2574.fix.md
@@ -1,0 +1,1 @@
+Initialize Redis connection pool objects with specified connection opts rather than ignoring them.

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -529,6 +529,7 @@ def get_redis_object(
                 connection_pool=ConnectionPool.from_url(
                     str(url),
                     **conn_pool_opts,
+                    **conn_opts,
                 ),
                 **conn_opts,
                 auto_close_connection_pool=True,


### PR DESCRIPTION
This is an auto-generated backport PR of #2574 to the 24.03 release.