### PR TITLE
fix: session `status_info` not reflecting batch failures

### DIFF
--- a/changes/3085.fix.md
+++ b/changes/3085.fix.md
@@ -1,0 +1,1 @@
+Fix session `status_info` not being updated correctly when batch executions fail, ensuring failed batch execution states are properly reflected in the sessions table

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1756,7 +1756,7 @@ class AbstractAgent(
                     if result["exitCode"] == 0:
                         await self.produce_event(
                             SessionSuccessEvent(
-                                session_id, KernelLifecycleEventReason.TASK_DONE, 0
+                                session_id, KernelLifecycleEventReason.TASK_FINISHED, 0
                             ),
                         )
                     else:

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -230,7 +230,6 @@ class KernelLifecycleEventReason(enum.StrEnum):
     RESTART_TIMEOUT = "restart-timeout"
     RESUMING_AGENT_OPERATION = "resuming-agent-operation"
     SELF_TERMINATED = "self-terminated"
-    TASK_DONE = "task-done"
     TASK_FAILED = "task-failed"
     TASK_TIMEOUT = "task-timeout"
     TASK_CANCELLED = "task-cancelled"


### PR DESCRIPTION
Currently, the `status_info` column in the sessions table is being set to the same value regardless of batch execution result. Only the `result` column reflects the result as updating the value to "SUCCESS" or "FAILURE"
Let's update the `status_info` column to the reason value of Session result events.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue