### PR TITLE
chore: Create storage DB table and migrate

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
+++ b/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
@@ -1,7 +1,7 @@
 """create storage table and migrate
 
 Revision ID: a9e4e4a72fa1
-Revises: 59a622c31820
+Revises: 3596bc12ec09
 Create Date: 2024-08-29 12:38:13.941982
 
 """
@@ -24,7 +24,7 @@ from ai.backend.manager.models.storage import StorageSessionManager
 
 # revision identifiers, used by Alembic.
 revision = "a9e4e4a72fa1"
-down_revision = "59a622c31820"
+down_revision = "3596bc12ec09"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
+++ b/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
@@ -35,7 +35,7 @@ branch_labels = None
 depends_on = None
 
 VOLUMES_KEY = "volumes"
-ETCD_BACKUP_FILENAME_PATTERN: Final = "backup.etcd.storage.{timestamp}.json"
+ETCD_BACKUP_FILENAME_PATTERN: Final = "backup.etcd.storages.{timestamp}.json"
 
 
 class StorageProxyRow(Base):
@@ -158,7 +158,7 @@ def upgrade() -> None:
         backup_path = Path(os.getenv("BACKEND_ETCD_BACKUP_PATH", "."))
         backup_path /= ETCD_BACKUP_FILENAME_PATTERN.format(timestamp=datetime.now().isoformat())
         with open(backup_path, "w") as f:
-            json.dump(raw_storage_config, f, indent=4)
+            json.dump(dict(raw_storage_config), f, indent=4)
 
     queue: Queue = Queue()
     with ThreadPoolExecutor() as executor:
@@ -186,6 +186,7 @@ def upgrade() -> None:
                 #         }
                 #     }
                 # }
