### PR TITLE
ci: Preserves stacked pr order in backport pr

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,7 @@ jobs:
           echo "labels<<EOF" >> $GITHUB_OUTPUT
           echo "$labels" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Get target milestones
+      - name: Get target branches
         id: milestones
         if: ${{ steps.commit.outputs.pr_number }}
         run: |
@@ -76,10 +76,23 @@ jobs:
               break
             fi
           done
-          matrix=$(jq -nc '{include: $ARGS.positional | map_values({milestone: .})}' --args "${target_milestones[@]}")
+
+          pr_head=$(gh pr view ${{ steps.commit.outputs.pr_number }} --json headRepositoryOwner,headRefName --jq '.headRepositoryOwner.login + ":" + .headRefName')
+          response=$(curl -s -o response.json -w "%{http_code}" -X GET "${{ secrets.KVSTORE_URL }}/?key=head_$pr_head" \
+            -H "Authorization: Bearer ${{ secrets.KVSTORE_TOKEN }}")
+          if [ "$(cat response.json)" == "404" ]; then
+            target_branchs=($target_milestones)
+          else
+            pr_base=$(jq -r '.value' response.json)
+            target_branchs=("backport/${{ steps.commit.outputs.pr_number }}-to-${target_milestones[@]}")
+            echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
+          fi
+
+          matrix=$(jq -nc '{include: $ARGS.positional | map_values({target_branch: .})}' --args "${target_branches[@]}")
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
+
 
   backport:
     if: ${{ needs.backport-target-branch.outputs.matrix }}
@@ -92,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.milestone }}
+          ref: ${{ matrix.target_branch }}
       - name: Cherry-pick
         env:
           COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
@@ -104,12 +117,12 @@ jobs:
           git commit \
             --amend -m "${COMMIT_MESSAGE}" \
             --trailer "Backported-from=main (${{ needs.backport-target-branch.outputs.latest_release }})" \
-            --trailer "Backported-to=${{ matrix.milestone }}" \
+            --trailer "Backported-to=${{ matrix.target_branch }}" \
             --trailer "Backport-of=${{ needs.backport-target-branch.outputs.pr_number }}"
       - name: When cherry-pick is failed
         if: failure()
         run: |
-          gh pr comment ${{ needs.backport-target-branch.outputs.pr_number }} -b "Backport to ${{ matrix.milestone }} is failed. Please backport manually."
+          gh pr comment ${{ needs.backport-target-branch.outputs.pr_number }} -b "Backport to ${{ matrix.target_branch }} is failed. Please backport manually."
         env:
           GH_TOKEN: ${{ github.token }}
       - id: commit_message
@@ -131,9 +144,9 @@ jobs:
           token: ${{ secrets.OCTODOG }}
           author: "${{ needs.backport-target-branch.outputs.author }} <${{ needs.backport-target-branch.outputs.author_email }}>"
           title: "${{ steps.commit_message.outputs.commit_header }}"
-          body: "This is an auto-generated backport PR of #${{ needs.backport-target-branch.outputs.pr_number }} to the ${{ matrix.milestone }} release."
-          branch: "backport/${{ needs.backport-target-branch.outputs.pr_number }}-to-${{ matrix.milestone }}"
-          base: ${{ matrix.milestone }}
+          body: "This is an auto-generated backport PR of #${{ needs.backport-target-branch.outputs.pr_number }} to the ${{ matrix.target_branch }} release."
+          branch: "backport/${{ needs.backport-target-branch.outputs.pr_number }}-to-${{ matrix.target_branch }}"
+          base: ${{ matrix.target_branch }}
           labels: |
             backport
             ${{ needs.backport-target-branch.outputs.labels }}
@@ -157,7 +170,7 @@ jobs:
           commit_footer="Co-authored-by: ${{ needs.backport-target-branch.outputs.author }} <${{ needs.backport-target-branch.outputs.author_email }}>
           ${{ steps.commit_message.outputs.commit_footer }}
           Backported-from: main (${{ needs.backport-target-branch.outputs.latest_release }})
-          Backported-to: ${{ matrix.milestone }}
+          Backported-to: ${{ matrix.target_branch }}
           Backport-of: ${{ needs.backport-target-branch.outputs.pr_number }}"
           commit_footer=$(echo "$commit_footer" | grep '.')  # remove empty lines
           echo "commit_footer<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ref. #2847 
For stacked PRs, the backport process should also be merged, preserving the existing order.

Similar to PR above, store stacked PR information externally and utilize it to implement

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
