### PR TITLE
feat: Add `show_non_installed_images` config on webserver (#3124)

### DIFF
--- a/changes/3124.feature.md
+++ b/changes/3124.feature.md
@@ -1,0 +1,1 @@
+Add an `show_non_installed_images` option to show all images regardless of installation on environment select section in session/service launcher page.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -98,6 +98,8 @@ max_file_upload_size = 4294967296
 # e.g. cr.backend.ai/stable/python
 # You should pick default_environment in ui section too.
 #allowlist = ""
+# Show all environment images regardless of installation
+show_non_installed_images = false
 
 [plugin]
 # Comma-separated string

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -86,6 +86,7 @@ config_iv = t.Dict({
     }).allow_extra("*"),
     t.Key("environments"): t.Dict({
         t.Key("allowlist", default=None): t.Null | tx.StringList(empty_str_as_empty_list=True),
+        t.Key("show_non_installed_images", default=False): t.ToBool,
     }).allow_extra("*"),
     t.Key("plugin"): t.Dict({
         t.Key("page", default=None): t.Null | tx.StringList(empty_str_as_empty_list=True),

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -53,6 +53,7 @@ connectionMode = "SESSION"
 
 [environments]
 {% toml_strlist_field "allowlist" config["environments"]["allowlist"] %}
+{% toml_field "showNonInstalledImages" config["environments"]["show_non_installed_images"] %}
 
 [menu]
 {% toml_strlist_field "blocklist" config["ui"]["menu_blocklist"] %}

--- a/src/ai/backend/web/templates/config_ini.toml.j2
+++ b/src/ai/backend/web/templates/config_ini.toml.j2
@@ -6,6 +6,10 @@
 {% toml_field "enableLLMPlayground" config["ui"]["enable_LLM_playground"] %}
 connectionMode = "SESSION"
 
+[environments]
+{% toml_strlist_field "allowlist" config["environments"]["allowlist"] %}
+{% toml_field "showNonInstalledImages" config["environments"]["show_non_installed_images"] %}
+
 [wsproxy]
 {% toml_field "proxyURL" config["service"]["wsproxy"]["url"] %}
 # proxyBaseURL =


### PR DESCRIPTION
This is an auto-generated backport PR of #3124 to the 24.03 release.