### PR TITLE
chore: Add a helper script to esaily access the scie's internal shell

### DIFF
--- a/scripts/scie-shell.sh
+++ b/scripts/scie-shell.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+# Refer to more details in KB1207
+SCIE_PATH=$1
+NCE_PYTHON=$(SCIE=inspect "${SCIE_PATH}" | jq -r '.scie.lift.files[] | select(.key == "cpython") | .hash')
+NCE_PEX_CLIENT=$(SCIE=inspect "${SCIE_PATH}" | jq -r '.scie.lift.files[] | select(.name | endswith("/pex.pex")) | .hash')
+# Referring KB1208, you may need to specify explicit terminfo database locations for scies built using indygreg builds older than 20240224.
+# export TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo"
+# Run the Python REPL within the pex evironment
+PEX_INTERPRETER=1 ~/.cache/nce/$NCE_PYTHON/cpython*/python/bin/python3 ~/.cache/nce/$NCE_PEX_CLIENT/src.ai.backend*/pex.pex


### PR DESCRIPTION
This PR adds a small helper script to easily access the Python interactive shell in the given SCIE executable's environment.

### How to use

```shell
# Build the manager scie executable.
pants --tag=scie --tag=+lazy package src/ai/backend/manager::

# Run a Python interactive shell in the manager's scie environment.
# You may import any dependency inside and inspect their extracted paths.
scripts/scie-shell.sh dist/backendai-manager-linux-aarch64
```