### PR TITLE
fix: customized image not pushed when target registry diverges

### DIFF
--- a/changes/2997.fix.md
+++ b/changes/2997.fix.md
@@ -1,0 +1,1 @@
+Enable session commit to different registry, project.

--- a/src/ai/backend/common/docker.py
+++ b/src/ai/backend/common/docker.py
@@ -373,7 +373,7 @@ class ImageRef:
     """
 
     name: str
-    project: str
+    project: str | None
     tag: str
     registry: str
     architecture: str
@@ -383,7 +383,7 @@ class ImageRef:
     def from_image_str(
         cls,
         image_str: str,
-        project: str,
+        project: str | None,
         registry: str,
         *,
         architecture: str = "x86_64",
@@ -395,7 +395,9 @@ class ImageRef:
 
         parsed = cls.parse_image_str(image_str, registry)
 
-        if parsed.project_and_image_name == project:
+        if not project:
+            image_name = parsed.project_and_image_name
+        elif parsed.project_and_image_name == project:
             image_name = ""
         else:
             if not parsed.project_and_image_name.startswith(f"{project}/"):

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1155,8 +1155,8 @@ async def convert_session_to_image(
         query = (
             sa.select(ContainerRegistryRow)
             .where(
-                ContainerRegistryRow.registry_name == registry_hostname
-                and ContainerRegistryRow.project == registry_project
+                (ContainerRegistryRow.registry_name == registry_hostname)
+                & (ContainerRegistryRow.project == registry_project)
             )
             .options(
                 load_only(
@@ -1192,7 +1192,14 @@ async def convert_session_to_image(
                 x for x in base_image_ref.tag.split("-") if not x.startswith("customized_")
             ]
 
-            new_canonical = f"{registry_hostname}/{base_image_ref.project}/{base_image_ref.name}:{"-".join(filtered_tag_set)}"
+            if base_image_ref.name == "":
+                new_name = base_image_ref.project
+            else:
+                new_name = base_image_ref.name
+
+            new_canonical = (
+                f"{registry_hostname}/{registry_project}/{new_name}:{"-".join(filtered_tag_set)}"
+            )
 
             async with root_ctx.db.begin_readonly_session() as sess:
                 # check if user has passed its limit of customized image count
@@ -1244,8 +1251,8 @@ async def convert_session_to_image(
             new_canonical += f"-customized_{customized_image_id.replace("-", "")}"
             new_image_ref = ImageRef.from_image_str(
                 new_canonical,
-                base_image_ref.project,
-                base_image_ref.registry,
+                None,
+                registry_hostname,
                 architecture=base_image_ref.architecture,
                 is_local=base_image_ref.is_local,
             )

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -143,6 +143,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
         project = image.project
         repository = image.name
 
+        if project is None:
+            raise ValueError("project is required for Harbor registry")
+
         base_url = (
             self.registry_url
             / "api"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Modifies the existing incorrect code to allow committing and uploading sessions to different types of registries and other projects.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--2997.org.readthedocs.build/en/2997/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--2997.org.readthedocs.build/ko/2997/

<!-- readthedocs-preview sorna-ko end -->