### PR TITLE
feat: add `enable_LLM_playground` config on webserver

### DIFF
--- a/changes/2677.feature.md
+++ b/changes/2677.feature.md
@@ -1,0 +1,1 @@
+Add an `enable_LLM_playground` option to show/hide the LLM playground tab on the serving page.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -122,6 +122,8 @@ brand = "Lablup Cloud"
 #menu_blocklist = "pipeline"
 # Comma-separated sidebar menu pages to disable
 #menu_inactivelist = "statistics"
+# Enable/disable the LLM Playground tab in the service page
+# enable_LLM_playground = false
 
 [api]
 domain = "default"

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -108,6 +108,7 @@ config_iv = t.Dict({
         t.Key("menu_blocklist", default=None): t.Null | tx.StringList(empty_str_as_empty_list=True),
         t.Key("menu_inactivelist", default=None): t.Null
         | tx.StringList(empty_str_as_empty_list=True),
+        t.Key("enable_LLM_playground", default=False): t.ToBool,
     }).allow_extra("*"),
     t.Key("api"): t.Dict({
         t.Key("domain"): t.String,

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -4,6 +4,7 @@
 {% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
 {% toml_field "defaultImportEnvironment" config["ui"]["default_import_environment"] %}
 {% toml_field "siteDescription" config["ui"]["brand"] %}
+{% toml_field "enableLLMPlayground" config["ui"]["enable_LLM_playground"] %}
 connectionMode = "SESSION"
 {% toml_field "signupSupport" config["service"]["enable_signup"] %}
 {% toml_field "allowChangeSigninMode" config["service"]["allow_change_signin_mode"] %}

--- a/src/ai/backend/web/templates/config_ini.toml.j2
+++ b/src/ai/backend/web/templates/config_ini.toml.j2
@@ -3,6 +3,7 @@
 {% toml_field "apiEndpointText" config["api"]["text"] %}
 {% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
 {% toml_field "siteDescription" config["ui"]["brand"] %}
+{% toml_field "enableLLMPlayground" config["ui"]["enable_LLM_playground"] %}
 connectionMode = "SESSION"
 
 [wsproxy]


### PR DESCRIPTION
related PR: https://app.graphite.dev/github/pr/lablup/backend.ai-webui/2620

### TL;DR

Enable/disable the LLM Playground tab in the service page via the new `enable_LLM_playground` configuration option.

### What changed?

- Added `enable_LLM_playground` option to `sample.conf`.
- Updated `config.py` to process the new option.
- Modified `config.toml.j2` and `config_ini.toml.j2` templates to incorporate the new option.

### How to test?

1. Go to `configs/webserver/sample.conf` and set `enable_LLM_playground` to true or false.
2. Restart the webserver.
3. Verify that the LLM Playground tab appears or disappears in the service page based on the configuration.

### Why make this change?

The change introduces a flexible way to enable or disable the LLM Playground tab in the service page, providing better control over the web server's UI configuration.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
