### PR TITLE
ci: backport to handle commit messages safely

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -146,7 +146,7 @@ jobs:
           echo "commit_footer<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_footer" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Create Bakport PR
+      - name: Create Backport PR
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -133,14 +133,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - id: commit_message
+        env:
+          COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
         run: |
-          commit_header=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | head -n 1)
+          commit_header=$(echo "${COMMIT_MESSAGE}" | head -n 1)
           echo "commit_header=$commit_header" >> $GITHUB_OUTPUT
-          commit_body=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | awk '/^$/{p++;next} p==1')
+          commit_body=$(echo "${COMMIT_MESSAGE}" | awk '/^$/{p++;next} p==1')
           echo "commit_body<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_body" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          commit_footer=$(echo '${{ needs.backport-target-branch.outputs.commit_message }}' | awk '/^$/{p++;next} p==2')
+          commit_footer=$(echo "${COMMIT_MESSAGE}" | awk '/^$/{p++;next} p==2')
           echo "commit_footer<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_footer" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/backport.yml` file. The change involves setting an environment variable for the commit message to simplify and clean up the script.

* Added `COMMIT_MESSAGE` environment variable to store the commit message and updated the script to use this variable instead of directly referencing the output from `needs.backport-target-branch.outputs.commit_message`. This change improves readability and maintainability of the script.

Make the same modifications as in #2512.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
