### PR TITLE
feat: allow `Bearer` as valid token type on model service authentication (#2583)

### DIFF
--- a/changes/2583.feature.md
+++ b/changes/2583.feature.md
@@ -1,0 +1,1 @@
+Allow `Bearer` as valid token type on model service authentication

--- a/src/ai/backend/wsproxy/proxy/frontend/http/abc.py
+++ b/src/ai/backend/wsproxy/proxy/frontend/http/abc.py
@@ -48,7 +48,7 @@ class AbstractHTTPFrontend(Generic[TCircuitKey], AbstractFrontend[HTTPBackend, T
                 if not auth_header:
                     raise InvalidCredentials("E20006: Authorization header not provided")
                 auth_type, auth_key = auth_header.split(" ", maxsplit=2)
-                if auth_type == "BackendAI":
+                if auth_type in ("BackendAI", "Bearer"):
                     token = auth_key
                 else:
                     raise InvalidCredentials(
@@ -64,7 +64,7 @@ class AbstractHTTPFrontend(Generic[TCircuitKey], AbstractFrontend[HTTPBackend, T
                 except jwt.PyJWTError as e:
                     raise InvalidCredentials from e
 
-                if decoded.get("id") != circuit.id:
+                if decoded.get("id") != str(circuit.id):
                     raise InvalidCredentials("E20008: Authorization token mismatch")
 
     async def initialize_backend(self, circuit: Circuit, routes: list[RouteInfo]) -> HTTPBackend:


### PR DESCRIPTION
This is an auto-generated backport PR of #2583 to the 24.03 release.