### PR TITLE
fix: Use safer TLS version when creating SSL socket in logstash handler

### DIFF
--- a/changes/2827.fix.md
+++ b/changes/2827.fix.md
@@ -1,0 +1,1 @@
+Use a safer TLS version (v1.2) when creating SSL sockets in the logstash handler

--- a/src/ai/backend/logging/handler/logstash.py
+++ b/src/ai/backend/logging/handler/logstash.py
@@ -58,6 +58,7 @@ class LogstashHandler(logging.Handler):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if self._ssl_enabled:
                 self._sslctx = ssl.create_default_context()
+                self._sslctx.minimum_version = ssl.TLSVersion.TLSv1_2
                 if not self._ssl_verify:
                     self._sslctx.check_hostname = False
                     self._sslctx.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
ref) https://github.com/lablup/backend.ai/security/code-scanning/27

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
