### PR TITLE
ci: Modify to accommodate the changed release naming convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - 'main'
-      - '[0-9][0-9].0[39]'
+      - '[0-9][0-9].[0-9]'
+      - '[0-9][0-9].[0-9][0-9]'
     tags:
-      - '[0-9][0-9].0[39].*'
+      - '[0-9][0-9].[0-9].*'
+      - '[0-9][0-9].[0-9][0-9].*'
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:


### PR DESCRIPTION
We decided to have a faster release cycle going forward.
This has led to a wider variety of versions in rules, where minor versions were only available in 03,09.

https://docs.github.com/ko/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

The github actions pattern match syntax does not provide a way to match only numbers, so we chose the current way without using *.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
