### PR TITLE
fix: Calculate correct expiration time of VAST auth token

### DIFF
--- a/changes/2911.fix.md
+++ b/changes/2911.fix.md
@@ -1,0 +1,1 @@
+Calculate correct expiration time of VAST auth token

--- a/changes/2911.fix.md
+++ b/changes/2911.fix.md
@@ -1,1 +1,1 @@
-Calculate correct expiration time of VAST auth token
+Calculate correct expiration time of VAST auth token and add `vast_force_login` config to enable login before every REST API call

--- a/src/ai/backend/storage/vast/__init__.py
+++ b/src/ai/backend/storage/vast/__init__.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Final, FrozenSet, Literal, Mapping, Optional
+from typing import Any, Final, FrozenSet, Literal, Optional, cast
 
 import aiofiles
 import aiofiles.os
@@ -22,6 +23,7 @@ from ..exception import (
 )
 from ..types import CapacityUsage, FSPerfMetric, QuotaUsage
 from ..vfs import BaseQuotaModel, BaseVolume
+from .config import config_iv
 from .exceptions import VASTInvalidParameterError, VASTNotFoundError, VASTUnknownError
 from .vastdata_client import VASTAPIClient, VASTQuota, VASTQuotaID
 
@@ -189,6 +191,7 @@ class VASTVolume(BaseVolume):
             event_dispathcer=event_dispathcer,
             event_producer=event_producer,
         )
+        self.config = cast(Mapping[str, Any], config_iv.check(self.config))
         ssl_verify = self.config.get("vast_verify_ssl", False)
         self.api_client = VASTAPIClient(
             self.config["vast_endpoint"],
@@ -197,7 +200,7 @@ class VASTVolume(BaseVolume):
             storage_base_dir=self.config["vast_storage_base_dir"],
             api_version=self.config["vast_api_version"],
             ssl=ssl_verify,
-            use_auth_token=self.config["vast_use_auth_token"],
+            force_login=self.config["vast_force_login"],
         )
 
     async def shutdown(self) -> None:

--- a/src/ai/backend/storage/vast/config.py
+++ b/src/ai/backend/storage/vast/config.py
@@ -19,7 +19,7 @@ config_iv = t.Dict({
     t.Key("vast_username"): t.String(),
     t.Key("vast_password"): t.String(),
     t.Key("vast_verify_ssl", default=False): t.ToBool(),
-    t.Key("vast_use_auth_token", default=False): t.ToBool(),
+    t.Key("vast_force_login", default=False): t.ToBool(),
     t.Key("vast_api_version", default=APIVersion.V2): tx.Enum(APIVersion),
     t.Key("vast_cluster_id", default=DEFAULT_CLUSTER_ID): t.Int,
     t.Key("vast_storage_base_dir", default="/"): t.String(),

--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -173,9 +173,9 @@ class VASTAPIClient:
 
         if self._auth_token is None:
             return await self._login()
-        elif get_exp_dt(self._auth_token["access_token"]) < current_dt:
+        elif get_exp_dt(self._auth_token["access_token"]) > current_dt:
             return
-        elif get_exp_dt(self._auth_token["refresh_token"]) < current_dt:
+        elif get_exp_dt(self._auth_token["refresh_token"]) > current_dt:
             return await self._refresh()
         return await self._login()
 

--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -174,8 +174,12 @@ class VASTAPIClient:
         if self._auth_token is None:
             return await self._login()
         elif get_exp_dt(self._auth_token["access_token"]) > current_dt:
+            # The access token has not expired yet
+            # Auth requests using the access token
             return
         elif get_exp_dt(self._auth_token["refresh_token"]) > current_dt:
+            # The access token has expired but the refresh token has not expired
+            # Refresh tokens
             return await self._refresh()
         return await self._login()
 


### PR DESCRIPTION
1. Fix calculation of expiration datetime of VAST auth token by comparing current time with token's `exp` time.
2. Change config name from `use_auth_token` to `force_login`
3. Replace `dateutil.tz.tzutc()` with `datetime.timezone.utc`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
