### PR TITLE
chore: Update git pre-push hook to use correct base branch name

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -15,10 +15,12 @@ if ! command -v gh &> /dev/null; then
   pants lint check ::
 else
   # Get the base branch name from GitHub if we are on a pull request.
-  if gh pr view "$CURRENT_BRANCH" &> /dev/null; then
-    BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName')
-  else
+  BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName' 2>/dev/null)
+  if [[ -z "$BASE_BRANCH" ]]; then
     BASE_BRANCH="main"
+    echo "No pull request found for the branch $CURRENT_BRANCH, falling back to main."
+  else
+    echo "Detected the pull request's base branch: $BASE_BRANCH"
   fi
   if [ "$1" != "origin" ]; then
     # extract the owner name of the target repo

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -9,30 +9,30 @@ fi
 CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Get the base branch name from GitHub.
 if ! command -v gh &> /dev/null; then
-  echo "GitHub CLI (gh) is not installed. Please install it and authenticate."
-  exit 1
-fi
-if gh pr view "$CURRENT_BRANCH" &> /dev/null; then
-  # Get the base branch name if we are on a pull request.
-  BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName')
+  echo "GitHub CLI (gh) is not installed. Since we cannot determine the base branch, running the full check before push."
+  pants tailor --check update-build-files --check ::
+  pants lint check ::
 else
-  BASE_BRANCH="main"
+  # Get the base branch name from GitHub if we are on a pull request.
+  if gh pr view "$CURRENT_BRANCH" &> /dev/null; then
+    BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName')
+  else
+    BASE_BRANCH="main"
+  fi
+  if [ "$1" != "origin" ]; then
+    # extract the owner name of the target repo
+    ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
+    cleanup_remote() {
+      git remote remove "$ORIGIN"
+    }
+    trap cleanup_remote EXIT
+    git remote add "$ORIGIN" "$1"
+    git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
+  else
+    ORIGIN="origin"
+  fi
+  echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
+  pants tailor --check update-build-files --check ::
+  pants lint check --changed-since="${ORIGIN}/${BASE_BRANCH}"
 fi
-
-if [ "$1" != "origin" ]; then
-  # extract the owner name of the target repo
-  ORIGIN="$(echo "$1" | grep -o '://[^/]\+/[^/]\+/' | grep -o '/[^/]\+/$' | tr -d '/')"
-  cleanup_remote() {
-    git remote remove "$ORIGIN"
-  }
-  trap cleanup_remote EXIT
-  git remote add "$ORIGIN" "$1"
-  git fetch -q --depth=1 --no-tags "$ORIGIN" "$BASE_BRANCH"
-else
-  ORIGIN="origin"
-fi
-echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
-pants tailor --check update-build-files --check ::
-pants lint check --changed-since="${ORIGIN}/${BASE_BRANCH}"


### PR DESCRIPTION
While working on #2625, I found that the current pre-push hook does not detect the correct base branch name when it run `pants ... --changed-since=...`.

To maintain independency of the toolchain from GitHub, let the pre-push script gracefully fallback to the full lint & check when `gh` (GitHub CLI) is not available.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version