### PR TITLE
fix: vfolder listing issue in CLI integration test

### DIFF
--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -607,7 +607,7 @@ class VFolder(BaseFunction):
 
     @api_function
     async def list_files(self, path: Union[str, Path] = "."):
-        rqst = Request("GET", "/folders/{}/files".format(self.name))
+        rqst = Request("POST", "/folders/{}/files".format(self.name))
         rqst.set_json({
             "path": path,
         })

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -3515,7 +3515,7 @@ def create_app(default_cors_options):
     cors.add(add_route("DELETE", r"/{name}/delete-files", delete_files))
     cors.add(add_route("POST", r"/{name}/rename_file", rename_file))  # legacy underbar
     cors.add(add_route("DELETE", r"/{name}/delete_files", delete_files))  # legacy underbar
-    cors.add(add_route("GET", r"/{name}/files", list_files))
+    cors.add(add_route("POST", r"/{name}/files", list_files))
     cors.add(add_route("POST", r"/{name}/invite", invite))
     cors.add(add_route("POST", r"/{name}/leave", leave))
     cors.add(add_route("POST", r"/{name}/share", share))

--- a/src/ai/backend/test/utils/cli.py
+++ b/src/ai/backend/test/utils/cli.py
@@ -22,7 +22,7 @@ class ClientRunnerFunc(Protocol):
 def run(
     args: Sequence[str | Path],
     *,
-    default_timeout: int = 5,
+    default_timeout: int = 15,
     **kwargs,
 ) -> pexpect.spawn:
     p = pexpect.spawn(


### PR DESCRIPTION
Currently, the vfolder CLI integration test is failing when executing the `./backend.ai vfolder ls` command.

(When sending a command like `./backend.ai vfolder ls {vfolder_name} {dir_name}`, it displays the contents of the root directory instead of showing the contents inside dir_name.)

This issue arises because the API request related to this command is being sent as a **GET request.**

When using GET, the [@check_api_params decorator](https://github.com/lablup/backend.ai/blob/62eca72efffa3de057534b7ebaaf0cb55d1a8060/src/ai/backend/manager/api/utils.py#L171C1-L214C16) places the request query into the parameters, which causes this unexpected behavior.

To resolve this, we need to either use query parameters when keeping GET requests or change the request method to POST for correct operation.

With this PR merged, the tests will function as expected.

**Additionally, I have increased the timeout duration for pexpect because the previous timeout was too short, causing frequent test failures. Please review this change.**

----

### Future Work:
It seems necessary to refactor `test_vfolder.py.`

This test code involves creating and deleting folders, but it does not completely delete them (it only uses `delete`, not `delete-trash`), leaving residuals after the tests. 


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


