### PR TITLE
fix: Include legacy logging module

### DIFF
--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -13,6 +13,7 @@ python_sources(
         "src/ai/backend/agent/kubernetes:src",  # not auto-inferred
         "src/ai/backend/runner:src",
         "src/ai/backend/helpers:src",
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
         "//:reqs#backend.ai-krunner-static-gnu",  # not auto-inferred
         ":resources",
         "!./__init__.py:src-watcher",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -7,6 +7,7 @@ python_sources(
         "src/ai/backend/manager/plugin:src",  # not auto-inferred (due to lazy-loading plugins)
         "src/ai/backend/manager/scheduler:src",
         "src/ai/backend/manager/models/alembic:migrations",  # not auto-inferred
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
         ":resources",
     ],
 )


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

When the code of a plugin loaded at runtime is outdated, it attempt to import `BraceStyleAdapter` from `ai.backend.common.logging`.

(This module has been moved to `ai.backend.logging`, See https://github.com/lablup/backend.ai/pull/2760.)

When packaging a pex file, any unused source code in the component is automatically excluded. 
Therefore, in the case of an updated component that no longer imports the legacy logging module, the legacy logging module will be excluded from the pex.

This causes a ModuleNotFound error when an outdated legacy module is dynamically imported.

So let's update out BUILD configuration to ensure that the legacy logging module is always included in the pex, even if it's not imported.



---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
