### PR TITLE
feat: Add `canonical` field to `Image`, `ImageNode` GQL API

### DIFF
--- a/changes/3016.feature.md
+++ b/changes/3016.feature.md
@@ -1,0 +1,1 @@
+Add `canonical` field to `Image`, `ImageNode` GQL API.

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -1576,7 +1576,7 @@ type Mutations {
 
   """
   Completely delete domain from DB.
-
+  
   Domain-bound kernels will also be all deleted.
   To purge domain, there should be no users and groups in the target domain.
   """
@@ -1595,7 +1595,7 @@ type Mutations {
 
   """
   Completely deletes a group from DB.
-
+  
   Group's vfolders and their data will also be lost
   as well as the kernels run from the group.
   There is no migration of the ownership for group folders.
@@ -1606,23 +1606,23 @@ type Mutations {
 
   """
   Instead of really deleting user, just mark the account as deleted status.
-
+  
   All related keypairs will also be inactivated.
   """
   delete_user(email: String!): DeleteUser
 
   """
   Delete user as well as all user-related DB informations such as keypairs, kernels, etc.
-
+  
   If target user has virtual folders, they can be purged together or migrated to the superadmin.
-
+  
   vFolder treatment policy:
     User-type:
     - vfolder is not shared: delete
     - vfolder is shared:
       + if purge_shared_vfolder is True: delete
       + else: change vfolder's owner to requested admin
-
+  
   This action cannot be undone.
   """
   purge_user(email: String!, props: PurgeUserInput!): PurgeUser

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -338,7 +338,7 @@ type ImageNode implements Node {
   """Added in 24.03.4. The array of image aliases."""
   aliases: [String]
 
-  """Added in 24.09.0"""
+  """Added in 24.12.0"""
   canonical: String
 }
 
@@ -767,7 +767,7 @@ type Image {
   installed_agents: [String]
   hash: String
 
-  """Added in 24.09.0"""
+  """Added in 24.12.0"""
   canonical: String
 }
 

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -337,6 +337,9 @@ type ImageNode implements Node {
 
   """Added in 24.03.4. The array of image aliases."""
   aliases: [String]
+
+  """Added in 24.12.0"""
+  canonical: String
 }
 
 type KVPair {
@@ -763,6 +766,9 @@ type Image {
   installed: Boolean
   installed_agents: [String]
   hash: String
+
+  """Added in 24.12.0"""
+  canonical: String
 }
 
 type User implements Item {
@@ -1570,7 +1576,7 @@ type Mutations {
 
   """
   Completely delete domain from DB.
-  
+
   Domain-bound kernels will also be all deleted.
   To purge domain, there should be no users and groups in the target domain.
   """
@@ -1589,7 +1595,7 @@ type Mutations {
 
   """
   Completely deletes a group from DB.
-  
+
   Group's vfolders and their data will also be lost
   as well as the kernels run from the group.
   There is no migration of the ownership for group folders.
@@ -1600,23 +1606,23 @@ type Mutations {
 
   """
   Instead of really deleting user, just mark the account as deleted status.
-  
+
   All related keypairs will also be inactivated.
   """
   delete_user(email: String!): DeleteUser
 
   """
   Delete user as well as all user-related DB informations such as keypairs, kernels, etc.
-  
+
   If target user has virtual folders, they can be purged together or migrated to the superadmin.
-  
+
   vFolder treatment policy:
     User-type:
     - vfolder is not shared: delete
     - vfolder is shared:
       + if purge_shared_vfolder is True: delete
       + else: change vfolder's owner to requested admin
-  
+
   This action cannot be undone.
   """
   purge_user(email: String!, props: PurgeUserInput!): PurgeUser

--- a/src/ai/backend/manager/api/schema.graphql
+++ b/src/ai/backend/manager/api/schema.graphql
@@ -338,7 +338,7 @@ type ImageNode implements Node {
   """Added in 24.03.4. The array of image aliases."""
   aliases: [String]
 
-  """Added in 24.12.0"""
+  """Added in 24.09.0"""
   canonical: String
 }
 
@@ -767,7 +767,7 @@ type Image {
   installed_agents: [String]
   hash: String
 
-  """Added in 24.12.0"""
+  """Added in 24.09.0"""
   canonical: String
 }
 

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -96,7 +96,7 @@ class Image(graphene.ObjectType):
     # internal attributes
     raw_labels: dict[str, Any]
 
-    canonical = graphene.String(description="Added in 24.12.0")
+    canonical = graphene.String(description="Added in 24.09.0")
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")
@@ -338,7 +338,7 @@ class ImageNode(graphene.ObjectType):
         graphene.String, description="Added in 24.03.4. The array of image aliases."
     )
 
-    canonical = graphene.String(description="Added in 24.12.0")
+    canonical = graphene.String(description="Added in 24.09.0")
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -100,7 +100,7 @@ class Image(graphene.ObjectType):
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")
-        return join(self.registry, self.name, self.tag)
+        return f"{join(self.registry, self.name)}:{self.tag}"
 
     @classmethod
     def populate_row(
@@ -342,7 +342,7 @@ class ImageNode(graphene.ObjectType):
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")
-        return join(self.registry, self.name, self.tag)
+        return f"{join(self.registry, self.name)}:{self.tag}"
 
     @overload
     @classmethod

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from collections.abc import MutableMapping, Sequence
 from decimal import Decimal
@@ -26,6 +27,7 @@ from ai.backend.common.exception import UnknownImageReference
 from ai.backend.common.types import (
     ImageAlias,
 )
+from ai.backend.common.utils import join_non_empty
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow, ContainerRegistryType
 
@@ -93,6 +95,12 @@ class Image(graphene.ObjectType):
 
     # internal attributes
     raw_labels: dict[str, Any]
+
+    canonical = graphene.String(description="Added in 24.12.0")
+
+    def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
+        join = functools.partial(join_non_empty, sep="/")
+        return join(self.registry, self.name, self.tag)
 
     @classmethod
     def populate_row(
@@ -329,6 +337,12 @@ class ImageNode(graphene.ObjectType):
     aliases = graphene.List(
         graphene.String, description="Added in 24.03.4. The array of image aliases."
     )
+
+    canonical = graphene.String(description="Added in 24.12.0")
+
+    def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
+        join = functools.partial(join_non_empty, sep="/")
+        return join(self.registry, self.name, self.tag)
 
     @overload
     @classmethod

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -96,7 +96,7 @@ class Image(graphene.ObjectType):
     # internal attributes
     raw_labels: dict[str, Any]
 
-    canonical = graphene.String(description="Added in 24.09.0")
+    canonical = graphene.String(description="Added in 24.12.0")
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")
@@ -338,7 +338,7 @@ class ImageNode(graphene.ObjectType):
         graphene.String, description="Added in 24.03.4. The array of image aliases."
     )
 
-    canonical = graphene.String(description="Added in 24.09.0")
+    canonical = graphene.String(description="Added in 24.12.0")
 
     def resolve_canonical(self, info: graphene.ResolveInfo) -> str:
         join = functools.partial(join_non_empty, sep="/")


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

On the client side, it would be more convenient to query a field called `canonical` directly rather than querying and combining multiple fields (`registry_name`, `project`, `name`, `is_local` ... ) each time a canonical name is needed.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

