### PR TITLE
fix: Make the config file be treated as multiline by re (#2771)

### DIFF
--- a/changes/2771.fix.md
+++ b/changes/2771.fix.md
@@ -1,0 +1,1 @@
+Make the regex patterns to update configuration files working with multiline texts correctly in the TUI installer

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -341,7 +341,7 @@ class Context(metaclass=ABCMeta):
         self.sed_in_place_multi(
             toml_path,
             [
-                (re.compile("^num-proc = .*"), "num-proc = 1"),
+                (re.compile("^num-proc = .*", flags=re.M), "num-proc = 1"),
                 ("port = 8120", f"port = {halfstack.etcd_addr[0].face.port}"),
                 ("port = 8100", f"port = {halfstack.postgres_addr.face.port}"),
                 (
@@ -349,7 +349,7 @@ class Context(metaclass=ABCMeta):
                     f"port = {self.install_info.service_config.manager_addr.bind.port}",
                 ),
                 (
-                    re.compile("^(# )?ipc-base-path =.*"),
+                    re.compile("^(# )?ipc-base-path =.*", flags=re.M),
                     f'ipc-base-path = "{self.install_info.service_config.manager_ipc_base_path}"',
                 ),
             ],
@@ -424,15 +424,15 @@ class Context(metaclass=ABCMeta):
                 ("port = 6001", f"port = {service.agent_rpc_addr.bind.port}"),
                 ("port = 6009", f"port = {service.agent_watcher_addr.bind.port}"),
                 (
-                    re.compile("^(# )?ipc-base-path = .*"),
+                    re.compile("^(# )?ipc-base-path = .*", flags=re.M),
                     f'ipc-base-path = "{service.agent_ipc_base_path}"',
                 ),
                 (
-                    re.compile("^(# )?var-base-path = .*"),
+                    re.compile("^(# )?var-base-path = .*", flags=re.M),
                     f'var-base-path = "{service.agent_var_base_path}"',
                 ),
                 (
-                    re.compile("(# )?mount_path = .*"),
+                    re.compile("(# )?mount_path = .*", flags=re.M),
                     f'"{self.install_info.base_path / service.vfolder_relpath}"',
                 ),
             ],
@@ -445,7 +445,7 @@ class Context(metaclass=ABCMeta):
         # "cuda.devices = 0" as the agent capacity, but it will still run.
         self.sed_in_place(
             toml_path,
-            re.compile("^(# )?allow-compute-plugins = .*"),
+            re.compile("^(# )?allow-compute-plugins = .*", flags=re.M),
             'allow-compute-plugins = ["ai.backend.accelerator.cuda_open"]',
         )
         # TODO: let the installer enable the CUDA plugin only when it verifies CUDA availability or


### PR DESCRIPTION
This is an auto-generated backport PR of #2771 to the 23.09 release.