### PR TITLE
fix: Include missing legacy logging module in the pex (#3054)

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -47,7 +47,7 @@ jobs:
         echo "email=$author_email" >> $GITHUB_OUTPUT
 
     - name: Make commit message for changing change log file
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5
       if: ${{ steps.assign_pr_number.outputs.has_renamed_pairs == 'true' }}
       with:
         commit_author: ${{ steps.get_author_info.outputs.name }} <${{ steps.get_author_info.outputs.email }}>

--- a/changes/3054.fix.md
+++ b/changes/3054.fix.md
@@ -1,0 +1,1 @@
+Include missing legacy logging module in the pex.

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -13,6 +13,7 @@ python_sources(
         "src/ai/backend/agent/kubernetes:src",  # not auto-inferred
         "src/ai/backend/runner:src",
         "src/ai/backend/helpers:src",
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
         "//:reqs#backend.ai-krunner-static-gnu",  # not auto-inferred
         ":resources",
         "!./__init__.py:src-watcher",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -7,6 +7,7 @@ python_sources(
         "src/ai/backend/manager/plugin:src",  # not auto-inferred (due to lazy-loading plugins)
         "src/ai/backend/manager/scheduler:src",
         "src/ai/backend/manager/models/alembic:migrations",  # not auto-inferred
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
         ":resources",
     ],
 )

--- a/src/ai/backend/storage/BUILD
+++ b/src/ai/backend/storage/BUILD
@@ -2,6 +2,7 @@ python_sources(
     name="src",
     dependencies=[
         ":resources",
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
     ],
 )
 

--- a/src/ai/backend/web/BUILD
+++ b/src/ai/backend/web/BUILD
@@ -2,6 +2,7 @@ python_sources(
     name="src",
     dependencies=[
         ":resources",
+        "src/ai/backend/common/logging.py:src",  # not auto-inferred (due to lazy-loading plugins)
         "//:reqs#coloredlogs",  # indirectly referred by logging config string
     ],
 )


### PR DESCRIPTION
This is an auto-generated backport PR of #3054 to the 24.09 release.