### PR TITLE
fix: Scan parent directory of created qtree for robust check

### DIFF
--- a/changes/2696.fix.md
+++ b/changes/2696.fix.md
@@ -1,0 +1,1 @@
+Scan parent directory of created qtree to avoid creating quota on non-existing directory.

--- a/src/ai/backend/storage/netapp/__init__.py
+++ b/src/ai/backend/storage/netapp/__init__.py
@@ -103,7 +103,13 @@ class QTreeQuotaModel(BaseQuotaModel):
             ):
                 with attempt:
                     if not qspath.exists():
-                        raise TryAgain
+                        # Scan all sibling directories to check the qtree is created
+                        # since os.path.stat() is cached and it takes long to update path cache on NFS.
+                        for sibling_path in os.scandir(qspath.parent):
+                            if sibling_path.name == qspath.name:
+                                break
+                        else:
+                            raise TryAgain
         except RetryError:
             raise QuotaScopeNotFoundError
 


### PR DESCRIPTION
follow-up #2170 

When we create a quota after creating Netapp qtree, sometimes Netapp API responds not found error.
#2170 is to avoid such timing issue but it causes another error because Python's Path implementation cache directory data and it takes long to update the cache with newly created qtree directory.

So, let's scan directories from the parent directory of created qtree.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)