### PR TITLE
ci(doc): fix HTML syntax error (#2732)

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,6 +3,6 @@
 {%- else %}
     {% extends "!layout.html" %}
     {% block extrahead %}
-    <link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css">
+    <link href="{{ pathto("_static/custom.css", True) }}" rel="stylesheet" type="text/css" />
     {% endblock %}
 {%- endif %}


### PR DESCRIPTION
This is an auto-generated backport PR of #2732 to the 24.03 release.