### PR TITLE
chore: Refactor session status determine function

### DIFF
--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -313,7 +313,7 @@ SESSION_STATUS_TRANSITION_MAP: Mapping[SessionStatus, set[SessionStatus]] = {
     },
     SessionStatus.TERMINATING: {SessionStatus.TERMINATED, SessionStatus.ERROR},
     SessionStatus.TERMINATED: set(),
-    SessionStatus.ERROR: {SessionStatus.TERMINATED},
+    SessionStatus.ERROR: {SessionStatus.TERMINATING, SessionStatus.TERMINATED},
     SessionStatus.CANCELLED: set(),
 }
 


### PR DESCRIPTION
For better readability, change the `determine_session_status()` function

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
