### PR TITLE
refactor: Convert VFolder deletion from blocking response to event-driven pattern

### DIFF
--- a/changes/3063.enhance.md
+++ b/changes/3063.enhance.md
@@ -1,0 +1,1 @@
+Convert VFolder deletion from blocking response to event-driven pattern

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -18,6 +18,7 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
+    Self,
     Type,
     TypedDict,
     TypeVar,
@@ -44,6 +45,7 @@ from .types import (
     QuotaScopeID,
     RedisConnectionInfo,
     SessionId,
+    VFolderID,
     VolumeMountableNodeType,
     aobject,
 )
@@ -808,6 +810,39 @@ class VolumeMounted(VolumeMountEventArgs, AbstractEvent):
 
 class VolumeUnmounted(VolumeMountEventArgs, AbstractEvent):
     name = "volume_unmounted"
+
+
+@attrs.define(auto_attribs=True, slots=True)
+class VFolderDeletionSuccessEvent(AbstractEvent):
+    vfid: VFolderID
+
+    def serialize(self) -> tuple:
+        return (str(self.vfid),)
+
+    @classmethod
+    def deserialize(cls, value: tuple) -> Self:
+        return cls(
+            VFolderID.from_str(value[0]),
+        )
+
+
+@attrs.define(auto_attribs=True, slots=True)
+class VFolderDeletionFailureEvent(AbstractEvent):
+    vfid: VFolderID
+    message: str
+
+    def serialize(self) -> tuple:
+        return (
+            str(self.vfid),
+            self.message,
+        )
+
+    @classmethod
+    def deserialize(cls, value: tuple) -> Self:
+        return cls(
+            VFolderID.from_str(value[0]),
+            value[1],
+        )
 
 
 class RedisConnectorFunc(Protocol):

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -1272,7 +1272,7 @@ async def initiate_vfolder_deletion(
             ) as (_, resp):
                 pass
         except (VFolderOperationFailed, InvalidAPIParameters) as e:
-            if e.status == 404:
+            if e.status in (404, 410):
                 already_deleted.append(vfolder_info)
     if already_deleted:
         vfolder_ids = tuple(vf_id.folder_id for vf_id, _ in already_deleted)

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -1272,7 +1272,7 @@ async def initiate_vfolder_deletion(
             ) as (_, resp):
                 pass
         except (VFolderOperationFailed, InvalidAPIParameters) as e:
-            if e.status in (404, 410):
+            if e.status == 410:
                 already_deleted.append(vfolder_info)
     if already_deleted:
         vfolder_ids = tuple(vf_id.folder_id for vf_id, _ in already_deleted)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -368,8 +368,8 @@ class AgentRegistry:
         evd.consume(AgentHeartbeatEvent, self, handle_agent_heartbeat)
         evd.consume(RouteCreatedEvent, self, handle_route_creation)
 
-        evd.consume(VFolderDeletionSuccessEvent, self, handle_vfolder_deletion)
-        evd.consume(VFolderDeletionFailureEvent, self, handle_vfolder_deletion)
+        evd.consume(VFolderDeletionSuccessEvent, self, handle_vfolder_deletion_success)
+        evd.consume(VFolderDeletionFailureEvent, self, handle_vfolder_deletion_failure)
 
         # action-trigerring events
         evd.consume(DoSyncKernelLogsEvent, self, handle_kernel_log, name="api.session.syncklog")
