### PR TITLE
feat(BA-147): Implement m2m table for `container_registries`, and `groups`

### DIFF
--- a/changes/3065.feature.md
+++ b/changes/3065.feature.md
@@ -1,0 +1,1 @@
+Implement `AssociationContainerRegistriesGroups` as m2m table of `container_registries`, and `groups`.

--- a/src/ai/backend/manager/models/__init__.py
+++ b/src/ai/backend/manager/models/__init__.py
@@ -1,5 +1,6 @@
 from . import acl as _acl
 from . import agent as _agent
+from . import association_container_registries_groups as _association_container_registries_groups
 from . import container_registry as _container_registry
 from . import domain as _domain
 from . import dotfile as _dotfile
@@ -31,6 +32,7 @@ __all__ = (
     "metadata",
     *_acl.__all__,
     *_agent.__all__,
+    *_association_container_registries_groups.__all__,
     *_container_registry.__all__,
     *_domain.__all__,
     *_endpoint.__all__,
@@ -60,6 +62,7 @@ __all__ = (
 
 from .acl import *  # noqa
 from .agent import *  # noqa
+from .association_container_registries_groups import *  # noqa
 from .container_registry import *  # noqa
 from .domain import *  # noqa
 from .dotfile import *  # noqa

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,6 +1,6 @@
 """Add association table with `ContainerRegistries`, and `Groups` table.Revision ID: 8f85e9d0bd4e
 Revision ID: 8f85e9d0bd4e
-Revises: fb89f5d7817b
+Revises: f6ca2f2d04c1
 Create Date: 2024-11-11 01:59:47.584430
 
 """
@@ -12,7 +12,7 @@ from ai.backend.manager.models.base import GUID, IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "8f85e9d0bd4e"
-down_revision = "fb89f5d7817b"
+down_revision = "f6ca2f2d04c1"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,6 +1,6 @@
 """Add association table with `ContainerRegistries`, and `Groups` table.Revision ID: 8f85e9d0bd4e
 Revision ID: 8f85e9d0bd4e
-Revises: f6ca2f2d04c1
+Revises: ecc9f6322be4
 Create Date: 2024-11-11 01:59:47.584430
 
 """
@@ -12,7 +12,7 @@ from ai.backend.manager.models.base import GUID, IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "8f85e9d0bd4e"
-down_revision = "f6ca2f2d04c1"
+down_revision = "ecc9f6322be4"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,7 +1,7 @@
 """Add association table with `ContainerRegistries`, and `Groups` table.
 
 Revision ID: 8f85e9d0bd4e
-Revises: e9e574a6e22d
+Revises: 6e44ea67d26e
 Create Date: 2024-11-11 01:59:47.584430
 
 """
@@ -13,7 +13,7 @@ from ai.backend.manager.models.base import GUID, IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "8f85e9d0bd4e"
-down_revision = "e9e574a6e22d"
+down_revision = "6e44ea67d26e"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -32,6 +32,7 @@ def upgrade() -> None:
             GUID,
             nullable=False,
         ),
+        sa.UniqueConstraint("registry_id", "group_id", name="uq_registry_id_group_id"),
     )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,7 +1,6 @@
-"""Add association table with `ContainerRegistries`, and `Groups` table.
-
+"""Add association table with `ContainerRegistries`, and `Groups` table.Revision ID: 8f85e9d0bd4e
 Revision ID: 8f85e9d0bd4e
-Revises: 0bb88d5a46bf
+Revises: fb89f5d7817b
 Create Date: 2024-11-11 01:59:47.584430
 
 """
@@ -13,7 +12,7 @@ from ai.backend.manager.models.base import GUID, IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "8f85e9d0bd4e"
-down_revision = "0bb88d5a46bf"
+down_revision = "fb89f5d7817b"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
         "association_container_registries_groups",
         IDColumn("id"),
         sa.Column(
-            "container_registry_id",
+            "registry_id",
             GUID,
             sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
             nullable=False,

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -25,13 +25,11 @@ def upgrade() -> None:
         sa.Column(
             "registry_id",
             GUID,
-            sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
             nullable=False,
         ),
         sa.Column(
             "group_id",
             GUID,
-            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
             nullable=False,
         ),
     )

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,7 +1,7 @@
 """Add association table with `ContainerRegistries`, and `Groups` table.
 
 Revision ID: 8f85e9d0bd4e
