### PR TITLE
fix: Allow regular users to assign agent manually when creating sessions

### DIFF
--- a/changes/2614.feature.md
+++ b/changes/2614.feature.md
@@ -1,1 +1,1 @@
-Loosen querying agent-specific information from client when `hide-agents` feature is set to false so that user could select agents on demand.
+Allow regular users to manually assign agents for session creation when `hide-agent` configuration is disabled

--- a/changes/2614.feature.md
+++ b/changes/2614.feature.md
@@ -1,0 +1,1 @@
+Loosen querying agent-specific information from client when `hide-agents` feature is set to false so that user could select agents on demand.

--- a/changes/2614.feature.md
+++ b/changes/2614.feature.md
@@ -1,1 +1,1 @@
-Allow regular users to manually assign agents for session creation when `hide-agent` configuration is disabled
+Allow regular users to assign agent manually if `hide-agent` configuration is disabled

--- a/changes/2614.fix.md
+++ b/changes/2614.fix.md
@@ -1,0 +1,1 @@
+Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas

--- a/changes/2614.fix.md
+++ b/changes/2614.fix.md
@@ -1,1 +1,0 @@
-Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas

--- a/src/ai/backend/client/cli/session/execute.py
+++ b/src/ai/backend/client/cli/session/execute.py
@@ -384,7 +384,6 @@ def prepare_mount_arg(
     type=list_expr,
     help=(
         "Show mapping list of tuple which mapped containers with agent. "
-        "When user role is Super Admin. "
         "(e.g., --assign-agent agent_id_1,agent_id_2,...)"
     ),
 )

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -134,7 +134,6 @@ def _create_cmd(docs: Optional[str] = None):
         type=list_expr,
         help=(
             "Assign the session to specific agents. "
-            "This option is only applicable when the user role is Super Admin. "
             "(e.g., --assign-agent agent_id_1,agent_id_2,...)"
         ),
     )

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -654,13 +654,18 @@ async def create_from_params(request: web.Request, params: dict[str, Any]) -> we
     else:
         raise InvalidAPIParameters("API version not supported")
     params["config"] = creation_config
-    if params["config"]["agent_list"] is not None and request["user"]["role"] != (
-        UserRole.SUPERADMIN
-    ):
-        raise InsufficientPrivilege(
-            "You are not allowed to manually assign agents for your session."
-        )
-    if request["user"]["role"] == (UserRole.SUPERADMIN):
+
+    root_ctx: RootContext = request.app["_root.context"]
+
+    # if params["config"]["agent_list"] is not None and request["user"]["role"] != (
+    #     UserRole.SUPERADMIN
+    # ):
+    #     raise InsufficientPrivilege(
+    #         "You are not allowed to manually assign agents for your session."
+    #     )
+    if not root_ctx.local_config["manager"][
+        "hide-agents"
+    ]:  # request["user"]["role"] == (UserRole.SUPERADMIN):
         if not params["config"]["agent_list"]:
             pass
         else:

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -25,6 +25,7 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    Optional,
     Set,
     Tuple,
     Union,
@@ -657,32 +658,29 @@ async def create_from_params(request: web.Request, params: dict[str, Any]) -> we
 
     root_ctx: RootContext = request.app["_root.context"]
 
-    # if params["config"]["agent_list"] is not None and request["user"]["role"] != (
-    #     UserRole.SUPERADMIN
-    # ):
-    #     raise InsufficientPrivilege(
-    #         "You are not allowed to manually assign agents for your session."
-    #     )
-    if not root_ctx.local_config["manager"][
-        "hide-agents"
-    ]:  # request["user"]["role"] == (UserRole.SUPERADMIN):
-        if not params["config"]["agent_list"]:
-            pass
+    agent_list = cast(Optional[list[str]], params["config"]["agent_list"])
+    if agent_list is not None:
+        if (
+            request["user"]["role"] != UserRole.SUPERADMIN
+            and root_ctx.local_config["manager"]["hide-agents"]
+        ):
+            raise InsufficientPrivilege(
+                "You are not allowed to manually assign agents for your session."
+            )
+        agent_count = len(agent_list)
+        if params["cluster_mode"] == "multi-node":
+            if agent_count != params["cluster_size"]:
+                raise InvalidAPIParameters(
+                    "For multi-node cluster sessions, the number of manually assigned"
+                    " agents must be same to the cluster size. Note that you may specify"
+                    " duplicate agents in the list.",
+                )
         else:
-            agent_count = len(params["config"]["agent_list"])
-            if params["cluster_mode"] == "multi-node":
-                if agent_count != params["cluster_size"]:
-                    raise InvalidAPIParameters(
-                        "For multi-node cluster sessions, the number of manually assigned"
-                        " agents must be same to the cluster size. Note that you may specify"
-                        " duplicate agents in the list.",
-                    )
-            else:
-                if agent_count != 1:
-                    raise InvalidAPIParameters(
-                        "For non-cluster sessions and single-node cluster sessions, "
-                        "you may specify only one manually assigned agent.",
-                    )
+            if agent_count != 1:
+                raise InvalidAPIParameters(
+                    "For non-cluster sessions and single-node cluster sessions, "
+                    "you may specify only one manually assigned agent.",
+                )
     return await _create(request, params)
 
 


### PR DESCRIPTION
related to 
- https://github.com/lablup/giftbox/issues/704
- https://github.com/lablup/backend.ai-webui/pull/2599

`hide-agents` configuration disallow regular users to get info of agents. When it is set to false, regular users should be allowed to get agent info and assign agents when creating compute sessions.

**Checklist:**
- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2614.org.readthedocs.build/en/2614/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2614.org.readthedocs.build/ko/2614/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2614.org.readthedocs.build/en/2614/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2614.org.readthedocs.build/ko/2614/

<!-- readthedocs-preview sorna-ko end -->