### PR TITLE
fix: Do not multiply session occupying slots

### DIFF
--- a/changes/3186.fix.md
+++ b/changes/3186.fix.md
@@ -1,1 +1,1 @@
-Fix the issue where the number of occupying slots abnormally multiplies when creating a compute session
+Fix the issue where the value of occupying slots abnormally multiplies when creating a compute session

--- a/changes/3186.fix.md
+++ b/changes/3186.fix.md
@@ -1,0 +1,1 @@
+Fix the issue where the number of occupying slots abnormally multiplies when creating a compute session

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -1309,7 +1309,7 @@ class SessionLifecycleManager:
             transited = session_row.determine_and_set_status(status_changed_at=now)
 
             def _calculate_session_occupied_slots(session_row: SessionRow):
-                session_occupying_slots = ResourceSlot.from_json({**session_row.occupying_slots})
+                session_occupying_slots = ResourceSlot()
                 for row in session_row.kernels:
                     kernel_row = cast(KernelRow, row)
                     kernel_allocs = kernel_row.occupied_slots


### PR DESCRIPTION
resolves #3187 

Whenever `_transit_session_status()` is called, it accumulates session's occupying slots

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] API server-client counterparts (e.g., manager API -> client SDK)