### PR TITLE
ci: Skip `timeline-check` on draft PR

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -9,7 +9,12 @@ permissions:
 
 jobs:
   assign-pr-number:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name) && github.event.pull_request.number != null && github.event.pull_request.merged == false }}
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'skip:changelog')
+      && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
+      && github.event.pull_request.number != null
+      && github.event.pull_request.merged == false
+      && github.event.pull_request.draft == false
     uses: ./.github/workflows/assign-pr-number.yml
     secrets:
       WORKFLOW_PAT: ${{ secrets.OCTODOG }}


### PR DESCRIPTION
CI like lint and test, which the PR author needs to check while writing the PR, and timeline-check, which the admin needs to check before merging the PR, do not need to be checked in draft, but only in the final version.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
