### PR TITLE
feat: Support GitHub Container Registry based on `PostgreSQL`

### DIFF
--- a/changes/2621.feature.md
+++ b/changes/2621.feature.md
@@ -1,0 +1,1 @@
+Support GitHub Container Registry.

--- a/fixtures/manager/example-container-registries-ghcr.json
+++ b/fixtures/manager/example-container-registries-ghcr.json
@@ -1,0 +1,16 @@
+{
+    "container_registries": [
+        {
+            "id": "abc42a05-4471-41fa-8772-10bf6452c7d1",
+            "registry_name": "ghcr.io",
+            "url": "https://ghcr.io",
+            "type": "github",
+            "username": "<username>",
+            "password": "<github_pat>",
+            "project": "<username>",
+            "extra": {
+                "entity_type": "users"
+            }
+        }
+    ]
+}

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1514,7 +1514,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'local').
+    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'local').
     """
     type: ContainerRegistryTypeField!
 
@@ -1546,7 +1546,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Registry type. One of ('docker', 'harbor', 'harbor2', 'local'). Added in 24.09.0.
+    Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'local'). Added in 24.09.0.
     """
     type: ContainerRegistryTypeField
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -31,9 +31,9 @@ def get_container_registry_cls(registry_info: ContainerRegistryRow) -> Type[Base
 
         cr_cls = HarborRegistry_v2
     elif registry_type == ContainerRegistryType.GITHUB:
-        from .github import GitHubRegistry_v2
+        from .github import GitHubRegistry
 
-        cr_cls = GitHubRegistry_v2
+        cr_cls = GitHubRegistry
     elif registry_type == ContainerRegistryType.LOCAL:
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -30,6 +30,10 @@ def get_container_registry_cls(registry_info: ContainerRegistryRow) -> Type[Base
         from .harbor import HarborRegistry_v2
 
         cr_cls = HarborRegistry_v2
+    elif registry_type == ContainerRegistryType.GITHUB:
+        from .github import GitHubRegistry_v2
+
+        cr_cls = GitHubRegistry_v2
     elif registry_type == ContainerRegistryType.LOCAL:
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -12,7 +12,7 @@ from .base import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
 
 
-class GitHubRegistry_v2(BaseContainerRegistry):
+class GitHubRegistry(BaseContainerRegistry):
     async def fetch_repositories(
         self,
         sess: aiohttp.ClientSession,

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -19,7 +19,10 @@ class GitHubRegistry(BaseContainerRegistry):
     ) -> AsyncIterator[str]:
         username = self.registry_info.username
         access_token = self.registry_info.password
-        entity_type = self.registry_info.extra.get("entity_type")
+        entity_type = self.registry_info.extra.get("entity_type", None)
+
+        if entity_type is None:
+            raise RuntimeError("Entity type is not provided for GitHub registry!")
 
         base_url = f"https://api.github.com/{entity_type}/{username}/packages"
 

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator
 
 import aiohttp
 
-from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 
 from .base import (
     BaseContainerRegistry,

--- a/src/ai/backend/manager/container_registry/github.py
+++ b/src/ai/backend/manager/container_registry/github.py
@@ -1,0 +1,49 @@
+import logging
+from typing import AsyncIterator
+
+import aiohttp
+
+from ai.backend.common.logging import BraceStyleAdapter
+
+from .base import (
+    BaseContainerRegistry,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+class GitHubRegistry_v2(BaseContainerRegistry):
+    async def fetch_repositories(
+        self,
+        sess: aiohttp.ClientSession,
+    ) -> AsyncIterator[str]:
+        username = self.registry_info.username
+        access_token = self.registry_info.password
+        entity_type = self.registry_info.extra.get("entity_type")
+
+        base_url = f"https://api.github.com/{entity_type}/{username}/packages"
+
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+        page = 1
+
+        while True:
+            async with sess.get(
+                base_url,
+                headers=headers,
+                params={"package_type": "container", "per_page": 30, "page": page},
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    for repo in data:
+                        yield f"{username}/{repo["name"]}"
+                    if "next" in response.links:
+                        page += 1
+                    else:
+                        break
+                else:
+                    raise RuntimeError(
+                        f"Failed to fetch repositories! {response.status} error occured."
+                    )

--- a/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
+++ b/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
@@ -83,6 +83,7 @@ def get_container_registry_row_schema():
         password = sa.Column("password", sa.String, nullable=True)
         ssl_verify = sa.Column("ssl_verify", sa.Boolean, server_default=sa.text("true"), index=True)
         is_global = sa.Column("is_global", sa.Boolean, server_default=sa.text("true"), index=True)
+        extra = sa.Column("extra", sa.JSON, nullable=True, default=None)
 
     return ContainerRegistryRow
 

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -51,6 +51,7 @@ class ContainerRegistryType(enum.StrEnum):
     DOCKER = "docker"
     HARBOR = "harbor"
     HARBOR2 = "harbor2"
+    GITHUB = "github"
     LOCAL = "local"
 
 
@@ -76,6 +77,7 @@ class ContainerRegistryRow(Base):
     is_global = sa.Column(
         "is_global", sa.Boolean, nullable=True, server_default=sa.text("true"), index=True
     )
+    extra = sa.Column("extra", sa.JSON, nullable=True, default=None)
 
     @classmethod
     async def get(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix #2337.

# Test

Manually tested it using the following methods.

In this PR, the `cr.backend.ai/stable/python:3.9-ubuntu20.04` image is used as a placeholder for testing.

## Prerequisite

1. Tag and push the `cr.backend.ai/stable/python` image to your GitHub package for testing.

```
❯ docker tag cr.backend.ai/stable/python:3.9-ubuntu20.04 ghcr.io/<github_username>/python:3.9-ubuntu20.04
❯ docker push ghcr.io/<github_username>/python:3.9-ubuntu20.04
```

2. After filling in the required fields in the fixtures/manager/example-container-registries-ghcr.json file, execute the following command.

```
❯ ./backend.ai mgr fixture populate ./fixtures/manager/example-container-registries-ghcr.json
```

> [!NOTE]  
The `entity_type` should be either "users" or "orgs".

3. Insert the following value into the `container_registry` column of the `groups` table.

```
{
	"registry": "ghcr.io",
	"project": "<github_username>"
}
```

4. Add `ghcr.io` value to `allowed_docker_registries` column of `domains` table using below command

```
❯ ./backend.ai admin domain update default --allowed-docker-registries=ghcr.io
```

## Test scenarios

Verify that the container registry added in this PR is functioning based on several scenarios.

If there are additional scenarios that need testing, please leave a comment.

### 1. Image Rescan

Image rescanning should work through the following command.

```
❯ ./backend.ai mgr image rescan ghcr.io
```

###  2. Create a session from the pulled image

Run a session using the downloaded image.

```
❯ ./backend.ai session create ghcr.io/<github_username>/python:3.9-ubuntu20.04
```

### 3. Commit the changes and push it to the container registry.

Commit the changes using the `convert-to-image` command and push them to the container registry.

```
❯ ./backend.ai session convert-to-image <session_id> test_imgname

∙ Request to commit Session(name or id: ce592e27-b90a-4859-92b1-360fdd6d8464)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.02it/s]
✓ Session export process completed.
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue