### PR TITLE
feat: Add `open_to_public` to filter and order of endpoint relay API

### DIFF
--- a/changes/2954.feature.md
+++ b/changes/2954.feature.md
@@ -1,0 +1,1 @@
+Allow `open_to_public` filter and order in endpoint.

--- a/changes/2954.feature.md
+++ b/changes/2954.feature.md
@@ -1,1 +1,1 @@
-Allow `open_to_public` filter and order in endpoint.
+Add filtering and ordering by `open_to_public` field in endpoint queries

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -771,6 +771,7 @@ class Endpoint(graphene.ObjectType):
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
         "lifecycle_stage": (EnumFieldItem("endpoints_lifecycle_stage", EndpointLifecycle), None),
+        "open_to_public": ("endpoints_open_to_public", None),
         "created_user_email": ("users_email", None),
     }
 
@@ -781,6 +782,7 @@ class Endpoint(graphene.ObjectType):
         "domain": ("endpoints_domain", None),
         "url": ("endpoints_url", None),
         "lifecycle_stage": (EnumFieldItem("endpoints_lifecycle_stage", EndpointLifecycle), None),
+        "open_to_public": ("endpoints_open_to_public", None),
         "created_user_email": ("users_email", None),
     }
 


### PR DESCRIPTION
follows https://github.com/lablup/backend.ai/pull/2805
This PR adds `open_to_public` to filter and order of endpoint relay API. 

**Checklist:**

- [x] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations