### PR TITLE
fix: Strengthen join condition between kernels and images

### DIFF
--- a/changes/2993.fix.md
+++ b/changes/2993.fix.md
@@ -1,1 +1,1 @@
-Set more strict join condition between kernels and images
+Strengthen join condition between kernels and images to prevent incorrect matches

--- a/changes/2993.fix.md
+++ b/changes/2993.fix.md
@@ -1,0 +1,1 @@
+Set more strict join condition between kernels and images

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -562,7 +562,7 @@ class KernelRow(Base):
     image_row = relationship(
         "ImageRow",
         foreign_keys="KernelRow.image",
-        primaryjoin="KernelRow.image == ImageRow.name",
+        primaryjoin="and_(KernelRow.image == ImageRow.name, KernelRow.architecture == ImageRow.architecture)",
     )
     agent_row = relationship("AgentRow", back_populates="kernels")
     group_row = relationship("GroupRow", back_populates="kernels")


### PR DESCRIPTION
Currently `KernelRow.image_row` requires a join on `kernels.image` and `images.name` column which is not unique.
e.g. multiarch images may have multiple records with the same name value and in different architecture values.

Let's apply a strict join condition by check `architecture` column

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version