### PR TITLE
refactor: image configuration when create kernels

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -229,12 +229,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         self.agent_id = agent_id
         self.event_producer = event_producer
         self.kernel_config = kernel_config
-        self.image_ref = ImageRef(
-            kernel_config["image"]["canonical"],
-            known_registries=[kernel_config["image"]["registry"]["name"]],
-            is_local=kernel_config["image"]["is_local"],
-            architecture=kernel_config["image"].get("architecture", get_arch_name()),
-        )
+        self.image_ref = ImageRef.from_image_config(kernel_config["image"])
         self.distro = distro
         self.internal_data = kernel_config["internal_data"] or {}
         self.computers = computers

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import (
+    TYPE_CHECKING,
     Any,
     Final,
     Iterable,
@@ -20,6 +21,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    cast,
 )
 
 import aiohttp
@@ -36,6 +38,9 @@ from .etcd import quote as etcd_quote
 from .etcd import unquote as etcd_unquote
 from .exception import InvalidImageName, InvalidImageTag, UnknownImageRegistry
 from .service_ports import parse_service_ports
+
+if TYPE_CHECKING:
+    from .types import ImageConfig, ImageRegistry
 
 __all__ = (
     "arch_name_aliases",
@@ -310,7 +315,7 @@ def is_known_registry(
     return False
 
 
-async def get_registry_info(etcd: AsyncEtcd, name: str) -> tuple[yarl.URL, dict]:
+async def get_registry_info(etcd: AsyncEtcd, name: str) -> ImageRegistry:
     reg_path = f"config/docker/registry/{etcd_quote(name)}"
     item = await etcd.get_prefix(reg_path)
     if not item:
@@ -319,14 +324,14 @@ async def get_registry_info(etcd: AsyncEtcd, name: str) -> tuple[yarl.URL, dict]
     if not registry_addr:
         raise UnknownImageRegistry(name)
     assert isinstance(registry_addr, str)
-    creds = {}
-    username = item.get("username")
-    if username is not None:
-        creds["username"] = username
-    password = item.get("password")
-    if password is not None:
-        creds["password"] = password
-    return yarl.URL(registry_addr), creds
+    username = cast(str | None, item.get("username"))
+    password = cast(str | None, item.get("password"))
+    return {
+        "name": name,
+        "url": registry_addr,
+        "username": username,
+        "password": password,
+    }
 
 
 def validate_image_labels(labels: dict[str, str]) -> dict[str, str]:
@@ -450,6 +455,15 @@ class ImageRef:
             if not rx_slug.search(self._tag):
                 raise InvalidImageTag(self._tag, self._value)
         self._update_tag_set()
+
+    @classmethod
+    def from_image_config(cls, config: ImageConfig) -> ImageRef:
+        return ImageRef(
+            config["canonical"],
+            known_registries=[config["registry"]["name"]],
+            is_local=config["is_local"],
+            architecture=config["architecture"],
+        )
 
     @staticmethod
     def _parse_image_tag(s: str, using_default_registry: bool = False) -> tuple[str, str]:

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1034,6 +1034,7 @@ class ImageConfig(TypedDict):
     registry: ImageRegistry
     labels: Mapping[str, str]
     is_local: bool
+    auto_pull: str  # AutoPullBehavior value
 
 
 class ServicePort(TypedDict):


### PR DESCRIPTION
`ai.backend.common.types.ImageRegistry` is image registry info.
`ai.backend.common.types.ImageConf` contains image information to use when creating kernels including image reference and image registry.

Use both types to create kernels.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)