### PR TITLE
ci: Allow adding required GQL field argument to schema

### DIFF
--- a/changes/2712.misc.md
+++ b/changes/2712.misc.md
@@ -1,0 +1,1 @@
+Allow adding required GQL field argument to schema.

--- a/gql-inspector-checker.js
+++ b/gql-inspector-checker.js
@@ -54,11 +54,10 @@ module.exports = (props) => {
     } else if (
       ["FIELD_ARGUMENT_ADDED", "FIELD_ARGUMENT_DESCRIPTION_CHANGED"].includes(
         change.type
-      ) &&
-      change.criticality.level !== "BREAKING"
+      )
     ) {
-      const [type, filedName, argumentName] = change.path.split(".");
-      const field = newSchema.getTypeMap()[type].getFields()[filedName];
+      const [type, fieldName, argumentName] = change.path.split(".");
+      const field = newSchema.getTypeMap()[type].getFields()[fieldName];
       const description = field.args.find(
         (arg) => arg.name === argumentName
       )?.description;
@@ -70,6 +69,8 @@ module.exports = (props) => {
         change.message =
           'New arguments must include a description with a version number in the format "Added in XX.XX.X.", ' +
           change.message;
+      } else {
+        change.criticality.level = "DANGEROUS";
       }
     }
     return change;


### PR DESCRIPTION
Allow adding required GQL field argument by relaxing `BREAKING` criticality level to `DANGEROUS`.
It has been prohibited to add a required field argument to existing types.
```gql
type Queries {
  vfolders(
    """Added in 24.09.0. This is a required argument and now it is allowed to add such field arguments."""
    project_id: UUID!
  }
}
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version