### PR TITLE
ci: make workflow also work for tag push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'main'
       - '[0-9][0-9].0[39]'
+    tags:
+      - '[0-9][0-9].0[39].*'
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

> If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref. If you define neither tags/tags-ignore or branches/branches-ignore, the workflow will run for events affecting either branches or tags. If you define both branches/branches-ignore and [paths/paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), the workflow will only run when both filters are satisfied.

In #2514, we restricted the CI workflow to run only for pushes from the main and release branches.
However, this setting also doesn't work for events that push the release tag, so currently the release creation automation logic is not running.
Follow the official documentation above to explicitly add a trigger for the tag action.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
