### PR TITLE
fix: Allow admins to purge other user's vfolders

### DIFF
--- a/changes/3223.fix.md
+++ b/changes/3223.fix.md
@@ -1,0 +1,1 @@
+Fix purge functionality that deletes VFolder records by allowing admins to query other users' VFolders

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -2556,6 +2556,7 @@ async def purge(request: web.Request, params: PurgeRequestModel) -> web.Response
             VFolderPermission.OWNER_PERM,
             folder_id,
             allowed_status_set=VFolderStatusSet.PURGABLE,
+            allow_privileged_access=True,
         )
     )[0]
     await check_vfolder_status(row, VFolderStatusSet.PURGABLE)


### PR DESCRIPTION
resolves #3224. Follow-up of #3176.

Let admins query other user's VFolders when listing purge target VFolders.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3223.org.readthedocs.build/en/3223/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3223.org.readthedocs.build/ko/3223/

<!-- readthedocs-preview sorna-ko end -->