### PR TITLE
fix: Increase dropbear's `MAX_CMD_LEN` to improve PyCharm debugger compatibility

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Increase `MAX_CMD_LEN` of dropbear to improve compatibility with PyCharm debugger

--- a/scripts/agent/build-dropbear.sh
+++ b/scripts/agent/build-dropbear.sh
@@ -54,6 +54,7 @@ autoreconf
 sed -i 's/\(DEFAULT_RECV_WINDOW\) [0-9][0-9]*/\1 2097152/' default_options.h
 sed -i 's/\(RECV_MAX_PAYLOAD_LEN\) [0-9][0-9]*/\1 2621440/' default_options.h
 sed -i 's/\(TRANS_MAX_PAYLOAD_LEN\) [0-9][0-9]*/\1 2621440/' default_options.h
+sed -i 's/\(MAX_CMD_LEN\) [0-9][0-9]*/\1 20000/' sysoptions.h
 sed -i '/channel->transwindow -= len;/s/^/\/\//' common-channel.c
 sed -i 's/DEFAULT_PATH/getenv("PATH")/' svr-chansession.c
 


### PR DESCRIPTION
resolves lablup/giftbox#329

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
