### PR TITLE
fix: Invalid image format log spam in Agent

### DIFF
--- a/changes/2894.fix.md
+++ b/changes/2894.fix.md
@@ -1,0 +1,1 @@
+Fix invalid image format log spam in Agent


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #2893.

This PR prevents the console from being flooded with duplicate error `Image name ... does not conform to Backend.AI's image naming rule` log messages.

Error log messages will now be printed only once, not being outputted on each image rescan cycle.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
