### PR TITLE
feat: add pipeline menu to blocklist in webserver configs (#3010)

### DIFF
--- a/changes/3010.feature.md
+++ b/changes/3010.feature.md
@@ -1,0 +1,1 @@
+Hide FastTrack (`pipeline`) menu by default on installation by `install-dev.sh` script.

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -39,7 +39,7 @@ jwt.secret = "7<:~[X,^Z1XM!*,Pe:PHR!bv,H~Q#l177<7gf_XHD6.<*<.t<[o|V5W(=0x:jTh-"
 
 [ui]
 brand = "Lablup Cloud"
-#menu_blocklist = "statistics,pipeline"
+menu_blocklist = "pipeline"
 
 [api]
 domain = "default"

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -119,7 +119,7 @@ brand = "Lablup Cloud"
 # Default environment to import GitHub repositories / notebooks
 # default_import_environment = 'index.docker.io/lablup/python:3.6-ubuntu18.04'
 # Comma-separated sidebar menu pages to hide
-#menu_blocklist = "pipeline"
+menu_blocklist = "pipeline"
 # Comma-separated sidebar menu pages to disable
 #menu_inactivelist = "statistics"
 # Enable/disable the LLM Playground tab in the service page


### PR DESCRIPTION
This is an auto-generated backport PR of #3010 to the 24.09 release.