### PR TITLE
fix: Implement missing `StrEnumType` handling in `populate_fixture()`

### DIFF
--- a/changes/2648.fix.md
+++ b/changes/2648.fix.md
@@ -1,0 +1,1 @@
+Implement missing `StrEnumType` handling in `populate_fixture()`.


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR Implement missing `StrEnumType` handling in `populate_fixture()`

This PR is a prerequisite for PR #1917.
This issue was discovered during the process of changing `ContaineRegistryRow.registry_type` to an `StrEnum` type.
This is separated into a distinct PR for backporting.


---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

