### PR TITLE
fix: The URL of docker compose installation guide in install-dev.sh (#2673)

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -611,12 +611,12 @@ if [ $CODESPACES != "true" ] || [ $CODESPACES_ON_CREATE -eq 1 ]; then
   # checking docker compose v2 -f flag
   if $(docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
     show_error "When run as a user, 'docker compose' seems not to be a compatible version (v2)."
-    show_info "Please check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on ${HOME}/.docker/cli-plugins"
+    show_info "Please check the following link: https://docs.docker.com/compose/install/ to install Docker Compose and its CLI plugin on ${HOME}/.docker/cli-plugins"
     exit 1
   fi
   if $(sudo docker compose -f 2>&1 | grep -q 'unknown shorthand flag'); then
     show_error "When run as the root, 'docker compose' seems not to be a compatible version (v2)"
-    show_info "Please check the following link: https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually to install Docker Compose CLI plugin on /usr/local/lib/docker/cli-plugins"
+    show_info "Please check the following link: https://docs.docker.com/compose/install/ to install Docker Compose and its CLI plugin on /usr/local/lib/docker/cli-plugins"
     exit 1
   fi
   if [ "$DISTRO" = "Darwin" ]; then


### PR DESCRIPTION
This is an auto-generated backport PR of #2673 to the 23.03 release.