### PR TITLE
fix: Regression of `LegacyComputeSession` GQL

### DIFF
--- a/changes/3046.fix.md
+++ b/changes/3046.fix.md
@@ -1,1 +1,1 @@
-Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas
+Fix broken `LegacyComputeSession` GQL.

--- a/changes/3046.fix.md
+++ b/changes/3046.fix.md
@@ -1,0 +1,1 @@
+Fix broken `LegacyComputeSession` GQL.

--- a/changes/3046.fix.md
+++ b/changes/3046.fix.md
@@ -1,1 +1,1 @@
-Fix broken `LegacyComputeSession` GQL.
+Fix model service traffics not distributed equally to every sessions when there are 10 or more replicas

--- a/changes/3046.fix.md
+++ b/changes/3046.fix.md
@@ -1,1 +1,1 @@
-Fix broken `LegacyComputeSession` GQL.
+Fix regression of `LegacyComputeSession` GraphQL queries.

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -13,7 +13,7 @@ from graphql.type import GraphQLField
 
 set_input_object_type_default_value(Undefined)
 
-from ai.backend.common.types import QuotaScopeID
+from ai.backend.common.types import QuotaScopeID, SessionId
 from ai.backend.manager.defs import DEFAULT_IMAGE_ARCH
 from ai.backend.manager.models.gql_relay import (
     AsyncNode,
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
         AccessKey,
         AgentId,
         RedisConnectionInfo,
-        SessionId,
         SlotName,
         SlotTypes,
     )
@@ -2258,7 +2257,7 @@ class Queries(graphene.ObjectType):
         )
 
         # Since sess_id is declared as a string type, we have to convert this to UUID type manually.
-        matches = await loader.load(uuid.UUID(sess_id) if isinstance(sess_id, str) else sess_id)
+        matches = await loader.load(SessionId(uuid.UUID(sess_id)))
         if len(matches) == 0:
             return None
         elif len(matches) == 1:

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -2256,7 +2256,9 @@ class Queries(graphene.ObjectType):
             access_key=access_key,
             status=status,
         )
-        matches = await loader.load(sess_id)
+
+        # Since sess_id is declared as a string type, we have to convert this to UUID type manually.
+        matches = await loader.load(uuid.UUID(sess_id) if isinstance(sess_id, str) else sess_id)
         if len(matches) == 0:
             return None
         elif len(matches) == 1:

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1358,7 +1358,11 @@ class LegacyComputeSession(graphene.ObjectType):
     def from_row(cls, context: GraphQueryContext, row: Row) -> Optional[LegacyComputeSession]:
         if row is None:
             return None
-        props = cls.parse_row(context, row)
+        props = dict(cls.parse_row(context, row))
+
+        props.pop("status_data", None)
+        props.pop("vfolder_mounts", None)
+
         return cls(**props)
 
     @classmethod
@@ -1525,7 +1529,7 @@ class LegacyComputeSession(graphene.ObjectType):
                 query,
                 cls,
                 sess_ids,
-                lambda row: row["session_name"],
+                lambda row: row["session_id"],
             )
 
 

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1360,6 +1360,7 @@ class LegacyComputeSession(graphene.ObjectType):
             return None
         props = dict(cls.parse_row(context, row))
 
+        # Unsupported fields in the Legacy API have to be removed to prevent error.
         props.pop("status_data", None)
         props.pop("vfolder_mounts", None)
 

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1319,14 +1319,12 @@ class LegacyComputeSession(graphene.ObjectType):
             "status": row["status"].name,
             "status_changed": row["status_changed"],
             "status_info": row["status_info"],
-            "status_data": row["status_data"],
             "created_at": row["created_at"],
             "terminated_at": row["terminated_at"],
             "startup_command": row["startup_command"],
             "result": row["result"].name,
             "service_ports": row["service_ports"],
             "occupied_slots": row["occupied_slots"].to_json(),
-            "vfolder_mounts": row["vfolder_mounts"],
             "resource_opts": row["resource_opts"],
             "num_queries": row["num_queries"],
             # optionally hidden
@@ -1358,12 +1356,7 @@ class LegacyComputeSession(graphene.ObjectType):
     def from_row(cls, context: GraphQueryContext, row: Row) -> Optional[LegacyComputeSession]:
         if row is None:
             return None
-        props = dict(cls.parse_row(context, row))
-
-        # Unsupported fields in the Legacy API have to be removed to prevent error.
-        props.pop("status_data", None)
-        props.pop("vfolder_mounts", None)
-
+        props = cls.parse_row(context, row)
         return cls(**props)
 
     @classmethod


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

When using `LegacyComputeSession` GQL in the main branch, the following error occurs:

```
2024-11-07 17:53:22.275 ERROR ai.backend.manager.api.admin [61844] ADMIN.GQL Exception: {'message': "'bai-serve-robert64-7175c9c1-79d8-41bf-b8d9-ddc938422486'", 'locations': [{'line': 2, 'column': 5}], 'path': ['legacy_compute_session']}
2024-11-07 17:53:22.279 DEBUG ai.backend.manager.api.admin [61844] Traceback (most recent call last):
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/graphql/execution/execute.py", line 530, in await_result
    return_type, field_nodes, info, path, await result
                                          ^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 1060, in wrapped
    return await resolve_func(root, info, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/gql.py", line 2259, in resolve_legacy_compute_session
    matches = await loader.load(sess_id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/dist/export/python/virtualenvs/python-default/3.12.6/lib/python3.12/site-packages/aiodataloader.py", line 215, in dispatch_queue_batch
    values = await batch_future
             ^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/aiotools/src/aiotools/func.py", line 23, in wrapped
    return await coro(*args, *cargs, **kwargs, **ckwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/kernel.py", line 1522, in batch_load_detail
    return await batch_multiresult(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jopemachine/Desktop/backend.ai/src/ai/backend/manager/models/base.py", line 895, in batch_multiresult
    objs_per_key[key_getter(row)].append(
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
graphql.error.graphql_error.GraphQLError: 'bai-serve-robert64-7175c9c1-79d8-41bf-b8d9-ddc938422486'

GraphQL request:2:5
1 | query ComputeContainer {
2 |     legacy_compute_session (sess_id: "478b3827-f766-4331-bba0-270e350ad71d") {
  |     ^
3 |       # items {

```


This PR resolves several issues that are causing the `LegacyComputeSession` GQL to malfunction in the current main branch.




**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3046.org.readthedocs.build/en/3046/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3046.org.readthedocs.build/ko/3046/

<!-- readthedocs-preview sorna-ko end -->