### PR TITLE
ci: Make it possible to backport multiple commits

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,8 +6,29 @@ on:
       - 'main'
 
 jobs:
+  backport-commits:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.commits.outputs.commits }}
+    steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+      - name: Get all commits in the push event
+        id: commits
+        run: |
+          commits=$(git rev-list ${{ github.event.before }}..${{ github.event.after }})
+          commits_json=$(jq -nc --arg commits "$commits" '$commits | split("\n") | map(select(length > 0)) | map({commit: .})')
+          echo "commits=$commits_json" >> $GITHUB_OUTPUT
+
+
   backport-target-branch:
     runs-on: ubuntu-latest
+    needs: backport-commits
+    strategy:
+      matrix:
+        commits: ${{ fromJson(needs.backport-commits.outputs.matrix) }}
     outputs:
       matrix: ${{ steps.milestones.outputs.matrix }}
       latest_commit: ${{ steps.commit.outputs.latest_commit }}
@@ -22,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: false
+          ref: ${{ matrix.commits }}
       - name: Extract pr_number from commit message
         id: commit
         run: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,7 @@ jobs:
         id: commits
         run: |
           commits=$(git rev-list ${{ github.event.before }}..${{ github.event.after }})
-          commits_json=$(jq -nc --arg commits "$commits" '$commits | split("\n") | map(select(length > 0)) | map({commit: .})')
+          commits_json=$(jq -nc --arg commits "$commits" '$commits | split("\n") | map(select(length > 0))')
           echo "commits=$commits_json" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -100,7 +100,7 @@ jobs:
               break
             fi
           done
-          matrix=$(jq -nc '{include: $ARGS.positional | map_values({milestone: .})}' --args "${target_milestones[@]}")
+          matrix=$(jq -nc --argjson milestones "$(printf '%s\n' "${target_milestones[@]}" | jq -R . | jq -s .)" '$milestones')
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
@@ -110,7 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: backport-target-branch
     strategy:
-      matrix: ${{ fromJson(needs.backport-target-branch.outputs.matrix) }}
+      matrix:
+        milestone: ${{ fromJson(needs.backport-target-branch.outputs.matrix) }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,16 +11,11 @@ jobs:
     outputs:
       matrix: ${{ steps.commits.outputs.commits }}
     steps:
-      - name: Checkout the revision
-        uses: actions/checkout@v4
-        with:
-          lfs: false
       - name: Get all commits in the push event
         id: commits
         run: |
-          commits=$(git rev-list ${{ github.event.before }}..${{ github.event.after }})
-          commits_json=$(jq -nc --arg commits "$commits" '$commits | split("\n") | map(select(length > 0))')
-          echo "commits=$commits_json" >> $GITHUB_OUTPUT
+          commits_json=$(echo '${{ toJSON(github.event.commits) }}' | jq -c '[.[].id]')
+          echo "commits=${commits_json}" >> $GITHUB_OUTPUT
 
 
   backport-target-branch:


### PR DESCRIPTION
close #3192 
Change the matrix to backport all commits, even if multiple commits are pushed at once using the merge queue.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version