### PR TITLE
fix: allow `ifs_path` config of PowerScale to not exists

### DIFF
--- a/src/ai/backend/storage/dellemc/config.py
+++ b/src/ai/backend/storage/dellemc/config.py
@@ -7,6 +7,6 @@ config_iv = t.Dict({
     tx.AliasedKey(["dell_username", "dell_admin"]): t.String(),
     t.Key("dell_password"): t.String(),
     t.Key("dell_api_version"): t.String(),
-    t.Key("dell_ifs_path"): tx.Path(type="dir"),
+    t.Key("dell_ifs_path"): tx.Path(type="dir", allow_nonexisting=True),
     t.Key("dell_system_name", default=None): t.Null | t.String(),
 }).allow_extra("*")


### PR DESCRIPTION
follow-up #2918 

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)