### PR TITLE
fix: Omit null parameter when call usage per period API (#2777)

### DIFF
--- a/changes/2777.fix.md
+++ b/changes/2777.fix.md
@@ -1,0 +1,1 @@
+Omit null parameter when call `usage-per-period` API.

--- a/src/ai/backend/client/func/resource.py
+++ b/src/ai/backend/client/func/resource.py
@@ -61,7 +61,7 @@ class Resource(BaseFunction):
 
     @api_function
     @classmethod
-    async def usage_per_period(cls, group_id: str, start_date: str, end_date: str):
+    async def usage_per_period(cls, group_id: str | None, start_date: str, end_date: str):
         """
         Get usage statistics for a group specified by `group_id` for time between
         `start_date` and `end_date`.
@@ -70,14 +70,16 @@ class Resource(BaseFunction):
         :param end_date: end date in string format (yyyymmdd).
         :param group_id: Groups ID to list usage statistics.
         """
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        if group_id is not None:
+            params["group_id"] = group_id
         rqst = Request(
             "GET",
             "/resource/usage/period",
-            params={
-                "group_id": group_id,
-                "start_date": start_date,
-                "end_date": end_date,
-            },
+            params=params,
         )
         async with rqst.fetch() as resp:
             return await resp.json()

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -517,7 +517,7 @@ async def usage_per_month(request: web.Request, params: Any) -> web.Response:
 @superadmin_required
 @check_api_params(
     t.Dict({
-        t.Key("group_id"): t.String | t.Null,
+        tx.AliasedKey(["project_id", "group_id"], default=None): t.Null | t.String,
         t.Key("start_date"): t.Regexp(r"^\d{8}$", re.ASCII),
         t.Key("end_date"): t.Regexp(r"^\d{8}$", re.ASCII),
     }),


### PR DESCRIPTION
This is an auto-generated backport PR of #2777 to the 23.09 release.