### PR TITLE
fix: Invalid image format log spam in Agent (#2894)

### DIFF
--- a/changes/2894.fix.md
+++ b/changes/2894.fix.md
@@ -1,0 +1,1 @@
+Fix invalid image format log spam in Agent

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1055,6 +1055,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     metadata_server: MetadataServer
     docker_ptask_group: aiotools.PersistentTaskGroup
     gwbridge_subnet: Optional[str]
+    checked_invalid_images: Set[str]
 
     def __init__(
         self,
@@ -1074,6 +1075,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             skip_initial_scan=skip_initial_scan,
             agent_public_key=agent_public_key,
         )
+        self.checked_invalid_images = set()
 
     async def __ainit__(self) -> None:
         async with closing_async(Docker()) as docker:
@@ -1254,12 +1256,15 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     if repo_tag.endswith("<none>"):
                         continue
                     try:
-                        ImageRef(repo_tag, ["*"])
-                    except ValueError:
-                        log.warning(
-                            "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored.",
-                            repo_tag,
-                        )
+                        ImageRef.parse_image_str(repo_tag, "*")
+                    except (InvalidImageName, InvalidImageTag) as e:
+                        if repo_tag not in self.checked_invalid_images:
+                            log.warning(
+                                "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored. Details: {}",
+                                repo_tag,
+                                e,
+                            )
+                            self.checked_invalid_images.add(repo_tag)
                         continue
 
                     img_detail = await docker.images.inspect(repo_tag)

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1264,6 +1264,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                                 repo_tag,
                             )
                             self.checked_invalid_images.add(repo_tag)
+                        continue
 
                     img_detail = await docker.images.inspect(repo_tag)
                     labels = img_detail["Config"]["Labels"]

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1256,16 +1256,14 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     if repo_tag.endswith("<none>"):
                         continue
                     try:
-                        ImageRef.parse_image_str(repo_tag, "*")
-                    except (InvalidImageName, InvalidImageTag) as e:
+                        ImageRef(repo_tag, ["*"])
+                    except ValueError:
                         if repo_tag not in self.checked_invalid_images:
                             log.warning(
-                                "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored. Details: {}",
+                                "Image name {} does not conform to Backend.AI's image naming rule. This image will be ignored.",
                                 repo_tag,
-                                e,
                             )
                             self.checked_invalid_images.add(repo_tag)
-                        continue
 
                     img_detail = await docker.images.inspect(repo_tag)
                     labels = img_detail["Config"]["Labels"]


### PR DESCRIPTION
This is an auto-generated backport PR of #2894 to the 24.03 release.