### PR TITLE
fix: Calculate correct expiration time of VAST auth token (#2911)

### DIFF
--- a/changes/2911.fix.md
+++ b/changes/2911.fix.md
@@ -1,0 +1,1 @@
+Calculate correct expiration time of VAST auth token and add `vast_force_login` config to enable login before every REST API call

--- a/src/ai/backend/storage/vast/__init__.py
+++ b/src/ai/backend/storage/vast/__init__.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Final, FrozenSet, Literal, Mapping, Optional
+from typing import Any, Final, FrozenSet, Literal, Optional, cast
 
 import aiofiles
 import aiofiles.os
@@ -22,6 +23,7 @@ from ..exception import (
 )
 from ..types import CapacityUsage, FSPerfMetric, QuotaUsage
 from ..vfs import BaseQuotaModel, BaseVolume
+from .config import config_iv
 from .exceptions import VASTInvalidParameterError, VASTNotFoundError, VASTUnknownError
 from .vastdata_client import VASTAPIClient, VASTQuota, VASTQuotaID
 
@@ -189,6 +191,7 @@ class VASTVolume(BaseVolume):
             event_dispathcer=event_dispathcer,
             event_producer=event_producer,
         )
+        self.config = cast(Mapping[str, Any], config_iv.check(self.config))
         ssl_verify = self.config.get("vast_verify_ssl", False)
         self.api_client = VASTAPIClient(
             self.config["vast_endpoint"],
@@ -197,7 +200,7 @@ class VASTVolume(BaseVolume):
             storage_base_dir=self.config["vast_storage_base_dir"],
             api_version=self.config["vast_api_version"],
             ssl=ssl_verify,
-            use_auth_token=self.config["vast_use_auth_token"],
+            force_login=self.config["vast_force_login"],
         )
 
     async def shutdown(self) -> None:

--- a/src/ai/backend/storage/vast/config.py
+++ b/src/ai/backend/storage/vast/config.py
@@ -19,7 +19,7 @@ config_iv = t.Dict({
     t.Key("vast_username"): t.String(),
     t.Key("vast_password"): t.String(),
     t.Key("vast_verify_ssl", default=False): t.ToBool(),
-    t.Key("vast_use_auth_token", default=False): t.ToBool(),
+    t.Key("vast_force_login", default=False): t.ToBool(),
     t.Key("vast_api_version", default=APIVersion.V2): tx.Enum(APIVersion),
     t.Key("vast_cluster_id", default=DEFAULT_CLUSTER_ID): t.Int,
     t.Key("vast_storage_base_dir", default="/"): t.String(),

--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import logging
 import ssl
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Final, Mapping, NewType, TypedDict
+from typing import Any, Mapping, NewType, TypedDict
 
 import aiohttp
 import jwt
-from dateutil.tz import tzutc
 from yarl import URL
 
 from ai.backend.common.logging import BraceStyleAdapter
@@ -27,10 +26,6 @@ from .exceptions import (
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-DEFAULT_ACCESS_TOKEN_SPAN: Final = timedelta(minutes=1)
-DEFAULT_REFRESH_TOKEN_SPAN: Final = timedelta(minutes=10)
 
 
 VASTQuotaID = NewType("VASTQuotaID", str)
@@ -139,7 +134,7 @@ class VASTAPIClient:
         api_version: APIVersion,
         storage_base_dir: str,
         ssl: ssl.SSLContext | bool = False,
-        use_auth_token: bool = False,
+        force_login: bool = False,
     ) -> None:
         self.api_endpoint = URL(endpoint)
         self.api_version = api_version
@@ -150,7 +145,7 @@ class VASTAPIClient:
 
         self._auth_token = None
         self.ssl_context = ssl
-        self.use_auth_token = use_auth_token
+        self.force_login = force_login
 
     @property
     def _req_header(self) -> Mapping[str, str]:
@@ -161,10 +156,10 @@ class VASTAPIClient:
         }
 
     async def _validate_token(self) -> None:
-        if not self.use_auth_token:
+        if self.force_login:
             return await self._login()
 
-        current_dt = datetime.now(tzutc())
+        current_dt = datetime.now(timezone.utc)
 
         def get_exp_dt(token: str) -> datetime:
             decoded: Mapping[str, Any] = jwt.decode(
@@ -178,11 +173,13 @@ class VASTAPIClient:
 
         if self._auth_token is None:
             return await self._login()
-        elif get_exp_dt(self._auth_token["access_token"]) + DEFAULT_ACCESS_TOKEN_SPAN > current_dt:
+        elif get_exp_dt(self._auth_token["access_token"]) > current_dt:
+            # The access token has not expired yet
+            # Auth requests using the access token
             return
-        elif (
-            get_exp_dt(self._auth_token["refresh_token"]) + DEFAULT_REFRESH_TOKEN_SPAN > current_dt
-        ):
+        elif get_exp_dt(self._auth_token["refresh_token"]) > current_dt:
+            # The access token has expired but the refresh token has not expired
+            # Refresh tokens
             return await self._refresh()
         return await self._login()
 
@@ -222,8 +219,7 @@ class VASTAPIClient:
                 ssl=self.ssl_context,
             )
             data = await response.json()
-        if self.use_auth_token:
-            self._parse_token(data)
+        self._parse_token(data)
 
     async def _build_request(
         self,


### PR DESCRIPTION
This is an auto-generated backport PR of #2911 to the 24.03 release.