### PR TITLE
fix: login session does not expire or cannot login

### DIFF
--- a/changes/2816.fix.md
+++ b/changes/2816.fix.md
@@ -1,0 +1,1 @@
+Refresh expiration time of login session when login.

--- a/src/ai/backend/common/web/session/__init__.py
+++ b/src/ai/backend/common/web/session/__init__.py
@@ -58,12 +58,12 @@ class Session(MutableMapping[str, Any]):
 
     def __init__(
         self,
-        identity: Any | None,
+        identity: Optional[Any],
         *,
-        data: SessionData | None,
+        data: Optional[SessionData],
         new: bool,
-        max_age: int | None = None,
-        lifespan: int | None = None,
+        max_age: Optional[int] = None,
+        lifespan: Optional[int] = None,
     ) -> None:
         self._changed: bool = False
         self._mapping: dict[str, Any] = {}

--- a/src/ai/backend/common/web/session/redis_storage.py
+++ b/src/ai/backend/common/web/session/redis_storage.py
@@ -141,5 +141,5 @@ class RedisStorage(AbstractStorage):
         await self._redis.set(
             name=self.cookie_name + "_" + key,
             value=data_str,
-            ex=session.expiration_dt - current,
+            ex=self.max_age,
         )

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -31,8 +31,8 @@ from ai.backend.common import config, redis_helper
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.web.session import (
     extra_config_headers,
-    get_current_time,
     get_session,
+    get_time,
 )
 from ai.backend.common.web.session import setup as setup_session
 from ai.backend.common.web.session.redis_storage import RedisStorage
@@ -271,6 +271,7 @@ async def login_handler(request: web.Request) -> web.Response:
             }),
             content_type="application/problem+json",
         )
+    session.update_creation_time()
     request_headers = extra_config_headers.check(request.headers)
     secure_context = request_headers.get("X-BackendAI-Encoded", None)
     client_ip = get_client_ip(request)
@@ -442,7 +443,7 @@ async def extend_login_session(request: web.Request) -> web.Response:
     config = request.app["config"]
     login_session_extension_sec = cast(int, config["session"]["login_session_extension_sec"])
 
-    current = await get_current_time(request)
+    current = get_time()
     session = await get_session(request)
 
     session.expiration_dt = current + login_session_extension_sec


### PR DESCRIPTION
follow-up #2456 

- `redis.set()` has `ex` parameter and it allows numeric value bigger than 0 or `null`. Let's pass a fixed value (`max_age`) which is always bigger than 0 or null.
- Cannot login after login session expiration because expiration date-time is saved in session storage and it is always earlier than the current time. Let the login handler refresh the session with new expiration date time.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version