### PR TITLE
chore: change vastdata API token span (#2785)

### DIFF
--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -28,8 +28,8 @@ from .exceptions import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-DEFAULT_ACCESS_TOKEN_SPAN: Final = timedelta(hours=1)
-DEFAULT_REFRESH_TOKEN_SPAN: Final = timedelta(hours=24)
+DEFAULT_ACCESS_TOKEN_SPAN: Final = timedelta(minutes=1)
+DEFAULT_REFRESH_TOKEN_SPAN: Final = timedelta(minutes=10)
 
 
 VASTQuotaID = NewType("VASTQuotaID", str)


### PR DESCRIPTION
This is an auto-generated backport PR of #2785 to the 24.03 release.