### PR TITLE
fix: Update `get_container_logs()` method to handle unassigned kernels

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fix `get_logs_from_agent()` to return `None` for kernels not assigned to agents

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2824,13 +2824,15 @@ class AgentRegistry:
         self,
         session: SessionRow,
         kernel_id: KernelId | None = None,
-    ) -> str:
+    ) -> str | None:
         async with handle_session_exception(self.db, "get_logs_from_agent", session.id):
             kernel = (
                 session.get_kernel_by_id(kernel_id)
                 if kernel_id is not None
                 else session.main_kernel
             )
+            if kernel.agent is None:
+                return None
             async with self.agent_cache.rpc_context(
                 agent_id=kernel.agent,
                 invoke_timeout=30,


### PR DESCRIPTION
Follow-up of #2364.

This pull request updates the `get_container_logs()` method to return `None` for kernels that are not yet assigned to agents, in order to prevent the internal server error mentioned below:

```bash
2024-11-06 10:47:58.967 ERROR ai.backend.manager.server [94975] Uncaught exception in HTTP request handlers TypeError("'NoneType' object is not subscriptable")
Traceback (most recent call last):
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/server.py", line 255, in exception_middleware
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/server.py", line 242, in api_middleware
    resp = await _handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/auth.py", line 581, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/aiotools/func.py", line 23, in wrapped
    return await coro(*args, *cargs, **kwargs, **ckwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/ratelimit.py", line 73, in rlim_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/manager.py", line 74, in wrapped
    return await handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/auth.py", line 588, in wrapped
    return await handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/utils.py", line 303, in wrapped
    result = await handler(request, checked_params, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/api/session.py", line 2270, in get_container_logs
    resp["result"]["logs"] = await registry.get_logs_from_agent(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/registry.py", line 2834, in get_logs_from_agent
    async with self.agent_cache.rpc_context(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/.pyenv/versions/3.12.6/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/agent_cache.py", line 122, in rpc_context
    agent_addr, agent_public_key = await self.get_rpc_args(agent_id)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rapsealk/Desktop/git/backend.ai-dev/src/ai/backend/manager/agent_cache.py", line 112, in get_rpc_args
    return agent["addr"], agent["public_key"]
           ~~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
