### PR TITLE
feat: Allow empty image name

### DIFF
--- a/src/ai/backend/common/utils.py
+++ b/src/ai/backend/common/utils.py
@@ -417,3 +417,11 @@ def is_ip_address_format(str: str) -> bool:
         return False
     except ValueError:
         return False
+
+
+def join_non_empty(*args, sep):
+    """
+    Joins non-empty strings from the given arguments using the specified separator.
+    """
+    filtered_args = [arg for arg in args if arg]
+    return sep.join(filtered_args)

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -28,6 +28,7 @@ from ai.backend.common.exception import (
     ProjectMismatchWithCanonical,
 )
 from ai.backend.common.types import SlotName, SSLContextType
+from ai.backend.common.utils import join_non_empty
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 
@@ -181,7 +182,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                                 project=registry.project,
                                 registry=parsed_img.registry,
                                 registry_id=registry.id,
-                                image=f"{parsed_img.project}/{parsed_img.name}",
+                                image=join_non_empty(parsed_img.project, parsed_img.name, sep="/"),
                                 tag=parsed_img.tag,
                                 architecture=image_identifier.architecture,
                                 is_local=is_local,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -265,8 +265,13 @@ class ImageRow(Base):
 
     @property
     def image_ref(self) -> ImageRef:
-        image_and_tag = self.name.split(f"{self.registry}/{self.project}/", maxsplit=1)[1]
-        image_name, tag = ImageRef.parse_image_tag(image_and_tag)
+        # Empty image name
+        if self.project == self.image:
+            image_name = ""
+            _, tag = ImageRef.parse_image_tag(self.name.split(f"{self.registry}/", maxsplit=1)[1])
+        else:
+            image_and_tag = self.name.split(f"{self.registry}/{self.project}/", maxsplit=1)[1]
+            image_name, tag = ImageRef.parse_image_tag(image_and_tag)
 
         return ImageRef(
             image_name, self.project, tag, self.registry, self.architecture, self.is_local

--- a/tests/common/test_docker.py
+++ b/tests/common/test_docker.py
@@ -327,6 +327,32 @@ def test_image_ref_formats():
     assert str(result) == result.canonical
     assert repr(result) == f'<ImageRef: "{result.canonical}" ({result.architecture})>'
 
+    result = ImageRef.from_image_str(
+        "registry.gitlab.com/user/python:3.6-cuda9-ubuntu", "user/python", "registry.gitlab.com"
+    )
+    assert result.canonical == "registry.gitlab.com/user/python:3.6-cuda9-ubuntu"
+    assert result.short == "user/python:3.6-cuda9-ubuntu"
+    assert str(result) == result.canonical
+    assert repr(result) == f'<ImageRef: "{result.canonical}" ({result.architecture})>'
+
+    result = ImageRef.from_image_str(
+        "registry.gitlab.com/user/python/img:3.6-cuda9-ubuntu", "user/python", "registry.gitlab.com"
+    )
+    assert result.canonical == "registry.gitlab.com/user/python/img:3.6-cuda9-ubuntu"
+    assert result.short == "user/python/img:3.6-cuda9-ubuntu"
+    assert str(result) == result.canonical
+    assert repr(result) == f'<ImageRef: "{result.canonical}" ({result.architecture})>'
+
+    result = ImageRef.from_image_str(
+        "registry.gitlab.com/user/workspace/python/img:3.6-cuda9-ubuntu",
+        "user/workspace/python",
+        "registry.gitlab.com",
+    )
+    assert result.canonical == "registry.gitlab.com/user/workspace/python/img:3.6-cuda9-ubuntu"
+    assert result.short == "user/workspace/python/img:3.6-cuda9-ubuntu"
+    assert str(result) == result.canonical
+    assert repr(result) == f'<ImageRef: "{result.canonical}" ({result.architecture})>'
+
 
 def test_image_ref_generate_aliases():
     ref = ImageRef(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

## Why?

In the existing code, an `InvalidImageName` exception is raised when the image name is empty. I think this can be confusing when using the container registry from the user's perspective.

When the project is `username/python` in a GitLab-hosted registry, for example, only images with names like `registry.gitlab.com/username/python/python_img` are allowed, and images like `registry.gitlab.com/username/python` cannot be scanned because the image name is empty.

This PR updates the system to allow scanning of images when the image name is empty.
The empty name images can be used for operations such as session creation and commit just like other images.

## Notes

If we allow the empty image name, image name parsing logic in the frontend that uses the `Images` GQL may need to be modified accordingly.

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
