### PR TITLE
fix: Allow compute session mutation without the priority input field (#2985)

### DIFF
--- a/changes/2985.fix.md
+++ b/changes/2985.fix.md
@@ -1,0 +1,1 @@
+Allow the `modify_compute_session` mutation works without `priority` field in input argument and let the mutation validates `name` value

--- a/src/ai/backend/common/validators.py
+++ b/src/ai/backend/common/validators.py
@@ -739,3 +739,10 @@ class Delay(t.Trafaret):
                 return 0
             case _:
                 self._failure(f"Value must be (float, tuple of float or None), not {type(value)}.")
+
+
+class SessionName(t.Regexp):
+    _re = r"^(?=.{4,64}$)\w[\w.-]*\w$"
+
+    def __init__(self) -> None:
+        super().__init__(self._re, re.ASCII)

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -10,7 +10,6 @@ import enum
 import functools
 import json
 import logging
-import re
 import secrets
 import uuid
 from datetime import datetime, timedelta
@@ -265,7 +264,7 @@ creation_config_v5_template = t.Dict({
 
 overwritten_param_check = t.Dict({
     t.Key("template_id"): tx.UUID,
-    t.Key("session_name"): t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
+    t.Key("session_name"): tx.SessionName,
     t.Key("image", default=None): t.Null | t.String,
     tx.AliasedKey(["session_type", "sess_type"]): tx.Enum(SessionTypes),
     t.Key("group", default=None): t.Null | t.String,
@@ -413,7 +412,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
     t.Dict({
         tx.AliasedKey(["template_id", "templateId"]): t.Null | tx.UUID,
         tx.AliasedKey(["name", "session_name", "clientSessionToken"], default=undefined)
-        >> "session_name": UndefChecker | t.Regexp(r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII),
+        >> "session_name": UndefChecker | tx.SessionName,
         t.Key("priority", default=SESSION_PRIORITY_DEFUALT): t.ToInt(
             gte=SESSION_PRIORITY_MIN, lte=SESSION_PRIORITY_MAX
         ),
@@ -598,9 +597,8 @@ async def create_from_template(request: web.Request, params: dict[str, Any]) -> 
 @auth_required
 @check_api_params(
     t.Dict({
-        tx.AliasedKey(["name", "session_name", "clientSessionToken"]) >> "session_name": t.Regexp(
-            r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII
-        ),
+        tx.AliasedKey(["name", "session_name", "clientSessionToken"])
+        >> "session_name": tx.SessionName,
         t.Key("priority", default=SESSION_PRIORITY_DEFUALT): t.ToInt(
             gte=SESSION_PRIORITY_MIN, lte=SESSION_PRIORITY_MAX
         ),
@@ -684,9 +682,7 @@ async def create_from_params(request: web.Request, params: dict[str, Any]) -> we
 @auth_required
 @check_api_params(
     t.Dict({
-        t.Key("clientSessionToken") >> "session_name": t.Regexp(
-            r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII
-        ),
+        t.Key("clientSessionToken") >> "session_name": tx.SessionName,
         tx.AliasedKey(["template_id", "templateId"]): t.Null | tx.UUID,
         tx.AliasedKey(["type", "sessionType"], default="interactive") >> "sess_type": tx.Enum(
             SessionTypes
@@ -1399,9 +1395,8 @@ async def report_stats(root_ctx: RootContext, interval: float) -> None:
 @auth_required
 @check_api_params(
     t.Dict({
-        tx.AliasedKey(["name", "session_name", "clientSessionToken"]) >> "session_name": t.Regexp(
-            r"^(?=.{4,64}$)\w[\w.-]*\w$", re.ASCII
-        ),
+        tx.AliasedKey(["name", "session_name", "clientSessionToken"])
+        >> "session_name": tx.SessionName,
     }),
 )
 async def rename_session(request: web.Request, params: Any) -> web.Response:

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -14,11 +14,13 @@ from typing import (
 import graphene
 import graphql
 import sqlalchemy as sa
+import trafaret as t
 from dateutil.parser import parse as dtparse
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from ai.backend.common import validators as tx
 from ai.backend.common.types import ClusterMode, SessionId, SessionResult
 from ai.backend.manager.idle import ReportInfo
 
@@ -38,6 +40,7 @@ from ..gql_relay import (
     GlobalIDField,
     ResolvedGlobalID,
 )
+from ..kernel import KernelRow
 from ..minilang import ArrayFieldItem, JSONFieldItem
 from ..minilang.ordering import ColumnMapType, QueryOrderParser
 from ..minilang.queryfilter import FieldSpecType, QueryFilterParser, enum_field_getter
@@ -549,7 +552,7 @@ class ModifyComputeSession(graphene.relay.ClientIDMutation):
         graph_ctx: GraphQueryContext = info.context
         _, raw_session_id = cast(ResolvedGlobalID, input["id"])
         session_id = SessionId(uuid.UUID(raw_session_id))
-        if input["priority"] is not graphql.Undefined:
+        if "priority" in input and input["priority"] is not graphql.Undefined:
             if not (SESSION_PRIORITY_MIN <= input["priority"] <= SESSION_PRIORITY_MAX):
                 raise ValueError(
                     f"The priority value {input["priority"]!r} is out of range: "
@@ -557,7 +560,14 @@ class ModifyComputeSession(graphene.relay.ClientIDMutation):
                 )
 
         data: dict[str, Any] = {}
-        set_if_set(input, data, "name")
+        new_name = input.get("name")
+        if new_name is not None:
+            try:
+                tx.SessionName().check(new_name)
+            except t.DataError:
+                raise ValueError(f"Not allowed session name (n:{new_name})")
+            else:
+                data["name"] = new_name
         set_if_set(input, data, "priority")
 
         async def _update(db_session: AsyncSession) -> Optional[SessionRow]:
@@ -572,7 +582,14 @@ class ModifyComputeSession(graphene.relay.ClientIDMutation):
                 .from_statement(_update_stmt)
                 .execution_options(populate_existing=True)
             )
-            return await db_session.scalar(_stmt)
+            ret = await db_session.scalar(_stmt)
+            if new_name is not None:
+                await db_session.execute(
+                    sa.update(KernelRow)
+                    .values(session_name=new_name)
+                    .where(KernelRow.session_id == session_id)
+                )
+            return ret
 
         async with graph_ctx.db.connect() as db_conn:
             session_row = await execute_with_txn_retry(_update, graph_ctx.db.begin_session, db_conn)


### PR DESCRIPTION
This is an auto-generated backport PR of #2985 to the 24.09 release.