### PR TITLE
fix: bugs related to `endpoint` and `endpoint_list` GQL queries

### DIFF
--- a/changes/2805.fix.md
+++ b/changes/2805.fix.md
@@ -1,0 +1,1 @@
+Fix `endpoint_list.total_count` GQL field returning incorrect value

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -816,16 +816,7 @@ class Endpoint(graphene.ObjectType):
         user_uuid: Optional[uuid.UUID] = None,
         filter: Optional[str] = None,
     ) -> int:
-        query = (
-            sa.select([sa.func.count()])
-            .select_from(EndpointRow)
-            .filter(
-                EndpointRow.lifecycle_stage.in_([
-                    EndpointLifecycle.CREATED,
-                    EndpointLifecycle.DESTROYING,
-                ])
-            )
-        )
+        query = sa.select([sa.func.count()]).select_from(EndpointRow)
         if project is not None:
             query = query.where(EndpointRow.project == project)
         if domain_name is not None:

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -815,7 +815,6 @@ class Endpoint(graphene.ObjectType):
         domain_name: Optional[str] = None,
         user_uuid: Optional[uuid.UUID] = None,
         filter: Optional[str] = None,
-        order: Optional[str] = None,
     ) -> int:
         query = (
             sa.select([sa.func.count()])
@@ -836,11 +835,6 @@ class Endpoint(graphene.ObjectType):
         if filter is not None:
             filter_parser = QueryFilterParser(cls._queryfilter_fieldspec)
             query = filter_parser.append_filter(query, filter)
-        if order is not None:
-            order_parser = QueryOrderParser(cls._queryorder_colmap)
-            query = order_parser.append_ordering(query, order)
-        else:
-            query = query.order_by(sa.desc(EndpointRow.created_at))
 
         async with ctx.db.begin_readonly() as conn:
             result = await conn.execute(query)

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -836,6 +836,7 @@ class Endpoint(graphene.ObjectType):
         "model": ("endpoints_model", None),
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
+        "lifecycle_stage": ("endpoints_lifecycle_stage", None),
         "created_user_email": ("users_email", None),
     }
 

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -846,6 +846,7 @@ class Endpoint(graphene.ObjectType):
         "model": ("endpoints_model", None),
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
+        "lifecycle_stage": ("endpoints_lifecycle_stage", None),
         "created_user_email": ("users_email", None),
     }
 

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -2156,7 +2156,6 @@ class Queries(graphene.ObjectType):
             domain_name=domain_name,
             user_uuid=user_uuid,
             filter=filter,
-            order=order,
         )
         endpoint_list = await Endpoint.load_slice(
             info.context,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -2155,6 +2155,8 @@ class Queries(graphene.ObjectType):
             project=project,
             domain_name=domain_name,
             user_uuid=user_uuid,
+            filter=filter,
+            order=order,
         )
         endpoint_list = await Endpoint.load_slice(
             info.context,

--- a/src/ai/backend/manager/models/minilang/__init__.py
+++ b/src/ai/backend/manager/models/minilang/__init__.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, NamedTuple
+from enum import Enum
+from typing import Any, Callable, Generic, NamedTuple, TypeVar
 
 import sqlalchemy as sa
 
@@ -12,8 +13,20 @@ class JSONFieldItem(NamedTuple):
     key_name: str
 
 
-FieldSpecItem = tuple[str | ArrayFieldItem | JSONFieldItem, Callable[[str], Any] | None]
-OrderSpecItem = tuple[str | ArrayFieldItem | JSONFieldItem, Callable[[sa.Column], Any] | None]
+TEnum = TypeVar("TEnum", bound=Enum)
+
+
+class EnumFieldItem(NamedTuple, Generic[TEnum]):
+    column_name: str
+    enum_cls: TEnum
+
+
+FieldSpecItem = tuple[
+    str | ArrayFieldItem | JSONFieldItem | EnumFieldItem, Callable[[str], Any] | None
+]
+OrderSpecItem = tuple[
+    str | ArrayFieldItem | JSONFieldItem | EnumFieldItem, Callable[[sa.Column], Any] | None
+]
 
 
 def get_col_from_table(table, column_name: str):


### PR DESCRIPTION
Fixes regressions created after PR #2723, where `total_count` value of `endpoint_list` GQL query does not match actual item count. Also fixes `endpoint.status` GQL field reporting `ready` instead of `destroyed` when the endpoint is in `DESTROYED` status.
 
**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2805.org.readthedocs.build/en/2805/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2805.org.readthedocs.build/ko/2805/

<!-- readthedocs-preview sorna-ko end -->