### PR TITLE
refactor: Avoid using OrderedDict in the manager API and client SDK (#2842)

### DIFF
--- a/changes/2842.enhance.md
+++ b/changes/2842.enhance.md
@@ -1,0 +1,1 @@
+Avoid using `collections.OrderedDict` when not necessary in the manager API and client SDK

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -6,7 +6,7 @@ import io
 import json as modjson
 import logging
 import sys
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -412,7 +412,7 @@ class AsyncResponseMixin:
         return await self._raw_response.text()
 
     async def json(self, *, loads=modjson.loads) -> Any:
-        loads = functools.partial(loads, object_pairs_hook=OrderedDict)
+        loads = functools.partial(loads)
         return await self._raw_response.json(loads=loads)
 
     async def read(self, n: int = -1) -> bytes:
@@ -433,7 +433,7 @@ class SyncResponseMixin:
         )
 
     def json(self, *, loads=modjson.loads) -> Any:
-        loads = functools.partial(loads, object_pairs_hook=OrderedDict)
+        loads = functools.partial(loads)
         sync_session = cast(SyncSession, self._session)
         return sync_session.worker_thread.execute(
             self._raw_response.json(loads=loads),

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -19,7 +19,6 @@ from typing import (
     Callable,
     ClassVar,
     Coroutine,
-    Final,
     Generic,
     List,
     NamedTuple,

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 import enum
 import functools
 import logging
@@ -20,7 +19,7 @@ from typing import (
     Callable,
     ClassVar,
     Coroutine,
-    Dict,
+    Final,
     Generic,
     List,
     NamedTuple,
@@ -806,8 +805,8 @@ async def batch_result(
     """
     A batched query adaptor for (key -> item) resolving patterns.
     """
-    objs_per_key: Dict[_Key, Optional[_GenericSQLBasedGQLObject]]
-    objs_per_key = collections.OrderedDict()
+    objs_per_key: dict[_Key, Optional[_GenericSQLBasedGQLObject]]
+    objs_per_key = dict()
     for key in key_list:
         objs_per_key[key] = None
     if isinstance(db_conn, SASession):
@@ -830,8 +829,8 @@ async def batch_multiresult(
     """
     A batched query adaptor for (key -> [item]) resolving patterns.
     """
-    objs_per_key: Dict[_Key, List[_GenericSQLBasedGQLObject]]
-    objs_per_key = collections.OrderedDict()
+    objs_per_key: dict[_Key, list[_GenericSQLBasedGQLObject]]
+    objs_per_key = dict()
     for key in key_list:
         objs_per_key[key] = list()
     if isinstance(db_conn, SASession):
@@ -857,8 +856,8 @@ async def batch_result_in_session(
     A batched query adaptor for (key -> item) resolving patterns.
     stream the result in async session.
     """
-    objs_per_key: Dict[_Key, Optional[_GenericSQLBasedGQLObject]]
-    objs_per_key = collections.OrderedDict()
+    objs_per_key: dict[_Key, Optional[_GenericSQLBasedGQLObject]]
+    objs_per_key = dict()
     for key in key_list:
         objs_per_key[key] = None
     async for row in await db_sess.stream(query):
@@ -878,8 +877,8 @@ async def batch_multiresult_in_session(
     A batched query adaptor for (key -> [item]) resolving patterns.
     stream the result in async session.
     """
-    objs_per_key: Dict[_Key, List[_GenericSQLBasedGQLObject]]
-    objs_per_key = collections.OrderedDict()
+    objs_per_key: dict[_Key, list[_GenericSQLBasedGQLObject]]
+    objs_per_key = dict()
     for key in key_list:
         objs_per_key[key] = list()
     async for row in await db_sess.stream(query):


### PR DESCRIPTION
This is an auto-generated backport PR of #2842 to the 24.03 release.