### PR TITLE
fix: Broken `ComputeContainer.batch_load_detail` due to misuse of `selectinload` (#3078)

### DIFF
--- a/changes/3078.fix.md
+++ b/changes/3078.fix.md
@@ -1,0 +1,1 @@
+Fix the broken `ComputeContainer.batch_load_detail` due to the misuse of `selectinload` as follow-up to #3042

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1115,11 +1115,9 @@ class ComputeContainer(graphene.ObjectType):
             )
             .options(
                 noload("*"),
-                selectinload(
-                    KernelRow.group_row,
-                    KernelRow.user_row,
-                    KernelRow.image_row,
-                ),
+                selectinload(KernelRow.group_row),
+                selectinload(KernelRow.user_row),
+                selectinload(KernelRow.image_row),
             )
         )
         if domain_name is not None:


### PR DESCRIPTION
This is an auto-generated backport PR of #3078 to the 24.09 release.