### PR TITLE
fix: Reflect `target_path` changes in `PackageContext` (#2768)

### DIFF
--- a/changes/2768.fix.md
+++ b/changes/2768.fix.md
@@ -1,0 +1,1 @@
+Change the initialization order of PackageContext to apply `target_path` correctly in the TUI installer


### PR DESCRIPTION
This is an auto-generated backport PR of #2768 to the 24.03 release.