### PR TITLE
fix: Update `webserver` logout API to respond with HTTP 200 OK (#2681)

### DIFF
--- a/changes/2681.fix.md
+++ b/changes/2681.fix.md
@@ -1,0 +1,1 @@
+Update `webserver` logout API to respond with HTTP 200 OK

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -429,7 +429,7 @@ async def logout_handler(request: web.Request) -> web.Response:
     stats.active_logout_handlers.add(asyncio.current_task())  # type: ignore
     session = await get_session(request)
     session.invalidate()
-    return web.Response(status=201)
+    return web.HTTPOk()
 
 
 async def webserver_healthcheck(request: web.Request) -> web.Response:


### PR DESCRIPTION
This is an auto-generated backport PR of #2681 to the 24.03 release.