### PR TITLE
ci: run alembic migration checker on release situations (#2585)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
 
   check-alembic-migrations:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'require:db-migration')
+      (
+        contains(github.event.pull_request.labels.*.name, 'require:db-migration')
+        || (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
+      )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
       && github.event.pull_request.merged == false
       && needs.optimize-ci.outputs.skip == 'false'


### PR DESCRIPTION
This is an auto-generated backport PR of #2585 to the 23.09 release.