### PR TITLE
feat: Add CREATING status to compute session and kernel

### DIFF
--- a/changes/3114.breaking.md
+++ b/changes/3114.breaking.md
@@ -1,0 +1,1 @@
+Add new `CREATING` session status to represent container creation phase, and redefine `PREPARING` status to specifically indicate pre-container preparation phases

--- a/docs/client/cli/sessions.rst
+++ b/docs/client/cli/sessions.rst
@@ -39,11 +39,11 @@ For other options, please consult the output of ``--help``.
      - Included Session Status
 
    * - (no option)
-     - ``PENDING``, ``PREPARED``, ``PREPARING``, ``RUNNING``, ``RESTARTING``,
+     - ``PENDING``, ``PREPARING``, ``PREPARED``, ``CREATING``, ``RUNNING``, ``RESTARTING``,
        ``TERMINATING``, ``RESIZING``, ``SUSPENDED``, and ``ERROR``.
 
    * - ``--running``
-     - ``PREPARING``, ``PULLING``, and ``RUNNING``.
+     - ``CREATING``, ``PULLING``, and ``RUNNING``.
 
    * - ``--dead``
      - ``CANCELLED`` and ``TERMINATED``.

--- a/docs/dev/adding-kernels.rst
+++ b/docs/dev/adding-kernels.rst
@@ -301,7 +301,7 @@ This per-image bootstrap script is executed as *root* by the agent-injected ``en
 
 .. warning::
 
-   ``/opt/container/bootstrap.sh`` **must return immediately** to prevent the session from staying in the ``PREPARING`` status.
+   ``/opt/container/bootstrap.sh`` **must return immediately** to prevent the session from staying in the ``CREATING`` status.
    This means that it should run service applications in background by *daemonization*.
 
 To run a process as the user privilege, you should use ``su-exec`` which is also injected by the agent like:

--- a/docs/locales/ko/LC_MESSAGES/client/cli/sessions.po
+++ b/docs/locales/ko/LC_MESSAGES/client/cli/sessions.po
@@ -69,7 +69,7 @@ msgstr ""
 
 #: ../../client/cli/sessions.rst:42 4f067c02b259464f84aeade4874f054f
 msgid ""
-"``PENDING``, ``PREPARING``, ``PREPARED``, ``CREATING``, ``RUNNING``, ``RESTARTING``, ``TERMINATING``,"
+"``PENDING``, ``PREPARING``, `PULLING`, ``PREPARED``, ``CREATING``, ``RUNNING``, ``RESTARTING``, ``TERMINATING``,"
 " ``RESIZING``, ``SUSPENDED``, and ``ERROR``."
 msgstr ""
 

--- a/docs/locales/ko/LC_MESSAGES/client/cli/sessions.po
+++ b/docs/locales/ko/LC_MESSAGES/client/cli/sessions.po
@@ -69,7 +69,7 @@ msgstr ""
 
 #: ../../client/cli/sessions.rst:42 4f067c02b259464f84aeade4874f054f
 msgid ""
-"``PENDING``, ``PREPARED``, ``PREPARING``, ``RUNNING``, ``RESTARTING``, ``TERMINATING``,"
+"``PENDING``, ``PREPARING``, ``PREPARED``, ``CREATING``, ``RUNNING``, ``RESTARTING``, ``TERMINATING``,"
 " ``RESIZING``, ``SUSPENDED``, and ``ERROR``."
 msgstr ""
 
@@ -78,7 +78,7 @@ msgid "``--running``"
 msgstr ""
 
 #: ../../client/cli/sessions.rst:46 e9096ba3896544348e2c88ac765dc5c6
-msgid "``PREPARING``, ``PULLING``, and ``RUNNING``."
+msgid "``CREATING``, ``PULLING``, and ``RUNNING``."
 msgstr ""
 
 #: ../../client/cli/sessions.rst:48 7675c8771d0d4d20984e45e995ae38de
@@ -311,4 +311,3 @@ msgstr ""
 #~ "``created_at``, ``status_changed``, ``result``, "
 #~ "``image``, ``type``, ``tag``, ``occupying_slots``."
 #~ msgstr ""
