### PR TITLE
fix: `backend.ai apps` command's faulty argument handling logic (#3015)

### DIFF
--- a/changes/3015.fix.md
+++ b/changes/3015.fix.md
@@ -1,0 +1,1 @@
+Fix `backend.ai apps` command's faulty argument handling logic.

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -343,7 +343,7 @@ def apps(session_name, app_name, list_names):
             compute_session = api_session.ComputeSession(session_name)
             apps = await compute_session.stream_app_info()
             if len(app_name) > 0:
-                apps = list(filter(lambda x: x["name"] in app_name))
+                apps = [app for app in apps if app["name"] in app_name]
         if list_names:
             print_info(
                 "This session provides the following app services: {0}".format(


### PR DESCRIPTION
Backported-from: main
Backported-to: 24.09
Backported-of: 3015

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
