### PR TITLE
fix: Assign valid value to `id` field in `ContainerRegistryNode` GQL schema query resolver

### DIFF
--- a/changes/2899.fix.md
+++ b/changes/2899.fix.md
@@ -1,1 +1,1 @@
-Add the missing `id` field to the `ContainerRegistryNode` API.
+Add the missing `id` field to the `ContainerRegistryNode.from_row()`.

--- a/changes/2899.fix.md
+++ b/changes/2899.fix.md
@@ -1,1 +1,1 @@
-Add the missing `id` field to the `ContainerRegistryNode.from_row()`.
+Assign valid value to `id` field in `ContainerRegistryNode` GQL schema query resolver.

--- a/changes/2899.fix.md
+++ b/changes/2899.fix.md
@@ -1,0 +1,1 @@
+Add the missing `id` field to the `ContainerRegistryNode` API.

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -347,6 +347,7 @@ class ContainerRegistryNode(graphene.ObjectType):
     @classmethod
     def from_row(cls, ctx: GraphQueryContext, row: ContainerRegistryRow) -> ContainerRegistryNode:
         return cls(
+            id=row.id,  # auto-converted to Relay global ID
             row_id=row.id,
             url=row.url,
             type=row.type,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR fixes the issue where all ContainerRegistryNodes in the ContainerRegistryNode API were returning the same ID.

Tested by manually.

<img width="1713" alt="2024-10-11_11-12-49" src="https://github.com/user-attachments/assets/1db224dd-c774-4a00-b4e2-1d710661634c">


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version