### PR TITLE
ci(doc): fix HTML syntax error (#2732)

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,4 +1,8 @@
-{% extends "!layout.html" %}
-{% block extrahead %}
-<link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css">
-{% endblock %}
+{%- if meta is mapping and meta.get("render_mode") == "raw" %}
+    {% block body %}{% endblock %}
+{%- else %}
+    {% extends "!layout.html" %}
+    {% block extrahead %}
+    <link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css" />
+    {% endblock %}
+{%- endif %}


### PR DESCRIPTION
This is an auto-generated backport PR of #2732 to the 23.09 release.