### PR TITLE
fix: Add missing resolver of `Agent.compute_containers` GraphQL field

### DIFF
--- a/changes/3011.fix.md
+++ b/changes/3011.fix.md
@@ -1,0 +1,1 @@
+Fix `Agent.compute_containers` GraphQL field by adding missing resolver

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -383,9 +383,9 @@ class Agent(graphene.ObjectType):
     ) -> list[ComputeContainer]:
         ctx: GraphQueryContext = info.context
         _status = KernelStatus[status] if status is not None else None
-        loader = ctx.dataloader_manager.get_loader(
+        loader = ctx.dataloader_manager.get_loader_by_func(
             ctx,
-            "ComputeContainer.by_agent_id",
+            ComputeContainer.batch_load_by_agent_id,
             status=_status,
         )
         return await loader.load(self.id)

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -35,6 +35,7 @@ from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.types import (
     AccessKey,
+    AgentId,
     BinarySize,
     ClusterMode,
     KernelId,
@@ -72,6 +73,7 @@ from .base import (
     StructuredJSONObjectListColumn,
     URLColumn,
     batch_multiresult,
+    batch_multiresult_in_scalar_stream,
     batch_result,
 )
 from .gql_models.image import ImageNode
@@ -1094,6 +1096,31 @@ class ComputeContainer(graphene.ObjectType):
                 cls,
                 session_ids,
                 lambda row: row.session_id,
+            )
+
+    @classmethod
+    async def batch_load_by_agent_id(
+        cls,
+        ctx: GraphQueryContext,
+        agent_ids: Sequence[AgentId],
+        *,
+        status: Optional[KernelStatus] = None,
+    ) -> Sequence[Sequence[ComputeContainer]]:
+        query_stmt = (
+            sa.select(KernelRow)
+            .where(KernelRow.agent.in_(agent_ids))
+            .options(selectinload(KernelRow.image_row).options(selectinload(ImageRow.aliases)))
+        )
+        if status is not None:
+            query_stmt = query_stmt.where(KernelRow.status == status)
+        async with ctx.db.begin_readonly_session() as db_session:
+            return await batch_multiresult_in_scalar_stream(
+                ctx,
+                db_session,
+                query_stmt,
+                cls,
+                agent_ids,
+                lambda row: row.agent,
             )
 
     @classmethod


### PR DESCRIPTION
### Example
```graphql
query AgentList {
    agent_list(limit: 10, offset: 0) {
        items {
            id
            status
            # live_stat
            compute_containers(status: "RUNNING") {
                status
                kernel_id
            }
        }
        total_count
    }
}

```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)