### PR TITLE
feat: Allow shell command and env-var access in model-definition and service-definition

### DIFF
--- a/changes/3248.feature.md
+++ b/changes/3248.feature.md
@@ -1,0 +1,1 @@
+Allow specifying a full shell script string in `start_command` of `model-definition.yaml` while preserving shell variable expansions to allow access to environment variables in service definitions

--- a/docs/dev/adding-kernels.rst
+++ b/docs/dev/adding-kernels.rst
@@ -56,7 +56,7 @@ Any Docker image based on Alpine 3.17+, CentOS 7+, and Ubuntu 16.04+ which satis
 
 .. versionchanged:: 24.09.0
 
-   It became possible to use vanilla Docker images in the registry that has *no* labels at all.
+   It became possible to use vanilla Docker images in the registry that have *no* Backend.AI-specific metadata labels at all.
    Those images will allow attaching arbitrary AI accelerators and provide the intrinsic ``ttyd`` and ``sshd`` services.
 
 * Required Labels
@@ -182,9 +182,8 @@ All the variable substitution follows the Python's brace-style formatting syntax
 .. versionchanged:: 24.09.5
 
    You may use a shell script string in the ``command`` field, including shell variable expansions along with the intrinsic/user-defined variables in curly braces.
-   This allows access to environment variables in the command to parametrize the service configuration.
-
-   In this case, we recommend to apply ``exec`` in the last command which spawns the actual service process, to let the subprocess tracker following with it instead of tracking the parent shell process who runs the script.
+   This allows access to environment variables in the command to parametrize the service configuration using per-session specifics like the cluster settings and accelerator device settings.
+   In this case, we highly recommend to apply ``exec`` in the last command which spawns the actual service process to let the service lifecycle tracker follow it instead of tracking the parent shell process.
 
 Available predefined variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/dev/adding-kernels.rst
+++ b/docs/dev/adding-kernels.rst
@@ -183,7 +183,7 @@ All the variable substitution follows the Python's brace-style formatting syntax
 
    You may use a shell script string in the ``command`` field, including shell variable expansions along with the intrinsic/user-defined variables in curly braces.
    This allows access to environment variables in the command to parametrize the service configuration using per-session specifics like the cluster settings and accelerator device settings.
-   In this case, we highly recommend to apply ``exec`` in the last command which spawns the actual service process to let the service lifecycle tracker follow it instead of tracking the parent shell process.
+   In this case, we highly recommend to apply ``exec`` in the last command which spawns the actual service process to let the service lifecycle tracker follow it instead of the parent shell process.
 
 Available predefined variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/dev/adding-kernels.rst
+++ b/docs/dev/adding-kernels.rst
@@ -184,6 +184,8 @@ All the variable substitution follows the Python's brace-style formatting syntax
    You may use a shell script string in the ``command`` field, including shell variable expansions along with the intrinsic/user-defined variables in curly braces.
    This allows access to environment variables in the command to parametrize the service configuration.
 
+   In this case, we recommend to apply ``exec`` in the last command which spawns the actual service process, to let the subprocess tracker following with it instead of tracking the parent shell process who runs the script.
+
 Available predefined variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/dev/adding-kernels.rst
+++ b/docs/dev/adding-kernels.rst
@@ -54,6 +54,11 @@ Metadata Labels
 
 Any Docker image based on Alpine 3.17+, CentOS 7+, and Ubuntu 16.04+ which satisfies the above prerequisites may become a Backend.AI kernel image if you add the following image labels:
 
+.. versionchanged:: 24.09.0
+
+   It became possible to use vanilla Docker images in the registry that has *no* labels at all.
+   Those images will allow attaching arbitrary AI accelerators and provide the intrinsic ``ttyd`` and ``sshd`` services.
+
 * Required Labels
 
   * ``ai.backend.kernelspec``: ``1`` (this will be used for future versioning of the metadata specification)
@@ -173,6 +178,11 @@ A service definition is composed of three major fields: ``prestart`` that contai
 
 The "template-enabled" strings may have references to a contextual set of variables in curly braces.
 All the variable substitution follows the Python's brace-style formatting syntax and rules.