-

--- a/docs/locales/ko/LC_MESSAGES/client/func/session.po
+++ b/docs/locales/ko/LC_MESSAGES/client/func/session.po
@@ -71,16 +71,16 @@ msgstr ""
 #: add68a71730b4299bc4175c5ec9e6261
 #: ai.backend.client.func.session.ComputeSession.paginated_list:4 of
 msgid ""
-"Fetches sessions in a specific status (PENDING, SCHEDULED, PULLING, "
-"PREPARED, PREPARING,  RUNNING, RESTARTING, RUNNING_DEGRADED,  TERMINATING, "
+"Fetches sessions in a specific status (PENDING, SCHEDULED, PREPARING, PULLING, "
+"PREPARED, CREATING, RUNNING, RESTARTING, RUNNING_DEGRADED,  TERMINATING, "
 "TERMINATED, ERROR, CANCELLED)"
 msgstr ""
 
 #: 0435d36edb8d480b8abc9c1bf2011b75
 #: ai.backend.client.func.session.ComputeSession.paginated_list:4 of
 msgid ""
-"Fetches sessions in a specific status (PENDING, SCHEDULED, PULLING, "
-"PREPARING,"
+"Fetches sessions in a specific status (PENDING, SCHEDULED, PREPARED, PULLING, "
+"CREATING,"
 msgstr ""
 
 #: 0d33952fe7344b56bf4cecb9537cd08a

--- a/docs/locales/ko/LC_MESSAGES/dev/adding-kernels.po
+++ b/docs/locales/ko/LC_MESSAGES/dev/adding-kernels.po
@@ -576,7 +576,7 @@ msgstr ""
 #: ../../dev/adding-kernels.rst:304 fc4cb9f5e7884254aa1fbc0d08fe0c8d
 msgid ""
 "``/opt/container/bootstrap.sh`` **must return immediately** to prevent "
-"the session from staying in the ``PREPARING`` status. This means that it "
+"the session from staying in the ``CREATING`` status. This means that it "
 "should run service applications in background by *daemonization*."
 msgstr ""
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -530,7 +530,7 @@ class AgentRPCServer(aobject):
                         img_ref, img_conf["registry"], timeout=image_pull_timeout
                     )
                 except asyncio.TimeoutError:
-                    log.exception(f"Image pull timeout after {image_pull_timeout} sec")
+                    log.exception(f"Image pull timeout (img:{str(img_ref)},s:{image_pull_timeout})")
                     await self.agent.produce_event(
                         ImagePullFailedEvent(
                             image=str(img_ref),
@@ -539,7 +539,7 @@ class AgentRPCServer(aobject):
                         )
                     )
                 except Exception as e:
-                    log.exception(f"Image pull failed (e:{repr(e)})")
+                    log.exception(f"Image pull failed (img:{str(img_ref)},e:{repr(e)})")
                     await self.agent.produce_event(
                         ImagePullFailedEvent(
                             image=str(img_ref),
@@ -548,6 +548,7 @@ class AgentRPCServer(aobject):
                         )
                     )
                 else:
+                    log.info(f"Image pull succeeded {str(img_ref)}")
                     await self.agent.produce_event(
                         ImagePullFinishedEvent(
                             image=str(img_ref),
@@ -556,6 +557,7 @@ class AgentRPCServer(aobject):
                         )
                     )
             else:
