### PR TITLE
fix: String formatting of BinarySize

### DIFF
--- a/changes/3272.fix.md
+++ b/changes/3272.fix.md
@@ -1,0 +1,1 @@
+Ensure the string formatting of BinarySize values containing subtle fractions to be floating point numbers (instead of scientific notations) always

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -581,7 +581,7 @@ class BinarySize(int):
             suffix = type(self).suffices[suffix_idx]
             multiplier = type(self).suffix_map[suffix.lower()]
             value = self._quantize(self, multiplier)
-            return f"{value} {suffix.upper()}iB"
+            return f"{value:f} {suffix.upper()}iB"
 
     def __format__(self, format_spec):
         if len(format_spec) != 1:
@@ -594,7 +594,7 @@ class BinarySize(int):
             suffix = type(self).suffices[suffix_idx]
             multiplier = type(self).suffix_map[suffix.lower()]
             value = self._quantize(self, multiplier)
-            return f"{value}{suffix.lower()}"
+            return f"{value:f}{suffix.lower()}"
         else:
             # use the given scale
             suffix = format_spec.lower()
@@ -602,7 +602,7 @@ class BinarySize(int):
             if multiplier is None:
                 raise ValueError("Unsupported scale unit.", suffix)
             value = self._quantize(self, multiplier)
-            return f"{value}{suffix.lower()}".strip()
+            return f"{value:f}{suffix.lower()}".strip()
 
 
 class ResourceSlot(UserDict):

--- a/tests/common/test_types.py
+++ b/tests/common/test_types.py
@@ -104,6 +104,8 @@ def test_binary_size():
     assert str(BinarySize(105935)) == "103.45 KiB"
     assert str(BinarySize(127303)) == "124.32 KiB"
     assert str(BinarySize(1048576)) == "1 MiB"
+    # If we don't apply ":f" when stringifying decimals, 1048576123 would produce "1E+3"
+    assert str(BinarySize(1048576123)) == "1000 MiB"
 
     x = BinarySize.from_str("inf")
     assert isinstance(x, Decimal)
@@ -122,6 +124,7 @@ def test_binary_size():
     assert "{:k}".format(BinarySize(1048576)) == "1024k"  # type: ignore
     assert "{:m}".format(BinarySize(524288)) == "0.5m"  # type: ignore
     assert "{:m}".format(BinarySize(1048576)) == "1m"  # type: ignore
+    assert "{:m}".format(BinarySize(1048576123)) == "1000m"  # type: ignore
     assert "{:g}".format(BinarySize(2**30)) == "1g"
     with pytest.raises(ValueError):
         "{:x}".format(BinarySize(1))


### PR DESCRIPTION
resolves #3271

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Test case(s)
