### PR TITLE
ci: octodog assign pr number to news fragment (#2358)

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:changelog') && github.event.pull_request.number != null && github.event.pull_request.merged == false }}
     uses: ./.github/workflows/pr-number-assign.yml
     secrets:
-      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+      WORKFLOW_PAT: ${{ secrets.OCTODOG }}
 
   towncrier:
     needs: [pr-number-assign]

--- a/changes/2358.misc.md
+++ b/changes/2358.misc.md
@@ -1,0 +1,1 @@
+Fix broken the workflow call for the action that auto-assigns PR numbers to news fragments


### PR DESCRIPTION
This is an backport PR of https://github.com/lablup/backend.ai/pull/2358 to the 24.03 release.