### PR TITLE
fix: Delete vfolder invitation and permission rows when deleting vfolders (#2780)

### DIFF
--- a/changes/2780.fix.md
+++ b/changes/2780.fix.md
@@ -1,0 +1,1 @@
+Delete vfolder invitation and permission rows when deleting vfolders.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -100,7 +100,11 @@ from ..models import (
     vfolder_status_map,
     vfolders,
 )
-from ..models.utils import execute_with_retry
+from ..models.utils import execute_with_retry, execute_with_txn_retry
+from ..models.vfolder import (
+    VFolderPermissionRow,
+    delete_vfolder_relation_rows,
+)
 from .auth import admin_required, auth_required, superadmin_required
 from .exceptions import (
     BackendAgentError,
@@ -2254,9 +2258,12 @@ async def _delete(
             permission=VFolderHostPermission.DELETE,
         )
 
+    vfolder_row_ids = (entry["id"],)
+    async with root_ctx.db.connect() as db_conn:
+        await delete_vfolder_relation_rows(db_conn, root_ctx.db.begin_session, vfolder_row_ids)
     await update_vfolder_status(
         root_ctx.db,
-        (entry["id"],),
+        vfolder_row_ids,
         VFolderOperationStatus.DELETE_PENDING,
     )
 

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -100,9 +100,8 @@ from ..models import (
     vfolder_status_map,
     vfolders,
 )
-from ..models.utils import execute_with_retry, execute_with_txn_retry
+from ..models.utils import execute_with_retry
 from ..models.vfolder import (
-    VFolderPermissionRow,
     delete_vfolder_relation_rows,
 )
 from .auth import admin_required, auth_required, superadmin_required
@@ -2259,8 +2258,7 @@ async def _delete(
         )
 
     vfolder_row_ids = (entry["id"],)
-    async with root_ctx.db.connect() as db_conn:
-        await delete_vfolder_relation_rows(db_conn, root_ctx.db.begin_session, vfolder_row_ids)
+    await delete_vfolder_relation_rows(root_ctx.db, vfolder_row_ids)
     await update_vfolder_status(
         root_ctx.db,
         vfolder_row_ids,


### PR DESCRIPTION
This is an auto-generated backport PR of #2780 to the 24.03 release.