### PR TITLE
fix: Silence falsy Redis timeout warnings with blocking commands

### DIFF
--- a/changes/2632.fix.md
+++ b/changes/2632.fix.md
@@ -1,0 +1,1 @@
+Silence falsy Redis timeout warnings when retrying blocking commands if the timeout does not exceed the expected command timeout

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -267,6 +267,7 @@ async def execute(
                 now = time.perf_counter()
                 if now - first_trial >= command_timeout + 1.0:
                     show_retry_warning(e)
+                first_trial = now
             continue
         except redis.exceptions.ResponseError as e:
             if "NOREPLICAS" in e.args[0]:


### PR DESCRIPTION
This looks like an uncovered logical error after #2574.

When we retry the Redis command upon timeout errors, we should distinguish if the timeout is a "normally expected" one like blocking commands or if it's really a server/network failure.

For instance, in `common.redis_helper.read_stream()` and `common.redis_helper.read_stream_by_group()`, we apply 10 seconds command timeout for `XREAD` and `XREADGROUP`.

This PR silences retry warnings by resetting the `first_trial` timestamp when we loop through infinite retries for such blocking commands. It now emits the retry warning only if the detected elapsed time exceeds _the expected command timeout_ (only when explicitly given) + 1 second, **where the elapsed time is measured from the beginning of each iteration.**

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
