### PR TITLE
fix: Wrong GQL ordering field spec parser

### DIFF
--- a/changes/2927.fix.md
+++ b/changes/2927.fix.md
@@ -1,0 +1,1 @@
+Fix `order` GQL query argument parser of `group_nodes`

--- a/src/ai/backend/manager/models/gql_models/group.py
+++ b/src/ai/backend/manager/models/gql_models/group.py
@@ -48,8 +48,8 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
     "row_id": ("id", None),
     "name": ("name", None),
     "is_active": ("is_active", None),
-    "created_at": ("created_at", dtparse),
-    "modified_at": ("modified_at", dtparse),
+    "created_at": ("created_at", None),
+    "modified_at": ("modified_at", None),
     "domain_name": ("domain_name", None),
     "resource_policy": ("resource_policy", None),
 }


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)