### PR TITLE
fix: Wrong default value of `total_resource_slots` column

### DIFF
--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -98,7 +98,7 @@ domains = sa.Table(
         onupdate=sa.func.current_timestamp(),
     ),
     # TODO: separate resource-related fields with new domain resource policy table when needed.
-    sa.Column("total_resource_slots", ResourceSlotColumn(), default="{}"),
+    sa.Column("total_resource_slots", ResourceSlotColumn(), default={}),
     sa.Column(
         "allowed_vfolder_hosts",
         VFolderHostPermissionColumn(),

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -164,7 +164,7 @@ groups = sa.Table(
         index=True,
     ),
     # TODO: separate resource-related fields with new domain resource policy table when needed.
-    sa.Column("total_resource_slots", ResourceSlotColumn(), default="{}"),
+    sa.Column("total_resource_slots", ResourceSlotColumn(), default={}),
     sa.Column(
         "allowed_vfolder_hosts",
         VFolderHostPermissionColumn(),


### PR DESCRIPTION
`total_resource_slots` column of `domains` and `groups` tables has `"{}"` default value as a string not a JSON data, which causes error when initialize `ResourceSlot()` object from the value.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version