### PR TITLE
fix: Prevent misinterpreting alembic migration errors as event loop errors

### DIFF
--- a/src/ai/backend/manager/models/alembic/env.py
+++ b/src/ai/backend/manager/models/alembic/env.py
@@ -87,8 +87,11 @@ if not invoked_programmatically.get():  # when executed via `alembic` commands
     if context.is_offline_mode():
         run_migrations_offline()
     else:
+        run_standalone = False
         try:
             loop = asyncio.get_running_loop()
             loop.run_until_complete(run_migrations_online())
         except RuntimeError:
+            run_standalone = True
+        if run_standalone:
             asyncio.run(run_migrations_online())


### PR DESCRIPTION
This PR removes the extra exception context to check if there is no event loop running when executing alembic migrations, which makes it often confusing whether the migration failure is from the event loop handling mistake or actual migration scripts.

Before:
```
INFO  [alembic.runtime.migration] Running upgrade 20218a73401b -> 1d42c726d8a3, Migrate container registry config storage from `Etcd` to `PostgreSQL`
Traceback (most recent call last):
  ...
RuntimeError: no running event loop

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
asyncpg.exceptions.NotNullViolationError: column "registry_id" of relation "images" contains null values
```

After:
```
INFO  [alembic.runtime.migration] Running upgrade 20218a73401b -> 1d42c726d8a3, Migrate container registry config storage from `Etcd` to `PostgreSQL`
There is no container registries data to migrate in etcd.
Traceback (most recent call last):
  ...
asyncpg.exceptions.NotNullViolationError: column "registry_id" of relation "images" contains null values
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
