### PR TITLE
fix: Handle fs error when deleting vfolder (#2741)

### DIFF
--- a/changes/2741.fix.md
+++ b/changes/2741.fix.md
@@ -1,0 +1,1 @@
+Handle OS Error when deleting vfolders.

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -384,7 +384,8 @@ async def delete_vfolder(request: web.Request) -> web.Response:
         await log_manager_api_entry(log, "delete_vfolder", params)
         ctx: RootContext = request.app["ctx"]
         async with ctx.get_volume(params["volume"]) as volume:
-            await volume.delete_vfolder(params["vfid"])
+            with handle_fs_errors(volume, params["vfid"]):
+                await volume.delete_vfolder(params["vfid"])
             return web.Response(status=204)
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2741 to the 24.03 release.