### PR TITLE
fix: Implement missing error handling in image scanning

### DIFF
--- a/changes/2594.fix.md
+++ b/changes/2594.fix.md
@@ -1,0 +1,1 @@
+Implement missing error handling in image scanning.

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -194,6 +194,13 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         while tag_list_url is not None:
             async with sess.get(tag_list_url, **rqst_args) as resp:
                 data = json.loads(await resp.read())
+                if "errors" in data:
+                    error_details = []
+                    for error in data["errors"]:
+                        error_details.append(f"{error['code']}: {error['message']}")
+                    error_messages = "; ".join(error_details)
+                    raise RuntimeError(f"Errors occurred: {error_messages}")
+
                 if "tags" in data:
                     # sometimes there are dangling image names in the hub.
                     tags.extend(data["tags"])


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

In the existing code, when credential information is incorrect, the image rescan command simply print logs stating that the image could not be found in the registry, without any warning or raising error.

## Test

Tested manually.

For example, if the credentials were incorrect, no warnings were printed.

```
❯ ./backend.ai mgr image rescan public.ecr.aws
2024-07-30 06:42:39.051 INFO ai.backend.common.etcd [27444] using etcd cluster from 127.0.0.1:8121 with namespace "local"
2024-07-30 06:42:39.053 INFO ai.backend.manager.models.image [27444] Scanning kernel images from the registry "public.ecr.aws"
2024-07-30 06:42:39.093 INFO ai.backend.manager.container_registry.base [27444] rescan_single_registry()
2024-07-30 06:42:40.001 INFO ai.backend.manager.container_registry.base [27444] _scan_image()
2024-07-30 06:42:40.012 INFO ai.backend.manager.container_registry.base [27444] _scan_image()
2024-07-30 06:42:40.836 INFO ai.backend.manager.container_registry.base [27444] No images found in registry https://public.ecr.aws
```

However, cases where an image cannot be found in the registry due to its absence and cases where an error occurs due to incorrect credential information should be distinguished.

The PR modifies the `_scan_image` function to throw an error explicitly indicating that the Authorization Token is invalid when an authentication error occurs.

```
❯ ./backend.ai mgr image rescan public.ecr.aws
2024-07-30 06:49:21.365 INFO ai.backend.common.etcd [33988] using etcd cluster from 127.0.0.1:8121 with namespace "local"
2024-07-30 06:49:21.367 INFO ai.backend.manager.models.image [33988] Scanning kernel images from the registry "public.ecr.aws"
2024-07-30 06:49:21.407 INFO ai.backend.manager.container_registry.base [33988] rescan_single_registry()
2024-07-30 06:49:22.309 INFO ai.backend.manager.container_registry.base [33988] _scan_image()
2024-07-30 06:49:22.321 INFO ai.backend.manager.container_registry.base [33988] _scan_image()
--- Logging error ---
  + Exception Group Traceback (most recent call last):
  |   File "/home/jopemachine/backend.ai/src/ai/backend/manager/cli/image_impl.py", line 161, in rescan_images
  |     await rescan_images_func(etcd, db, registry_or_image, local=local)
  |   File "/home/jopemachine/backend.ai/src/ai/backend/manager/models/image.py", line 158, in rescan_images
  |     async with aiotools.TaskGroup() as tg:
  |   File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/aiotools/taskgroup/base.py", line 39, in __aexit__
  |     raise TaskGroupError(eg.message, eg.exceptions) from None
  | aiotools.taskgroup.types.TaskGroupError: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Exception Group Traceback (most recent call last):
    |   File "/home/jopemachine/backend.ai/src/ai/backend/manager/container_registry/base.py", line 98, in rescan_single_registry
    |     async with aiotools.TaskGroup() as tg:
    |   File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/aiotools/taskgroup/base.py", line 39, in __aexit__
    |     raise TaskGroupError(eg.message, eg.exceptions) from None
    | aiotools.taskgroup.types.TaskGroupError: unhandled errors in a TaskGroup (1 sub-exception)
    +-+---------------- 1 ----------------
      | Traceback (most recent call last):
      |   File "/home/jopemachine/backend.ai/src/ai/backend/manager/container_registry/base.py", line 202, in _scan_image
      |     raise RuntimeError(f"Errors occurred: {error_messages}")
      | RuntimeError: Errors occurred: DENIED: Your Authorization Token is invalid.

```



**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation