### PR TITLE
fix: Check Vast data quota with the given quota name exists

### DIFF
--- a/changes/3023.fix.md
+++ b/changes/3023.fix.md
@@ -1,0 +1,1 @@
+Check Vast data quota with a given name exists before creating quota and change default value of `force_login` config to true

--- a/src/ai/backend/storage/vast/config.py
+++ b/src/ai/backend/storage/vast/config.py
@@ -19,7 +19,7 @@ config_iv = t.Dict({
     t.Key("vast_username"): t.String(),
     t.Key("vast_password"): t.String(),
     t.Key("vast_verify_ssl", default=False): t.ToBool(),
-    t.Key("vast_force_login", default=False): t.ToBool(),
+    t.Key("vast_force_login", default=True): t.ToBool(),
     t.Key("vast_api_version", default=APIVersion.V2): tx.Enum(APIVersion),
     t.Key("vast_cluster_id", default=DEFAULT_CLUSTER_ID): t.Int,
     t.Key("vast_storage_base_dir", default="/"): t.String(),

--- a/src/ai/backend/storage/vast/vastdata_client.py
+++ b/src/ai/backend/storage/vast/vastdata_client.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import ssl
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Mapping, NewType, TypedDict
+from typing import Any, Mapping, NewType, Optional, TypedDict
 
 import aiohttp
 import jwt
@@ -27,6 +27,7 @@ from .exceptions import (
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
+TOKEN_EXPIRATION_BUFFER = timedelta(minutes=1)
 
 VASTQuotaID = NewType("VASTQuotaID", str)
 
@@ -134,7 +135,7 @@ class VASTAPIClient:
         api_version: APIVersion,
         storage_base_dir: str,
         ssl: ssl.SSLContext | bool = False,
-        force_login: bool = False,
+        force_login: bool = True,
     ) -> None:
         self.api_endpoint = URL(endpoint)
         self.api_version = api_version
@@ -173,18 +174,21 @@ class VASTAPIClient:
 
         if self._auth_token is None:
             return await self._login()
-        elif get_exp_dt(self._auth_token["access_token"]) > current_dt:
+        elif get_exp_dt(self._auth_token["access_token"]) > current_dt + TOKEN_EXPIRATION_BUFFER:
             # The access token has not expired yet
             # Auth requests using the access token
             return
-        elif get_exp_dt(self._auth_token["refresh_token"]) > current_dt:
+        elif get_exp_dt(self._auth_token["refresh_token"]) > current_dt + TOKEN_EXPIRATION_BUFFER:
             # The access token has expired but the refresh token has not expired
             # Refresh tokens
             return await self._refresh()
         return await self._login()
 
     def _parse_token(self, data: Mapping[str, Any]) -> None:
-        self._auth_token = TokenPair(access_token=data["access"], refresh_token=data["refresh"])
+        try:
+            self._auth_token = TokenPair(access_token=data["access"], refresh_token=data["refresh"])
+        except KeyError:
+            raise VASTAPIError(f"Cannot parse token with given data (d:{str(data)})")
 
     async def _refresh(self) -> None:
         if self._auth_token is None:
@@ -226,7 +230,8 @@ class VASTAPIClient:
         sess: aiohttp.ClientSession,
         method: RequestMethod,
         path: str,
-        body: Mapping[str, Any] | None = None,
+        body: Optional[Mapping[str, Any]] = None,
+        params: Optional[Mapping[str, Any]] = None,
     ) -> aiohttp.ClientResponse:
         await self._validate_token()
 
@@ -243,9 +248,37 @@ class VASTAPIClient:
                 raise VASTAPIError(f"Unsupported request method {method}")
 
         real_rel_path = URL("/api/") / str(self.api_version) / path
-        return await func(real_rel_path, headers=self._req_header, json=body, ssl=self.ssl_context)
+        try:
+            return await func(
+                real_rel_path,
+                headers=self._req_header,
+                json=body,
+                params=params,
+                ssl=self.ssl_context,
+            )
+        except (
+            VASTAPIError,
+            VASTUnauthorizedError,
+            VASTUnknownError,
+            VASTInvalidParameterError,
+        ) as e:
+            log.warning(
+                f"Error occurs during communicating with Vast data API. Login and retry (e:{repr(e)})"
+            )
+            await self._login()
+            return await func(
+                real_rel_path,
+                headers=self._req_header,
+                json=body,
+                params=params,
+                ssl=self.ssl_context,
+            )
 
-    async def list_quotas(self) -> list[VASTQuota]:
+    async def list_quotas(self, qname: Optional[str] = None) -> list[VASTQuota]:
+        if qname is not None:
+            params = {"name": qname}
+        else:
+            params = None
         async with aiohttp.ClientSession(
             base_url=self.api_endpoint,
         ) as sess:
@@ -253,6 +286,7 @@ class VASTAPIClient:
                 sess,
                 GET,
                 "quotas/",
+                params=params,
             )
             data: list[Mapping[str, Any]] = await response.json()
         return [VASTQuota.from_json(info) for info in data]
@@ -313,7 +347,7 @@ class VASTAPIClient:
                 case 201 | 200:
                     pass
                 case 400 | 401:
-                    raise VASTInvalidParameterError
+                    raise VASTInvalidParameterError(f"Invalid parameter (data:{str(data)})")
                 case 403:
                     raise VASTUnauthorizedError
                 case 503:
@@ -359,8 +393,7 @@ class VASTAPIClient:
                 case 2:
                     pass
                 case 4:
-                    err_msg = data.get("detail", "Invalid parameter")
-                    raise VASTInvalidParameterError(err_msg)
+                    raise VASTInvalidParameterError(f"Invalid parameter (data:{str(data)})")
                 case 5:
                     err_msg = data.get("detail", "VAST server error")
                     raise VASTUnknownError(err_msg)


### PR DESCRIPTION
- Check Vast data quota with a given name exists before creating quota 
- Change default value of `force_login` config to true

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version