### PR TITLE
ci: always set `skip` output of `optimize-ci` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,22 @@ jobs:
       contents: read
       pull-requests: write
     outputs:
-      skip: ${{ steps.check_skip.outputs.skip }}
+      skip: ${{ steps.check_skip.outputs.SKIP }}
     steps:
       - name: Optimize CI
         if: ${{ github.event_name == 'pull_request' }}
-        id: check_skip
+        id: graphite-ci-action
         uses: withgraphite/graphite-ci-action@main
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+      - name: Check if should skip the CI
+        id: check_skip
+        run: |
+          if [ "${{ steps.graphite-ci-action.outputs.skip }}" == "true" ]; then
+            echo "SKIP=true" >> $GITHUB_OUTPUT
+          else
+            echo "SKIP=false" >> $GITHUB_OUTPUT
+          fi
       - name: labeler
         if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'syncrhonize'
         uses: lablup/auto-labeler@main # actions/labeler, lablup/size-label-action, lablup/auto-label-in-issue


### PR DESCRIPTION
follow-up #2588
If a step in optimize-ci was previously skipped, the value of outputs.skip did not exist to satisfy the syntax `outputs.skip == 'false'`.
So we assign the value of outputs.skip to 'false' if the value doesn't exist.

In the future, if it is confirmed that graphite-ci-action returns false if the event is not a pull_request, we may want to remove this logic and change to using graphite-ci-action only

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
