### PR TITLE
fix: Broken `ComputeContainer.batch_load_detail` due to misuse of `selectinload` (#3078)

### DIFF
--- a/changes/3078.fix.md
+++ b/changes/3078.fix.md
@@ -1,0 +1,1 @@
+Fix the broken `ComputeContainer.batch_load_detail` due to the misuse of `selectinload` as follow-up to #3042

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1020,7 +1020,13 @@ class ComputeContainer(graphene.ObjectType):
             sa.select([kernels])
             .select_from(j)
             .where(
-                (kernels.c.id.in_(container_ids)),
+                (KernelRow.id.in_(container_ids)),
+            )
+            .options(
+                noload("*"),
+                selectinload(KernelRow.group_row),
+                selectinload(KernelRow.user_row),
+                selectinload(KernelRow.image_row),
             )
         )
         if domain_name is not None:


### PR DESCRIPTION
This is an auto-generated backport PR of #3078 to the 23.09 release.