### PR TITLE
ci: Setting up git commiter

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -42,8 +42,8 @@ jobs:
         git add changes/*.md
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
-        git config --global user.email "$author_email"
-        git config --global user.name "$author_name"
+        git config user.email "$author_email"
+        git config user.name "$author_name"
         git commit \
           -m "docs: Rename the news fragment with the PR number\n\n${{ join(fromJSON(steps.assign_pr_number.outputs.rename_results), '\n') }}" \
           --author="$author_name <$author_email>" \

--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -42,6 +42,8 @@ jobs:
         git add changes/*.md
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
+        git config --global user.email "$author_email"
+        git config --global user.name "$author_name"
         git commit \
           -m "docs: Rename the news fragment with the PR number\n\n${{ join(fromJSON(steps.assign_pr_number.outputs.rename_results), '\n') }}" \
           --author="$author_name <$author_email>" \

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -99,8 +99,8 @@ jobs:
         env:
           COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
         run: |
-          git config --global user.name "${{ needs.backport-target-branch.outputs.author }}"
-          git config --global user.email "${{ needs.backport-target-branch.outputs.author_email }}"
+          git config user.name "${{ needs.backport-target-branch.outputs.author }}"
+          git config user.email "${{ needs.backport-target-branch.outputs.author_email }}"
           git fetch origin main --depth=10
           git cherry-pick --strategy=recursive --strategy-option=theirs ${{ needs.backport-target-branch.outputs.latest_commit }}
           git commit \

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -60,6 +60,8 @@ jobs:
         git add src/ai/backend/manager/api/schema.graphql
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
+        git config --global user.email "$author_email"
+        git config --global user.name "$author_name"
         git commit \
           -m "chore: update GraphQL schema dump" \
           --author="$author_name <$author_email>" \

--- a/.github/workflows/update-api-schema.yml
+++ b/.github/workflows/update-api-schema.yml
@@ -60,8 +60,8 @@ jobs:
         git add src/ai/backend/manager/api/schema.graphql
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
-        git config --global user.email "$author_email"
-        git config --global user.name "$author_name"
+        git config user.email "$author_email"
+        git config user.name "$author_name"
         git commit \
           -m "chore: update GraphQL schema dump" \
           --author="$author_name <$author_email>" \


### PR DESCRIPTION
After #3083, an error like https://github.com/lablup/backend.ai/actions/runs/11811508600/job/32905198275?pr=3047 occurs.
Even if you set the author of git commit, it is treated separately from the commiter, so you need to explicitly set the commiter.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
