### PR TITLE
fix: Regression of `AgentSummary` GQL resolver

### DIFF
--- a/changes/3045.fix.md
+++ b/changes/3045.fix.md
@@ -1,0 +1,1 @@
+Fix wrong `AgentSummary` GQL implementation.

--- a/changes/3045.fix.md
+++ b/changes/3045.fix.md
@@ -1,1 +1,1 @@
-Fix wrong `AgentSummary` GQL implementation.
+Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas

--- a/changes/3045.fix.md
+++ b/changes/3045.fix.md
@@ -1,1 +1,1 @@
-Fix wrong `AgentSummary` GQL implementation.
+Fix regression of the `AgentSummary` resolver caused by an incorrect `batch_load_func` assignment.

--- a/changes/3045.fix.md
+++ b/changes/3045.fix.md
@@ -1,1 +1,1 @@
-Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas
+Fix wrong `AgentSummary` GQL implementation.

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -947,9 +947,9 @@ class Queries(graphene.ObjectType):
         if ctx.local_config["manager"]["hide-agents"]:
             raise ObjectNotFound(object_name="agent")
 
-        loader = ctx.dataloader_manager.get_loader(
+        loader = ctx.dataloader_manager.get_loader_by_func(
             ctx,
-            "Agent",
+            AgentSummary.batch_load,
             raw_status=None,
             scaling_group=scaling_group,
             domain_name=domain_name,

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 
 from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.types import (
+    AccessKey,
     AgentId,
     BinarySize,
     HardwareMetadata,
@@ -733,14 +734,11 @@ class AgentSummary(graphene.ObjectType):
         graph_ctx: GraphQueryContext,
         agent_ids: Sequence[AgentId],
         *,
-        access_key: Optional[str] = None,
+        access_key: AccessKey,
         domain_name: Optional[str] = None,
         raw_status: Optional[str] = None,
         scaling_group: Optional[str] = None,
-    ) -> Sequence[Self | None]:
-        if access_key is None:
-            raise ValueError("access_key is required for the AgentSummary.batch_load().")
-
+    ) -> Sequence[Optional[Self]]:
         query = (
             sa.select([agents])
             .select_from(agents)

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -700,7 +700,7 @@ class AgentSummary(graphene.ObjectType):
         cls,
         ctx: GraphQueryContext,
         row: Row,
-    ) -> AgentSummary:
+    ) -> Self:
         return cls(
             id=row["id"],
             status=row["status"].name,
@@ -737,7 +737,7 @@ class AgentSummary(graphene.ObjectType):
         domain_name: Optional[str] = None,
         raw_status: Optional[str] = None,
         scaling_group: Optional[str] = None,
-    ) -> Sequence[AgentSummary | None]:
+    ) -> Sequence[Self | None]:
         if access_key is None:
             raise ValueError("access_key is required for the AgentSummary.batch_load().")
 
@@ -802,7 +802,7 @@ class AgentSummary(graphene.ObjectType):
         raw_status: Optional[str] = None,
         filter: Optional[str] = None,
         order: Optional[str] = None,
-    ) -> Sequence[AgentSummary]:
+    ) -> Sequence[Self]:
         query = sa.select([agents]).select_from(agents).limit(limit).offset(offset)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -738,7 +738,8 @@ class AgentSummary(graphene.ObjectType):
         raw_status: Optional[str] = None,
         scaling_group: Optional[str] = None,
     ) -> Sequence[AgentSummary | None]:
-        assert access_key is not None
+        if access_key is None:
+            raise ValueError("access_key is required for the AgentSummary.batch_load().")
 
         query = (
             sa.select([agents])

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -700,7 +700,7 @@ class AgentSummary(graphene.ObjectType):
         cls,
         ctx: GraphQueryContext,
         row: Row,
-    ) -> Agent:
+    ) -> AgentSummary:
         return cls(
             id=row["id"],
             status=row["status"].name,
@@ -733,11 +733,13 @@ class AgentSummary(graphene.ObjectType):
         graph_ctx: GraphQueryContext,
         agent_ids: Sequence[AgentId],
         *,
-        domain_name: str | None,
+        access_key: Optional[str] = None,
+        domain_name: Optional[str] = None,
         raw_status: Optional[str] = None,
         scaling_group: Optional[str] = None,
-        access_key: str,
-    ) -> Sequence[Agent | None]:
+    ) -> Sequence[AgentSummary | None]:
+        assert access_key is not None
+
         query = (
             sa.select([agents])
             .select_from(agents)
@@ -799,7 +801,7 @@ class AgentSummary(graphene.ObjectType):
         raw_status: Optional[str] = None,
         filter: Optional[str] = None,
         order: Optional[str] = None,
-    ) -> Sequence[Agent]:
+    ) -> Sequence[AgentSummary]:
         query = sa.select([agents]).select_from(agents).limit(limit).offset(offset)
         query = await _append_sgroup_from_clause(
             graph_ctx, query, access_key, domain_name, scaling_group


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

When using the `AgentSummary` GQL query in the main branch, the following error occurs.

```
{
  "data": {
    "agent_summary": null
  },
  "errors": [
    {
      "message": "Agent.batch_load() got an unexpected keyword argument 'scaling_group'",
      "locations": [
        {
          "line": 2,
          "column": 5
        }
      ],
      "path": [
        "agent_summary"
      ]
    }
  ]
}
```

This PR fixes the above error and additionally resolves several type errors.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3045.org.readthedocs.build/en/3045/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3045.org.readthedocs.build/ko/3045/

<!-- readthedocs-preview sorna-ko end -->