### PR TITLE
fix: Use dropbear 'multi' build and allow overwriting scp in containers

### DIFF
--- a/changes/2667.fix.md
+++ b/changes/2667.fix.md
@@ -1,0 +1,1 @@
+Allow sudo-enabled container users to ovewrite `/usr/bin/scp` and `/usr/libexec/sftp-server` by unifying the intrinsic ssh binaries to use the merged `dropbearmulti` executable.

--- a/scripts/agent/build-dropbear.sh
+++ b/scripts/agent/build-dropbear.sh
@@ -35,6 +35,8 @@ autoconf && autoheader
 sed -i 's/\(DEFAULT_RECV_WINDOW\) [0-9][0-9]*/\1 2097152/' src/default_options.h
 sed -i 's/\(RECV_MAX_PAYLOAD_LEN\) [0-9][0-9]*/\1 2621440/' src/default_options.h
 sed -i 's/\(TRANS_MAX_PAYLOAD_LEN\) [0-9][0-9]*/\1 2621440/' src/default_options.h
+sed -i 's/\(TRANS_MAX_PAYLOAD_LEN\) [0-9][0-9]*/\1 2621440/' src/default_options.h
+sed -i 's/\(SFTPSERVER_PATH\) "[^"]\+"/\1 "\/opt\/kernel\/sftp-server"/' src/default_options.h
 sed -i 's/\(MAX_CMD_LEN\) [0-9][0-9]*/\1 20000/' src/sysoptions.h
 sed -i '/channel->transwindow -= len;/s/^/\/\//' src/common-channel.c
 sed -i 's/DEFAULT_PATH/getenv("PATH")/' src/svr-chansession.c
@@ -42,10 +44,8 @@ sed -i 's/DEFAULT_PATH/getenv("PATH")/' src/svr-chansession.c
 # Disable clearing environment variables for new pty sessions and remote commands
 sed -i 's%/\* *#define \+DEBUG_VALGRIND *\*/%#define DEBUG_VALGRIND%' src/debug.h
 
-make -j$(nproc)
-cp dropbear        ../dropbear.$X_ARCH.bin
-cp dropbearkey     ../dropbearkey.$X_ARCH.bin
-cp dropbearconvert ../dropbearconvert.$X_ARCH.bin
+make -j$(nproc) PROGRAMS='dropbear dropbearkey dropbearconvert scp' MULTI=1 SCPPROGRESS=1
+cp dropbearmulti ../dropbearmulti.$X_ARCH.bin
 make clean
 EOF
 )
@@ -68,9 +68,7 @@ docker run --rm -it \
   dropbear-builder \
   /workspace/build.sh
 
-cp $temp_dir/dropbear.*.bin        $SCRIPT_DIR/../../src/ai/backend/runner
-cp $temp_dir/dropbearkey.*.bin     $SCRIPT_DIR/../../src/ai/backend/runner
-cp $temp_dir/dropbearconvert.*.bin $SCRIPT_DIR/../../src/ai/backend/runner
+cp $temp_dir/dropbearmulti.*.bin        $SCRIPT_DIR/../../src/ai/backend/runner
 ls -lh src/ai/backend/runner
 
 rm -rf "$temp_dir"

--- a/scripts/agent/build-sftpserver.sh
+++ b/scripts/agent/build-sftpserver.sh
@@ -29,9 +29,8 @@ autoreconf
 
 sed -i 's/^# \?define SFTP_MAX_MSG_LENGTH[ \t]*.*/#define SFTP_MAX_MSG_LENGTH 5242880/g' sftp-common.h
 
-make -j$(nproc) sftp-server scp
+make -j$(nproc) sftp-server
 cp sftp-server /workspace/sftp-server.$X_ARCH.bin
-cp scp /workspace/scp.$X_ARCH.bin
 EOF
 )
 
@@ -53,7 +52,6 @@ docker run --rm -it \
     /workspace/build.sh
 
 cp $temp_dir/sftp-server.*.bin $SCRIPT_DIR/../../src/ai/backend/runner
-cp $temp_dir/scp.*.bin $SCRIPT_DIR/../../src/ai/backend/runner
 ls -lh src/ai/backend/runner
 
 cd $SCRIPT_DIR/..

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -448,11 +448,8 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
 
         mount_static_binary(f"su-exec.{arch}.bin", "/opt/kernel/su-exec")
         mount_versioned_binary(f"libbaihook.*.{arch}.so", "/opt/kernel/libbaihook.so")
