### PR TITLE
feat: Allow container user to join extra Linux groups

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -522,6 +522,10 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
                 computer_ctx.instance,
                 device_alloc,
             )
+
+            additional_gids = computer_ctx.instance.get_additional_gids()
+            environ["ADDITIONAL_GIDS"] = ",".join(map(str, additional_gids))
+
             for mount_info in accelerator_mounts:
                 _mount(mount_info.mode, mount_info.src_path, mount_info.dst_path.as_posix())
             alloc_sum = Decimal(0)

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -421,6 +421,13 @@ class AbstractComputePlugin(AbstractPlugin, metaclass=ABCMeta):
         """
         return []
 
+    def get_additional_gids(self) -> list[int]:
+        """
+        Override this function to pass the additional GIDs the 'work' user will belong to in the container.
+        This is useful when the accelerator plugin assumes that the 'work' is part of a specific group.
+        """
+        return []
+
 
 class ComputePluginContext(BasePluginContext[AbstractComputePlugin]):
     plugin_group = "backendai_accelerator_v21"

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -137,7 +137,7 @@ else
 
   # The gid 42 is a reserved gid for "shadow" to allow passwrd-based SSH login. (lablup/backend.ai#751)
   # Note that we also need to use our own patched version of su-exec to support multiple gids.
-  echo "Executing the main program: /opt/kernel/su-exec \"$USER_ID:$GROUP_ID,42\" \"$@\"..."
-  exec /opt/kernel/su-exec "$USER_ID:$GROUP_ID,42" "$@"
+  echo "Executing the main program: /opt/kernel/su-exec \"$USER_ID:$GROUP_ID${ADDITIONAL_GIDS:+,$ADDITIONAL_GIDS},42\" \"$@\"..."
+  exec /opt/kernel/su-exec "$USER_ID:$GROUP_ID${ADDITIONAL_GIDS:+,$ADDITIONAL_GIDS},42" "$@"
 
 fi


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #2850.

This PR modifies the `AbstractComputePlugin` interface by adding `get_additional_gids()`, allowing additional GIDs that the work user will belong to be specified through the accelerator plugin configuration.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

