### PR TITLE
fix: invalid `selected_route` calculation logic (#3075)

### DIFF
--- a/changes/3075.fix.md
+++ b/changes/3075.fix.md
@@ -1,0 +1,1 @@
+Fix model service not routing traffics based on traffic ratio

--- a/src/ai/backend/wsproxy/proxy/backend/http.py
+++ b/src/ai/backend/wsproxy/proxy/backend/http.py
@@ -44,7 +44,7 @@ class HTTPBackend(AbstractBackend):
                 ranges.append(ratio_sum)
             rand = random.random() * ranges[-1]
             for i in range(len(ranges)):
-                ceiling = ranges[0]
+                ceiling = ranges[i]
                 if (i == 0 and rand < ceiling) or (ranges[i - 1] <= rand and rand < ceiling):
                     selected_route = routes[i]
                     break

--- a/src/ai/backend/wsproxy/proxy/backend/tcp.py
+++ b/src/ai/backend/wsproxy/proxy/backend/tcp.py
@@ -41,7 +41,7 @@ class TCPBackend(AbstractBackend):
                 ranges.append(ratio_sum)
             rand = random.random() * ranges[-1]
             for i in range(len(ranges)):
-                ceiling = ranges[0]
+                ceiling = ranges[i]
                 if (i == 0 and rand < ceiling) or (ranges[i - 1] <= rand and rand < ceiling):
                     selected_route = routes[i]
                     break


### PR DESCRIPTION
This is an auto-generated backport PR of #3075 to the 24.03 release.