### PR TITLE
chore: change vastdata API token span

### DIFF
--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -28,8 +28,8 @@ from .exceptions import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-DEFAULT_ACCESS_TOKEN_SPAN: Final = timedelta(hours=1)
-DEFAULT_REFRESH_TOKEN_SPAN: Final = timedelta(hours=24)
+DEFAULT_ACCESS_TOKEN_SPAN: Final = timedelta(minutes=1)
+DEFAULT_REFRESH_TOKEN_SPAN: Final = timedelta(minutes=10)
 
 
 VASTQuotaID = NewType("VASTQuotaID", str)


### PR DESCRIPTION
Change Vast data client's API token life span since there are some API call failure due to outdate tokens.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version