### PR TITLE
fix: typo in minilang query field spec and column map (#2605)

### DIFF
--- a/changes/2605.fix.md
+++ b/changes/2605.fix.md
@@ -1,0 +1,1 @@
+Fix typo in minilang query field spec and column map.

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -238,9 +238,9 @@ class Agent(graphene.ObjectType):
         "status_changed": ("status_changed", dtparse),
         "region": ("region", None),
         "scaling_group": ("scaling_group", None),
-        "schedulable": ("schedulabe", None),
+        "schedulable": ("schedulable", None),
         "addr": ("addr", None),
-        "first_contact": ("first_contat", dtparse),
+        "first_contact": ("first_contact", dtparse),
         "lost_at": ("lost_at", dtparse),
         "version": ("version", None),
     }

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -931,7 +931,7 @@ class ComputeContainer(graphene.ObjectType):
         "cluster_hostname": ("cluster_hostname", None),
         "status": ("status", None),
         "status_info": ("status_info", None),
-        "status_changed": ("status_info", None),
+        "status_changed": ("status_changed", None),
         "created_at": ("created_at", None),
         "terminated_at": ("terminated_at", None),
         "scheduled_at": (JSONFieldItem("status_history", KernelStatus.SCHEDULED.name), None),


### PR DESCRIPTION
This is an auto-generated backport PR of #2605 to the 24.03 release.