### PR TITLE
ci: make workflow also work for tag push events (#2588)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'main'
       - '[0-9][0-9].0[39]'
+    tags:
+      - '[0-9][0-9].0[39].*'
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:


### PR DESCRIPTION
This is an auto-generated backport PR of #2588 to the 24.03 release.