### PR TITLE
docs: Update readme for the cuda_open plugin in the monorepo

### DIFF
--- a/src/ai/backend/accelerator/cuda_open/README.md
+++ b/src/ai/backend/accelerator/cuda_open/README.md
@@ -6,23 +6,8 @@ This will allow the agents to detect CUDA devices on their hosts and make them
 available to Backend.AI kernel sessions.
 
 ```console
-$ pip install backend.ai-accelerator-cuda
+$ pip install backend.ai-accelerator-cuda-open
 ```
 
 This open-source edition of CUDA plugins support allocation of one or more CUDA
 devices to a container, slot-by-slot.
-
-Compatibility Matrix
---------------------
-
-|       Backend.AI Agent       |    CUDA Plugin   |
-|:----------------------------:|:----------------:|
-|  20.09.x                     |  2.0.0           |
-|  20.03.9 ~                   |  2.0.0           |
-|  20.03.0 ~ 20.03.8           |  0.14.x          |
-|  19.09.17 ~                  |  0.13.x          |
-|  19.06.x, 19.09.0 ~ 19.09.16 |  0.11.x, 0.12.x  |
-|  19.03.x                     |  0.10.x          |
-
-In the versions released after the above matrix, the agent will set the required
-version range of this plugin as an extra requirements set "cuda".


### PR DESCRIPTION

![CleanShot 2024-09-26 at 15 37 33@2x](https://github.com/user-attachments/assets/bbcb980b-c8c5-4b67-8d51-1c913b43230c)
Since the cuda_open plugin is integrated into the monorepo and uses the same version, there is no need to mark version compatibility.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
