### PR TITLE
fix: architecture condition not applied when querying image rows (#2989)

### DIFF
--- a/changes/2989.fix.md
+++ b/changes/2989.fix.md
@@ -1,0 +1,1 @@
+Fix `architecture` condition not applied when query `images` rows

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -278,7 +278,7 @@ class ImageRow(Base):
     ) -> ImageRow:
         query = sa.select(ImageRow).where(
             (ImageRow.name == identifier.canonical)
-            and (ImageRow.architecture == identifier.architecture)
+            & (ImageRow.architecture == identifier.architecture)
         )
 
         if load_aliases:


### PR DESCRIPTION
This is an auto-generated backport PR of #2989 to the 24.09 release.