### PR TITLE
fix: session `status_info` not reflecting batch failures (#3085)

### DIFF
--- a/changes/3085.fix.md
+++ b/changes/3085.fix.md
@@ -1,0 +1,1 @@
+Fix session `status_info` not being updated correctly when batch executions fail, ensuring failed batch execution states are properly reflected in the sessions table

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1748,7 +1748,7 @@ class AbstractAgent(
                     if result["exitCode"] == 0:
                         await self.produce_event(
                             SessionSuccessEvent(
-                                session_id, KernelLifecycleEventReason.TASK_DONE, 0
+                                session_id, KernelLifecycleEventReason.TASK_FINISHED, 0
                             ),
                         )
                     else:

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -230,7 +230,6 @@ class KernelLifecycleEventReason(enum.StrEnum):
     RESTART_TIMEOUT = "restart-timeout"
     RESUMING_AGENT_OPERATION = "resuming-agent-operation"
     SELF_TERMINATED = "self-terminated"
-    TASK_DONE = "task-done"
     TASK_FAILED = "task-failed"
     TASK_TIMEOUT = "task-timeout"
     TASK_CANCELLED = "task-cancelled"


### PR DESCRIPTION
This is an auto-generated backport PR of #3085 to the 24.09 release.