### PR TITLE
fix: Correct `msgpack` deserialization of `ResourceSlot`

### DIFF
--- a/changes/2754.fix.md
+++ b/changes/2754.fix.md
@@ -1,0 +1,1 @@
+Correct `msgpack` deserialization of `ResourceSlot`.

--- a/src/ai/backend/common/msgpack.py
+++ b/src/ai/backend/common/msgpack.py
@@ -14,7 +14,7 @@ from typing import Any
 import msgpack as _msgpack
 import temporenc
 
-from .types import BinarySize
+from .types import BinarySize, ResourceSlot
 
 __all__ = ("packb", "unpackb")
 
@@ -27,6 +27,7 @@ class ExtTypes(enum.IntEnum):
     POSIX_PATH = 4
     PURE_POSIX_PATH = 5
     ENUM = 6
+    RESOURCE_SLOT = 8
     BACKENDAI_BINARY_SIZE = 16
 
 
@@ -46,6 +47,8 @@ def _default(obj: object) -> Any:
             return _msgpack.ExtType(ExtTypes.POSIX_PATH, os.fsencode(obj))
         case PurePosixPath():
             return _msgpack.ExtType(ExtTypes.PURE_POSIX_PATH, os.fsencode(obj))
+        case ResourceSlot():
+            return _msgpack.ExtType(ExtTypes.RESOURCE_SLOT, pickle.dumps(obj, protocol=5))
         case enum.Enum():
             return _msgpack.ExtType(ExtTypes.ENUM, pickle.dumps(obj, protocol=5))
     raise TypeError(f"Unknown type: {obj!r} ({type(obj)})")
@@ -64,6 +67,8 @@ def _ext_hook(code: int, data: bytes) -> Any:
         case ExtTypes.PURE_POSIX_PATH:
             return PurePosixPath(os.fsdecode(data))
         case ExtTypes.ENUM:
+            return pickle.loads(data)
+        case ExtTypes.RESOURCE_SLOT:
             return pickle.loads(data)
         case ExtTypes.BACKENDAI_BINARY_SIZE:
             return pickle.loads(data)

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -132,3 +132,13 @@ def test_msgpack_resource_slot():
     packed = msgpack.packb(resource_slot)
     unpacked = msgpack.unpackb(packed)
     assert unpacked == resource_slot
+
+    resource_slot = ResourceSlot({"cpu": 2, "mem": Decimal(1024**5)})
+    packed = msgpack.packb(resource_slot)
+    unpacked = msgpack.unpackb(packed)
+    assert unpacked == resource_slot
+
+    resource_slot = ResourceSlot({"cpu": 3, "mem": "1125899906842624"})
+    packed = msgpack.packb(resource_slot)
+    unpacked = msgpack.unpackb(packed)
+    assert unpacked == resource_slot

--- a/tests/common/test_msgpack.py
+++ b/tests/common/test_msgpack.py
@@ -6,7 +6,7 @@ from pathlib import PosixPath
 from dateutil.tz import gettz, tzutc
 
 from ai.backend.common import msgpack
-from ai.backend.common.types import BinarySize, SlotTypes
+from ai.backend.common.types import BinarySize, ResourceSlot, SlotTypes
 
 
 def test_msgpack_with_unicode():
@@ -125,3 +125,10 @@ def test_msgpack_posixpath():
     unpacked = msgpack.unpackb(packed)
     assert isinstance(unpacked["path"], PosixPath)
     assert unpacked["path"] == path
+
+
+def test_msgpack_resource_slot():
+    resource_slot = ResourceSlot({"cpu": 1, "mem": 1024})
+    packed = msgpack.packb(resource_slot)
+    unpacked = msgpack.unpackb(packed)
+    assert unpacked == resource_slot


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

## Overview

Currently, when deserializing the `ResourceSlot` type with `msgpack.unpack()`, the following *"Unknown Type"* error occurs.

This PR resolves the issue by explicitly adding `ResourceSlot` to `ExtTypes`, allowing `msgpack.unpack()` to correctly deserialize the `ResourceSlot` type.

## Steps to reproduce the bug

When restarting the session using the session restart command, the agent outputs the following error.

1. Create a session.

```
./backend.ai session create python
```

2. Restart the created session.

```
./backend.ai session restart <sess_id>
```

3. Now the following error is displayed on the agent with the assigned session.
```
2024-08-22 02:04:17.302 ERROR ai.backend.agent.agent [36527] restart_kernel(s:5becdfbb-747d-47d8-9a86-b682e137e646, k:e3251e6a-1986-4b2e-a069-0e848081c907): re-creation failure
Traceback (most recent call last):
  File "/home/jopemachine/backend.ai/src/ai/backend/agent/agent.py", line 2453, in restart_kernel
    await self.create_kernel(
  File "/home/jopemachine/backend.ai/src/ai/backend/agent/agent.py", line 2170, in create_kernel
    raise e
  File "/home/jopemachine/backend.ai/src/ai/backend/agent/agent.py", line 2151, in create_kernel
    await self.produce_event(
  File "/home/jopemachine/backend.ai/src/ai/backend/agent/agent.py", line 801, in produce_event
    await self.event_producer.produce_event(event, source=str(self.id))
  File "/home/jopemachine/backend.ai/src/ai/backend/common/events.py", line 1129, in produce_event
    b"args": msgpack.packb(event.serialize()),
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/src/ai/backend/common/msgpack.py", line 82, in packb
    return _msgpack.packb(data, default=_default, **opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/msgpack/__init__.py", line 36, in packb
    return Packer(**kwargs).pack(o)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "msgpack/_packer.pyx", line 279, in msgpack._cmsgpack.Packer.pack
  File "msgpack/_packer.pyx", line 276, in msgpack._cmsgpack.Packer.pack
  File "msgpack/_packer.pyx", line 270, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 232, in msgpack._cmsgpack.Packer._pack_inner
  File "msgpack/_packer.pyx", line 265, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 213, in msgpack._cmsgpack.Packer._pack_inner
  File "msgpack/_packer.pyx", line 265, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 213, in msgpack._cmsgpack.Packer._pack_inner
  File "msgpack/_packer.pyx", line 267, in msgpack._cmsgpack.Packer._pack
  File "/home/jopemachine/backend.ai/src/ai/backend/common/msgpack.py", line 54, in _default
    raise TypeError(f"Unknown type: {obj!r} ({type(obj)})")
TypeError: Unknown type: {'cpu': '1', 'mem': '335544320'} (<class 'ai.backend.common.types.ResourceSlot'>)
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
