### PR TITLE
ci(doc): load extra fonts to correctly render non-latin characters

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,15 @@ build:
     pre_build:
       # Auto-generate REST API reference
       - PYTHONPATH="src" python -m ai.backend.manager.openapi -o docs/manager/rest-reference/openapi.json
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
+        then
+          mkdir docs/fonts
+          curl -L https://github.com/orioncactus/pretendard/releases/download/v1.3.9/Pretendard-1.3.9.zip -o pretendard.zip
+          unzip -o pretendard.zip -d docs/fonts/Pretendard
+          curl -L https://github.com/naver/d2codingfont/releases/download/VER1.3.2/D2Coding-Ver1.3.2-20180524.zip -o d2coding.zip
+          unzip -o d2coding.zip -d docs/fonts/D2Coding
+        fi
 python:
   install:
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
     post_checkout:
       # Skip building the documentation if there are no changes in the docs/ directory
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml;
+        if [ "$READTHEDOCS_VERSION_TYPE" != "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml;
         then
           exit 183;
         fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,12 +91,17 @@ Building PDF requires following libraries to be present on your system.
 
 ### Installing dependencies on macOS
 1. Install MacTeX from [here](https://www.tug.org/mactex/). There are two types of MacTeX distributions; The BasicTeX one is more lightweight and MacTeX contains most of the libraries commonly used.
-2. Follow [here](http://wiki.ktug.org/wiki/wiki.php/KtugPrivateRepository) (Korean) to set up KTUG repository.
-3. Execute following command to install missing dependencies.
+2. Execute following command to install missing dependencies.
 ```console
 sudo tlmgr install latexmk tex-gyre fncychap wrapfig capt-of framed needspace collection-langkorean collection-fontsrecommended tabulary varwidth titlesec
 ```
-4. Install both Pretendard (used for main font) and D2Coding (used to draw monospace characters) fonts on your system.
+3. Install both Pretendard (used for main font) and D2Coding (used to draw monospace characters) fonts
+```console
+curl -L https://github.com/orioncactus/pretendard/releases/download/v1.3.9/Pretendard-1.3.9.zip -o pretendard.zip
+unzip -o pretendard.zip -d fonts/Pretendard
+curl -L https://github.com/naver/d2codingfont/releases/download/VER1.3.2/D2Coding-Ver1.3.2-20180524.zip -o d2coding.zip
+unzip -o d2coding.zip -d fonts/D2Coding
+```
 
 
 ## Advanced Settings
@@ -154,11 +159,11 @@ To preview the full documentation including the REST API reference seamlessly, y
 You may use [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql)
 to interact and inspect the Backend.AI Manager's GraphQL API.
 
-1. Ensure you have the access to the manager server.  
+1. Ensure you have the access to the manager server.
    The manager's *etcd* configuration should say `config/api/allow-openapi-schema-introspection` is true.
-2. Run `backend.ai proxy` command of the client SDK.  Depending on your setup, adjust `--bind` and `--port` options.  
+2. Run `backend.ai proxy` command of the client SDK.  Depending on your setup, adjust `--bind` and `--port` options.
    Use the client SDK version 21.03.7+ or 20.09.9+ at least to avoid unexpected CORS issues.
-3. From your web browser, navigate to `/spec/openapi` under proxy server set up at step 2. 
+3. From your web browser, navigate to `/spec/openapi` under proxy server set up at step 2.
    Enjoy auto-completion and schema introspection of Backend.AI admin API!
 
 ### Interactive GraphQL browser
@@ -166,11 +171,11 @@ to interact and inspect the Backend.AI Manager's GraphQL API.
 You may use [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#graphiql)
 to interact and inspect the Backend.AI Manager's GraphQL API.
 
-1. Ensure you have the access to the manager server.  
+1. Ensure you have the access to the manager server.
    The manager's *etcd* configuration should say `config/api/allow-graphql-schema-introspection` is true.
-2. Run `backend.ai proxy` command of the client SDK.  Depending on your setup, adjust `--bind` and `--port` options.  
+2. Run `backend.ai proxy` command of the client SDK.  Depending on your setup, adjust `--bind` and `--port` options.
    Use the client SDK version 21.03.7+ or 20.09.9+ at least to avoid unexpected CORS issues.
-3. From your web browser, navigate to `/spec/graphiql` under proxy server set up at step 2. 
+3. From your web browser, navigate to `/spec/graphiql` under proxy server set up at step 2.
    Enjoy auto-completion and schema introspection of Backend.AI admin API!
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,8 +170,22 @@ latex_elements = {
     "pointsize": "12pt",
     "fontpkg": "\n".join([
         "\\usepackage{fontspec}",
-        "\\setmainfont{Pretendard}",
-        "\\setmonofont{D2Coding}",
+        "\\setmainfont{Pretendard}[" +
+        "  Path = ./fonts/Pretendard/public/static/, " +
+        "  Extension = .otf, " +
+        "  UprightFont = *-Regular, " +
+        "  BoldFont = *-Bold, " +
+        "  ItalicFont = *-Regular, " +
+        "  BoldItalicFont = *-Bold" +
+        "]",
+        "\\setmonofont{D2Coding}[" +
+        "  Path = ./fonts/D2Coding/D2Coding/, " +
+        "  Extension = .ttf, " +
+        "  UprightFont = *-Ver1.3.2-20180524, " +
+        "  BoldFont = *Bold-Ver1.3.2-20180524, " +
+        "  ItalicFont = *-Ver1.3.2-20180524, " +
+        "  BoldItalicFont = *Bold-Ver1.3.2-20180524" +
+        "]",
         "\\usepackage{kotex}",
         ""
     ])


### PR DESCRIPTION
In #1529, after changing font in rtd build, all letters in the document are not visible.
Please download the relevant font and make it available before performing pdf build.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2750.org.readthedocs.build/en/2750/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2750.org.readthedocs.build/ko/2750/

<!-- readthedocs-preview sorna-ko end -->