### PR TITLE
ci: Let backport workflow succeed with vanilla commits

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,7 @@ jobs:
           echo "commit_message<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_message" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          pr_number=$(echo $commit_message | grep -oP "\(#\d+\)" | grep -oP "\d+")  # Get pr number from commit message
+          pr_number=$(echo $commit_message | grep -oP "\(#\d+\)" || true | grep -oP "\d+" || true)  # Get pr number from commit message
           echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
           latest_release=$(cat VERSION | grep -oP "\d+\.\d+")
           echo "latest_release=$latest_release" >> $GITHUB_OUTPUT
@@ -43,15 +43,9 @@ jobs:
           echo "labels<<EOF" >> $GITHUB_OUTPUT
           echo "$labels" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Check if this is a merged pr commit
-        run: |
-          if [[ -z "${{ steps.commit.outputs.pr_number }}" ]]; then
-            echo "This is not a merge commit of a PR."
-            exit 0
-          fi
-          # Modified in a way to terminate without failure indication
       - name: Get target milestones
         id: milestones
+        if: ${{ steps.commit.outputs.pr_number }}
         run: |
           target_milestone=$(gh pr view ${{ steps.commit.outputs.pr_number }} --json milestone --jq .milestone.title)
 
@@ -88,6 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   backport:
+    if: ${{ needs.backport-target-branch.outputs.matrix }}
     runs-on: ubuntu-latest
     needs: backport-target-branch
     strategy:


### PR DESCRIPTION

![CleanShot 2024-10-15 at 20 40 25@2x](https://github.com/user-attachments/assets/d3c19334-cb38-4ef0-b2ad-7610b13ebc86)
If it was merged into main but committed directly (not through a pr), the backport workflow will not work.
In this case, the workflow worked fine, so modify the logic to mark it as successful.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
