### PR TITLE
feat: Insert container id to kernel obj of registry

### DIFF
--- a/changes/2819.enhance.md
+++ b/changes/2819.enhance.md
@@ -1,0 +1,1 @@
+Insert container id to kernel objects whose `container_id` field is missing.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1071,7 +1071,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     sport["container_ports"] = created_host_ports
 
         return {
-            "container_id": container._id,
+            "container_id": ContainerId(cid),
             "kernel_host": advertised_kernel_host or container_bind_host,
             "repl_in_port": repl_in_port,
             "repl_out_port": repl_out_port,

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -177,7 +177,7 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
     stats_enabled: bool
     # FIXME: apply TypedDict to data in Python 3.8
     environ: Mapping[str, Any]
-    status: KernelLifecycleStatus
+    state: KernelLifecycleStatus
 
     _tasks: Set[asyncio.Task]
 

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -428,8 +428,13 @@ class StatContext:
             kernel_id_map: Dict[ContainerId, KernelId] = {}
             for kid, info in self.agent.kernel_registry.items():
                 try:
-                    cid = info["container_id"]
-                except KeyError:
+                    cid = info.container_id
+                    if cid is None:
+                        log.warning(
+                            f"collect_container_stat(): no container for kernel (kid:{kid}, state:{info.state})"
+                        )
+                        continue
+                except (KeyError, AttributeError):
                     log.warning("collect_container_stat(): no container for kernel {}", kid)
                 else:
                     kernel_id_map[ContainerId(cid)] = kid


### PR DESCRIPTION
follow-up #2178 

Some kernel objects in agent's registry does not have container id.
Let `sync_container_lifecycles()` insert container id to such kernel objects.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version