### PR TITLE
doc: Deprecate non relay container registry GQL explicitly

### DIFF
--- a/changes/3231.doc.md
+++ b/changes/3231.doc.md
@@ -1,1 +1,1 @@
-Deprecate non relay container registry API explicitly.
+Deprecate non relay container registry GQL explicitly.

--- a/changes/3231.doc.md
+++ b/changes/3231.doc.md
@@ -1,0 +1,1 @@
+Deprecate non relay container registry API explicitly.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1471,6 +1471,7 @@ type QuotaDetails {
   hard_limit_bytes: BigInt
 }
 
+"""Deprecated since 24.09.0. use `ContainerRegistryNode` instead"""
 type ContainerRegistry implements Node {
   """The ID of the object"""
   id: ID!
@@ -1478,6 +1479,7 @@ type ContainerRegistry implements Node {
   config: ContainerRegistryConfig
 }
 
+"""Deprecated since 24.09.0."""
 type ContainerRegistryConfig {
   url: String!
   type: String!
@@ -1848,8 +1850,14 @@ type Mutations {
     """Object id. Can be either global id or object id. Added in 24.09.0."""
     id: String!
   ): DeleteContainerRegistryNode
+
+  """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
   create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry
+
+  """Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead"""
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
+
+  """Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
 
@@ -2581,10 +2589,12 @@ type DeleteContainerRegistryNode {
   container_registry: ContainerRegistryNode
 }
 
+"""Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
 type CreateContainerRegistry {
   container_registry: ContainerRegistry
 }
 
+"""Deprecated since 24.09.0."""
 input CreateContainerRegistryInput {
   url: String!
   type: String!
@@ -2597,10 +2607,12 @@ input CreateContainerRegistryInput {
   is_global: Boolean
 }
 
+"""Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead"""
 type ModifyContainerRegistry {
   container_registry: ContainerRegistry
 }
 
+"""Deprecated since 24.09.0."""
 input ModifyContainerRegistryInput {
   url: String
   type: String
@@ -2613,6 +2625,7 @@ input ModifyContainerRegistryInput {
   is_global: Boolean
 }
 
+"""Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
 type DeleteContainerRegistry {
   container_registry: ContainerRegistry
 }

--- a/src/ai/backend/manager/models/container_registry.py
+++ b/src/ai/backend/manager/models/container_registry.py
@@ -186,6 +186,10 @@ class ContainerRegistryTypeField(graphene.Scalar):
 
 # Legacy
 class CreateContainerRegistryInput(graphene.InputObjectType):
+    """
+    Deprecated since 24.09.0.
+    """
+
     url = graphene.String(required=True)
     type = graphene.String(required=True)
     project = graphene.List(graphene.String)
@@ -197,6 +201,10 @@ class CreateContainerRegistryInput(graphene.InputObjectType):
 
 # Legacy
 class ModifyContainerRegistryInput(graphene.InputObjectType):
+    """
+    Deprecated since 24.09.0.
+    """
+
     url = graphene.String()
     type = graphene.String()
     project = graphene.List(graphene.String)
@@ -208,6 +216,10 @@ class ModifyContainerRegistryInput(graphene.InputObjectType):
 
 # Legacy
 class ContainerRegistryConfig(graphene.ObjectType):
+    """
+    Deprecated since 24.09.0.
+    """
+
     url = graphene.String(required=True)
     type = graphene.String(required=True)
     project = graphene.List(graphene.String)
@@ -219,6 +231,10 @@ class ContainerRegistryConfig(graphene.ObjectType):
 
 # Legacy
 class ContainerRegistry(graphene.ObjectType):
+    """
+    Deprecated since 24.09.0. use `ContainerRegistryNode` instead
+    """
+
     hostname = graphene.String()
     config = graphene.Field(ContainerRegistryConfig)
 
@@ -555,6 +571,10 @@ class DeleteContainerRegistryNode(graphene.Mutation):
 
 # Legacy mutations
 class CreateContainerRegistry(graphene.Mutation):
+    """
+    Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead
+    """
+
     allowed_roles = (UserRole.SUPERADMIN,)
     container_registry = graphene.Field(ContainerRegistry)
 
@@ -593,7 +613,12 @@ class CreateContainerRegistry(graphene.Mutation):
             )
 
 
+# Legacy mutations
 class ModifyContainerRegistry(graphene.Mutation):
+    """
+    Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead
+    """
+
     allowed_roles = (UserRole.SUPERADMIN,)
     container_registry = graphene.Field(ContainerRegistry)
 
@@ -641,7 +666,12 @@ class ModifyContainerRegistry(graphene.Mutation):
             return cls(container_registry=ContainerRegistry.from_row(ctx, reg_row))
 
 
+# Legacy mutations
 class DeleteContainerRegistry(graphene.Mutation):
+    """
+    Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead
+    """
+
     allowed_roles = (UserRole.SUPERADMIN,)
     container_registry = graphene.Field(ContainerRegistry)
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Mark the `ContainerRegistry` GQL API as deprecated since *24.09*.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3231.org.readthedocs.build/en/3231/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3231.org.readthedocs.build/ko/3231/

<!-- readthedocs-preview sorna-ko end -->