### PR TITLE
fix: Disallow `None` id encoding in `AsyncNode.to_global_id()` (#2898)

### DIFF
--- a/changes/2898.fix.md
+++ b/changes/2898.fix.md
@@ -1,0 +1,1 @@
+Disallow `None` id encoding in `AsyncNode.to_global_id()`.

--- a/src/ai/backend/manager/models/gql_relay.py
+++ b/src/ai/backend/manager/models/gql_relay.py
@@ -92,8 +92,10 @@ class AsyncNode(Node):
         return await cls.get_node_from_global_id(info, id, only_type=only_type)
 
     @staticmethod
-    def to_global_id(type_, id) -> str:
-        return base64(f"{type_}:{id}")
+    def to_global_id(type_, id_) -> str:
+        if id_ is None:
+            raise Exception("Encoding None value as Global ID is not allowed.")
+        return base64(f"{type_}:{id_}")
 
     @classmethod
     def resolve_global_id(cls, info, global_id: str) -> tuple[str, str]:


### PR DESCRIPTION
Backported-from: main
Backported-to: 23.09
Backported-of: 2898

