### PR TITLE
ci: Fix labeling of backport PRs due to missing github token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,8 @@ jobs:
           echo "labels<<EOF" >> $GITHUB_OUTPUT
           echo "$labels" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Get target milestones
         id: milestones
         if: ${{ steps.commit.outputs.pr_number }}


### PR DESCRIPTION
Follow-up #2508 
![CleanShot 2024-10-25 at 11 00 01@2x](https://github.com/user-attachments/assets/7528d921-4a62-4754-b7e2-27cfa875c30f)
The part calling labelinfo has been failing due to unauthorized permissions, but was not being tracked because it was not marked as fail.
Information about labels that may be essential for merging backport pr's, such as skip:changelog, was not being reflected, affecting backport automation.
Authorize via github.token authentication.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
