### PR TITLE
fix: Handle IndexError when parse BinarySize (#2962)

### DIFF
--- a/changes/2962.fix.md
+++ b/changes/2962.fix.md
@@ -1,0 +1,1 @@
+Handle `IndexError` when parse string to `BinarySize`

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -516,7 +516,7 @@ class BinarySize(int):
                         # has no suffix and is not an integer
                         # -> fractional bytes (e.g., 1.5 byte)
                         raise ValueError("Fractional bytes are not allowed")
-            except ArithmeticError:
+            except (ArithmeticError, IndexError):
                 raise ValueError("Unconvertible value", orig_expr, ending)
             try:
                 multiplier = cls.suffix_map[suffix]


### PR DESCRIPTION
This is an auto-generated backport PR of #2962 to the 24.09 release.