### PR TITLE
fix: Broken `ComputeContainer` GQL (#3042)

### DIFF
--- a/changes/3042.fix.md
+++ b/changes/3042.fix.md
@@ -1,0 +1,1 @@
+Fix regression of `ComputeContainer` GraphQL queries due to newly introduced relationship fields

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1022,6 +1022,14 @@ class ComputeContainer(graphene.ObjectType):
             .where(
                 (kernels.c.id.in_(container_ids)),
             )
+            .options(
+                noload("*"),
+                selectinload(
+                    KernelRow.group_row,
+                    KernelRow.user_row,
+                    KernelRow.image_row,
+                ),
+            )
         )
         if domain_name is not None:
             query = query.where(kernels.c.domain_name == domain_name)


### PR DESCRIPTION
This is an auto-generated backport PR of #3042 to the 23.09 release.