### PR TITLE
chore: Correct typos and change agent selector plugin config key to kebab-case

### DIFF
--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -348,7 +348,7 @@ _config_defaults: Mapping[str, Any] = {
     "plugins": {
         "accelerator": {},
         "scheduler": {},
-        "agent_selector": {},
+        "agent-selector": {},
     },
     "watcher": {
         "token": None,
@@ -438,7 +438,7 @@ shared_config_iv = t.Dict({
         t.Key("scheduler", default=_config_defaults["plugins"]["scheduler"]): t.Mapping(
             t.String, t.Mapping(t.String, t.Any)
         ),
-        t.Key("agent_selector", default=_config_defaults["plugins"]["agent_selector"]): t.Mapping(
+        t.Key("agent-selector", default=_config_defaults["plugins"]["agent-selector"]): t.Mapping(
             t.String, config.agent_selector_globalconfig_iv
         ),
     }).allow_extra("*"),

--- a/src/ai/backend/manager/scheduler/agent_selector.py
+++ b/src/ai/backend/manager/scheduler/agent_selector.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import logging
 import sys
 from decimal import Decimal
-from typing import Optional, Self, Sequence, override
+from typing import Optional, Sequence, override
 
-import pydantic
 import trafaret as t
 
 from ai.backend.common.types import (
@@ -18,7 +17,8 @@ from ..models import AgentRow, KernelRow, SessionRow
 from .types import (
     AbstractAgentSelector,
     NullAgentSelectorState,
-    ResourceGroupState,
+    RoundRobinState,
+    RRAgentSelectorState,
     T_ResourceGroupState,
 )
 from .utils import (
@@ -106,19 +106,6 @@ class LegacyAgentSelector(BaseAgentSelector[NullAgentSelectorState]):
             ],
         )
         return chosen_agent.id
-
-
-class RoundRobinState(pydantic.BaseModel):
-    next_index: int = 0
-
-
-class RRAgentSelectorState(ResourceGroupState):
-    roundrobin_states: dict[ArchName, RoundRobinState]
-
-    @override
-    @classmethod
-    def create_empty_state(cls) -> Self:
-        return cls(roundrobin_states={})
 
 
 class RoundRobinAgentSelector(BaseAgentSelector[RRAgentSelectorState]):

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -102,13 +102,13 @@ from .predicates import (
 )
 from .types import (
     AbstractAgentSelector,
+    AbstractResourceGroupState,
     AbstractScheduler,
     AgentAllocationContext,
     DefaultResourceGroupStateStore,
     KernelAgentBinding,
     PendingSession,
     PredicateResult,
-    ResourceGroupState,
     SchedulingContext,
     T_ResourceGroupState,
 )
@@ -149,7 +149,7 @@ def load_agent_selector(
     selector_config: Mapping[str, Any],
     agent_selection_resource_priority: list[str],
     shared_config: SharedConfig,
-) -> AbstractAgentSelector[ResourceGroupState]:
+) -> AbstractAgentSelector[AbstractResourceGroupState]:
     def create_agent_selector(
         selector_cls: type[AbstractAgentSelector[T_ResourceGroupState]],
     ) -> AbstractAgentSelector[T_ResourceGroupState]:
@@ -406,8 +406,8 @@ class SchedulerDispatcher(aobject):
                 scheduler_name, {}
             )
         scheduler_config = {**global_scheduler_opts, **sgroup_opts.config}
-        if self.shared_config["plugins"]["agent_selector"]:
-            global_agselector_opts = self.shared_config["plugins"]["agent_selector"].get(
+        if self.shared_config["plugins"]["agent-selector"]:
+            global_agselector_opts = self.shared_config["plugins"]["agent-selector"].get(
                 agselector_name, {}
             )
         agselector_config = {**global_agselector_opts, **sgroup_opts.agent_selector_config}


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow up of #1655.

## Details

- Fix several typos.

- Change snake case mistakenly used in Etcd configuration key.

- `ResourceGroupState` -> `AbstractResourceGroupState`.
: Abstract type names should start with Abstract, similar to other types.

- Move the type declarations for `RoundRobinState` and `RRAgentSelectorState`.
: These types would be better placed in `types.py`.

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

