### PR TITLE
feat: Configurable GQL query depth limit & Connection page limit

### DIFF
--- a/changes/2709.feature.md
+++ b/changes/2709.feature.md
@@ -1,0 +1,3 @@
+* Add query depth limit config of GQL.
+* Add page size limit config of GQL Connection.
+* Set default page size of GQL Connection to 10.

--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import TYPE_CHECKING, Any, Iterable, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, Tuple, cast
 
 import aiohttp_cors
 import attrs
 import graphene
 import trafaret as t
 from aiohttp import web
-from graphene.validation import DisableIntrospection
+from graphene.validation import DisableIntrospection, depth_limit_validator
 from graphql import parse, validate
 from graphql.error import GraphQLError  # pants: no-infer-dep
 from graphql.execution import ExecutionResult  # pants: no-infer-dep
@@ -18,7 +18,12 @@ from ai.backend.common import validators as tx
 from ai.backend.common.logging import BraceStyleAdapter
 
 from ..models.base import DataLoaderManager
-from ..models.gql import GQLMutationPrivilegeCheckMiddleware, GraphQueryContext, Mutations, Queries
+from ..models.gql import (
+    GQLMutationPrivilegeCheckMiddleware,
+    GraphQueryContext,
+    Mutations,
+    Queries,
+)
 from .auth import auth_required
 from .exceptions import GraphQLError as BackendGQLError
 from .manager import GQLMutationUnfrozenRequiredMiddleware
@@ -50,11 +55,17 @@ async def _handle_gql_common(request: web.Request, params: Any) -> ExecutionResu
     app_ctx: PrivateContext = request.app["admin.context"]
     manager_status = await root_ctx.shared_config.get_manager_status()
     known_slot_types = await root_ctx.shared_config.get_resource_slots()
+    rules = []
     if not root_ctx.shared_config["api"]["allow-graphql-schema-introspection"]:
+        rules.append(DisableIntrospection)
+    max_depth = cast(int | None, root_ctx.shared_config["api"]["max-gql-query-depth"])
+    if max_depth is not None:
+        rules.append(depth_limit_validator(max_depth=max_depth))
+    if rules:
         validate_errors = validate(
             schema=app_ctx.gql_schema.graphql_schema,
             document_ast=parse(params["query"]),
-            rules=(DisableIntrospection,),
+            rules=rules,
         )
         if validate_errors:
             return ExecutionResult(None, errors=validate_errors)

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -329,6 +329,8 @@ _config_defaults: Mapping[str, Any] = {
         "allow-origins": "*",
         "allow-openapi-schema-introspection": False,
         "allow-graphql-schema-introspection": False,
+        "max-gql-query-depth": None,
+        "max-gql-connection-page-size": None,
     },
     "redis": config.redis_default_config,
     "docker": {
@@ -415,6 +417,12 @@ shared_config_iv = t.Dict({
             "allow-openapi-schema-introspection",
             default=_config_defaults["api"]["allow-openapi-schema-introspection"],
         ): t.ToBool,
+        t.Key("max-gql-query-depth", default=_config_defaults["api"]["max-gql-query-depth"]): t.Null
+        | t.ToInt[1:],
+        t.Key(
+            "max-gql-connection-page-size",
+            default=_config_defaults["api"]["max-gql-connection-page-size"],
+        ): t.Null | t.ToInt[1:],
     }).allow_extra("*"),
     t.Key("redis", default=_config_defaults["redis"]): config.redis_config_iv,
     t.Key("docker", default=_config_defaults["docker"]): t.Dict({

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional
 
 import attrs
 import graphene

--- a/src/ai/backend/manager/models/gql_relay.py
+++ b/src/ai/backend/manager/models/gql_relay.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import enum
 import functools
 import re
-from typing import Any, Awaitable, Callable, NamedTuple, Protocol
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    NamedTuple,
+    Protocol,
+)
 
 import graphene
 from graphene.relay.connection import (


### PR DESCRIPTION
1. To set GQL query depth limit, set etcd's `config/api/max-gql-query-depth` value to integer bigger than 1. Default value is null, which means there is no depth limit.
2. To set GQL Connection page size limit, set etcd's `config/api/max-gql-connection-page-size` value to integer bigger than 1. Default value is null, which means there is no page size limit.
3. Default GQL Connection page size is 10.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2709.org.readthedocs.build/en/2709/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2709.org.readthedocs.build/ko/2709/

<!-- readthedocs-preview sorna-ko end -->