### PR TITLE
fix:let vfolder GET requests contain data in params rather than body (#2706)

### DIFF
--- a/changes/2706.fix.md
+++ b/changes/2706.fix.md
@@ -1,0 +1,1 @@
+Fix `list_files`, `get_fstab_contents`, `get_performance_metric` and `shared_vfolder_info` Python SDK function not working with `ValidationError` exception printed

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -607,10 +607,7 @@ class VFolder(BaseFunction):
 
     @api_function
     async def list_files(self, path: Union[str, Path] = "."):
-        rqst = Request("GET", "/folders/{}/files".format(self.name))
-        rqst.set_json({
-            "path": path,
-        })
+        rqst = Request("GET", "/folders/{}/files".format(self.name), params={"path": str(path)})
         async with rqst.fetch() as resp:
             return await resp.json()
 
@@ -650,20 +647,20 @@ class VFolder(BaseFunction):
     @api_function
     @classmethod
     async def get_fstab_contents(cls, agent_id=None):
-        rqst = Request("GET", "/folders/_/fstab")
-        rqst.set_json({
-            "agent_id": agent_id,
-        })
+        rqst = Request(
+            "GET",
+            "/folders/_/fstab",
+            params={
+                "agent_id": agent_id,
+            },
+        )
         async with rqst.fetch() as resp:
             return await resp.json()
 
     @api_function
     @classmethod
     async def get_performance_metric(cls, folder_host: str):
-        rqst = Request("GET", "/folders/_/perf-metric")
-        rqst.set_json({
-            "folder_host": folder_host,
-        })
+        rqst = Request("GET", "/folders/_/perf-metric", params={"folder_host": folder_host})
         async with rqst.fetch() as resp:
             return await resp.json()
 
@@ -762,8 +759,7 @@ class VFolder(BaseFunction):
     @api_function
     @classmethod
     async def shared_vfolder_info(cls, vfolder_id: str):
-        rqst = Request("GET", "folders/_/shared")
-        rqst.set_json({"vfolder_id": vfolder_id})
+        rqst = Request("GET", "folders/_/shared", params={"vfolder_id": vfolder_id})
         async with rqst.fetch() as resp:
             return await resp.json()
 

--- a/tests/client/test_vfolder.py
+++ b/tests/client/test_vfolder.py
@@ -1,18 +1,21 @@
+from typing import Mapping, Union
 from unittest import mock
 
 import pytest
 from aioresponses import aioresponses
 
-from ai.backend.client.config import API_VERSION
+from ai.backend.client.config import API_VERSION, APIConfig
 from ai.backend.client.session import Session
 from ai.backend.testutils.mock import AsyncMock
 
 
-def build_url(config, path: str):
+def build_url(config: APIConfig, path: str, params: Mapping[str, Union[str, int]] = None):
     base_url = config.endpoint.path.rstrip("/")
     query_path = path.lstrip("/") if len(path) > 0 else ""
     path = "{0}/{1}".format(base_url, query_path)
     canonical_url = config.endpoint.with_path(path)
+    if params:
+        canonical_url = canonical_url.with_query(params)
     return canonical_url
 
 
@@ -138,7 +141,9 @@ def test_vfolder_list_files():
             "folder_path": "/mnt/local/1f6bd27fde1248cabfb50306ea83fc0a",
         }
         m.get(
-            build_url(session.config, "/folders/{}/files".format(vfolder_name)),
+            build_url(
+                session.config, "/folders/{}/files".format(vfolder_name), params={"path": "."}
+            ),
             status=200,
             payload=payload,
         )


### PR DESCRIPTION
This is an auto-generated backport PR of #2706 to the 24.03 release.