### PR TITLE
ci: matrix to match the `GITHUB_OUTPUT` format

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -95,7 +95,7 @@ jobs:
               break
             fi
           done
-          matrix=$(printf '%s\n' "${target_milestones[@]}" | grep -v '^$' | jq -R . | jq -s .)
+          matrix=$(printf '%s\n' "${target_milestones[@]}" | grep -v '^$' | jq -R . | jq -sc .)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -101,7 +101,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   backport:
-    if: ${{ needs.backport-target-branch.outputs.matrix != '[]'}}
+    if: ${{ needs.backport-target-branch.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     needs: backport-target-branch
     strategy:


### PR DESCRIPTION
This pull request includes a small change to the `jobs:` section in the `.github/workflows/backport.yml` file. The change modifies the `matrix` assignment line to use the `-sc` option with `jq` instead of just `-s`.

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L98-R98): Changed `matrix` assignment to use `jq -sc` for more concise output.

GITHUB_OUTPUT does not allow whitespace in arrays.
To match its format, use the -c option to jq to remove spaces.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
