### PR TITLE
fix: Mishandling of undefined value in the `ModifyImage` mutation

### DIFF
--- a/changes/2028.fix.md
+++ b/changes/2028.fix.md
@@ -1,0 +1,1 @@
+Fix handling of undefined values in the ModifyImage GraphQL mutation.

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -1228,7 +1228,7 @@ class ModifyImage(graphene.Mutation):
         )
         set_if_set(props, data, "labels", clean_func=lambda v: {pair.key: pair.value for pair in v})
 
-        if props.resource_limits is not None:
+        if props.resource_limits is not Undefined:
             resources_data = {}
             for limit_option in props.resource_limits:
                 limit_data = {}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This is a backport PR of https://github.com/lablup/backend.ai/pull/2028 to the 24.03 release.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version