### PR TITLE
fix: Missing batch execution call after session starts

### DIFF
--- a/changes/2884.fix.md
+++ b/changes/2884.fix.md
@@ -1,0 +1,1 @@
+Add missing batch execution call after session starts

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -272,6 +272,7 @@ class AgentRegistry:
             event_dispatcher,
             event_producer,
             hook_plugin_ctx,
+            self,
         )
 
     async def init(self) -> None:


### PR DESCRIPTION
follow-up #2327 #2311 

Manager does not call batch execution after batch-type session starts because the caller part is missing.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version