### PR TITLE
fix: Change vfolder name when deleted to allow reusing the name

### DIFF
--- a/changes/3061.fix.md
+++ b/changes/3061.fix.md
@@ -1,1 +1,1 @@
-Change the name of deleted vfolders to include a suffix with a timestamp before sending them to DELETE_ONGOING status to avoid preventing creation of new vfolders with the same name
+Change the name of deleted vfolders with a timestamp suffix when sending them to DELETE_ONGOING status to allow reuse of the vfolder name, for cases when actual deletion takes a long time

--- a/changes/3061.fix.md
+++ b/changes/3061.fix.md
@@ -1,1 +1,1 @@
-Update vfolder name before delete-forever
+Change the name of deleted vfolders to include a suffix with a timestamp before sending them to DELETE_ONGOING status to avoid preventing creation of new vfolders with the same name

--- a/changes/3061.fix.md
+++ b/changes/3061.fix.md
@@ -1,0 +1,1 @@
+Update vfolder name before delete-forever

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Container, Iterable, Mapping
 from contextlib import AbstractAsyncContextManager as AbstractAsyncCtxMgr
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import PurePosixPath
 from typing import (
     TYPE_CHECKING,
@@ -29,7 +29,6 @@ import graphene
 import sqlalchemy as sa
 import trafaret as t
 from dateutil.parser import parse as dtparse
-from dateutil.tz import tzutc
 from graphene.types.datetime import DateTime as GQLDateTime
 from graphql import Undefined
 from sqlalchemy.dialects import postgresql as pgsql
@@ -1019,7 +1018,7 @@ async def update_vfolder_status(
     elif vfolder_info_len == 1:
         cond = vfolders.c.id == vfolder_ids[0]
 
-    now = datetime.now(tzutc())
+    now = datetime.now(timezone.utc)
 
     if update_status == VFolderOperationStatus.DELETE_PENDING:
         select_stmt = sa.select(VFolderRow).where(VFolderRow.id.in_(vfolder_ids))
@@ -1049,7 +1048,7 @@ async def update_vfolder_status(
                 ),
             }
             if update_status == VFolderOperationStatus.DELETE_ONGOING:
-                values["name"] = VFolderRow.name + f"_deleted_{now}"
+                values["name"] = VFolderRow.name + f"_deleted_{now.isoformat()}"
             query = sa.update(vfolders).values(**values).where(cond)
             await db_session.execute(query)
 

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -1048,9 +1048,7 @@ async def update_vfolder_status(
                 ),
             }
             if update_status == VFolderOperationStatus.DELETE_ONGOING:
-                values["name"] = (
-                    VFolderRow.name + f"_deleted_{now.strftime("%Y-%m-%dT%HH%MM%SS%z")}"
-                )
+                values["name"] = VFolderRow.name + f"_deleted_{now.strftime("%Y-%m-%dT%H%M%S%z")}"
             query = sa.update(vfolders).values(**values).where(cond)
             await db_session.execute(query)
 

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -1048,7 +1048,9 @@ async def update_vfolder_status(
                 ),
             }
             if update_status == VFolderOperationStatus.DELETE_ONGOING:
-                values["name"] = VFolderRow.name + f"_deleted_{now.isoformat()}"
+                values["name"] = (
+                    VFolderRow.name + f"_deleted_{now.strftime("%Y-%m-%dT%HH%MM%SS%z")}"
+                )
             query = sa.update(vfolders).values(**values).where(cond)
             await db_session.execute(query)
 


### PR DESCRIPTION
resolves #3041 

Update vfolder name before delete-forever.
The deletion date time format is `%Y-%m-%dT%HH%MM%SS%z`, update the name to `{ORIGINAL}_deleted_{DATE-TIME}`.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Update of end-to-end CLI integration tests in `ai.backend.test`