### PR TITLE
fix: Wrong field reference in `ImageNode` resolver (#3002)

### DIFF
--- a/changes/3002.fix.md
+++ b/changes/3002.fix.md
@@ -1,0 +1,1 @@
+Wrong field reference in `ImageNode` resolver

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -379,7 +379,7 @@ class ImageNode(graphene.ObjectType):
             registry=row.registry,
             architecture=row.architecture,
             is_local=row.is_local,
-            digest=row.trimmed_digest,
+            digest=row.digest,
             labels=row.labels,
             size_bytes=row.size_bytes,
             resource_limits=row.resource_limits,


### PR DESCRIPTION
This is an auto-generated backport PR of #3002 to the 24.09 release.