### PR TITLE
feat(BA-463): Implement APIs for associating, disassociating `container_registries` with `groups`

### DIFF
--- a/changes/3067.feature.md
+++ b/changes/3067.feature.md
@@ -1,0 +1,1 @@
+Implement APIs for associating, disassociating `container_registries` with `groups`.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1957,10 +1957,10 @@ type Mutations {
   """Added in 25.1.0."""
   delete_endpoint_auto_scaling_rule_node(id: String!): DeleteEndpointAutoScalingRuleNode
 
-  """Added in 25.1.0."""
+  """Added in 25.2.0."""
   associate_container_registry_with_group(group_id: String!, registry_id: String!): AssociateContainerRegistryWithGroup
 
-  """Added in 25.1.0."""
+  """Added in 25.2.0."""
   disassociate_container_registry_with_group(group_id: String!, registry_id: String!): DisassociateContainerRegistryWithGroup
 
   """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
@@ -2775,13 +2775,13 @@ type DeleteEndpointAutoScalingRuleNode {
   msg: String
 }
 
-"""Added in 25.1.0."""
+"""Added in 25.2.0."""
 type AssociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.1.0."""
+"""Added in 25.2.0."""
 type DisassociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1957,6 +1957,12 @@ type Mutations {
   """Added in 25.1.0."""
   delete_endpoint_auto_scaling_rule_node(id: String!): DeleteEndpointAutoScalingRuleNode
 
+  """Added in 24.12.0"""
+  associate_container_registry_with_group(group_id: String!, registry_id: String!): AssociateContainerRegistryWithGroup
+
+  """Added in 24.12.0"""
+  disassociate_container_registry_with_group(group_id: String!, registry_id: String!): DisassociateContainerRegistryWithGroup
+
   """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
   create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry
 
@@ -2765,6 +2771,18 @@ input ModifyEndpointAutoScalingRuleInput {
 
 """Added in 25.1.0."""
 type DeleteEndpointAutoScalingRuleNode {
+  ok: Boolean
+  msg: String
+}
+
+"""Added in 24.12.0."""
+type AssociateContainerRegistryWithGroup {
+  ok: Boolean
+  msg: String
+}
+
+"""Added in 24.12.0."""
+type DisassociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String
 }

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1957,10 +1957,10 @@ type Mutations {
   """Added in 25.1.0."""
   delete_endpoint_auto_scaling_rule_node(id: String!): DeleteEndpointAutoScalingRuleNode
 
-  """Added in 25.01.0."""
+  """Added in 25.1.0."""
   associate_container_registry_with_group(group_id: String!, registry_id: String!): AssociateContainerRegistryWithGroup
 
-  """Added in 25.01.0."""
+  """Added in 25.1.0."""
   disassociate_container_registry_with_group(group_id: String!, registry_id: String!): DisassociateContainerRegistryWithGroup
 
   """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
@@ -2775,13 +2775,13 @@ type DeleteEndpointAutoScalingRuleNode {
   msg: String
 }
 
-"""Added in 25.01.0."""
+"""Added in 25.1.0."""
 type AssociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.01.0."""
+"""Added in 25.1.0."""
 type DisassociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1957,10 +1957,10 @@ type Mutations {
   """Added in 25.1.0."""
   delete_endpoint_auto_scaling_rule_node(id: String!): DeleteEndpointAutoScalingRuleNode
 
-  """Added in 24.12.0"""
+  """Added in 25.01.0."""
   associate_container_registry_with_group(group_id: String!, registry_id: String!): AssociateContainerRegistryWithGroup
 
-  """Added in 24.12.0"""
+  """Added in 25.01.0."""
   disassociate_container_registry_with_group(group_id: String!, registry_id: String!): DisassociateContainerRegistryWithGroup
 
   """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
@@ -2775,13 +2775,13 @@ type DeleteEndpointAutoScalingRuleNode {
   msg: String
 }
 
-"""Added in 24.12.0."""
+"""Added in 25.01.0."""
 type AssociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.12.0."""
+"""Added in 25.01.0."""
 type DisassociateContainerRegistryWithGroup {
   ok: Boolean
   msg: String

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20,6 +20,46 @@
       }
     },
     "schemas": {
+      "AssociationRequestModel": {
+        "properties": {
+          "registry_id": {
+            "description": "Container registry row's ID",
+            "title": "Registry Id",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "Group row's ID",
+            "title": "Group Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "registry_id",
+          "group_id"
+        ],
+        "title": "AssociationRequestModel",
+        "type": "object"
+      },
+      "DisassociationRequestModel": {
+        "properties": {
+          "registry_id": {
+            "description": "Container registry row's ID",
+            "title": "Registry Id",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "Group row's ID",
+            "title": "Group Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "registry_id",
+          "group_id"
+        ],
+        "title": "DisassociationRequestModel",
+        "type": "object"
+      },
       "VFolderPermission": {
         "description": "Permissions for a virtual folder given to a specific access key.\nRW_DELETE includes READ_WRITE and READ_WRITE includes READ_ONLY.",
         "enum": [
@@ -1216,6 +1256,64 @@
         ],
         "parameters": [],
         "description": "\n**Preconditions:**\n* User privilege required.\n* Manager status required: RUNNING\n"
+      }
+    },
+    "/container-registries/associate-with-group": {
+      "post": {
+        "operationId": "container-registries.associate_with_group",
+        "tags": [
+          "container-registries"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssociationRequestModel"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "\n**Preconditions:**\n* Superadmin privilege required.\n* Manager status required: one of FROZEN, RUNNING\n"
+      }
+    },
+    "/container-registries/disassociate-with-group": {
+      "post": {
+        "operationId": "container-registries.disassociate_with_group",
+        "tags": [
+          "container-registries"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisassociationRequestModel"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "\n**Preconditions:**\n* Superadmin privilege required.\n* Manager status required: one of FROZEN, RUNNING\n"
       }
     },
     "/config/resource-slots": {

--- a/src/ai/backend/client/func/container_registry.py
+++ b/src/ai/backend/client/func/container_registry.py
@@ -20,11 +20,6 @@ class ContainerRegistry(BaseFunction):
       have the *admin* privilege.
     """
 
-    registry_id: str
-
-    def __init__(self, registry_id: str):
-        self.registry_id = registry_id
-
     @api_function
     @classmethod
     async def associate_group(cls, registry_id: str, group_id: str) -> dict:

--- a/src/ai/backend/client/func/container_registry.py
+++ b/src/ai/backend/client/func/container_registry.py
@@ -26,8 +26,8 @@ class ContainerRegistry(BaseFunction):
         """
         Associate container_registry with group.
 
-        :param registry_id: Id of the container registry.
-        :param group_id: Id of the group.
+        :param registry_id: ID of the container registry.
+        :param group_id: ID of the group.
         """
         query = textwrap.dedent(
             """\
@@ -49,8 +49,8 @@ class ContainerRegistry(BaseFunction):
         """
         Disassociate container_registry with group.
 
-        :param registry_id: Id of the container registry.
-        :param group_id: Id of the group.
+        :param registry_id: ID of the container registry.
+        :param group_id: ID of the group.
         """
         query = textwrap.dedent(
             """\

--- a/src/ai/backend/client/func/container_registry.py
+++ b/src/ai/backend/client/func/container_registry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import textwrap
+
+from ..session import api_session
+from .base import BaseFunction, api_function
+
+__all__ = ("ContainerRegistry",)
+
+
+class ContainerRegistry(BaseFunction):
+    """
+    Provides a shortcut of :func:`Admin.query()
+    <ai.backend.client.admin.Admin.query>` that fetches, modifies various container registry
+    information.
+
+    .. note::
+
+      All methods in this function class require your API access key to
+      have the *admin* privilege.
+    """
+
+    registry_id: str
+
+    def __init__(self, registry_id: str):
+        self.registry_id = registry_id
+
+    @api_function
+    @classmethod
+    async def associate_group(cls, registry_id: str, group_id: str) -> dict:
+        """
+        Associate container_registry with group.
+
+        :param registry_id: The id of a container registry.
+        :param group_id: The id of a group.
+        """
+        query = textwrap.dedent(
+            """\
+            mutation($registry_id: String!, $group_id: String!) {
+                associate_container_registry_with_group(
+                        registry_id: $registry_id, group_id: $group_id) {
+                    ok msg
+                }
+            }
+        """
+        )
+        variables = {"registry_id": registry_id, "group_id": group_id}
+        data = await api_session.get().Admin._query(query, variables)
+        return data["associate_container_registry_with_group"]
+
+    @api_function
+    @classmethod
+    async def disassociate_group(cls, registry_id: str, group_id: str) -> dict:
+        """
+        Disassociate container_registry with group.
+
+        :param registry_id: The id of a container registry.
+        :param group_id: The id of a group.
+        """
+        query = textwrap.dedent(
+            """\
+            mutation($registry_id: String!, $group_id: String!) {
+                disassociate_container_registry_with_group(
+                        registry_id: $registry_id, group_id: $group_id) {
+                    ok msg
+                }
+            }
+        """
+        )
+        variables = {"registry_id": registry_id, "group_id": group_id}
+        data = await api_session.get().Admin._query(query, variables)
+        return data["disassociate_container_registry_with_group"]

--- a/src/ai/backend/client/func/container_registry.py
+++ b/src/ai/backend/client/func/container_registry.py
@@ -26,8 +26,8 @@ class ContainerRegistry(BaseFunction):
         """
         Associate container_registry with group.
 
-        :param registry_id: The id of a container registry.
-        :param group_id: The id of a group.
+        :param registry_id: Id of the container registry.
+        :param group_id: Id of the group.
         """
         query = textwrap.dedent(
             """\
@@ -49,8 +49,8 @@ class ContainerRegistry(BaseFunction):
         """
         Disassociate container_registry with group.
 
-        :param registry_id: The id of a container registry.
-        :param group_id: The id of a group.
+        :param registry_id: Id of the container registry.
+        :param group_id: Id of the group.
         """
         query = textwrap.dedent(
             """\

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -254,6 +254,7 @@ class BaseSession(metaclass=abc.ABCMeta):
         "ScalingGroup",
         "Storage",
         "Image",
+        "ContainerRegistry",
         "ComputeSession",
         "SessionTemplate",
         "Domain",
@@ -299,6 +300,7 @@ class BaseSession(metaclass=abc.ABCMeta):
         from .func.agent import Agent, AgentWatcher
         from .func.auth import Auth
         from .func.bgtask import BackgroundTask
+        from .func.container_registry import ContainerRegistry
         from .func.domain import Domain
         from .func.dotfile import Dotfile
         from .func.etcd import EtcdConfig
@@ -329,6 +331,7 @@ class BaseSession(metaclass=abc.ABCMeta):
         self.Storage = Storage
         self.Auth = Auth
         self.BackgroundTask = BackgroundTask
+        self.ContainerRegistry = ContainerRegistry
         self.EtcdConfig = EtcdConfig
         self.Domain = Domain
         self.Group = Group

--- a/src/ai/backend/manager/api/container_registry.py
+++ b/src/ai/backend/manager/api/container_registry.py
@@ -53,7 +53,7 @@ async def associate_with_group(request: web.Request, params: Any) -> web.Respons
         except IntegrityError:
             raise GenericBadRequest("Association already exists.")
 
-    return web.json_response({})
+    return web.Response(status=204)
 
 
 @server_status_required(READ_ALLOWED)
@@ -81,7 +81,7 @@ async def disassociate_with_group(request: web.Request, params: Any) -> web.Resp
         if result.rowcount == 0:
             raise ContainerRegistryNotFound()
 
-    return web.json_response({})
+    return web.Response(status=204)
 
 
 def create_app(

--- a/src/ai/backend/manager/api/container_registry.py
+++ b/src/ai/backend/manager/api/container_registry.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Iterable, Tuple
+
+import aiohttp_cors
+import sqlalchemy as sa
+import trafaret as t
+from aiohttp import web
+
+from ai.backend.common import validators as tx
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.models.association_container_registries_groups import (
+    AssociationContainerRegistriesGroupsRow,
+)
+
+if TYPE_CHECKING:
+    from .context import RootContext
+
+from .auth import superadmin_required
+from .manager import READ_ALLOWED, server_status_required
+from .types import CORSOptions, WebMiddleware
+from .utils import check_api_params
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+@server_status_required(READ_ALLOWED)
+@superadmin_required
+@check_api_params(
+    t.Dict({
+        tx.AliasedKey(["registry_id", "registry"]): t.String,
+        tx.AliasedKey(["group_id", "group"]): t.String,
+    })
+)
+async def associate_with_group(request: web.Request, params: Any) -> web.Response:
+    log.info("ASSOCIATE_WITH_GROUP (cr:{}, gr:{})", params["registry_id"], params["group_id"])
+    root_ctx: RootContext = request.app["_root.context"]
+    registry_id = params["registry_id"]
+    group_id = params["group_id"]
+
+    async with root_ctx.db.begin_session() as db_sess:
+        insert_query = sa.insert(AssociationContainerRegistriesGroupsRow).values({
+            "registry_id": registry_id,
+            "group_id": group_id,
+        })
+
+        await db_sess.execute(insert_query)
+
+    return web.json_response({})
+
+
+@server_status_required(READ_ALLOWED)
+@superadmin_required
+@check_api_params(
+    t.Dict({
+        tx.AliasedKey(["registry_id", "registry"]): t.String,
+        tx.AliasedKey(["group_id", "group"]): t.String,
+    })
+)
+async def disassociate_with_group(request: web.Request, params: Any) -> web.Response:
+    log.info("DISASSOCIATE_WITH_GROUP (cr:{}, gr:{})", params["registry_id"], params["group_id"])
+    root_ctx: RootContext = request.app["_root.context"]
+    registry_id = params["registry_id"]
+    group_id = params["group_id"]
+
+    async with root_ctx.db.begin_session() as db_sess:
+        delete_query = (
+            sa.delete(AssociationContainerRegistriesGroupsRow)
+            .where(AssociationContainerRegistriesGroupsRow.registry_id == registry_id)
+            .where(AssociationContainerRegistriesGroupsRow.group_id == group_id)
+        )
+
+        await db_sess.execute(delete_query)
+
+    return web.json_response({})
+
+
+def create_app(
+    default_cors_options: CORSOptions,
+) -> Tuple[web.Application, Iterable[WebMiddleware]]:
+    app = web.Application()
+    app["api_versions"] = (1, 2, 3, 4, 5)
+    app["prefix"] = "container-registries"
+    cors = aiohttp_cors.setup(app, defaults=default_cors_options)
+    cors.add(app.router.add_route("POST", "/associate-with-group", associate_with_group))
+    cors.add(app.router.add_route("POST", "/disassociate-with-group", disassociate_with_group))
+    return app, []

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -246,6 +246,10 @@ class EndpointTokenNotFound(ObjectNotFound):
     object_name = "endpoint_token"
 
 
+class ContainerRegistryNotFound(ObjectNotFound):
+    object_name = "container_registry"
+
+
 class TooManySessionsMatched(BackendError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/too-many-sessions-matched"
     error_title = "Too many sessions matched."

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -356,10 +356,10 @@ class Mutations(graphene.ObjectType):
         description="Added in 25.1.0."
     )
     associate_container_registry_with_group = AssociateContainerRegistryWithGroup.Field(
-        description="Added in 24.12.0"
+        description="Added in 25.01.0."
     )
     disassociate_container_registry_with_group = DisassociateContainerRegistryWithGroup.Field(
-        description="Added in 24.12.0"
+        description="Added in 25.01.0."
     )
 
     # Legacy mutations

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -356,10 +356,10 @@ class Mutations(graphene.ObjectType):
         description="Added in 25.1.0."
     )
     associate_container_registry_with_group = AssociateContainerRegistryWithGroup.Field(
-        description="Added in 25.01.0."
+        description="Added in 25.1.0."
     )
     disassociate_container_registry_with_group = DisassociateContainerRegistryWithGroup.Field(
-        description="Added in 25.01.0."
+        description="Added in 25.1.0."
     )
 
     # Legacy mutations

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -74,6 +74,10 @@ from .gql_models.agent import (
     AgentSummaryList,
     ModifyAgent,
 )
+from .gql_models.container_registry import (
+    AssociateContainerRegistryWithGroup,
+    DisassociateContainerRegistryWithGroup,
+)
 from .gql_models.domain import (
     CreateDomainNode,
     DomainConnection,
@@ -350,6 +354,12 @@ class Mutations(graphene.ObjectType):
     )
     delete_endpoint_auto_scaling_rule_node = DeleteEndpointAutoScalingRuleNode.Field(
         description="Added in 25.1.0."
+    )
+    associate_container_registry_with_group = AssociateContainerRegistryWithGroup.Field(
+        description="Added in 24.12.0"
+    )
+    disassociate_container_registry_with_group = DisassociateContainerRegistryWithGroup.Field(
+        description="Added in 24.12.0"
     )
 
     # Legacy mutations

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -356,10 +356,10 @@ class Mutations(graphene.ObjectType):
         description="Added in 25.1.0."
     )
     associate_container_registry_with_group = AssociateContainerRegistryWithGroup.Field(
-        description="Added in 25.1.0."
+        description="Added in 25.2.0."
     )
     disassociate_container_registry_with_group = DisassociateContainerRegistryWithGroup.Field(
-        description="Added in 25.1.0."
+        description="Added in 25.2.0."
     )
 
     # Legacy mutations

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -7,12 +7,12 @@ import graphene
 import sqlalchemy as sa
 
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.models.association_container_registries_groups import (
+
+from ..association_container_registries_groups import (
     AssociationContainerRegistriesGroupsRow,
 )
-from ai.backend.manager.models.base import simple_db_mutate
-
-from .user import UserRole
+from ..base import simple_db_mutate
+from ..user import UserRole
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
 

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -18,7 +18,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
 
 
 class AssociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 25.1.0."""
+    """Added in 25.2.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 
@@ -45,7 +45,7 @@ class AssociateContainerRegistryWithGroup(graphene.Mutation):
 
 
 class DisassociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 25.1.0."""
+    """Added in 25.2.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -6,7 +6,7 @@ from typing import Self
 import graphene
 import sqlalchemy as sa
 
-from ai.backend.common.logging_utils import BraceStyleAdapter
+from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.association_container_registries_groups import (
     AssociationContainerRegistriesGroupsRow,
 )

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -18,7 +18,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
 
 
 class AssociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 24.12.0."""
+    """Added in 25.01.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 
@@ -45,7 +45,7 @@ class AssociateContainerRegistryWithGroup(graphene.Mutation):
 
 
 class DisassociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 24.12.0."""
+    """Added in 25.01.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from typing import Self
+
+import graphene
+import sqlalchemy as sa
+
+from ai.backend.common.logging_utils import BraceStyleAdapter
+from ai.backend.manager.models.association_container_registries_groups import (
+    AssociationContainerRegistriesGroupsRow,
+)
+from ai.backend.manager.models.base import simple_db_mutate
+
+from .user import UserRole
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
+
+
+class AssociateContainerRegistryWithGroup(graphene.Mutation):
+    """Added in 24.12.0."""
+
+    allowed_roles = (UserRole.SUPERADMIN,)
+
+    class Arguments:
+        registry_id = graphene.String(required=True)
+        group_id = graphene.String(required=True)
+
+    ok = graphene.Boolean()
+    msg = graphene.String()
+
+    @classmethod
+    async def mutate(
+        cls,
+        root,
+        info: graphene.ResolveInfo,
+        registry_id: str,
+        group_id: str,
+    ) -> Self:
+        insert_query = sa.insert(AssociationContainerRegistriesGroupsRow).values({
+            "registry_id": registry_id,
+            "group_id": group_id,
+        })
+        return await simple_db_mutate(cls, info.context, insert_query)
+
+
+class DisassociateContainerRegistryWithGroup(graphene.Mutation):
+    """Added in 24.12.0."""
+
+    allowed_roles = (UserRole.SUPERADMIN,)
+
+    class Arguments:
+        registry_id = graphene.String(required=True)
+        group_id = graphene.String(required=True)
+
+    ok = graphene.Boolean()
+    msg = graphene.String()
+
+    @classmethod
+    async def mutate(
+        cls,
+        root,
+        info: graphene.ResolveInfo,
+        registry_id: str,
+        group_id: str,
+    ) -> Self:
+        delete_query = (
+            sa.delete(AssociationContainerRegistriesGroupsRow)
+            .where(AssociationContainerRegistriesGroupsRow.registry_id == registry_id)
+            .where(AssociationContainerRegistriesGroupsRow.group_id == group_id)
+        )
+        return await simple_db_mutate(cls, info.context, delete_query)

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -18,7 +18,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
 
 
 class AssociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 25.01.0."""
+    """Added in 25.1.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 
@@ -45,7 +45,7 @@ class AssociateContainerRegistryWithGroup(graphene.Mutation):
 
 
 class DisassociateContainerRegistryWithGroup(graphene.Mutation):
-    """Added in 25.01.0."""
+    """Added in 25.1.0."""
 
     allowed_roles = (UserRole.SUPERADMIN,)
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -176,6 +176,7 @@ public_interface_objs: MutableMapping[str, Any] = {}
 
 global_subapp_pkgs: Final[list[str]] = [
     ".acl",
+    ".container_registry",
     ".etcd",
     ".events",
     ".auth",

--- a/tests/manager/api/test_container_registries.py
+++ b/tests/manager/api/test_container_registries.py
@@ -1,0 +1,158 @@
+import json
+
+import pytest
+
+from ai.backend.manager.server import (
+    database_ctx,
+    hook_plugin_ctx,
+    monitoring_ctx,
+    redis_ctx,
+    shared_config_ctx,
+)
+
+FIXTURES_WITH_NOASSOC = [
+    {
+        "groups": [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "mock_group",
+                "description": "",
+                "is_active": True,
+                "domain_name": "default",
+                "resource_policy": "default",
+                "total_resource_slots": {},
+                "allowed_vfolder_hosts": {},
+                "type": "general",
+            }
+        ],
+        "container_registries": [
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "url": "https://mock.registry.com",
+                "type": "docker",
+                "project": "mock_project",
+                "registry_name": "mock_registry",
+            }
+        ],
+    }
+]
+
+FIXTURES_WITH_ASSOC = [
+    {
+        **fixture,
+        "association_container_registries_groups": [
+            {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "group_id": "00000000-0000-0000-0000-000000000001",
+                "registry_id": "00000000-0000-0000-0000-000000000002",
+            }
+        ],
+    }
+    for fixture in FIXTURES_WITH_NOASSOC
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra_fixtures",
+    FIXTURES_WITH_NOASSOC + FIXTURES_WITH_ASSOC,
+    ids=["(No association)", "(With association)"],
+)
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "group_id": "00000000-0000-0000-0000-000000000001",
+            "registry_id": "00000000-0000-0000-0000-000000000002",
+        },
+    ],
+    ids=["Associate One group with one container registry"],
+)
+async def test_associate_container_registry_with_group(
+    test_case,
+    etcd_fixture,
+    extra_fixtures,
+    database_fixture,
+    create_app_and_client,
+    get_headers,
+):
+    app, client = await create_app_and_client(
+        [
+            shared_config_ctx,
+            database_ctx,
+            monitoring_ctx,
+            hook_plugin_ctx,
+            redis_ctx,
+        ],
+        [".container_registry", ".auth"],
+    )
+
+    group_id = test_case["group_id"]
+    registry_id = test_case["registry_id"]
+
+    url = "/container-registries/associate-with-group"
+    params = {"group_id": group_id, "registry_id": registry_id}
+
+    req_bytes = json.dumps(params).encode()
+    headers = get_headers("POST", url, req_bytes)
+
+    resp = await client.post(url, data=req_bytes, headers=headers)
+    association_exist = "association_container_registries_groups" in extra_fixtures
+
+    if association_exist:
+        assert resp.status == 400
+    else:
+        assert resp.status == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra_fixtures",
+    FIXTURES_WITH_ASSOC + FIXTURES_WITH_NOASSOC,
+    ids=["(With association)", "(No association)"],
+)
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "group_id": "00000000-0000-0000-0000-000000000001",
+            "registry_id": "00000000-0000-0000-0000-000000000002",
+        },
+    ],
+    ids=["Disassociate One group with one container registry"],
+)
+async def test_disassociate_container_registry_with_group(
+    test_case,
+    etcd_fixture,
+    extra_fixtures,
+    database_fixture,
+    create_app_and_client,
+    get_headers,
+):
+    app, client = await create_app_and_client(
+        [
+            shared_config_ctx,
+            database_ctx,
+            monitoring_ctx,
+            hook_plugin_ctx,
+            redis_ctx,
+        ],
+        [".container_registry", ".auth"],
+    )
+
+    group_id = test_case["group_id"]
+    registry_id = test_case["registry_id"]
+
+    url = "/container-registries/disassociate-with-group"
+    params = {"group_id": group_id, "registry_id": registry_id}
+
+    req_bytes = json.dumps(params).encode()
+    headers = get_headers("POST", url, req_bytes)
+
+    resp = await client.post(url, data=req_bytes, headers=headers)
+    association_exist = "association_container_registries_groups" in extra_fixtures
+
+    if association_exist:
+        assert resp.status == 200
+    else:
+        assert resp.status == 404

