### PR TITLE
chore: fix typo in storage backend

### DIFF
--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -198,7 +198,7 @@ class AbstractVolume(metaclass=ABCMeta):
         mount_path: Path,
         *,
         etcd: AsyncEtcd,
-        event_dispathcer: EventDispatcher,
+        event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
         options: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -206,7 +206,7 @@ class AbstractVolume(metaclass=ABCMeta):
         self.mount_path = mount_path
         self.config = options or {}
         self.etcd = etcd
-        self.event_dispathcer = event_dispathcer
+        self.event_dispatcher = event_dispatcher
         self.event_producer = event_producer
 
     async def init(self) -> None:

--- a/src/ai/backend/storage/context.py
+++ b/src/ai/backend/storage/context.py
@@ -195,7 +195,7 @@ class RootContext:
                 mount_path=Path(volume_config["path"]),
                 options=volume_config["options"] or {},
                 etcd=self.etcd,
-                event_dispathcer=self.event_dispatcher,
+                event_dispatcher=self.event_dispatcher,
                 event_producer=self.event_producer,
             )
 

--- a/src/ai/backend/storage/gpfs/__init__.py
+++ b/src/ai/backend/storage/gpfs/__init__.py
@@ -117,7 +117,7 @@ class GPFSVolume(BaseVolume):
         mount_path: Path,
         *,
         etcd: AsyncEtcd,
-        event_dispathcer: EventDispatcher,
+        event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
         options: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -126,7 +126,7 @@ class GPFSVolume(BaseVolume):
             mount_path,
             etcd=etcd,
             options=options,
-            event_dispathcer=event_dispathcer,
+            event_dispatcher=event_dispatcher,
             event_producer=event_producer,
         )
         verify_ssl = self.config.get("gpfs_verify_ssl", False)

--- a/src/ai/backend/storage/vast/__init__.py
+++ b/src/ai/backend/storage/vast/__init__.py
@@ -179,7 +179,7 @@ class VASTVolume(BaseVolume):
         mount_path: Path,
         *,
         etcd: AsyncEtcd,
-        event_dispathcer: EventDispatcher,
+        event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
         options: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -188,7 +188,7 @@ class VASTVolume(BaseVolume):
             mount_path,
             etcd=etcd,
             options=options,
-            event_dispathcer=event_dispathcer,
+            event_dispatcher=event_dispatcher,
             event_producer=event_producer,
         )
         self.config = cast(Mapping[str, Any], config_iv.check(self.config))

--- a/src/ai/backend/storage/weka/__init__.py
+++ b/src/ai/backend/storage/weka/__init__.py
@@ -105,7 +105,7 @@ class WekaVolume(BaseVolume):
         mount_path: Path,
         *,
         etcd: AsyncEtcd,
-        event_dispathcer: EventDispatcher,
+        event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
         options: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -114,7 +114,7 @@ class WekaVolume(BaseVolume):
             mount_path,
             etcd=etcd,
             options=options,
-            event_dispathcer=event_dispathcer,
+            event_dispatcher=event_dispatcher,
             event_producer=event_producer,
         )
         ssl_verify = self.config.get("weka_verify_ssl", False)

--- a/tests/storage-proxy/conftest.py
+++ b/tests/storage-proxy/conftest.py
@@ -123,7 +123,7 @@ async def volume(
         volume_path,
         etcd=mock_etcd,
         options=backend_options,
-        event_dispathcer=mock_event_dispatcher,
+        event_dispatcher=mock_event_dispatcher,
         event_producer=mock_event_producer,
     )
     await volume.init()


### PR DESCRIPTION
Change `event_dispathcer` to `event_dispatcher`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version