### PR TITLE
fix: Handle container port mismatch when creating kernel (#2786)

### DIFF
--- a/changes/2786.fix.md
+++ b/changes/2786.fix.md
@@ -1,0 +1,1 @@
+Handle container port mismatch when creating kernel.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -945,7 +945,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                         )
                     host_port = int(ports[0]["HostPort"])
                     if host_port != host_ports[idx]:
-                        await _rollback_container_creation()
                         raise ContainerCreationError(
                             container_id=cid,
                             message=f"Port mapping mismatch. {host_port = }, {host_ports[idx] = }",


### PR DESCRIPTION
This is an auto-generated backport PR of #2786 to the 23.09 release.