### PR TITLE
fix: Explicitly specify protected service ports not to expose publicly

### DIFF
--- a/changes/2796.feature.md
+++ b/changes/2796.feature.md
@@ -1,0 +1,1 @@
+Add an explicit configuration `scaling-group-type` to `agent.toml` so that the agent could distinguish whether itself belongs to an SFTP resource group or not

--- a/changes/2797.fix.md
+++ b/changes/2797.fix.md
@@ -1,0 +1,1 @@
+Explicitly set the protected service ports depending on the resource group type and the service types

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -48,9 +48,15 @@ agent-sock-port = 6007
 # This affects the per-node configuration scope.
 # id = "i-something-special"
 
-# Set the scaling group of this agent.
+# Set the scaling group (aka resource group) of this agent.
 # This affects the per-sgroup configuration scope.
 scaling-group = "default"
+
+# Set the type of scaling group (aka resource group) of this agent.
+# - "compute": The agent hosts computing workloads, facing the internal cluster nodes.
+# - "storage": The agent hosts storage-access containers, directly facing public/user-side netweorks.
+# [default: "compute"]
+# scaling-group-type = "compute"
 
 # Set the volume mount path for the agent node.
 # mount-path = "/vfroot"

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -265,6 +265,22 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         """
         self.kernel_config["bootstrap_script"] = script
 
+    @property
+    @abstractmethod
+    def repl_ports(self) -> Sequence[int]:
+        """
+        Return the list of intrinsic REPL ports to exclude from public mapping.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def protected_services(self) -> Sequence[str]:
+        """
+        Return the list of protected (intrinsic) service names to exclude from public mapping.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     async def apply_network(self, cluster_info: ClusterInfo) -> None:
         """

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -4,6 +4,7 @@ import trafaret as t
 
 from ai.backend.common import config
 from ai.backend.common import validators as tx
+from ai.backend.common.types import ResourceGroupType
 
 from .affinity_map import AffinityPolicy
 from .stats import StatModes
