### PR TITLE
ci: Handle cases where target milesones is empty

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -95,13 +95,13 @@ jobs:
               break
             fi
           done
-          matrix=$(jq -nc --argjson milestones "$(printf '%s\n' "${target_milestones[@]}" | jq -R . | jq -s .)" '$milestones')
+          matrix=$(printf '%s\n' "${target_milestones[@]}" | grep -v '^$' | jq -R . | jq -s .)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 
   backport:
-    if: ${{ needs.backport-target-branch.outputs.matrix }}
+    if: ${{ needs.backport-target-branch.outputs.matrix != '[]'}}
     runs-on: ubuntu-latest
     needs: backport-target-branch
     strategy:


### PR DESCRIPTION
It is also normal behavior to not perform a backport because the branch corresponding to the target milestone does not currently exist.
github actions does not judge an empty list as false, so it handles this explicitly.

[before]
![CleanShot 2024-12-10 at 15 56 04@2x](https://github.com/user-attachments/assets/0adbf90c-3fa7-474c-b727-7ce99a25680c)

[after]
![CleanShot 2024-12-10 at 15 56 27@2x](https://github.com/user-attachments/assets/9e0d4791-dcb6-4f11-bbbc-45bb002af5f9)


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
