### PR TITLE
feat: automate `model-store` project creation

### DIFF
--- a/changes/2611.feature.md
+++ b/changes/2611.feature.md
@@ -1,0 +1,1 @@
+Introduce automatic creation of a 'model-store' group upon inserting a new domain.

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -7,6 +7,7 @@ import graphene
 import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.dialects import postgresql as pgsql
+from sqlalchemy.engine.result import Result
 from sqlalchemy.engine.row import Row
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.orm import relationship
@@ -14,6 +15,7 @@ from sqlalchemy.orm import relationship
 from ai.backend.common import msgpack
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.models.group import ProjectType
 
 from ..defs import RESERVED_DOTFILES
 from .base import (
@@ -124,9 +126,11 @@ class Domain(graphene.ObjectType):
             is_active=row["is_active"],
             created_at=row["created_at"],
             modified_at=row["modified_at"],
-            total_resource_slots=row["total_resource_slots"].to_json()
-            if row["total_resource_slots"] is not None
-            else {},
+            total_resource_slots=(
+                row["total_resource_slots"].to_json()
+                if row["total_resource_slots"] is not None
+                else {}
+            ),
             allowed_vfolder_hosts=row["allowed_vfolder_hosts"].to_json(),
             allowed_docker_registries=row["allowed_docker_registries"],
             integration_id=row["integration_id"],
@@ -222,7 +226,26 @@ class CreateDomain(graphene.Mutation):
             "integration_id": props.integration_id,
         }
         insert_query = sa.insert(domains).values(data)
-        return await simple_db_mutate_returning_item(cls, ctx, insert_query, item_cls=Domain)
+
+        async def _post_func(conn: SAConnection, result: Result) -> Row:
+            from .group import groups
+
+            model_store_insert_query = sa.insert(groups).values({
+                "name": "model-store",
+                "description": "Model Store",
+                "is_active": True,
+                "domain_name": name,
+                "total_resource_slots": {},
+                "allowed_vfolder_hosts": {},
+                "integration_id": None,
+                "resource_policy": "default",
+                "type": ProjectType.MODEL_STORE,
+            })
+            await conn.execute(model_store_insert_query)
+
+        return await simple_db_mutate_returning_item(
+            cls, ctx, insert_query, item_cls=Domain, post_func=_post_func
+        )
 
 
 class ModifyDomain(graphene.Mutation):


### PR DESCRIPTION
This PR includes the addition of `sqlalchemy.engine.result.Result` import, `from ai.backend.manager.models.group import ProjectType`, and enhancements to the `from_row` class method of the Domain model. **These changes introduce automatic creation of a 'model-store' group upon inserting a new domain to database**, only when `CreateDomain` mutation is performed. The process involves modifying the `mutate` async method to include a `_post_func` that inserts a 'model-store' group into the groups table using the `ProjectType.MODEL_STORE` value. The `total_resource_slots` field handling has also been refactored for clarity.

related PR: https://github.com/lablup/backend.ai-control-panel/pull/810

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
