### PR TITLE
fix: Implement missing `StrEnumType` handling in `populate_fixture()` (#2648)

### DIFF
--- a/changes/2648.fix.md
+++ b/changes/2648.fix.md
@@ -1,0 +1,1 @@
+Implement missing `StrEnumType` handling in `populate_fixture()`.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -64,9 +64,7 @@ from ai.backend.common.types import (
     VFolderHostPermission,
     VFolderHostPermissionMap,
 )
-from ai.backend.manager.models.utils import execute_with_retry
 
-from .. import models
 from ..api.exceptions import GenericForbidden, InvalidAPIParameters
 from .gql_relay import (
     AsyncListConnectionField,
@@ -75,6 +73,7 @@ from .gql_relay import (
 )
 from .minilang.ordering import OrderDirection, OrderingItem, QueryOrderParser
 from .minilang.queryfilter import QueryFilterParser, WhereClauseType
+from .utils import execute_with_retry
 
 if TYPE_CHECKING:
     from .gql import GraphQueryContext
@@ -1083,11 +1082,13 @@ async def populate_fixture(
             # skip reserved names like "__mode"
             continue
         assert not isinstance(rows, str)
-        table: sa.Table = getattr(models, table_name)
+
+        table: sa.Table = metadata.tables.get(table_name)
+
         assert isinstance(table, sa.Table)
         if not rows:
             return
-        log.debug("Loading the fixture taable {0} (mode:{1})", table_name, op_mode.name)
+        log.debug("Loading the fixture table {0} (mode:{1})", table_name, op_mode.name)
         async with engine.begin() as conn:
             # Apply typedecorator manually for required columns
             for col in table.columns:
@@ -1095,7 +1096,7 @@ async def populate_fixture(
                     for row in rows:
                         if col.name in row:
                             row[col.name] = col.type._enum_cls[row[col.name]]
-                elif isinstance(col.type, EnumValueType):
+                elif isinstance(col.type, (StrEnumType, EnumValueType)):
                     for row in rows:
                         if col.name in row:
                             row[col.name] = col.type._enum_cls(row[col.name])


### PR DESCRIPTION
This is an auto-generated backport PR of #2648 to the 23.09 release.