### PR TITLE
fix: Silence falsy Redis timeout warnings with blocking commands (#2632)

### DIFF
--- a/changes/2632.fix.md
+++ b/changes/2632.fix.md
@@ -1,0 +1,1 @@
+Silence falsy Redis timeout warnings when retrying blocking commands if the timeout does not exceed the expected command timeout

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -267,6 +267,7 @@ async def execute(
                 now = time.perf_counter()
                 if now - first_trial >= command_timeout + 1.0:
                     show_retry_warning(e)
+                first_trial = now
             continue
         except redis.exceptions.ResponseError as e:
             if "NOREPLICAS" in e.args[0]:


### PR DESCRIPTION
This is an auto-generated backport PR of #2632 to the 24.03 release.