### PR TITLE
fix: Prevent vfolder `request-download` API from accessing host filesystem (#3241)

### DIFF
--- a/changes/3241.fix.md
+++ b/changes/3241.fix.md
@@ -1,0 +1,1 @@
+Prevent vfolder `request-download` API from accessing host filesystem.

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -156,7 +156,7 @@ async def download(request: web.Request) -> web.StreamResponse:
                 if (dst_dir := params["dst_dir"]) is not None:
                     parent_dir = vfpath / dst_dir
                 file_path = parent_dir / token_data["relpath"]
-                file_path.relative_to(vfpath)
+                file_path.resolve().relative_to(vfpath)
                 if not file_path.exists():
                     raise FileNotFoundError
             except (ValueError, FileNotFoundError):


### PR DESCRIPTION
This is an auto-generated backport PR of #3241 to the 24.03 release.