### PR TITLE
fix: Correct session status determiner function (#2803)

### DIFF
--- a/changes/2803.fix.md
+++ b/changes/2803.fix.md
@@ -1,0 +1,1 @@
+Correct session status determiner function.

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -128,7 +128,7 @@ FOLLOWING_SESSION_STATUSES = (
     SessionStatus.RUNNING,
     SessionStatus.TERMINATED,
 )
-LEADING_SESSION_STATUSES = (
+LEADING_SESSION_STATUSES = tuple(
     # Session statuses that declare first, do not need to wait any sibling kernel
     s
     for s in SessionStatus
@@ -281,6 +281,14 @@ def determine_session_status(sibling_kernels: Sequence[KernelRow]) -> SessionSta
         return candidate
     for k in sibling_kernels:
         match candidate:
+            case SessionStatus.TERMINATING:
+                match k.status:
+                    case KernelStatus.TERMINATING | KernelStatus.TERMINATED:
+                        continue
+                    case KernelStatus.RUNNING | KernelStatus.ERROR:
+                        return SessionStatus.ERROR
+                    case _:
+                        pass
             case SessionStatus.RUNNING:
                 match k.status:
                     case (
@@ -300,8 +308,10 @@ def determine_session_status(sibling_kernels: Sequence[KernelRow]) -> SessionSta
                         candidate = SessionStatus.PREPARING
                     case KernelStatus.RUNNING | KernelStatus.RESTARTING | KernelStatus.RESIZING:
                         continue
-                    case KernelStatus.TERMINATING | KernelStatus.ERROR:
-                        candidate = SessionStatus.RUNNING_DEGRADED
+                    case KernelStatus.TERMINATING:
+                        return SessionStatus.ERROR
+                    case KernelStatus.ERROR:
+                        return SessionStatus.ERROR
             case SessionStatus.TERMINATED:
                 match k.status:
                     case KernelStatus.PENDING | KernelStatus.CANCELLED:


### PR DESCRIPTION
This is an auto-generated backport PR of #2803 to the 24.03 release.