### PR TITLE
fix: image without explicit metadata labels not working

### DIFF
--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1272,6 +1272,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
 
             container = await docker.containers.create(container_config)
             await container.start()
+            await container.wait()  # wait until container finishes to prevent race condition
             container_log = await container.log(stdout=True, stderr=True, follow=False)
             await container.stop()
             await container.delete()

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -4,7 +4,6 @@ Common definitions/constants used throughout the manager.
 
 import enum
 import re
-from decimal import Decimal
 from typing import Final
 
 from ai.backend.common.arch import CURRENT_ARCH
@@ -18,8 +17,10 @@ INTRINSIC_SLOTS: Final = {
 }
 
 INTRINSIC_SLOTS_MIN: Final = {
-    SlotName("cpu"): Decimal(1),  # 1 core
-    SlotName("mem"): Decimal(1073741824),  # 1 GiB
+    # Values below are representing default value of image label -
+    # so they must be string instead of Decimal.
+    SlotName("cpu"): "1",  # 1 core
+    SlotName("mem"): "1073741824",  # 1 GiB
 }
 
 arch_name_aliases: Final = arch_name_aliases_


### PR DESCRIPTION
Follow-up of #2582. Fixes following things:
- image without minimum resource label not set not scanned
- image Libc version detection not working

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue