### PR TITLE
fix: Wrong creation of raw_configs in `_create_kernels_in_one_agent`

### DIFF
--- a/changes/2896.fix.md
+++ b/changes/2896.fix.md
@@ -1,0 +1,1 @@
+Fix wrong creation of `raw_configs` in `_create_kernels_in_one_agent`


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up of #2707.

Fixed wrong logic generating `raw_configs`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
