### PR TITLE
feat: Replace image rescan command's `--local` flag with the `local` type ContainerRegistry record

### DIFF
--- a/changes/2665.feature.md
+++ b/changes/2665.feature.md
@@ -1,0 +1,1 @@
+Replace rescan command's `--local` flag with local container registry record.

--- a/fixtures/manager/example-container-registries-local.json
+++ b/fixtures/manager/example-container-registries-local.json
@@ -1,0 +1,11 @@
+{
+    "container_registries": [
+        {
+            "id": "fe878f09-06cc-4b91-9242-4c71015cce05",
+            "registry_name": "local",
+            "url": "http://localhost",
+            "type": "local",
+            "project": ""
+        }
+    ]
+}

--- a/fixtures/manager/example-container-registries-local.json
+++ b/fixtures/manager/example-container-registries-local.json
@@ -5,7 +5,7 @@
             "registry_name": "local",
             "url": "http://localhost",
             "type": "local",
-            "project": ""
+            "project": "stable"
         }
     ]
 }

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -825,9 +825,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         container_log_file_size = BinarySize(container_log_size // container_log_file_count)
 
         if self.image_ref.is_local:
-            image = self.image_ref.canonical
-        else:
             image = self.image_ref.short
+        else:
+            image = self.image_ref.canonical
 
         container_config: MutableMapping[str, Any] = {
             "Image": image,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -823,8 +823,14 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         container_log_size = self.local_config["agent"]["container-logs"]["max-length"]
         container_log_file_count = 5
         container_log_file_size = BinarySize(container_log_size // container_log_file_count)
+
+        if self.image_ref.is_local:
+            image = self.image_ref.canonical
+        else:
+            image = self.image_ref.short
+
         container_config: MutableMapping[str, Any] = {
-            "Image": self.image_ref.canonical,
+            "Image": image,
             "Tty": True,
             "OpenStdin": True,
             "Privileged": False,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1307,7 +1307,6 @@ async def convert_session_to_image(
             await rescan_images(
                 root_ctx.db,
                 new_image_ref.canonical,
-                local=new_image_ref.is_local,
             )
             await reporter.update(increment=1, message="Completed")
         except BackendError:

--- a/src/ai/backend/manager/cli/etcd.py
+++ b/src/ai/backend/manager/cli/etcd.py
@@ -261,7 +261,7 @@ def rescan_images(cli_ctx: CLIContext, registry: str) -> None:
     Pass the name (usually hostname or "lablup") of the Docker registry configured as REGISTRY.
     """
     log.warning("etcd rescan-images command is deprecated, use image rescan instead")
-    asyncio.run(rescan_images_impl(cli_ctx, registry, False))
+    asyncio.run(rescan_images_impl(cli_ctx, registry))
 
 
 @cli.command()

--- a/src/ai/backend/manager/cli/image.py
+++ b/src/ai/backend/manager/cli/image.py
@@ -82,20 +82,14 @@ def set_resource_limit(
 
 @cli.command()
 @click.argument("registry_or_image", required=False, default="")
-@click.option(
-    "--local",
-    is_flag=True,
-    default=False,
-    help="Scan the local Docker daemon instead of a registry",
-)
 @click.pass_obj
-def rescan(cli_ctx, registry_or_image: str, local: bool) -> None:
+def rescan(cli_ctx, registry_or_image: str) -> None:
     """
     Update the kernel image metadata from all configured docker registries.
 
     Pass the name (usually hostname or "lablup") of the Docker registry configured as REGISTRY.
     """
-    asyncio.run(rescan_images_impl(cli_ctx, registry_or_image, local))
+    asyncio.run(rescan_images_impl(cli_ctx, registry_or_image))
 
 
 @cli.command()

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -151,14 +151,14 @@ async def set_image_resource_limit(
             log.exception("An error occurred.")
 
 
-async def rescan_images(cli_ctx: CLIContext, registry_or_image: str, local: bool) -> None:
-    if not registry_or_image and not local:
+async def rescan_images(cli_ctx: CLIContext, registry_or_image: str) -> None:
+    if not registry_or_image:
         raise click.BadArgumentUsage("Please specify a valid registry or full image name.")
     async with (
         connect_database(cli_ctx.local_config) as db,
     ):
         try:
-            await rescan_images_func(db, registry_or_image, local=local)
+            await rescan_images_func(db, registry_or_image)
         except Exception:
             log.exception("An error occurred.")
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -516,14 +516,12 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 except ValueError as e:
                     skip_reason = str(e)
                     continue
-                if self.registry_name == "local":
-                    if image.partition("/")[1] == "":
-                        image = "library/" + image
-                    update_key = ImageIdentifier(f"{image}:{tag}", architecture)
-                else:
-                    update_key = ImageIdentifier(
-                        f"{self.registry_name}/{image}:{tag}", architecture
-                    )
+
+                update_key = ImageIdentifier(
+                    f"{self.registry_name}/{image}:{tag}",
+                    architecture,
+                )
+
                 updates = {
                     "config_digest": manifest["digest"],
                     "size_bytes": manifest["size"],

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -41,7 +41,7 @@ from ai.backend.common.types import (
     ResourceSlot,
 )
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow, ContainerRegistryType
 
 from ..api.exceptions import ImageNotFound, ObjectNotFound
 from ..container_registry import get_container_registry_cls

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -41,7 +41,7 @@ from ai.backend.common.types import (
     ResourceSlot,
 )
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.models.container_registry import ContainerRegistryRow, ContainerRegistryType
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 
 from ..api.exceptions import ImageNotFound, ObjectNotFound
 from ..container_registry import get_container_registry_cls
@@ -131,51 +131,41 @@ async def rescan_images(
     db: ExtendedAsyncSAEngine,
     registry_or_image: str | None = None,
     *,
-    local: bool | None = False,
     reporter: ProgressReporter | None = None,
 ) -> None:
-    if local:
-        registries = {
-            "local": ContainerRegistryRow(
-                registry_name="local",
-                url="http://localhost",
-                type=ContainerRegistryType.LOCAL,
-            )
-        }
-    else:
-        async with db.begin_readonly_session() as session:
-            result = await session.execute(sa.select(ContainerRegistryRow))
-            latest_registry_config = cast(
-                dict[str, ContainerRegistryRow],
-                {row.registry_name: row for row in result.scalars().all()},
-            )
+    async with db.begin_readonly_session() as session:
+        result = await session.execute(sa.select(ContainerRegistryRow))
+        latest_registry_config = cast(
+            dict[str, ContainerRegistryRow],
+            {row.registry_name: row for row in result.scalars().all()},
+        )
 
-        # TODO: delete images from registries removed from the previous config?
-        if registry_or_image is None:
-            # scan all configured registries
-            registries = latest_registry_config
+    # TODO: delete images from registries removed from the previous config?
+    if registry_or_image is None:
+        # scan all configured registries
+        registries = latest_registry_config
+    else:
+        # find if it's a full image ref of one of configured registries
+        for registry_name, registry_info in latest_registry_config.items():
+            if registry_or_image.startswith(registry_name + "/"):
+                repo_with_tag = registry_or_image.removeprefix(registry_name + "/")
+                log.debug(
+                    "running a per-image metadata scan: {}, {}",
+                    registry_name,
+                    repo_with_tag,
+                )
+                scanner_cls = get_container_registry_cls(registry_info)
+                scanner = scanner_cls(db, registry_name, registry_info)
+                await scanner.scan_single_ref(repo_with_tag)
+                return
         else:
-            # find if it's a full image ref of one of configured registries
-            for registry_name, registry_info in latest_registry_config.items():
-                if registry_or_image.startswith(registry_name + "/"):
-                    repo_with_tag = registry_or_image.removeprefix(registry_name + "/")
-                    log.debug(
-                        "running a per-image metadata scan: {}, {}",
-                        registry_name,
-                        repo_with_tag,
-                    )
-                    scanner_cls = get_container_registry_cls(registry_info)
-                    scanner = scanner_cls(db, registry_name, registry_info)
-                    await scanner.scan_single_ref(repo_with_tag)
-                    return
-            else:
-                # treat it as a normal registry name
-                registry = registry_or_image
-                try:
-                    registries = {registry: latest_registry_config[registry]}
-                    log.debug("running a per-registry metadata scan")
-                except KeyError:
-                    raise RuntimeError("It is an unknown registry.", registry)
+            # treat it as a normal registry name
+            registry = registry_or_image
+            try:
+                registries = {registry: latest_registry_config[registry]}
+                log.debug("running a per-registry metadata scan")
+            except KeyError:
+                raise RuntimeError("It is an unknown registry.", registry)
     async with aiotools.TaskGroup() as tg:
         for registry_name, registry_info in registries.items():
             log.info('Scanning kernel images from the registry "{0}"', registry_name)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Partially fix [#411](https://github.com/lablup/backend.ai/issues/411), ref: https://github.com/lablup/backend.ai/pull/1097

This PR removes the existing image rescan code that uses the `--local` flag and instead uses a `Local` type container registry record to reuse existing code paths.

## Test

Manually tested according to the following procedure.

1. Create a `Dockerfile` with the following content.
(Copy-pasted from https://github.com/lablup/backend.ai/pull/1097#issuecomment-1442909515)

```dockerfile
FROM python:3.11

# Install ipython kernelspec
RUN python3.11 -m pip install ipython ipykernel
RUN python3.11 -m ipykernel install --display-name "Python 3.11 on Backend.AI" && \
    cat /usr/local/share/jupyter/kernels/python3/kernel.json

LABEL ai.backend.kernelspec=1 \
      ai.backend.features="uid-match batch query" \
      ai.backend.base-distro="ubuntu18.04" \
      ai.backend.runtime-type="python" \
      ai.backend.runtime-path="/usr/local/bin/python3"
```

2. Build using `docker build`

```
docker build -t stable/bai-python:3.11 -f Dockerfile .
```

> Note: We don't need to prepend `index.docker.io/library` to the image name through this patch.

3. Create a fixture for generating a row in a "local" type container registry.

```
./backend.ai mgr fixture populate ./fixtures/manager/example-container-registries-local.json
```

4. Rescan the image

Perform an image rescan.
Verify that the built `bai-python` image has been scanned correctly.

```
./backend.ai mgr image rescan local
```

5. Create a session through the scanned image

```
./backend.ai session create local/stable/bai-python:3.11
```


---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2665.org.readthedocs.build/en/2665/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2665.org.readthedocs.build/ko/2665/

<!-- readthedocs-preview sorna-ko end -->