### PR TITLE
fix: Wrong GQL ordering field spec parser (#2927)

### DIFF
--- a/changes/2927.fix.md
+++ b/changes/2927.fix.md
@@ -1,0 +1,1 @@
+Fix `order` GQL query argument parser of `group_nodes`

--- a/src/ai/backend/manager/models/gql_models/group.py
+++ b/src/ai/backend/manager/models/gql_models/group.py
@@ -48,8 +48,8 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
     "row_id": ("id", None),
     "name": ("name", None),
     "is_active": ("is_active", None),
-    "created_at": ("created_at", dtparse),
-    "modified_at": ("modified_at", dtparse),
+    "created_at": ("created_at", None),
+    "modified_at": ("modified_at", None),
     "domain_name": ("domain_name", None),
     "resource_policy": ("resource_policy", None),
 }


### PR DESCRIPTION
This is an auto-generated backport PR of #2927 to the 24.09 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2928.org.readthedocs.build/en/2928/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2928.org.readthedocs.build/ko/2928/

<!-- readthedocs-preview sorna-ko end -->