### PR TITLE
fix: Wrong parameter when call 'recalc_agent_resource_occupancy()'

### DIFF
--- a/changes/2982.fix.md
+++ b/changes/2982.fix.md
@@ -1,0 +1,1 @@
+Fix a wrong parameter when call 'recalc_agent_resource_occupancy()'


### PR DESCRIPTION
`manager.models.agent.recalc_agent_resource_occupancy()` accepts an SQLAlchemy AsyncSession type object rather than SQLAlchemy AsyncConnection type object.
This causes error since the result of AsyncSession.scalars() and AsyncConnection.scalars() are different

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version