### PR TITLE
fix: Allow admins to delete other user's vfolders

### DIFF
--- a/changes/3137.fix.md
+++ b/changes/3137.fix.md
@@ -1,0 +1,1 @@
+Allow admins to delete other users' vfolders by enabling vfolder fetching for precondition checks

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2423,6 +2423,7 @@ async def get_vfolder_id(request: web.Request, params: IDRequestModel) -> Compac
         entries = await query_accessible_vfolders(
             db_session.bind,
             user_uuid,
+            allow_privileged_access=True,
             user_role=user_role,
             domain_name=domain_name,
             allowed_vfolder_types=allowed_vfolder_types,


### PR DESCRIPTION
resolves https://github.com/lablup/giftbox/issues/773

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] API server-client counterparts (e.g., manager API -> client SDK)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3137.org.readthedocs.build/en/3137/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3137.org.readthedocs.build/ko/3137/

<!-- readthedocs-preview sorna-ko end -->