### PR TITLE
fix: do not reuse `Base` class on alembic migration script (#3254)

### DIFF
--- a/changes/3254.fix.md
+++ b/changes/3254.fix.md
@@ -1,0 +1,1 @@
+Fix `1d42c726d8a3` revision execution failing

--- a/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
+++ b/src/ai/backend/manager/models/alembic/versions/1d42c726d8a3_migrate_container_registries_from_etcd_to_psql.py
@@ -24,11 +24,12 @@ import sqlalchemy as sa
 import trafaret as t
 from alembic import op
 from sqlalchemy.exc import SAWarning
+from sqlalchemy.orm import registry
 
 from ai.backend.common import validators as tx
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.manager.config import load
-from ai.backend.manager.models.base import GUID, Base, IDColumn, StrEnumType, convention
+from ai.backend.manager.models.base import GUID, IDColumn, StrEnumType, convention
 
 # revision identifiers, used by Alembic.
 revision = "1d42c726d8a3"
@@ -43,6 +44,10 @@ warnings.filterwarnings(
     message="This declarative base already contains a class with the same class name and module name as .*",
     category=SAWarning,
 )
+
+metadata = sa.MetaData(naming_convention=convention)
+mapper_registry = registry(metadata=metadata)
+Base: Any = mapper_registry.generate_base()
 
 etcd_container_registry_iv = t.Dict({
     t.Key(""): tx.URL,


### PR DESCRIPTION
This is an auto-generated backport PR of #3254 to the 24.09 release.