### PR TITLE
ci: Remove the `git-auto-commit` dependency (#3083)

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -36,19 +36,14 @@ jobs:
         pip install tomlkit
         python scripts/pr-number-assign.py ${{ github.event.pull_request.number }}
 
-    - name: Extract the author information
-      id: get_author_info
+    - name: Make commit message for changing change log file
       if: ${{ steps.assign_pr_number.outputs.has_renamed_pairs == 'true' }}
       run: |
+        git add changes/*.md
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
-        echo "Retrieved author information: $author_name <$author_email>"
-        echo "name=$author_name" >> $GITHUB_OUTPUT
-        echo "email=$author_email" >> $GITHUB_OUTPUT
-
-    - name: Make commit message for changing change log file
-      uses: stefanzweifel/git-auto-commit-action@v5
-      if: ${{ steps.assign_pr_number.outputs.has_renamed_pairs == 'true' }}
-      with:
-        commit_author: ${{ steps.get_author_info.outputs.name }} <${{ steps.get_author_info.outputs.email }}>
-        commit_message: "docs: Rename the news fragment with the PR number\n\n${{ join(fromJSON(steps.assign_pr_number.outputs.rename_results), '\n') }}"
+        git commit \
+          -m "docs: Rename the news fragment with the PR number\n\n${{ join(fromJSON(steps.assign_pr_number.outputs.rename_results), '\n') }}" \
+          --author="$author_name <$author_email>" \
+          --trailer "Co-authored-by: octodog <mu001@lablup.com>"
+        git push

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -55,19 +55,16 @@ jobs:
     - name: Create GraphQL schema dump
       run: |
         ./backend.ai mgr api dump-gql-schema --output src/ai/backend/manager/api/schema.graphql
-    - name: Extract the author information
-      id: get_author_info
+    - name: Make commit message for changing change log file
       run: |
+        git add src/ai/backend/manager/api/schema.graphql
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
-        echo "Retrieved author information: $author_name <$author_email>"
-        echo "name=$author_name" >> $GITHUB_OUTPUT
-        echo "email=$author_email" >> $GITHUB_OUTPUT
-    - name: Make commit message for changing change log file
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_author: ${{ steps.get_author_info.outputs.name }} <${{ steps.get_author_info.outputs.email }}>
-        commit_message: 'chore: update GraphQL schema dump'
+        git commit \
+          -m "chore: update GraphQL schema dump" \
+          --author="$author_name <$author_email>" \
+          --trailer "Co-authored-by: octodog <mu001@lablup.com>"
+        git push
 
   graphql-inspector:
     needs: graphql-updated


### PR DESCRIPTION
This is an auto-generated backport PR of #3083 to the 24.09 release.