+                backup(raw_storage_config)
                 storage_config = config.volume_config_iv.check(raw_storage_config)
                 for proxy_name, proxy_config in storage_config["proxies"].items():
                     proxies.append({

--- a/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
+++ b/src/ai/backend/manager/models/alembic/versions/a9e4e4a72fa1_create_storage_table_and_migrate.py
@@ -1,0 +1,244 @@
+"""create storage table and migrate
+
+Revision ID: a9e4e4a72fa1
+Revises: 59a622c31820
+Create Date: 2024-08-29 12:38:13.941982
+
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from typing import (
+    Any,
+    cast,
+)
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
+from ai.backend.manager import config
+from ai.backend.manager.models.base import GUID, Base, IDColumn, URLColumn
+from ai.backend.manager.models.storage import StorageSessionManager
+
+# revision identifiers, used by Alembic.
+revision = "a9e4e4a72fa1"
+down_revision = "59a622c31820"
+branch_labels = None
+depends_on = None
+
+VOLUMES_KEY = "volumes"
+
+
+class StorageProxyRow(Base):
+    __tablename__ = "storage_proxies"
+    __table_args__ = {"extend_existing": True}
+    id = IDColumn()
+    name = sa.Column("name", sa.String(length=64), nullable=False, unique=True)
+    client_api = sa.Column("client_api", URLColumn, nullable=False)
+    manager_api = sa.Column("manager_api", URLColumn, nullable=False)
+    secret = sa.Column("secret", sa.String(length=64), nullable=False)
+    ssl_verify = sa.Column("ssl_verify", sa.Boolean, default=False, server_default=sa.false())
+
+
+class StorageVolumeRow(Base):
+    __tablename__ = "storage_volumes"
+    __table_args__ = (
+        sa.UniqueConstraint("name", "proxy_name", name="uq_storage_volumes_name_proxy_name"),
+        {"extend_existing": True},
+    )
+    id = IDColumn()
+    name = sa.Column("name", sa.String(length=64), nullable=False)
+    proxy_name = sa.Column("proxy_name", sa.String(length=64), nullable=False)
+    host_name = sa.Column(
+        "host_name", sa.String(length=128), sa.Computed("proxy_name || ':' || name")
+    )
+    backend = sa.Column("backend", sa.String(length=64), nullable=False)
+
+
+class _AssociationScalingGroupStorageProxyRow(Base):
+    __tablename__ = "association_sgroups_storage_proxies"
+    id = IDColumn()
+    __table_args__ = (
+        sa.Index(
+            "ix_sgroup_name_storage_proxy_name", "sgroup_name", "storage_proxy_name", unique=True
+        ),
+        {"extend_existing": True},
+    )
+    sgroup_name = sa.Column("sgroup_name", sa.String(length=64), nullable=False)
+    storage_proxy_name = sa.Column("storage_proxy_name", sa.String(length=64), nullable=False)
+
+
+class _ScalingGroupRow(Base):
+    __tablename__ = "scaling_groups"
+    __table_args__ = {"extend_existing": True}
+    name = sa.Column("name", sa.String(length=64), primary_key=True)
+    is_public = sa.Column(
+        "is_public", sa.Boolean, index=True, default=True, server_default=sa.true(), nullable=False
+    )
+
+
+def get_etcd_client() -> AsyncEtcd:
+    local_config = config.load()
+    etcd_config = local_config.get("etcd", None)
+    assert etcd_config is not None, "etcd configuration is not found"
+    etcd_credentials = None
+    if local_config["etcd"]["user"]:
+        etcd_credentials = {
+            "user": local_config["etcd"]["user"],
+            "password": local_config["etcd"]["password"],
+        }
+    scope_prefix_map = {
+        ConfigScopes.GLOBAL: "",
+    }
+    return AsyncEtcd(
+        local_config["etcd"]["addr"],
+        local_config["etcd"]["namespace"],
+        scope_prefix_map,
+        credentials=etcd_credentials,
+    )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    # Create tables
+    op.create_table(
+        "association_sgroups_storage_proxies",
+        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
+        sa.Column("sgroup_name", sa.String(length=64), nullable=False),
+        sa.Column("storage_proxy_name", sa.String(length=64), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_association_sgroups_storage_proxies")),
+    )
+    op.create_index(
+        "ix_sgroup_name_storage_proxy_name",
+        "association_sgroups_storage_proxies",
+        ["sgroup_name", "storage_proxy_name"],
+        unique=True,
+    )
+    op.create_table(
+        "storage_proxies",
+        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("client_api", URLColumn(), nullable=False),
+        sa.Column("manager_api", URLColumn(), nullable=False),
+        sa.Column("secret", sa.String(length=64), nullable=False),
+        sa.Column("ssl_verify", sa.Boolean(), server_default=sa.text("false"), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_storage_proxies")),
+        sa.UniqueConstraint("name", name=op.f("uq_storage_proxies_name")),
+    )
+    op.create_table(
+        "storage_volumes",
+        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("proxy_name", sa.String(length=64), nullable=False),
+        sa.Column(
+            "host_name",
+            sa.String(length=128),
+            sa.Computed(
+                "proxy_name || ':' || name",
+            ),
+            nullable=True,
+        ),
+        sa.Column("backend", sa.String(length=64), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_storage_volumes")),
+        sa.UniqueConstraint("name", "proxy_name", name="uq_storage_volumes_name_proxy_name"),
+    )
+
+    # Get volume data from etcd
+    queue: Queue = Queue()
+    with ThreadPoolExecutor() as executor:
+
+        def get_volume_data(queue: Queue) -> None:
+            async def _get_data() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+                proxies = []
+                volumes = []
+                etcd = get_etcd_client()
+                raw_storage_config = await etcd.get_prefix(VOLUMES_KEY)
+                # {
+                #     "_types": {
+                #         "group": "",
+                #         "user": ""
+                #     },
+                #     "default_host": "local:volume1",
+                #     "exposed_volume_info": "percentage",
+                #     "proxies": {
+                #         "local": {
+                #             "client_api": "http://127.0.0.1:6021",
+                #             "manager_api": "https://127.0.0.1:6022",
+                #             "secret": "SECRET...",
+                #             "ssl_verify": "false"
+                #         }
+                #     }
+                # }
+                storage_config = config.volume_config_iv.check(raw_storage_config)
+                for proxy_name, proxy_config in storage_config["proxies"].items():
+                    proxies.append({
+                        "name": proxy_name,
+                        "client_api": proxy_config["client_api"],
+                        "manager_api": proxy_config["manager_api"],
+                        "secret": proxy_config["secret"],
+                        "ssl_verify": proxy_config["ssl_verify"],
+                        "sftp_scaling_groups": proxy_config["sftp_scaling_groups"] or [],
+                    })
+                storage_mgr = StorageSessionManager(storage_config)
+                for proxy_name, volume_info in await storage_mgr.get_all_volumes():
+                    volumes.append({
+                        "name": volume_info["name"],
+                        "proxy_name": proxy_name,
+                        "backend": volume_info["backend"],
+                    })
+                return proxies, volumes
+
+            queue.put(asyncio.run(_get_data()))
+
+        executor.submit(get_volume_data, queue)
+
+    proxy_data, volume_data = cast(tuple[list[dict[str, Any]], list[dict[str, Any]]], queue.get())
+
+    # Insert Storage proxy data
+    sftp_sgroup_mappings = []
+    for proxy in proxy_data:
+        try:
+            sftp_scaling_groups = cast(list[str], proxy.pop("sftp_scaling_groups"))
+        except KeyError:
+            continue
+        for sgroup in sftp_scaling_groups:
+            sftp_sgroup_mappings.append({
+                "storage_proxy_name": proxy["name"],
+                "sgroup_name": sgroup,
+            })
+    connection.execute(sa.insert(StorageProxyRow).values(proxy_data))
+    if sftp_sgroup_mappings:
+        connection.execute(sa.insert(_AssociationScalingGroupStorageProxyRow), sftp_sgroup_mappings)
+
+    public_sgroups = connection.scalars(
+        sa.select(_ScalingGroupRow.__table__.c.name).where(
+            _ScalingGroupRow.__table__.c.is_public == sa.true()
+        )
+    ).all()
+    public_sgroups = cast(list[str], public_sgroups)
+
+    assoc_data = []
+    for sgroup in public_sgroups:
+        for proxy in proxy_data:
+            proxy_name = proxy["name"]
+            assoc_data.append({
+                "storage_proxy_name": proxy_name,
+                "sgroup_name": sgroup,
+            })
+    connection.execute(sa.insert(_AssociationScalingGroupStorageProxyRow), assoc_data)
+
+    # Insert Storage volume data
+    connection.execute(sa.insert(StorageVolumeRow).values(volume_data))
+
+
+def downgrade() -> None:
+    # Drop tables
+    op.drop_table("storage_volumes")
+    op.drop_table("storage_proxies")
+    op.drop_index(
+        "ix_sgroup_name_storage_proxy_name", table_name="association_sgroups_storage_proxies"
+    )
+    op.drop_table("association_sgroups_storage_proxies")

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -215,6 +215,30 @@ class ScalingGroupForKeypairsRow(Base):
 sgroups_for_keypairs = ScalingGroupForKeypairsRow.__table__
 
 
+class AssociationScalingGroupStorageProxyRow(Base):
+    __tablename__ = "association_sgroups_storage_proxies"
+    __table_args__ = (
+        sa.Index(
+            "ix_sgroup_name_storage_proxy_name", "sgroup_name", "storage_proxy_name", unique=True
+        ),
+    )
+
+    id = IDColumn()
+    sgroup_name = sa.Column("sgroup_name", sa.String(length=64), nullable=False)
+    storage_proxy_name = sa.Column("storage_proxy_name", sa.String(length=64), nullable=False)
+
+    sgroup_row = relationship(
+        "ScalingGroupRow",
+        back_populates="storage_proxy_rows",
+        primaryjoin="ScalingGroupRow.name == foreign(AssociationScalingGroupStorageProxyRow.sgroup_name)",
+    )
+    storage_proxy_row = relationship(
+        "StorageProxyRow",
+        back_populates="sgroup_rows",
+        primaryjoin="StorageProxyRow.name == foreign(AssociationScalingGroupStorageProxyRow.storage_proxy_name)",
+    )
+
+
 class ScalingGroupRow(Base):
     __tablename__ = "scaling_groups"
     name = sa.Column("name", sa.String(length=64), primary_key=True)
@@ -253,6 +277,11 @@ class ScalingGroupRow(Base):
         "KeyPairRow",
         secondary=sgroups_for_keypairs,
         back_populates="scaling_groups",
+    )
+    storage_proxy_rows = relationship(
+        "AssociationScalingGroupStorageProxyRow",
+        back_populates="sgroup_row",
+        primaryjoin="ScalingGroupRow.name == foreign(AssociationScalingGroupStorageProxyRow.sgroup_name)",
     )
 
 

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -465,6 +465,11 @@ class VFolderRow(Base):
     )
     permission_rows = relationship(VFolderPermissionRow, back_populates="vfolder_row")
     invitation_rows = relationship(VFolderInvitationRow, back_populates="vfolder_row")
+    storage_volume_row = relationship(
+        "StorageVolumeRow",
+        back_populates="vfolder_rows",
+        primaryjoin="StorageVolumeRow.host_name == foreign(VFolderRow.host)",
+    )
 
     @classmethod
     async def get(


### PR DESCRIPTION
Create `storage_proxies` and `storage_volumes` tables and add an alembic migration script.
`storage_volumes` table is used to represent a "storage host" of vfolders.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version