### PR TITLE
ci: Upgrade the image version of the macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,9 +331,9 @@ jobs:
       matrix:
         # ubuntu-latest: x86-64
         # ubuntu-22.04-arm64: aarch64
-        # macos-12: intel
-        # macos-13: apple silicon
-        os: [ubuntu-latest, ubuntu-22.04-arm64, macos-13-xlarge, macos-12-large]
+        # macos-13: intel
+        # macos-14: apple silicon
+        os: [ubuntu-latest, ubuntu-22.04-arm64, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out the revision


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721
Support for macOS 12 has been discontinued.
Upgrade your version as that runner image will be removed soon.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

