### PR TITLE
fix: Scan parent directory of created qtree for robust check (#2696)

### DIFF
--- a/changes/2696.fix.md
+++ b/changes/2696.fix.md
@@ -1,0 +1,1 @@
+Scan parent directory of created qtree to avoid creating quota on non-existing directory.

--- a/src/ai/backend/storage/netapp/__init__.py
+++ b/src/ai/backend/storage/netapp/__init__.py
@@ -103,7 +103,13 @@ class QTreeQuotaModel(BaseQuotaModel):
             ):
                 with attempt:
                     if not qspath.exists():
-                        raise TryAgain
+                        # Scan all sibling directories to check the qtree is created
+                        # since os.path.stat() is cached and it takes long to update path cache on NFS.
+                        for sibling_path in os.scandir(qspath.parent):
+                            if sibling_path.name == qspath.name:
+                                break
+                        else:
+                            raise TryAgain
         except RetryError:
             raise QuotaScopeNotFoundError
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2696 to the 24.03 release.