### PR TITLE
fix: Allow `testutils` component visibility rules

### DIFF
--- a/src/ai/backend/account_manager/BUILD
+++ b/src/ai/backend/account_manager/BUILD
@@ -9,7 +9,9 @@ python_sources(
 )
 
 visibility_private_component(
-    allowed_dependents=[],
+    allowed_dependents=[
+        "//src/ai/backend/testutils/**",
+    ],
     allowed_dependencies=[
         "//src/ai/backend/**",
         "!//src/ai/backend/web/**",

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -35,6 +35,7 @@ python_sources(
 visibility_private_component(
     allowed_dependents=[
         "//src/ai/backend/accelerator/**",
+        "//src/ai/backend/testutils/**",
     ],
     allowed_dependencies=[
         "//src/ai/backend/**",

--- a/src/ai/backend/manager/BUILD
+++ b/src/ai/backend/manager/BUILD
@@ -13,7 +13,9 @@ python_sources(
 )
 
 visibility_private_component(
-    allowed_dependents=[],
+    allowed_dependents=[
+        "//src/ai/backend/testutils/**",
+    ],
     allowed_dependencies=[
         "//src/ai/backend/**",
         "!//src/ai/backend/web/**",

--- a/src/ai/backend/storage/BUILD
+++ b/src/ai/backend/storage/BUILD
@@ -7,7 +7,9 @@ python_sources(
 )
 
 visibility_private_component(
-    allowed_dependents=[],
+    allowed_dependents=[
+        "//src/ai/backend/testutils/**",
+    ],
     allowed_dependencies=[
         "//src/ai/backend/**",
         "!//src/ai/backend/web/**",

--- a/src/ai/backend/testutils/BUILD
+++ b/src/ai/backend/testutils/BUILD
@@ -8,10 +8,5 @@ visibility_private_component(
     ],
     allowed_dependencies=[
         "//src/ai/backend/**",
-        "!//src/ai/backend/web/**",
-        "!//src/ai/backend/manager/**",
-        "!//src/ai/backend/agent/**",
-        "!//src/ai/backend/storage/**",
-        "!//src/ai/backend/wsproxy/**",
     ],
 )

--- a/src/ai/backend/web/BUILD
+++ b/src/ai/backend/web/BUILD
@@ -8,7 +8,9 @@ python_sources(
 )
 
 visibility_private_component(
-    allowed_dependents=[],
+    allowed_dependents=[
+        "//src/ai/backend/testutils/**",
+    ],
     allowed_dependencies=[
         "//src/ai/backend/**",
         "!//src/ai/backend/manager/**",

--- a/src/ai/backend/wsproxy/BUILD
+++ b/src/ai/backend/wsproxy/BUILD
@@ -8,7 +8,9 @@ python_sources(
 )
 
 visibility_private_component(
-    allowed_dependents=[],
+    allowed_dependents=[
+        "//src/ai/backend/testutils/**",
+    ],
     allowed_dependencies=[
         "//src/ai/backend/**",
         "!//src/ai/backend/web/**",


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #3242.

## How to test

1. Open any file within the `testutils` package and import the types of components such as `manager`.
2. Run `pants check ::` to verify if any visibility rule violation errors occur.

---


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
