### PR TITLE
fix: Update `get_container_logs()` method to handle unassigned kernels (#3032)

### DIFF
--- a/changes/3032.fix.md
+++ b/changes/3032.fix.md
@@ -1,0 +1,1 @@
+Fix `get_logs_from_agent()` to raise `InstanceNotFound` exception for kernels not assigned to agents

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2898,6 +2898,10 @@ class AgentRegistry:
                 if kernel_id is not None
                 else session.main_kernel
             )
+            if kernel.agent is None:
+                raise InstanceNotFound(
+                    "Kernel has not been assigned to an agent.", extra_data={"kernel_id": kernel_id}
+                )
             async with self.agent_cache.rpc_context(
                 agent_id=kernel.agent,
                 invoke_timeout=30,


### PR DESCRIPTION
This is an auto-generated backport PR of #3032 to the 24.03 release.