### PR TITLE
ci: Make sure the first half of the tag is the same as the latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,7 +535,7 @@ jobs:
         release_version=$(git branch -r | grep -E 'origin/[0-9]{2}\.[0-9]{2}$' | awk -F'/' '{print $2}' | sort -V | tail -n 1)
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update edge installer shorten URL
-      if: ${{ github.ref_name == steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ startsWith(github.ref_name, steps.extract_edge_release_version.outputs.RELEASE_VERSION) }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-edge-macos-aarch64' \


### PR DESCRIPTION
The release process occurs on tag push events.
That's why github.ref_name is tag name, and tag name also contains the patch version, like 24.09.0, unlike the release branch.
So we modify it to make sure that the first half of the tag name is the same as the release branch name.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
