### PR TITLE
fix: Outdated image string join logic in `ImageRow.image_ref` (#3125)

### DIFF
--- a/changes/3125.fix.md
+++ b/changes/3125.fix.md
@@ -1,0 +1,1 @@
+Fix outdated image string join logic in `ImageRow.image_ref`.

--- a/src/ai/backend/common/utils.py
+++ b/src/ai/backend/common/utils.py
@@ -419,7 +419,7 @@ def is_ip_address_format(str: str) -> bool:
         return False
 
 
-def join_non_empty(*args, sep):
+def join_non_empty(*args: Optional[str], sep: str) -> str:
     """
     Joins non-empty strings from the given arguments using the specified separator.
     """

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -33,6 +33,7 @@ from ai.backend.common.types import (
     ImageRegistry,
     ResourceSlot,
 )
+from ai.backend.common.utils import join_non_empty
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 
@@ -242,7 +243,8 @@ class ImageRow(Base):
             image_name = ""
             _, tag = ImageRef.parse_image_tag(self.name.split(f"{self.registry}/", maxsplit=1)[1])
         else:
-            image_and_tag = self.name.split(f"{self.registry}/{self.project}/", maxsplit=1)[1]
+            join = functools.partial(join_non_empty, sep="/")
+            image_and_tag = self.name.removeprefix(f"{join(self.registry, self.project)}/")
             image_name, tag = ImageRef.parse_image_tag(image_and_tag)
 
         return ImageRef(


### PR DESCRIPTION
This is an auto-generated backport PR of #3125 to the 24.09 release.