--- a/tests/manager/api/test_container_registries.py
+++ b/tests/manager/api/test_container_registries.py
@@ -102,7 +102,7 @@ async def test_associate_container_registry_with_group(
     if association_exist:
         assert resp.status == 400
     else:
-        assert resp.status == 200
+        assert resp.status == 204
 
 
 @pytest.mark.asyncio
@@ -153,6 +153,6 @@ async def test_disassociate_container_registry_with_group(
     association_exist = "association_container_registries_groups" in extra_fixtures
 
     if association_exist:
-        assert resp.status == 200
+        assert resp.status == 204
     else:
         assert resp.status == 404

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -262,6 +262,7 @@ def etcd_fixture(
     cli_ctx._local_config = local_config  # override the lazy-loaded config
     with tempfile.NamedTemporaryFile(mode="w", suffix=".etcd.json") as f:
         etcd_fixture = {
+            "manager": {"status": "running"},
             "volumes": {
                 "_mount": str(vfolder_mount),
                 "_fsprefix": str(vfolder_fsprefix),

--- a/tests/manager/models/gql_models/BUILD
+++ b/tests/manager/models/gql_models/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/manager/models/gql_models/test_container_registries.py
+++ b/tests/manager/models/gql_models/test_container_registries.py
@@ -31,6 +31,7 @@ def get_graphquery_context(database_engine: ExtendedAsyncSAEngine) -> GraphQuery
         storage_manager=None,  # type: ignore
         registry=None,  # type: ignore
         idle_checker_host=None,  # type: ignore
+        network_plugin_ctx=None,  # type: ignore
     )
 
 

--- a/tests/manager/models/gql_models/test_container_registries.py
+++ b/tests/manager/models/gql_models/test_container_registries.py
@@ -1,0 +1,150 @@
+import pytest
+from graphene import Schema
+from graphene.test import Client
+
+from ai.backend.manager.models.gql import GraphQueryContext, Mutations, Queries
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.server import database_ctx
+
+
+@pytest.fixture(scope="module")
+def client() -> Client:
+    return Client(Schema(query=Queries, mutation=Mutations, auto_camelcase=False))
+
+
+def get_graphquery_context(database_engine: ExtendedAsyncSAEngine) -> GraphQueryContext:
+    return GraphQueryContext(
+        schema=None,  # type: ignore
+        dataloader_manager=None,  # type: ignore
+        local_config=None,  # type: ignore
+        shared_config=None,  # type: ignore
+        etcd=None,  # type: ignore
+        user={"domain": "default", "role": "superadmin"},
+        access_key="AKIAIOSFODNN7EXAMPLE",
+        db=database_engine,  # type: ignore
+        redis_stat=None,  # type: ignore
+        redis_image=None,  # type: ignore
+        redis_live=None,  # type: ignore
+        manager_status=None,  # type: ignore
+        known_slot_types=None,  # type: ignore
+        background_task_manager=None,  # type: ignore
+        storage_manager=None,  # type: ignore
+        registry=None,  # type: ignore
+        idle_checker_host=None,  # type: ignore
+    )
+
+
+FIXTURES_WITH_NOASSOC = [
+    {
+        "groups": [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "mock_group",
+                "description": "",
+                "is_active": True,
+                "domain_name": "default",
+                "resource_policy": "default",
+                "total_resource_slots": {},
+                "allowed_vfolder_hosts": {},
+                "type": "general",
+            }
+        ],
+        "container_registries": [
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "url": "https://mock.registry.com",
+                "type": "docker",
+                "project": "mock_project",
+                "registry_name": "mock_registry",
+            }
+        ],
+    }
+]
+
+FIXTURES_WITH_ASSOC = [
+    {
+        "groups": [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "mock_group",
+                "description": "",
+                "is_active": True,
+                "domain_name": "default",
+                "resource_policy": "default",
+                "total_resource_slots": {},
+                "allowed_vfolder_hosts": {},
+                "type": "general",
+            }
+        ],
+        "container_registries": [
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "url": "https://mock.registry.com",
+                "type": "docker",
+                "project": "mock_project",
+                "registry_name": "mock_registry",
+            }
+        ],
+        "association_container_registries_groups": [
+            {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "group_id": "00000000-0000-0000-0000-000000000001",
+                "registry_id": "00000000-0000-0000-0000-000000000002",
+            }
+        ],
+    }
+]
+
+
+@pytest.mark.dependency()
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra_fixtures",
+    FIXTURES_WITH_NOASSOC + FIXTURES_WITH_ASSOC,
+    ids=["(No association)", "(With association)"],
+)
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "group_id": "00000000-0000-0000-0000-000000000001",
+            "registry_id": "00000000-0000-0000-0000-000000000002",
+        },
+    ],
+    ids=["Associate One group with one container registry"],
+)
+async def test_associate_container_registry_with_group(
+    extra_fixtures, client: Client, test_case, database_fixture, create_app_and_client
+):
+    test_app, _ = await create_app_and_client(
+        [
+            database_ctx,
+        ],
+        [],
+    )
+
+    root_ctx = test_app["_root.context"]
+    context = get_graphquery_context(root_ctx.db)
+
+    query = """
+        mutation ($group_id: String!, $registry_id: String!) {
+            associate_container_registry_with_group(group_id: $group_id, registry_id: $registry_id) {
+                ok
+                msg
+            }
+        }
+        """
+
+    variables = {
+        "group_id": test_case["group_id"],
+        "registry_id": test_case["registry_id"],
+    }
+
+    response = await client.execute_async(query, variables=variables, context_value=context)
+    already_associated = "association_container_registries_groups" in extra_fixtures
+
+    if already_associated:
+        assert not response["data"]["associate_container_registry_with_group"]["ok"]
+    else:
+        assert response["data"]["associate_container_registry_with_group"]["ok"]
+        assert response["data"]["associate_container_registry_with_group"]["msg"] == "success"

