### PR TITLE
fix: Create kernels with correct scaling group value (#2837)

### DIFF
--- a/changes/2837.fix.md
+++ b/changes/2837.fix.md
@@ -1,0 +1,1 @@
+Create kernels with correct `scaling_group` value.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1325,7 +1325,7 @@ class AgentRegistry:
                 agent_alloc_ctx=AgentAllocationContext(
                     agent_id=k.agent,
                     agent_addr=k.agent_addr,
-                    scaling_group=scheduled_session.scaling_group,
+                    scaling_group=scheduled_session.scaling_group_name,
                 ),
                 allocated_host_ports=set(),
             )


### PR DESCRIPTION
This is an auto-generated backport PR of #2837 to the 24.03 release.