### PR TITLE
fix: Wrong `password` limit in container registry migration script

### DIFF
--- a/changes/2986.fix.md
+++ b/changes/2986.fix.md
@@ -1,1 +1,1 @@
-Fix wrong password limit in containe registry migration script.
+Fix wrong password limit in container registry migration script.

--- a/changes/2986.fix.md
+++ b/changes/2986.fix.md
@@ -1,0 +1,1 @@
+Fix wrong password limit in containe registry migration script.

--- a/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
+++ b/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
@@ -369,7 +369,7 @@ def upgrade():
         ),
         sa.Column("project", sa.String(length=255), nullable=False, index=True),
         sa.Column("username", sa.String(length=255), nullable=True),
-        sa.Column("password", sa.String(length=255), nullable=True),
+        sa.Column("password", sa.String(), nullable=True),
         sa.Column(
             "ssl_verify", sa.Boolean(), server_default=sa.text("true"), nullable=True, index=True
         ),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Hotfix of https://github.com/lablup/backend.ai/pull/1917 migration script.

Remove the incorrect length restriction applied to the password field in the existing migration script.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

