### PR TITLE
refactor: Base ContainerRegistry's `scan_tag` and implement `MEDIA_TYPE_DOCKER_MANIFEST` type handling

### DIFF
--- a/changes/2615.feature.md
+++ b/changes/2615.feature.md
@@ -1,0 +1,1 @@
+Implement ID-based client workflow to ContainerRegistry API.

--- a/changes/2620.feature.md
+++ b/changes/2620.feature.md
@@ -1,0 +1,1 @@
+Rafactor Base ContainerRegistry's `scan_tag` and implement `MEDIA_TYPE_DOCKER_MANIFEST` type handling.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -230,7 +230,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         self.agent_id = agent_id
         self.event_producer = event_producer
         self.kernel_config = kernel_config
-        self.image_ref = ImageRef.from_image_config(kernel_config["image"])
+        self.image_ref = kernel_image
         self.distro = distro
         self.internal_data = kernel_config["internal_data"] or {}
         self.computers = computers

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2356,7 +2356,7 @@ class AbstractAgent(
         return [port for port in service_ports if port["protocol"] != ServicePortProtocols.INTERNAL]
 
     @abstractmethod
-    async def extract_image_command(self, image_ref: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1351,7 +1351,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     try:
                         ImageRef.parse_image_str(repo_tag, "*")
                     except (InvalidImageName, InvalidImageTag) as e:
-                        log.warn(
+                        log.warning(
                             "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored. Details: {}",
                             repo_tag,
                             e,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1238,8 +1238,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
 
     async def extract_image_command(self, image: str) -> str | None:
         async with closing_async(Docker()) as docker:
-            image = await docker.images.get(image)
-            return image["Config"].get("Cmd")
+            result = await docker.images.get(image)
+            return result["Config"].get("Cmd")
 
     async def enumerate_containers(
         self,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1236,9 +1236,9 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             self.local_config, {name: cctx.instance for name, cctx in self.computers.items()}
         )
 
-    async def extract_image_command(self, image_ref: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | None:
         async with closing_async(Docker()) as docker:
-            image = await docker.images.get(image_ref)
+            image = await docker.images.get(image)
             return image["Config"].get("Cmd")
 
     async def enumerate_containers(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -51,7 +51,6 @@ from ai.backend.common.cgroup import get_cgroup_mount_point
 from ai.backend.common.docker import MAX_KERNELSPEC, MIN_KERNELSPEC, ImageRef
 from ai.backend.common.events import EventProducer, KernelLifecycleEventReason
 from ai.backend.common.exception import ImageNotAvailable, InvalidImageName, InvalidImageTag
-from ai.backend.common.logging import BraceStyleAdapter, pretty
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
 from ai.backend.common.types import (
     AgentId,

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -250,7 +250,7 @@ class DummyAgent(
     async def sync_container_lifecycles(self, interval: float) -> None:
         return
 
-    async def extract_command(self, image_ref: str) -> str | None:
+    async def extract_command(self, image: str) -> str | None:
         return None
 
     async def enumerate_containers(
@@ -270,7 +270,7 @@ class DummyAgent(
             self.local_config, {name: cctx.instance for name, cctx in self.computers.items()}
         )
 
-    async def extract_image_command(self, image_ref: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | None:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
         return "cr.backend.ai/stable/python:3.9-ubuntu20.04"

--- a/src/ai/backend/agent/kubernetes/utils.py
+++ b/src/ai/backend/agent/kubernetes/utils.py
@@ -20,14 +20,14 @@ class PersistentServiceContainer:
     def __init__(
         self,
         docker: Docker,
-        image_ref: str,
+        image: str,
         container_config: Mapping[str, Any],
         *,
         name: Optional[str] = None,
     ) -> None:
         self.docker = docker
-        self.image_ref = image_ref
-        default_container_name = image_ref.split(":")[0].rsplit("/", maxsplit=1)[-1]
+        self.image = image
+        default_container_name = image.split(":")[0].rsplit("/", maxsplit=1)[-1]
         if name is None:
             self.container_name = default_container_name
         else:
@@ -69,7 +69,7 @@ class PersistentServiceContainer:
 
     async def get_image_version(self) -> int:
         try:
-            img = await self.docker.images.inspect(self.image_ref)
+            img = await self.docker.images.inspect(self.image)
         except DockerError as e:
             if e.status == 404:
                 return 0
@@ -80,22 +80,22 @@ class PersistentServiceContainer:
     async def ensure_running_latest(self) -> None:
         image_version = await self.get_image_version()
         if image_version == 0:
-            log.info("PersistentServiceContainer({}): installing...", self.image_ref)
+            log.info("PersistentServiceContainer({}): installing...", self.image)
             await self.install_latest()
         elif image_version < self.img_version:
             log.info(
                 "PersistentServiceContainer({}): upgrading (v{} -> v{})",
-                self.image_ref,
+                self.image,
                 image_version,
                 self.img_version,
             )
             await self.install_latest()
         container_version, is_running = await self.get_container_version_and_status()
         if container_version == 0 or image_version != container_version or not is_running:
-            log.info("PersistentServiceContainer({}): recreating...", self.image_ref)
+            log.info("PersistentServiceContainer({}): recreating...", self.image)
             await self.recreate()
         if not is_running:
-            log.info("PersistentServiceContainer({}): starting...", self.image_ref)
+            log.info("PersistentServiceContainer({}): starting...", self.image)
             await self.start()
 
     async def install_latest(self) -> None:
@@ -112,7 +112,7 @@ class PersistentServiceContainer:
                     stderr = await proc.stderr.read()
                 raise RuntimeError(
                     "loading the image has failed!",
-                    self.image_ref,
+                    self.image,
                     proc.returncode,
                     stderr,
                 )
@@ -130,7 +130,7 @@ class PersistentServiceContainer:
             else:
                 raise
         container_config: dict[str, Any] = {
-            "Image": self.image_ref,
+            "Image": self.image,
             "Tty": True,
             "Privileged": False,
             "AttachStdin": False,

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import sys
-from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import (
@@ -16,6 +15,7 @@ from typing import (
     Final,
     Iterable,
     Mapping,
+    NamedTuple,
     Optional,
 )
 
@@ -347,7 +347,11 @@ class PlatformTagSet(Mapping):
         return self._data == other
 
 
-class ParsedImageStr(namedtuple("ParsedImageStr", ["registry", "project_and_image_name", "tag"])):
+class ParsedImageStr(NamedTuple):
+    registry: str
+    project_and_image_name: str
+    tag: str
+
     @property
     def canonical(self) -> str:
         return f"{self.registry}/{self.project_and_image_name}:{self.tag}"
@@ -357,10 +361,7 @@ class ParsedImageStr(namedtuple("ParsedImageStr", ["registry", "project_and_imag
         return f"{self.project_and_image_name}:{self.tag}"
 
     @property
-    def tag_set(self) -> tuple[str | None, PlatformTagSet]:
-        if self.tag is None:
-            return (None, PlatformTagSet([], self.project_and_image_name))
-
+    def tag_set(self) -> tuple[str, PlatformTagSet]:
         tags = self.tag.split("-")
         return (tags[0], PlatformTagSet(tags[1:], self.project_and_image_name))
 
@@ -523,9 +524,6 @@ class ImageRef:
         return image, tag
 
     def _update_tag_set(self):
-        if self.tag is None:
-            self._tag_set = (None, PlatformTagSet([], self.name))
-            return
         tags = self.tag.split("-")
         self._tag_set = (tags[0], PlatformTagSet(tags[1:], self.name))
 

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -408,7 +408,7 @@ class ImageRef:
                 f'Project "{project}" mismatch with the image canonical: {parsed.canonical}'
             )
 
-        image_name = parsed.project_and_image_name.split(f"{project}/")[-1]
+        image_name = parsed.project_and_image_name.split(f"{project}/", maxsplit=1)[1]
 
         return cls(
             name=image_name,

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -11,7 +11,6 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import (
-    TYPE_CHECKING,
     Final,
     Iterable,
     Mapping,
@@ -31,9 +30,6 @@ from .arch import arch_name_aliases
 from .exception import InvalidImageName, InvalidImageTag, ProjectMismatchWithCanonical
 from .service_ports import parse_service_ports
 from .utils import is_ip_address_format
-
-if TYPE_CHECKING:
-    pass
 
 __all__ = (
     "arch_name_aliases",

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -29,7 +29,7 @@ from ai.backend.logging import BraceStyleAdapter
 
 from . import validators as tx
 from .arch import arch_name_aliases
-from .exception import InvalidImageName, InvalidImageTag
+from .exception import InvalidImageName, InvalidImageTag, ProjectMismatchWithCanonical
 from .service_ports import parse_service_ports
 from .utils import is_ip_address_format
 
@@ -401,14 +401,12 @@ class ImageRef:
         # Image name part can be empty depending on the container registry,
         # however, we will not allow that case.
         if parsed.project_and_image_name == project:
-            reason = f'Empty image name is not allowed. Image canonical: "{parsed.canonical}", project: "{project}"'
-            log.warning(reason)
-            raise ValueError(reason)
+            raise InvalidImageName(
+                f'Empty image name is not allowed. Image canonical: "{parsed.canonical}", project: "{project}"'
+            )
 
         if not parsed.project_and_image_name.startswith(f"{project}/"):
-            raise ValueError(
-                f'Project "{project}" mismatch with the image canonical: {parsed.canonical}'
-            )
+            raise ProjectMismatchWithCanonical(project, parsed.canonical)
 
         image_name = parsed.project_and_image_name.split(f"{project}/", maxsplit=1)[1]
 

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -452,8 +452,8 @@ class ImageRef:
         1. Passing '*' to `registry` parse any characters before the first '/' as the registry part.
         2. Passing 'None' to `registry` use the default registry (`index.docker.io`).
            In this case, the `image_str` should be a combination of the project and image name without the registry part.
-        3. If the registry part of the `image_str` is in IP address format, it parses that value as the 'registry' regardless of the `registry` argument.
-        4. The function can not distinguish the 'project' and the 'image name', and returns them together.
+        3. If the registry part of the `image_str` is in IP address format, it parses that value as the registry part regardless of the `registry` argument.
+        4. The function can not distinguish the project and the image name.
         """
 
         if "://" in image_str or image_str.startswith("//"):

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -24,7 +24,6 @@ import trafaret as t
 import yarl
 from packaging import version
 
-from ai.backend.common.utils import is_ip_address_format
 from ai.backend.logging import BraceStyleAdapter
 
 from . import validators as tx

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -404,7 +404,7 @@ class ImageRef:
 
         if not parsed.project_and_image_name.startswith(f"{project}/"):
             raise ValueError(
-                f"project mismatch with the canonical: {parsed.project_and_image_name}"
+                f'Project "{project}" mismatch with the image canonical: {parsed.canonical}'
             )
 
         image_name = parsed.project_and_image_name.split(f"{project}/")[1]

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -418,25 +418,27 @@ class ImageRef:
             is_local=is_local,
         )
 
-    @staticmethod
-    def parse_image_tag(image: str, *, using_default_repository: bool = False) -> tuple[str, str]:
+    @classmethod
+    def parse_image_tag(
+        cls, image_str: str, *, using_default_repository: bool = False
+    ) -> tuple[str, str]:
         """
         Parses the image name and tag from the given image string.
 
         When the image does not contain '/', and `using_default_repository` is True, it includes the default_repository (lablup) in the image.
         """
-        image_tag = image.rsplit(":", maxsplit=1)
+        image_tag = image_str.rsplit(":", maxsplit=1)
         if len(image_tag) == 1:
-            image = image_tag[0]
+            image_str = image_tag[0]
             tag = "latest"
         else:
-            image = image_tag[0]
+            image_str = image_tag[0]
             tag = image_tag[1]
-        if not image:
+        if not image_str:
             raise InvalidImageName("Empty image repository/name")
-        if ("/" not in image) and using_default_repository:
-            image = default_repository + "/" + image
-        return image, tag
+        if ("/" not in image_str) and using_default_repository:
+            image_str = default_repository + "/" + image_str
+        return image_str, tag
 
     @classmethod
     def parse_image_str(cls, image_str: str, registry: str | None = None) -> ParsedImageStr:
@@ -444,13 +446,13 @@ class ImageRef:
         Parses a string representing an image.
 
         `image_str` can be a variety of strings, such as the image name, the name of the project the image belongs to, or the canonical name of the image.
-        For more details, please refer to `test_docker.py`.
+        For more details, please refer to the `tests/common/test_docker.py`.
 
         Here are some details about this function's behavior.
         1. Passing '*' to `registry` parse any characters before the first '/' as the registry part.
-        2. Passing 'None' to `registry` use the default registry.
-        In this case, the `image_str` is considered as the project and name without the registry part.
-        3. If the registry part of the `image_str` is in IP address format, it parses that value as the 'registry' regardless of the `registry` value.
+        2. Passing 'None' to `registry` use the default registry (`index.docker.io`).
+           In this case, the `image_str` should be a combination of the project and image name without the registry part.
+        3. If the registry part of the `image_str` is in IP address format, it parses that value as the 'registry' regardless of the `registry` argument.
         4. The function can not distinguish the 'project' and the 'image name', and returns them together.
         """
 

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -407,7 +407,7 @@ class ImageRef:
                 f'Project "{project}" mismatch with the image canonical: {parsed.canonical}'
             )
 
-        image_name = parsed.project_and_image_name.split(f"{project}/")[1]
+        image_name = parsed.project_and_image_name.split(f"{project}/")[-1]
 
         return cls(
             name=image_name,

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -278,18 +278,23 @@ async def login(
 
 
 def is_default_registry(registry_name: str, project: str) -> bool:
-    return project == "" and registry_name == default_registry
+    if project != "":
+        return False
+
+    return registry_name == default_registry
 
 
 def is_dockerhub_library_registry(
     project: str,
     known_registries: dict[str, dict[str, Any]] | list[str] | None,
 ) -> bool:
-    if project == "":
-        if isinstance(known_registries, list):
-            return "index.docker.io" in known_registries
-        if isinstance(known_registries, dict):
-            return "index.docker.io" in known_registries.get("library", [])
+    if project != "":
+        return False
+
+    if isinstance(known_registries, list):
+        return "index.docker.io" in known_registries
+    if isinstance(known_registries, dict):
+        return "index.docker.io" in known_registries.get("library", [])
 
     return False
 
@@ -297,7 +302,9 @@ def is_dockerhub_library_registry(
 def is_in_known_library_list(
     registry_name: str, known_registries: dict[str, dict[str, Any]] | list[str] | None
 ) -> bool:
-    return isinstance(known_registries, list) and registry_name in known_registries
+    if not isinstance(known_registries, list):
+        return False
+    return registry_name in known_registries
 
 
 def is_in_known_library_dict(
@@ -305,11 +312,10 @@ def is_in_known_library_dict(
     project: str,
     known_registries: dict[str, dict[str, Any]] | list[str] | None,
 ) -> bool:
-    return (
-        isinstance(known_registries, dict)
-        and project in known_registries
-        and registry_name in known_registries[project]
-    )
+    if not isinstance(known_registries, dict):
+        return False
+
+    return project in known_registries and registry_name in known_registries[project]
 
 
 def is_ip_address_format(registry_name: str) -> bool:

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -446,8 +446,10 @@ class ImageRef:
         """
         Parses a string representing an image.
 
-        `image_str` can be a variety of strings, such as the image name, the name of the project the image belongs to, or the canonical name of the image.
-        For more details, please refer to the `tests/common/test_docker.py`.
+        `image_str` basically follow the format below: `<registry>/<project>/<image name>:<version>-<tag>-<tag>...`
+        And if certain values are not provided (for example, if only the image name is given), hardcoded default values will be used.
+        Tags must begin with a letter and cannot end with a hyphen. And since hyphens are used to separate tags, a tag cannot contain a hyphen within itself.
+        For more details, you can refer to the `tests/common/test_docker.py`.
 
         Here are some details about this function's behavior.
         1. Passing '*' to `registry` parse any characters before the first '/' as the registry part.

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -605,8 +605,10 @@ class ImageRef:
     def __lt__(self, other) -> bool:
         if self == other:  # call __eq__ first for resolved check
             return False
-        if self.name != other.name:
-            raise ValueError("only the image-refs with same names can be compared.")
+        if not (self.name == other.name and self.project == other.project):
+            raise ValueError(
+                "Only the image-refs with the same names and projects can be compared."
+            )
         if self.tag_set[0] != other.tag_set[0]:
             return version.parse(self.tag_set[0]) < version.parse(other.tag_set[0])
         ptagset_self, ptagset_other = self.tag_set[1], other.tag_set[1]

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -33,7 +33,7 @@ from .service_ports import parse_service_ports
 from .utils import is_ip_address_format
 
 if TYPE_CHECKING:
-    from .types import ImageConfig
+    pass
 
 __all__ = (
     "arch_name_aliases",
@@ -503,15 +503,6 @@ class ImageRef:
     ) -> None:
         self.architecture = arch_name_aliases.get(self.architecture, self.architecture)
         self._update_tag_set()
-
-    @classmethod
-    def from_image_config(cls, config: ImageConfig) -> ImageRef:
-        return ImageRef(
-            config["canonical"],
-            known_registries=[config["registry"]["name"]],
-            is_local=config["is_local"],
-            architecture=config["architecture"],
-        )
 
     @staticmethod
     def _parse_image_tag(s: str, using_default_registry: bool = False) -> tuple[str, str]:

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -401,7 +401,9 @@ class ImageRef:
         # Image name part can be empty depending on the container registry,
         # however, we will not allow that case.
         if parsed.project_and_image_name == project:
-            raise ValueError("Empty image name is not allowed.")
+            reason = f'Empty image name is not allowed. Image canonical: "{parsed.canonical}", project: "{project}"'
+            log.warning(reason)
+            raise ValueError(reason)
 
         if not parsed.project_and_image_name.startswith(f"{project}/"):
             raise ValueError(

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -48,20 +48,6 @@ class InvalidImageName(ValueError):
         return f"Invalid image name: {self.args[0]}"
 
 
-class ProjectMismatchWithCanonical(ValueError):
-    """
-    Represent the project value does not match the canonical value when parsing the string representing the image in ImageRef.
-    """
-
-    def __init__(self, project: str, canonical: str) -> None:
-        super().__init__(project, canonical)
-        self._project = project
-        self._canonical = canonical
-
-    def __str__(self) -> str:
-        return f'Project "{self._project}" mismatch with the image canonical: {self._canonical}'
-
-
 class InvalidImageTag(ValueError):
     """
     Represents an invalid string for image tag and full image name.
@@ -82,6 +68,20 @@ class InvalidImageTag(ValueError):
             return f"Invalid or duplicate image name tag: {self._tag}, full image name: {self._full_name}"
         else:
             return f"Invalid or duplicate image name tag: {self._tag}"
+
+
+class ProjectMismatchWithCanonical(ValueError):
+    """
+    Represent the project value does not match the canonical value when parsing the string representing the image in ImageRef.
+    """
+
+    def __init__(self, project: str, canonical: str) -> None:
+        super().__init__(project, canonical)
+        self._project = project
+        self._canonical = canonical
+
+    def __str__(self) -> str:
+        return f'Project "{self._project}" mismatch with the image canonical: {self._canonical}'
 
 
 class AliasResolutionFailed(ValueError):

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -48,6 +48,20 @@ class InvalidImageName(ValueError):
         return f"Invalid image name: {self.args[0]}"
 
 
+class ProjectMismatchWithCanonical(ValueError):
+    """
+    Represent the project value does not match the canonical value when parsing the string representing the image in ImageRef.
+    """
+
+    def __init__(self, project: str, canonical: str) -> None:
+        super().__init__(project, canonical)
+        self._project = project
+        self._canonical = canonical
+
+    def __str__(self) -> str:
+        return f'Project "{self._project}" mismatch with the image canonical: {self._canonical}'
+
+
 class InvalidImageTag(ValueError):
     """
     Represents an invalid string for image tag and full image name.

--- a/src/ai/backend/common/msgpack.py
+++ b/src/ai/backend/common/msgpack.py
@@ -14,8 +14,6 @@ from typing import Any
 import msgpack as _msgpack
 import temporenc
 
-from ai.backend.common.docker import ImageRef
-
 from .types import BinarySize, ResourceSlot
 
 __all__ = ("packb", "unpackb")

--- a/src/ai/backend/common/msgpack.py
+++ b/src/ai/backend/common/msgpack.py
@@ -35,6 +35,8 @@ class ExtTypes(enum.IntEnum):
 
 
 def _default(obj: object) -> _msgpack.ExtType:
+    from .docker import ImageRef
+
     match obj:
         case tuple():
             return list(obj)

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1004,7 +1004,6 @@ class ImageRegistry(TypedDict):
     url: str
     username: Optional[str]
     password: Optional[str]
-    project: str
 
 
 class ImageConfig(TypedDict):

--- a/src/ai/backend/common/utils.py
+++ b/src/ai/backend/common/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import ipaddress
 import numbers
 import random
 import re
@@ -25,6 +26,7 @@ from typing import (
 )
 
 import aiofiles
+import yarl
 from async_timeout import timeout
 
 if TYPE_CHECKING:
@@ -405,3 +407,13 @@ async def umount(
             fstab = Fstab(fp)
             await fstab.remove_by_mountpoint(str(mountpoint))
     return True
+
+
+def is_ip_address_format(str: str) -> bool:
+    try:
+        url = yarl.URL("//" + str)
+        if url.host and ipaddress.ip_address(url.host):
+            return True
+        return False
+    except ValueError:
+        return False

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1493,7 +1493,9 @@ type Mutations {
   disassociate_all_scaling_groups_with_group(user_group: UUID!): DisassociateAllScalingGroupsWithGroup
   set_quota_scope(props: QuotaScopeInput!, quota_scope_id: String!, storage_host_name: String!): SetQuotaScope
   unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope
-  create_container_registry(
+
+  """Added in 24.09.0."""
+  create_container_registry_node(
     """Added in 24.09.0."""
     is_global: Boolean
 
@@ -1519,8 +1521,10 @@ type Mutations {
 
     """Added in 24.09.0."""
     username: String
-  ): CreateContainerRegistry
-  modify_container_registry(
+  ): CreateContainerRegistryNode
+
+  """Added in 24.09.0."""
+  modify_container_registry_node(
     """Object id. Can be either global id or object id. Added in 24.09.0."""
     id: String!
 
@@ -1549,11 +1553,16 @@ type Mutations {
 
     """Added in 24.09.0."""
     username: String
-  ): ModifyContainerRegistry
-  delete_container_registry(
+  ): ModifyContainerRegistryNode
+
+  """Added in 24.09.0."""
+  delete_container_registry_node(
     """Object id. Can be either global id or object id. Added in 24.09.0."""
     id: String!
-  ): DeleteContainerRegistry
+  ): DeleteContainerRegistryNode
+  create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry
+  modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
+  delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
 }
 
@@ -2206,16 +2215,55 @@ type UnsetQuotaScope {
   quota_scope: QuotaScope
 }
 
-type CreateContainerRegistry {
+"""Added in 24.09.0."""
+type CreateContainerRegistryNode {
   container_registry: ContainerRegistryNode
+}
+
+"""Added in 24.09.0."""
+type ModifyContainerRegistryNode {
+  container_registry: ContainerRegistryNode
+}
+
+"""Added in 24.09.0."""
+type DeleteContainerRegistryNode {
+  container_registry: ContainerRegistryNode
+}
+
+type CreateContainerRegistry {
+  container_registry: ContainerRegistry
+}
+
+input CreateContainerRegistryInput {
+  url: String!
+  type: String!
+  project: [String]
+  username: String
+  password: String
+  ssl_verify: Boolean
+
+  """Added in 24.09.0."""
+  is_global: Boolean
 }
 
 type ModifyContainerRegistry {
-  container_registry: ContainerRegistryNode
+  container_registry: ContainerRegistry
+}
+
+input ModifyContainerRegistryInput {
+  url: String
+  type: String
+  project: [String]
+  username: String
+  password: String
+  ssl_verify: Boolean
+
+  """Added in 24.09.0."""
+  is_global: Boolean
 }
 
 type DeleteContainerRegistry {
-  container_registry: ContainerRegistryNode
+  container_registry: ContainerRegistry
 }
 
 type ModifyEndpoint {

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -158,8 +158,18 @@ type Queries {
   endpoint_token(token: String!): EndpointToken
   endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList
   quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
-  container_registry(hostname: String!): ContainerRegistry
-  container_registries: [ContainerRegistry]
+
+  """Added in 24.09.0."""
+  container_registry(id: UUID!): ContainerRegistry
+
+  """Added in 24.09.0."""
+  container_registries(registry_name: String!): [ContainerRegistry]
+
+  """Added in 24.09.0."""
+  container_registry_node(id: String!): ContainerRegistry
+
+  """Added in 24.09.0."""
+  container_registry_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ContainerRegistryConnection
 
   """Added in 24.03.0."""
   model_card(id: String!): ModelCard
@@ -1231,20 +1241,57 @@ type QuotaDetails {
 type ContainerRegistry implements Node {
   """The ID of the object"""
   id: ID!
-  hostname: String
   config: ContainerRegistryConfig
 }
 
 type ContainerRegistryConfig {
+  """Added in 24.09.0."""
   url: String!
-  type: String!
-  project: [String]
-  username: String
-  password: String
-  ssl_verify: Boolean
+
+  """Added in 24.09.0."""
+  type: ContainerRegistryTypeField!
+
+  """Added in 24.09.0."""
+  registry_name: String!
 
   """Added in 24.09.0."""
   is_global: Boolean
+
+  """Added in 24.09.0."""
+  project: String
+
+  """Added in 24.09.0."""
+  username: String
+
+  """Added in 24.09.0."""
+  password: String
+
+  """Added in 24.09.0."""
+  ssl_verify: Boolean
+}
+
+"""Added in 24.09.0."""
+scalar ContainerRegistryTypeField
+
+"""Added in 24.09.0."""
+type ContainerRegistryConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ContainerRegistryEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""A Relay edge containing a `ContainerRegistry` and its cursor."""
+type ContainerRegistryEdge {
+  """The item at the end of the edge"""
+  node: ContainerRegistry
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 type ModelCard implements Node {
@@ -1427,9 +1474,12 @@ type Mutations {
   disassociate_all_scaling_groups_with_group(user_group: UUID!): DisassociateAllScalingGroupsWithGroup
   set_quota_scope(props: QuotaScopeInput!, quota_scope_id: String!, storage_host_name: String!): SetQuotaScope
   unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope
-  create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry
-  modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
-  delete_container_registry(hostname: String!): DeleteContainerRegistry
+  create_container_registry(
+    """Added in 24.09.0."""
+    props: CreateContainerRegistryInput!
+  ): CreateContainerRegistry
+  modify_container_registry(props: ModifyContainerRegistryInput!): ModifyContainerRegistry
+  delete_container_registry(props: DeleteContainerRegistryInput!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
 }
 
@@ -2083,19 +2133,36 @@ type UnsetQuotaScope {
 }
 
 type CreateContainerRegistry {
+  id: UUID!
   container_registry: ContainerRegistry
 }
 
 input CreateContainerRegistryInput {
+  """Added in 24.09.0."""
   url: String!
-  type: String!
-  project: [String]
-  username: String
-  password: String
-  ssl_verify: Boolean
+
+  """
+  Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
+  """
+  type: ContainerRegistryTypeField!
+
+  """Added in 24.09.0."""
+  registry_name: String!
 
   """Added in 24.09.0."""
   is_global: Boolean
+
+  """Added in 24.09.0."""
+  project: String
+
+  """Added in 24.09.0."""
+  username: String
+
+  """Added in 24.09.0."""
+  password: String
+
+  """Added in 24.09.0."""
+  ssl_verify: Boolean
 }
 
 type ModifyContainerRegistry {
@@ -2103,19 +2170,44 @@ type ModifyContainerRegistry {
 }
 
 input ModifyContainerRegistryInput {
+  """Object id. Can be either global id or object id. Added in 24.09.0."""
+  id: String!
+
+  """Added in 24.09.0."""
   url: String
-  type: String
-  project: [String]
-  username: String
-  password: String
-  ssl_verify: Boolean
+
+  """
+  Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
+  """
+  type: ContainerRegistryTypeField
+
+  """Added in 24.09.0."""
+  registry_name: String
 
   """Added in 24.09.0."""
   is_global: Boolean
+
+  """Added in 24.09.0."""
+  project: String
+
+  """Added in 24.09.0."""
+  username: String
+
+  """Added in 24.09.0."""
+  password: String
+
+  """Added in 24.09.0."""
+  ssl_verify: Boolean
 }
 
 type DeleteContainerRegistry {
   container_registry: ContainerRegistry
+}
+
+"""Added in 24.09.0."""
+input DeleteContainerRegistryInput {
+  """Object id. Can be either global id or object id. Added in 24.09.0."""
+  id: String!
 }
 
 type ModifyEndpoint {

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -158,15 +158,11 @@ type Queries {
   endpoint_token(token: String!): EndpointToken
   endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList
   quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
+  container_registry(hostname: String!): ContainerRegistry
+  container_registries: [ContainerRegistry]
 
   """Added in 24.09.0."""
-  container_registry(id: UUID!): ContainerRegistry
-
-  """Added in 24.09.0."""
-  container_registries(registry_name: String!): [ContainerRegistry]
-
-  """Added in 24.09.0."""
-  container_registry_node(id: String!): ContainerRegistry
+  container_registry_node(id: String!): ContainerRegistryNode
 
   """Added in 24.09.0."""
   container_registry_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ContainerRegistryConnection
@@ -1241,10 +1237,33 @@ type QuotaDetails {
 type ContainerRegistry implements Node {
   """The ID of the object"""
   id: ID!
+  hostname: String
   config: ContainerRegistryConfig
 }
 
 type ContainerRegistryConfig {
+  url: String!
+  type: String!
+  project: [String]
+  username: String
+  password: String
+  ssl_verify: Boolean
+
+  """Added in 24.09.0."""
+  is_global: Boolean
+}
+
+"""Added in 24.09.0."""
+type ContainerRegistryNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """
+  Added in 24.09.0. The undecoded UUID type id of DB container_registries row.
+  """
+  row_id: UUID
+  name: String
+
   """Added in 24.09.0."""
   url: String!
 
@@ -1288,7 +1307,7 @@ type ContainerRegistryConnection {
 """A Relay edge containing a `ContainerRegistry` and its cursor."""
 type ContainerRegistryEdge {
   """The item at the end of the edge"""
-  node: ContainerRegistry
+  node: ContainerRegistryNode
 
   """A cursor for use in pagination"""
   cursor: String!
@@ -1476,10 +1495,65 @@ type Mutations {
   unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope
   create_container_registry(
     """Added in 24.09.0."""
-    props: CreateContainerRegistryInput!
+    is_global: Boolean
+
+    """Added in 24.09.0."""
+    password: String
+
+    """Added in 24.09.0."""
+    project: String
+
+    """Added in 24.09.0."""
+    registry_name: String!
+
+    """Added in 24.09.0."""
+    ssl_verify: Boolean
+
+    """
+    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'local').
+    """
+    type: ContainerRegistryTypeField!
+
+    """Added in 24.09.0."""
+    url: String!
+
+    """Added in 24.09.0."""
+    username: String
   ): CreateContainerRegistry
-  modify_container_registry(props: ModifyContainerRegistryInput!): ModifyContainerRegistry
-  delete_container_registry(props: DeleteContainerRegistryInput!): DeleteContainerRegistry
+  modify_container_registry(
+    """Object id. Can be either global id or object id. Added in 24.09.0."""
+    id: String!
+
+    """Added in 24.09.0."""
+    is_global: Boolean
+
+    """Added in 24.09.0."""
+    password: String
+
+    """Added in 24.09.0."""
+    project: String
+
+    """Added in 24.09.0."""
+    registry_name: String
+
+    """Added in 24.09.0."""
+    ssl_verify: Boolean
+
+    """
+    Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
+    """
+    type: ContainerRegistryTypeField
+
+    """Added in 24.09.0."""
+    url: String
+
+    """Added in 24.09.0."""
+    username: String
+  ): ModifyContainerRegistry
+  delete_container_registry(
+    """Object id. Can be either global id or object id. Added in 24.09.0."""
+    id: String!
+  ): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
 }
 
@@ -2133,81 +2207,15 @@ type UnsetQuotaScope {
 }
 
 type CreateContainerRegistry {
-  id: UUID!
-  container_registry: ContainerRegistry
-}
-
-input CreateContainerRegistryInput {
-  """Added in 24.09.0."""
-  url: String!
-
-  """
-  Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
-  """
-  type: ContainerRegistryTypeField!
-
-  """Added in 24.09.0."""
-  registry_name: String!
-
-  """Added in 24.09.0."""
-  is_global: Boolean
-
-  """Added in 24.09.0."""
-  project: String
-
-  """Added in 24.09.0."""
-  username: String
-
-  """Added in 24.09.0."""
-  password: String
-
-  """Added in 24.09.0."""
-  ssl_verify: Boolean
+  container_registry: ContainerRegistryNode
 }
 
 type ModifyContainerRegistry {
-  container_registry: ContainerRegistry
-}
-
-input ModifyContainerRegistryInput {
-  """Object id. Can be either global id or object id. Added in 24.09.0."""
-  id: String!
-
-  """Added in 24.09.0."""
-  url: String
-
-  """
-  Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
-  """
-  type: ContainerRegistryTypeField
-
-  """Added in 24.09.0."""
-  registry_name: String
-
-  """Added in 24.09.0."""
-  is_global: Boolean
-
-  """Added in 24.09.0."""
-  project: String
-
-  """Added in 24.09.0."""
-  username: String
-
-  """Added in 24.09.0."""
-  password: String
-
-  """Added in 24.09.0."""
-  ssl_verify: Boolean
+  container_registry: ContainerRegistryNode
 }
 
 type DeleteContainerRegistry {
-  container_registry: ContainerRegistry
-}
-
-"""Added in 24.09.0."""
-input DeleteContainerRegistryInput {
-  """Object id. Can be either global id or object id. Added in 24.09.0."""
-  id: String!
+  container_registry: ContainerRegistryNode
 }
 
 type ModifyEndpoint {

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1304,7 +1304,9 @@ type ContainerRegistryConnection {
   count: Int
 }
 
-"""A Relay edge containing a `ContainerRegistry` and its cursor."""
+"""
+Added in 24.09.0. A Relay edge containing a `ContainerRegistry` and its cursor.
+"""
 type ContainerRegistryEdge {
   """The item at the end of the edge"""
   node: ContainerRegistryNode

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -282,6 +282,9 @@ type ImageNode implements Node {
   """Added in 24.03.4. The undecoded id value stored in DB."""
   row_id: UUID
   name: String
+
+  """Added in 24.03.10."""
+  project: String
   humanized_name: String
   tag: String
   registry: String
@@ -496,6 +499,9 @@ type Group {
 type Image {
   id: UUID
   name: String
+
+  """Added in 24.03.10."""
+  project: String
   humanized_name: String
   tag: String
   registry: String

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -45,6 +45,7 @@ from ai.backend.common.types import (
     AccessKey,
     AgentId,
     ClusterMode,
+    ImageAlias,
     RuntimeVariant,
     SessionTypes,
     VFolderMount,
@@ -530,8 +531,12 @@ async def create(request: web.Request, params: NewServiceRequestModel) -> ServeI
     validation_result = await _validate(request, params)
 
     async with root_ctx.db.begin_readonly_session() as session:
-        image_row = await ImageRow.resolve_by_identifier(
-            session, ImageIdentifier(params.image, params.architecture)
+        image_row = await ImageRow.resolve(
+            session,
+            [
+                ImageIdentifier(params.image, params.architecture),
+                ImageAlias(params.image),
+            ],
         )
 
     creation_config = params.config.model_dump()
@@ -644,8 +649,12 @@ async def try_start(request: web.Request, params: NewServiceRequestModel) -> Try
     validation_result = await _validate(request, params)
 
     async with root_ctx.db.begin_readonly_session() as session:
-        image_row = await ImageRow.resolve_by_identifier(
-            session, ImageIdentifier(params.image, params.architecture)
+        image_row = await ImageRow.resolve(
+            session,
+            [
+                ImageIdentifier(params.image, params.architecture),
+                ImageAlias(params.image),
+            ],
         )
         query = sa.select(sa.join(UserRow, KeyPairRow, KeyPairRow.user == UserRow.uuid)).where(
             UserRow.uuid == request["user"]["uuid"]

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1186,7 +1186,7 @@ async def convert_session_to_image(
                 x for x in base_image_ref.tag.split("-") if not x.startswith("customized_")
             ]
 
-            new_canonical = f"{registry_hostname}/{base_image_ref.project}/{base_image_ref.name}:{'-'.join(filtered_tag_set)}"
+            new_canonical = f"{registry_hostname}/{base_image_ref.project}/{base_image_ref.name}:{"-".join(filtered_tag_set)}"
 
             async with root_ctx.db.begin_readonly_session() as sess:
                 # check if user has passed its limit of customized image count
@@ -1235,11 +1235,11 @@ async def convert_session_to_image(
                 else:
                     customized_image_id = str(uuid.uuid4())
 
-            new_canonical += f"-customized_{customized_image_id.replace('-', '')}"
-            new_image_ref = ImageRef.parse(
+            new_canonical += f"-customized_{customized_image_id.replace("-", "")}"
+            new_image_ref = ImageRef.from_image_str(
                 new_canonical,
                 base_image_ref.project,
-                known_registries=["*"],
+                base_image_ref.registry,
                 architecture=base_image_ref.architecture,
                 is_local=base_image_ref.is_local,
             )

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -72,6 +72,7 @@ from ai.backend.common.types import (
     AccessKey,
     AgentId,
     ClusterMode,
+    ImageAlias,
     ImageRegistry,
     KernelId,
     MountPermission,
@@ -355,12 +356,15 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
 
     try:
         async with root_ctx.db.begin_session() as session:
-            image_row = await ImageRow.resolve_by_identifier(
+            image_row = await ImageRow.resolve(
                 session,
-                ImageIdentifier(
-                    params["image"],
-                    params["architecture"],
-                ),
+                [
+                    ImageIdentifier(
+                        params["image"],
+                        params["architecture"],
+                    ),
+                    ImageAlias(params["image"]),
+                ],
             )
 
         resp = await root_ctx.registry.create_session(

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1280,7 +1280,6 @@ async def convert_session_to_image(
                     url=str(registry_conf.url),
                     username=registry_conf.username,
                     password=registry_conf.password,
-                    project=registry_conf.project,
                 )
                 resp = await root_ctx.registry.push_image(
                     session.main_kernel.agent,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1174,7 +1174,12 @@ async def convert_session_to_image(
                 f"Project {registry_project} not found in registry {registry_hostname}."
             )
 
-    base_image_ref = await session.main_kernel.get_image_ref(root_ctx.db)
+    async with root_ctx.db.begin_readonly_session() as db_sess:
+        image_row = await ImageRow.resolve(
+            db_sess, [ImageIdentifier(session.main_kernel.image, session.main_kernel.architecture)]
+        )
+
+    base_image_ref = image_row.image_ref
     image_owner_id = request["user"]["uuid"]
 
     async def _commit_and_upload(reporter: ProgressReporter) -> None:

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1162,6 +1162,7 @@ async def convert_session_to_image(
                     ContainerRegistryRow.url,
                     ContainerRegistryRow.username,
                     ContainerRegistryRow.password,
+                    ContainerRegistryRow.project,
                 )
             )
         )

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -124,19 +124,18 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 is_local = self.registry_name == "local"
 
                 for image_row in existing_images:
-                    key = image_row.image_ref
-                    values = _all_updates.get(key)
-                    if values is None:
+                    image_ref = image_row.image_ref
+                    update_key = ImageIdentifier(image_ref.canonical, image_ref.architecture)
+                    update = _all_updates.get(update_key)
+                    if update is None:
                         continue
-                    _all_updates.pop(ImageIdentifier(key.canonical, key.architecture))
-                    image_row.config_digest = values["config_digest"]
-                    image_row.size_bytes = values["size_bytes"]
-                    image_row.accelerators = values.get("accels")
-                    image_row.labels = values["labels"]
+                    _all_updates.pop(update_key)
+                    image_row.config_digest = update["config_digest"]
+                    image_row.size_bytes = update["size_bytes"]
+                    image_row.accelerators = update.get("accels")
+                    image_row.labels = update["labels"]
+                    image_row.resources = update["resources"]
                     image_row.is_local = is_local
-                    image_row.resources = values["resources"]
-                    # TODO ? - Check if this work
-                    image_row.project = values["project"]
 
                 registry_cache: dict[str, list[ContainerRegistryRow]] = {}
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -149,6 +149,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         except ValueError as e:
                             skip_reason = str(e)
                             progress_msg = f"Skipped image - {image_identifier.canonical}/{image_identifier.architecture} ({skip_reason})"
+                            continue
 
                         session.add(
                             ImageRow(

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -13,6 +13,7 @@ import aiotools
 import sqlalchemy as sa
 import trafaret as t
 import yarl
+from sqlalchemy.orm import load_only
 
 from ai.backend.common.bgtask import ProgressReporter
 from ai.backend.common.docker import (

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -144,8 +144,8 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                                     ContainerRegistryRow.url,
                                 )
                             )
-                        ).all()
-                    ),
+                        )
+                    ).all(),
                 )
 
                 for image_identifier, update in _all_updates.items():

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -126,16 +126,13 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 for image_row in existing_images:
                     image_ref = image_row.image_ref
                     update_key = ImageIdentifier(image_ref.canonical, image_ref.architecture)
-                    update = _all_updates.get(update_key)
-                    if update is None:
-                        continue
-                    _all_updates.pop(update_key)
-                    image_row.config_digest = update["config_digest"]
-                    image_row.size_bytes = update["size_bytes"]
-                    image_row.accelerators = update.get("accels")
-                    image_row.labels = update["labels"]
-                    image_row.resources = update["resources"]
-                    image_row.is_local = is_local
+                    if update := _all_updates.pop(update_key, None):
+                        image_row.config_digest = update["config_digest"]
+                        image_row.size_bytes = update["size_bytes"]
+                        image_row.accelerators = update.get("accels")
+                        image_row.labels = update["labels"]
+                        image_row.resources = update["resources"]
+                        image_row.is_local = is_local
 
                 registry_cache: dict[str, list[ContainerRegistryRow]] = {}
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -150,7 +150,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         registries,
                     )
 
-                    if registry := next(matching_registries):
+                    if registry := next(matching_registries, None):
                         session.add(
                             ImageRow(
                                 name=parsed_img.canonical,

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -154,9 +154,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                             parsed_img = ImageRef.from_image_str(
                                 image_identifier.canonical, registry.project, registry.registry_name
                             )
-                        except ValueError as e:
-                            skip_reason = str(e)
-                            progress_msg = f"Skipped image - {image_identifier.canonical}/{image_identifier.architecture} ({skip_reason})"
+                        except ValueError:
                             continue
 
                         session.add(

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -189,7 +189,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         break
 
                     else:
-                        skip_reason = "No registry found"
+                        skip_reason = "No container registry found matching the image."
                         progress_msg = f"Skipped image - {image_identifier.canonical}/{image_identifier.architecture} ({skip_reason})"
                         log.warning(progress_msg)
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -152,10 +152,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                             log.warning(progress_msg)
                             break
 
-                        # Assume empty project value as matching with all other projects
-                        if registry.project == "" or parsed_img.project_and_image_name.startswith(
-                            registry.project + "/"
-                        ):
+                        if parsed_img.project_and_image_name.startswith(registry.project + "/"):
                             session.add(
                                 ImageRow(
                                     name=parsed_img.canonical,

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -144,6 +144,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                     parsed_img = ParsedImageStr.parse(image_identifier.canonical, ["*"])
 
                     matching_registries = filter(
+                        # Assume empty project value as matching with all other projects
                         lambda reg: reg.project == ""
                         or parsed_img.project_and_image_name.startswith(reg.project + "/"),
                         registries,
@@ -169,7 +170,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                             )
                         )
                     else:
-                        log.warning("No project found for image: {}", parsed_img.canonical)
+                        log.warning("No registry found for image: {}", parsed_img.canonical)
 
                 await session.flush()
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -133,12 +133,20 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         image_row.resources = update["resources"]
                         image_row.is_local = is_local
 
-                query = sa.select([
-                    ContainerRegistryRow.id,
-                    ContainerRegistryRow.project,
-                    ContainerRegistryRow.registry_name,
-                ])
-                registries = (await session.execute(query)).fetchall()
+                registries = cast(
+                    list[ContainerRegistryRow],
+                    (
+                        await session.scalars(
+                            sa.select(ContainerRegistryRow).options(
+                                load_only(
+                                    ContainerRegistryRow.project,
+                                    ContainerRegistryRow.registry_name,
+                                    ContainerRegistryRow.url,
+                                )
+                            )
+                        ).all()
+                    ),
+                )
 
                 for image_identifier, update in _all_updates.items():
                     for registry in registries:

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -263,15 +263,15 @@ class HarborRegistry_v2(BaseContainerRegistry):
                             match image_info["manifest_media_type"]:
                                 case self.MEDIA_TYPE_OCI_INDEX:
                                     await self._process_oci_index(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                                     await self._process_docker_v2_multiplatform_image(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case self.MEDIA_TYPE_DOCKER_MANIFEST:
                                     await self._process_docker_v2_image(
-                                        tg, sess, rqst_args, image, image_info
+                                        tg, sess, rqst_args, image, tag, image_info
                                     )
                                 case _ as media_type:
                                     raise RuntimeError(
@@ -312,15 +312,19 @@ class HarborRegistry_v2(BaseContainerRegistry):
             resp.raise_for_status()
             resp_json = await resp.json()
             async with aiotools.TaskGroup() as tg:
+                tag = resp_json["tags"][0]["name"]
+
                 match resp_json["manifest_media_type"]:
                     case self.MEDIA_TYPE_OCI_INDEX:
-                        await self._process_oci_index(tg, sess, rqst_args, image, resp_json)
+                        await self._process_oci_index(tg, sess, rqst_args, image, tag, resp_json)
                     case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                         await self._process_docker_v2_multiplatform_image(
-                            tg, sess, rqst_args, image, resp_json
+                            tg, sess, rqst_args, image, tag, resp_json
                         )
                     case self.MEDIA_TYPE_DOCKER_MANIFEST:
-                        await self._process_docker_v2_image(tg, sess, rqst_args, image, resp_json)
+                        await self._process_docker_v2_image(
+                            tg, sess, rqst_args, image, tag, resp_json
+                        )
                     case _ as media_type:
                         raise RuntimeError(f"Unsupported artifact media-type: {media_type}")
 
@@ -330,6 +334,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -337,7 +342,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             rqst_args["headers"] = {}
         rqst_args["headers"].update({"Accept": "application/vnd.oci.image.manifest.v1+json"})
         digests: list[tuple[str, str]] = []
-        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
@@ -355,7 +359,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                         rqst_args,
                         image,
                         digest=digest,
-                        tag=tag_name,
+                        tag=tag,
                         architecture=architecture,
                     )
                 )
@@ -366,6 +370,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -375,7 +380,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             "Accept": "application/vnd.docker.distribution.manifest.v2+json"
         })
         digests: list[tuple[str, str]] = []
-        tag_name = image_info["tags"][0]["name"]
         for reference in image_info["references"]:
             if (
                 reference["platform"]["os"] == "unknown"
@@ -393,7 +397,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
                         rqst_args,
                         image,
                         digest=digest,
-                        tag=tag_name,
+                        tag=tag,
                         architecture=architecture,
                     )
                 )
@@ -404,6 +408,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
         sess: aiohttp.ClientSession,
         _rqst_args: Mapping[str, Any],
         image: str,
+        tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         rqst_args = dict(_rqst_args)
@@ -414,14 +419,13 @@ class HarborRegistry_v2(BaseContainerRegistry):
         })
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
-        tag_name = image_info["tags"][0]["name"]
         async with aiotools.TaskGroup() as tg:
             tg.create_task(
                 self._harbor_scan_tag_single_arch(
                     sess,
                     rqst_args,
                     image,
-                    tag=tag_name,
+                    tag=tag,
                 )
             )
 

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -4,7 +4,7 @@ import enum
 import logging
 import uuid
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, cast
 
 import graphene
 import graphql
@@ -217,6 +217,7 @@ class ContainerRegistry(graphene.ObjectType):
     @classmethod
     def from_row(cls, ctx: GraphQueryContext, row: ContainerRegistryRow) -> ContainerRegistry:
         return cls(
+            id=row.registry_name,
             hostname=row.registry_name,
             config=ContainerRegistryConfig(
                 url=row.url,
@@ -248,7 +249,7 @@ class ContainerRegistry(graphene.ObjectType):
         ctx: GraphQueryContext,
     ) -> Sequence[ContainerRegistry]:
         async with ctx.db.begin_readonly_session() as session:
-            rows = await session.execute(sa.select(ContainerRegistryRow))
+            rows = await session.scalars(sa.select(ContainerRegistryRow))
             return [cls.from_row(ctx, row) for row in rows]
 
 

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -19,7 +19,6 @@ from sqlalchemy.orm import relationship, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
 from ai.backend.common.config import model_definition_iv
-from ai.backend.common.logging_utils import BraceStyleAdapter
 from ai.backend.common.types import (
     MODEL_SERVICE_RUNTIME_PROFILES,
     AccessKey,

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1253,7 +1253,6 @@ class ModifyEndpoint(graphene.Mutation):
                             ImageIdentifier(
                                 endpoint_row.image_row.name, endpoint_row.image_row.architecture
                             ),
-                            ImageAlias(endpoint_row.image_row.name),
                         ],
                     )
 

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -24,6 +24,7 @@ from ai.backend.manager.models.gql_relay import (
 
 from .container_registry import (
     ContainerRegistry,
+    ContainerRegistryConnection,
     CreateContainerRegistry,
     DeleteContainerRegistry,
     ModifyContainerRegistry,
@@ -778,9 +779,23 @@ class Queries(graphene.ObjectType):
         quota_scope_id=graphene.String(required=True),
     )
 
-    container_registry = graphene.Field(ContainerRegistry, hostname=graphene.String(required=True))
+    container_registry = graphene.Field(
+        ContainerRegistry, id=graphene.UUID(required=True), description="Added in 24.09.0."
+    )
 
-    container_registries = graphene.List(ContainerRegistry)
+    container_registries = graphene.List(
+        ContainerRegistry,
+        registry_name=graphene.String(required=True),
+        description="Added in 24.09.0.",
+    )
+
+    container_registry_node = graphene.Field(
+        ContainerRegistry, id=graphene.String(required=True), description="Added in 24.09.0."
+    )
+
+    container_registry_nodes = PaginatedConnectionField(
+        ContainerRegistryConnection, description="Added in 24.09.0."
+    )
 
     model_card = graphene.Field(
         ModelCard, id=graphene.String(required=True), description="Added in 24.03.0."
@@ -2313,19 +2328,54 @@ class Queries(graphene.ObjectType):
     async def resolve_container_registry(
         root: Any,
         info: graphene.ResolveInfo,
-        hostname: str,
+        id: graphene.UUID,
     ) -> ContainerRegistry:
         ctx: GraphQueryContext = info.context
-        return await ContainerRegistry.load_by_hostname(ctx, hostname)
+        return await ContainerRegistry.load(ctx, id)
 
     @staticmethod
     @privileged_query(UserRole.SUPERADMIN)
     async def resolve_container_registries(
         root: Any,
         info: graphene.ResolveInfo,
+        registry_name: graphene.String,
     ) -> Sequence[ContainerRegistry]:
         ctx: GraphQueryContext = info.context
-        return await ContainerRegistry.load_all(ctx)
+        return await ContainerRegistry.list_by_registry_name(ctx, registry_name)
+
+    @staticmethod
+    @privileged_query(UserRole.SUPERADMIN)
+    async def resolve_container_registry_node(
+        root: Any,
+        info: graphene.ResolveInfo,
+        id: str,
+    ) -> ContainerRegistry:
+        return await ContainerRegistry.get_node(info, id)
+
+    @staticmethod
+    @privileged_query(UserRole.SUPERADMIN)
+    async def resolve_container_registry_nodes(
+        root: Any,
+        info: graphene.ResolveInfo,
+        *,
+        filter: str | None = None,
+        order: str | None = None,
+        offset: int | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        before: str | None = None,
+        last: int | None = None,
+    ) -> ConnectionResolverResult:
+        return await ContainerRegistry.get_connection(
+            info,
+            filter,
+            order,
+            offset,
+            after,
+            first,
+            before,
+            last,
+        )
 
     async def resolve_model_card(
         root: Any,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -2347,7 +2347,6 @@ class Queries(graphene.ObjectType):
     async def resolve_container_registries(
         root: Any,
         info: graphene.ResolveInfo,
-        registry_name: graphene.String,
     ) -> Sequence[ContainerRegistry]:
         ctx: GraphQueryContext = info.context
         return await ContainerRegistry.load_all(ctx)

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -27,8 +27,11 @@ from .container_registry import (
     ContainerRegistryConnection,
     ContainerRegistryNode,
     CreateContainerRegistry,
+    CreateContainerRegistryNode,
     DeleteContainerRegistry,
+    DeleteContainerRegistryNode,
     ModifyContainerRegistry,
+    ModifyContainerRegistryNode,
 )
 
 if TYPE_CHECKING:
@@ -296,6 +299,17 @@ class Mutations(graphene.ObjectType):
     set_quota_scope = SetQuotaScope.Field()
     unset_quota_scope = UnsetQuotaScope.Field()
 
+    create_container_registry_node = CreateContainerRegistryNode.Field(
+        description="Added in 24.09.0."
+    )
+    modify_container_registry_node = ModifyContainerRegistryNode.Field(
+        description="Added in 24.09.0."
+    )
+    delete_container_registry_node = DeleteContainerRegistryNode.Field(
+        description="Added in 24.09.0."
+    )
+
+    # Legacy mutations
     create_container_registry = CreateContainerRegistry.Field()
     modify_container_registry = ModifyContainerRegistry.Field()
     delete_container_registry = DeleteContainerRegistry.Field()

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -10,8 +10,6 @@ from typing import (
     Any,
     AsyncIterator,
     List,
-    Mapping,
-    MutableMapping,
     NamedTuple,
     Optional,
     Tuple,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import enum
 import functools
 import logging
-from collections import namedtuple
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from decimal import Decimal
 from typing import (
@@ -11,6 +10,9 @@ from typing import (
     Any,
     AsyncIterator,
     List,
+    Mapping,
+    MutableMapping,
+    NamedTuple,
     Optional,
     Tuple,
     cast,
@@ -70,7 +72,12 @@ if TYPE_CHECKING:
     from .gql import GraphQueryContext
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-ImageIdentifier = namedtuple("ImageIdentifier", ["canonical", "architecture"])
+
+
+class ImageIdentifier(NamedTuple):
+    canonical: str
+    architecture: str
+
 
 __all__ = (
     "rescan_images",
@@ -300,8 +307,8 @@ class ImageRow(Base):
         load_aliases: bool = True,
     ) -> ImageRow:
         query = sa.select(ImageRow).where(
-            ImageRow.name == identifier.canonical
-            and ImageRow.architecture == identifier.architecture
+            (ImageRow.name == identifier.canonical)
+            and (ImageRow.architecture == identifier.architecture)
         )
 
         if load_aliases:

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -297,7 +297,7 @@ class ImageRow(Base):
         cls,
         session: AsyncSession,
         identifier: ImageIdentifier,
-        load_aliases=True,
+        load_aliases: bool = True,
     ) -> ImageRow:
         query = sa.select(ImageRow).where(
             ImageRow.name == identifier.canonical

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -377,7 +377,8 @@ class ImageRow(Base):
                        architecture,
                        is_local,
                    ),
-                   image_alias,
+                   ImageIdentifier(canonical, architecture),
+                   ImageAlias(image_alias),
                ],
            )
 

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -74,15 +74,6 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-class ImageIdentifier(NamedTuple):
-    """
-    Represent a tuple of image's canonical string and architecture, uniquely corresponding to an ImageRow.
-    """
-
-    canonical: str
-    architecture: str
-
-
 __all__ = (
     "rescan_images",
     "ImageType",
@@ -90,6 +81,7 @@ __all__ = (
     "ImageLoadFilter",
     "ImageRow",
     "Image",
+    "ImageNode",
     "ImageIdentifier",
     "PreloadImage",
     "PublicImageLoadFilter",
@@ -102,6 +94,15 @@ __all__ = (
     "DealiasImage",
     "ClearImages",
 )
+
+
+class ImageIdentifier(NamedTuple):
+    """
+    Represent a tuple of image's canonical string and architecture, uniquely corresponding to an ImageRow.
+    """
+
+    canonical: str
+    architecture: str
 
 
 class PublicImageLoadFilter(enum.StrEnum):

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -272,7 +272,7 @@ class ImageRow(Base):
 
     @property
     def image_ref(self) -> ImageRef:
-        image_and_tag = self.name.split(f"{self.registry}/{self.project}/")[-1]
+        image_and_tag = self.name.split(f"{self.registry}/{self.project}/", maxsplit=1)[1]
         image_name, tag = ImageRef.parse_image_tag(image_and_tag)
 
         return ImageRef(

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -29,7 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 from sqlalchemy.orm import load_only, relationship, selectinload
 
 from ai.backend.common import redis_helper
-from ai.backend.common.docker import ImageRef, parse_image_tag
+from ai.backend.common.docker import ImageRef
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.exception import UnknownImageReference
 from ai.backend.common.types import (
@@ -266,7 +266,7 @@ class ImageRow(Base):
     @property
     def image_ref(self) -> ImageRef:
         image_and_tag = self.name.split(f"{self.registry}/{self.project}/")[-1]
-        image_name, tag = parse_image_tag(image_and_tag)
+        image_name, tag = ImageRef.parse_image_tag(image_and_tag)
 
         return ImageRef(
             image_name, self.project, tag, self.registry, self.architecture, self.is_local

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -265,7 +265,7 @@ class ImageRow(Base):
 
     @property
     def image_ref(self) -> ImageRef:
-        image_and_tag = self.name.split(f"{self.project}/")[1]
+        image_and_tag = self.name.split(f"{self.registry}/{self.project}/")[-1]
         image_name, tag = parse_image_tag(image_and_tag)
 
         return ImageRef(

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -75,6 +75,10 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class ImageIdentifier(NamedTuple):
+    """
+    Represent a tuple of image's canonical string and architecture, uniquely corresponding to an ImageRow.
+    """
+
     canonical: str
     architecture: str
 

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -632,6 +632,7 @@ ImageAliasRow.image = relationship("ImageRow", back_populates="aliases")
 class Image(graphene.ObjectType):
     id = graphene.UUID()
     name = graphene.String()
+    project = graphene.String(description="Added in 24.03.10.")
     humanized_name = graphene.String()
     tag = graphene.String()
     registry = graphene.String()
@@ -663,6 +664,7 @@ class Image(graphene.ObjectType):
         ret = cls(
             id=row.id,
             name=row.image,
+            project=row.project,
             humanized_name=row.image,
             tag=row.tag,
             registry=row.registry,
@@ -871,6 +873,7 @@ class ImageNode(graphene.ObjectType):
 
     row_id = graphene.UUID(description="Added in 24.03.4. The undecoded id value stored in DB.")
     name = graphene.String()
+    project = graphene.String(description="Added in 24.03.10.")
     humanized_name = graphene.String()
     tag = graphene.String()
     registry = graphene.String()
@@ -901,6 +904,7 @@ class ImageNode(graphene.ObjectType):
             id=row.id,
             row_id=row.id,
             name=row.image,
+            project=row.project,
             humanized_name=row.image,
             tag=row.tag,
             registry=row.registry,
@@ -928,6 +932,7 @@ class ImageNode(graphene.ObjectType):
             name=row.name,
             humanized_name=row.humanized_name,
             tag=row.tag,
+            project=row.project,
             registry=row.registry,
             architecture=row.architecture,
             is_local=row.is_local,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -929,6 +929,7 @@ class ImageNode(graphene.ObjectType):
     def from_legacy_image(cls, row: Image) -> ImageNode:
         return cls(
             id=row.id,
+            row_id=row.id,
             name=row.name,
             humanized_name=row.humanized_name,
             tag=row.tag,

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -75,7 +75,7 @@ from .base import (
     batch_result,
 )
 from .group import groups
-from .image import ImageIdentifier, ImageNode, ImageRow
+from .image import ImageNode, ImageRow
 from .minilang import JSONFieldItem
 from .minilang.ordering import ColumnMapType, QueryOrderParser
 from .minilang.queryfilter import FieldSpecType, QueryFilterParser, enum_field_getter
@@ -568,20 +568,8 @@ class KernelRow(Base):
     user_row = relationship("UserRow", back_populates="kernels")
 
     @property
-    def image_ref(self) -> ImageRef:
-        if self.image_row is None:
-            raise Exception("image_row is None")
-        return self.image_row.image_ref
-
-    async def get_image_ref(self, db: ExtendedAsyncSAEngine) -> ImageRef:
-        if self.image_row is not None:
-            return self.image_ref
-
-        async with db.begin_readonly_session() as db_sess:
-            image_row = await ImageRow.resolve(
-                db_sess, [ImageIdentifier(self.image, self.architecture)]
-            )
-            return image_row.image_ref
+    def image_ref(self) -> ImageRef | None:
+        return self.image_row.image_ref if self.image_row else None
 
     @property
     def cluster_name(self) -> str:

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -578,8 +578,8 @@ class KernelRow(Base):
             return self.image_ref
 
         async with db.begin_readonly_session() as db_sess:
-            image_row = await ImageRow.resolve_by_identifier(
-                db_sess, ImageIdentifier(self.image, self.architecture)
+            image_row = await ImageRow.resolve(
+                db_sess, [ImageIdentifier(self.image, self.architecture)]
             )
             return image_row.image_ref
 

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -424,7 +424,7 @@ class KernelRow(Base):
     group_id = sa.Column("group_id", GUID, sa.ForeignKey("groups.id"), nullable=False)
     user_uuid = sa.Column("user_uuid", GUID, sa.ForeignKey("users.uuid"), nullable=False)
     access_key = sa.Column("access_key", sa.String(length=20), sa.ForeignKey("keypairs.access_key"))
-    # `image` is a canonical name which shaped "<REGISTRY>/<PROJECT>/<IMAGE>:<TAG>".
+    # `image` is a string representing canonical name which shaped "<REGISTRY>/<PROJECT>/<IMAGE_NAME>:<TAG>".
     image = sa.Column("image", sa.String(length=512))
     # ForeignKeyIDColumn("image_id", "images.id")
     architecture = sa.Column("architecture", sa.String(length=32), default="x86_64")

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1385,18 +1385,22 @@ class AgentRegistry:
                 idle_timeout = cast(int, resource_policy.idle_timeout)
                 auto_pull = cast(str, self.shared_config["docker"]["image"]["auto_pull"])
 
-            # Aggregate image registry information
-            image_refs: set[ImageRef] = set()
+                # Aggregate image registry information
+                image_refs: set[ImageRef] = set()
 
-            for binding in kernel_agent_bindings:
-                image_refs.add(
-                    (
-                        await ImageRow.resolve(
-                            db_sess,
-                            [ImageIdentifier(binding.kernel.image, binding.kernel.architecture)],
-                        )
-                    ).image_ref
-                )
+                for binding in kernel_agent_bindings:
+                    image_refs.add(
+                        (
+                            await ImageRow.resolve(
+                                db_sess,
+                                [
+                                    ImageIdentifier(
+                                        binding.kernel.image, binding.kernel.architecture
+                                    )
+                                ],
+                            )
+                        ).image_ref
+                    )
 
             _log_msg = ",".join([f"image ref => {ref} ({ref.architecture})" for ref in image_refs])
             log.debug(f"start_session(): {_log_msg}")
@@ -1619,68 +1623,80 @@ class AgentRegistry:
         await execute_with_retry(_update_kernel)
 
         try:
-            kernel_image_refs: dict[KernelId, ImageRef] = {}
-
             async with self.agent_cache.rpc_context(
                 agent_alloc_ctx.agent_id,
                 order_key=str(scheduled_session.id),
             ) as rpc:
 
                 def get_image_conf(kernel: KernelRow) -> ImageConfig:
-                    return image_configs[str(kernel.image_ref)]
+                    return image_configs[kernel.image]
 
-                for binding in items:
-                    raw_kernel_ids = [str(binding.kernel.id) for binding in items]
+                kernel_image_refs: dict[KernelId, ImageRef] = {}
 
-                    raw_configs = [
-                        {
-                            "image": {
-                                # TODO: refactor registry and is_local to be specified per kernel.
-                                "registry": get_image_conf(binding.kernel)["registry"],
-                                "digest": get_image_conf(binding.kernel)["digest"],
-                                "repo_digest": get_image_conf(binding.kernel)["repo_digest"],
-                                "canonical": get_image_conf(binding.kernel)["canonical"],
-                                "architecture": get_image_conf(binding.kernel)["architecture"],
-                                "labels": get_image_conf(binding.kernel)["labels"],
-                                "is_local": get_image_conf(binding.kernel)["is_local"],
-                            },
-                            "session_type": scheduled_session.session_type.value,
-                            "cluster_role": binding.kernel.cluster_role,
-                            "cluster_idx": binding.kernel.cluster_idx,
-                            "local_rank": binding.kernel.local_rank,
-                            "cluster_hostname": binding.kernel.cluster_hostname,
-                            "idle_timeout": idle_timeout,
-                            "mounts": [item.to_json() for item in scheduled_session.vfolder_mounts],
-                            "environ": {
-                                # inherit per-session environment variables
-                                **scheduled_session.environ,
-                                # set per-kernel environment variables
-                                "BACKENDAI_KERNEL_ID": str(binding.kernel.id),
-                                "BACKENDAI_KERNEL_IMAGE": get_image_conf(binding.kernel)[
-                                    "canonical"
-                                ],
-                                "BACKENDAI_CLUSTER_ROLE": binding.kernel.cluster_role,
-                                "BACKENDAI_CLUSTER_IDX": str(binding.kernel.cluster_idx),
-                                "BACKENDAI_CLUSTER_LOCAL_RANK": str(binding.kernel.local_rank),
-                                "BACKENDAI_CLUSTER_HOST": str(binding.kernel.cluster_hostname),
-                                "BACKENDAI_SERVICE_PORTS": str(
-                                    get_image_conf(binding.kernel)["labels"].get(
-                                        "ai.backend.service-ports"
+                async with self.db.begin_readonly_session() as db_sess:
+                    for binding in items:
+                        kernel_image_refs[binding.kernel.id] = (
+                            await ImageRow.resolve(
+                                db_sess,
+                                [
+                                    ImageIdentifier(
+                                        binding.kernel.image, binding.kernel.architecture
                                     )
-                                ),
-                            },
-                            "resource_slots": binding.kernel.requested_slots.to_json(),
-                            "resource_opts": binding.kernel.resource_opts,
-                            "bootstrap_script": binding.kernel.bootstrap_script,
-                            "startup_command": binding.kernel.startup_command,
-                            "internal_data": scheduled_session.main_kernel.internal_data,
-                            "auto_pull": get_image_conf(binding.kernel)["auto_pull"],
-                            "preopen_ports": scheduled_session.main_kernel.preopen_ports,
-                            "allocated_host_ports": list(binding.allocated_host_ports),
-                            "agent_addr": binding.agent_alloc_ctx.agent_addr,
-                            "scaling_group": binding.agent_alloc_ctx.scaling_group,
-                        }
-                    ]
+                                ],
+                            )
+                        ).image_ref
+
+                        raw_configs = [
+                            {
+                                "image": {
+                                    # TODO: refactor registry and is_local to be specified per kernel.
+                                    "registry": get_image_conf(binding.kernel)["registry"],
+                                    "digest": get_image_conf(binding.kernel)["digest"],
+                                    "repo_digest": get_image_conf(binding.kernel)["repo_digest"],
+                                    "canonical": get_image_conf(binding.kernel)["canonical"],
+                                    "architecture": get_image_conf(binding.kernel)["architecture"],
+                                    "labels": get_image_conf(binding.kernel)["labels"],
+                                    "is_local": get_image_conf(binding.kernel)["is_local"],
+                                },
+                                "session_type": scheduled_session.session_type.value,
+                                "cluster_role": binding.kernel.cluster_role,
+                                "cluster_idx": binding.kernel.cluster_idx,
+                                "local_rank": binding.kernel.local_rank,
+                                "cluster_hostname": binding.kernel.cluster_hostname,
+                                "idle_timeout": idle_timeout,
+                                "mounts": [
+                                    item.to_json() for item in scheduled_session.vfolder_mounts
+                                ],
+                                "environ": {
+                                    # inherit per-session environment variables
+                                    **scheduled_session.environ,
+                                    # set per-kernel environment variables
+                                    "BACKENDAI_KERNEL_ID": str(binding.kernel.id),
+                                    "BACKENDAI_KERNEL_IMAGE": get_image_conf(binding.kernel)[
+                                        "canonical"
+                                    ],
+                                    "BACKENDAI_CLUSTER_ROLE": binding.kernel.cluster_role,
+                                    "BACKENDAI_CLUSTER_IDX": str(binding.kernel.cluster_idx),
+                                    "BACKENDAI_CLUSTER_LOCAL_RANK": str(binding.kernel.local_rank),
+                                    "BACKENDAI_CLUSTER_HOST": str(binding.kernel.cluster_hostname),
+                                    "BACKENDAI_SERVICE_PORTS": str(
+                                        get_image_conf(binding.kernel)["labels"].get(
+                                            "ai.backend.service-ports"
+                                        )
+                                    ),
+                                },
+                                "resource_slots": binding.kernel.requested_slots.to_json(),
+                                "resource_opts": binding.kernel.resource_opts,
+                                "bootstrap_script": binding.kernel.bootstrap_script,
+                                "startup_command": binding.kernel.startup_command,
+                                "internal_data": scheduled_session.main_kernel.internal_data,
+                                "auto_pull": get_image_conf(binding.kernel)["auto_pull"],
+                                "preopen_ports": scheduled_session.main_kernel.preopen_ports,
+                                "allocated_host_ports": list(binding.allocated_host_ports),
+                                "agent_addr": binding.agent_alloc_ctx.agent_addr,
+                                "scaling_group": binding.agent_alloc_ctx.scaling_group,
+                            }
+                        ]
 
                 raw_kernel_ids = [str(binding.kernel.id) for binding in items]
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1521,7 +1521,7 @@ class AgentRegistry:
 
         # Aggregate by agents to minimize RPC calls
         per_agent_tasks = []
-        keyfunc = lambda binding: str(binding.agent_alloc_ctx.agent_id)
+        keyfunc = lambda binding: binding.agent_alloc_ctx.agent_id
         for agent_id, group_iterator in itertools.groupby(
             sorted(kernel_agent_bindings, key=keyfunc),
             key=keyfunc,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -700,24 +700,12 @@ class AgentRegistry:
         if _environ := template["spec"].get("environ"):  # noqa
             environ = _environ
 
-        image = template["spec"]["kernel"]["image"]
-        architecture = template["spec"]["kernel"].get("architecture", DEFAULT_IMAGE_ARCH)
-
-        async with self.db.begin_readonly_session() as session:
-            image_row = await ImageRow.resolve(
-                session,
-                [
-                    ImageIdentifier(image, architecture),
-                    ImageAlias(image),
-                ],
-            )
-
         kernel_configs: List[KernelEnqueueingConfig] = []
         for node in template["spec"]["nodes"]:
+            # Resolve session template.
             kernel_config = {
-                "image": image,
-                "project": image_row.project,
-                "architecture": architecture,
+                "image": template["spec"]["kernel"]["image"],
+                "architecture": template["spec"]["kernel"].get("architecture", DEFAULT_IMAGE_ARCH),
                 "cluster_role": node["cluster_role"],
                 "creation_config": {
                     "mount": mounts,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -476,10 +476,7 @@ class AgentRegistry:
             async with self.db.begin_readonly_session() as session:
                 image_row = await ImageRow.resolve(
                     session,
-                    [
-                        ImageIdentifier(image_ref.canonical, image_ref.architecture),
-                        ImageAlias(image_ref.canonical),
-                    ],
+                    [image_ref],
                 )
             if (
                 _owner_id := image_row.labels.get("ai.backend.customized-image.owner")
@@ -3383,7 +3380,7 @@ class AgentRegistry:
                     email,
                     filename=filename,
                     extra_labels=extra_labels,
-                    canonical=kernel.image,
+                    canonical=ParsedImageStr.parse(kernel.image, [registry]).canonical,
                 )
         return resp
 

--- a/src/ai/backend/manager/scheduler/drf.py
+++ b/src/ai/backend/manager/scheduler/drf.py
@@ -16,7 +16,6 @@ from ai.backend.common.types import (
 from ai.backend.logging import BraceStyleAdapter
 
 from ..models import KernelRow, SessionRow
-from ..models.kernel import KernelRow
 from ..models.scaling_group import ScalingGroupOpts
 from .types import AbstractScheduler
 

--- a/src/ai/backend/manager/scheduler/drf.py
+++ b/src/ai/backend/manager/scheduler/drf.py
@@ -17,6 +17,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.kernel import KernelRow
 
 from ..models import KernelRow, SessionRow
+from ..models.kernel import KernelRow
 from ..models.scaling_group import ScalingGroupOpts
 from .types import AbstractScheduler
 

--- a/src/ai/backend/manager/scheduler/drf.py
+++ b/src/ai/backend/manager/scheduler/drf.py
@@ -14,7 +14,6 @@ from ai.backend.common.types import (
     SessionId,
 )
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.models.kernel import KernelRow
 
 from ..models import KernelRow, SessionRow
 from ..models.kernel import KernelRow

--- a/src/ai/backend/manager/scheduler/fifo.py
+++ b/src/ai/backend/manager/scheduler/fifo.py
@@ -12,9 +12,9 @@ from ai.backend.common.types import (
     ResourceSlot,
     SessionId,
 )
-from ai.backend.manager.models.kernel import KernelRow
 
 from ..models import KernelRow, SessionRow
+from ..models.kernel import KernelRow
 from .types import AbstractScheduler
 
 

--- a/src/ai/backend/manager/scheduler/fifo.py
+++ b/src/ai/backend/manager/scheduler/fifo.py
@@ -14,7 +14,6 @@ from ai.backend.common.types import (
 )
 
 from ..models import KernelRow, SessionRow
-from ..models.kernel import KernelRow
 from .types import AbstractScheduler
 
 

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -10,6 +10,7 @@ import pytest
 
 from ai.backend.common.docker import (
     ImageRef,
+    ParsedImageStr,
     PlatformTagSet,
     _search_docker_socket_files_impl,
     default_registry,
@@ -121,146 +122,141 @@ async def test_get_docker_connector(monkeypatch):
 
 
 def test_image_ref_typing():
-    ref = ImageRef("c", "lablup")
+    ref = ImageRef.parse("c", "lablup")
     assert isinstance(ref, collections.abc.Hashable)
 
 
 def test_image_ref_parsing():
-    ref = ImageRef("c", "lablup")
-    assert ref.name == f"{default_repository}/c"
-    assert ref.architecture == "x86_64"
-    assert ref.tag == "latest"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("latest", set())
+    result = ParsedImageStr.parse("c")
+    assert result.project_and_image_name == f"{default_repository}/c"
+    assert result.tag == "latest"
+    assert result.registry == default_registry
+    assert result.tag_set == ("latest", set())
 
-    ref = ImageRef("c:gcc6.3-alpine3.8", "lablup", architecture="aarch64")
-    assert ref.name == f"{default_repository}/c"
-    assert ref.architecture == "aarch64"
-    assert ref.tag == "gcc6.3-alpine3.8"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("gcc6.3", {"alpine"})
+    result = ParsedImageStr.parse("c:gcc6.3-alpine3.8")
+    assert result.project_and_image_name == f"{default_repository}/c"
+    assert result.tag == "gcc6.3-alpine3.8"
+    assert result.registry == default_registry
+    assert result.tag_set == ("gcc6.3", {"alpine"})
 
-    ref = ImageRef("python:3.6-ubuntu", "lablup", architecture="amd64")
-    assert ref.name == f"{default_repository}/python"
-    assert ref.architecture == "x86_64"
-    assert ref.tag == "3.6-ubuntu"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("3.6", {"ubuntu"})
+    result = ParsedImageStr.parse("python:3.6-ubuntu")
+    assert result.project_and_image_name == f"{default_repository}/python"
+    assert result.tag == "3.6-ubuntu"
+    assert result.registry == default_registry
+    assert result.tag_set == ("3.6", {"ubuntu"})
 
-    ref = ImageRef("kernel-python:3.6-ubuntu", "lablup")
-    assert ref.name == f"{default_repository}/kernel-python"
-    assert ref.tag == "3.6-ubuntu"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("3.6", {"ubuntu"})
+    result = ParsedImageStr.parse("kernel-python:3.6-ubuntu")
+    assert result.project_and_image_name == f"{default_repository}/kernel-python"
+    assert result.tag == "3.6-ubuntu"
+    assert result.registry == default_registry
+    assert result.tag_set == ("3.6", {"ubuntu"})
 
-    ref = ImageRef("lablup/python-tensorflow:1.10-py36-ubuntu", "lablup")
-    assert ref.name == "lablup/python-tensorflow"
-    assert ref.tag == "1.10-py36-ubuntu"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("1.10", {"ubuntu", "py"})
+    result = ParsedImageStr.parse("lablup/python-tensorflow:1.10-py36-ubuntu")
+    assert result.project_and_image_name == "lablup/python-tensorflow"
+    assert result.tag == "1.10-py36-ubuntu"
+    assert result.registry == default_registry
+    assert result.tag_set == ("1.10", {"ubuntu", "py"})
 
-    ref = ImageRef("lablup/kernel-python:3.6-ubuntu", "lablup")
-    assert ref.name == "lablup/kernel-python"
-    assert ref.tag == "3.6-ubuntu"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("3.6", {"ubuntu"})
+    result = ParsedImageStr.parse("lablup/kernel-python:3.6-ubuntu")
+    assert result.project_and_image_name == "lablup/kernel-python"
+    assert result.tag == "3.6-ubuntu"
+    assert result.registry == default_registry
+    assert result.tag_set == ("3.6", {"ubuntu"})
 
     # To parse registry URLs correctly, we first need to give
     # the valid registry URLs!
-    ref = ImageRef("myregistry.org/lua", "lablup", [])
-    assert ref.name == "myregistry.org/lua"
-    assert ref.tag == "latest"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("latest", set())
+    result = ParsedImageStr.parse("myregistry.org/lua", [])
+    assert result.project_and_image_name == "myregistry.org/lua"
+    assert result.tag == "latest"
+    assert result.registry == default_registry
+    assert result.tag_set == ("latest", set())
 
-    ref = ImageRef("myregistry.org/lua", "lablup", ["myregistry.org"])
-    assert ref.name == "lua"
-    assert ref.tag == "latest"
-    assert ref.registry == "myregistry.org"
-    assert ref.tag_set == ("latest", set())
+    result = ParsedImageStr.parse("myregistry.org/lua", ["myregistry.org"])
+    assert result.project_and_image_name == "lua"
+    assert result.tag == "latest"
+    assert result.registry == "myregistry.org"
+    assert result.tag_set == ("latest", set())
 
-    ref = ImageRef("myregistry.org/lua:5.3-alpine", "lablup"["myregistry.org"])
-    assert ref.name == "lua"
-    assert ref.tag == "5.3-alpine"
-    assert ref.registry == "myregistry.org"
-    assert ref.tag_set == ("5.3", {"alpine"})
+    result = ParsedImageStr.parse("myregistry.org/lua:5.3-alpine", ["myregistry.org"])
+    assert result.project_and_image_name == "lua"
+    assert result.tag == "5.3-alpine"
+    assert result.registry == "myregistry.org"
+    assert result.tag_set == ("5.3", {"alpine"})
 
     # Non-standard port number should be a part of the known registry value.
-    ref = ImageRef(
-        "myregistry.org:999/mybase/python:3.6-cuda9-ubuntu", "lablup", ["myregistry.org:999"]
+    result = ParsedImageStr.parse(
+        "myregistry.org:999/mybase/python:3.6-cuda9-ubuntu", ["myregistry.org:999"]
     )
-    assert ref.name == "mybase/python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == "myregistry.org:999"
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    assert result.project_and_image_name == "mybase/python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == "myregistry.org:999"
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
-    ref = ImageRef(
-        "myregistry.org/mybase/moon/python:3.6-cuda9-ubuntu", "lablup", ["myregistry.org"]
+    result = ParsedImageStr.parse(
+        "myregistry.org/mybase/moon/python:3.6-cuda9-ubuntu", ["myregistry.org"]
     )
-    assert ref.name == "mybase/moon/python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == "myregistry.org"
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    assert result.project_and_image_name == "mybase/moon/python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == "myregistry.org"
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
     # IP addresses are treated as valid registry URLs.
-    ref = ImageRef("127.0.0.1:5000/python:3.6-cuda9-ubuntu", "lablup")
-    assert ref.name == "python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == "127.0.0.1:5000"
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    result = ParsedImageStr.parse("127.0.0.1:5000/python:3.6-cuda9-ubuntu")
+    assert result.project_and_image_name == "python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == "127.0.0.1:5000"
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
     # IPv6 addresses must be bracketted.
-    ref = ImageRef("::1/python:3.6-cuda9-ubuntu", "lablup")
-    assert ref.name == "::1/python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == default_registry
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    result = ParsedImageStr.parse("::1/python:3.6-cuda9-ubuntu")
+    assert result.project_and_image_name == "::1/python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == default_registry
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
-    ref = ImageRef("[::1]/python:3.6-cuda9-ubuntu", "lablup")
-    assert ref.name == "python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == "[::1]"
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    result = ParsedImageStr.parse("[::1]/python:3.6-cuda9-ubuntu")
+    assert result.project_and_image_name == "python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == "[::1]"
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
-    ref = ImageRef("[::1]:5000/python:3.6-cuda9-ubuntu", "lablup")
-    assert ref.name == "python"
-    assert ref.tag == "3.6-cuda9-ubuntu"
-    assert ref.registry == "[::1]:5000"
-    assert ref.tag_set == ("3.6", {"ubuntu", "cuda"})
+    result = ParsedImageStr.parse("[::1]:5000/python:3.6-cuda9-ubuntu")
+    assert result.project_and_image_name == "python"
+    assert result.tag == "3.6-cuda9-ubuntu"
+    assert result.registry == "[::1]:5000"
+    assert result.tag_set == ("3.6", {"ubuntu", "cuda"})
 
-    ref = ImageRef("[212c:9cb9:eada:e57b:84c9:6a9:fbec:bdd2]:1024/python", "lablup")
-    assert ref.name == "python"
-    assert ref.tag == "latest"
-    assert ref.registry == "[212c:9cb9:eada:e57b:84c9:6a9:fbec:bdd2]:1024"
-    assert ref.tag_set == ("latest", set())
-
-    with pytest.raises(ValueError):
-        ref = ImageRef("a:!", "lablup")
+    result = ParsedImageStr.parse("[212c:9cb9:eada:e57b:84c9:6a9:fbec:bdd2]:1024/python")
+    assert result.project_and_image_name == "python"
+    assert result.tag == "latest"
+    assert result.registry == "[212c:9cb9:eada:e57b:84c9:6a9:fbec:bdd2]:1024"
+    assert result.tag_set == ("latest", set())
 
     with pytest.raises(ValueError):
-        ref = ImageRef("127.0.0.1:5000/a:-x-", "lablup")
+        result = ParsedImageStr.parse("a:!")
 
     with pytest.raises(ValueError):
-        ref = ImageRef("http://127.0.0.1:5000/xyz", "lablup")
+        result = ParsedImageStr.parse("127.0.0.1:5000/a:-x-")
 
     with pytest.raises(ValueError):
-        ref = ImageRef("//127.0.0.1:5000/xyz", "lablup")
+        result = ParsedImageStr.parse("http://127.0.0.1:5000/xyz")
+
+    with pytest.raises(ValueError):
+        result = ParsedImageStr.parse("//127.0.0.1:5000/xyz")
 
 
 def test_image_ref_formats():
-    ref = ImageRef("python:3.6-cuda9-ubuntu", "lablup", [])
-    assert ref.canonical == "index.docker.io/lablup/python:3.6-cuda9-ubuntu"
-    assert ref.short == "lablup/python:3.6-cuda9-ubuntu"
-    assert str(ref) == ref.canonical
-    assert repr(ref) == f'<ImageRef: "{ref.canonical}" (x86_64)>'
+    result = ParsedImageStr.parse("python:3.6-cuda9-ubuntu", [])
+    assert result.canonical == "index.docker.io/lablup/python:3.6-cuda9-ubuntu"
+    assert result.short == "lablup/python:3.6-cuda9-ubuntu"
+    assert str(result) == result.canonical
+    assert repr(result) == f'<ParsedImageStr: "{result.canonical}">'
 
-    ref = ImageRef(
-        "myregistry.org/user/python:3.6-cuda9-ubuntu", "lablup", ["myregistry.org"], "aarch64"
-    )
-    assert ref.canonical == "myregistry.org/user/python:3.6-cuda9-ubuntu"
-    assert ref.short == "user/python:3.6-cuda9-ubuntu"
-    assert str(ref) == ref.canonical
-    assert repr(ref) == f'<ImageRef: "{ref.canonical}" (aarch64)>'
+    result = ParsedImageStr.parse("myregistry.org/user/python:3.6-cuda9-ubuntu", ["myregistry.org"])
+    assert result.canonical == "myregistry.org/user/python:3.6-cuda9-ubuntu"
+    assert result.short == "user/python:3.6-cuda9-ubuntu"
+    assert str(result) == result.canonical
+    assert repr(result) == f'<ParsedImageStr: "{result.canonical}">'
 
 
 def test_platform_tag_set_typing():
@@ -300,7 +296,15 @@ def test_platform_tag_set_abbreviations():
 
 
 def test_image_ref_generate_aliases():
-    ref = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04", "lablup")
+    ref = ImageRef(
+        name="python-tensorflow",
+        project=default_repository,
+        registry=default_registry,
+        architecture="x86_64",
+        tag="1.5-py36-ubuntu16.04",
+        is_local=False,
+    )
+
     aliases = ref.generate_aliases()
     possible_names = ["python-tensorflow", "tensorflow"]
     possible_platform_tags = [
@@ -316,7 +320,14 @@ def test_image_ref_generate_aliases():
 
 
 def test_image_ref_generate_aliases_with_accelerator():
-    ref = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup")
+    ref = ImageRef(
+        name="python-tensorflow",
+        project=default_repository,
+        registry=default_registry,
+        architecture="x86_64",
+        tag="1.5-py36-ubuntu16.04-cuda10.0",
+        is_local=False,
+    )
     aliases = ref.generate_aliases()
     possible_names = ["python-tensorflow", "tensorflow"]
     possible_platform_tags = [
@@ -334,7 +345,14 @@ def test_image_ref_generate_aliases_with_accelerator():
 
 def test_image_ref_generate_aliases_of_names():
     # an alias may include only last framework name in the name.
-    ref = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup")
+    ref = ImageRef(
+        name="python-tensorflow",
+        project=default_repository,
+        registry=default_registry,
+        architecture="x86_64",
+        tag="1.5-py36-ubuntu16.04-cuda10.0",
+        is_local=False,
+    )
     aliases = ref.generate_aliases()
     assert "python-tensorflow" in aliases
     assert "tensorflow" in aliases
@@ -343,7 +361,14 @@ def test_image_ref_generate_aliases_of_names():
 
 def test_image_ref_generate_aliases_disallowed():
     # an alias must include the main platform version tag
-    ref = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup")
+    ref = ImageRef(
+        name="python-tensorflow",
+        project=default_repository,
+        registry=default_registry,
+        architecture="x86_64",
+        tag="1.5-py36-ubuntu16.04-cuda10.0",
+        is_local=False,
+    )
     aliases = ref.generate_aliases()
     # always the main version must be included!
     assert "python-tensorflow:py3" not in aliases
@@ -357,26 +382,27 @@ def test_image_ref_generate_aliases_disallowed():
 def test_image_ref_ordering():
     # ordering is defined as the tuple-ordering of platform tags.
     # (tag components that come first have higher priority when comparing.)
-    r1 = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup")
-    r2 = ImageRef("lablup/python-tensorflow:1.7-py36-ubuntu16.04-cuda10.0", "lablup")
-    r3 = ImageRef("lablup/python-tensorflow:1.7-py37-ubuntu18.04-cuda9.0", "lablup")
+    r1 = ImageRef.parse("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup")
+    r2 = ImageRef.parse("lablup/python-tensorflow:1.7-py36-ubuntu16.04-cuda10.0", "lablup")
+    r3 = ImageRef.parse("lablup/python-tensorflow:1.7-py37-ubuntu16.04-cuda9.0", "lablup")
+
     assert r1 < r2
     assert r1 < r3
     assert r2 < r3
 
     # only the image-refs with same names can be compared.
-    rx = ImageRef("lablup/python:3.6-ubuntu")
+    rx = ImageRef.parse("lablup/python:3.6-ubuntu", "lablup")
     with pytest.raises(ValueError):
         rx < r1
     with pytest.raises(ValueError):
         r1 < rx
 
     # test case added for explicit behavior documentation
-    # ImageRef(...:ubuntu16.04) > ImageRef(...:ubuntu) == False
-    # ImageRef(...:ubuntu16.04) > ImageRef(...:ubuntu) == False
+    # ImageRef.parse(...:ubuntu16.04) > ImageRef.parse(...:ubuntu) == False
+    # ImageRef.parse(...:ubuntu16.04) > ImageRef.parse(...:ubuntu) == False
     # by keeping naming convetion, no need to handle these cases
-    r4 = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda9.0", "lablup")
-    r5 = ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu-cuda9.0", "lablup")
+    r4 = ImageRef.parse("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda9.0", "lablup")
+    r5 = ImageRef.parse("lablup/python-tensorflow:1.5-py36-ubuntu-cuda9.0", "lablup")
     assert not r4 > r5
     assert not r5 > r4
 
@@ -385,13 +411,13 @@ def test_image_ref_merge_aliases():
     # After merging, aliases that indicates two or more references should
     # indicate most recent versions.
     refs = [
-        ImageRef("lablup/python:3.7-ubuntu18.04", "lablup"),  # 0
-        ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup"),  # 1
-        ImageRef("lablup/python-tensorflow:1.7-py36-ubuntu16.04-cuda10.0", "lablup"),  # 2
-        ImageRef("lablup/python-tensorflow:1.7-py37-ubuntu16.04-cuda9.0", "lablup"),  # 3
-        ImageRef("lablup/python-tensorflow:1.5-py36-ubuntu16.04", "lablup"),  # 4
-        ImageRef("lablup/python-tensorflow:1.7-py36-ubuntu16.04", "lablup"),  # 5
-        ImageRef("lablup/python-tensorflow:1.7-py37-ubuntu16.04", "lablup"),  # 6
+        ImageRef.parse("lablup/python:3.7-ubuntu18.04", "lablup"),  # 0
+        ImageRef.parse("lablup/python-tensorflow:1.5-py36-ubuntu16.04-cuda10.0", "lablup"),  # 1
+        ImageRef.parse("lablup/python-tensorflow:1.7-py36-ubuntu16.04-cuda10.0", "lablup"),  # 2
+        ImageRef.parse("lablup/python-tensorflow:1.7-py37-ubuntu16.04-cuda9.0", "lablup"),  # 3
+        ImageRef.parse("lablup/python-tensorflow:1.5-py36-ubuntu16.04", "lablup"),  # 4
+        ImageRef.parse("lablup/python-tensorflow:1.7-py36-ubuntu16.04", "lablup"),  # 5
+        ImageRef.parse("lablup/python-tensorflow:1.7-py37-ubuntu16.04", "lablup"),  # 6
     ]
     aliases = [ref.generate_aliases() for ref in refs]
     aliases = functools.reduce(ImageRef.merge_aliases, aliases)

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -121,7 +121,14 @@ async def test_get_docker_connector(monkeypatch):
 
 
 def test_image_ref_typing():
-    ref = ImageRef("c")
+    ref = ImageRef(
+        name="python-tensorflow",
+        project=default_repository,
+        registry=default_registry,
+        architecture="x86_64",
+        tag="1.5-py36-ubuntu16.04",
+        is_local=False,
+    )
     assert isinstance(ref, collections.abc.Hashable)
 
 

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import functools
 import itertools
 import typing
@@ -118,6 +118,11 @@ async def test_get_docker_connector(monkeypatch):
         m.setattr("sys.platform", "aix")
         with pytest.raises(RuntimeError, match="unsupported platform"):
             get_docker_connector()
+
+
+def test_image_ref_typing():
+    ref = ImageRef("c")
+    assert isinstance(ref, collections.abc.Hashable)
 
 
 def test_image_ref_parsing():
@@ -314,11 +319,6 @@ def test_image_ref_formats():
     assert result.short == "user/python:3.6-cuda9-ubuntu"
     assert str(result) == result.canonical
     assert repr(result) == f'<ImageRef: "{result.canonical}" ({result.architecture})>'
-
-
-def test_image_ref_typing():
-    ref = ImageRef.from_image_str("c", default_repository, default_registry)
-    assert isinstance(ref, collections.abc.Hashable)
 
 
 def test_image_ref_generate_aliases():

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -7,6 +7,7 @@ from dateutil.tz import gettz, tzutc
 
 from ai.backend.common import msgpack
 from ai.backend.common.types import BinarySize, ResourceSlot, SlotTypes
+from ai.backend.common.docker import ImageRef
 
 
 def test_msgpack_with_unicode():
@@ -125,6 +126,20 @@ def test_msgpack_posixpath():
     unpacked = msgpack.unpackb(packed)
     assert isinstance(unpacked["path"], PosixPath)
     assert unpacked["path"] == path
+
+
+def test_msgpack_image_ref():
+    imgref = ImageRef(
+        name="python",
+        project="lablup",
+        tag="3.9-ubuntu20.04",
+        registry="index.docker.io",
+        architecture="x86_64",
+        is_local=False,
+    )
+    packed = msgpack.packb(imgref)
+    unpacked = msgpack.unpackb(packed)
+    assert imgref == unpacked
 
 
 def test_msgpack_resource_slot():

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -6,8 +6,8 @@ from pathlib import PosixPath
 from dateutil.tz import gettz, tzutc
 
 from ai.backend.common import msgpack
-from ai.backend.common.types import BinarySize, ResourceSlot, SlotTypes
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.types import BinarySize, ResourceSlot, SlotTypes
 
 
 def test_msgpack_with_unicode():

--- a/tests/manager/models/test_container_registries.py
+++ b/tests/manager/models/test_container_registries.py
@@ -7,9 +7,8 @@ from ai.backend.manager.models.gql import GraphQueryContext, Mutations, Queries
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 CONTAINER_REGISTRY_FIELDS = """
-    id
+    hostname
     config {
-        registry_name
         url
         type
         project
@@ -54,8 +53,8 @@ async def test_create_container_registry(client: Client, database_engine: Extend
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation CreateContainerRegistry($props: CreateContainerRegistryInput!) {
-                create_container_registry(props: $props) {
+            mutation CreateContainerRegistry($hostname: String!, $props: CreateContainerRegistryInput!) {
+                create_container_registry(hostname: $hostname, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -64,11 +63,11 @@ async def test_create_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
+        "hostname": "cr.example.com",
         "props": {
-            "registry_name": "cr.example.com",
             "url": "http://cr.example.com",
             "type": "docker",
-            "project": "default",
+            "project": ["default"],
             "username": "username",
             "password": "password",
             "ssl_verify": False,
@@ -80,55 +79,25 @@ async def test_create_container_registry(client: Client, database_engine: Extend
 
     container_registry = response["data"]["create_container_registry"]["container_registry"]
 
-    id = container_registry.pop("id", None)
-    assert id is not None
-
     assert container_registry["config"] == {
-        "registry_name": "cr.example.com",
         "url": "http://cr.example.com",
         "type": "docker",
-        "project": "default",
+        "project": ["default"],
         "username": "username",
         "password": PASSWORD_PLACEHOLDER,
         "ssl_verify": False,
         "is_global": False,
     }
 
-    variables["props"]["project"] = "default2"
-    await client.execute_async(query, variables=variables, context_value=context)
 
-
-@pytest.mark.dependency(depends=["test_get_container_registry"])
+@pytest.mark.dependency(depends=["test_create_container_registry"])
 @pytest.mark.asyncio
 async def test_modify_container_registry(client: Client, database_engine: ExtendedAsyncSAEngine):
     context = get_graphquery_context(database_engine)
 
     query = """
-        query ContainerRegistries($registry_name: String!) {
-            container_registries (registry_name: $registry_name) {
-                $CONTAINER_REGISTRY_FIELDS
-            }
-        }
-        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
-
-    variables: dict[str, dict | str] = {
-        "registry_name": "cr.example.com",
-    }
-
-    response = await client.execute_async(query, variables=variables, context_value=context)
-
-    target_container_registries = list(
-        filter(
-            lambda item: item["config"]["project"] == "default",
-            response["data"]["container_registries"],
-        )
-    )
-    assert len(target_container_registries) == 1
-    target_container_registry = target_container_registries[0]
-
-    query = """
-            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(id: $id, props: $props) {
+            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(hostname: $hostname, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -137,9 +106,8 @@ async def test_modify_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
-        "id": target_container_registry["id"],
+        "hostname": "cr.example.com",
         "props": {
-            "registry_name": "cr.example.com",
             "username": "username2",
         },
     }
@@ -147,31 +115,28 @@ async def test_modify_container_registry(client: Client, database_engine: Extend
     response = await client.execute_async(query, variables=variables, context_value=context)
 
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
-    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr.example.com"
     assert container_registry["config"]["type"] == "docker"
-    assert container_registry["config"]["project"] == "default"
+    assert container_registry["config"]["project"] == ["default"]
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["ssl_verify"] is False
     assert container_registry["config"]["is_global"] is False
 
     variables = {
-        "id": target_container_registry["id"],
+        "hostname": "cr.example.com",
         "props": {
-            "registry_name": "cr.example.com",
             "url": "http://cr2.example.com",
             "type": "harbor2",
-            "project": "example",
+            "project": ["example"],
         },
     }
 
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
 
-    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == "example"
+    assert container_registry["config"]["project"] == ["example"]
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["ssl_verify"] is False
     assert container_registry["config"]["is_global"] is False
@@ -185,31 +150,8 @@ async def test_modify_container_registry_allows_empty_string(
     context = get_graphquery_context(database_engine)
 
     query = """
-        query ContainerRegistries($registry_name: String!) {
-            container_registries (registry_name: $registry_name) {
-                $CONTAINER_REGISTRY_FIELDS
-            }
-        }
-        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
-
-    variables: dict[str, dict | str] = {
-        "registry_name": "cr.example.com",
-    }
-
-    response = await client.execute_async(query, variables=variables, context_value=context)
-
-    target_container_registries = list(
-        filter(
-            lambda item: item["config"]["project"] == "example",
-            response["data"]["container_registries"],
-        )
-    )
-    assert len(target_container_registries) == 1
-    target_container_registry = target_container_registries[0]
-
-    query = """
-            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(id: $id, props: $props) {
+            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(hostname: $hostname, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -219,9 +161,8 @@ async def test_modify_container_registry_allows_empty_string(
 
     # Given an empty string to password
     variables = {
-        "id": target_container_registry["id"],
+        "hostname": "cr.example.com",
         "props": {
-            "registry_name": "cr.example.com",
             "password": "",
         },
     }
@@ -229,10 +170,9 @@ async def test_modify_container_registry_allows_empty_string(
     # Then password is set to empty string
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
-    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == "example"
+    assert container_registry["config"]["project"] == ["example"]
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["password"] == PASSWORD_PLACEHOLDER
     assert container_registry["config"]["ssl_verify"] is False
@@ -247,31 +187,8 @@ async def test_modify_container_registry_allows_null_for_unset(
     context = get_graphquery_context(database_engine)
 
     query = """
-        query ContainerRegistries($registry_name: String!) {
-            container_registries (registry_name: $registry_name) {
-                $CONTAINER_REGISTRY_FIELDS
-            }
-        }
-        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
-
-    variables: dict[str, dict | str] = {
-        "registry_name": "cr.example.com",
-    }
-
-    response = await client.execute_async(query, variables=variables, context_value=context)
-
-    target_container_registries = list(
-        filter(
-            lambda item: item["config"]["project"] == "example",
-            response["data"]["container_registries"],
-        )
-    )
-    assert len(target_container_registries) == 1
-    target_container_registry = target_container_registries[0]
-
-    query = """
-            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(id: $id, props: $props) {
+            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(hostname: $hostname, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -281,9 +198,8 @@ async def test_modify_container_registry_allows_null_for_unset(
 
     # Given a null to password
     variables = {
-        "id": target_container_registry["id"],
+        "hostname": "cr.example.com",
         "props": {
-            "registry_name": "cr.example.com",
             "password": None,
         },
     }
@@ -291,10 +207,9 @@ async def test_modify_container_registry_allows_null_for_unset(
     # Then password is unset
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
-    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == "example"
+    assert container_registry["config"]["project"] == ["example"]
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["password"] is None
     assert container_registry["config"]["ssl_verify"] is False
@@ -307,31 +222,8 @@ async def test_delete_container_registry(client: Client, database_engine: Extend
     context = get_graphquery_context(database_engine)
 
     query = """
-        query ContainerRegistries($registry_name: String!) {
-            container_registries (registry_name: $registry_name) {
-                $CONTAINER_REGISTRY_FIELDS
-            }
-        }
-        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
-
-    variables = {
-        "registry_name": "cr.example.com",
-    }
-
-    response = await client.execute_async(query, variables=variables, context_value=context)
-
-    target_container_registries = list(
-        filter(
-            lambda item: item["config"]["project"] == "example",
-            response["data"]["container_registries"],
-        )
-    )
-    assert len(target_container_registries) == 1
-    target_container_registry = target_container_registries[0]
-
-    query = """
-            mutation DeleteContainerRegistry($id: String!) {
-                delete_container_registry(id: $id) {
+            mutation DeleteContainerRegistry($hostname: String!) {
+                delete_container_registry(hostname: $hostname) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -340,16 +232,17 @@ async def test_delete_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
-        "id": target_container_registry["id"],
+        "hostname": "cr.example.com",
     }
 
     response = await client.execute_async(query, variables=variables, context_value=context)
+
     container_registry = response["data"]["delete_container_registry"]["container_registry"]
-    assert container_registry["config"]["registry_name"] == "cr.example.com"
+    assert container_registry["hostname"] == "cr.example.com"
 
     query = """
-        query ContainerRegistries($registry_name: String!) {
-            container_registries (registry_name: $registry_name) {
+        query ContainerRegistries() {
+            container_registries () {
                 $CONTAINER_REGISTRY_FIELDS
             }
         }

--- a/tests/manager/models/test_container_registries.py
+++ b/tests/manager/models/test_container_registries.py
@@ -7,8 +7,9 @@ from ai.backend.manager.models.gql import GraphQueryContext, Mutations, Queries
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 CONTAINER_REGISTRY_FIELDS = """
-    hostname
+    id
     config {
+        registry_name
         url
         type
         project
@@ -53,8 +54,8 @@ async def test_create_container_registry(client: Client, database_engine: Extend
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation CreateContainerRegistry($hostname: String!, $props: CreateContainerRegistryInput!) {
-                create_container_registry(hostname: $hostname, props: $props) {
+            mutation CreateContainerRegistry($props: CreateContainerRegistryInput!) {
+                create_container_registry(props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -63,11 +64,11 @@ async def test_create_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
-        "hostname": "cr.example.com",
         "props": {
+            "registry_name": "cr.example.com",
             "url": "http://cr.example.com",
             "type": "docker",
-            "project": ["default"],
+            "project": "default",
             "username": "username",
             "password": "password",
             "ssl_verify": False,
@@ -79,25 +80,55 @@ async def test_create_container_registry(client: Client, database_engine: Extend
 
     container_registry = response["data"]["create_container_registry"]["container_registry"]
 
+    id = container_registry.pop("id", None)
+    assert id is not None
+
     assert container_registry["config"] == {
+        "registry_name": "cr.example.com",
         "url": "http://cr.example.com",
         "type": "docker",
-        "project": ["default"],
+        "project": "default",
         "username": "username",
         "password": PASSWORD_PLACEHOLDER,
         "ssl_verify": False,
         "is_global": False,
     }
 
+    variables["props"]["project"] = "default2"
+    await client.execute_async(query, variables=variables, context_value=context)
 
-@pytest.mark.dependency(depends=["test_create_container_registry"])
+
+@pytest.mark.dependency(depends=["test_get_container_registry"])
 @pytest.mark.asyncio
 async def test_modify_container_registry(client: Client, database_engine: ExtendedAsyncSAEngine):
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(hostname: $hostname, props: $props) {
+        query ContainerRegistries($registry_name: String!) {
+            container_registries (registry_name: $registry_name) {
+                $CONTAINER_REGISTRY_FIELDS
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, dict | str] = {
+        "registry_name": "cr.example.com",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["config"]["project"] == "default",
+            response["data"]["container_registries"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]
+
+    query = """
+            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(id: $id, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -106,8 +137,9 @@ async def test_modify_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
-        "hostname": "cr.example.com",
+        "id": target_container_registry["id"],
         "props": {
+            "registry_name": "cr.example.com",
             "username": "username2",
         },
     }
@@ -115,28 +147,31 @@ async def test_modify_container_registry(client: Client, database_engine: Extend
     response = await client.execute_async(query, variables=variables, context_value=context)
 
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
+    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr.example.com"
     assert container_registry["config"]["type"] == "docker"
-    assert container_registry["config"]["project"] == ["default"]
+    assert container_registry["config"]["project"] == "default"
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["ssl_verify"] is False
     assert container_registry["config"]["is_global"] is False
 
     variables = {
-        "hostname": "cr.example.com",
+        "id": target_container_registry["id"],
         "props": {
+            "registry_name": "cr.example.com",
             "url": "http://cr2.example.com",
             "type": "harbor2",
-            "project": ["example"],
+            "project": "example",
         },
     }
 
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
 
+    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == ["example"]
+    assert container_registry["config"]["project"] == "example"
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["ssl_verify"] is False
     assert container_registry["config"]["is_global"] is False
@@ -150,8 +185,31 @@ async def test_modify_container_registry_allows_empty_string(
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(hostname: $hostname, props: $props) {
+        query ContainerRegistries($registry_name: String!) {
+            container_registries (registry_name: $registry_name) {
+                $CONTAINER_REGISTRY_FIELDS
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, dict | str] = {
+        "registry_name": "cr.example.com",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["config"]["project"] == "example",
+            response["data"]["container_registries"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]
+
+    query = """
+            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(id: $id, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -161,8 +219,9 @@ async def test_modify_container_registry_allows_empty_string(
 
     # Given an empty string to password
     variables = {
-        "hostname": "cr.example.com",
+        "id": target_container_registry["id"],
         "props": {
+            "registry_name": "cr.example.com",
             "password": "",
         },
     }
@@ -170,9 +229,10 @@ async def test_modify_container_registry_allows_empty_string(
     # Then password is set to empty string
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
+    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == ["example"]
+    assert container_registry["config"]["project"] == "example"
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["password"] == PASSWORD_PLACEHOLDER
     assert container_registry["config"]["ssl_verify"] is False
@@ -187,8 +247,31 @@ async def test_modify_container_registry_allows_null_for_unset(
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation ModifyContainerRegistry($hostname: String!, $props: ModifyContainerRegistryInput!) {
-                modify_container_registry(hostname: $hostname, props: $props) {
+        query ContainerRegistries($registry_name: String!) {
+            container_registries (registry_name: $registry_name) {
+                $CONTAINER_REGISTRY_FIELDS
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, dict | str] = {
+        "registry_name": "cr.example.com",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["config"]["project"] == "example",
+            response["data"]["container_registries"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]
+
+    query = """
+            mutation ModifyContainerRegistry($id: String!, $props: ModifyContainerRegistryInput!) {
+                modify_container_registry(id: $id, props: $props) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -198,8 +281,9 @@ async def test_modify_container_registry_allows_null_for_unset(
 
     # Given a null to password
     variables = {
-        "hostname": "cr.example.com",
+        "id": target_container_registry["id"],
         "props": {
+            "registry_name": "cr.example.com",
             "password": None,
         },
     }
@@ -207,9 +291,10 @@ async def test_modify_container_registry_allows_null_for_unset(
     # Then password is unset
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["modify_container_registry"]["container_registry"]
+    assert container_registry["config"]["registry_name"] == "cr.example.com"
     assert container_registry["config"]["url"] == "http://cr2.example.com"
     assert container_registry["config"]["type"] == "harbor2"
-    assert container_registry["config"]["project"] == ["example"]
+    assert container_registry["config"]["project"] == "example"
     assert container_registry["config"]["username"] == "username2"
     assert container_registry["config"]["password"] is None
     assert container_registry["config"]["ssl_verify"] is False
@@ -222,8 +307,31 @@ async def test_delete_container_registry(client: Client, database_engine: Extend
     context = get_graphquery_context(database_engine)
 
     query = """
-            mutation DeleteContainerRegistry($hostname: String!) {
-                delete_container_registry(hostname: $hostname) {
+        query ContainerRegistries($registry_name: String!) {
+            container_registries (registry_name: $registry_name) {
+                $CONTAINER_REGISTRY_FIELDS
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "registry_name": "cr.example.com",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["config"]["project"] == "example",
+            response["data"]["container_registries"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]
+
+    query = """
+            mutation DeleteContainerRegistry($id: String!) {
+                delete_container_registry(id: $id) {
                     container_registry {
                         $CONTAINER_REGISTRY_FIELDS
                     }
@@ -232,16 +340,16 @@ async def test_delete_container_registry(client: Client, database_engine: Extend
         """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
 
     variables = {
-        "hostname": "cr.example.com",
+        "id": target_container_registry["id"],
     }
 
     response = await client.execute_async(query, variables=variables, context_value=context)
     container_registry = response["data"]["delete_container_registry"]["container_registry"]
-    assert container_registry["hostname"] == "cr.example.com"
+    assert container_registry["config"]["registry_name"] == "cr.example.com"
 
     query = """
-        query ContainerRegistries() {
-            container_registries () {
+        query ContainerRegistries($registry_name: String!) {
+            container_registries (registry_name: $registry_name) {
                 $CONTAINER_REGISTRY_FIELDS
             }
         }

--- a/tests/manager/models/test_container_registry_nodes.py
+++ b/tests/manager/models/test_container_registry_nodes.py
@@ -1,0 +1,379 @@
+import pytest
+from graphene import Schema
+from graphene.test import Client
+
+from ai.backend.manager.defs import PASSWORD_PLACEHOLDER
+from ai.backend.manager.models.container_registry import ContainerRegistryType
+from ai.backend.manager.models.gql import GraphQueryContext, Mutations, Queries
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+CONTAINER_REGISTRY_FIELDS = """
+    row_id
+    registry_name
+    url
+    type
+    project
+    username
+    password
+    ssl_verify
+    is_global
+"""
+
+
+@pytest.fixture(scope="module")
+def client() -> Client:
+    return Client(Schema(query=Queries, mutation=Mutations, auto_camelcase=False))
+
+
+def get_graphquery_context(database_engine: ExtendedAsyncSAEngine) -> GraphQueryContext:
+    return GraphQueryContext(
+        schema=None,  # type: ignore
+        dataloader_manager=None,  # type: ignore
+        local_config=None,  # type: ignore
+        shared_config=None,  # type: ignore
+        etcd=None,  # type: ignore
+        user={"domain": "default", "role": "superadmin"},
+        access_key="AKIAIOSFODNN7EXAMPLE",
+        db=database_engine,  # type: ignore
+        redis_stat=None,  # type: ignore
+        redis_image=None,  # type: ignore
+        redis_live=None,  # type: ignore
+        manager_status=None,  # type: ignore
+        known_slot_types=None,  # type: ignore
+        background_task_manager=None,  # type: ignore
+        storage_manager=None,  # type: ignore
+        registry=None,  # type: ignore
+        idle_checker_host=None,  # type: ignore
+    )
+
+
+@pytest.mark.dependency()
+@pytest.mark.asyncio
+async def test_create_container_registry(client: Client, database_engine: ExtendedAsyncSAEngine):
+    context = get_graphquery_context(database_engine)
+
+    query = """
+            mutation CreateContainerRegistryNode($type: ContainerRegistryTypeField!, $registry_name: String!, $url: String!, $project: String!, $username: String!, $password: String!, $ssl_verify: Boolean!, $is_global: Boolean!) {
+                create_container_registry_node(type: $type, registry_name: $registry_name, url: $url, project: $project, username: $username, password: $password, ssl_verify: $ssl_verify, is_global: $is_global) {
+                    container_registry {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                }
+            }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "registry_name": "cr.example.com",
+        "url": "http://cr.example.com",
+        "type": ContainerRegistryType.DOCKER,
+        "project": "default",
+        "username": "username",
+        "password": "password",
+        "ssl_verify": False,
+        "is_global": False,
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    container_registry = response["data"]["create_container_registry_node"]["container_registry"]
+
+    id = container_registry.pop("row_id", None)
+    assert id is not None
+
+    assert container_registry == {
+        "registry_name": "cr.example.com",
+        "url": "http://cr.example.com",
+        "type": "docker",
+        "project": "default",
+        "username": "username",
+        "password": PASSWORD_PLACEHOLDER,
+        "ssl_verify": False,
+        "is_global": False,
+    }
+
+    variables["project"] = "default2"
+    await client.execute_async(query, variables=variables, context_value=context)
+
+
+@pytest.mark.dependency(depends=["test_create_container_registry"])
+@pytest.mark.asyncio
+async def test_modify_container_registry(client: Client, database_engine: ExtendedAsyncSAEngine):
+    context = get_graphquery_context(database_engine)
+
+    query = """
+        query ContainerRegistryNodes($filter: String!) {
+            container_registry_nodes (filter: $filter) {
+                edges {
+                    node {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                    cursor
+                }
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, dict | str] = {
+        "filter": 'registry_name == "cr.example.com"',
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["node"]["project"] == "default",
+            response["data"]["container_registry_nodes"]["edges"],
+        )
+    )
+
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]["node"]
+
+    query = """
+            mutation ModifyContainerRegistryNode($id: String!, $type: ContainerRegistryTypeField, $registry_name: String, $url: String, $project: String, $username: String, $password: String, $ssl_verify: Boolean, $is_global: Boolean) {
+                modify_container_registry_node(id: $id, type: $type, registry_name: $registry_name, url: $url, project: $project, username: $username, password: $password, ssl_verify: $ssl_verify, is_global: $is_global) {
+                    container_registry {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                }
+            }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "id": target_container_registry["row_id"],
+        "registry_name": "cr.example.com",
+        "username": "username2",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    container_registry = response["data"]["modify_container_registry_node"]["container_registry"]
+    assert container_registry["registry_name"] == "cr.example.com"
+    assert container_registry["url"] == "http://cr.example.com"
+    assert container_registry["type"] == "docker"
+    assert container_registry["project"] == "default"
+    assert container_registry["username"] == "username2"
+    assert container_registry["ssl_verify"] is False
+    assert container_registry["is_global"] is False
+
+    variables = {
+        "id": target_container_registry["row_id"],
+        "registry_name": "cr.example.com",
+        "url": "http://cr2.example.com",
+        "type": ContainerRegistryType.HARBOR2,
+        "project": "example",
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    container_registry = response["data"]["modify_container_registry_node"]["container_registry"]
+
+    assert container_registry["registry_name"] == "cr.example.com"
+    assert container_registry["url"] == "http://cr2.example.com"
+    assert container_registry["type"] == ContainerRegistryType.HARBOR2
+    assert container_registry["project"] == "example"
+    assert container_registry["username"] == "username2"
+    assert container_registry["ssl_verify"] is False
+    assert container_registry["is_global"] is False
+
+
+@pytest.mark.dependency(depends=["test_modify_container_registry"])
+@pytest.mark.asyncio
+async def test_modify_container_registry_allows_empty_string(
+    client: Client, database_engine: ExtendedAsyncSAEngine
+):
+    context = get_graphquery_context(database_engine)
+
+    query = """
+        query ContainerRegistryNodes($filter: String!) {
+            container_registry_nodes (filter: $filter) {
+                edges {
+                    node {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                    cursor
+                }
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, dict | str] = {
+        "filter": 'registry_name == "cr.example.com"',
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+    target_container_registries = list(
+        filter(
+            lambda item: item["node"]["project"] == "example",
+            response["data"]["container_registry_nodes"]["edges"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]["node"]
+
+    query = """
+            mutation ModifyContainerRegistryNode($id: String!, $type: ContainerRegistryTypeField, $registry_name: String, $url: String, $project: String, $username: String, $password: String, $ssl_verify: Boolean, $is_global: Boolean) {
+                modify_container_registry_node(id: $id, type: $type, registry_name: $registry_name, url: $url, project: $project, username: $username, password: $password, ssl_verify: $ssl_verify, is_global: $is_global) {
+                    container_registry {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                }
+            }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    # Given an empty string to password
+    variables = {
+        "id": target_container_registry["row_id"],
+        "registry_name": "cr.example.com",
+        "password": "",
+    }
+
+    # Then password is set to empty string
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    container_registry = response["data"]["modify_container_registry_node"]["container_registry"]
+    assert container_registry["registry_name"] == "cr.example.com"
+    assert container_registry["url"] == "http://cr2.example.com"
+    assert container_registry["type"] == ContainerRegistryType.HARBOR2
+    assert container_registry["project"] == "example"
+    assert container_registry["username"] == "username2"
+    assert container_registry["password"] == PASSWORD_PLACEHOLDER
+    assert container_registry["ssl_verify"] is False
+    assert container_registry["is_global"] is False
+
+
+@pytest.mark.dependency(depends=["test_modify_container_registry_allows_empty_string"])
+@pytest.mark.asyncio
+async def test_modify_container_registry_allows_null_for_unset(
+    client: Client, database_engine: ExtendedAsyncSAEngine
+):
+    context = get_graphquery_context(database_engine)
+
+    query = """
+        query ContainerRegistryNodes($filter: String!) {
+            container_registry_nodes (filter: $filter) {
+                edges {
+                    node {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                    cursor
+                }
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables: dict[str, str | None] = {
+        "filter": 'registry_name == "cr.example.com"',
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["node"]["project"] == "example",
+            response["data"]["container_registry_nodes"]["edges"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]["node"]
+
+    query = """
+            mutation ModifyContainerRegistryNode($id: String!, $type: ContainerRegistryTypeField, $registry_name: String, $url: String, $project: String, $username: String, $password: String, $ssl_verify: Boolean, $is_global: Boolean) {
+                modify_container_registry_node(id: $id, type: $type, registry_name: $registry_name, url: $url, project: $project, username: $username, password: $password, ssl_verify: $ssl_verify, is_global: $is_global) {
+                    container_registry {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                }
+            }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    # Given a null to password
+    variables = {
+        "id": target_container_registry["row_id"],
+        "registry_name": "cr.example.com",
+        "password": None,
+    }
+
+    # Then password is unset
+    response = await client.execute_async(query, variables=variables, context_value=context)
+    container_registry = response["data"]["modify_container_registry_node"]["container_registry"]
+    assert container_registry["registry_name"] == "cr.example.com"
+    assert container_registry["url"] == "http://cr2.example.com"
+    assert container_registry["type"] == ContainerRegistryType.HARBOR2
+    assert container_registry["project"] == "example"
+    assert container_registry["username"] == "username2"
+    assert container_registry["password"] is None
+    assert container_registry["ssl_verify"] is False
+    assert container_registry["is_global"] is False
+
+
+@pytest.mark.dependency(depends=["test_modify_container_registry_allows_null_for_unset"])
+@pytest.mark.asyncio
+async def test_delete_container_registry(client: Client, database_engine: ExtendedAsyncSAEngine):
+    context = get_graphquery_context(database_engine)
+
+    query = """
+        query ContainerRegistryNodes($filter: String!) {
+            container_registry_nodes (filter: $filter) {
+                edges {
+                    node {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                    cursor
+                }
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "filter": 'registry_name == "cr.example.com"',
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    target_container_registries = list(
+        filter(
+            lambda item: item["node"]["project"] == "example",
+            response["data"]["container_registry_nodes"]["edges"],
+        )
+    )
+    assert len(target_container_registries) == 1
+    target_container_registry = target_container_registries[0]["node"]
+
+    query = """
+            mutation DeleteContainerRegistryNode($id: String!) {
+                delete_container_registry_node(id: $id) {
+                    container_registry {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                }
+            }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "id": str(target_container_registry["row_id"]),
+    }
+    response = await client.execute_async(query, variables=variables, context_value=context)
+
+    container_registry = response["data"]["delete_container_registry_node"]["container_registry"]
+    assert container_registry["registry_name"] == "cr.example.com"
+
+    query = """
+        query ContainerRegistryNodes($filter: String!) {
+            container_registry_nodes (filter: $filter) {
+                edges {
+                    node {
+                        $CONTAINER_REGISTRY_FIELDS
+                    }
+                    cursor
+                }
+            }
+        }
+        """.replace("$CONTAINER_REGISTRY_FIELDS", CONTAINER_REGISTRY_FIELDS)
+
+    variables = {
+        "filter": f'row_id == "${target_container_registry["row_id"]}"',
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+    assert response["data"]["container_registry_nodes"] is None

--- a/tests/manager/models/test_container_registry_nodes.py
+++ b/tests/manager/models/test_container_registry_nodes.py
@@ -138,7 +138,6 @@ async def test_modify_container_registry(client: Client, database_engine: Extend
     }
 
     response = await client.execute_async(query, variables=variables, context_value=context)
-    print("response 1!!", response)
 
     target_container_registries = list(
         filter(

--- a/tests/manager/scheduler_utils.py
+++ b/tests/manager/scheduler_utils.py
@@ -35,9 +35,12 @@ ARCH_FOR_TEST: Final = "x86_64"
 agent_selection_resource_priority: Final = ["cuda", "rocm", "tpu", "cpu", "mem"]
 
 common_image_ref: Final = ImageRef(
-    "lablup/python:3.6-ubunt18.04",
-    ["*"],
+    name="python",
+    project="lablup",
+    tag="3.6-ubuntu18.04",
+    registry="index.docker.io",
     architecture=ARCH_FOR_TEST,
+    is_local=False,
 )
 
 example_group_id = uuid4()


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

## `base.py`'s `_scan_tag` update for handling `MEDIA_TYPE_DOCKER_MANIFEST`

In the existing code, only `MEDIA_TYPE_DOCKER_MANIFEST_LIST` and `MEDIA_TYPE_OCI_INDEX` types were handled in `_scan_tag`, so a runtime error occurred when `MEDIA_TYPE_DOCKER_MANIFEST` type was passed as `content_type`.

However, in `harbor.py`, handling based on `manifest_media_type` is processed by separate functions such as `_process_oci_index` and `_process_docker_v2_multiplatform_image`, so handling for `MEDIA_TYPE_DOCKER_MANIFEST` has been added by extracting these functions with the same signatures.

Adding handling for the `MEDIA_TYPE_DOCKER_MANIFEST` type (`_process_docker_v2_image`) seems not to be specific only to ghcr, so it was added to `base.py`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
