### PR TITLE
fix: Handle IndexError when parse BinarySize

### DIFF
--- a/changes/2962.fix.md
+++ b/changes/2962.fix.md
@@ -1,0 +1,1 @@
+Handle `IndexError` when parse string to `BinarySize`

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -518,7 +518,7 @@ class BinarySize(int):
                         # has no suffix and is not an integer
                         # -> fractional bytes (e.g., 1.5 byte)
                         raise ValueError("Fractional bytes are not allowed")
-            except ArithmeticError:
+            except (ArithmeticError, IndexError):
                 raise ValueError("Unconvertible value", orig_expr, ending)
             try:
                 multiplier = cls.suffix_map[suffix]


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version