--- a/tests/manager/models/gql_models/test_container_registries.py
+++ b/tests/manager/models/gql_models/test_container_registries.py
@@ -63,28 +63,7 @@ FIXTURES_WITH_NOASSOC = [
 
 FIXTURES_WITH_ASSOC = [
     {
-        "groups": [
-            {
-                "id": "00000000-0000-0000-0000-000000000001",
-                "name": "mock_group",
-                "description": "",
-                "is_active": True,
-                "domain_name": "default",
-                "resource_policy": "default",
-                "total_resource_slots": {},
-                "allowed_vfolder_hosts": {},
-                "type": "general",
-            }
-        ],
-        "container_registries": [
-            {
-                "id": "00000000-0000-0000-0000-000000000002",
-                "url": "https://mock.registry.com",
-                "type": "docker",
-                "project": "mock_project",
-                "registry_name": "mock_registry",
-            }
-        ],
+        **fixture,
         "association_container_registries_groups": [
             {
                 "id": "00000000-0000-0000-0000-000000000000",
@@ -93,6 +72,7 @@ FIXTURES_WITH_ASSOC = [
             }
         ],
     }
+    for fixture in FIXTURES_WITH_NOASSOC
 ]
 
 

--- a/tests/manager/models/gql_models/test_container_registries.py
+++ b/tests/manager/models/gql_models/test_container_registries.py
@@ -94,7 +94,7 @@ FIXTURES_WITH_ASSOC = [
     ids=["Associate One group with one container registry"],
 )
 async def test_associate_container_registry_with_group(
-    extra_fixtures, client: Client, test_case, database_fixture, create_app_and_client
+    client: Client, database_fixture, extra_fixtures, test_case, create_app_and_client
 ):
     test_app, _ = await create_app_and_client(
         [
@@ -148,7 +148,7 @@ async def test_associate_container_registry_with_group(
     ids=["Disassociate One group with one container registry"],
 )
 async def test_disassociate_container_registry_with_group(
-    extra_fixtures, client: Client, test_case, database_fixture, create_app_and_client
+    client: Client, database_fixture, extra_fixtures, test_case, create_app_and_client
 ):
     test_app, _ = await create_app_and_client(
         [


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #3396 ([BA-463](https://lablup.atlassian.net/browse/BA-463)).

Implement APIs for associating, disassociating `container_registries` with `groups`.

## Implementation Check list 

- [x] REST API
- [x] Graphql API
- [x] Client SDK

## Client code example

```py
import asyncio
from ai.backend.client.session import AsyncSession

async def main():
    async with AsyncSession() as session:
        # result: {'ok': True, 'msg': 'success'}
        result = await session.ContainerRegistry.associate_group("<registry_id>", "<group_id>")

if __name__ == "__main__":
    asyncio.run(main())
```

## GQL example

```gql
mutation {
  associate_container_registry_with_group (group_id: "<GROUP_ID>", registry_id: "<REGISTRY_ID>") {
    ok
  }
}
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3067.org.readthedocs.build/en/3067/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3067.org.readthedocs.build/ko/3067/

<!-- readthedocs-preview sorna-ko end -->

[BA-463]: https://lablup.atlassian.net/browse/BA-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