### PR TITLE
fix: `backend.ai apps` command's faulty argument handling logic (#3015)

### DIFF
--- a/changes/3015.fix.md
+++ b/changes/3015.fix.md
@@ -1,0 +1,1 @@
+Fix `backend.ai apps` command's faulty argument handling logic.

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -343,7 +343,7 @@ def apps(session_name, app_name, list_names):
             compute_session = api_session.ComputeSession(session_name)
             apps = await compute_session.stream_app_info()
             if len(app_name) > 0:
-                apps = list(filter(lambda x: x["name"] in app_name))
+                apps = [app for app in apps if app["name"] in app_name]
         if list_names:
             print_info(
                 "This session provides the following app services: {0}".format(


### PR DESCRIPTION
Backported-from: main
Backported-to: 23.09
Backported-of: 3015
