### PR TITLE
fix: Set readonly flag to false when begin new generic txn (#2946)

### DIFF
--- a/changes/2946.fix.md
+++ b/changes/2946.fix.md
@@ -1,0 +1,1 @@
+Set the `postgres_readonly` flag to `false` when begin generic sessions

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -103,7 +103,10 @@ class ExtendedAsyncSAEngine(SAEngine):
         """
         Begin generic transaction within the given connection.
         """
-        async with connection.begin():
+        conn_with_exec_opts = await connection.execution_options(
+            postgresql_readonly=False,
+        )
+        async with conn_with_exec_opts.begin():
             self._generic_txn_count += 1
             self._check_generic_txn_cnt()
             try:


### PR DESCRIPTION
This is an auto-generated backport PR of #2946 to the 24.09 release.