### PR TITLE
fix: vfolder id doesn't match in `list_shared_vfolders`

### DIFF
--- a/changes/2731.fix.md
+++ b/changes/2731.fix.md
@@ -1,0 +1,1 @@
+Resolve the issue where the vfolder id does not match in `list_shared_vfolders`.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2869,7 +2869,7 @@ async def list_shared_vfolders(request: web.Request, params: Any) -> web.Respons
         )
         query = sa.select([
             vfolder_permissions,
-            vfolders.c.id,
+            vfolders.c.id.label("vfolder_id"),
             vfolders.c.name,
             vfolders.c.group,
             vfolders.c.status,
@@ -2885,7 +2885,7 @@ async def list_shared_vfolders(request: web.Request, params: Any) -> web.Respons
         owner = shared.group if shared.group else shared.vfolder_user
         folder_type = "project" if shared.group else "user"
         shared_info.append({
-            "vfolder_id": str(shared.id),
+            "vfolder_id": str(shared.vfolder_id),
             "vfolder_name": str(shared.name),
             "status": shared.status.value,
             "owner": str(owner),


### PR DESCRIPTION
### TL;DR

Updated the vfolder_id field in the list_shared_vfolders function to fix a potential naming conflict.

### What changed?

- Modified the `list_shared_vfolders` function in the `vfolder.py` file.
- Changed the `vfolders.c.id` column selection to `vfolders.c.id.label("vfolder_id")` in the SQL query.
- Updated the dictionary creation to use `shared.vfolder_id` instead of `shared.id` when setting the `vfolder_id` key.

### How to test?

1. Call the `list_shared_vfolders` API endpoint.
2. Verify that the response contains the correct `vfolder_id` for each shared folder.
3. Check if the Vfolder id matches.

### Why make this change?

This change addresses a potential naming conflict between the `id` field from the `vfolder_permissions` table and the `id` field from the `vfolders` table. By explicitly labeling the `vfolders.c.id` as `vfolder_id`, we ensure that the correct ID is used when creating the shared folder information dictionary. This improves the reliability and consistency of the API response.

---


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2731.org.readthedocs.build/en/2731/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2731.org.readthedocs.build/ko/2731/

<!-- readthedocs-preview sorna-ko end -->