### PR TITLE
fix: Wrong value of concurrency used (#2829)

### DIFF
--- a/changes/2829.fix.md
+++ b/changes/2829.fix.md
@@ -1,0 +1,1 @@
+Wrong count of concurrent compute sessions.

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -540,8 +540,8 @@ class ConcurrencyUsed:
 
     def to_cnt_map(self) -> Mapping[str, int]:
         return {
-            self.compute_concurrency_used_key: len(self.compute_concurrency_used_key),
-            self.system_concurrency_used_key: len(self.system_concurrency_used_key),
+            self.compute_concurrency_used_key: len(self.compute_session_ids),
+            self.system_concurrency_used_key: len(self.system_session_ids),
         }
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #2829 to the 24.03 release.