### PR TITLE
fix: Use a valid value for the `id` field in the GQL schema query resolver for `ContainerRegistry`.

### DIFF
--- a/changes/2908.feature.md
+++ b/changes/2908.feature.md
@@ -1,0 +1,1 @@
+Use a valid value for the `id` field in the GQL schema query resolver for `ContainerRegistry`.

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -222,7 +222,7 @@ class ContainerRegistry(graphene.ObjectType):
     @classmethod
     def from_row(cls, ctx: GraphQueryContext, row: ContainerRegistryRow) -> ContainerRegistry:
         return cls(
-            id=row.registry_name,
+            id=row.id,  # auto-converted to Relay global ID
             hostname=row.registry_name,
             config=ContainerRegistryConfig(
                 url=row.url,


### PR DESCRIPTION
follows https://github.com/lablup/backend.ai/pull/1917

By using `id` instead of `registry_name`, I have resolved the issue where the `id` values returned in the `ContainerRegistry` API were all the same.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/d0f4d8f3-9559-4a94-b4f6-e3dfcc23e48d.png)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
