### PR TITLE
fix: Regression of `session create-from-template` command (#2761)

### DIFF
--- a/changes/2761.fix.md
+++ b/changes/2761.fix.md
@@ -1,0 +1,1 @@
+Fix regression error of `session create_from_template` command.

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -440,7 +440,9 @@ def _create_from_template_cmd(docs: str = None):
             else undefined
         )
         prepared_mount, prepared_mount_map, _ = (
-            prepare_mount_arg(mount) if len(mount) > 0 or no_mount else (undefined, undefined)
+            prepare_mount_arg(mount)
+            if len(mount) > 0 or no_mount
+            else (undefined, undefined, undefined)
         )
         kwargs = {
             "name": name,


### PR DESCRIPTION
This is an auto-generated backport PR of #2761 to the 24.03 release.