### PR TITLE
fix: Silence `model_` namespace warnings in pydantic models (#2765)

### DIFF
--- a/changes/2765.fix.md
+++ b/changes/2765.fix.md
@@ -1,0 +1,1 @@
+Silence `model_` namespace warnings with pydantic-based model classes

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -393,7 +393,7 @@ class MountPoint(BaseModel):
     target: Path | None = Field(default=None)
     permission: MountPermission | None = Field(alias="perm", default=None)
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
 
 class MountExpression:

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -17,6 +17,7 @@ from pydantic import (
     AliasChoices,
     AnyUrl,
     BaseModel,
+    ConfigDict,
     Field,
     HttpUrl,
     NonNegativeFloat,
@@ -229,6 +230,8 @@ class ServeInfoModel(BaseResponseModel):
         Field(description="Type of the inference runtime the image will try to load."),
     ]
 
+    model_config = ConfigDict(protected_namespaces=())
+
 
 @auth_required
 @server_status_required(READ_ALLOWED)
@@ -309,6 +312,8 @@ class ServiceConfigModel(BaseModel):
     )
     resources: dict[str, str | int] = Field(examples=[{"cpu": 4, "mem": "32g", "cuda.shares": 2.5}])
     resource_opts: dict[str, str | int] = Field(examples=[{"shmem": "2g"}], default={})
+
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class NewServiceRequestModel(BaseModel):


### PR DESCRIPTION
This is an auto-generated backport PR of #2765 to the 24.03 release.