### PR TITLE
fix: Missing notification of bgtask cancellation or failure when shutting down the server (#2579)

### DIFF
--- a/changes/2579.fix.md
+++ b/changes/2579.fix.md
@@ -1,0 +1,1 @@
+Fix missing notification of cancellation or failure of background tasks when shutting down the server

--- a/src/ai/backend/common/bgtask.py
+++ b/src/ai/backend/common/bgtask.py
@@ -167,7 +167,11 @@ class BackgroundTaskManager:
                             else:
                                 await resp.send("{}", event="bgtask_done")
                             await resp.send("{}", event="server_close")
-                        case BgtaskCancelledEvent() | BgtaskFailedEvent():
+                        case BgtaskCancelledEvent():
+                            await resp.send(json.dumps(body), event="bgtask_cancelled")
+                            await resp.send("{}", event="server_close")
+                        case BgtaskFailedEvent():
+                            await resp.send(json.dumps(body), event="bgtask_failed")
                             await resp.send("{}", event="server_close")
             except:
                 log.exception("")


### PR DESCRIPTION
This is an auto-generated backport PR of #2579 to the 24.03 release.