### PR TITLE
ci: Upgrade `readthedocs` build environment to Python 3.12 (#2814)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     post_checkout:
       # Skip building the documentation if there are no changes in the docs/ directory

--- a/changes/2814.misc.md
+++ b/changes/2814.misc.md
@@ -1,0 +1,1 @@
+Upgrade `readthedocs` build environment to Python 3.12


### PR DESCRIPTION
This is an auto-generated backport PR of #2814 to the 24.03 release.