### PR TITLE
feat: Support GitLab Container Registry based on `PostgreSQL`

### DIFF
--- a/changes/2622.feature.md
+++ b/changes/2622.feature.md
@@ -1,0 +1,1 @@
+Support GitLab Container Registry.

--- a/fixtures/manager/example-container-registries-gitlab.json
+++ b/fixtures/manager/example-container-registries-gitlab.json
@@ -7,10 +7,7 @@
             "type": "gitlab",
             "username": "<username>",
             "password": "<gitlab_pat>",
-            "project": "<username>",
-            "extra": {
-                "gitlab_project": "<project>"
-            }
+            "project": "<username>"
         }
     ]
 }

--- a/fixtures/manager/example-container-registries-gitlab.json
+++ b/fixtures/manager/example-container-registries-gitlab.json
@@ -7,7 +7,10 @@
             "type": "gitlab",
             "username": "<username>",
             "password": "<gitlab_pat>",
-            "project": "<username>"
+            "project": "<username>",
+            "extra": {
+                "api_endpoint": "https://gitlab.com"
+            }
         }
     ]
 }

--- a/fixtures/manager/example-container-registries-gitlab.json
+++ b/fixtures/manager/example-container-registries-gitlab.json
@@ -1,0 +1,16 @@
+{
+    "container_registries": [
+        {
+            "id": "abc42a05-4471-41fa-8772-10bf6452c7d2",
+            "registry_name": "registry.gitlab.com",
+            "url": "https://registry.gitlab.com",
+            "type": "gitlab",
+            "username": "<username>",
+            "password": "<gitlab_pat>",
+            "project": "<username>",
+            "extra": {
+                "gitlab_project": "<project>"
+            }
+        }
+    ]
+}

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1514,7 +1514,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'local').
+    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'local').
     """
     type: ContainerRegistryTypeField!
 
@@ -1546,7 +1546,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'local'). Added in 24.09.0.
+    Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'local'). Added in 24.09.0.
     """
     type: ContainerRegistryTypeField
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -34,6 +34,10 @@ def get_container_registry_cls(registry_info: ContainerRegistryRow) -> Type[Base
         from .github import GitHubRegistry
 
         cr_cls = GitHubRegistry
+    elif registry_type == ContainerRegistryType.GITLAB:
+        from .gitlab import GitLabRegistry
+
+        cr_cls = GitLabRegistry
     elif registry_type == ContainerRegistryType.LOCAL:
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -5,7 +5,7 @@ from typing import AsyncIterator, cast
 import aiohttp
 import sqlalchemy as sa
 
-from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 
 from .base import (

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -15,16 +15,15 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 
 class GitLabRegistry(BaseContainerRegistry):
     async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
-        name, access_token, gitlab_project = (
-            self.registry_info.username,
+        access_token, projects = (
             self.registry_info.password,
-            self.registry_info.extra.get("gitlab_project"),
+            self.registry_info.project,
         )
 
-        projects = gitlab_project.split(",")
+        projects = projects.split(",")
 
         for project in projects:
-            encoded_project_id = urllib.parse.quote(f"{name}/{project}", safe="")
+            encoded_project_id = urllib.parse.quote(project, safe="")
             repo_list_url = (
                 f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
             )

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -18,6 +18,10 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-d
 class GitLabRegistry(BaseContainerRegistry):
     async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
         access_token = self.registry_info.password
+        api_endpoint = self.registry_info.extra.get("api_endpoint", None)
+
+        if api_endpoint is None:
+            raise RuntimeError('"api_endpoint" is not provided for GitLab registry!')
 
         async with self.db.begin_readonly_session() as db_sess:
             result = await db_sess.execute(
@@ -30,7 +34,7 @@ class GitLabRegistry(BaseContainerRegistry):
         for project in projects:
             encoded_project_id = urllib.parse.quote(project, safe="")
             repo_list_url = (
-                f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
+                f"{api_endpoint}/api/v4/projects/{encoded_project_id}/registry/repositories"
             )
 
             headers = {

--- a/src/ai/backend/manager/container_registry/gitlab.py
+++ b/src/ai/backend/manager/container_registry/gitlab.py
@@ -1,0 +1,56 @@
+import logging
+import urllib.parse
+from typing import AsyncIterator
+
+import aiohttp
+
+from ai.backend.common.logging import BraceStyleAdapter
+
+from .base import (
+    BaseContainerRegistry,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+class GitLabRegistry(BaseContainerRegistry):
+    async def fetch_repositories(self, sess: aiohttp.ClientSession) -> AsyncIterator[str]:
+        name, access_token, gitlab_project = (
+            self.registry_info.username,
+            self.registry_info.password,
+            self.registry_info.extra.get("gitlab_project"),
+        )
+
+        projects = gitlab_project.split(",")
+
+        for project in projects:
+            encoded_project_id = urllib.parse.quote(f"{name}/{project}", safe="")
+            repo_list_url = (
+                f"https://gitlab.com/api/v4/projects/{encoded_project_id}/registry/repositories"
+            )
+
+            headers = {
+                "Accept": "application/json",
+                "PRIVATE-TOKEN": access_token,
+            }
+            page = 1
+
+            while True:
+                async with sess.get(
+                    repo_list_url,
+                    headers=headers,
+                    params={"per_page": 30, "page": page},
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+
+                        for repo in data:
+                            yield repo["path"]
+                        if "next" in response.headers.get("Link", ""):
+                            page += 1
+                        else:
+                            break
+                    else:
+                        raise RuntimeError(
+                            f"Failed to fetch repositories for project {project}! {response.status} error occurred."
+                        )

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -52,6 +52,7 @@ class ContainerRegistryType(enum.StrEnum):
     HARBOR = "harbor"
     HARBOR2 = "harbor2"
     GITHUB = "github"
+    GITLAB = "gitlab"
     LOCAL = "local"
 
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix #2337.

# Test

Manually tested it using the following methods.

In this PR, the `cr.backend.ai/stable/python:3.9-ubuntu20.04` image is used as a placeholder for testing.

## Prerequisite

> Note: The example given refers to GitLab Hosted Registry, but it also works in an on-premises environment.

1. Tag and push the `cr.backend.ai/stable/python` image to your GitLab package for testing.

```
❯ docker tag cr.backend.ai/stable/python:3.9-ubuntu20.04 registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
❯ docker push registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
```

2. After filling in the required fields in the `fixtures/manager/example-container-registries-gitlab.json` file, execute the following command.

```
❯ ./backend.ai mgr fixture populate ./fixtures/manager/example-container-registries-gitlab.json
```

3. Insert the following value into the `container_registry` column of the `groups` table.

```
{
	"registry": "registry.gitlab.com",
	"project": "<gitlab_username>/<project>"
}
```

4. Add `registry.gitlab.com` value to `allowed_docker_registries` column of `domains` table using below command

```
❯ ./backend.ai admin domain update default --allowed-docker-registries=registry.gitlab.com
```

## Test scenarios

Verify that the container registry added in this PR is functioning based on several scenarios.

If there are additional scenarios that need testing, please leave a comment.

### 1. Image Rescan

Image rescanning should work through the following command.

```
❯ ./backend.ai mgr image rescan registry.gitlab.com
```

###  2. Create a session from the pulled image

Run a session using the downloaded image.

```
❯ ./backend.ai session create registry.gitlab.com/<gitlab_username>/python:3.9-ubuntu20.04
```

### 3. Commit the changes and push it to the container registry.

Commit the changes using the `convert-to-image` command and push them to the container registry.

```
❯ ./backend.ai session convert-to-image <session_id> test_imgname

∙ Request to commit Session(name or id: ce592e27-b90a-4859-92b1-360fdd6d8464)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.02it/s]
✓ Session export process completed.
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue