### PR TITLE
chore: better changelog of 2647

### DIFF
--- a/changes/2647.breaking.md
+++ b/changes/2647.breaking.md
@@ -1,1 +1,1 @@
-Add `PREPARED` status for compute sessions and kernels.
+Add `PREPARED` status to indicate compute sessions and kernels are ready for creation after completing pre-creation tasks such as image pulling

--- a/changes/2647.breaking.md
+++ b/changes/2647.breaking.md
@@ -1,1 +1,1 @@
-Add `PREPARED` status to indicate compute sessions and kernels are ready for creation after completing pre-creation tasks such as image pulling
+Add `PREPARED` status for compute sessions and kernels to indicate completion of pre-creation tasks such as image pull


### PR DESCRIPTION
Update the news fragmen of #2647 to provide more context about new `PREPARED` status

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version