### PR TITLE
fix: delete dependent sessions when purging project (#2573)

### DIFF
--- a/changes/2573.fix.md
+++ b/changes/2573.fix.md
@@ -1,0 +1,1 @@
+Delete sessions DB records when purging project.


### PR DESCRIPTION
This is an auto-generated backport PR of #2573 to the 24.03 release.