### PR TITLE
ci: Make sure to check out the head branch, not the HEAD commit

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ github.head_ref}}
         fetch-depth: 2
         lfs: false
         token: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
https://github.com/lablup/backend.ai/actions/runs/11851900854/job/33029158862?pr=3101
The assign-pr-number action is throwing an error after the #3083 action.
The actions/checkout action is getting the current branch by default, but in the case of pull_request branch, it only gets information about the HEAD commit without branch information, so we need to get the branch information as well so we can push it.
https://github.com/actions/checkout#push-a-commit-to-a-pr-using-the-built-in-token
The checkout readmd also says the following.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
