### PR TITLE
fix: let GET requests contain data in param rather than body (#2661)

### DIFF
--- a/changes/2661.fix.md
+++ b/changes/2661.fix.md
@@ -1,0 +1,1 @@
+Let `GET /resource/usage/period` request contain data in query parameter rather than JSON body.

--- a/src/ai/backend/client/func/resource.py
+++ b/src/ai/backend/client/func/resource.py
@@ -70,12 +70,15 @@ class Resource(BaseFunction):
         :param end_date: end date in string format (yyyymmdd).
         :param group_id: Groups ID to list usage statistics.
         """
-        rqst = Request("GET", "/resource/usage/period")
-        rqst.set_json({
-            "group_id": group_id,
-            "start_date": start_date,
-            "end_date": end_date,
-        })
+        rqst = Request(
+            "GET",
+            "/resource/usage/period",
+            params={
+                "group_id": group_id,
+                "start_date": start_date,
+                "end_date": end_date,
+            },
+        )
         async with rqst.fetch() as resp:
             return await resp.json()
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2661 to the 23.09 release.