### PR TITLE
ci: run alembic migration checker on release situations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     if: |
       (
         contains(github.event.pull_request.labels.*.name, 'require:db-migration')
-        || github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        || (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
       )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
 
   check-alembic-migrations:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'require:db-migration')
+      (
+        contains(github.event.pull_request.labels.*.name, 'require:db-migration')
+        || github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+      )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false
       && needs.optimize-ci.outputs.skip == 'false'


### PR DESCRIPTION
In our CI workflow, we are creating a release when push a tag.
The release-related jobs are preceded by `lint`, `typecheck`, `test`, and `check-alembic-migration` jobs to increase the stability of the release version.
However, the `check-alembic-migration` job is currently only triggered if the label `require:db-migration` exists, which is preventing the release-related jobs from running.
So we're modifying the `check-alembic-migration` job to also fire on the tag push event.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
