### PR TITLE
chore: Delete the parts of the BUILD settings that don't need

### DIFF
--- a/src/ai/backend/wsproxy/proxy/BUILD
+++ b/src/ai/backend/wsproxy/proxy/BUILD
@@ -1,1 +1,0 @@
-python_sources(name="src")

--- a/tests/manager/BUILD
+++ b/tests/manager/BUILD
@@ -1,10 +1,8 @@
 python_test_utils(
     sources=[
         "conftest.py",
-        "model_factory.py",
     ],
     dependencies=[
-        ":fixtures",
         "src/ai/backend/manager/api:src",  # indirectly referred via create_app_and_client() fixture
         "src/ai/backend/manager/scheduler:src",  # entrypoint-based import
         "src/ai/backend/manager/plugin:src",  # entrypoint-based import
@@ -13,8 +11,3 @@ python_test_utils(
 )
 
 python_tests(name="tests")
-
-files(
-    name="fixtures",
-    sources=["fixtures/*"],
-)


### PR DESCRIPTION
```
13:34:10.64 [WARN] Unmatched globs from tests/wsproxy:wsproxy's `sources` field: ["tests/wsproxy/*_test.pyi", "tests/wsproxy/conftest.py", "tests/wsproxy/test_*.pyi", "tests/wsproxy/tests.pyi"]

Do the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file(s) even though they exist on disk. Refer to https://www.pantsbuild.org/troubleshooting#pants-cannot-find-a-file-in-your-project.
13:34:10.68 [WARN] Unmatched glob from tests/manager:fixtures's `sources` field: "tests/manager/fixtures/*"

Do the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file(s) even though they exist on disk. Refer to https://www.pantsbuild.org/troubleshooting#pants-cannot-find-a-file-in-your-project.
13:34:10.68 [WARN] Unmatched glob from tests/manager:manager's `sources` field: "tests/manager/model_factory.py"

Do the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file(s) even though they exist on disk. Refer to https://www.pantsbuild.org/troubleshooting#pants-cannot-find-a-file-in-your-project.
13:34:10.69 [WARN] Unmatched globs from src/ai/backend/wsproxy/proxy:src's `sources` field: ["src/ai/backend/wsproxy/proxy/*.py", "src/ai/backend/wsproxy/proxy/*.pyi"], excludes: ["src/ai/backend/wsproxy/proxy/*_test.py", "src/ai/backend/wsproxy/proxy/*_test.pyi", "src/ai/backend/wsproxy/proxy/conftest.py", "src/ai/backend/wsproxy/proxy/test_*.py", "src/ai/backend/wsproxy/proxy/test_*.pyi", "src/ai/backend/wsproxy/proxy/tests.py", "src/ai/backend/wsproxy/proxy/tests.pyi"]

Do the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file(s) even though they exist on disk. Refer to https://www.pantsbuild.org/troubleshooting#pants-cannot-find-a-file-in-your-project.
13:34:10.72 [WARN] Unmatched glob from src/ai/backend/wsproxy:resources's `sources` field: "src/ai/backend/wsproxy/**/py.typed"

Do the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global `pants_ignore` option, which may result in Pants not being able to see the file(s) even though they exist on disk. Refer to https://www.pantsbuild.org/troubleshooting#pants-cannot-find-a-file-in-your-project.
```

Resolves several warnings that occur when packaging with pants.
These are mainly issues that rely on files that don't exist.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
