### PR TITLE
fix: Skip mounting zero-byte lxcfs files (#2604)

### DIFF
--- a/changes/2604.fix.md
+++ b/changes/2604.fix.md
@@ -1,0 +1,1 @@
+Skip mounting zero-byte lxcfs files when lxcfs is activated to prevent crashes in session containers

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -339,6 +339,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     MountPermission.READ_WRITE,
                 )
                 for lxcfs_proc_path in (lxcfs_root / "proc").iterdir()
+                if lxcfs_proc_path.stat().st_size > 0
             )
             mounts.extend(
                 Mount(


### PR DESCRIPTION
This is an auto-generated backport PR of #2604 to the 23.09 release.