### PR TITLE
feat: enable filter order in endpoint model

### DIFF
--- a/changes/2723.feature.md
+++ b/changes/2723.feature.md
@@ -1,0 +1,1 @@
+Allow filter and order in endpointlist gql request.

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -884,11 +884,11 @@ class Endpoint(graphene.ObjectType):
             query = query.where(EndpointRow.session_owner == user_uuid)
 
         if filter is not None:
-            parser = QueryFilterParser(cls._queryfilter_fieldspec)
-            query = parser.append_filter(query, filter)
+            filter_parser = QueryFilterParser(cls._queryfilter_fieldspec)
+            query = filter_parser.append_filter(query, filter)
         if order is not None:
-            parser = QueryOrderParser(cls._queryorder_colmap)
-            query = parser.append_ordering(query, order)
+            order_parser = QueryOrderParser(cls._queryorder_colmap)
+            query = order_parser.append_ordering(query, order)
         else:
             query = query.order_by(sa.desc(EndpointRow.created_at))
 

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -65,7 +65,7 @@ from .base import (
 from .gql_models.vfolder import VirtualFolderNode
 from .image import ImageNode, ImageRefType, ImageRow
 from .minilang.ordering import OrderSpecItem, QueryOrderParser
-from .minilang.queryfilter import FieldSpecItem, QueryFilterParser, enum_field_getter
+from .minilang.queryfilter import FieldSpecItem, QueryFilterParser
 from .resource_policy import keypair_resource_policies
 from .routing import RouteStatus, Routing
 from .scaling_group import scaling_groups

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -840,7 +840,6 @@ class Endpoint(graphene.ObjectType):
         "model": ("endpoints_model", None),
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
-        "status": ("endpoints_lifecycle_stage", enum_field_getter(EndpointLifecycle)),
         "created_user_email": ("users_email", None),
     }
 
@@ -850,7 +849,6 @@ class Endpoint(graphene.ObjectType):
         "model": ("endpoints_model", None),
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
-        "status": ("endpoints_lifecycle_stage", None),
         "created_user_email": ("users_email", None),
     }
 
@@ -869,7 +867,7 @@ class Endpoint(graphene.ObjectType):
     ) -> Sequence["Endpoint"]:
         query = (
             sa.select(EndpointRow)
-            .join(EndpointRow.created_user_row)
+            .select_from(sa.join(EndpointRow, UserRow, EndpointRow.created_user == UserRow.uuid, isouter=True, ))
             .limit(limit)
             .offset(offset)
             .options(selectinload(EndpointRow.image_row).selectinload(ImageRow.aliases))

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -64,6 +64,8 @@ from .base import (
 )
 from .gql_models.vfolder import VirtualFolderNode
 from .image import ImageNode, ImageRefType, ImageRow
+from .minilang.ordering import OrderSpecItem, QueryOrderParser
+from .minilang.queryfilter import FieldSpecItem, QueryFilterParser, enum_field_getter
 from .resource_policy import keypair_resource_policies
 from .routing import RouteStatus, Routing
 from .scaling_group import scaling_groups
@@ -833,10 +835,29 @@ class Endpoint(graphene.ObjectType):
             result = await conn.execute(query)
             return result.scalar()
 
+    _queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
+        "name": ("endpoints_name", None),
+        "model": ("endpoints_model", None),
+        "domain": ("endpoints_domain", None),
+        "url": ("endpoints_url", None),
+        "status": ("endpoints_lifecycle_stage", enum_field_getter(EndpointLifecycle)),
+        "created_user_email": ("users_email", None),
+    }
+
+    _queryorder_colmap: Mapping[str, OrderSpecItem] = {
+        "name": ("endpoints_name", None),
+        "created_at": ("endpoints_created_at", None),
+        "model": ("endpoints_model", None),
+        "domain": ("endpoints_domain", None),
+        "url": ("endpoints_url", None),
+        "status": ("endpoints_lifecycle_stage", None),
+        "created_user_email": ("users_email", None),
+    }
+
     @classmethod
     async def load_slice(
         cls,
-        ctx,  # ctx: GraphQueryContext,
+        ctx,  #: GraphQueryContext,  # ctx: GraphQueryContext,
         limit: int,
         offset: int,
         *,
@@ -848,19 +869,12 @@ class Endpoint(graphene.ObjectType):
     ) -> Sequence["Endpoint"]:
         query = (
             sa.select(EndpointRow)
+            .join(EndpointRow.created_user_row)
             .limit(limit)
             .offset(offset)
             .options(selectinload(EndpointRow.image_row).selectinload(ImageRow.aliases))
             .options(selectinload(EndpointRow.routings))
-            .options(selectinload(EndpointRow.created_user_row))
             .options(selectinload(EndpointRow.session_owner_row))
-            .order_by(sa.desc(EndpointRow.created_at))
-            .filter(
-                EndpointRow.lifecycle_stage.in_([
-                    EndpointLifecycle.CREATED,
-                    EndpointLifecycle.DESTROYING,
-                ])
-            )
         )
         if project is not None:
             query = query.where(EndpointRow.project == project)
@@ -868,16 +882,18 @@ class Endpoint(graphene.ObjectType):
             query = query.where(EndpointRow.domain == domain_name)
         if user_uuid is not None:
             query = query.where(EndpointRow.session_owner == user_uuid)
-        """
+
         if filter is not None:
             parser = QueryFilterParser(cls._queryfilter_fieldspec)
             query = parser.append_filter(query, filter)
         if order is not None:
             parser = QueryOrderParser(cls._queryorder_colmap)
             query = parser.append_ordering(query, order)
-        """
-        async with ctx.db.begin_readonly_session() as session:
-            result = await session.execute(query)
+        else:
+            query = query.order_by(sa.desc(EndpointRow.created_at))
+
+        async with ctx.db.begin_readonly_session() as db_session:
+            result = await db_session.execute(query)
             return [await cls.from_row(ctx, row) for row in result.scalars().all()]
 
     @classmethod

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -867,7 +867,14 @@ class Endpoint(graphene.ObjectType):
     ) -> Sequence["Endpoint"]:
         query = (
             sa.select(EndpointRow)
-            .select_from(sa.join(EndpointRow, UserRow, EndpointRow.created_user == UserRow.uuid, isouter=True, ))
+            .select_from(
+                sa.join(
+                    EndpointRow,
+                    UserRow,
+                    EndpointRow.created_user == UserRow.uuid,
+                    isouter=True,
+                )
+            )
             .limit(limit)
             .offset(offset)
             .options(selectinload(EndpointRow.image_row).selectinload(ImageRow.aliases))


### PR DESCRIPTION
 This is a follow up of #2722

Added filtering for ("name", "model", "domain", "url", "created_user_email")
and ordering for ("name", "created_at", "model", "domain", "url", "created_user_email")
(Used .minilang for filtering)



**CANNOT filter/order for the next items.** 
- Session_owner's columns(only filtering for created_user is available due to the label)
- Status(The manager resolves the status every time which isn't in the db)

Besides this adding more ways for filtering and ordering is welcome

Would be grateful for comments if this is an okay way, and if there is more filtering and ordering needed.

**Checklist:** (if applicable)
- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
