### PR TITLE
fix: Set readonly flag to false when begin new generic txn

### DIFF
--- a/changes/2946.fix.md
+++ b/changes/2946.fix.md
@@ -1,0 +1,1 @@
+Set the `postgres_readonly` flag to `false` when begin generic sessions

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -103,7 +103,10 @@ class ExtendedAsyncSAEngine(SAEngine):
         """
         Begin generic transaction within the given connection.
         """
-        async with connection.begin():
+        conn_with_exec_opts = await connection.execution_options(
+            postgresql_readonly=False,
+        )
+        async with conn_with_exec_opts.begin():
             self._generic_txn_count += 1
             self._check_generic_txn_cnt()
             try:


### PR DESCRIPTION
`ExtendedAsyncSAEngine` begins readonly sessions by setting `postgres_readonly` flag of a given connection and it causes an error when any other generic transactions in the same connection try to insert or update.
```
<'asyncpg.exceptions.ReadOnlySQLTransactionError'>: cannot execute UPDATE in a read-only transaction
```
Let's set the `postgres_readonly` flag to false when begin generic sessions.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version