### PR TITLE
feat: Support AWS ECR Public Container Registry based on `PostgreSQL`

### DIFF
--- a/changes/2623.feature.md
+++ b/changes/2623.feature.md
@@ -1,0 +1,1 @@
+Support AWS ECR Public Container Registry.

--- a/fixtures/manager/example-container-registries-aws-ecr.json
+++ b/fixtures/manager/example-container-registries-aws-ecr.json
@@ -1,0 +1,18 @@
+{
+    "container_registries": [
+        {
+            "id": "abc42a05-4471-41fa-8772-10bf6452c7d3",
+            "registry_name": "public.ecr.aws",
+            "url": "https://public.ecr.aws",
+            "type": "ecr",
+            "username": "AWS",
+            "password": "<password>",
+            "project": "<registry_alias>",
+            "extra": {
+                "access_token": "<access_token>",
+                "secret_access_token": "<secret_access_token>",
+                "region": "us-east-1"
+            }
+        }
+    ]
+}

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -253,7 +253,7 @@ async def login(
         return {"auth": basic_auth, "headers": {}}
     elif ping_status == 404:
         raise RuntimeError(f"Unsupported docker registry: {registry_url}! (API v2 not implemented)")
-    elif ping_status == 401:
+    elif ping_status in [400, 401]:
         params = {
             "scope": scope,
             "offline_token": "true",

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -253,6 +253,8 @@ async def login(
         return {"auth": basic_auth, "headers": {}}
     elif ping_status == 404:
         raise RuntimeError(f"Unsupported docker registry: {registry_url}! (API v2 not implemented)")
+    # Check also 400 response since the AWS ECR Public server returns a 400 response
+    # when given invalid credential authorization.
     elif ping_status in [400, 401]:
         params = {
             "scope": scope,

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1514,7 +1514,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'local').
+    Added in 24.09.0. Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'ecr', 'ecr-public', 'local').
     """
     type: ContainerRegistryTypeField!
 
@@ -1546,7 +1546,7 @@ type Mutations {
     ssl_verify: Boolean
 
     """
-    Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'local'). Added in 24.09.0.
+    Registry type. One of ('docker', 'harbor', 'harbor2', 'github', 'gitlab', 'ecr', 'ecr-public', 'local'). Added in 24.09.0.
     """
     type: ContainerRegistryTypeField
 

--- a/src/ai/backend/manager/container_registry/__init__.py
+++ b/src/ai/backend/manager/container_registry/__init__.py
@@ -38,6 +38,10 @@ def get_container_registry_cls(registry_info: ContainerRegistryRow) -> Type[Base
         from .gitlab import GitLabRegistry
 
         cr_cls = GitLabRegistry
+    elif registry_type in [ContainerRegistryType.ECR, ContainerRegistryType.ECR_PUB]:
+        from .aws_ecr import AWSElasticContainerRegistry
+
+        cr_cls = AWSElasticContainerRegistry
     elif registry_type == ContainerRegistryType.LOCAL:
         from .local import LocalRegistry
 

--- a/src/ai/backend/manager/container_registry/aws_ecr.py
+++ b/src/ai/backend/manager/container_registry/aws_ecr.py
@@ -1,0 +1,52 @@
+import logging
+from typing import AsyncIterator
+
+import aiohttp
+import boto3
+
+from ai.backend.common.logging import BraceStyleAdapter
+
+from .base import (
+    BaseContainerRegistry,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
+
+
+class AWSElasticContainerRegistry(BaseContainerRegistry):
+    async def fetch_repositories(
+        self,
+        sess: aiohttp.ClientSession,
+    ) -> AsyncIterator[str]:
+        access_key, secret_access_key, region, type_ = (
+            self.registry_info.extra.get("access_key"),
+            self.registry_info.extra.get("secret_access_key"),
+            self.registry_info.extra.get("region"),
+            self.registry_info.type,
+        )
+
+        client = boto3.client(
+            type_,
+            region_name=region,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_access_key,
+        )
+
+        next_token = None
+        try:
+            while True:
+                if next_token:
+                    response = client.describe_repositories(nextToken=next_token, maxResults=30)
+                else:
+                    response = client.describe_repositories(maxResults=30)
+
+                for repo in response["repositories"]:
+                    registry_alias = (repo["repositoryUri"].split("/"))[1]
+                    yield f"{registry_alias}/{repo["repositoryName"]}"
+
+                next_token = response.get("nextToken")
+
+                if not next_token:
+                    break
+        except Exception as e:
+            log.error(f"Error occurred: {e}")

--- a/src/ai/backend/manager/container_registry/aws_ecr.py
+++ b/src/ai/backend/manager/container_registry/aws_ecr.py
@@ -4,7 +4,7 @@ from typing import AsyncIterator
 import aiohttp
 import boto3
 
-from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 
 from .base import (
     BaseContainerRegistry,

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -53,6 +53,8 @@ class ContainerRegistryType(enum.StrEnum):
     HARBOR2 = "harbor2"
     GITHUB = "github"
     GITLAB = "gitlab"
+    ECR = "ecr"
+    ECR_PUB = "ecr-public"
     LOCAL = "local"
 
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix #2337.

# Test

## ecr-public

Manually tested it using the following methods.

In this PR, the `cr.backend.ai/stable/python:3.9-ubuntu20.04` image is used as a placeholder for testing.

## Prerequisite

Create and configure the relevant users and policies appropriately through AWS IAM for testing this PR.

Then, generate the "access key" and store the `access_key` and `secret_access_key` in etcd.

---

1. Tag and push the `cr.backend.ai/stable/python` image to your AWS ECR package for testing.

```
❯ docker tag cr.backend.ai/stable/python:3.9-ubuntu20.04 public.ecr.aws/<registry_alias>/python:3.9-ubuntu20.04
❯ docker push public.ecr.aws/<registry_alias>/python:3.9-ubuntu20.04
```

2. After filling in the required fields in the `fixtures/manager/example-container-registries-aws-ecr.json` file, execute the following command.

```
❯ ./backend.ai mgr fixture populate ./fixtures/manager/example-container-registries-aws-ecr.json
```

3. Insert the following value into the `container_registry` column of the `groups` table.

```
{
	"registry": "public.ecr.aws",
	"project": "<registry_alias>"
}
```

4. Add `public.ecr.aws` value to `allowed_docker_registries` column of `domains` table using below command

```
❯ ./backend.ai admin domain update default --allowed-docker-registries=public.ecr.aws
```

### Test scenarios

Verify that the container registry added in this PR is functioning based on several scenarios.

If there are additional scenarios that need testing, please leave a comment.

#### 1. Image Rescan

Image rescanning should work through the following command.

```
❯ ./backend.ai mgr image rescan public.ecr.aws
```

####  2. Create a session from the pulled image

Run a session using the downloaded image.

```
❯ ./backend.ai session create public.ecr.aws/<registry_alias>/python:3.9-ubuntu20.04
```

#### 3. Commit the changes and push it to the container registry.

Commit the changes using the `convert-to-image` command and push them to the container registry.

```
❯ ./backend.ai session convert-to-image <session_id> test_imgname

∙ Request to commit Session(name or id: ce592e27-b90a-4859-92b1-360fdd6d8464)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.02it/s]
✓ Session export process completed.
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2549.org.readthedocs.build/en/2549/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2549.org.readthedocs.build/ko/2549/

<!-- readthedocs-preview sorna-ko end -->