### PR TITLE
fix: Outdated image string join logic

### DIFF
--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -35,6 +35,7 @@ from ai.backend.common.types import (
     ImageRegistry,
     ResourceSlot,
 )
+from ai.backend.common.utils import join_non_empty
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 
@@ -264,7 +265,8 @@ class ImageRow(Base):
             image_name = ""
             _, tag = ImageRef.parse_image_tag(self.name.split(f"{self.registry}/", maxsplit=1)[1])
         else:
-            image_and_tag = self.name.split(f"{self.registry}/{self.project}/", maxsplit=1)[1]
+            join = functools.partial(join_non_empty, sep="/")
+            image_and_tag = self.name.split(f"{join(self.registry, self.project)}/", maxsplit=1)[1]
             image_name, tag = ImageRef.parse_image_tag(image_and_tag)
 
         return ImageRef(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up to #2978.

Since `project` value was changed to be nullable in PR #2978, the `image` string join logic also should be updated.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
