### PR TITLE
chore: Upgrade ruff to 0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ asyncio_mode = "auto"
 [tool.ruff]
 line-length = 100
 src = ["src"]
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -82,13 +84,13 @@ select = [
 ]
 ignore = ["E203","E731","E501"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["ai.backend"]
 known-local-folder = ["src"]
 known-third-party = ["alembic", "redis"]
 split-on-trailing-comma = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "src/ai/backend/manager/config.py" = ["E402"]
 "src/ai/backend/manager/models/alembic/env.py" = ["E402"]
 

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -169,7 +169,7 @@ class CUDAPlugin(AbstractComputePlugin):
             if dev_id in self.device_mask:
                 continue
             raw_info = libcudart.get_device_props(int(dev_id))
-            sysfs_node_path = f"/sys/bus/pci/devices/{raw_info['pciBusID_str'].lower()}/numa_node"
+            sysfs_node_path = f"/sys/bus/pci/devices/{raw_info["pciBusID_str"].lower()}/numa_node"
             node: Optional[int]
             try:
                 node = int(Path(sysfs_node_path).read_text().strip())

--- a/src/ai/backend/accelerator/mock/plugin.py
+++ b/src/ai/backend/accelerator/mock/plugin.py
@@ -297,7 +297,7 @@ class MockPlugin(AbstractComputePlugin):
                     init_kwargs["is_mig_device"] = dev_info["is_mig_device"]
                     if dev_info["is_mig_device"]:
                         init_kwargs["device_id"] = DeviceId(
-                            f"MIG-{dev_info['mother_uuid']}/{idx}/0"
+                            f"MIG-{dev_info["mother_uuid"]}/{idx}/0"
                         )
                     device_cls = CUDADevice
                 case _:
@@ -810,7 +810,7 @@ class MockPlugin(AbstractComputePlugin):
 
         device_format = self.device_formats[format_key]
         return {
-            "slot_name": f"{self.mock_config['slot_name']}.{format_key}",
+            "slot_name": f"{self.mock_config["slot_name"]}.{format_key}",
             "human_readable_name": device_format["human_readable_name"],
             "description": device_format["description"],
             "display_unit": device_format["display_unit"],

--- a/src/ai/backend/account_manager/config.py
+++ b/src/ai/backend/account_manager/config.py
@@ -424,7 +424,7 @@ def generate_example_json(
     if isinstance(schema, types.UnionType):
         return generate_example_json(typing.get_args(schema)[0], parent=[*parent])
     elif isinstance(schema, types.GenericAlias):
-        if typing.get_origin(schema) != list:
+        if typing.get_origin(schema) is not list:
             raise RuntimeError("GenericAlias other than list not supported!")
         return [generate_example_json(typing.get_args(schema)[0], parent=[*parent])]
     elif issubclass(schema, BaseSchema):

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1961,7 +1961,7 @@ class AbstractAgent(
                         if len(overlapping_services) > 0:
                             raise AgentError(
                                 f"Port {port_no} overlaps with built-in service"
-                                f" {overlapping_services[0]['name']}"
+                                f" {overlapping_services[0]["name"]}"
                             )
 
                         preopen_sport: ServicePort = {
@@ -1980,7 +1980,7 @@ class AbstractAgent(
                             exposed_ports.append(cport)
                     for index, port in enumerate(ctx.kernel_config["allocated_host_ports"]):
                         service_ports.append({
-                            "name": f"hostport{index+1}",
+                            "name": f"hostport{index + 1}",
                             "protocol": ServicePortProtocols.INTERNAL,
                             "container_ports": (port,),
                             "host_ports": (port,),
@@ -2315,11 +2315,11 @@ class AbstractAgent(
                     ]
                     if len(overlapping_services) > 0:
                         raise AgentError(
-                            f"Port {service['port']} overlaps with built-in service"
-                            f" {overlapping_services[0]['name']}"
+                            f"Port {service["port"]} overlaps with built-in service"
+                            f" {overlapping_services[0]["name"]}"
                         )
                     service_ports.append({
-                        "name": f"{model['name']}-{service['port']}",
+                        "name": f"{model["name"]}-{service["port"]}",
                         "protocol": ServicePortProtocols.PREOPEN,
                         "container_ports": (service["port"],),
                         "host_ports": (None,),

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -926,7 +926,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             label for label in service_ports_label if label
         ])
         update_nested_dict(container_config, self.computer_docker_args)
-        kernel_name = f"kernel.{self.image_ref.name.split('/')[-1]}.{self.kernel_id}"
+        kernel_name = f"kernel.{self.image_ref.name.split("/")[-1]}.{self.kernel_id}"
 
         # optional local override of docker config
         extra_container_opts_name = "agent-docker-container-opts.json"
@@ -1165,7 +1165,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 {
                     "Cmd": [
                         f"UNIX-LISTEN:/ipc/{self.agent_sockpath.name},unlink-early,fork,mode=777",
-                        f"TCP-CONNECT:127.0.0.1:{self.local_config['agent']['agent-sock-port']}",
+                        f"TCP-CONNECT:127.0.0.1:{self.local_config["agent"]["agent-sock-port"]}",
                     ],
                     "HostConfig": {
                         "Mounts": [
@@ -1399,7 +1399,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         while True:
             agent_sock = zmq_ctx.socket(zmq.REP)
             try:
-                agent_sock.bind(f"tcp://127.0.0.1:{self.local_config['agent']['agent-sock-port']}")
+                agent_sock.bind(f"tcp://127.0.0.1:{self.local_config["agent"]["agent-sock-port"]}")
                 while True:
                     msg = await agent_sock.recv_multipart()
                     if not msg:

--- a/src/ai/backend/agent/docker/utils.py
+++ b/src/ai/backend/agent/docker/utils.py
@@ -60,7 +60,7 @@ class PersistentServiceContainer:
                     raise
         if c["Config"].get("Labels", {}).get("ai.backend.system", "0") != "1":
             raise RuntimeError(
-                f"An existing container named \"{c['Name'].lstrip('/')}\" is not a system container"
+                f"An existing container named \"{c["Name"].lstrip("/")}\" is not a system container"
                 " spawned by Backend.AI. Please check and remove it."
             )
         return (

--- a/src/ai/backend/agent/kubernetes/utils.py
+++ b/src/ai/backend/agent/kubernetes/utils.py
@@ -59,7 +59,7 @@ class PersistentServiceContainer:
                 raise
         if c["Config"].get("Labels", {}).get("ai.backend.system", "0") != "1":
             raise RuntimeError(
-                f"An existing container named \"{c['Name'].lstrip('/')}\" is not a system container"
+                f"An existing container named \"{c["Name"].lstrip("/")}\" is not a system container"
                 " spawned by Backend.AI. Please check and remove it."
             )
         return (

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -874,7 +874,7 @@ async def server_main(
 
     log.info("Preparing kernel runner environments...")
     kernel_mod = importlib.import_module(
-        f"ai.backend.agent.{local_config['agent']['backend'].value}.kernel",
+        f"ai.backend.agent.{local_config["agent"]["backend"].value}.kernel",
     )
     krunner_volumes = await kernel_mod.prepare_krunner_env(local_config)  # type: ignore
     # TODO: merge k8s branch: nfs_mount_path = local_config['baistatic']['mounted-at']
@@ -894,8 +894,8 @@ async def server_main(
         }
     scope_prefix_map = {
         ConfigScopes.GLOBAL: "",
-        ConfigScopes.SGROUP: f"sgroup/{local_config['agent']['scaling-group']}",
-        ConfigScopes.NODE: f"nodes/agents/{local_config['agent']['id']}",
+        ConfigScopes.SGROUP: f"sgroup/{local_config["agent"]["scaling-group"]}",
+        ConfigScopes.NODE: f"nodes/agents/{local_config["agent"]["id"]}",
     }
     etcd = AsyncEtcd(
         local_config["etcd"]["addr"],

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -409,7 +409,7 @@ def main(
         fn = Path(cfg["logging"]["file"]["filename"])
         cfg["logging"]["file"]["filename"] = f"{fn.stem}-watcher{fn.suffix}"
 
-    setproctitle(f"backend.ai: watcher {cfg['etcd']['namespace']}")
+    setproctitle(f"backend.ai: watcher {cfg["etcd"]["namespace"]}")
     with logger:
         log.info("Backend.AI Agent Watcher {0}", VERSION)
         log.info("runtime: {0}", utils.env_info())

--- a/src/ai/backend/cli/interaction.py
+++ b/src/ai/backend/cli/interaction.py
@@ -73,12 +73,12 @@ def ask_string_in_array(prompt: str, choices: list, default: str) -> Optional[st
 
     if default:
         question = (
-            f"{prompt} (choices: {'/'.join(choices)}, "
+            f"{prompt} (choices: {"/".join(choices)}, "
             f"if left empty, this will use default value: {default}): "
         )
     else:
         question = (
-            f"{prompt} (choices: {'/'.join(choices)}, if left empty, this will remove this key): "
+            f"{prompt} (choices: {"/".join(choices)}, if left empty, this will remove this key): "
         )
 
     while True:
@@ -92,7 +92,7 @@ def ask_string_in_array(prompt: str, choices: list, default: str) -> Optional[st
         elif user_reply.lower() in choices:
             break
         else:
-            print(f"Please answer in {'/'.join(choices)}.")
+            print(f"Please answer in {"/".join(choices)}.")
     return user_reply
 
 

--- a/src/ai/backend/client/cli/admin/image.py
+++ b/src/ai/backend/client/cli/admin/image.py
@@ -61,7 +61,7 @@ def rescan(registry: str) -> None:
                 print_error(e)
                 sys.exit(ExitCode.FAILURE)
             if not result["ok"]:
-                print_fail(f"Failed to begin registry scanning: {result['msg']}")
+                print_fail(f"Failed to begin registry scanning: {result["msg"]}")
                 sys.exit(ExitCode.FAILURE)
             print_done("Started updating the image metadata from the configured registries.")
             bgtask_id = result["task_id"]

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -126,7 +126,7 @@ def format_error(exc: Exception):
             if matches:
                 yield "\nCandidates (up to 10 recent entries):\n"
             for item in matches:
-                yield f"- {item['id']} ({item['name']}, {item['status']})\n"
+                yield f"- {item["id"]} ({item["name"]}, {item["status"]})\n"
         elif exc.data["type"].endswith("/session-already-exists"):
             existing_session_id = exc.data["data"].get("existingSessionId", None)
             if existing_session_id is not None:
@@ -145,7 +145,7 @@ def format_error(exc: Exception):
             if exc.data["type"].endswith("/graphql-error"):
                 yield "\n\u279c Message:\n"
                 for err_item in exc.data.get("data", []):
-                    yield f"{err_item['message']}"
+                    yield f"{err_item["message"]}"
                     if err_path := err_item.get("path"):
                         yield f" (path: {_format_gql_path(err_path)})"
                     yield "\n"

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -113,7 +113,7 @@ def info(ctx: CLIContext, service_name_or_id: str):
             )
             print()
             for route in routes:
-                print(f"Route {route['routing_id']}: ")
+                print(f"Route {route["routing_id"]}: ")
                 ctx.output.print_item(
                     route,
                     _default_routing_fields,
@@ -645,7 +645,7 @@ def generate_token(ctx: CLIContext, service_name_or_id: str, duration: str, quie
             if quiet:
                 print(resp["token"])
             else:
-                print_done(f"Generated API token {resp['token']}")
+                print_done(f"Generated API token {resp["token"]}")
         except Exception as e:
             ctx.output.print_error(e)
             sys.exit(ExitCode.FAILURE)

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -495,7 +495,7 @@ class VFolder(BaseFunction):
                 input_file = open(base_path / file_path, "rb")
             else:
                 input_file = open(str(Path(file_path).relative_to(base_path)), "rb")
-            print(f"Uploading {base_path / file_path} via {upload_info['url']} ...")
+            print(f"Uploading {base_path / file_path} via {upload_info["url"]} ...")
             # TODO: refactor out the progress bar
             uploader = tus_client.async_uploader(
                 file_stream=input_file,

--- a/src/ai/backend/client/output/formatters.py
+++ b/src/ai/backend/client/output/formatters.py
@@ -17,7 +17,7 @@ def format_stats(raw_stats: Optional[str], indent="") -> str:
     if raw_stats is None:
         return "(unavailable)"
     stats = json.loads(raw_stats)
-    text = "\n".join(f"- {k + ': ':18s}{v}" for k, v in stats.items())
+    text = "\n".join(f"- {k + ": ":18s}{v}" for k, v in stats.items())
     return "\n" + textwrap.indent(text, indent)
 
 
@@ -239,7 +239,7 @@ class AgentStatFormatter(OutputFormatter):
                 if metric["pct"] is None:
                     node_metric_bufs.append(f"{stat_key}: (calculating...) % ({num_cores} cores)")
                 else:
-                    node_metric_bufs.append(f"{stat_key}: {metric['pct']} % ({num_cores} cores)")
+                    node_metric_bufs.append(f"{stat_key}: {metric["pct"]} % ({num_cores} cores)")
             else:
                 binary = stat_key == "mem"
                 node_metric_bufs.append(f"{stat_key}: {format_value(metric, binary)}")
@@ -322,10 +322,10 @@ class ContainerListFormatter(NestedObjectFormatter):
         else:
             text = ""
             for item in value:
-                text += f"+ {item['id']}\n"
+                text += f"+ {item["id"]}\n"
                 text += "\n".join(
                     f"  - {f.humanized_name}: "
-                    f"{_fit_multiline_in_cell(f.formatter.format_console(item[f.field_name], f), '    ')}"  # noqa
+                    f"{_fit_multiline_in_cell(f.formatter.format_console(item[f.field_name], f), "    ")}"  # noqa
                     for f in field.subfields.values()
                     if f.field_name != "id"
                 )
@@ -340,10 +340,10 @@ class DependencyListFormatter(NestedObjectFormatter):
         else:
             text = ""
             for item in value:
-                text += f"+ {item['name']} ({item['id']})\n"
+                text += f"+ {item["name"]} ({item["id"]})\n"
                 text += "\n".join(
                     f"  - {f.humanized_name}: "
-                    f"{_fit_multiline_in_cell(f.formatter.format_console(item[f.field_name], f), '    ')}"  # noqa
+                    f"{_fit_multiline_in_cell(f.formatter.format_console(item[f.field_name], f), "    ")}"  # noqa
                     for f in field.subfields.values()
                     if f.field_name not in ("id", "name")
                 )

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -500,7 +500,7 @@ class ImageRef:
         for name in possible_names:
             ret[name] = self
         for name, ptags in itertools.product(possible_names, itertools.product(*possible_ptags)):
-            ret[f"{name}:{'-'.join(t for t in ptags if t)}"] = self
+            ret[f"{name}:{"-".join(t for t in ptags if t)}"] = self
         return ret
 
     @staticmethod

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -723,7 +723,7 @@ class ResourceSlot(UserDict):
         known_slots = current_resource_slots.get()
         unset_slots = known_slots.keys() - self.data.keys()
         if not ignore_unknown and (unknown_slots := self.data.keys() - known_slots.keys()):
-            raise ValueError(f"Unknown slots: {', '.join(map(repr, unknown_slots))}")
+            raise ValueError(f"Unknown slots: {", ".join(map(repr, unknown_slots))}")
         data = {k: v for k, v in self.data.items() if k in known_slots}
         for k in unset_slots:
             data[k] = Decimal(0)

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -621,8 +621,8 @@ class Context(metaclass=ABCMeta):
                     file=fp,
                 )
                 print("export BACKEND_ENDPOINT_TYPE=api", file=fp)
-                print(f"export BACKEND_ACCESS_KEY={keypair['access_key']}", file=fp)
-                print(f"export BACKEND_SECRET_KEY={keypair['secret_key']}", file=fp)
+                print(f"export BACKEND_ACCESS_KEY={keypair["access_key"]}", file=fp)
+                print(f"export BACKEND_SECRET_KEY={keypair["secret_key"]}", file=fp)
         with self.resource_path("ai.backend.install.fixtures", "example-users.json") as user_path:
             current_shell = os.environ.get("SHELL", "sh")
             user_data = json.loads(Path(user_path).read_bytes())
@@ -651,8 +651,8 @@ class Context(metaclass=ABCMeta):
                     f"""echo 'Run `./{client_executable} login` to activate a login session.'""",
                     file=fp,
                 )
-                print(f"""echo 'Your email: {user['email']}'""", file=fp)
-                print(f"""echo 'Your password: {user['password']}'""", file=fp)
+                print(f"""echo 'Your email: {user["email"]}'""", file=fp)
+                print(f"""echo 'Your password: {user["password"]}'""", file=fp)
 
     async def dump_install_info(self) -> None:
         self.log_header("Dumping the installation configs...")

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -698,7 +698,7 @@ class BaseRunner(metaclass=ABCMeta):
             if model_service_info is None:
                 result = {"status": "failed", "error": "service info not provided"}
                 return
-            service_name = f"{model_info['name']}-{model_service_info['port']}"
+            service_name = f"{model_info["name"]}-{model_service_info["port"]}"
             self.service_parser.add_model_service(service_name, model_service_info)
             service_info = {
                 "name": service_name,
@@ -734,7 +734,7 @@ class BaseRunner(metaclass=ABCMeta):
     async def check_model_health(self, model_name, model_service_info):
         health_check_info = model_service_info.get("health_check")
         health_check_endpoint = (
-            f"http://localhost:{model_service_info['port']}{health_check_info['path']}"
+            f"http://localhost:{model_service_info["port"]}{health_check_info["path"]}"
         )
         retries = 0
         current_health_status = HealthStatus.UNDETERMINED
@@ -875,7 +875,7 @@ class BaseRunner(metaclass=ABCMeta):
                             await terminate_and_wait(proc, timeout=10.0)
                             self.services_running.pop(service_info["name"], None)
                             error_reason = (
-                                f"opening the service port timed out: {service_info['name']}"
+                                f"opening the service port timed out: {service_info["name"]}"
                             )
                         else:
                             error_reason = "TimeoutError (unknown)"

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -36,7 +36,7 @@ async def init_sshd_service(child_env):
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"sshd init error: {stderr.decode('utf8')}")
+            raise RuntimeError(f"sshd init error: {stderr.decode("utf8")}")
         pub_key = stdout.splitlines()[1]
         auth_path.write_bytes(pub_key)
         auth_path.chmod(0o600)
@@ -57,7 +57,7 @@ async def init_sshd_service(child_env):
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"sshd init error: {stderr.decode('utf8')}")
+            raise RuntimeError(f"sshd init error: {stderr.decode("utf8")}")
     else:
         try:
             if (auth_path.parent.stat().st_mode & 0o077) != 0:
@@ -83,7 +83,7 @@ async def init_sshd_service(child_env):
     )
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
-        raise RuntimeError(f"sshd init error: {stderr.decode('utf8')}")
+        raise RuntimeError(f"sshd init error: {stderr.decode("utf8")}")
 
     cluster_privkey_src_path = Path("/home/config/ssh/id_cluster")
     cluster_ssh_port_mapping_path = Path("/home/config/ssh/port-mapping.json")

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -106,7 +106,7 @@ class ServiceParser:
                 action_impl = getattr(service_actions, action["action"])
             except AttributeError:
                 raise InvalidServiceDefinition(
-                    f"Service-def for {service_name} used invalid action: {action['action']}"
+                    f"Service-def for {service_name} used invalid action: {action["action"]}"
                 )
             ret = await action_impl(self.variables, **action["args"])
             if (ref := action.get("ref")) is not None:

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -1112,8 +1112,8 @@ async def generate_ssh_keypair(request: web.Request) -> web.Response:
 async def upload_ssh_keypair(request: web.Request, params: Any) -> web.Response:
     domain_name = request["user"]["domain_name"]
     access_key = request["keypair"]["access_key"]
-    pubkey = f"{params['pubkey'].rstrip()}\n"
-    privkey = f"{params['privkey'].rstrip()}\n"
+    pubkey = f"{params["pubkey"].rstrip()}\n"
+    privkey = f"{params["privkey"].rstrip()}\n"
     log_fmt = "AUTH.SAVE_SSH_KEYPAIR(d:{}, ak:{})"
     log_args = (domain_name, access_key)
     log.info(log_fmt, *log_args)

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -220,7 +220,7 @@ async def perform_scheduler_ops(request: web.Request, params: Any) -> web.Respon
         args = iv_scheduler_ops_args[params["op"]].check(params["args"])
     except t.DataError as e:
         raise InvalidAPIParameters(
-            f"Input validation failed for args with {params['op']}",
+            f"Input validation failed for args with {params["op"]}",
             extra_data=e.as_dict(),
         )
     if params["op"] in (SchedulerOps.INCLUDE_AGENTS, SchedulerOps.EXCLUDE_AGENTS):

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -161,11 +161,11 @@ async def check_presets(request: web.Request, params: Any) -> web.Response:
         result = await conn.execute(query)
         row = result.first()
         if row is None:
-            raise InvalidAPIParameters(f"Unknown project (name: {params['group']})")
+            raise InvalidAPIParameters(f"Unknown project (name: {params["group"]})")
         group_id = row["id"]
         group_resource_slots = row["total_resource_slots"]
         if group_id is None:
-            raise InvalidAPIParameters(f"Unknown project (name: {params['group']})")
+            raise InvalidAPIParameters(f"Unknown project (name: {params["group"]})")
         group_resource_policy = {
             "total_resource_slots": group_resource_slots,
             "default_for_unspecified": DefaultForUnspecified.UNLIMITED,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -376,7 +376,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
         )
         return web.json_response(resp, status=201)
     except UnknownImageReference:
-        raise UnknownImageReferenceError(f"Unknown image reference: {params['image']}")
+        raise UnknownImageReferenceError(f"Unknown image reference: {params["image"]}")
     except BackendError:
         log.exception("GET_OR_CREATE: exception")
         raise
@@ -734,7 +734,7 @@ async def create_cluster(request: web.Request, params: dict[str, Any]) -> web.Re
         log.exception("GET_OR_CREATE: exception")
         raise
     except UnknownImageReference:
-        raise UnknownImageReferenceError(f"Unknown image reference: {params['image']}")
+        raise UnknownImageReferenceError(f"Unknown image reference: {params["image"]}")
     except Exception:
         await root_ctx.error_monitor.capture_exception()
         log.exception("GET_OR_CREATE: unexpected error!")
@@ -821,7 +821,7 @@ async def start_service(request: web.Request, params: Mapping[str, Any]) -> web.
                     hport_idx = sport["container_ports"].index(params["port"])
                 except ValueError:
                     raise InvalidAPIParameters(
-                        f"Service {service} does not open the port number {params['port']}."
+                        f"Service {service} does not open the port number {params["port"]}."
                     )
                 host_port = sport["host_ports"][hport_idx]
             else:
@@ -1100,7 +1100,7 @@ async def convert_session_to_image(
             ]
 
             new_canonical = (
-                f"{registry_hostname}/{registry_project}/{new_name}:{'-'.join(filtered_tag_set)}"
+                f"{registry_hostname}/{registry_project}/{new_name}:{"-".join(filtered_tag_set)}"
             )
 
             async with root_ctx.db.begin_readonly_session() as sess:
@@ -1150,7 +1150,7 @@ async def convert_session_to_image(
                 else:
                     customized_image_id = str(uuid.uuid4())
 
-            new_canonical += f"-customized_{customized_image_id.replace('-', '')}"
+            new_canonical += f"-customized_{customized_image_id.replace("-", "")}"
             new_image_ref: ImageRef = ImageRef(
                 new_canonical,
                 architecture=base_image_ref.architecture,

--- a/src/ai/backend/manager/api/stream.py
+++ b/src/ai/backend/manager/api/stream.py
@@ -170,7 +170,7 @@ async def stream_pty(defer, request: web.Request) -> web.StreamResponse:
                         )
                         run_id = secrets.token_hex(8)
                         if data["type"] == "resize":
-                            code = f"%resize {data['rows']} {data['cols']}"
+                            code = f"%resize {data["rows"]} {data["cols"]}"
                             await root_ctx.registry.execute(
                                 session,
                                 api_version,
@@ -470,7 +470,7 @@ async def stream_proxy(
                     hport_idx = sport["container_ports"].index(params["port"])
                 except ValueError:
                     raise InvalidAPIParameters(
-                        f"Service {service} does not open the port number {params['port']}."
+                        f"Service {service} does not open the port number {params["port"]}."
                     )
                 host_port = sport["host_ports"][hport_idx]
             else:  # using the default (primary) port of the app
@@ -500,7 +500,7 @@ async def stream_proxy(
     elif sport["protocol"] == "preopen":
         proxy_cls = TCPProxy
     else:
-        raise InvalidAPIParameters(f"Unsupported service protocol: {sport['protocol']}")
+        raise InvalidAPIParameters(f"Unsupported service protocol: {sport["protocol"]}")
 
     redis_live = root_ctx.redis_live
     conn_tracker_key = f"session.{kernel_id}.active_app_connections"

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -810,7 +810,7 @@ async def list_hosts(request: web.Request, params: Any) -> web.Response:
             )
             allowed_hosts = allowed_hosts | allowed_hosts_by_group
     all_volumes = await root_ctx.storage_manager.get_all_volumes()
-    all_hosts = {f"{proxy_name}:{volume_data['name']}" for proxy_name, volume_data in all_volumes}
+    all_hosts = {f"{proxy_name}:{volume_data["name"]}" for proxy_name, volume_data in all_volumes}
     allowed_hosts = VFolderHostPermissionMap({
         host: perms for host, perms in allowed_hosts.items() if host in all_hosts
     })
@@ -819,7 +819,7 @@ async def list_hosts(request: web.Request, params: Any) -> web.Response:
         default_host = None
 
     volume_info = {
-        f"{proxy_name}:{volume_data['name']}": {
+        f"{proxy_name}:{volume_data["name"]}": {
             "backend": volume_data["backend"],
             "capabilities": volume_data["capabilities"],
             "usage": await fetch_exposed_volume_fields(
@@ -833,7 +833,7 @@ async def list_hosts(request: web.Request, params: Any) -> web.Response:
             ),
         }
         for proxy_name, volume_data in all_volumes
-        if f"{proxy_name}:{volume_data['name']}" in allowed_hosts
+        if f"{proxy_name}:{volume_data["name"]}" in allowed_hosts
     }
 
     resp = {
@@ -855,7 +855,7 @@ async def list_all_hosts(request: web.Request) -> web.Response:
         access_key,
     )
     all_volumes = await root_ctx.storage_manager.get_all_volumes()
-    all_hosts = {f"{proxy_name}:{volume_data['name']}" for proxy_name, volume_data in all_volumes}
+    all_hosts = {f"{proxy_name}:{volume_data["name"]}" for proxy_name, volume_data in all_volumes}
     default_host = await root_ctx.shared_config.get_raw("volumes/default_host")
     if default_host not in all_hosts:
         default_host = None
@@ -2111,7 +2111,7 @@ async def share(request: web.Request, params: Any, row: VFolderRow) -> web.Respo
             users_not_invfolder_group = list(set(params["emails"]) - set(emails_to_share))
             raise ObjectNotFound(
                 "Some users do not belong to folder's group:"
-                f" {','.join(users_not_invfolder_group)}",
+                f" {",".join(users_not_invfolder_group)}",
                 object_name="user",
             )
 
@@ -3137,7 +3137,7 @@ async def list_mounts(request: web.Request) -> web.Response:
     all_volumes = [*await root_ctx.storage_manager.get_all_volumes()]
     all_mounts = [volume_data["path"] for proxy_name, volume_data in all_volumes]
     all_vfolder_hosts = [
-        f"{proxy_name}:{volume_data['name']}" for proxy_name, volume_data in all_volumes
+        f"{proxy_name}:{volume_data["name"]}" for proxy_name, volume_data in all_volumes
     ]
     resp: MutableMapping[str, Any] = {
         "manager": {

--- a/src/ai/backend/manager/cli/__main__.py
+++ b/src/ai/backend/manager/cli/__main__.py
@@ -127,8 +127,8 @@ def dbshell(cli_ctx: CLIContext, container_name, psql_help, psql_args):
         cmd = [
             "psql",
             (
-                f"postgres://{local_config['db']['user']}:{local_config['db']['password']}"
-                f"@{local_config['db']['addr']}/{local_config['db']['name']}"
+                f"postgres://{local_config["db"]["user"]}:{local_config["db"]["password"]}"
+                f"@{local_config["db"]["addr"]}/{local_config["db"]["name"]}"
             ),
             *psql_args,
         ]
@@ -196,8 +196,8 @@ def generate_rpc_keypair(cli_ctx: CLIContext, dst_dir: pathlib.Path, name: str) 
     public_key_path, secret_key_path = create_certificates(dst_dir, name)
     public_key, secret_key = load_certificate(secret_key_path)
     assert secret_key is not None
-    print(f"Public Key: {public_key.decode('ascii')} (stored at {public_key_path})")
-    print(f"Secret Key: {secret_key.decode('ascii')} (stored at {secret_key_path})")
+    print(f"Public Key: {public_key.decode("ascii")} (stored at {public_key_path})")
+    print(f"Secret Key: {secret_key.decode("ascii")} (stored at {secret_key_path})")
 
 
 @main.command()

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -246,7 +246,7 @@ async def validate_image_canonical(
                 for i, image_row in enumerate(image_rows):
                     if i > 0:
                         print("-" * 50)
-                    print(f"{'architecture':<40}: {image_row.architecture}")
+                    print(f"{"architecture":<40}: {image_row.architecture}")
                     for key, value in validate_image_labels(image_row.labels).items():
                         print(f"{key:<40}: ", end="")
                         if isinstance(value, list):

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -251,14 +251,14 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             rqst_args["headers"]["Accept"] = request_type
             for manifest in manifest_list:
                 platform_arg = (
-                    f"{manifest['platform']['os']}/{manifest['platform']['architecture']}"
+                    f"{manifest["platform"]["os"]}/{manifest["platform"]["architecture"]}"
                 )
                 if variant := manifest["platform"].get("variant", None):
                     platform_arg += f"/{variant}"
                 architecture = manifest["platform"]["architecture"]
                 architecture = arch_name_aliases.get(architecture, architecture)
                 async with sess.get(
-                    self.registry_url / f"v2/{image}/manifests/{manifest['digest']}", **rqst_args
+                    self.registry_url / f"v2/{image}/manifests/{manifest["digest"]}", **rqst_args
                 ) as resp:
                     data = await resp.json()
                 config_digest = data["config"]["digest"]
@@ -378,7 +378,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                         architecture,
                         manifest["digest"],
                     )
-                    progress_msg = f"Updated {image}:{tag}/{architecture} ({manifest['digest']})"
+                    progress_msg = f"Updated {image}:{tag}/{architecture} ({manifest["digest"]})"
                 if (reporter := progress_reporter.get()) is not None:
                     await reporter.update(1, message=progress_msg)
 

--- a/src/ai/backend/manager/container_registry/docker.py
+++ b/src/ai/backend/manager/container_registry/docker.py
@@ -45,7 +45,7 @@ class DockerHubRegistry(BaseContainerRegistry):
                         # skip legacy images
                         if item["name"].startswith("kernel-"):
                             continue
-                        yield f"{username}/{item['name']}"
+                        yield f"{username}/{item["name"]}"
                 else:
                     log.error(
                         "Failed to fetch repository list from {0} (status={1})",

--- a/src/ai/backend/manager/models/alembic/versions/b6b884fbae1f_add_session_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/b6b884fbae1f_add_session_table.py
@@ -40,7 +40,7 @@ PAGE_SIZE = 100
 
 def default_hostname(context) -> str:
     params = context.get_current_parameters()
-    return f"{params['cluster_role']}{params['cluster_idx']}"
+    return f"{params["cluster_role"]}{params["cluster_idx"]}"
 
 
 def upgrade() -> None:

--- a/src/ai/backend/manager/models/dotfile.py
+++ b/src/ai/backend/manager/models/dotfile.py
@@ -77,7 +77,7 @@ async def prepare_dotfiles(
         if dotfile_path in vfolder_kernel_paths:
             raise BackendError(
                 "There is a kernel-side path from vfolders that conflicts with "
-                f"a dotfile '{dotfile['path']}'.",
+                f"a dotfile '{dotfile["path"]}'.",
             )
 
     return internal_data

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1048,10 +1048,10 @@ class ExtraMountInput(graphene.InputObjectType):
     vfolder_id = graphene.String()
     mount_destination = graphene.String()
     type = graphene.String(
-        description=f"Added in 24.03.4. Set bind type of this mount. Shoud be one of ({','.join([type_.value for type_ in MountTypes])}). Default is 'bind'."
+        description=f"Added in 24.03.4. Set bind type of this mount. Shoud be one of ({",".join([type_.value for type_ in MountTypes])}). Default is 'bind'."
     )
     permission = graphene.String(
-        description=f"Added in 24.03.4. Set permission of this mount. Should be one of ({','.join([perm.value for perm in MountPermission])}). Default is null"
+        description=f"Added in 24.03.4. Set permission of this mount. Should be one of ({",".join([perm.value for perm in MountPermission])}). Default is null"
     )
 
 

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -389,7 +389,7 @@ class Queries(graphene.ObjectType):
             graphene.String,
             default_value=[ProjectType.GENERAL.name],
             description=(
-                f"Added in 24.03.0. Available values: {', '.join([p.name for p in ProjectType])}"
+                f"Added in 24.03.0. Available values: {", ".join([p.name for p in ProjectType])}"
             ),
         ),
     )
@@ -412,13 +412,13 @@ class Queries(graphene.ObjectType):
         load_filters=graphene.List(
             graphene.String,
             default_value=None,
-            description=f"Added in 24.03.8. Allowed values are: [{', '.join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.",
+            description=f"Added in 24.03.8. Allowed values are: [{", ".join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.",
         ),
         image_filters=graphene.List(
             graphene.String,
             default_value=None,
             deprecation_reason="Deprecated since 24.03.8. Use `load_filters` instead.",
-            description=f"Added in 24.03.4. Allowed values are: [{', '.join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by caller). To list the owned images only call `customized_images`.",
+            description=f"Added in 24.03.4. Allowed values are: [{", ".join([f.value for f in PublicImageLoadFilter])}]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by caller). To list the owned images only call `customized_images`.",
         ),
     )
 
@@ -2291,7 +2291,7 @@ class Queries(graphene.ObjectType):
         qsid = QuotaScopeID.parse(quota_scope_id)
         volumes_by_host = await graph_ctx.storage_manager.get_all_volumes()
         for host, volume in volumes_by_host:
-            if f"{host}:{volume['name']}" == storage_host_name:
+            if f"{host}:{volume["name"]}" == storage_host_name:
                 break
         else:
             raise ValueError(f"storage volume {storage_host_name} does not exist")

--- a/src/ai/backend/manager/models/gql_models/group.py
+++ b/src/ai/backend/manager/models/gql_models/group.py
@@ -35,7 +35,7 @@ class GroupInput(graphene.InputObjectType):
         required=False,
         default_value="GENERAL",
         description=(
-            f"Added in 24.03.0. Available values: {', '.join([p.name for p in ProjectType])}"
+            f"Added in 24.03.0. Available values: {", ".join([p.name for p in ProjectType])}"
         ),
     )
     description = graphene.String(required=False, default_value="")

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -430,7 +430,7 @@ class GroupInput(graphene.InputObjectType):
         required=False,
         default_value="GENERAL",
         description=(
-            f"Added in 24.03.0. Available values: {', '.join([p.name for p in ProjectType])}"
+            f"Added in 24.03.0. Available values: {", ".join([p.name for p in ProjectType])}"
         ),
     )
     description = graphene.String(required=False, default_value="")

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -745,7 +745,7 @@ class Image(graphene.ObjectType):
                     ):
                         return False
                     if ImageLoadFilter.CUSTOMIZED in load_filters:
-                        if label.value == f"user:{ctx.user['uuid']}":
+                        if label.value == f"user:{ctx.user["uuid"]}":
                             is_valid = True
                         else:
                             return False
@@ -964,7 +964,7 @@ class ForgetImageById(graphene.Mutation):
                 )
                 if (
                     not customized_image_owner
-                    or customized_image_owner != f"user:{ctx.user['uuid']}"
+                    or customized_image_owner != f"user:{ctx.user["uuid"]}"
                 ):
                     return ForgetImageById(ok=False, msg="Forbidden")
             await session.delete(image_row)
@@ -1011,7 +1011,7 @@ class ForgetImage(graphene.Mutation):
                 )
                 if (
                     not customized_image_owner
-                    or customized_image_owner != f"user:{ctx.user['uuid']}"
+                    or customized_image_owner != f"user:{ctx.user["uuid"]}"
                 ):
                     return ForgetImage(ok=False, msg="Forbidden")
             await session.delete(image_row)
@@ -1065,7 +1065,7 @@ class UntagImageFromRegistry(graphene.Mutation):
                 )
                 if (
                     not customized_image_owner
-                    or customized_image_owner != f"user:{ctx.user['uuid']}"
+                    or customized_image_owner != f"user:{ctx.user["uuid"]}"
                 ):
                     return UntagImageFromRegistry(ok=False, msg="Forbidden")
 

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -208,7 +208,7 @@ async def get_user_email(
 
 def default_hostname(context) -> str:
     params = context.get_current_parameters()
-    return f"{params['cluster_role']}{params['cluster_idx']}"
+    return f"{params["cluster_role"]}{params["cluster_idx"]}"
 
 
 KERNEL_STATUS_TRANSITION_MAP: Mapping[KernelStatus, set[KernelStatus]] = {

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -289,7 +289,7 @@ class StorageVolume(graphene.ObjectType):
     @classmethod
     def from_info(cls, proxy_name: str, volume_info: VolumeInfo) -> StorageVolume:
         return cls(
-            id=f"{proxy_name}:{volume_info['name']}",
+            id=f"{proxy_name}:{volume_info["name"]}",
             backend=volume_info["backend"],
             path=volume_info["path"],
             fsprefix=volume_info["fsprefix"],

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -955,7 +955,7 @@ async def prepare_vfolder_mounts(
             # Normal vfolders
             kernel_path_raw = requested_vfolder_dstpaths.get(key)
             if kernel_path_raw is None:
-                kernel_path = PurePosixPath(f"/home/work/{vfolder['name']}")
+                kernel_path = PurePosixPath(f"/home/work/{vfolder["name"]}")
             else:
                 kernel_path = PurePosixPath(kernel_path_raw)
                 if not kernel_path.is_absolute():
@@ -966,7 +966,7 @@ async def prepare_vfolder_mounts(
                 case MountPermission.READ_WRITE | MountPermission.RW_DELETE:
                     if vfolder["permission"] == VFolderPermission.READ_ONLY:
                         raise VFolderPermissionError(
-                            f"VFolder {vfolder_name} is allowed to be accessed in '{vfolder['permission'].value}' mode, "
+                            f"VFolder {vfolder_name} is allowed to be accessed in '{vfolder["permission"].value}' mode, "
                             f"but attempted with '{requested_perm.value}' mode."
                         )
                     mount_perm = requested_perm

--- a/src/ai/backend/manager/openapi.py
+++ b/src/ai/backend/manager/openapi.py
@@ -278,7 +278,7 @@ def generate_openapi(subapps: list[web.Application], verbose=False) -> dict[str,
                     else:
                         preconds.append(
                             "Manager status required: one of "
-                            f"{', '.join([e.value.upper() for e in manager_status])}"
+                            f"{", ".join([e.value.upper() for e in manager_status])}"
                         )
                 if preconds:
                     description.append("\n**Preconditions:**")

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -900,7 +900,7 @@ class AgentRegistry:
         if cluster_size > int(resource_policy["max_containers_per_session"]):
             raise QuotaExceeded(
                 "You cannot create session with more than "
-                f"{resource_policy['max_containers_per_session']} containers.",
+                f"{resource_policy["max_containers_per_session"]} containers.",
             )
 
         async with self.db.begin_readonly() as conn:
@@ -1222,7 +1222,7 @@ class AgentRegistry:
                 "cluster_idx": kernel["cluster_idx"],
                 "local_rank": kernel["local_rank"],
                 "cluster_hostname": (
-                    f"{kernel['cluster_role']}{kernel['cluster_idx']}"
+                    f"{kernel["cluster_role"]}{kernel["cluster_idx"]}"
                     if not kernel["cluster_hostname"]
                     else kernel["cluster_hostname"]
                 ),
@@ -1301,7 +1301,7 @@ class AgentRegistry:
             if getattr(e.orig, "pgcode", None) == "23503":
                 match = re.search(r"Key \(agent\)=\((?P<agent>[^)]+)\)", repr(e.orig))
                 if match:
-                    raise InvalidAPIParameters(f"No such agent: {match.group('agent')}")
+                    raise InvalidAPIParameters(f"No such agent: {match.group("agent")}")
                 else:
                     raise InvalidAPIParameters("No such agent")
             raise

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -550,7 +550,7 @@ class SchedulerDispatcher(aobject):
                 case str():
                     hook_name = hook_result.src_plugin
                 case list():
-                    hook_name = f"({', '.join(hook_result.src_plugin)})"
+                    hook_name = f"({", ".join(hook_result.src_plugin)})"
                 case _:
                     hook_name = ""
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -247,7 +247,7 @@ async def exception_middleware(
         resp = await handler(request)
     except InvalidArgument as ex:
         if len(ex.args) > 1:
-            raise InvalidAPIParameters(f"{ex.args[0]}: {', '.join(map(str, ex.args[1:]))}")
+            raise InvalidAPIParameters(f"{ex.args[0]}: {", ".join(map(str, ex.args[1:]))}")
         elif len(ex.args) == 1:
             raise InvalidAPIParameters(ex.args[0])
         else:

--- a/src/ai/backend/storage/config.py
+++ b/src/ai/backend/storage/config.py
@@ -147,7 +147,7 @@ def load_shared_config(local_config: dict[str, Any]) -> AsyncEtcd:
         }
     scope_prefix_map = {
         ConfigScopes.GLOBAL: "",
-        ConfigScopes.NODE: f"nodes/storage/{local_config['storage-proxy']['node-id']}",
+        ConfigScopes.NODE: f"nodes/storage/{local_config["storage-proxy"]["node-id"]}",
     }
     etcd = AsyncEtcd(
         local_config["etcd"]["addr"],

--- a/src/ai/backend/storage/migration.py
+++ b/src/ai/backend/storage/migration.py
@@ -182,8 +182,8 @@ async def upgrade_2_to_3(
 
     script = (
         "#! /bin/sh\n",
-        *[f"mkdir -p {m['dst_path'].parent}\n" for m in migration_informations],
-        *[f"mv {m['src_path']} {m['dst_path']}\n" for m in migration_informations],
+        *[f"mkdir -p {m["dst_path"].parent}\n" for m in migration_informations],
+        *[f"mv {m["src_path"]} {m["dst_path"]}\n" for m in migration_informations],
         f"echo 3 > {volume_id}/version.txt\n",
     )
     if outfile == "-":

--- a/src/ai/backend/storage/netapp/netappclient.py
+++ b/src/ai/backend/storage/netapp/netappclient.py
@@ -197,7 +197,7 @@ class NetAppClient:
             if result["code"] in _allowed_codes:
                 pass
             else:
-                raise NetAppClientError(f"{result['state']} [{result['code']}] {result['message']}")
+                raise NetAppClientError(f"{result["state"]} [{result["code"]}] {result["message"]}")
 
     async def get_volume_metadata(self, volume_id: VolumeID) -> Mapping[str, Any]:
         raise NotImplementedError
@@ -497,7 +497,7 @@ class NetAppClient:
         record = await self._find_quota_rule(svm_id, volume_id, qtree_name)
         async with self.send_request(
             "patch",
-            f"/api/storage/quota/rules/{record['uuid']}",
+            f"/api/storage/quota/rules/{record["uuid"]}",
             data={
                 "space": {
                     "hard_limit": config.limit_bytes,
@@ -532,7 +532,7 @@ class NetAppClient:
         record = await self._find_quota_rule(svm_id, volume_id, qtree_name)
         async with self.send_request(
             "delete",
-            f"/api/storage/quota/rules/{record['uuid']}",
+            f"/api/storage/quota/rules/{record["uuid"]}",
         ) as resp:
             data = await resp.json()
         return await self.wait_job(data["job"]["uuid"])

--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -153,7 +153,7 @@ class VASTAPIClient:
     def _req_header(self) -> Mapping[str, str]:
         assert self._auth_token is not None
         return {
-            "Authorization": f"Bearer {self._auth_token['access_token']}",
+            "Authorization": f"Bearer {self._auth_token["access_token"]}",
             "Content-Type": "application/json",
         }
 

--- a/src/ai/backend/storage/weka/__init__.py
+++ b/src/ai/backend/storage/weka/__init__.py
@@ -132,7 +132,7 @@ class WekaVolume(BaseVolume):
                 self._fs_uid = fs.uid
                 break
         else:
-            raise WekaInitError(f"FileSystem {self.config['weka_fs_name']} not found")
+            raise WekaInitError(f"FileSystem {self.config["weka_fs_name"]} not found")
         await super().init()
 
     async def create_quota_model(self) -> AbstractQuotaModel:

--- a/src/ai/backend/test/cli_integration/admin/test_keypair.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair.py
@@ -36,7 +36,7 @@ def test_add_keypair(
         with closing(run_admin(arguments)) as p:
             p.expect(EOF)
             response = json.loads(p.before.decode())
-            assert response.get("ok") is True, f"Account#{i+1} add error"
+            assert response.get("ok") is True, f"Account#{i + 1} add error"
             user_ids.append(response["user"]["uuid"])
 
     # find group
@@ -87,7 +87,7 @@ def test_add_keypair(
         with closing(run_admin(keypair_add_arguments)) as p:
             p.expect(EOF)
             response = json.loads(p.before.decode())
-            assert response.get("ok") is True, f"Keypair#{i+1} add error"
+            assert response.get("ok") is True, f"Keypair#{i + 1} add error"
     # Check if keypair is added
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
@@ -98,18 +98,18 @@ def test_add_keypair(
 
     for i, (user, keypair_option) in enumerate(zip(users, keypair_options)):
         keypair = get_keypair_from_list(keypair_list, user.email)
-        assert "access_key" in keypair, f"Keypair#{i+1} doesn't exist"
+        assert "access_key" in keypair, f"Keypair#{i + 1} doesn't exist"
         assert (
             keypair.get("is_active") is keypair_option.is_active
-        ), f"Keypair#{i+1} is_active mismatch"
+        ), f"Keypair#{i + 1} is_active mismatch"
         assert (
             keypair.get("is_admin") is keypair_option.is_admin
-        ), f"Keypair#{i+1} is_admin mismatch"
+        ), f"Keypair#{i + 1} is_admin mismatch"
         if (rate_limit := keypair_option.rate_limit) is not None:
-            assert keypair.get("rate_limit") == rate_limit, f"Keypair#{i+1} rate_limit mismatch"
+            assert keypair.get("rate_limit") == rate_limit, f"Keypair#{i + 1} rate_limit mismatch"
         assert (
             keypair.get("resource_policy") == keypair_option.resource_policy
-        ), f"Keypair#{i+1} resource_policy mismatch"
+        ), f"Keypair#{i + 1} resource_policy mismatch"
 
 
 def test_update_keypair(
@@ -131,7 +131,7 @@ def test_update_keypair(
 
     for i, (user, new_keypair_option) in enumerate(zip(users, new_keypair_options)):
         keypair = get_keypair_from_list(keypair_list, user.email)
-        assert "access_key" in keypair, f"Keypair#{i+1} info doesn't exist"
+        assert "access_key" in keypair, f"Keypair#{i + 1} info doesn't exist"
 
         keypair_update_arguments = [
             "--output=json",
@@ -150,7 +150,7 @@ def test_update_keypair(
         with closing(run_admin(keypair_update_arguments)) as p:
             p.expect(EOF)
             response = json.loads(p.before.decode())
-            assert response.get("ok") is True, f"Keypair#{i+1} update error"
+            assert response.get("ok") is True, f"Keypair#{i + 1} update error"
 
     # Check if keypair is updated
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
@@ -162,19 +162,19 @@ def test_update_keypair(
 
     for i, (user, new_keypair_option) in enumerate(zip(users, new_keypair_options)):
         updated_keypair = get_keypair_from_list(updated_keypair_list, user.email)
-        assert "access_key" in updated_keypair, f"Keypair#{i+1} doesn't exist"
+        assert "access_key" in updated_keypair, f"Keypair#{i + 1} doesn't exist"
         assert (
             updated_keypair.get("is_active") is new_keypair_option.is_active
-        ), f"Keypair#{i+1} is_active mismatch"
+        ), f"Keypair#{i + 1} is_active mismatch"
         assert (
             updated_keypair.get("is_admin") is new_keypair_option.is_admin
-        ), f"Keypair#{i+1} is_admin mismatch"
+        ), f"Keypair#{i + 1} is_admin mismatch"
         assert (
             updated_keypair.get("rate_limit") == new_keypair_option.rate_limit
-        ), f"Keypair#{i+1} rate_limit mismatch"
+        ), f"Keypair#{i + 1} rate_limit mismatch"
         assert (
             updated_keypair.get("resource_policy") == new_keypair_option.resource_policy
-        ), f"Keypair#{i+1} resource_policy mismatch"
+        ), f"Keypair#{i + 1} resource_policy mismatch"
 
 
 def test_delete_keypair(run_admin: ClientRunnerFunc, users: Tuple[User]):
@@ -194,7 +194,7 @@ def test_delete_keypair(run_admin: ClientRunnerFunc, users: Tuple[User]):
 
     for i, user in enumerate(users):
         keypair = get_keypair_from_list(keypair_list, user.email)
-        assert "access_key" in keypair, f"Keypair#{i+1} info doesn't exist"
+        assert "access_key" in keypair, f"Keypair#{i + 1} info doesn't exist"
 
         # Delete keypair
         with closing(run_admin(["admin", "keypair", "delete", keypair["access_key"]])) as p:

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -36,7 +36,7 @@ def test_add_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
         with closing(run_admin(add_arguments)) as p:
             p.expect(EOF)
             response = json.loads(p.before.decode())
-            assert response.get("ok") is True, f"Account creation failed: Account#{i+1}"
+            assert response.get("ok") is True, f"Account creation failed: Account#{i + 1}"
 
     # Check if user is added
     with closing(run_admin(["--output=json", "admin", "user", "list"])) as p:
@@ -49,14 +49,14 @@ def test_add_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
     added_users = tuple(get_user_from_list(user_list, user.username) for user in users)
 
     for i, (added_user, user) in enumerate(zip(added_users, users)):
-        assert bool(added_user), f"Added account doesn't exist: Account#{i+1}"
-        assert added_user.get("email") == user.email, f"E-mail mismatch: Account#{i+1}"
-        assert added_user.get("full_name") == user.full_name, f"Full name mismatch: Account#{i+1}"
-        assert added_user.get("status") == user.status, f"User status mismatch: Account#{i+1}"
-        assert added_user.get("role") == user.role, f"Role mismatch: Account#{i+1}"
+        assert bool(added_user), f"Added account doesn't exist: Account#{i + 1}"
+        assert added_user.get("email") == user.email, f"E-mail mismatch: Account#{i + 1}"
+        assert added_user.get("full_name") == user.full_name, f"Full name mismatch: Account#{i + 1}"
+        assert added_user.get("status") == user.status, f"User status mismatch: Account#{i + 1}"
+        assert added_user.get("role") == user.role, f"Role mismatch: Account#{i + 1}"
         assert (
             added_user.get("need_password_change") is user.need_password_change
-        ), f"Password change status mismatch: Account#{i+1}"
+        ), f"Password change status mismatch: Account#{i + 1}"
 
 
 def test_update_user(
@@ -121,20 +121,20 @@ def test_update_user(
 
     for i, updated_user in enumerate(updated_users):
         user_dict: dict = get_user_from_list(updated_user_list, updated_user.username)
-        assert bool(user_dict), f"Account not found - Account#{i+1}"
+        assert bool(user_dict), f"Account not found - Account#{i + 1}"
         assert (
             user_dict.get("full_name") == updated_user.full_name
-        ), f"Full name mismatch: Account#{i+1}"
+        ), f"Full name mismatch: Account#{i + 1}"
         assert (
             user_dict.get("status") == updated_user.status
-        ), f"User status mismatch: Account#{i+1}"
-        assert user_dict.get("role") == updated_user.role, f"Role mismatch: Account#{i+1}"
+        ), f"User status mismatch: Account#{i + 1}"
+        assert user_dict.get("role") == updated_user.role, f"Role mismatch: Account#{i + 1}"
         assert (
             user_dict.get("need_password_change") is updated_user.need_password_change
-        ), f"Password change status mismatch: Account#{i+1}"
+        ), f"Password change status mismatch: Account#{i + 1}"
         assert (
             user_dict.get("domain_name") == updated_user.domain_name
-        ), f"Domain mismatch: Account#{i+1}"
+        ), f"Domain mismatch: Account#{i + 1}"
 
 
 def test_delete_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
@@ -150,7 +150,7 @@ def test_delete_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
             p.expect(EOF)
             before = p.before.decode()
             response = json.loads(before[before.index("{") :])
-            assert response.get("ok") is True, f"Account deletion failed: Account#{i+1}"
+            assert response.get("ok") is True, f"Account deletion failed: Account#{i + 1}"
 
 
 def test_list_user(run_admin: ClientRunnerFunc):

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -802,7 +802,7 @@ def main(
             )
             with logger:
                 setproctitle(
-                    f"backend.ai: webserver {cfg['service']['ip']}:{cfg['service']['port']}"
+                    f"backend.ai: webserver {cfg["service"]["ip"]}:{cfg["service"]["port"]}"
                 )
                 log.info("Backend.AI Web Server {0}", __version__)
                 log.info("runtime: {0}", sys.prefix)

--- a/src/ai/backend/wsproxy/config.py
+++ b/src/ai/backend/wsproxy/config.py
@@ -476,7 +476,7 @@ def generate_example_json(
     if isinstance(schema, types.UnionType):
         return generate_example_json(typing.get_args(schema)[0], parent=[*parent])
     elif isinstance(schema, types.GenericAlias):
-        if typing.get_origin(schema) != list:
+        if typing.get_origin(schema) is not list:
             raise RuntimeError("GenericAlias other than list not supported!")
         return [generate_example_json(typing.get_args(schema)[0], parent=[*parent])]
     elif issubclass(schema, BaseSchema):

--- a/src/ai/backend/wsproxy/proxy/backend/http.py
+++ b/src/ai/backend/wsproxy/proxy/backend/http.py
@@ -110,7 +110,7 @@ class HTTPBackend(AbstractBackend):
             headers["forwarded"] = f"host={host};proto={protocol}"
             headers["x-forwarded-host"] = host
             if self.circuit.app == "rstudio":
-                headers["x-rstudio-request"] = f"{protocol}://{host}{request.path or ''}"
+                headers["x-rstudio-request"] = f"{protocol}://{host}{request.path or ""}"
             split = host.split(":")
             if len(split) >= 2:
                 headers["x-forwarded-port"] = split[1]

--- a/tests/common/redis_helper/docker.py
+++ b/tests/common/redis_helper/docker.py
@@ -289,7 +289,7 @@ class DockerComposeRedisSentinelCluster(AbstractRedisSentinelCluster):
                     container["Id"]
                 )
                 if self.verbose:
-                    print(f"--- logs of {container['Id']} ---")
+                    print(f"--- logs of {container["Id"]} ---")
                     try:
                         p = await simple_run_cmd(["docker", "logs", container["Id"]])
                     finally:

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -306,7 +306,7 @@ def test_image_ref_generate_aliases():
     for name, ptags in itertools.product(
         possible_names, itertools.product(*possible_platform_tags)
     ):
-        assert f"{name}:{'-'.join(t for t in ptags if t)}" in aliases
+        assert f"{name}:{"-".join(t for t in ptags if t)}" in aliases
 
 
 def test_image_ref_generate_aliases_with_accelerator():
@@ -323,7 +323,7 @@ def test_image_ref_generate_aliases_with_accelerator():
     for name, ptags in itertools.product(
         possible_names, itertools.product(*possible_platform_tags)
     ):
-        assert f"{name}:{'-'.join(t for t in ptags if t)}" in aliases
+        assert f"{name}:{"-".join(t for t in ptags if t)}" in aliases
 
 
 def test_image_ref_generate_aliases_of_names():

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -665,7 +665,7 @@ def get_headers(app, default_keypair):
     ) -> dict[str, str]:
         now = datetime.now(tzutc())
         root_ctx: RootContext = app["_root.context"]
-        hostname = f"127.0.0.1:{root_ctx.local_config['manager']['service-addr'].port}"
+        hostname = f"127.0.0.1:{root_ctx.local_config["manager"]["service-addr"].port}"
         headers = {
             "Date": now.isoformat(),
             "Content-Type": ctype,

--- a/tools/ruff-requirements.txt
+++ b/tools/ruff-requirements.txt
@@ -1,2 +1,2 @@
-ruff~=0.1.11
-ruff-lsp~=0.0.49
+ruff~=0.6.4
+ruff-lsp~=0.0.56

--- a/tools/ruff.lock
+++ b/tools/ruff.lock
@@ -9,8 +9,8 @@
 //     "CPython==3.12.4"
 //   ],
 //   "generated_with_requirements": [
-//     "ruff-lsp~=0.0.49",
-//     "ruff~=0.1.11"
+//     "ruff-lsp~=0.0.56",
+//     "ruff~=0.6.4"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -25,6 +25,7 @@
   "allow_wheels": true,
   "build_isolation": true,
   "constraints": [],
+  "excluded": [],
   "locked_resolves": [
     {
       "locked_requirements": [
@@ -32,54 +33,73 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1",
-              "url": "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl"
+              "hash": "81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2",
+              "url": "https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
-              "url": "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz"
+              "hash": "5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
+              "url": "https://files.pythonhosted.org/packages/fc/0f/aafca9af9315aee06a89ffde799a10a582fe8de76c563ee80bbcdc08b3fb/attrs-24.2.0.tar.gz"
             }
           ],
           "project_name": "attrs",
           "requires_dists": [
-            "attrs[tests-mypy]; extra == \"tests-no-zope\"",
-            "attrs[tests-no-zope]; extra == \"tests\"",
-            "attrs[tests]; extra == \"cov\"",
-            "attrs[tests]; extra == \"dev\"",
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"benchmark\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"cov\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"dev\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests\"",
+            "cogapp; extra == \"docs\"",
             "coverage[toml]>=5.3; extra == \"cov\"",
             "furo; extra == \"docs\"",
-            "hypothesis; extra == \"tests-no-zope\"",
+            "hypothesis; extra == \"benchmark\"",
+            "hypothesis; extra == \"cov\"",
+            "hypothesis; extra == \"dev\"",
+            "hypothesis; extra == \"tests\"",
             "importlib-metadata; python_version < \"3.8\"",
-            "mypy>=1.6; (platform_python_implementation == \"CPython\" and python_version >= \"3.8\") and extra == \"tests-mypy\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\") and extra == \"benchmark\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\") and extra == \"cov\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\") and extra == \"dev\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\") and extra == \"tests\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\") and extra == \"tests-mypy\"",
             "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"dev\"",
-            "pympler; extra == \"tests-no-zope\"",
-            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.8\") and extra == \"tests-mypy\"",
-            "pytest-xdist[psutil]; extra == \"tests-no-zope\"",
-            "pytest>=4.3.0; extra == \"tests-no-zope\"",
+            "pympler; extra == \"benchmark\"",
+            "pympler; extra == \"cov\"",
+            "pympler; extra == \"dev\"",
+            "pympler; extra == \"tests\"",
+            "pytest-codspeed; extra == \"benchmark\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\") and extra == \"benchmark\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\") and extra == \"cov\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\") and extra == \"dev\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\") and extra == \"tests\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and python_version < \"3.13\") and extra == \"tests-mypy\"",
+            "pytest-xdist[psutil]; extra == \"benchmark\"",
+            "pytest-xdist[psutil]; extra == \"cov\"",
+            "pytest-xdist[psutil]; extra == \"dev\"",
+            "pytest-xdist[psutil]; extra == \"tests\"",
+            "pytest>=4.3.0; extra == \"benchmark\"",
+            "pytest>=4.3.0; extra == \"cov\"",
+            "pytest>=4.3.0; extra == \"dev\"",
+            "pytest>=4.3.0; extra == \"tests\"",
             "sphinx-notfound-page; extra == \"docs\"",
             "sphinx; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
-            "towncrier; extra == \"docs\"",
-            "zope-interface; extra == \"docs\"",
-            "zope-interface; extra == \"tests\""
+            "towncrier<24.7; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "23.2.0"
+          "version": "24.2.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108",
-              "url": "https://files.pythonhosted.org/packages/b3/0d/cd4a4071c7f38385dc5ba91286723b4d1090b87815db48216212c6c6c30e/cattrs-23.2.3-py3-none-any.whl"
+              "hash": "043bb8af72596432a7df63abcff0055ac0f198a4d2e95af8db5a936a7074a761",
+              "url": "https://files.pythonhosted.org/packages/90/ef/3ae217389caeef1bf4b4b29280d8f8cba554f673d9dd5251329406e9e6d0/cattrs-24.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f",
-              "url": "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz"
+              "hash": "8274f18b253bf7674a43da851e3096370d67088165d23138b04a1c04c8eaf48e",
+              "url": "https://files.pythonhosted.org/packages/f2/9c/22b4010404d899d7012474f1539c4163b22e77ca55f444e945c2095dbdde/cattrs-24.1.0.tar.gz"
             }
           ],
           "project_name": "cattrs",
@@ -88,6 +108,7 @@
             "cbor2>=5.4.6; extra == \"cbor2\"",
             "exceptiongroup>=1.1.1; python_version < \"3.11\"",
             "msgpack>=1.0.5; extra == \"msgpack\"",
+            "msgspec>=0.18.5; implementation_name == \"cpython\" and extra == \"msgspec\"",
             "orjson>=3.9.2; implementation_name == \"cpython\" and extra == \"orjson\"",
             "pymongo>=4.4.0; extra == \"bson\"",
             "pyyaml>=6.0; extra == \"pyyaml\"",
@@ -96,7 +117,7 @@
             "ujson>=5.7.0; extra == \"ujson\""
           ],
           "requires_python": ">=3.8",
-          "version": "23.2.3"
+          "version": "24.1.0"
         },
         {
           "artifacts": [
@@ -163,91 +184,96 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1bab866aafb53da39c2cadfb8e1c4550ac5340bb40300083eb8967ba25481447",
-              "url": "https://files.pythonhosted.org/packages/e5/bf/de34ad339e0d1f6faa858cbcf793f3abc168b7aa516dd9227d843b992be8/ruff-0.1.15-py3-none-musllinux_1_2_x86_64.whl"
+              "hash": "34d5efad480193c046c86608dbba2bccdc1c5fd11950fb271f8086e0c763a5d1",
+              "url": "https://files.pythonhosted.org/packages/9c/7c/dcf2c10562346ecdf6f0e5f6669b2ddc9a74a72956c3f419abd6820c2aff/ruff-0.6.4-py3-none-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fd4025ac5e87d9b80e1f300207eb2fd099ff8200fa2320d7dc066a3f4622dc6b",
-              "url": "https://files.pythonhosted.org/packages/0c/57/dbc885f94450335fcff82301c4b25cf614894e79d9afbd249714e709ab42/ruff-0.1.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "0308610470fcc82969082fc83c76c0d362f562e2f0cdab0586516f03a4e06ec6",
+              "url": "https://files.pythonhosted.org/packages/17/c6/906bf895640521ca5115ccdd857b2bac42bd61facde6620fdc2efc0a4806/ruff-0.6.4-py3-none-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5fe8d54df166ecc24106db7dd6a68d44852d14eb0729ea4672bb4d96c320b7df",
-              "url": "https://files.pythonhosted.org/packages/11/2c/fac0658910ea3ea87a23583e58277533154261b73f9460388eb2e6e02e8f/ruff-0.1.15-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+              "hash": "803b96dea21795a6c9d5bfa9e96127cc9c31a1987802ca68f35e5c95aed3fc0d",
+              "url": "https://files.pythonhosted.org/packages/28/da/1284eb04172f8a5d42eb52fce9d643dd747ac59a4ed6c5d42729f72e934d/ruff-0.6.4-py3-none-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e0d432aec35bfc0d800d4f70eba26e23a352386be3a6cf157083d18f6f5881c8",
-              "url": "https://files.pythonhosted.org/packages/18/d7/2199ecb42cef4d70de0e72ce4ca8878d060e25fe4434cb66f51e26158a2a/ruff-0.1.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "eebe4ff1967c838a1a9618a5a59a3b0a00406f8d7eefee97c70411fefc353617",
+              "url": "https://files.pythonhosted.org/packages/3b/10/8ed14ff60a4e5eb08cac0a04a9b4e8590c72d1ce4d29ef22cef97d19536d/ruff-0.6.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b17b93c02cdb6aeb696effecea1095ac93f3884a49a554a9afa76bb125c114c1",
-              "url": "https://files.pythonhosted.org/packages/39/75/8dea2fc156ae525971fdada8723f78e605dcf89428f5686728438b12f9ef/ruff-0.1.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "50e30b437cebef547bd5c3edf9ce81343e5dd7c737cb36ccb4fe83573f3d392e",
+              "url": "https://files.pythonhosted.org/packages/42/00/9623494087272643e8f02187c266638306c6829189a5bf1446968bbe438b/ruff-0.6.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e",
-              "url": "https://files.pythonhosted.org/packages/42/33/7165f88a156be1c2fd13a18b3af6e75bbf82da5b6978cd2128d666accc18/ruff-0.1.15.tar.gz"
+              "hash": "0ea086601b22dc5e7693a78f3fcfc460cceabfdf3bdc36dc898792aba48fbad6",
+              "url": "https://files.pythonhosted.org/packages/5b/35/f1d8b746aedd4c8fde4f83397e940cc4c8fc619860ebbe3073340381a34d/ruff-0.6.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ddb87643be40f034e97e97f5bc2ef7ce39de20e34608f3f829db727a93fb82c5",
-              "url": "https://files.pythonhosted.org/packages/47/41/96b770475c46590bfd051ca0c5f797b2d45f2638c45f3a9daf1ae55b96d6/ruff-0.1.15-py3-none-musllinux_1_2_aarch64.whl"
+              "hash": "bedff9e4f004dad5f7f76a9d39c4ca98af526c9b1695068198b3bda8c085ef60",
+              "url": "https://files.pythonhosted.org/packages/69/63/ef398fcacdbd3995618ed30b5a6c809a1ebbf112ba604b3f5b8c3be464cf/ruff-0.6.4-py3-none-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f8ad828f01e8dd32cc58bc28375150171d198491fc901f6f98d2a39ba8e3ff5",
-              "url": "https://files.pythonhosted.org/packages/55/09/c09d0f9b41d1f5e3de117579f2fcdb7063fd76cd92d6614eae1b77ccbccb/ruff-0.1.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              "hash": "66dbfea86b663baab8fcae56c59f190caba9398df1488164e2df53e216248baa",
+              "url": "https://files.pythonhosted.org/packages/6c/e2/f8250b54edbb2e9222e22806e1bcc35a192ac18d1793ea556fa4977a843a/ruff-0.6.4-py3-none-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f0bfbb53c4b4de117ac4d6ddfd33aa5fc31beeaa21d23c45c6dd249faf9126f",
-              "url": "https://files.pythonhosted.org/packages/5b/c1/2116927385c761ffb786dfb77654a634ecd7803dee4de3b47b59536374f1/ruff-0.1.15-py3-none-macosx_10_12_x86_64.whl"
+              "hash": "7862f42fc1a4aca1ea3ffe8a11f67819d183a5693b228f0bb3a531f5e40336fc",
+              "url": "https://files.pythonhosted.org/packages/6d/bc/c69db2d68ac7bfbb222c81dc43a86e0402d0063e20b13e609f7d17d81d3f/ruff-0.6.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "86811954eec63e9ea162af0ffa9f8d09088bab51b7438e8b6488b9401863c25e",
-              "url": "https://files.pythonhosted.org/packages/72/48/c9dfc2c87dc6b92446d8092c2be25b42ca4fb201cecb2499996ccf483c34/ruff-0.1.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "ac3b5bfbee99973f80aa1b7cbd1c9cbce200883bdd067300c22a6cc1c7fba212",
+              "url": "https://files.pythonhosted.org/packages/a4/55/9f485266e6326cab707369601b13e3e72eb90ba3eee2d6779549a00a0d58/ruff-0.6.4.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "c66ec24fe36841636e814b8f90f572a8c0cb0e54d8b5c2d0e300d28a0d7bffec",
-              "url": "https://files.pythonhosted.org/packages/98/fa/2a627747a5a5f7e1d3447704f795fd35d486460838485762cd569ef8eb0e/ruff-0.1.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "d02a4127a86de23002e694d7ff19f905c51e338c72d8e09b56bfb60e1681724f",
+              "url": "https://files.pythonhosted.org/packages/a6/fd/8784e3bbd79bc17de0a62de05fe5165f494ff7d77cb06630d6428c2f10d2/ruff-0.6.4-py3-none-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c629cf64bacfd136c07c78ac10a54578ec9d1bd2a9d395efbee0935868bf852",
-              "url": "https://files.pythonhosted.org/packages/b8/85/da93f0fc8f2424cf776fcce6daef9291162345179d16faf1401ff2890068/ruff-0.1.15-py3-none-musllinux_1_2_i686.whl"
+              "hash": "932063a03bac394866683e15710c25b8690ccdca1cf192b9a98260332ca93408",
+              "url": "https://files.pythonhosted.org/packages/a9/69/13316b8d64ffd6a43627cf0753339a7f95df413450c301a60904581bee6e/ruff-0.6.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9405fa9ac0e97f35aaddf185a1be194a589424b8713e3b97b762336ec79ff807",
-              "url": "https://files.pythonhosted.org/packages/bb/e0/8a6f9db2c5b8c7108c7e7347cd6beca805d1b2ae618569c72f2515d11e52/ruff-0.1.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "c44536df7b93a587de690e124b89bd47306fddd59398a0fb12afd6133c7b3818",
+              "url": "https://files.pythonhosted.org/packages/c5/31/e0c9d881db42ea1267e075c29aafe0db5a8a3024b131f952747f6234f858/ruff-0.6.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "abf4822129ed3a5ce54383d5f0e964e7fef74a41e48eb1dfad404151efc130a2",
-              "url": "https://files.pythonhosted.org/packages/e8/ca/4066dbcc3631a4efe1fe695f42f20aca50474d760b3bd8e57d7565d75aa5/ruff-0.1.15-py3-none-musllinux_1_2_armv7l.whl"
+              "hash": "0b52387d3289ccd227b62102c24714ed75fbba0b16ecc69a923a37e3b5e0aaaa",
+              "url": "https://files.pythonhosted.org/packages/c5/70/899b03cbb3eb48ed0507d4b32b6f7aee562bc618ef9ffda855ec98c0461a/ruff-0.6.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c4b153fc152af51855458e79e835fb6b933032921756cec9af7d0ba2aa01a258",
+              "url": "https://files.pythonhosted.org/packages/e3/78/307591f81d09c8721b5e64539f287c82c81a46f46d16278eb27941ac17f9/ruff-0.6.4-py3-none-linux_armv6l.whl"
             }
           ],
           "project_name": "ruff",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.1.15"
+          "version": "0.6.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1cc7d2f1cb69cbea1dfeba0f2d7dd5832bc68b0b052c7166530bcce63aa75f57",
-              "url": "https://files.pythonhosted.org/packages/b0/84/fdf5ea32fb3bedb784f5c45d1888c905a71031b65b016a33c828bfc6a131/ruff_lsp-0.0.54-py3-none-any.whl"
+              "hash": "96b2bea6e3cae75ad40bf470041cbeb06c0125a228e05d3aef47b8622a38b900",
+              "url": "https://files.pythonhosted.org/packages/c6/b3/efec03af837a53150db5d3e0672996073fe82a7f96d6008c6f270f05f4eb/ruff_lsp-0.0.56-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33e1d4dd20ca481fc6a811afcfdd451798c22fc39f2104df23c2855e322a0582",
-              "url": "https://files.pythonhosted.org/packages/aa/ff/68b1dd0bf5bce5d4bfbad6fcfddc7fc46ea070e0d191aa9a2972acb51f8a/ruff_lsp-0.0.54.tar.gz"
+              "hash": "5d2622d22032944d54b0a0e84e16048d081d3c8716bf2bac5a155227ffe1d78a",
+              "url": "https://files.pythonhosted.org/packages/77/56/a1836adc11c516f75fb7f468b238cdd5d4a248fe9113176b002d09f02ecf/ruff_lsp-0.0.56.tar.gz"
             }
           ],
           "project_name": "ruff-lsp",
@@ -264,7 +290,7 @@
             "typing-extensions"
           ],
           "requires_python": ">=3.7",
-          "version": "0.0.54"
+          "version": "0.0.56"
         },
         {
           "artifacts": [
@@ -290,13 +316,14 @@
   ],
   "only_builds": [],
   "only_wheels": [],
+  "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.3.1",
-  "pip_version": "24.0",
+  "pex_version": "2.10.0",
+  "pip_version": "24.1.2",
   "prefer_older_binary": false,
   "requirements": [
-    "ruff-lsp~=0.0.49",
-    "ruff~=0.1.11"
+    "ruff-lsp~=0.0.56",
+    "ruff~=0.6.4"
   ],
   "requires_python": [
     "==3.12.4"


### PR DESCRIPTION
This is a revisit of #2053.
Despite astral-sh/ruff#6591 and astral-sh/ruff#11056, let's upgrade Ruff to the latest version because:

* Now most backports will target 24.03 and 24.09 (based on Python 3.12) only and we will move on to 25.03 (based on Python 3.13) as the main branch soon.
* There are more new lint errors found with the latest version of Ruff.
  - e.g., The result of [`typing.get_origin()`](https://docs.python.org/3/library/typing.html#typing.get_origin) should be compared with a type using the `is` operator.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
