### PR TITLE
ci: Explicitly adding permissions because the default permissions have changed (#2265)

### DIFF
--- a/.github/workflows/timeline-check.yml
+++ b/.github/workflows/timeline-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
   merge_group:
+permissions:
+  contents: write
 
 jobs:
   pr-number-assign:


### PR DESCRIPTION
This is an backport PR of https://github.com/lablup/backend.ai/pull/2265 to the 24.03 release.