### PR TITLE
fix: usage_per_period doesn't work if project_id is None

### DIFF
--- a/changes/2776.fix.md
+++ b/changes/2776.fix.md
@@ -1,0 +1,1 @@
+Set `None` to None in `project_id` in order to fix the issue where `usage_per_period` does not work properly when `project_id` is "None".

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -561,7 +561,7 @@ async def usage_per_period(request: web.Request, params: Any) -> web.Response:
     :param end_date str: "yyyymmdd" format.
     """
     root_ctx: RootContext = request.app["_root.context"]
-    project_id = params["project_id"]
+    project_id = None if (project_id := params.get("project_id", None)) == "None" else project_id
     local_tz = root_ctx.shared_config["system"]["timezone"]
     try:
         start_date = datetime.strptime(params["start_date"], "%Y%m%d").replace(tzinfo=local_tz)


### PR DESCRIPTION
related PR: https://github.com/lablup/backend.ai-control-panel/pull/830 

### TL;DR

Updated project_id handling in usage_per_period function

### What changed?

Modified the project_id assignment in the usage_per_period function to handle "None" string values. Now, if the project_id parameter is "None", it will be set to None instead of the string "None".

### How to test?

1. Call the usage_per_period endpoint with project_id set to "None" (e.g. `./backend.ai admin resource usage-per-period None 20240720 20240827`)
2. Verify that the function treats this as if no project_id was provided
3. Test with valid project_id values to ensure normal functionality is maintained

### Why make this change?

This change improves the handling of project_id parameter, allowing for more flexible API usage. It prevents potential issues that could arise from treating the string "None" as a valid project_id, ensuring that the absence of a project_id is correctly interpreted by the function.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2776.org.readthedocs.build/en/2776/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2776.org.readthedocs.build/ko/2776/

<!-- readthedocs-preview sorna-ko end -->