### PR TITLE
chore: Allow extra keys dummy agent configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ ENV/
 /dev.etcd.volumes.json
 /dev.etcd.installed.json
 /env-*.sh
-/agent.dummy.toml
+/*dummy*.toml
 /wsproxy.toml
 
 # Local temp and installer-generated directories

--- a/configs/agent/sample-dummy-config.toml
+++ b/configs/agent/sample-dummy-config.toml
@@ -15,7 +15,7 @@ missing = []
 
 
 [agent.resource.cpu]
-core-indexes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+num-core = 10
 
 
 [agent.resource.memory]

--- a/src/ai/backend/agent/dummy/config.py
+++ b/src/ai/backend/agent/dummy/config.py
@@ -15,12 +15,13 @@ dummy_local_config = t.Dict({
         t.Key("delay"): t.Dict({
             t.Key("scan-image", default=0.1): tx.Delay,
             t.Key("pull-image", default=1.0): tx.Delay,
+            t.Key("push-image", default=1.0): tx.Delay,
             t.Key("destroy-kernel", default=1.0): tx.Delay,
             t.Key("clean-kernel", default=1.0): tx.Delay,
             t.Key("create-network", default=1.0): tx.Delay,
             t.Key("destroy-network", default=1.0): tx.Delay,
             t.Key("destroy-network", default=1.0): tx.Delay,
-        }),
+        }).allow_extra("*"),
         t.Key("image"): t.Dict({
             t.Key("already-have", default=None): t.Null | t.List(t.String),
             t.Key("need-to-pull", default=None): t.Null | t.List(t.String),
@@ -34,7 +35,7 @@ dummy_local_config = t.Dict({
                 t.Key("size", default=34359738368): t.Int,
             }),
         }),
-    }),
+    }).allow_extra("*"),
     t.Key("kernel-creation-ctx"): t.Dict({
         t.Key("delay"): t.Dict({
             t.Key("prepare-scratch", default=1.0): tx.Delay,
@@ -62,4 +63,4 @@ dummy_local_config = t.Dict({
             t.Key("list-files", default=0.1): tx.Delay,
         }),
     }),
-})
+}).allow_extra("*")

--- a/src/ai/backend/agent/dummy/config.py
+++ b/src/ai/backend/agent/dummy/config.py
@@ -7,7 +7,7 @@ from ai.backend.common import validators as tx
 DEFAULT_CONFIG_PATH = Path.cwd() / "agent.dummy.toml"
 
 RandomRange = t.Tuple(t.ToFloat, t.ToFloat)
-core_idx = {0, 1, 2, 3, 4}
+num_core = 4
 
 
 dummy_local_config = t.Dict({
@@ -29,7 +29,7 @@ dummy_local_config = t.Dict({
         }),
         t.Key("resource"): t.Dict({
             t.Key("cpu"): t.Dict({
-                t.Key("core-indexes", default=core_idx): tx.ToSet,
+                t.Key("num-core", default=num_core): t.ToInt,
             }),
             t.Key("memory"): t.Dict({
                 t.Key("size", default=34359738368): t.Int,

--- a/src/ai/backend/agent/dummy/intrinsic.py
+++ b/src/ai/backend/agent/dummy/intrinsic.py
@@ -79,7 +79,7 @@ class CPUPlugin(AbstractComputePlugin):
         }
 
     async def list_devices(self) -> Collection[AbstractComputeDevice]:
-        num_core: int = self.resource_config["cpu"]["num_core"]
+        num_core: int = self.resource_config["cpu"]["num-core"]
         return [
             CPUDevice(
                 device_id=DeviceId(str(core_idx)),

--- a/src/ai/backend/agent/dummy/intrinsic.py
+++ b/src/ai/backend/agent/dummy/intrinsic.py
@@ -79,7 +79,7 @@ class CPUPlugin(AbstractComputePlugin):
         }
 
     async def list_devices(self) -> Collection[AbstractComputeDevice]:
-        cores = self.resource_config["cpu"]["core-indexes"]
+        num_core: int = self.resource_config["cpu"]["num_core"]
         return [
             CPUDevice(
                 device_id=DeviceId(str(core_idx)),
@@ -88,7 +88,7 @@ class CPUPlugin(AbstractComputePlugin):
                 memory_size=0,
                 processing_units=1,
             )
-            for core_idx in sorted(cores)
+            for core_idx in range(num_core)
         ]
 
     async def available_slots(self) -> Mapping[SlotName, Decimal]:

--- a/tests/agent/test_resources.py
+++ b/tests/agent/test_resources.py
@@ -197,7 +197,7 @@ async def test_allocate_rollback(monkeypatch):
         {},
         local_config,
         {
-            "agent": {"resource": {"cpu": {"core-indexes": [0, 1]}}},
+            "agent": {"resource": {"cpu": {"num-core": 2}}},
         },
     )
     mem_plugin = MemoryPlugin(


### PR DESCRIPTION
follow-up #2253 

- Allow extra keys dummy agent configs
- Change `core-indexes` to `num-cores` for easy config setup
- Update `.gitignore` to exclude any dummy config toml files

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version