### PR TITLE
fix: return `null` for missing user and group fields in VFolder lookup API response (#2584)

### DIFF
--- a/changes/2584.fix.md
+++ b/changes/2584.fix.md
@@ -1,0 +1,1 @@
+Fix `GET /func/folders/{folderName}` API returning string literal `"null"` instead of null value on `user` and `group` fields

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -929,8 +929,8 @@ async def get_info(request: web.Request, row: VFolderRow) -> web.Response:
         "created": str(row["created_at"]),  # legacy
         "created_at": str(row["created_at"]),
         "last_used": str(row["created_at"]),
-        "user": str(row["user"]),
-        "group": str(row["group"]),
+        "user": str(row["user"]) if row["user"] else None,
+        "group": str(row["group"]) if row["group"] else None,
         "type": "user" if row["user"] is not None else "group",
         "is_owner": is_owner,
         "permission": permission,


### PR DESCRIPTION
This is an auto-generated backport PR of #2584 to the 24.03 release.