-Revises: 6e44ea67d26e
+Revises: 0bb88d5a46bf
 Create Date: 2024-11-11 01:59:47.584430
 
 """
@@ -13,7 +13,7 @@ from ai.backend.manager.models.base import GUID, IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "8f85e9d0bd4e"
-down_revision = "6e44ea67d26e"
+down_revision = "0bb88d5a46bf"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f85e9d0bd4e_add_association_containerregistries_.py
@@ -1,0 +1,41 @@
+"""Add association table with `ContainerRegistries`, and `Groups` table.
+
+Revision ID: 8f85e9d0bd4e
+Revises: e9e574a6e22d
+Create Date: 2024-11-11 01:59:47.584430
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID, IDColumn
+
+# revision identifiers, used by Alembic.
+revision = "8f85e9d0bd4e"
+down_revision = "e9e574a6e22d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "association_container_registries_groups",
+        IDColumn("id"),
+        sa.Column(
+            "container_registry_id",
+            GUID,
+            sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "group_id",
+            GUID,
+            sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("association_container_registries_groups")

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -18,8 +18,8 @@ __all__: Sequence[str] = ("AssociationContainerRegistriesGroupsRow",)
 class AssociationContainerRegistriesGroupsRow(Base):
     __tablename__ = "association_container_registries_groups"
     id = IDColumn()
-    container_registry_id = sa.Column(
-        "container_registry_id",
+    registry_id = sa.Column(
+        "registry_id",
         GUID,
         sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
@@ -31,6 +31,6 @@ class AssociationContainerRegistriesGroupsRow(Base):
         nullable=False,
     )
 
-    def __init__(self, container_registry_id: uuid.UUID, group_id: uuid.UUID):
-        self.container_registry_id = container_registry_id
+    def __init__(self, registry_id: uuid.UUID, group_id: uuid.UUID):
+        self.registry_id = registry_id
         self.group_id = group_id

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -17,6 +17,11 @@ __all__: Sequence[str] = ("AssociationContainerRegistriesGroupsRow",)
 
 class AssociationContainerRegistriesGroupsRow(Base):
     __tablename__ = "association_container_registries_groups"
+    __table_args__ = (
+        # constraint
+        sa.UniqueConstraint("registry_id", "group_id", name="uq_registry_id_group_id"),
+    )
+
     id = IDColumn()
     registry_id = sa.Column(
         "registry_id",

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Sequence
+
+import sqlalchemy as sa
+
+from ai.backend.common.logging_utils import BraceStyleAdapter
+
+from .base import GUID, Base, IDColumn
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
+
+__all__: Sequence[str] = ("AssociationContainerRegistriesGroupsRow",)
+
+
+class AssociationContainerRegistriesGroupsRow(Base):
+    __tablename__ = "association_container_registries_groups"
+    id = IDColumn()
+    container_registry_id = sa.Column(
+        "container_registry_id",
+        GUID,
+        sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
+        nullable=False,
+    )
+    group_id = sa.Column(
+        "group_id",
+        GUID,
+        sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    def __init__(self, container_registry_id: uuid.UUID, group_id: uuid.UUID):
+        self.container_registry_id = container_registry_id
+        self.group_id = group_id

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -4,6 +4,7 @@ import logging
 from typing import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy.orm import relationship
 
 from ai.backend.logging import BraceStyleAdapter
 
@@ -20,12 +21,22 @@ class AssociationContainerRegistriesGroupsRow(Base):
     registry_id = sa.Column(
         "registry_id",
         GUID,
-        sa.ForeignKey("container_registries.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
     )
     group_id = sa.Column(
         "group_id",
         GUID,
-        sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
+    )
+
+    container_registry_row = relationship(
+        "ContainerRegistryRow",
+        back_populates="association_container_registries_groups_rows",
+        primaryjoin="ContainerRegistryRow.id == foreign(AssociationContainerRegistriesGroupsRow.registry_id)",
+    )
+
+    group_row = relationship(
+        "GroupRow",
+        back_populates="association_container_registries_groups_rows",
+        primaryjoin="GroupRow.id == foreign(AssociationContainerRegistriesGroupsRow.group_id)",
     )

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Sequence
 
 import sqlalchemy as sa
@@ -30,7 +29,3 @@ class AssociationContainerRegistriesGroupsRow(Base):
         sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
     )
-
-    def __init__(self, registry_id: uuid.UUID, group_id: uuid.UUID):
-        self.registry_id = registry_id
-        self.group_id = group_id

--- a/src/ai/backend/manager/models/association_container_registries_groups.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 import sqlalchemy as sa
 
-from ai.backend.common.logging_utils import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 
 from .base import GUID, Base, IDColumn
 

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -88,6 +88,12 @@ class ContainerRegistryRow(Base):
         primaryjoin="ContainerRegistryRow.id == foreign(ImageRow.registry_id)",
     )
 
+    association_container_registries_groups_rows = relationship(
+        "AssociationContainerRegistriesGroupsRow",
+        back_populates="container_registry_row",
+        primaryjoin="ContainerRegistryRow.id == foreign(AssociationContainerRegistriesGroupsRow.registry_id)",
+    )
+
     @classmethod
     async def get(
         cls,

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -216,6 +216,11 @@ class GroupRow(Base):
         back_populates="group_row",
         primaryjoin="GroupRow.id == foreign(VFolderRow.group)",
     )
+    association_container_registries_groups_rows = relationship(
+        "AssociationContainerRegistriesGroupsRow",
+        back_populates="group_row",
+        primaryjoin="GroupRow.id == foreign(AssociationContainerRegistriesGroupsRow.group_id)",
+    )
 
     @classmethod
     async def get(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Implement `AssociationContainerRegistriesGroups` as m2m table of `container_registries`, and `groups` for resolving https://github.com/lablup/backend.ai/issues/1908 ([BA-147](https://lablup.atlassian.net/browse/BA-147)).

> [!NOTE]
> #1908 mentions both user and project, but since project needs to be implemented first, this PR stack addresses only the project aspect.
> Refer to #1960 for adding an association table with the User table and related tasks.


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue


[BA-147]: https://lablup.atlassian.net/browse/BA-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3065.org.readthedocs.build/en/3065/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3065.org.readthedocs.build/ko/3065/

<!-- readthedocs-preview sorna-ko end -->