### PR TITLE
fix: Assign main kernel ID to `kernel_id` for correct log retrieval (#2820)

### DIFF
--- a/changes/2820.fix.md
+++ b/changes/2820.fix.md
@@ -1,0 +1,1 @@
+Fix `kernel_id` assignment for main kernel log retrieval


### PR DESCRIPTION
This is an auto-generated backport PR of #2820 to the 24.03 release.