### PR TITLE
feat: Allow `DataLoaderManager` to get a loader function by function itself

### DIFF
--- a/changes/2717.feature.md
+++ b/changes/2717.feature.md
@@ -1,0 +1,1 @@
+Allow `DataLoaderManager` to get a loader function by function itself rather than function name.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -7,6 +7,12 @@ import functools
 import logging
 import sys
 import uuid
+from collections.abc import (
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -17,15 +23,11 @@ from typing import (
     Dict,
     Final,
     Generic,
-    Iterable,
     List,
-    Mapping,
-    MutableMapping,
     NamedTuple,
     Optional,
     Protocol,
     Self,
-    Sequence,
     Type,
     TypeVar,
     Union,
@@ -682,6 +684,11 @@ def ForeignKeyIDColumn(name, fk_field, nullable=True):
     return sa.Column(name, GUID, sa.ForeignKey(fk_field), nullable=nullable)
 
 
+ContextT = TypeVar("ContextT")
+LoaderKeyT = TypeVar("LoaderKeyT")
+LoaderResultT = TypeVar("LoaderResultT")
+
+
 class DataLoaderManager:
     """
     For every different combination of filtering conditions, we need to make a
@@ -693,7 +700,7 @@ class DataLoaderManager:
     for every incoming API request.
     """
 
-    cache: Dict[int, DataLoader]
+    cache: dict[int, DataLoader]
 
     def __init__(self) -> None:
         self.cache = {}
@@ -726,6 +733,30 @@ class DataLoaderManager:
                 max_batch_size=128,
             )
             self.cache[k] = loader
+        return loader
+
+    @staticmethod
+    def _get_func_key(
+        func: Callable[[ContextT, Sequence[LoaderKeyT]], Awaitable[LoaderResultT]],
+    ) -> int:
+        return hash(func)
+
+    def get_loader_by_func(
+        self,
+        context: ContextT,
+        batch_load_func: Callable[[ContextT, Sequence[LoaderKeyT]], Awaitable[LoaderResultT]],
+    ) -> DataLoader:
+        key = self._get_func_key(batch_load_func)
+        loader = self.cache.get(key)
+        if loader is None:
+            loader = DataLoader(
+                functools.partial(
+                    batch_load_func,
+                    context,
+                ),
+                max_batch_size=128,
+            )
+            self.cache[key] = loader
         return loader
 
 


### PR DESCRIPTION
Since we can hash a function object or a method object in Python, let `ai.backend.manager.model.base.DataLoaderManager` cache and get batch load functions by the function object itself.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version