### PR TITLE
feat: Add log-level to background task message

### DIFF
--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -29,6 +29,7 @@ from redis.asyncio.client import Pipeline
 from ai.backend.logging import BraceStyleAdapter
 
 from . import redis_helper
+from .defs import BackgroundTaskLogLevel as LogLevel
 from .events import (
     BgtaskCancelledEvent,
     BgtaskDoneEvent,
@@ -71,6 +72,7 @@ class ProgressReporter:
         self,
         increment: Union[int, float] = 0,
         message: str | None = None,
+        log_level: LogLevel = LogLevel.INFO,
     ) -> None:
         self.current_progress += increment
         # keep the state as local variables because they might be changed
@@ -88,6 +90,7 @@ class ProgressReporter:
                     "total": str(total),
                     "msg": message or "",
                     "last_update": str(time.time()),
+                    "log_level": str(log_level),
                 },
             )
             await pipe.expire(tracker_key, MAX_BGTASK_ARCHIVE_PERIOD)
@@ -100,6 +103,7 @@ class ProgressReporter:
                 message=message,
                 current_progress=current,
                 total_progress=total,
+                log_level=log_level,
             ),
         )
 
@@ -158,6 +162,7 @@ class BackgroundTaskManager:
                         case BgtaskUpdatedEvent():
                             body["current_progress"] = event.current_progress
                             body["total_progress"] = event.total_progress
+                            body["log_level"] = event.log_level
                             await resp.send(json.dumps(body), event=event.name, retry=5)
                         case BgtaskDoneEvent():
                             if extra_data:

--- a/src/ai/backend/common/defs.py
+++ b/src/ai/backend/common/defs.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Final
 
 # Redis database IDs depending on purposes
@@ -10,3 +11,10 @@ REDIS_STREAM_LOCK: Final = 5
 
 
 DEFAULT_FILE_IO_TIMEOUT: Final = 10
+
+
+class BackgroundTaskLogLevel(enum.StrEnum):
+    INFO = enum.auto()
+    WARNING = enum.auto()
+    ERROR = enum.auto()
+    DEBUG = enum.auto()

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -36,6 +36,8 @@ from redis.asyncio import ConnectionPool
 from ai.backend.logging import BraceStyleAdapter, LogLevel
 
 from . import msgpack, redis_helper
+from .defs import BackgroundTaskLogLevel
+from .logging import BraceStyleAdapter
 from .types import (
     AgentId,
     EtcdRedisConfig,
@@ -559,6 +561,7 @@ class BgtaskUpdatedEvent(AbstractEvent):
     current_progress: float = attrs.field()
     total_progress: float = attrs.field()
     message: Optional[str] = attrs.field(default=None)
+    log_level: BackgroundTaskLogLevel = attrs.field(default=BackgroundTaskLogLevel.INFO)
 
     def serialize(self) -> tuple:
         return (
@@ -566,6 +569,7 @@ class BgtaskUpdatedEvent(AbstractEvent):
             self.current_progress,
             self.total_progress,
             self.message,
+            str(self.log_level),
         )
 
     @classmethod
@@ -575,6 +579,7 @@ class BgtaskUpdatedEvent(AbstractEvent):
             value[1],
             value[2],
             value[3],
+            BackgroundTaskLogLevel(value[4]),
         )
 
 


### PR DESCRIPTION
Let's add `log_level` field to background task event.
Current implementation of bgtask updates its progress with number type current & total progress and string type message.
Such implementation cannot inform clients of a granular failure of the total bgtask through progress reporter.
e.g. A task deleting multiple vfolders has failed to delete a few of them.

Adding `log_level` field could resolve this issue.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version