### PR TITLE
fix: Wrong value of concurrency used

### DIFF
--- a/changes/2829.fix.md
+++ b/changes/2829.fix.md
@@ -1,0 +1,1 @@
+Wrong count of concurrent compute sessions.

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -563,8 +563,8 @@ class ConcurrencyUsed:
 
     def to_cnt_map(self) -> Mapping[str, int]:
         return {
-            self.compute_concurrency_used_key: len(self.compute_concurrency_used_key),
-            self.system_concurrency_used_key: len(self.system_concurrency_used_key),
+            self.compute_concurrency_used_key: len(self.compute_session_ids),
+            self.system_concurrency_used_key: len(self.system_session_ids),
         }
 
 


### PR DESCRIPTION
follow-up #2275 

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