-        mount_static_binary(f"sftp-server.{arch}.bin", "/usr/libexec/sftp-server")
-        mount_static_binary(f"scp.{arch}.bin", "/usr/bin/scp")
-        mount_static_binary(f"dropbear.{arch}.bin", "/opt/kernel/dropbear")
-        mount_static_binary(f"dropbearconvert.{arch}.bin", "/opt/kernel/dropbearconvert")
-        mount_static_binary(f"dropbearkey.{arch}.bin", "/opt/kernel/dropbearkey")
+        mount_static_binary(f"dropbearmulti.{arch}.bin", "/opt/kernel/dropbearmulti")
+        mount_static_binary(f"sftp-server.{arch}.bin", "/opt/kernel/sftp-server")
         mount_static_binary(f"tmux.{arch}.bin", "/opt/kernel/tmux")
 
         jail_path: Optional[Path]

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -21,7 +21,8 @@ async def init_sshd_service(child_env):
         auth_path.parent.chmod(0o700)
         proc = await asyncio.create_subprocess_exec(
             *[
-                "/opt/kernel/dropbearkey",
+                "/opt/kernel/dropbearmulti",
+                "dropbearkey",
                 "-t",
                 "rsa",
                 "-s",
@@ -43,7 +44,8 @@ async def init_sshd_service(child_env):
         # Make the generated private key downloadable by users.
         proc = await asyncio.create_subprocess_exec(
             *[
-                "/opt/kernel/dropbearconvert",
+                "/opt/kernel/dropbearmulti",
+                "dropbearconvert",
                 "dropbear",
                 "openssh",
                 "/tmp/dropbear/id_dropbear",
@@ -66,7 +68,8 @@ async def init_sshd_service(child_env):
             log.warning("could not set the permission for /home/work/.ssh")
     proc = await asyncio.create_subprocess_exec(
         *[
-            "/opt/kernel/dropbearkey",
+            "/opt/kernel/dropbearmulti",
+            "dropbearkey",
             "-t",
             "rsa",
             "-s",
@@ -126,7 +129,8 @@ async def init_sshd_service(child_env):
 
 async def prepare_sshd_service(service_info):
     cmdargs = [
-        "/opt/kernel/dropbear",
+        "/opt/kernel/dropbearmulti",
+        "dropbear",
         "-r",
         "/tmp/dropbear/dropbear_rsa_host_key",
         "-E",  # show logs in stderr

--- a/src/ai/backend/runner/dropbear.aarch64.bin
+++ b/src/ai/backend/runner/dropbear.aarch64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9812f4ab7b4a7923d730d4bfd92976932719ca8a7abe2d1f767815e204c8553
-size 1284752

--- a/src/ai/backend/runner/dropbear.x86_64.bin
+++ b/src/ai/backend/runner/dropbear.x86_64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc2b28eac54d6057fe4911d535ea1ff0b69b52f557fee1a0d787970d367db9fb
-size 1164912

--- a/src/ai/backend/runner/dropbearconvert.aarch64.bin
+++ b/src/ai/backend/runner/dropbearconvert.aarch64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:893c9591353235a3bca02dbfbeb6d1d25ca8ef97ce6c23cd2b89a614da79f6f0
-size 813304

--- a/src/ai/backend/runner/dropbearconvert.x86_64.bin
+++ b/src/ai/backend/runner/dropbearconvert.x86_64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf2afc87d4ff765da37470c33a02f020b4db454831acadfaec2d57131fe035e9
-size 717448

--- a/src/ai/backend/runner/dropbearkey.aarch64.bin
+++ b/src/ai/backend/runner/dropbearkey.aarch64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4499e5bcfe7e66da72412254038ba3b5db821f0eca1a8e11d14505a6c239b84
-size 804776

--- a/src/ai/backend/runner/dropbearkey.x86_64.bin
+++ b/src/ai/backend/runner/dropbearkey.x86_64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dbf7b2c6f43b7b6f660773fab6fa2d6fa65549c3114457879539a3fbb8e3af1
-size 703448

--- a/src/ai/backend/runner/dropbearmulti.aarch64.bin
+++ b/src/ai/backend/runner/dropbearmulti.aarch64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd83f3735fda4e743037063b7d88ee8ad9ecc7f075d63d77d18f6b857ab24aa
+size 1394440

--- a/src/ai/backend/runner/dropbearmulti.x86_64.bin
+++ b/src/ai/backend/runner/dropbearmulti.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48eee916b5afd43a47abd7814d8b4397f4914b151b8761acf2d92207902bcc0
+size 1308136

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -16,6 +16,11 @@ fi
 #       Therefore, we must AVOID any filesystem operation applied RECURSIVELY to /home/work,
 #       to prevent indefinite "hangs" during a container startup.
 
+# Symlink the scp binary
+if [ ! -f "/usr/bin/scp" ]; then
+  ln -s /opt/kernel/dropbearmulti /usr/bin/scp
+fi
+
 if [ $USER_ID -eq 0 ]; then
 
   echo "WARNING: Running the user codes as root is not recommended."

--- a/src/ai/backend/runner/scp.aarch64.bin
+++ b/src/ai/backend/runner/scp.aarch64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9bcfa67166ba979edbace456e25151c6de203dea3759f28a3c06c9e0d19cf31
-size 1619224

--- a/src/ai/backend/runner/scp.x86_64.bin
+++ b/src/ai/backend/runner/scp.x86_64.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5867f8b3372c2d4a946fb1e3ee33072353cc9ae7b3b634a02ed3e2b83b14dca0
-size 1532624


### PR DESCRIPTION
## Problem

When sudo-enabled users run `apt install` or `apt upgrade` in session containers, `openssh-client` package is often (re)installed as being dependencies to some other packages.

This fails with "Resources or device is busy" error in session containers because `/usr/bin/scp` and `/usr/libexec/sftp-server` are read-only mounts of our statically built openssh-portable binaries.

## Solution

- Replace multiple `dropbear*` and `scp` binaries with a single `dropbearmulti` binary.
  - Dropbear offers `MULTI=1` Makefile option to merge multiple executables into a single binary just like Busybox.
  - Dropbear actually contains the `scp` implementation, so we don't have to build and ship scp from openssh-portable.
- In `entrypoint.sh`, symlink `/usr/bin/scp` to `/opt/kernel/dropbearmulti` so that it **could** be ovewritten by the package manager.
  - I assumed that any `scp` implementation is compatible with our Dropbear.
  - `scp` is just an invoked command in a plain SSH session, and there is no compile-time configuration to set its path because it is searched in the server-side `PATH`.
    - <img src="https://github.com/user-attachments/assets/cf0d00ab-f980-49a0-b608-94cf6e51a341" width="60%" />
- `/usr/libexec/sftp-server` is no longer used by us by changing the compilation options of dropbear to use `/opt/kernel/sftp-server`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
