### PR TITLE
ci: Make sure to check out the head branch, not the HEAD commit (#3118)

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ github.head_ref}}
         fetch-depth: 2
         lfs: false
         token: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
This is an auto-generated backport PR of #3118 to the 24.09 release.