### PR TITLE
feat: add pipeline menu to blocklist in webserver configs

### DIFF
--- a/changes/3010.feature.md
+++ b/changes/3010.feature.md
@@ -1,0 +1,1 @@
+Hide FastTrack (`pipeline`) menu by default on installation by `install-dev.sh` script.

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -39,7 +39,7 @@ jwt.secret = "7<:~[X,^Z1XM!*,Pe:PHR!bv,H~Q#l177<7gf_XHD6.<*<.t<[o|V5W(=0x:jTh-"
 
 [ui]
 brand = "Lablup Cloud"
-#menu_blocklist = "statistics,pipeline"
+menu_blocklist = "pipeline"
 
 [api]
 domain = "default"

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -119,7 +119,7 @@ brand = "Lablup Cloud"
 # Default environment to import GitHub repositories / notebooks
 # default_import_environment = 'index.docker.io/lablup/python:3.6-ubuntu18.04'
 # Comma-separated sidebar menu pages to hide
-#menu_blocklist = "pipeline"
+menu_blocklist = "pipeline"
 # Comma-separated sidebar menu pages to disable
 #menu_inactivelist = "statistics"
 # Enable/disable the LLM Playground tab in the service page


### PR DESCRIPTION

This PR blocks the pipeline menu by default in both sample and halfstack configurations of webserver component which is copied during installation, since FastTrack is opened for enterprise only, and should not be exposed in open source installation.

**Checklist:**

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations