### PR TITLE
fix: Obsolete logic of `untag()` of `HarborRegistry_v2` (#3004)

### DIFF
--- a/changes/3004.fix.md
+++ b/changes/3004.fix.md
@@ -1,0 +1,1 @@
+Fix obsolete logic of `untag()` of `HarborRegistry_v2`.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -140,7 +140,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         image: ImageRef,
     ) -> None:
-        project, repository = image.name.split("/", maxsplit=1)
+        project = image.project
+        repository = image.name
+
         base_url = (
             self.registry_url
             / "api"
@@ -152,10 +154,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
             / "artifacts"
             / image.tag
         )
-        username = self.registry_info["username"]
+        username = self.registry_info.username
         if username is not None:
             self.credentials["username"] = username
-        password = self.registry_info["password"]
+        password = self.registry_info.password
         if password is not None:
             self.credentials["password"] = password
 


### PR DESCRIPTION
This is an auto-generated backport PR of #3004 to the 24.09 release.