### PR TITLE
fix: hide third-party customized image from GQL query (#2557)

### DIFF
--- a/changes/2557.fix.md
+++ b/changes/2557.fix.md
@@ -1,0 +1,1 @@
+Prevent other user's customized image from being listed as a response of `images` GQL query

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -51,7 +51,7 @@ type Queries {
     is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `image_filters` is specified and is not null.")
 
     """
-    Added in 24.03.4. Allowed values are: [operational, customized]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.
+    Added in 24.03.4. Allowed values are: [general, operational, customized]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by caller). To list the owned images only call `customized_images`.
     """
     image_filters: [String] = null
   ): [Image]

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -374,7 +374,7 @@ class Queries(graphene.ObjectType):
         image_filters=graphene.List(
             graphene.String,
             default_value=None,
-            description=f"Added in 24.03.4. Allowed values are: [{', '.join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.",
+            description=f"Added in 24.03.4. Allowed values are: [{', '.join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by caller). To list the owned images only call `customized_images`.",
         ),
     )
 
@@ -1157,6 +1157,8 @@ class Queries(graphene.ObjectType):
                 image_load_filters.remove(ImageLoadFilter.CUSTOMIZED)
                 image_load_filters.add(ImageLoadFilter.CUSTOMIZED_GLOBAL)
         else:
+            image_load_filters.add(ImageLoadFilter.CUSTOMIZED)
+            image_load_filters.add(ImageLoadFilter.GENERAL)
             if is_operation is None:
                 # I know this logic is quite contradicts to the parameter name,
                 # but to conform with previous implementation...

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -85,6 +85,8 @@ __all__ = (
 
 
 class PublicImageLoadFilter(enum.StrEnum):
+    GENERAL = "general"
+    """Include general purpose images."""
     OPERATIONAL = "operational"
     """Include operational images."""
     CUSTOMIZED = "customized"
@@ -92,6 +94,8 @@ class PublicImageLoadFilter(enum.StrEnum):
 
 
 class ImageLoadFilter(enum.StrEnum):
+    GENERAL = "general"
+    """Include general purpose images."""
     OPERATIONAL = "operational"
     """Include operational images."""
     CUSTOMIZED = "customized"
@@ -715,12 +719,9 @@ class Image(graphene.ObjectType):
         """
         user_role = ctx.user["role"]
 
-        if not filters:
-            return True
-
         # If the image filtered by any of its labels, return False early.
         # If the image is not filtered and is determiend to be valid by any of its labels, `is_valid = True`.
-        is_valid = False
+        is_valid = ImageLoadFilter.GENERAL in filters
         for label in self.labels:
             match label.key:
                 case "ai.backend.features" if "operation" in label.value:


### PR DESCRIPTION
This is an auto-generated backport PR of #2557 to the 24.03 release.