### PR TITLE
fix: Strengthen join condition between kernels and images (#2993)

### DIFF
--- a/changes/2993.fix.md
+++ b/changes/2993.fix.md
@@ -1,0 +1,1 @@
+Strengthen join condition between kernels and images to prevent incorrect matches

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -536,7 +536,7 @@ class KernelRow(Base):
     image_row = relationship(
         "ImageRow",
         foreign_keys="KernelRow.image",
-        primaryjoin="KernelRow.image == ImageRow.name",
+        primaryjoin="and_(KernelRow.image == ImageRow.name, KernelRow.architecture == ImageRow.architecture)",
     )
     agent_row = relationship("AgentRow", back_populates="kernels")
     group_row = relationship("GroupRow", back_populates="kernels")


### PR DESCRIPTION
This is an auto-generated backport PR of #2993 to the 24.03 release.