### PR TITLE
fix: Disallow `None` id encoding in `AsyncNode.to_global_id()` (#2898)

### DIFF
--- a/changes/2898.fix.md
+++ b/changes/2898.fix.md
@@ -1,0 +1,1 @@
+Disallow `None` id encoding in `AsyncNode.to_global_id()`.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1269,9 +1269,7 @@ type ContainerRegistryNode implements Node {
   """The ID of the object"""
   id: ID!
 
-  """
-  Added in 24.09.0. The undecoded UUID type id of DB container_registries row.
-  """
+  """Added in 24.09.0. The UUID type id of DB container_registries row."""
   row_id: UUID
   name: String
 

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -264,7 +264,7 @@ class ContainerRegistryNode(graphene.ObjectType):
         description = "Added in 24.09.0."
 
     row_id = graphene.UUID(
-        description="Added in 24.09.0. The undecoded UUID type id of DB container_registries row."
+        description="Added in 24.09.0. The UUID type id of DB container_registries row."
     )
     name = graphene.String()
     url = graphene.String(required=True, description="Added in 24.09.0.")

--- a/src/ai/backend/manager/models/gql_relay.py
+++ b/src/ai/backend/manager/models/gql_relay.py
@@ -143,8 +143,10 @@ class AsyncNode(Node):
         return await cls.get_node_from_global_id(info, id, only_type=only_type)
 
     @staticmethod
-    def to_global_id(type_, id) -> str:
-        return base64(f"{type_}:{id}")
+    def to_global_id(type_, id_) -> str:
+        if id_ is None:
+            raise Exception("Encoding None value as Global ID is not allowed.")
+        return base64(f"{type_}:{id_}")
 
     @classmethod
     def resolve_global_id(cls, info, global_id: str) -> tuple[str, str]:


### PR DESCRIPTION
This is an auto-generated backport PR of #2898 to the 24.09 release.