### PR TITLE
fix: For repeated trials, add timestamp to etcd backups to prevent overwriting with empty data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,8 +142,6 @@ logs/
 
 # Generated files
 docs/manager/rest-reference/openapi.json
-
+backup.*.json
 /DIST-INFO
 /INSTALL-INFO
-
-etcd_container_registries_backup.json


### PR DESCRIPTION
This is a follow-up fix of #1917 to prevent human mistakes.

When we try the alemibc migration multiple times, #1917's initial implementation has overwritten the backup with empty data as the etcd key is already removed.

![image](https://github.com/user-attachments/assets/6246a888-7750-4d57-976f-47bc7781c06f)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
