### PR TITLE
fix: typo in AgentSummary queryfilter fieldspec (#2610)

### DIFF
--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -526,7 +526,7 @@ class AgentSummary(graphene.ObjectType):
         "id": ("id", None),
         "status": ("status", enum_field_getter(AgentStatus)),
         "scaling_group": ("scaling_group", None),
-        "schedulable": ("schedulabe", None),
+        "schedulable": ("schedulable", None),
     }
 
     _queryorder_colmap: Mapping[str, OrderSpecItem] = {


### PR DESCRIPTION
This is an auto-generated backport PR of #2610 to the 24.03 release.