### PR TITLE
refactor: Replace deprecated `log.warn()` with `log.warning()`

### DIFF
--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1311,7 +1311,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     try:
                         ImageRef(repo_tag, ["*"])
                     except ValueError:
-                        log.warn(
+                        log.warning(
                             "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored.",
                             repo_tag,
                         )

--- a/src/ai/backend/common/redis_client.py
+++ b/src/ai/backend/common/redis_client.py
@@ -164,16 +164,16 @@ class RedisClient(aobject):
 
                 try:
                     if not len(results) == len(commands):
-                        log.warn("requests: {}", commands)
-                        log.warn("responses: {}", results)
-                        log.warn("raw request: {}", _blobs)
-                        log.warn("raw response: {}", _buf)
-                        log.warn("previous raw response: {}", self._prev_buf)
+                        log.warning("requests: {}", commands)
+                        log.warning("responses: {}", results)
+                        log.warning("raw request: {}", _blobs)
+                        log.warning("raw response: {}", _buf)
+                        log.warning("previous raw response: {}", self._prev_buf)
                         if _buf.startswith(self._prev_buf):
-                            log.warn(
+                            log.warning(
                                 "new response contains data of previous response, without it the response should formed like:"
                             )
-                            log.warn("{}", _buf[len(self._prev_buf) :])
+                            log.warning("{}", _buf[len(self._prev_buf) :])
                         raise RedisError("Response count does not match with number of requests!")
                 finally:
                     self._prev_buf = _buf

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -904,7 +904,9 @@ class BaseRunner(metaclass=ABCMeta):
                     }
         finally:
             if error_reason:
-                log.warn("failed to start model service {}: {}", service_info["name"], error_reason)
+                log.warning(
+                    "failed to start model service {}: {}", service_info["name"], error_reason
+                )
 
     async def _wait_service_proc(
         self,

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -243,7 +243,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         ]
                         request_type = self.MEDIA_TYPE_OCI_MANIFEST
                     case _:
-                        log.warn("Unknown content type: {}", content_type)
+                        log.warning("Unknown content type: {}", content_type)
                         raise RuntimeError(
                             "The registry does not support the standard way of "
                             "listing multiarch images."

--- a/src/ai/backend/storage/purestorage/__init__.py
+++ b/src/ai/backend/storage/purestorage/__init__.py
@@ -69,7 +69,7 @@ class FlashBladeVolume(BaseVolume):
                     self._toolkit_version = 1
                     log.info("FlashBlade Toolkit 1 detected")
                 else:
-                    log.warn("Unrecogized FlashBlade Toolkit version: {}", version_line)
+                    log.warning("Unrecogized FlashBlade Toolkit version: {}", version_line)
                     self._toolkit_version = -1
         finally:
             await proc.wait()

--- a/src/ai/backend/wsproxy/api/proxy.py
+++ b/src/ai/backend/wsproxy/api/proxy.py
@@ -165,7 +165,7 @@ async def proxy(
     )
 
     if token["session_id"] != str(session_id):
-        log.warn(
+        log.warning(
             "User requested to create app of session {} but token authorizes session {}",
             session_id,
             token["session_id"],


### PR DESCRIPTION
This pull request is a follow-up of #1792.

Refs
- https://docs.python.org/3/library/logging.html#logging.Logger.warning

### TL;DR

Replaced deprecated `log.warn()` calls with `log.warning()` to ensure consistency and support future maintenance across multiple files.

### What changed?

- Replaced all instances of `log.warn()` with `log.warning()` in various files:
  - src/ai/backend/agent/docker/agent.py
  - src/ai/backend/common/redis_client.py
  - src/ai/backend/kernel/base.py
  - src/ai/backend/manager/container_registry/base.py
  - src/ai/backend/storage/purestorage/__init__.py
  - src/ai/backend/wsproxy/api/proxy.py

### How to test?

1. Run the application and trigger scenarios that would generate warning logs.
2. Verify that warning messages are still being logged correctly.
3. Check the log output to ensure that all warnings use the `warning` level instead of `warn`.

### Why make this change?

This change improves code consistency and follows Python's logging best practices. The `warning()` method is the standard way to log warnings in Python, while `warn()` is considered deprecated. This update ensures that all warning logs are using the correct and up-to-date method across the codebase.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
