### PR TITLE
fix: Regression of `session create-from-template` command

### DIFF
--- a/changes/2761.fix.md
+++ b/changes/2761.fix.md
@@ -1,1 +1,1 @@
-Fix regression error of `sesstpl create` command.
+Fix regression error of `session create_from_template` command.

--- a/changes/2761.fix.md
+++ b/changes/2761.fix.md
@@ -1,0 +1,1 @@
+Fix regression error of `sesstpl create` command.

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -440,7 +440,9 @@ def _create_from_template_cmd(docs: str = None):
             else undefined
         )
         prepared_mount, prepared_mount_map, _ = (
-            prepare_mount_arg(mount) if len(mount) > 0 or no_mount else (undefined, undefined)
+            prepare_mount_arg(mount)
+            if len(mount) > 0 or no_mount
+            else (undefined, undefined, undefined)
         )
         kwargs = {
             "name": name,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up of #1838.

## Steps to reproduce the issue

1. Create session template using `example-session-templates.yaml`

```
./backend.ai sesstpl create -f ./fixtures/manager/example-session-templates.yaml
```

2. Try to create a session using the created template.

```
./backend.ai session create-from-template <session_template_id>
```

Then the following error is displayed.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/jopemachine/backend.ai/src/ai/backend/cli/__main__.py", line 10, in <module>
    main(max_content_width=shutil.get_terminal_size().columns - 2)
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/src/ai/backend/cli/extensions.py", line 25, in main
    super().main(
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/dist/export/python/virtualenvs/python-default/3.12.4/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jopemachine/backend.ai/src/ai/backend/client/cli/session/lifecycle.py", line 442, in create_from_template
    prepared_mount, prepared_mount_map, _ = (
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 3, got 2)
```


---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