@@ -43,6 +44,9 @@ agent_local_config_iv = (
             t.Key("region", default=None): t.Null | t.String,
             t.Key("instance-type", default=None): t.Null | t.String,
             t.Key("scaling-group", default="default"): t.String,
+            t.Key("scaling-group-type", default=ResourceGroupType.COMPUTE): t.Enum(
+                *(e.value for e in ResourceGroupType)
+            ),
             t.Key("pid-file", default=os.devnull): tx.Path(
                 type="file", allow_nonexisting=True, allow_devnull=True
             ),
@@ -81,7 +85,8 @@ agent_local_config_iv = (
             t.Key("bind-host", default=""): t.String(allow_blank=True),
             t.Key("advertised-host", default=None): t.Null | t.String(),
             t.Key("port-range", default=(30000, 31000)): tx.PortRange,
-            t.Key("stats-type", default="docker"): t.Null | t.Enum(*[e.value for e in StatModes]),
+            t.Key("stats-type", default=StatModes.DOCKER): t.Null
+            | t.Enum(*(e.value for e in StatModes)),
             t.Key("sandbox-type", default="docker"): t.Enum("docker", "jail"),
             t.Key("jail-args", default=[]): t.List(t.String),
             t.Key("scratch-type"): t.Enum("hostdir", "hostfile", "memory", "k8s-nfs"),

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -32,6 +32,7 @@ from typing import (
     Tuple,
     Union,
     cast,
+    override,
 )
 from uuid import UUID
 
@@ -752,10 +753,12 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         return kernel_obj
 
     @property
+    @override
     def repl_ports(self) -> Sequence[int]:
         return (2000, 2001)
 
     @property
+    @override
     def protected_services(self) -> Sequence[str]:
         rgtype: ResourceGroupType = self.local_config["agent"]["scaling-group-type"]
         match rgtype:

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -66,6 +66,7 @@ from ai.backend.common.types import (
     KernelId,
     MountPermission,
     MountTypes,
+    ResourceGroupType,
     ResourceSlot,
     Sentinel,
     ServicePort,
@@ -750,6 +751,19 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         )
         return kernel_obj
 
+    @property
+    def repl_ports(self) -> Sequence[int]:
+        return (2000, 2001)
+
+    @property
+    def protected_services(self) -> Sequence[str]:
+        rgtype: ResourceGroupType = self.local_config["agent"]["scaling-group-type"]
+        match rgtype:
+            case ResourceGroupType.COMPUTE:
+                return ()
+            case ResourceGroupType.STORAGE:
+                return ("ttyd",)
+
     async def start_container(
         self,
         kernel_obj: AbstractKernel,
@@ -766,13 +780,13 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         # PHASE 4: Run!
         container_bind_host = self.local_config["container"]["bind-host"]
         advertised_kernel_host = self.local_config["container"].get("advertised-host")
-        repl_ports = [2000, 2001]
-        if len(service_ports) + len(repl_ports) > len(self.port_pool):
+        if len(service_ports) + len(self.repl_ports) > len(self.port_pool):
             raise RuntimeError(
                 f"Container ports are not sufficiently available. (remaining ports: {self.port_pool})"
             )
-        exposed_ports = repl_ports
-        host_ports = [self.port_pool.pop() for _ in repl_ports]
+        exposed_ports = [*self.repl_ports]
+        host_ports = [self.port_pool.pop() for _ in self.repl_ports]
+        host_ips = []
         for sport in service_ports:
             exposed_ports.extend(sport["container_ports"])
             if (
@@ -788,6 +802,18 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             else:
                 hport = self.port_pool.pop()
                 host_ports.append(hport)
+        protected_service_ports: set[int] = set()
+        for sport in service_ports:
+            if sport["name"] in self.protected_services:
+                protected_service_ports.update(sport["container_ports"])
+        for eport in exposed_ports:
+            if eport in self.repl_ports:  # always protected
+                host_ips.append("127.0.0.1")
+            elif eport in protected_service_ports:  # check if protected by resource group type
+                host_ips.append("127.0.0.1")
+            else:
+                host_ips.append(str(container_bind_host))
+        assert len(host_ips) == len(host_ports) == len(exposed_ports)
 
         container_log_size = self.local_config["agent"]["container-logs"]["max-length"]
         container_log_file_count = 5
@@ -815,8 +841,8 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             "HostConfig": {
                 "Init": True,
                 "PortBindings": {
-                    f"{eport}/tcp": [{"HostPort": str(hport), "HostIp": str(container_bind_host)}]
-                    for eport, hport in zip(exposed_ports, host_ports)
+                    f"{eport}/tcp": [{"HostPort": str(hport), "HostIp": hip}]
+                    for eport, hport, hip in zip(exposed_ports, host_ports, host_ips)
                 },
                 "PublishAllPorts": False,  # we manage port mapping manually!
                 "CapAdd": [

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -85,7 +85,7 @@ class DockerKernel(AbstractKernel):
             self.kernel_id,
             self.session_id,
             event_producer,
-            kernel_host=self.data["kernel_host"],
+            kernel_host="127.0.0.1",  # repl ports are always bound to 127.0.0.1
             repl_in_port=self.data["repl_in_port"],
             repl_out_port=self.data["repl_out_port"],
             exec_timeout=0,

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    override,
 )
 
 from ai.backend.common.config import read_from_file
@@ -110,6 +111,16 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
 
     async def get_intrinsic_mounts(self) -> Sequence[Mount]:
         return []
+
+    @property
+    @override
+    def repl_ports(self) -> Sequence[int]:
+        return (2000, 2001)
+
+    @property
+    @override
+    def protected_services(self) -> Sequence[str]:
+        return ()
 
     async def apply_network(self, cluster_info: ClusterInfo) -> None:
         return

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -23,6 +23,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    override,
 )
 
 import aiotools
@@ -305,6 +306,17 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
         # TODO: Find way to mount extra volumes
 
         return mounts
+
+    @property
+    @override
+    def repl_ports(self) -> Sequence[int]:
+        return (2000, 2001)
+
+    @property
+    @override
+    def protected_services(self) -> Sequence[str]:
+        # NOTE: Currently K8s does not support binding container ports to 127.0.0.1 when using NodePort.
+        return ()
 
     async def apply_network(self, cluster_info: ClusterInfo) -> None:
         pass
@@ -658,7 +670,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
         await kube_config.load_kube_config()
         core_api = kube_client.CoreV1Api()
         apps_api = kube_client.AppsV1Api()
-        exposed_ports = [2000, 2001]
+        exposed_ports = [*self.repl_ports]
         for sport in service_ports:
             exposed_ports.extend(sport["container_ports"])
 

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -67,7 +67,7 @@ def check_cgroup_available():
     return not is_containerized() and sys.platform.startswith("linux")
 
 
-class StatModes(enum.Enum):
+class StatModes(enum.StrEnum):
     CGROUP = "cgroup"
     DOCKER = "docker"
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -69,6 +69,7 @@ __all__ = (
     "SlotName",
     "IntrinsicSlotNames",
     "ResourceSlot",
+    "ResourceGroupType",
     "ReadableCIDR",
     "HardwareMetadata",
     "ModelServiceStatus",
@@ -284,6 +285,11 @@ class SessionResult(enum.StrEnum):
     UNDEFINED = "undefined"
     SUCCESS = "success"
     FAILURE = "failure"
+
+
+class ResourceGroupType(enum.StrEnum):
+    COMPUTE = enum.auto()
+    STORAGE = enum.auto()
 
 
 class ClusterMode(enum.StrEnum):


### PR DESCRIPTION
refs #2791

This is a temporary fix until we do full refactoring.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
