### PR TITLE
fix: Prevent redis password from being logged

### DIFF
--- a/changes/3031.fix.md
+++ b/changes/3031.fix.md
@@ -1,0 +1,1 @@
+Prevent redis password from being logged.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1142,6 +1142,13 @@ class EtcdRedisConfig(TypedDict, total=False):
     redis_helper_config: RedisHelperConfig
 
 
+def safe_print_redis_config(config: EtcdRedisConfig) -> str:
+    safe_config = config.copy()
+    if "password" in safe_config:
+        safe_config["password"] = "********"
+    return str(safe_config)
+
+
 class RedisHelperConfig(TypedDict, total=False):
     socket_timeout: float
     socket_connect_timeout: float

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -27,6 +27,7 @@ from ai.backend.common.defs import REDIS_STREAM_DB
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.events_experimental import EventDispatcher as ExperimentalEventDispatcher
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
+from ai.backend.common.types import safe_print_redis_config
 from ai.backend.common.utils import env_info
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel
 
@@ -104,7 +105,11 @@ async def server_main(
             redis_config = redis_config_iv.check(
                 await etcd.get_prefix("config/redis"),
             )
-            log.info("PID: {0} - configured redis_config: {1}", pidx, redis_config)
+            log.info(
+                "PID: {0} - configured redis_config: {1}",
+                pidx,
+                safe_print_redis_config(redis_config),
+            )
         except Exception as e:
             log.exception("Unable to read config from etcd")
             raise e
@@ -120,7 +125,11 @@ async def server_main(
             db=REDIS_STREAM_DB,
             log_events=local_config["debug"]["log-events"],
         )
-        log.info("PID: {0} - Event producer created. (redis_config: {1})", pidx, redis_config)
+        log.info(
+            "PID: {0} - Event producer created. (redis_config: {1})",
+            pidx,
+            safe_print_redis_config(redis_config),
+        )
         event_dispatcher = await event_dispatcher_cls.new(
             redis_config,
             db=REDIS_STREAM_DB,
@@ -128,7 +137,11 @@ async def server_main(
             node_id=local_config["storage-proxy"]["node-id"],
             consumer_group=EVENT_DISPATCHER_CONSUMER_GROUP,
         )
-        log.info("PID: {0} - Event dispatcher created. (redis_config: {1})", pidx, redis_config)
+        log.info(
+            "PID: {0} - Event dispatcher created. (redis_config: {1})",
+            pidx,
+            safe_print_redis_config(redis_config),
+        )
         if local_config["storage-proxy"]["use-watcher"]:
             if not _is_root():
                 raise ValueError(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Let's mask the password when outputting the Redis config.

<img width="1864" alt="2024-11-06_11-44-05" src="https://github.com/user-attachments/assets/bf140bc7-411c-48ad-bbbb-f633e70c9e54">

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