+
+.. versionchanged:: 24.09.5
+
+   You may use a shell script string in the ``command`` field, including shell variable expansions along with the intrinsic/user-defined variables in curly braces.
+   This allows access to environment variables in the command to parametrize the service configuration.
 
 Available predefined variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2362,11 +2362,6 @@ class AbstractAgent(
                         "host_ports": (None,),
                         "is_inference": True,
                     })
-                    start_command = service["start_command"]
-                    if isinstance(start_command, str):
-                        shell = service["shell"]
-                        start_command = [shell, "-c", start_command]
-                    service["start_command"] = start_command
             return model_definition
         except DataError as e:
             raise AgentError(

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2362,6 +2362,15 @@ class AbstractAgent(
                         "host_ports": (None,),
                         "is_inference": True,
                     })
+                    start_command = service["start_command"]
+                    if isinstance(start_command, str):
+                        shell = service["shell"]
+                        start_command = [shell, "-c", start_command]
+                    service["start_command"] = start_command
+                    print("start_command:", file=sys.stderr)
+                    print("----", file=sys.stderr)
+                    print(repr(start_command), file=sys.stderr)
+                    print("----", file=sys.stderr)
             return model_definition
         except DataError as e:
             raise AgentError(

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2367,10 +2367,6 @@ class AbstractAgent(
                         shell = service["shell"]
                         start_command = [shell, "-c", start_command]
                     service["start_command"] = start_command
-                    print("start_command:", file=sys.stderr)
-                    print("----", file=sys.stderr)
-                    print(repr(start_command), file=sys.stderr)
-                    print("----", file=sys.stderr)
             return model_definition
         except DataError as e:
             raise AgentError(

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -114,7 +114,8 @@ model_definition_iv = t.Dict({
                         t.Key("args"): t.Dict().allow_extra("*"),
                     })
                 ),
-                t.Key("start_command"): t.List(t.String),
+                t.Key("start_command"): t.String | t.List(t.String),
+                t.Key("shell", default="bash"): t.String,  # used if start_command is a string
                 t.Key("port"): t.ToInt[1:],
                 t.Key("health_check", default=None): t.Null
                 | t.Dict({

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -115,7 +115,7 @@ model_definition_iv = t.Dict({
                     })
                 ),
                 t.Key("start_command"): t.String | t.List(t.String),
-                t.Key("shell", default="bash"): t.String,  # used if start_command is a string
+                t.Key("shell", default="/bin/bash"): t.String,  # used if start_command is a string
                 t.Key("port"): t.ToInt[1:],
                 t.Key("health_check", default=None): t.Null
                 | t.Dict({

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -845,14 +845,14 @@ class BaseRunner(metaclass=ABCMeta):
                             "status": "failed",
                             "error": error_reason,
                         }
-                    log.debug("cmdargs: {0}", cmdargs)
-                    log.debug("env: {0}", env)
                     service_env = {**self.child_env, **env}
                     # avoid conflicts with Python binary used by service apps.
                     if "LD_LIBRARY_PATH" in service_env:
                         service_env["LD_LIBRARY_PATH"] = service_env["LD_LIBRARY_PATH"].replace(
                             "/opt/backend.ai/lib:", ""
                         )
+                    log.debug("cmdargs: {0}", cmdargs)
+                    log.debug("env: {0}", service_env)
                     try:
                         proc = await asyncio.create_subprocess_exec(
                             *map(str, cmdargs),

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -793,7 +793,13 @@ class BaseRunner(metaclass=ABCMeta):
             json.dumps(result).encode("utf8"),
         ])
 
-    async def _start_service(self, service_info, *, cwd: Optional[str] = None, do_not_wait=False):
+    async def _start_service(
+        self,
+        service_info,
+        *,
+        cwd: Optional[str] = None,
+        do_not_wait: bool = False,
+    ):
         error_reason = None
         try:
             async with self._service_lock:

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -114,7 +114,7 @@ class ServiceParser:
             if (ref := action.get("ref")) is not None:
                 self.variables[ref] = ret
 
-        cmdargs = []
+        cmdargs = [*service.command]
         env = {}
 
         additional_arguments = dict(service.default_arguments)
@@ -131,21 +131,19 @@ class ServiceParser:
                 cmdargs.append(arg_value)
             elif isinstance(arg_value, list):
                 cmdargs += arg_value
-
         cmdargs = ServiceArgumentInterpolator.apply(cmdargs, self.variables)
 
         if "envs" in opts.keys() and opts["envs"]:
-            for envname, envvalue in opts["envs"].items():
-                if envname not in service.allowed_envs:
+            for env_name, env_value in opts["envs"].items():
+                if env_name not in service.allowed_envs:
                     raise DisallowedEnvironment(
-                        f"Environment variable {envname} not allowed for service {service_name}"
+                        f"Environment variable {env_name} not allowed for service {service_name}"
                     )
-                elif envname in frozen_envs:
+                elif env_name in frozen_envs:
                     raise DisallowedEnvironment(
-                        f"Environment variable {envname} can't be overwritten"
+                        f"Environment variable {env_name} can't be overwritten"
                     )
-                env[envname] = envvalue
-
+                env[env_name] = env_value
         for env_name, env_value in service.env.items():
             env_name, env_value = ServiceArgumentInterpolator.apply(
                 [env_name, env_value],

--- a/src/ai/backend/kernel/service.py
+++ b/src/ai/backend/kernel/service.py
@@ -6,19 +6,21 @@ See more details at `the documentation about adding new kernel images
 <https://docs.backend.ai/en/latest/dev/adding-kernels.html#service-ports>`_.
 """
 
+import enum
 import json
 import logging
+import re
+from collections.abc import (
+    Collection,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
 from pathlib import Path
 from typing import (
     Any,
-    Collection,
-    Dict,
-    List,
-    Mapping,
-    MutableMapping,
     Optional,
-    Sequence,
-    Tuple,
     TypedDict,
     Union,
 )
@@ -40,19 +42,19 @@ class Action(TypedDict):
 
 @attrs.define(auto_attribs=True, slots=True)
 class ServiceDefinition:
-    command: List[str]
+    command: list[str]
     noop: bool = False
     url_template: str = ""
-    prestart_actions: List[Action] = attrs.Factory(list)
+    prestart_actions: list[Action] = attrs.Factory(list)
     env: Mapping[str, str] = attrs.Factory(dict)
-    allowed_envs: List[str] = attrs.Factory(list)
-    allowed_arguments: List[str] = attrs.Factory(list)
-    default_arguments: Mapping[str, Union[None, str, List[str]]] = attrs.Factory(dict)
+    allowed_envs: list[str] = attrs.Factory(list)
+    allowed_arguments: list[str] = attrs.Factory(list)
+    default_arguments: Mapping[str, Union[None, str, list[str]]] = attrs.Factory(dict)
 
 
 class ServiceParser:
     variables: MutableMapping[str, str]
-    services: MutableMapping[str, ServiceDefinition]
+    services: dict[str, ServiceDefinition]
 
     def __init__(self, variables: MutableMapping[str, str]) -> None:
         self.variables = variables
@@ -94,7 +96,7 @@ class ServiceParser:
         service_name: str,
         frozen_envs: Collection[str],
         opts: Mapping[str, Any],
-    ) -> Tuple[Optional[Sequence[str]], Mapping[str, str]]:
+    ) -> tuple[Optional[Sequence[str]], Mapping[str, str]]:
         if service_name not in self.services.keys():
             return None, {}
         service = self.services[service_name]
@@ -112,10 +114,8 @@ class ServiceParser:
             if (ref := action.get("ref")) is not None:
                 self.variables[ref] = ret
 
-        cmdargs, env = [], {}
-
-        for arg in service.command:
-            cmdargs.append(arg.format_map(self.variables))
+        cmdargs = []
+        env = {}
 
         additional_arguments = dict(service.default_arguments)
         if "arguments" in opts.keys() and opts["arguments"]:
@@ -125,9 +125,14 @@ class ServiceParser:
                         f"Argument {argname} not allowed for service {service_name}"
                     )
                 additional_arguments[argname] = argvalue
+        for arg_name, arg_value in additional_arguments.items():
+            cmdargs.append(arg_name)
+            if isinstance(arg_value, str):
+                cmdargs.append(arg_value)
+            elif isinstance(arg_value, list):
+                cmdargs += arg_value
 
-        for env_name, env_value in service.env.items():
-            env[env_name.format_map(self.variables)] = env_value.format_map(self.variables)
+        cmdargs = ServiceArgumentInterpolator.apply(cmdargs, self.variables)
 
         if "envs" in opts.keys() and opts["envs"]:
             for envname, envvalue in opts["envs"].items():
@@ -141,18 +146,18 @@ class ServiceParser:
                     )
                 env[envname] = envvalue
 
-        for arg_name, arg_value in additional_arguments.items():
-            cmdargs.append(arg_name)
-            if isinstance(arg_value, str):
-                cmdargs.append(arg_value)
-            elif isinstance(arg_value, list):
-                cmdargs += arg_value
+        for env_name, env_value in service.env.items():
+            env_name, env_value = ServiceArgumentInterpolator.apply(
+                [env_name, env_value],
+                self.variables,
+            )
+            env[env_name] = env_value
 
         return cmdargs, env
 
     async def get_apps(self, selected_service: str = "") -> Sequence[Mapping[str, Any]]:
         def _format(service_name: str) -> Mapping[str, Any]:
-            service_info: Dict[str, Any] = {"name": service_name}
+            service_info: dict[str, Any] = {"name": service_name}
             service = self.services[service_name]
             if len(service.url_template) > 0:
                 service_info["url_template"] = service.url_template
@@ -170,3 +175,46 @@ class ServiceParser:
             for service_name in self.services.keys():
                 apps.append(_format(service_name))
         return apps
+
+
+class TokenType(enum.Enum):
+    TEXT = enum.auto()
+    EXPR = enum.auto()
+
+
+class ServiceArgumentInterpolator:
+    @classmethod
+    def apply(cls, parts: list[str], variables: Mapping[str, Any]) -> list[str]:
+        patterns = r"""
+            (\${{\s*(?P<expr1>.*?)\s*}}) |     # ${{ ... }} (github-style)
+            ((?<![${]){\s*(?P<expr2>.*?)\s*})  # {...} (python-style)
+        """
+
+        def tokenize(s: str) -> Iterator[tuple[TokenType, str]]:
+            last_index = 0
+            for match in re.finditer(patterns, s, re.VERBOSE):
+                start, end = match.span()
+                # characters between tokens
+                if last_index < start:
+                    yield TokenType.TEXT, s[last_index:start]
+                # the matched expression
+                if (token := match.group("expr1")) is not None:
+                    yield TokenType.EXPR, token
+                elif (token := match.group("expr2")) is not None:
+                    yield TokenType.EXPR, token
+                last_index = end
+            # the rest of string
+            if last_index < len(s):
+                yield TokenType.TEXT, s[last_index:]
+
+        processed_parts = []
+        for part in parts:
+            tokens = []
+            for token_type, token in tokenize(part):
+                match token_type:
+                    case TokenType.TEXT:
+                        tokens.append(token)
+                    case TokenType.EXPR:
+                        tokens.append(("{" + token + "}").format_map(variables))
+            processed_parts.append("".join(tokens))
+        return processed_parts

--- a/tests/kernel/BUILD
+++ b/tests/kernel/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/kernel/test_service_variables.py
+++ b/tests/kernel/test_service_variables.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from ai.backend.kernel.service import ServiceArgumentInterpolator
+
+
+def test_service_argument_interpolation_intrinsic_python_style() -> None:
+    command = ["bash", "-c", 'echo "host = {host}, port = {ports[1]}"']
+    variables = {
+        "host": "99.99.99.99",
+        "ports": [11001, 11002],
+    }
+    ret = ServiceArgumentInterpolator.apply(command, variables)
+
+    assert ret[0] == "bash"  # unchanged
+    assert ret[1] == "-c"  # unchanged
+    assert ret[2] == 'echo "host = 99.99.99.99, port = 11002"'
+
+
+def test_service_argument_interpolation_intrinsic_github_style() -> None:
+    command = ["bash", "-c", 'echo "host = ${{ host }}, port = ${{ ports[1] }}"']
+    variables = {
+        "host": "99.99.99.99",
+        "ports": [11001, 11002],
+    }
+    ret = ServiceArgumentInterpolator.apply(command, variables)
+
+    assert ret[0] == "bash"  # unchanged
+    assert ret[1] == "-c"  # unchanged
+    assert ret[2] == 'echo "host = 99.99.99.99, port = 11002"'
+
+
+def test_service_argument_interpolation_skip_shell_envvar_simple() -> None:
+    command = ["bash", "-c", 'echo "kernel_id = $BACKENDAI_KERNEL_ID"']
+    variables: dict[str, Any] = {}
+    ret = ServiceArgumentInterpolator.apply(command, variables)
+
+    assert ret[0] == "bash"  # unchanged
+    assert ret[1] == "-c"  # unchanged
+    assert ret[2] == 'echo "kernel_id = $BACKENDAI_KERNEL_ID"'  # unchanged
+
+
+def test_service_argument_interpolation_skip_shell_envvar_braced() -> None:
+    command = ["bash", "-c", 'echo "kernel_id = ${BACKENDAI_KERNEL_ID/aaa/${magic}}"']
+    variables: dict[str, Any] = {}
+    ret = ServiceArgumentInterpolator.apply(command, variables)
+
+    assert ret[0] == "bash"  # unchanged
+    assert ret[1] == "-c"  # unchanged
+    assert ret[2] == 'echo "kernel_id = ${BACKENDAI_KERNEL_ID/aaa/${magic}}"'  # unchanged
+
+
+def test_service_argument_interpolation_mixed() -> None:
+    command = [
+        "bash",
+        "-c",
+        'echo "host = ${{ host }}, kernel_id = ${BACKENDAI_KERNEL_ID/aaa/${magic}}, port = {ports[0]}"',
+    ]
+    variables = {
+        "host": "99.99.99.99",
+        "ports": [11001, 11002],
+    }
+    ret = ServiceArgumentInterpolator.apply(command, variables)
+
+    assert ret[0] == "bash"  # unchanged
+    assert ret[1] == "-c"  # unchanged
+    assert (
+        ret[2]
+        == 'echo "host = 99.99.99.99, kernel_id = ${BACKENDAI_KERNEL_ID/aaa/${magic}}, port = 11001"'
+    )


### PR DESCRIPTION
resolves #2909

- Allow specifying a full shell script string (with an optional `shell` field which defaults to "bash") in the `start_command` field of `model-definition.yaml`.
- Add a simple regex-based tokenizer to process variable interpolation while preserve shell-specific env-var expressions for the command arguments in both `model-definition.yaml` and `/etc/backend.ai/service-defs/*.json` files.

> [!NOTE]
> The tokenizer is a simplified version and cannot handle nested overlapping of shell variable expansion and intrinsic variable expansion as such implementation requires a more sophisticated stack-based parser.  For complex cases like that, users may just flatten their variables references into multiple local variable declarations avoiding syntactic overlaps.

### A sample `model-definition.yaml`
It shows coexistence of shell env-var expansion and intrinsic service arguments:

```yaml
models:
  - name: "Simple-Webservice"
    model_path: "/home/work"
    service:
      pre_start_actions:
      start_command: |
        echo "hello world"
        echo "BACKENDAI_CLUSTER_SIZE=${BACKENDAI_CLUSTER_SIZE}"
        exec python -m http.server -b 0.0.0.0 {ports[0]}
      port: 8000
      health_check:
        path: /
        max_retries: 10
```

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Test case(s)
- [x] Documentation
