### PR TITLE
ci: Remove labeled triggers for skip:ci (#3122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - '[0-9][0-9].0[39].*'
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   merge_group:
 
 concurrency:
@@ -77,7 +77,8 @@ jobs:
   lint:
     if: |
       !(
-        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        contains(toJSON(github.event.commits.*.msg), 'skip:ci')
+        || contains(github.event.pull_request.labels.*.name, 'skip:ci')
         || needs.optimize-ci.outputs.skip == 'true'
       )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
@@ -182,7 +183,8 @@ jobs:
   typecheck:
     if: |
       !(
-        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        contains(toJSON(github.event.commits.*.msg), 'skip:ci')
+        || contains(github.event.pull_request.labels.*.name, 'skip:ci')
         || needs.optimize-ci.outputs.skip == 'true'
       )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)
@@ -254,7 +256,8 @@ jobs:
   test:
     if: |
       !(
-        contains(github.event.pull_request.labels.*.name, 'skip:ci')
+        contains(toJSON(github.event.commits.*.msg), 'skip:ci')
+        || contains(github.event.pull_request.labels.*.name, 'skip:ci')
         || needs.optimize-ci.outputs.skip == 'true'
       )
       && !contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.label.name)

--- a/.github/workflows/skip-ci.yml
+++ b/.github/workflows/skip-ci.yml
@@ -1,0 +1,33 @@
+name: skip-ci
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  skip_ci:
+    if: contains(github.event.pull_request.labels.*.name, 'skip:ci')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        token: ${{ secrets.OCTODOG }}
+    - name: Skip CI
+      if: github.event.action == 'labeled'
+      run:
+        git config --global user.email "mu001@lablup.com"
+        git config --global user.name "octodog"
+        git commit --allow-empty -m "skip:ci"
+        git push
+    - name: Revoke skip:ci
+      if: github.event.action == 'unlabeled'
+      run:
+        git config --global user.email "mu001@lablup.com"
+        git config --global user.name "octodog"
+        previous_commit_message=$(git log -n 1 --pretty=format:%s --skip 1)
+        if [[ "$previous_commit_message" == "skip:ci" ]]; then
+          git log -n 1 --pretty=format:%H --skip 1 | xargs git revert --no-edit
+          git push
+        fi


### PR DESCRIPTION
This is an auto-generated backport PR of #3122 to the 24.09 release.