### PR TITLE
ci: Modify to match XHTML syntax for EPUB builds

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,6 +3,6 @@
 {%- else %}
     {% extends "!layout.html" %}
     {% block extrahead %}
-    <link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css">
+    <link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css" />
     {% endblock %}
 {%- endif %}


### PR DESCRIPTION
![CleanShot 2024-08-20 at 12 15 49@2x](https://github.com/user-attachments/assets/6ed3c8da-cbc6-449f-b769-f18795f0e403)
https://readthedocs.org/projects/sorna/downloads/
When I download the epub file from the link above, I get the error shown in the picture.
This is because EPUB uses XHTML syntax, which enforces strict TAG rules.
I fix this by closing the unclosed tags.


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
