### PR TITLE
fix: Omit null parameter when call usage per period API

### DIFF
--- a/changes/2777.fix.md
+++ b/changes/2777.fix.md
@@ -1,0 +1,1 @@
+Omit null parameter when call `usage-per-period` API.

--- a/src/ai/backend/client/func/resource.py
+++ b/src/ai/backend/client/func/resource.py
@@ -67,7 +67,7 @@ class Resource(BaseFunction):
 
     @api_function
     @classmethod
-    async def usage_per_period(cls, group_id: str, start_date: str, end_date: str):
+    async def usage_per_period(cls, group_id: str | None, start_date: str, end_date: str):
         """
         Get usage statistics for a group specified by `group_id` for time between
         `start_date` and `end_date`.
@@ -76,14 +76,16 @@ class Resource(BaseFunction):
         :param end_date: end date in string format (yyyymmdd).
         :param group_id: Groups ID to list usage statistics.
         """
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        if group_id is not None:
+            params["group_id"] = group_id
         rqst = Request(
             "GET",
             "/resource/usage/period",
-            params={
-                "group_id": group_id,
-                "start_date": start_date,
-                "end_date": end_date,
-            },
+            params=params,
         )
         async with rqst.fetch() as resp:
             return await resp.json()

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -544,7 +544,7 @@ async def usage_per_month(request: web.Request, params: Any) -> web.Response:
 @superadmin_required
 @check_api_params(
     t.Dict({
-        tx.AliasedKey(["project_id", "group_id"], default=None): t.String | t.Null,
+        tx.AliasedKey(["project_id", "group_id"], default=None): t.Null | t.String,
         t.Key("start_date"): t.Regexp(r"^\d{8}$", re.ASCII),
         t.Key("end_date"): t.Regexp(r"^\d{8}$", re.ASCII),
     }),


### PR DESCRIPTION
For control panel testing, follow this way. ([Related threads.](https://teams.microsoft.com/l/message/19:14c484402d874dafb15806d093b95a82@thread.skype/1724735843276?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1724644510871&teamName=devops&channelName=Frontend&createdTime=1724735843276))

1. ./run_in_container.sh bash
2. patch with this code
3. modify something in `manage.py` such as adding space.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)