### PR TITLE
fix: Remove duplicate CPU quota options when creating containers (#2608)

### DIFF
--- a/changes/2608.fix.md
+++ b/changes/2608.fix.md
@@ -1,0 +1,1 @@
+Remove duplicate CPU quota arguments when creating containers

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -380,9 +380,7 @@ class CPUPlugin(AbstractComputePlugin):
         sorted_core_ids = [*map(str, sorted(cores))]
         return {
             "HostConfig": {
-                "CpuPeriod": 100_000,  # docker default
-                "CpuQuota": int(100_000 * len(cores)),
-                "Cpus": ",".join(sorted_core_ids),
+                "Cpus": len(cores),
                 "CpusetCpus": ",".join(sorted_core_ids),
                 # 'CpusetMems': f'{resource_spec.numa_node}',
             },


### PR DESCRIPTION
This is an auto-generated backport PR of #2608 to the 24.03 release.