### PR TITLE
feat(BA-512): Implement `ImageNode` GQL resolver based on RBAC

### DIFF
--- a/changes/3036.feature.md
+++ b/changes/3036.feature.md
@@ -1,1 +1,1 @@
-Implement `ImageNode`, `ImageNodes` GraphQL API.
+Implement `ImageNode` GQL resolver based on RBAC.

--- a/changes/3036.feature.md
+++ b/changes/3036.feature.md
@@ -1,0 +1,1 @@
+Implement `ImageNode`, `ImageNodes` GraphQL API.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -405,7 +405,7 @@ type ImageNode implements Node {
   aliases: [String]
 
   """
-  Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+  Added in 25.2.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
   """
   permissions: [ImagePermissionValueField]
 }
@@ -428,7 +428,7 @@ type ResourceLimit {
 }
 
 """
-Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+Added in 25.2.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
 """
 scalar ImagePermissionValueField
 

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -876,7 +876,7 @@ type Image {
   hash: String
 }
 
-"""Added in 24.12.0."""
+"""Added in 25.2.0."""
 type ImageConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -888,7 +888,7 @@ type ImageConnection {
   count: Int
 }
 
-"""Added in 24.12.0. A Relay edge containing a `Image` and its cursor."""
+"""Added in 25.2.0. A Relay edge containing a `Image` and its cursor."""
 type ImageEdge {
   """The item at the end of the edge"""
   node: ImageNode

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -109,6 +109,7 @@ type Queries {
   """Added in 24.12.0."""
   image_node(
     id: GlobalIDField!
+    scope_id: ScopeField!
 
     """Default is read_attribute."""
     permission: ImagePermissionValueField = "read_attribute"

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -106,7 +106,7 @@ type Queries {
   """Added in 24.03.1"""
   customized_images: [ImageNode]
 
-  """Added in 25.2.0."""
+  """Added in 25.3.0."""
   image_node(
     id: GlobalIDField!
     scope_id: ScopeField
@@ -115,7 +115,7 @@ type Queries {
     permission: ImagePermissionValueField = "read_attribute"
   ): ImageNode
 
-  """Added in 25.2.0."""
+  """Added in 25.3.0."""
   image_nodes(
     scope_id: ScopeField!
 
@@ -405,7 +405,7 @@ type ImageNode implements Node {
   aliases: [String]
 
   """
-  Added in 25.2.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+  Added in 25.3.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
   """
   permissions: [ImagePermissionValueField]
 }
@@ -428,7 +428,7 @@ type ResourceLimit {
 }
 
 """
-Added in 25.2.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+Added in 25.3.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
 """
 scalar ImagePermissionValueField
 
@@ -876,7 +876,7 @@ type Image {
   hash: String
 }
 
-"""Added in 25.2.0."""
+"""Added in 25.3.0."""
 type ImageConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -888,7 +888,7 @@ type ImageConnection {
   count: Int
 }
 
-"""Added in 25.2.0. A Relay edge containing a `Image` and its cursor."""
+"""Added in 25.3.0. A Relay edge containing a `Image` and its cursor."""
 type ImageEdge {
   """The item at the end of the edge"""
   node: ImageNode

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -105,6 +105,29 @@ type Queries {
 
   """Added in 24.03.1"""
   customized_images: [ImageNode]
+
+  """Added in 24.12.0."""
+  image_node(
+    id: GlobalIDField!
+
+    """Default is read_attribute."""
+    permission: ImagePermissionValueField = "read_attribute"
+  ): ImageNode
+
+  """Added in 24.12.0."""
+  image_nodes(
+    scope_id: ScopeField!
+
+    """Default is read_attribute."""
+    permission: ImagePermissionValueField = "read_attribute"
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ImageConnection
   user(domain_name: String, email: String): User
   user_from_uuid(domain_name: String, user_id: ID): User
   users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User]
@@ -379,6 +402,11 @@ type ImageNode implements Node {
 
   """Added in 24.03.4. The array of image aliases."""
   aliases: [String]
+
+  """
+  Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+  """
+  permissions: [ImagePermissionValueField]
 }
 
 type KVPair {
@@ -397,6 +425,11 @@ type ResourceLimit {
   min: String
   max: String
 }
+
+"""
+Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
+"""
+scalar ImagePermissionValueField
 
 type AgentList implements PaginatedList {
   items: [Agent]!
@@ -840,6 +873,27 @@ type Image {
   installed: Boolean
   installed_agents: [String]
   hash: String
+}
+
+"""Added in 24.12.0."""
+type ImageConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ImageEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0. A Relay edge containing a `Image` and its cursor."""
+type ImageEdge {
+  """The item at the end of the edge"""
+  node: ImageNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 type User implements Item {

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -106,7 +106,7 @@ type Queries {
   """Added in 24.03.1"""
   customized_images: [ImageNode]
 
-  """Added in 24.12.0."""
+  """Added in 25.2.0."""
   image_node(
     id: GlobalIDField!
     scope_id: ScopeField!
@@ -115,7 +115,7 @@ type Queries {
     permission: ImagePermissionValueField = "read_attribute"
   ): ImageNode
 
-  """Added in 24.12.0."""
+  """Added in 25.2.0."""
   image_nodes(
     scope_id: ScopeField!
 

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -109,7 +109,7 @@ type Queries {
   """Added in 25.2.0."""
   image_node(
     id: GlobalIDField!
-    scope_id: ScopeField!
+    scope_id: ScopeField
 
     """Default is read_attribute."""
     permission: ImagePermissionValueField = "read_attribute"

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -576,7 +576,7 @@ class Queries(graphene.ObjectType):
 
     image_node = graphene.Field(
         ImageNode,
-        description="Added in 25.2.0.",
+        description="Added in 25.3.0.",
         id=GlobalIDField(required=True),
         scope_id=ScopeField(),
         permission=ImagePermissionValueField(
@@ -586,7 +586,7 @@ class Queries(graphene.ObjectType):
     )
     image_nodes = PaginatedConnectionField(
         ImageConnection,
-        description="Added in 25.2.0.",
+        description="Added in 25.3.0.",
         scope_id=ScopeField(required=True),
         permission=ImagePermissionValueField(
             default_value=ImagePermission.READ_ATTRIBUTE,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -578,7 +578,7 @@ class Queries(graphene.ObjectType):
         ImageNode,
         description="Added in 25.2.0.",
         id=GlobalIDField(required=True),
-        scope_id=ScopeField(required=True),
+        scope_id=ScopeField(),
         permission=ImagePermissionValueField(
             default_value=ImagePermission.READ_ATTRIBUTE,
             description=f"Default is {ImagePermission.READ_ATTRIBUTE.value}.",
@@ -1712,9 +1712,11 @@ class Queries(graphene.ObjectType):
         root: Any,
         info: graphene.ResolveInfo,
         id: ResolvedGlobalID,
-        scope_id: ScopeType,
+        scope_id: Optional[ScopeType] = None,
         permission: ImagePermission = ImagePermission.READ_ATTRIBUTE,
     ) -> Optional[ImageNode]:
+        if scope_id is None:
+            scope_id = SystemScope()
         return await ImageNode.get_node(info, id, scope_id, permission)
 
     @staticmethod

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -576,7 +576,7 @@ class Queries(graphene.ObjectType):
 
     image_node = graphene.Field(
         ImageNode,
-        description="Added in 24.12.0.",
+        description="Added in 25.2.0.",
         id=GlobalIDField(required=True),
         scope_id=ScopeField(required=True),
         permission=ImagePermissionValueField(
@@ -586,7 +586,7 @@ class Queries(graphene.ObjectType):
     )
     image_nodes = PaginatedConnectionField(
         ImageConnection,
-        description="Added in 24.12.0.",
+        description="Added in 25.2.0.",
         scope_id=ScopeField(required=True),
         permission=ImagePermissionValueField(
             default_value=ImagePermission.READ_ATTRIBUTE,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -156,8 +156,8 @@ from .rbac.permission_defs import (
     AgentPermission,
     ComputeSessionPermission,
     DomainPermission,
-    ProjectPermission,
     ImagePermission,
+    ProjectPermission,
 )
 from .rbac.permission_defs import VFolderPermission as VFolderRBACPermission
 from .resource_policy import (

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -578,6 +578,7 @@ class Queries(graphene.ObjectType):
         ImageNode,
         description="Added in 24.12.0.",
         id=GlobalIDField(required=True),
+        scope_id=ScopeField(required=True),
         permission=ImagePermissionValueField(
             default_value=ImagePermission.READ_ATTRIBUTE,
             description=f"Default is {ImagePermission.READ_ATTRIBUTE.value}.",

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -371,7 +371,7 @@ class Image(graphene.ObjectType):
 
 class ImagePermissionValueField(graphene.Scalar):
     class Meta:
-        description = f"Added in 25.2.0. One of {[val.value for val in ImagePermission]}."
+        description = f"Added in 25.3.0. One of {[val.value for val in ImagePermission]}."
 
     @staticmethod
     def serialize(val: ImagePermission) -> str:
@@ -414,7 +414,7 @@ class ImageNode(graphene.ObjectType):
 
     permissions = graphene.List(
         ImagePermissionValueField,
-        description=f"Added in 25.2.0. One of {[val.value for val in ImagePermission]}.",
+        description=f"Added in 25.3.0. One of {[val.value for val in ImagePermission]}.",
     )
 
     @classmethod
@@ -640,7 +640,7 @@ class ImageNode(graphene.ObjectType):
 class ImageConnection(Connection):
     class Meta:
         node = ImageNode
-        description = "Added in 25.2.0."
+        description = "Added in 25.3.0."
 
 
 class ForgetImageById(graphene.Mutation):

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -654,7 +654,7 @@ class ImageNode(graphene.ObjectType):
 class ImageConnection(Connection):
     class Meta:
         node = ImageNode
-        description = "Added in 24.12.0."
+        description = "Added in 25.2.0."
 
 
 class ForgetImageById(graphene.Mutation):

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -7,18 +7,22 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Iterable,
     List,
     Optional,
+    Self,
     overload,
 )
 from uuid import UUID
 
 import graphene
+import graphql
 import sqlalchemy as sa
+from dateutil.parser import parse as dtparse
 from graphql import Undefined
 from redis.asyncio import Redis
 from redis.asyncio.client import Pipeline
-from sqlalchemy.orm import load_only, selectinload
+from sqlalchemy.orm import selectinload
 
 from ai.backend.common import redis_helper
 from ai.backend.common.container_registry import ContainerRegistryType
@@ -29,18 +33,35 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.minilang.ordering import ColumnMapType, QueryOrderParser
+from ai.backend.manager.models.minilang.queryfilter import (
+    FieldSpecType,
+    QueryFilterParser,
+    enum_field_getter,
+)
+from ai.backend.manager.models.rbac.context import ClientContext
+from ai.backend.manager.models.rbac.permission_defs import ImagePermission
 
 from ...api.exceptions import ImageNotFound, ObjectNotFound
 from ...defs import DEFAULT_IMAGE_ARCH
-from ..base import batch_multiresult_in_scalar_stream, set_if_set
-from ..gql_relay import AsyncNode
+from ..base import (
+    FilterExprArg,
+    OrderExprArg,
+    batch_multiresult_in_scalar_stream,
+    generate_sql_info_for_gql_connection,
+    set_if_set,
+)
+from ..gql_relay import AsyncNode, Connection, ConnectionResolverResult, ResolvedGlobalID
 from ..image import (
     ImageAliasRow,
     ImageIdentifier,
     ImageLoadFilter,
     ImageRow,
+    ImageType,
+    get_permission_ctx,
     rescan_images,
 )
+from ..rbac import ScopeType
 from ..user import UserRole
 from .base import (
     BigInt,
@@ -70,6 +91,34 @@ __all__ = (
     "DealiasImage",
     "ClearImages",
 )
+
+_queryfilter_fieldspec: FieldSpecType = {
+    "id": ("id", None),
+    "name": ("name", None),
+    "project": ("project", None),
+    "image": ("image", None),
+    "created_at": ("created_at", dtparse),
+    "registry": ("registry", None),
+    "registry_id": ("registry_id", None),
+    "architecture": ("architecture", None),
+    "is_local": ("is_local", None),
+    "type": ("session_type", enum_field_getter(ImageType)),
+    "accelerators": ("accelerators", None),
+}
+
+_queryorder_colmap: ColumnMapType = {
+    "id": ("id", None),
+    "name": ("name", None),
+    "project": ("project", None),
+    "image": ("image", None),
+    "created_at": ("created_at", None),
+    "registry": ("registry", None),
+    "registry_id": ("registry_id", None),
+    "architecture": ("architecture", None),
+    "is_local": ("is_local", None),
+    "type": ("session_type", None),
+    "accelerators": ("accelerators", None),
+}
 
 
 class Image(graphene.ObjectType):
@@ -320,6 +369,24 @@ class Image(graphene.ObjectType):
         return is_valid
 
 
+class ImagePermissionValueField(graphene.Scalar):
+    class Meta:
+        description = f"Added in 24.12.0. One of {[val.value for val in ImagePermission]}."
+
+    @staticmethod
+    def serialize(val: ImagePermission) -> str:
+        return val.value
+
+    @staticmethod
+    def parse_literal(node: Any, _variables=None):
+        if isinstance(node, graphql.language.ast.StringValueNode):
+            return ImagePermission(node.value)
+
+    @staticmethod
+    def parse_value(value: str) -> ImagePermission:
+        return ImagePermission(value)
+
+
 class ImageNode(graphene.ObjectType):
     class Meta:
         interfaces = (AsyncNode,)
@@ -343,6 +410,11 @@ class ImageNode(graphene.ObjectType):
     supported_accelerators = graphene.List(graphene.String)
     aliases = graphene.List(
         graphene.String, description="Added in 24.03.4. The array of image aliases."
+    )
+
+    permissions = graphene.List(
+        ImagePermissionValueField,
+        description=f"Added in 24.12.0. One of {[val.value for val in ImagePermission]}.",
     )
 
     @classmethod
@@ -381,10 +453,20 @@ class ImageNode(graphene.ObjectType):
 
     @overload
     @classmethod
-    def from_row(cls, row: None) -> None: ...
+    def from_row(
+        cls, row: ImageRow, *, permissions: Optional[Iterable[ImagePermission]] = None
+    ) -> ImageNode: ...
+
+    @overload
+    @classmethod
+    def from_row(
+        cls, row: None, *, permissions: Optional[Iterable[ImagePermission]] = None
+    ) -> None: ...
 
     @classmethod
-    def from_row(cls, row: ImageRow | None) -> ImageNode | None:
+    def from_row(
+        cls, row: ImageRow | None, *, permissions: Optional[Iterable[ImagePermission]] = None
+    ) -> ImageNode | None:
         if row is None:
             return None
         image_ref = row.image_ref
@@ -419,8 +501,10 @@ class ImageNode(graphene.ObjectType):
         )
 
     @classmethod
-    def from_legacy_image(cls, row: Image) -> ImageNode:
-        return cls(
+    def from_legacy_image(
+        cls, row: Image, *, permissions: Optional[Iterable[ImagePermission]] = None
+    ) -> ImageNode:
+        result = cls(
             id=row.id,
             row_id=row.id,
             name=row.name,
@@ -442,21 +526,131 @@ class ImageNode(graphene.ObjectType):
             aliases=row.aliases,
         )
 
+        result.permissions = [] if permissions is None else permissions
+        return result
+
     @classmethod
-    async def get_node(cls, info: graphene.ResolveInfo, id: str) -> ImageNode:
+    def from_row_with_permission(
+        cls,
+        ctx: GraphQueryContext,
+        row: ImageRow,
+        permissions: Iterable[ImagePermission],
+    ) -> Self:
+        ret = cls.from_row(row)
+        ret.permissions = permissions
+        return ret
+
+    @classmethod
+    async def get_node(
+        cls,
+        info: graphene.ResolveInfo,
+        id: ResolvedGlobalID,
+        scope_id: ScopeType,
+        permission: ImagePermission = ImagePermission.READ_ATTRIBUTE,
+    ) -> Optional[Self]:
         graph_ctx: GraphQueryContext = info.context
 
-        _, image_id = AsyncNode.resolve_global_id(info, id)
-        query = (
-            sa.select(ImageRow)
-            .where(ImageRow.id == image_id)
-            .options(selectinload(ImageRow.aliases).options(load_only(ImageAliasRow.alias)))
+        _, image_id = id
+        async with graph_ctx.db.connect() as db_conn:
+            user = graph_ctx.user
+            client_ctx = ClientContext(
+                graph_ctx.db, user["domain_name"], user["uuid"], user["role"]
+            )
+            permission_ctx = await get_permission_ctx(db_conn, client_ctx, scope_id, permission)
+            cond = permission_ctx.query_condition
+            if cond is None:
+                return None
+
+            query = (
+                sa.select(ImageRow)
+                .where(cond & (ImageRow.id == UUID(image_id)))
+                .options(selectinload(ImageRow.aliases))
+            )
+
+            async with graph_ctx.db.begin_readonly_session() as db_session:
+                image_row = await db_session.scalar(query)
+                if image_row is None:
+                    return None
+
+                return cls.from_row_with_permission(
+                    graph_ctx,
+                    image_row,
+                    permissions=await permission_ctx.calculate_final_permission(image_row),
+                )
+
+    @classmethod
+    async def get_connection(
+        cls,
+        info: graphene.ResolveInfo,
+        scope_id: ScopeType,
+        permission: ImagePermission,
+        filter_expr: Optional[str] = None,
+        order_expr: Optional[str] = None,
+        offset: Optional[int] = None,
+        after: Optional[str] = None,
+        first: Optional[int] = None,
+        before: Optional[str] = None,
+        last: Optional[int] = None,
+    ) -> ConnectionResolverResult[Self]:
+        graph_ctx: GraphQueryContext = info.context
+        _filter_arg = (
+            FilterExprArg(filter_expr, QueryFilterParser(_queryfilter_fieldspec))
+            if filter_expr is not None
+            else None
         )
-        async with graph_ctx.db.begin_readonly_session() as db_session:
-            image_row = await db_session.scalar(query)
-            if image_row is None:
-                raise ValueError(f"Image not found (id: {image_id})")
-            return cls.from_row(image_row)
+        _order_expr = (
+            OrderExprArg(order_expr, QueryOrderParser(_queryorder_colmap))
+            if order_expr is not None
+            else None
+        )
+        (
+            query,
+            cnt_query,
+            _,
+            cursor,
+            pagination_order,
+            page_size,
+        ) = generate_sql_info_for_gql_connection(
+            info,
+            ImageRow,
+            ImageRow.id,
+            _filter_arg,
+            _order_expr,
+            offset,
+            after=after,
+            first=first,
+            before=before,
+            last=last,
+        )
+        async with graph_ctx.db.connect() as db_conn:
+            user = graph_ctx.user
+            client_ctx = ClientContext(
+                graph_ctx.db, user["domain_name"], user["uuid"], user["role"]
+            )
+            permission_ctx = await get_permission_ctx(db_conn, client_ctx, scope_id, permission)
+            cond = permission_ctx.query_condition
+            if cond is None:
+                return ConnectionResolverResult([], cursor, pagination_order, page_size, 0)
+            query = query.where(cond).options(selectinload(ImageRow.aliases))
+            cnt_query = cnt_query.where(cond)
+            async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
+                image_rows = (await db_session.scalars(query)).all()
+                total_cnt = await db_session.scalar(cnt_query)
+                result: list[Self] = [
+                    cls.from_row_with_permission(
+                        graph_ctx,
+                        row,
+                        permissions=await permission_ctx.calculate_final_permission(row),
+                    )
+                    for row in image_rows
+                ]
+        return ConnectionResolverResult(result, cursor, pagination_order, page_size, total_cnt)
+
+
+class ImageConnection(Connection):
+    class Meta:
+        node = ImageNode
+        description = "Added in 24.12.0."
 
 
 class ForgetImageById(graphene.Mutation):

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -471,7 +471,8 @@ class ImageNode(graphene.ObjectType):
             return None
         image_ref = row.image_ref
         version, ptag_set = image_ref.tag_set
-        return cls(
+
+        result = cls(
             id=row.id,
             row_id=row.id,
             name=row.image,
@@ -499,6 +500,9 @@ class ImageNode(graphene.ObjectType):
             supported_accelerators=(row.accelerators or "").split(","),
             aliases=[alias_row.alias for alias_row in row.aliases],
         )
+
+        result.permissions = [] if permissions is None else permissions
+        return result
 
     @classmethod
     def from_legacy_image(

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -371,7 +371,7 @@ class Image(graphene.ObjectType):
 
 class ImagePermissionValueField(graphene.Scalar):
     class Meta:
-        description = f"Added in 24.12.0. One of {[val.value for val in ImagePermission]}."
+        description = f"Added in 25.2.0. One of {[val.value for val in ImagePermission]}."
 
     @staticmethod
     def serialize(val: ImagePermission) -> str:
@@ -414,7 +414,7 @@ class ImageNode(graphene.ObjectType):
 
     permissions = graphene.List(
         ImagePermissionValueField,
-        description=f"Added in 24.12.0. One of {[val.value for val in ImagePermission]}.",
+        description=f"Added in 25.2.0. One of {[val.value for val in ImagePermission]}.",
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import functools
 import logging
+import uuid
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from decimal import Decimal
@@ -19,7 +20,6 @@ from typing import (
     override,
 )
 from uuid import UUID
-import uuid
 
 import aiotools
 import sqlalchemy as sa
@@ -926,7 +926,9 @@ class ImagePermissionContextBuilder(
         perm_ctx.merge(non_global_container_registries_perm_ctx)
         return perm_ctx
 
-    async def _get_allowed_registries_for_user(self, ctx: ClientContext, user_id: uuid.UUID) -> set[str]:
+    async def _get_allowed_registries_for_user(
+        self, ctx: ClientContext, user_id: uuid.UUID
+    ) -> set[str]:
         _user_query_stmt = (
             sa.select(UserRow).where(UserRow.uuid == user_id).options(joinedload(UserRow.domain))
         )

--- a/src/ai/backend/manager/models/rbac/__init__.py
+++ b/src/ai/backend/manager/models/rbac/__init__.py
@@ -181,7 +181,7 @@ async def _calculate_role_in_scope_for_admin(
 
     match scope:
         case SystemScope():
-            return _EMPTY_FSET
+            return frozenset([PredefinedRole.ADMIN])
         case DomainScope(domain_name):
             if ctx.domain_name == domain_name:
                 return frozenset([PredefinedRole.ADMIN])
@@ -238,7 +238,7 @@ async def _calculate_role_in_scope_for_user(
 
     match scope:
         case SystemScope():
-            return _EMPTY_FSET
+            return frozenset([PredefinedRole.MEMBER])
         case DomainScope(domain_name):
             if ctx.domain_name == domain_name:
                 return frozenset([PredefinedRole.MEMBER])


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolve #1910 ([BA-512](https://lablup.atlassian.net/browse/BA-512)).
This PR adds an interface for testing the per-project image GQL API based on #2999.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3036.org.readthedocs.build/en/3036/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3036.org.readthedocs.build/ko/3036/

<!-- readthedocs-preview sorna-ko end -->

[BA-512]: https://lablup.atlassian.net/browse/BA-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