### PR TITLE
feat: Add session status checker GQL mutation

### DIFF
--- a/changes/2836.feature.md
+++ b/changes/2836.feature.md
@@ -1,0 +1,1 @@
+Add session status checker GQL mutation.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -2478,6 +2478,7 @@ input ExtraMountInput {
   permission: String
 }
 
+"""Added in 24.12.0"""
 type CheckAndTransitStatus {
   item: [ComputeSessionNode]
   client_mutation_id: String

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1676,7 +1676,7 @@ type Mutations {
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
 
   """Added in 24.09.0."""
-  check_and_transit_session_status(session_ids: [UUID]!): CheckAndTransitStatus
+  check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -2478,7 +2478,13 @@ input ExtraMountInput {
   permission: String
 }
 
-"""Added in 24.09.0."""
 type CheckAndTransitStatus {
-  sessions: [ComputeSessionNode]
+  item: [ComputeSessionNode]
+  client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+input CheckAndTransitStatusInput {
+  ids: [GlobalIDField]!
+  client_mutation_id: String
 }

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1674,6 +1674,9 @@ type Mutations {
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
+
+  """Added in 24.09.0."""
+  check_and_transit_session_status(session_ids: [UUID]!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -2473,4 +2476,9 @@ input ExtraMountInput {
   Added in 24.03.4. Set permission of this mount. Should be one of (ro,rw,wd). Default is null
   """
   permission: String
+}
+
+"""Added in 24.09.0."""
+type CheckAndTransitStatus {
+  sessions: [ComputeSessionNode]
 }

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1030,8 +1030,9 @@ async def check_and_transit_status(
                 log.warning(
                     f"You are not allowed to transit others's sessions status, skip (s:{sid})"
                 )
+
+    now = datetime.now(tzutc())
     if accessible_session_ids:
-        now = datetime.now(tzutc())
         session_rows = await root_ctx.registry.session_lifecycle_mgr.transit_session_status(
             accessible_session_ids, now
         )

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -88,6 +88,7 @@ from .gql_models.image import (
     UntagImageFromRegistry,
 )
 from .gql_models.session import (
+    CheckAndTransitStatus,
     ComputeSessionConnection,
     ComputeSessionNode,
     ModifyComputeSession,
@@ -328,6 +329,8 @@ class Mutations(graphene.ObjectType):
     delete_container_registry = DeleteContainerRegistry.Field()
 
     modify_endpoint = ModifyEndpoint.Field()
+
+    check_and_transit_session_status = CheckAndTransitStatus.Field(description="Added in 24.09.0.")
 
 
 class Queries(graphene.ObjectType):

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -595,6 +595,9 @@ class CheckAndTransitStatusInput(graphene.InputObjectType):
 class CheckAndTransitStatus(graphene.Mutation):
     allowed_roles = (UserRole.USER, UserRole.ADMIN, UserRole.SUPERADMIN)
 
+    class Meta:
+        description = "Added in 24.12.0"
+
     class Arguments:
         input = CheckAndTransitStatusInput(required=True)
 


### PR DESCRIPTION
### Mutation
```gql
mutation CheckandtransitSession {
    check_and_transit_session_status(
        input: {ids: ["SESSION-ID",]}
    ) {
        sessions {
            id
            row_id
            name
            status
            status_history
            occupied_slots
        }
    }
}
```

### Response
```json
{
    "data": {
        "check_and_transit_session_status": {
            "item": [
                {
                    "id": "NODE-ID",
                    "row_id": "SESSION-ID",
                    "name": "SESSION-NAME",
                    "status": "RUNNING",
                    "status_history": "{\"PENDING\": \"2024-09-14T03:35:54.218019+00:00\", \"RUNNING\": \"2024-09-14T03:36:05.431593+00:00\", \"PREPARING\": \"2024-09-14T03:35:55.013239+00:00\", \"SCHEDULED\": \"2024-09-14T03:35:54.996003+00:00\"}",
                    "occupied_slots": "{\"cpu\": \"90\", \"mem\": \"30198988800\", \"cuda.device\": \"0\"}"
                }
            ]
        }
    }
}
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2836.org.readthedocs.build/en/2836/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2836.org.readthedocs.build/ko/2836/

<!-- readthedocs-preview sorna-ko end -->