### PR TITLE
fix: Broken `ComputeContainer.batch_load_detail` due to misuse of `selectinload`

### DIFF
--- a/changes/3078.fix.md
+++ b/changes/3078.fix.md
@@ -1,1 +1,1 @@
-Fix the broken `ComputeContainer.batch_load_detail` due to the misuse of `selectinload`.
+Fix the broken `ComputeContainer.batch_load_detail` due to the misuse of `selectinload` as follow-up to #3042

--- a/changes/3078.fix.md
+++ b/changes/3078.fix.md
@@ -1,0 +1,1 @@
+Fix the broken `ComputeContainer.batch_load_detail` due to the misuse of `selectinload`.

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1115,11 +1115,9 @@ class ComputeContainer(graphene.ObjectType):
             )
             .options(
                 noload("*"),
-                selectinload(
-                    KernelRow.group_row,
-                    KernelRow.user_row,
-                    KernelRow.image_row,
-                ),
+                selectinload(KernelRow.group_row),
+                selectinload(KernelRow.user_row),
+                selectinload(KernelRow.image_row),
             )
         )
         if domain_name is not None:


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up to #3042.

> [!NOTE]
>  The two codes below do not have the same meaning.
> 
> ```py
> ...
>             .options(
>                 noload("*"),
>                 selectinload(KernelRow.group_row),
>                 selectinload(KernelRow.user_row),
>                 selectinload(KernelRow.image_row),
>             )
> ```
> ```py
> ...
>             .options(
>                 noload("*"),
>                 selectinload(
>                     KernelRow.group_row,
>                     KernelRow.user_row,
>                     KernelRow.image_row,
>                 ),
>             )
> ```

Since our code intends to load each relationship individually, the current code causes the following error:

```
graphql.error.graphql_error.GraphQLError: Attribute "KernelRow.user_row" does not link from element "mapped class GroupRow->groups".
```

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
