### PR TITLE
fix: Broken `ComputeContainer` GQL

### DIFF
--- a/changes/3042.fix.md
+++ b/changes/3042.fix.md
@@ -1,1 +1,1 @@
-Fix broken `ComputeContainer` GQL.
+Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas

--- a/changes/3042.fix.md
+++ b/changes/3042.fix.md
@@ -1,1 +1,1 @@
-Fix broken `ComputeContainer` GQL.
+Fix regression of `ComputeContainer` GraphQL queries due to newly introduced relationship fields

--- a/changes/3042.fix.md
+++ b/changes/3042.fix.md
@@ -1,1 +1,1 @@
-Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas
+Fix broken `ComputeContainer` GQL.

--- a/changes/3042.fix.md
+++ b/changes/3042.fix.md
@@ -1,0 +1,1 @@
+Fix broken `ComputeContainer` GQL.

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -605,8 +605,8 @@ class KernelRow(Base):
                     sa.select(KernelRow)
                     .where(KernelRow.id == kern_id)
                     .options(
-                        selectinload(KernelRow.agent_row).options(noload("*")),
                         noload("*"),
+                        selectinload(KernelRow.agent_row).options(noload("*")),
                     )
                 )
                 result = (await db_sess.execute(query)).scalars().all()
@@ -745,8 +745,8 @@ class KernelRow(Base):
                     .where(KernelRow.id == kernel_id)
                     .with_for_update()
                     .options(
-                        load_only(KernelRow.status, KernelRow.session_id),
                         noload("*"),
+                        load_only(KernelRow.status, KernelRow.session_id),
                     )
                 )
                 kernel_row = (await db_session.scalars(kernel_query)).first()

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1113,6 +1113,7 @@ class ComputeContainer(graphene.ObjectType):
             .where(
                 (KernelRow.id.in_(container_ids)),
             )
+            .options(selectinload(KernelRow.image_row))
             .options(noload("*"))
         )
         if domain_name is not None:

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1113,6 +1113,8 @@ class ComputeContainer(graphene.ObjectType):
             .where(
                 (KernelRow.id.in_(container_ids)),
             )
+            .options(selectinload(KernelRow.group_row))
+            .options(selectinload(KernelRow.user_row))
             .options(selectinload(KernelRow.image_row))
             .options(noload("*"))
         )

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -605,8 +605,8 @@ class KernelRow(Base):
                     sa.select(KernelRow)
                     .where(KernelRow.id == kern_id)
                     .options(
-                        noload("*"),
                         selectinload(KernelRow.agent_row).options(noload("*")),
+                        noload("*"),
                     )
                 )
                 result = (await db_sess.execute(query)).scalars().all()
@@ -745,8 +745,8 @@ class KernelRow(Base):
                     .where(KernelRow.id == kernel_id)
                     .with_for_update()
                     .options(
-                        noload("*"),
                         load_only(KernelRow.status, KernelRow.session_id),
+                        noload("*"),
                     )
                 )
                 kernel_row = (await db_session.scalars(kernel_query)).first()
@@ -1113,10 +1113,14 @@ class ComputeContainer(graphene.ObjectType):
             .where(
                 (KernelRow.id.in_(container_ids)),
             )
-            .options(selectinload(KernelRow.group_row))
-            .options(selectinload(KernelRow.user_row))
-            .options(selectinload(KernelRow.image_row))
-            .options(noload("*"))
+            .options(
+                noload("*"),
+                selectinload(
+                    KernelRow.group_row,
+                    KernelRow.user_row,
+                    KernelRow.image_row,
+                ),
+            )
         )
         if domain_name is not None:
             query = query.where(KernelRow.domain_name == domain_name)

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1113,9 +1113,7 @@ class ComputeContainer(graphene.ObjectType):
             .where(
                 (KernelRow.id.in_(container_ids)),
             )
-            .options(selectinload(KernelRow.group_row))
-            .options(selectinload(KernelRow.user_row))
-            .options(selectinload(KernelRow.image_row))
+            .options(noload("*"))
         )
         if domain_name is not None:
             query = query.where(KernelRow.domain_name == domain_name)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Currently, when using `ComputeContainer` GQL, the following error occurs.

```
2024-11-07 13:57:19.382 ERROR ai.backend.manager.api.admin [4278] ADMIN.GQL Exception: {'message': "greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/14/xd2s)", 'locations': [{'line': 2, 'column': 3}], 'path': ['compute_container']}
2024-11-07 13:57:19.397 DEBUG ai.backend.manager.api.admin [4278] Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/graphql/execution/execute.py", line 530, in await_result
    return_type, field_nodes, info, path, await result
                                          ^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 1060, in wrapped
    return await resolve_func(root, info, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/gql.py", line 2164, in resolve_compute_container
    return await loader.load(id)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/aiodataloader.py", line 215, in dispatch_queue_batch
    values = await batch_future
             ^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/aiotools/src/aiotools/func.py", line 23, in wrapped
    return await coro(*args, *cargs, **kwargs, **ckwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/kernel.py", line 1125, in batch_load_detail
    return await batch_result(
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 871, in batch_result
    objs_per_key[key_getter(row)] = obj_type.from_row(graph_ctx, row)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/kernel.py", line 949, in from_row
    props = cls.parse_row(ctx, row)
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/kernel.py", line 922, in parse_row
    "image_object": ImageNode.from_row(row.image_row),
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/gql_models/image.py", line 367, in from_row
    aliases=[alias_row.alias for alias_row in row.aliases],
                                              ^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 487, in __get__
    return self.impl.get(state, dict_)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 959, in get
    value = self._fire_loader_callables(state, key, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 995, in _fire_loader_callables
    return self.callable_(state, passive)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/strategies.py", line 912, in _load_for_state
    return self._emit_lazyload(
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/strategies.py", line 1046, in _emit_lazyload
    result = session.execute(
             ^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 1717, in execute
    result = conn._execute_20(statement, params or {}, execution_options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2138, in _handle_dbapi_exception
    util.raise_(exc_info[1], with_traceback=exc_info[2])
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/asyncpg.py", line 479, in execute
    self._adapt_connection.await_(
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 61, in await_only
    raise exc.MissingGreenlet(
graphql.error.graphql_error.GraphQLError: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/14/xd2s)

GraphQL request:2:3
1 | query($id: UUID!) {
2 |   compute_container (id:$id) {
  |   ^
3 |     session_id
```

This PR fixes this bug by removing part of the optimization in `ComputeContainer.batch_load_detail()` that retrieves `KernelRow`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version