### PR TITLE
ci: Make sure the first half of the tag is the same as the latest release (#2885)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,7 +535,7 @@ jobs:
         release_version=$(git branch -r | grep -E 'origin/[0-9]{2}\.[0-9]{2}$' | awk -F'/' '{print $2}' | sort -V | tail -n 1)
         echo "RELEASE_VERSION=$release_version" >> $GITHUB_OUTPUT
     - name: Update edge installer shorten URL
-      if: ${{ github.ref_name == steps.extract_edge_release_version.outputs.RELEASE_VERSION }}
+      if: ${{ startsWith(github.ref_name, steps.extract_edge_release_version.outputs.RELEASE_VERSION) }}
       run: |
         curl -X 'PATCH' \
           'https://bnd.ai/rest/v3/short-urls/installer-edge-macos-aarch64' \


### PR DESCRIPTION
This is an auto-generated backport PR of #2885 to the 24.03 release.