### PR TITLE
fix: `backend.ai apps` command's faulty argument handling logic

### DIFF
--- a/changes/3015.fix.md
+++ b/changes/3015.fix.md
@@ -1,0 +1,1 @@
+Fix `backend.ai apps` command's faulty argument handling logic.

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -343,7 +343,7 @@ def apps(session_name, app_name, list_names):
             compute_session = api_session.ComputeSession(session_name)
             apps = await compute_session.stream_app_info()
             if len(app_name) > 0:
-                apps = list(filter(lambda x: x["name"] in app_name))
+                apps = [app for app in apps if app["name"] in app_name]
         if list_names:
             print_info(
                 "This session provides the following app services: {0}".format(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

The following command currently raises the following error due to an issue with the filtering logic.

```
❯ ./backend.ai apps pysession sshd ttyd
✘ TypeError: filter expected 2 arguments, got 1
  *** Traceback ***
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/client/cli/app.py", line 370, in apps
      asyncio_run(print_arguments())
    File "/Users/jopemachine/.pyenv/versions/3.12.6/lib/python3.12/asyncio/runners.py", line 194, in run
      return runner.run(main)
             ^^^^^^^^^^^^^^^^
    File "/Users/jopemachine/.pyenv/versions/3.12.6/lib/python3.12/asyncio/runners.py", line 118, in run
      return self._loop.run_until_complete(task)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/jopemachine/.pyenv/versions/3.12.6/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
      return future.result()
             ^^^^^^^^^^^^^^^
    File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/client/cli/app.py", line 346, in print_arguments
      apps = list(filter(lambda x: x["name"] in app_name))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR modifies the faulty filtering logic to ensure the command functions correctly.

```
❯ ./backend.ai apps pysession sshd ttyd
∙ Service sshd does not have customizable arguments.
∙ Service ttyd does not have customizable arguments.
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version