### PR TITLE
ci: Fix matrix variable to use target_branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -74,7 +74,7 @@ jobs:
           target_milestone=$(gh pr view ${{ steps.commit.outputs.pr_number }} --json milestone --jq .milestone.title)
 
           milestones=$(gh api /repos/:owner/:repo/milestones --jq '.[].title')
-          echo $milestones
+          echo "milestones: $milestones"
 
           # Remove Backlog from the backport target branch
           milestones=($milestones)
@@ -83,17 +83,15 @@ jobs:
               unset 'milestones[$i]'
             fi
           done
-          echo "${milestones[@]}"
 
           for i in "${!milestones[@]}"; do
             if ! git ls-remote --heads | grep -q "refs/heads/${milestones[$i]}\$"; then
               unset 'milestones[$i]'
             fi
           done
-          echo "${milestones[@]}"
+          echo "Released milestones: ${milestones[@]}"
 
           sort_milestones=($(printf "%s\n" "${milestones[@]}" | sort -r))
-          echo "${sort_milestones[@]}"
           for i in "${!sort_milestones[@]}"; do
             if [[ "${sort_milestones[$i]}" == "$target_milestone" ]]; then
               target_milestones=("${sort_milestones[@]:0:$((i+1))}")

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -120,7 +120,7 @@ jobs:
           curl -X DELETE "${{ secrets.KVSTORE_URL }}/?key=base_$pr_base" \
             -H "Authorization: Bearer ${{ secrets.KVSTORE_TOKEN }}"
 
-          matrix=$(printf '%s\n' "${target_milestones[@]}" | grep -v '^$' | jq -R . | jq -sc .)
+          matrix=$(printf '%s\n' "${target_branches[@]}" | grep -v '^$' | jq -R . | jq -sc .)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -89,7 +89,7 @@ jobs:
               unset 'milestones[$i]'
             fi
           done
-          echo "Released milestones: ${milestones[@]}"
+          echo "Milestones with the corresponding release branch: ${milestones[@]}"
 
           sort_milestones=($(printf "%s\n" "${milestones[@]}" | sort -r))
           for i in "${!sort_milestones[@]}"; do

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,8 +16,10 @@ jobs:
     steps:
       - name: Get all commits in the push event
         id: commits
+        env:
+          COMMITS: ${{ toJson(github.event.commits) }}
         run: |
-          commits_json=$(echo '${{ toJSON(github.event.commits) }}' | jq -c '[.[].id]')
+          commits_json=$(echo "$COMMITS" | jq -c '[.[].id]')
           echo "commits=${commits_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -74,7 +74,7 @@ jobs:
           target_milestone=$(gh pr view ${{ steps.commit.outputs.pr_number }} --json milestone --jq .milestone.title)
 
           milestones=$(gh api /repos/:owner/:repo/milestones --jq '.[].title')
-          echo "milestones: $milestones"
+          echo "Milestones configured in the repo: $milestones"
 
           # Remove Backlog from the backport target branch
           milestones=($milestones)


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/backport.yml` file to enhance the handling of environment variables and improve the matrix generation logic.

Improvements to environment variable handling:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491R19-R22): Added an environment variable `COMMITS` to store the JSON representation of GitHub event commits, simplifying the retrieval of commit IDs.

Enhancements to matrix generation logic:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L121-R123): Changed the matrix generation to use `target_branches` instead of `target_milestones`, ensuring the correct branches are targeted for the backport process.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