@@ -4410,21 +4410,25 @@ async def handle_kernel_log(
         log_buffer.close()
 
 
-async def handle_vfolder_deletion(
+async def handle_vfolder_deletion_success(
     context: AgentRegistry,
     source: AgentId,
-    event: VFolderDeletionSuccessEvent | VFolderDeletionFailureEvent,
+    ev: VFolderDeletionSuccessEvent,
 ) -> None:
-    match event:
-        case VFolderDeletionSuccessEvent(vfid=vfid):
-            await update_vfolder_status(
-                context.db, [vfid.folder_id], VFolderOperationStatus.DELETE_COMPLETE, do_log=True
-            )
-        case VFolderDeletionFailureEvent(vfid=vfid, message=message):
-            log.exception(f"Failed to delete vfolder (vfid:{vfid}, msg:{message})")
-            await update_vfolder_status(
-                context.db, [vfid.folder_id], VFolderOperationStatus.DELETE_ERROR, do_log=True
-            )
+    await update_vfolder_status(
+        context.db, [ev.vfid.folder_id], VFolderOperationStatus.DELETE_COMPLETE, do_log=True
+    )
+
+
+async def handle_vfolder_deletion_failure(
+    context: AgentRegistry,
+    source: AgentId,
+    ev: VFolderDeletionFailureEvent,
+) -> None:
+    log.exception(f"Failed to delete vfolder (vfid:{ev.vfid}, msg:{ev.message})")
+    await update_vfolder_status(
+        context.db, [ev.vfid.folder_id], VFolderOperationStatus.DELETE_ERROR, do_log=True
+    )
 
 
 async def _make_session_callback(data: dict[str, Any], url: yarl.URL) -> None:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -86,6 +86,8 @@ from ai.backend.common.events import (
     SessionSuccessEvent,
     SessionTerminatedEvent,
     SessionTerminatingEvent,
+    VFolderDeletionFailureEvent,
+    VFolderDeletionSuccessEvent,
 )
 from ai.backend.common.exception import AliasResolutionFailed
 from ai.backend.common.plugin.hook import ALL_COMPLETED, PASSED, HookPluginContext
@@ -195,6 +197,7 @@ from .models.utils import (
     reenter_txn_session,
     sql_json_merge,
 )
+from .models.vfolder import VFolderOperationStatus, update_vfolder_status
 from .types import UserScope
 
 if TYPE_CHECKING:
@@ -364,6 +367,9 @@ class AgentRegistry:
         evd.consume(AgentTerminatedEvent, self, handle_agent_lifecycle)
         evd.consume(AgentHeartbeatEvent, self, handle_agent_heartbeat)
         evd.consume(RouteCreatedEvent, self, handle_route_creation)
+
+        evd.consume(VFolderDeletionSuccessEvent, self, handle_vfolder_deletion)
+        evd.consume(VFolderDeletionFailureEvent, self, handle_vfolder_deletion)
 
         # action-trigerring events
         evd.consume(DoSyncKernelLogsEvent, self, handle_kernel_log, name="api.session.syncklog")
@@ -4402,6 +4408,23 @@ async def handle_kernel_log(
             )
     finally:
         log_buffer.close()
+
+
+async def handle_vfolder_deletion(
+    context: AgentRegistry,
+    source: AgentId,
+    event: VFolderDeletionSuccessEvent | VFolderDeletionFailureEvent,
+) -> None:
+    match event:
+        case VFolderDeletionSuccessEvent(vfid=vfid):
+            await update_vfolder_status(
+                context.db, [vfid.folder_id], VFolderOperationStatus.DELETE_COMPLETE, do_log=True
+            )
+        case VFolderDeletionFailureEvent(vfid=vfid, message=message):
+            log.exception(f"Failed to delete vfolder (vfid:{vfid}, msg:{message})")
+            await update_vfolder_status(
+                context.db, [vfid.folder_id], VFolderOperationStatus.DELETE_ERROR, do_log=True
+            )
 
 
 async def _make_session_callback(data: dict[str, Any], url: yarl.URL) -> None:

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import weakref
 from contextlib import contextmanager as ctxmgr
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -24,6 +25,7 @@ from typing import (
 )
 
 import attr
+import attrs
 import jwt
 import trafaret as t
 from aiohttp import hdrs, web
@@ -32,6 +34,8 @@ from ai.backend.common import validators as tx
 from ai.backend.common.events import (
     DoVolumeMountEvent,
     DoVolumeUnmountEvent,
+    VFolderDeletionFailureEvent,
+    VFolderDeletionSuccessEvent,
     VolumeMountableNodeType,
     VolumeMounted,
     VolumeUnmounted,
@@ -386,10 +390,54 @@ async def delete_vfolder(request: web.Request) -> web.Response:
     ) as params:
         await log_manager_api_entry(log, "delete_vfolder", params)
         ctx: RootContext = request.app["ctx"]
-        async with ctx.get_volume(params["volume"]) as volume:
-            with handle_fs_errors(volume, params["vfid"]):
-                await volume.delete_vfolder(params["vfid"])
-            return web.Response(status=204)
+        app_ctx: PrivateContext = request.app["app_ctx"]
+        vfid: VFolderID = params["vfid"]
+
+        async def _delete_vfolder(
+            task_map: weakref.WeakValueDictionary[VFolderID, asyncio.Task],
+        ) -> None:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            task_map[vfid] = current_task
+
+            try:
+                async with ctx.get_volume(params["volume"]) as volume:
+                    await volume.delete_vfolder(vfid)
+            except OSError as e:
+                msg = str(e) if e.strerror is None else e.strerror
+                msg = f"{msg} (errno:{e.errno})"
+                await ctx.event_producer.produce_event(
+                    VFolderDeletionFailureEvent(
+                        vfid,
+                        msg,
+                    )
+                )
+            except ExternalError as e:
+                await ctx.event_producer.produce_event(
+                    VFolderDeletionFailureEvent(
+                        vfid,
+                        str(e),
+                    )
+                )
+            except asyncio.CancelledError:
+                pass
+            else:
+                await ctx.event_producer.produce_event(VFolderDeletionSuccessEvent(vfid))
+
+        try:
+            async with ctx.get_volume(params["volume"]) as volume:
+                await volume.get_vfolder_mount(vfid, ".")
+        except VFolderNotFoundError:
+            ongoing_task = app_ctx.deletion_tasks.get(vfid)
+            if ongoing_task is not None:
+                ongoing_task.cancel()
+            return web.Response(status=404)
+        else:
+            ongoing_task = app_ctx.deletion_tasks.get(vfid)
+            if ongoing_task is None or ongoing_task.done():
+                asyncio.create_task(_delete_vfolder(app_ctx.deletion_tasks))
+
+    return web.Response(status=202)
 
 
 async def clone_vfolder(request: web.Request) -> web.Response:
@@ -1076,6 +1124,20 @@ async def delete_files(request: web.Request) -> web.Response:
         )
 
 
+@attrs.define(slots=True)
+class PrivateContext:
+    deletion_tasks: weakref.WeakValueDictionary[VFolderID, asyncio.Task]
+
+
+async def _shutdown(app: web.Application) -> None:
+    app_ctx: PrivateContext = app["app_ctx"]
+    for task in app_ctx.deletion_tasks.values():
+        task.cancel()
+        await asyncio.sleep(0)
+        if not task.done():
+            await task
+
+
 async def init_manager_app(ctx: RootContext) -> web.Application:
     app = web.Application(
         middlewares=[
@@ -1083,6 +1145,9 @@ async def init_manager_app(ctx: RootContext) -> web.Application:
         ],
     )
     app["ctx"] = ctx
+    app_ctx = PrivateContext(deletion_tasks=weakref.WeakValueDictionary())
+    app["app_ctx"] = app_ctx
+    app.on_shutdown.append(_shutdown)
     app.router.add_route("GET", "/", check_status)
     app.router.add_route("GET", "/status", check_status)
     app.router.add_route("GET", "/volumes", get_volumes)

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -434,7 +434,7 @@ async def delete_vfolder(request: web.Request) -> web.Response:
             ongoing_task = app_ctx.deletion_tasks.get(vfid)
             if ongoing_task is not None:
                 ongoing_task.cancel()
-            return web.Response(status=404)
+            return web.Response(status=410)
         else:
             ongoing_task = app_ctx.deletion_tasks.get(vfid)
             if ongoing_task is None or ongoing_task.done():


### PR DESCRIPTION
resolves #3060

### As is
```mermaid
sequenceDiagram
    participant Client
    participant Manager
    participant StorageProxy
    participant FileSystem


    Client->>Manager: Request VFolder deletion
    Manager->>Manager: Update VFolder status to "DELETE-ONGOING"
    Manager->>Client: Response
    activate Manager
    Note right of Manager: Spawn async task
    Manager->>StorageProxy: HTTP Request
    StorageProxy->>FileSystem: Delete tree
    FileSystem->>FileSystem: Long term job
    FileSystem->>StorageProxy: Finish
    StorageProxy->>Manager: HTTP 204 Response
    alt Deletion Success
        Manager->>Manager: Update VFolder status to "DELETE-COMPLETE"
    else
        Manager->>Manager: Update VFolder status to "DELETE-ERROR"
    end
    deactivate Manager
```

### To do
```mermaid
sequenceDiagram
    participant Client
    participant Manager
    participant StorageProxy
    participant FileSystem
    participant EventBus


    Client->>Manager: Request VFolder deletion
    Manager->>Manager: Update VFolder status to "DELETE-ONGOING"
    Manager->>StorageProxy: HTTP Request
    
    opt VFolder not found
        StorageProxy->>Manager: HTTP 404 Response
        Manager->>Manager: Update VFolder status to "DELETE-COMPLETE"
        Manager->>Client: Response
    end
    
    activate StorageProxy
    Note right of StorageProxy: Spawn async task
    StorageProxy->>Manager: HTTP 202 Response
    Manager->>Client: Response
    StorageProxy->>FileSystem: Delete tree
    FileSystem->>FileSystem: Long term job
    FileSystem->>StorageProxy: Finish
    StorageProxy-->> EventBus: Publish deletion-finish event
    deactivate StorageProxy

    EventBus-->>Manager: Consume deletion-finish event
    alt Deletion Success
        Manager->>Manager: Update VFolder status to "DELETE-COMPLETE"
    else
        Manager->>Manager: Update VFolder status to "DELETE-ERROR"
    end
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] API server-client counterparts (e.g., manager API -> client SDK)