### PR TITLE
fix: libc version not parsed on images with custom `Entrypoint` set (#3173)

### DIFF
--- a/changes/3173.fix.md
+++ b/changes/3173.fix.md
@@ -1,0 +1,1 @@
+Fix Libc version not detected on unlabeled images when image has custom entrypoint set

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1315,7 +1315,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 "HostConfig": {
                     "Init": True,
                 },
-                "Cmd": ["ldd", "--version"],
+                "Entrypoint": "sh",
+                "Cmd": ["-c", "ldd", "--version"],
             }
 
             container = await docker.containers.create(container_config)


### PR DESCRIPTION
This is an auto-generated backport PR of #3173 to the 24.09 release.