### PR TITLE
fix: Prevent misinterpreting alembic migration errors as event loop errors (#2879)

### DIFF
--- a/src/ai/backend/manager/models/alembic/env.py
+++ b/src/ai/backend/manager/models/alembic/env.py
@@ -87,8 +87,11 @@ if not invoked_programmatically.get():  # when executed via `alembic` commands
     if context.is_offline_mode():
         run_migrations_offline()
     else:
+        run_standalone = False
         try:
             loop = asyncio.get_running_loop()
             loop.run_until_complete(run_migrations_online())
         except RuntimeError:
+            run_standalone = True
+        if run_standalone:
             asyncio.run(run_migrations_online())


### PR DESCRIPTION
This is an auto-generated backport PR of #2879 to the 23.09 release.