### PR TITLE
fix: Prevent vfolder `request-download` API from accessing host filesystem

### DIFF
--- a/changes/3241.fix.md
+++ b/changes/3241.fix.md
@@ -1,0 +1,1 @@
+Prevent vfolder `request-download` API from accessing host filesystem.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -156,7 +156,7 @@ async def download(request: web.Request) -> web.StreamResponse:
                 if (dst_dir := params["dst_dir"]) is not None:
                     parent_dir = vfpath / dst_dir
                 file_path = parent_dir / token_data["relpath"]
-                file_path.relative_to(vfpath)
+                file_path.resolve().relative_to(vfpath)
                 if not file_path.exists():
                     raise FileNotFoundError
             except (ValueError, FileNotFoundError):


### PR DESCRIPTION
Fixes https://github.com/lablup/giftbox/issues/786.

The existing VFolder `request-download` API could download files outside of the vfolder.
For example, using the vfolder CLI command that utilizes this API, we can download host files as shown below.

```
❯ ./backend.ai vfolder download test ../some_host_file -b vfolder_name
Downloading to /home/jopemachine/backend.ai/vfolder_name/../some_host_file ...
0.00bytes [00:00, ?bytes/s]
✓ Done.
```

This is clearly a security vulnerability, as it can be exploited, for example, as shown in [issue 786](https://github.com/lablup/giftbox/issues/786).
After applying the PR, passing a path outside the VFolder will result in a 404 error.


Thanks to @fregataa for resolving this issue.

---


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
