### PR TITLE
fix: `Agent` GQL Regression error

### DIFF
--- a/changes/3013.fix.md
+++ b/changes/3013.fix.md
@@ -1,0 +1,1 @@
+Fix `Agent` GQL Regression error.

--- a/src/ai/backend/manager/models/__init__.py
+++ b/src/ai/backend/manager/models/__init__.py
@@ -22,6 +22,7 @@ from . import storage as _storage
 from . import user as _user
 from . import vfolder as _vfolder
 from .base import metadata
+from .gql_models import agent as _relay_agent
 from .gql_models import kernel as _relay_kernel
 from .gql_models import session as _relay_session
 
@@ -50,6 +51,7 @@ __all__ = (
     *_sessiontemplate.__all__,
     *_storage.__all__,
     *_errorlogs.__all__,
+    *_relay_agent.__all__,
     *_relay_kernel.__all__,
     *_relay_session.__all__,
 )
@@ -77,5 +79,6 @@ from .session_template import *  # noqa
 from .storage import *  # noqa
 from .user import *  # noqa
 from .vfolder import *  # noqa
+from .gql_models.agent import *  # noqa
 from .gql_models.kernel import *  # noqa
 from .gql_models.session import *  # noqa

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -753,6 +753,8 @@ class DataLoaderManager:
         self,
         context: ContextT,
         batch_load_func: Callable[[ContextT, Sequence[LoaderKeyT]], Awaitable[LoaderResultT]],
+        *args,
+        **kwargs,
     ) -> DataLoader:
         key = self._get_func_key(batch_load_func)
         loader = self.cache.get(key)
@@ -761,6 +763,8 @@ class DataLoaderManager:
                 functools.partial(
                     batch_load_func,
                     context,
+                    *args,
+                    **kwargs,
                 ),
                 max_batch_size=128,
             )

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -881,9 +881,9 @@ class Queries(graphene.ObjectType):
         agent_id: AgentId,
     ) -> Agent:
         ctx: GraphQueryContext = info.context
-        loader = ctx.dataloader_manager.get_loader(
+        loader = ctx.dataloader_manager.get_loader_by_func(
             ctx,
-            "Agent",
+            Agent.batch_load,
             raw_status=None,
         )
         return await loader.load(agent_id)

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -59,6 +59,11 @@ from .kernel import KernelConnection, KernelNode
 if TYPE_CHECKING:
     from ..gql import GraphQueryContext
 
+__all__ = (
+    "Agent",
+    "AgentNode",
+    "AgentConnection",
+)
 
 _queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
     "id": ("id", None),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Fix regression of #2873.

Currently, attempting to use Agent GQL results in the following error.
It appears that this is due to the file location change of the Agent model not being handled properly in #2873.

```
2024-11-02 21:29:11.033 ERROR ai.backend.manager.api.admin [32559] ADMIN.GQL Exception: {'message': "module 'ai.backend.manager.models' has no attribute 'Agent'", 'locations': [{'line': 2, 'column': 3}], 'path': ['agent']}
2024-11-02 21:29:11.038 DEBUG ai.backend.manager.api.admin [32559] Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/graphql/execution/execute.py", line 530, in await_result
    return_type, field_nodes, info, path, await result
                                          ^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 978, in wrapped
    return await func(root, info, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/gql.py", line 884, in resolve_agent
    loader = ctx.dataloader_manager.get_loader(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 734, in get_loader
    objtype = getattr(self.mod, objtype_name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
graphql.error.graphql_error.GraphQLError: module 'ai.backend.manager.models' has no attribute 'Agent'

GraphQL request:2:3
1 | query ($agent_id: String!) {
2 |   agent(agent_id: $agent_id) {
  |   ^
3 |     lost_at
```



**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
