### PR TITLE
fix: Wrong parameter when call 'recalc_agent_resource_occupancy()' (#2982)

### DIFF
--- a/changes/2982.fix.md
+++ b/changes/2982.fix.md
@@ -1,0 +1,1 @@
+Fix a wrong parameter when call 'recalc_agent_resource_occupancy()'


### PR DESCRIPTION
This is a backported PR of https://github.com/lablup/backend.ai/pull/2982 to the 24.09 release.