+                log.debug(f"No need to pull image {str(img_ref)}")
                 await self.agent.produce_event(
                     ImagePullFinishedEvent(
                         image=str(img_ref),

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -530,7 +530,9 @@ class AgentRPCServer(aobject):
                         img_ref, img_conf["registry"], timeout=image_pull_timeout
                     )
                 except asyncio.TimeoutError:
-                    log.exception(f"Image pull timeout (img:{str(img_ref)},s:{image_pull_timeout})")
+                    log.exception(
+                        f"Image pull timeout (img:{str(img_ref)}, sec:{image_pull_timeout})"
+                    )
                     await self.agent.produce_event(
                         ImagePullFailedEvent(
                             image=str(img_ref),
@@ -539,7 +541,7 @@ class AgentRPCServer(aobject):
                         )
                     )
                 except Exception as e:
-                    log.exception(f"Image pull failed (img:{img_ref}, e:{repr(e)})")
+                    log.exception(f"Image pull failed (img:{img_ref}, err:{repr(e)})")
                     await self.agent.produce_event(
                         ImagePullFailedEvent(
                             image=str(img_ref),

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -539,7 +539,7 @@ class AgentRPCServer(aobject):
                         )
                     )
                 except Exception as e:
-                    log.exception(f"Image pull failed (img:{str(img_ref)},e:{repr(e)})")
+                    log.exception(f"Image pull failed (img:{img_ref}, e:{repr(e)})")
                     await self.agent.produce_event(
                         ImagePullFailedEvent(
                             image=str(img_ref),
@@ -548,7 +548,7 @@ class AgentRPCServer(aobject):
                         )
                     )
                 else:
-                    log.info(f"Image pull succeeded {str(img_ref)}")
+                    log.info(f"Image pull succeeded {img_ref}")
                     await self.agent.produce_event(
                         ImagePullFinishedEvent(
                             image=str(img_ref),
@@ -557,7 +557,7 @@ class AgentRPCServer(aobject):
                         )
                     )
             else:
-                log.debug(f"No need to pull image {str(img_ref)}")
+                log.debug(f"No need to pull image {img_ref}")
                 await self.agent.produce_event(
                     ImagePullFinishedEvent(
                         image=str(img_ref),

--- a/src/ai/backend/client/cli/admin/session.py
+++ b/src/ai/backend/client/cli/admin/session.py
@@ -40,6 +40,7 @@ def _list_cmd(name: str = "list", docs: Optional[str] = None):
             "PULLING",
             "PREPARED",
             "PREPARING",
+            "CREATING",
             "RUNNING",
             "RESTARTING",
             "RUNNING_DEGRADED",
@@ -157,6 +158,7 @@ def _list_cmd(name: str = "list", docs: Optional[str] = None):
                 "PULLING",
                 "PREPARED",
                 "PREPARING",
+                "CREATING",
                 "RUNNING",
                 "RUNNING_DEGRADED",
                 "TERMINATING",
@@ -165,7 +167,7 @@ def _list_cmd(name: str = "list", docs: Optional[str] = None):
             no_match_name = "active"
         if running:
             status = ",".join([
-                "PREPARING",
+                "CREATING",
                 "RUNNING",
                 "RUNNING_DEGRADED",
             ])
@@ -183,6 +185,7 @@ def _list_cmd(name: str = "list", docs: Optional[str] = None):
                 "PULLING",
                 "PREPARED",
                 "PREPARING",
+                "CREATING",
                 "RUNNING",
                 "RESTARTING",
                 "RUNNING_DEGRADED",

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -255,6 +255,20 @@ def _create_cmd(docs: Optional[str] = None):
                         )
                     )
                     return
+                elif compute_session.status == "PREPARING":
+                    print_info(
+                        "Session ID {0} preparation in progress and about to be started.".format(
+                            compute_session.id
+                        )
+                    )
+                    return
+                elif compute_session.status == "CREATING":
+                    print_info(
+                        "Session ID {0} creation in progress and about to be started.".format(
+                            compute_session.id
+                        )
+                    )
+                    return
                 elif compute_session.status == "RUNNING":
                     if compute_session.created:
                         print_info(
@@ -521,6 +535,18 @@ def _create_from_template_cmd(docs: Optional[str] = None):
                     return
                 elif compute_session.status == "PREPARED":
                     print_info("Session ID {0} is prepared and about to be started.".format(name))
+                    return
+                elif compute_session.status == "PREPARING":
+                    print_info(
+                        "Session ID {0} preparation in progress and about to be started.".format(
+                            name
+                        )
+                    )
+                    return
+                elif compute_session.status == "CREATING":
+                    print_info(
+                        "Session ID {0} creation in progress and about to be started.".format(name)
+                    )
                     return
                 elif compute_session.status == "RUNNING":
                     if compute_session.created:
@@ -1230,6 +1256,7 @@ def _fetch_session_names() -> tuple[str]:
         "SCHEDULED",
         "PREPARED",
         "PREPARING",
+        "CREATING",
         "RUNNING",
         "RUNNING_DEGRADED",
         "RESTARTING",

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -638,7 +638,7 @@ def _destroy_cmd(docs: Optional[str] = None):
                     if forced:
                         print_warn(
                             "If you have destroyed a session whose status is one of "
-                            "[`PULLING`, `SCHEDULED`, `PREPARING`, `TERMINATING`, `ERROR`], "
+                            "[`CREATING`, `TERMINATING`, `ERROR`], "
                             "Manual cleanup of actual containers may be required."
                         )
                 if stats:

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -116,7 +116,7 @@ class ComputeSession(BaseFunction):
 
         :param status: Fetches sessions in a specific status
                        (PENDING, SCHEDULED, PULLING, PREPARED, PREPARING,
-                        RUNNING, RESTARTING, RUNNING_DEGRADED,
+                        CREATING, RUNNING, RESTARTING, RUNNING_DEGRADED,
                         TERMINATING, TERMINATED, ERROR, CANCELLED)
         :param fields: Additional per-session query fields to fetch.
         """

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -121,6 +121,7 @@ class KernelStatus(enum.StrEnum):
     BUILDING = "BUILDING"
     PULLING = "PULLING"
     PREPARED = "PREPARED"
+    CREATING = "CREATING"
     # ---
     RUNNING = "RUNNING"
     RESTARTING = "RESTARTING"
@@ -211,26 +212,29 @@ KERNEL_STATUS_TRANSITION_MAP: Mapping[KernelStatus, set[KernelStatus]] = {
         KernelStatus.ERROR,
     },
     KernelStatus.SCHEDULED: {
+        KernelStatus.PREPARING,
         KernelStatus.PULLING,
         KernelStatus.PREPARED,
-        KernelStatus.PREPARING,  # TODO: Delete this after applying check-and-pull API
+        KernelStatus.CANCELLED,
+        KernelStatus.ERROR,
+    },
+    KernelStatus.PREPARING: {
+        KernelStatus.PULLING,
+        KernelStatus.PREPARED,
         KernelStatus.CANCELLED,
         KernelStatus.ERROR,
     },
     KernelStatus.PULLING: {
         KernelStatus.PREPARED,
-        KernelStatus.PREPARING,  # TODO: Delete this after applying check-and-pull API
-        KernelStatus.RUNNING,  # TODO: Delete this after applying check-and-pull API
         KernelStatus.CANCELLED,
         KernelStatus.ERROR,
     },
     KernelStatus.PREPARED: {
-        KernelStatus.PREPARING,
+        KernelStatus.CREATING,
         KernelStatus.CANCELLED,
         KernelStatus.ERROR,
     },
-    KernelStatus.PREPARING: {
-        KernelStatus.PULLING,  # TODO: Delete this after applying check-and-pull API
+    KernelStatus.CREATING: {
         KernelStatus.RUNNING,
         KernelStatus.TERMINATING,
         KernelStatus.TERMINATED,
@@ -706,7 +710,7 @@ class KernelRow(Base):
                 kernels.c.status_history,
                 (),
                 {
-                    status.name: now.isoformat(),  # ["PULLING", "PREPARING"]
+                    status.name: now.isoformat(),  # ["PULLING", "CREATING"]
                 },
             ),
         }

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1874,7 +1874,7 @@ class AgentRegistry:
                                     {
                                         KernelStatus.ERROR.name: (
                                             now.isoformat()
-                                        ),  # ["PULLING", "PREPARING"]
+                                        ),  # ["PULLING", "CREATING"]
                                     },
                                 ),
                                 status_data=err_info,
@@ -2260,9 +2260,9 @@ class AgentRegistry:
     ) -> Mapping[str, Any]:
         """
         Destroy session kernels. Do not destroy
-        PREPARING/TERMINATING/ERROR and PULLING sessions.
+        CREATING/TERMINATING/ERROR and PULLING sessions.
 
-        :param forced: If True, destroy PREPARING/TERMINATING/ERROR session.
+        :param forced: If True, destroy CREATING/TERMINATING/ERROR session.
         :param reason: Reason to destroy a session if client wants to specify it manually.
         """
         session_id = session.id
@@ -2398,14 +2398,15 @@ class AgentRegistry:
                     raise GenericForbidden("Cannot destroy sessions in pulling status")
                 case (
                     SessionStatus.SCHEDULED
-                    | SessionStatus.PREPARED
                     | SessionStatus.PREPARING
+                    | SessionStatus.PREPARED
+                    | SessionStatus.CREATING
                     | SessionStatus.TERMINATING
                     | SessionStatus.ERROR
                 ):
                     if not forced:
                         raise GenericForbidden(
-                            "Cannot destroy sessions in scheduled/pulling/preparing/terminating/error"
+                            "Cannot destroy sessions in scheduled/prepared/pulling/preparing/creating/terminating/error"
                             " status",
                         )
                     log.warning(
@@ -2492,15 +2493,16 @@ class AgentRegistry:
                                 )
                         case (
                             KernelStatus.SCHEDULED
-                            | KernelStatus.PREPARED
                             | KernelStatus.PREPARING
+                            | KernelStatus.PREPARED
+                            | KernelStatus.CREATING
                             | KernelStatus.TERMINATING
                             | KernelStatus.ERROR
                         ):
                             if not forced:
                                 raise GenericForbidden(
                                     "Cannot destroy kernels in"
-                                    " scheduled/preparing/terminating/error status",
+                                    " scheduled/prepared/preparing/terminating/error status",
                                 )
                             log.warning(
                                 "force-terminating kernel (k:{}, status:{})",
@@ -3288,7 +3290,7 @@ class AgentRegistry:
                 .where(
                     (KernelRow.image == image)
                     & (KernelRow.agent == agent_id)
-                    & (KernelRow.status == KernelStatus.SCHEDULED)
+                    & (KernelRow.status.in_(KernelStatus.SCHEDULED, KernelStatus.PREPARING))
                 )
                 # Ensures transition
                 .with_for_update()
@@ -3318,7 +3320,13 @@ class AgentRegistry:
                 .where(
                     (KernelRow.image == image)
                     & (KernelRow.agent == agent_id)
-                    & (KernelRow.status.in_((KernelStatus.SCHEDULED, KernelStatus.PULLING)))
+                    & (
+                        KernelRow.status.in_((
+                            KernelStatus.SCHEDULED,
+                            KernelStatus.PREPARING,
+                            KernelStatus.PULLING,
+                        ))
+                    )
                 )
                 # Ensures transition
                 .with_for_update()
@@ -3369,7 +3377,7 @@ class AgentRegistry:
         if session_ids:
             await self.session_lifecycle_mgr.register_status_updatable_session(session_ids)
 
-    async def mark_kernel_preparing(
+    async def mark_kernel_creating(
         self,
         db_conn: SAConnection,
         kernel_id: KernelId,
@@ -3381,7 +3389,7 @@ class AgentRegistry:
         async def _set_status(db_session: AsyncSession) -> None:
             kernel_row = await KernelRow.get_kernel_to_update_status(db_session, kernel_id)
             kernel_row.transit_status(
-                KernelStatus.PREPARING, reason, status_data={}, status_changed_at=now
+                KernelStatus.CREATING, reason, status_data={}, status_changed_at=now
             )
 
         await execute_with_txn_retry(_set_status, self.db.begin_session, db_conn)
@@ -3804,7 +3812,7 @@ async def handle_kernel_creation_lifecycle(
                 await context.mark_kernel_pulling(db_conn, kernel_id, session_id, reason)
         case KernelCreatingEvent(kernel_id, session_id, reason=reason):
             async with context.db.connect() as db_conn:
-                await context.mark_kernel_preparing(db_conn, kernel_id, session_id, reason)
+                await context.mark_kernel_creating(db_conn, kernel_id, session_id, reason)
         case KernelStartedEvent(kernel_id, session_id, reason=reason, creation_info=creation_info):
             async with context.db.connect() as db_conn:
                 await context.mark_kernel_running(

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3290,7 +3290,7 @@ class AgentRegistry:
                 .where(
                     (KernelRow.image == image)
                     & (KernelRow.agent == agent_id)
-                    & (KernelRow.status.in_(KernelStatus.SCHEDULED, KernelStatus.PREPARING))
+                    & (KernelRow.status.in_((KernelStatus.SCHEDULED, KernelStatus.PREPARING)))
                 )
                 # Ensures transition
                 .with_for_update()

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -1211,9 +1211,24 @@ class SchedulerDispatcher(aobject):
         try:
             async with self.lock_factory(LockID.LOCKID_CHECK_PRECOND, 600):
                 bindings: list[KernelAgentBinding] = []
-                async with self.db.begin_readonly_session() as db_session:
+
+                async def _transit_scheduled_to_preparing(
+                    db_session: SASession,
+                ) -> list[SessionRow]:
+                    now = datetime.now(timezone.utc)
                     scheduled_sessions = await SessionRow.get_sessions_by_status(
                         db_session, SessionStatus.SCHEDULED, load_kernel_image=True
+                    )
+                    for row in scheduled_sessions:
+                        for kernel_row in row.kernels:
+                            _kernel_row = cast(KernelRow, kernel_row)
+                            _kernel_row.set_status(KernelStatus.PREPARING, status_changed_at=now)
+                        row.set_status(SessionStatus.PREPARING, status_changed_at=now)
+                    return scheduled_sessions
+
+                async with self.db.connect() as db_conn:
+                    scheduled_sessions = await execute_with_txn_retry(
+                        _transit_scheduled_to_preparing, self.db.begin_session, db_conn
                     )
                 log.debug(
                     "check_precond(): checking-precond {} session(s)", len(scheduled_sessions)
@@ -1266,7 +1281,7 @@ class SchedulerDispatcher(aobject):
         """
         Scan the sessions ready to create and perform the agent RPC calls to create kernels.
 
-        Session status transition: PREPARED -> PREPARING
+        Session status transition: PREPARED -> CREATING
         """
         manager_id = self.local_config["manager"]["id"]
         redis_key = f"manager.{manager_id}.start"
@@ -1296,7 +1311,7 @@ class SchedulerDispatcher(aobject):
                     known_slot_types,
                 )
 
-                async def _mark_session_and_kernel_preparing(
+                async def _mark_session_and_kernel_creating(
                     db_session: SASession,
                 ) -> list[SessionRow]:
                     session_rows = await SessionRow.get_sessions_by_status(
@@ -1305,13 +1320,13 @@ class SchedulerDispatcher(aobject):
                     for row in session_rows:
                         for kernel_row in row.kernels:
                             _kernel_row = cast(KernelRow, kernel_row)
-                            _kernel_row.set_status(KernelStatus.PREPARING, status_changed_at=now)
-                        row.set_status(SessionStatus.PREPARING, status_changed_at=now)
+                            _kernel_row.set_status(KernelStatus.CREATING, status_changed_at=now)
+                        row.set_status(SessionStatus.CREATING, status_changed_at=now)
                     return session_rows
 
                 async with self.db.connect() as db_conn:
                     scheduled_sessions = await execute_with_txn_retry(
-                        _mark_session_and_kernel_preparing, self.db.begin_session, db_conn
+                        _mark_session_and_kernel_creating, self.db.begin_session, db_conn
                     )
 
                 log.debug("starting(): starting {} session(s)", len(scheduled_sessions))


### PR DESCRIPTION
## Changes

- Added new `CREATING` session(and kernel) status to represent the container creation phase
- Modified the meaning of existing `PREPARING` status to specifically represent pre-container preparation phases
- Updated status transition logic to accommodate new state

## Why
Previously, the `PREPARING` status was overloaded to represent both the pre-container preparation phase and the container creation phase. This made it difficult to:

- Track exactly where a session was in its lifecycle
- Debug issues specific to container creation

## Impact
This change provides clearer visibility into session lifecycle stages, enabling:

- Better debugging capabilities
- Clearer session status tracking for users

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3114.org.readthedocs.build/en/3114/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3114.org.readthedocs.build/ko/3114/

<!-- readthedocs-preview sorna-ko end -->