### PR TITLE
feat: Implement GPU config with `get_attached_devices()`

### DIFF
--- a/changes/3275.feature.md
+++ b/changes/3275.feature.md
@@ -1,0 +1,1 @@
+Add several commonly used GPU configuration environment variables defined in containers by default: `GPU_TYPE`, `GPU_COUNT`, `GPU_CONFIG`, `GPU_MODEL_NAME` and `TF_GPU_MEMORY_ALLOC`

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -413,6 +413,7 @@ class CUDAPlugin(AbstractComputePlugin):
         data["CUDA_GLOBAL_DEVICE_IDS"] = ",".join(
             f"{local_idx}:{global_id}" for local_idx, global_id in enumerate(active_device_ids)
         )
+        data["CUDA_RESOURCE_VIRTUALIZED"] = "0"
         return data
 
     async def get_docker_networks(

--- a/src/ai/backend/accelerator/mock/plugin.py
+++ b/src/ai/backend/accelerator/mock/plugin.py
@@ -227,7 +227,7 @@ class MockPlugin(AbstractComputePlugin):
         # Read the configurations.
         raw_unit_mem = self.plugin_config.get("unit_mem")
         if raw_unit_mem is not None:
-            unit_mem = int(raw_unit_mem)
+            unit_mem = int(BinarySize.from_str(raw_unit_mem))
             if unit_mem < MIN_MEM_UNIT:
                 raise InitializationError(f"{self.key} plugin: too small unit_mem")
             self._unit_mem = unit_mem

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1978,16 +1978,13 @@ class AbstractAgent(
                         # proc = dev_info["data"].get("proc", dev_info["data"].get("smp", 0))
                         # proc_items.append(f"{local_idx}:{proc}")
                     if attached_accelerators:
-                        first_gpu_model_name = attached_accelerators[0]["model_name"]
-                    else:
-                        first_gpu_model_name = ""
-                    # proc_str = ",".join(proc_items)  # (unused yet)
-                    environ["GPU_TYPE"] = dev_name
-                    environ["GPU_MODEL_NAME"] = first_gpu_model_name
+                        # proc_str = ",".join(proc_items)  # (unused yet)
+                        environ["GPU_TYPE"] = dev_name
+                        environ["GPU_MODEL_NAME"] = attached_accelerators[0]["model_name"]
+                        environ["GPU_CONFIG"] = ",".join(mem_per_device)
+                        environ["TF_GPU_MEMORY_ALLOC"] = ",".join(mem_per_device_tf)
                     environ["GPU_COUNT"] = str(len(attached_accelerators))
                     environ["N_GPUS"] = str(len(attached_accelerators))
-                    environ["GPU_CONFIG"] = ",".join(mem_per_device)
-                    environ["TF_GPU_MEMORY_ALLOC"] = ",".join(mem_per_device_tf)
                     has_gpu_config = True
                 if not has_gpu_config:
                     environ["GPU_COUNT"] = "0"

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -338,7 +338,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: MutableMapping[str, str],
+        environ: Mapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> KernelObjectType:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1971,7 +1971,7 @@ class AbstractAgent(
                     for local_idx, dev_info in enumerate(attached_accelerators):
                         mem = BinarySize(dev_info["data"].get("mem", 0))
                         mem_per_device.append(f"{local_idx}:{mem:s}")
-                        mem_in_megibytes = f"{mem // (2**20):d}"[:-1]
+                        mem_in_megibytes = f"{mem // (2**20):d}"
                         mem_per_device_tf.append(f"{local_idx}:{mem_in_megibytes}")
                         # The processor count is not used yet!
                         # NOTE: Keep backward-compatibility with the CUDA plugin ("smp")

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1974,7 +1974,7 @@ class AbstractAgent(
                         mem = BinarySize(dev_info["data"].get("mem", 0))
                         # Keep backward-compatibility with the CUDA plugin ("smp")
                         mem_per_device.append(f"{local_idx}:{mem:s}")
-                        mem_in_megibytes = f"{mem:m}"[:-1]
+                        mem_in_megibytes = f"{mem // (2**20):d}"[:-1]
                         mem_per_device_tf.append(f"{local_idx}:{mem_in_megibytes}")
                         # The processor count is not used yet!
                         # proc = dev_info["data"].get("proc", dev_info["data"].get("smp", 0))

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -110,6 +110,7 @@ from ai.backend.common.types import (
     AcceleratorMetadata,
     AgentId,
     AutoPullBehavior,
+    BinarySize,
     ClusterInfo,
     ClusterSSHPortMapping,
     CommitStatus,
@@ -1841,7 +1842,7 @@ class AbstractAgent(
                 restarting=restarting,
                 cluster_ssh_port_mapping=cluster_info.get("cluster_ssh_port_mapping"),
             )
-            environ: MutableMapping[str, str] = {**kernel_config["environ"]}
+            environ: dict[str, str] = {**kernel_config["environ"]}
 
             # Inject Backend.AI-intrinsic env-variables for gosu
             if KernelFeatures.UID_MATCH in ctx.kernel_features:
@@ -1954,6 +1955,45 @@ class AbstractAgent(
                     computer_ctx = self.computers[dev_name]
                     devices = await computer_ctx.instance.get_attached_devices(device_alloc)
                     attached_devices[dev_name] = devices
+
+                # Generate GPU config env-vars
+                has_gpu_config = False
+                for dev_name, device_alloc in resource_spec.allocations.items():
+                    if has_gpu_config:
+                        # Generate GPU config for the first-seen accelerator only
+                        continue
+                    if dev_name in (DeviceName("cpu"), DeviceName("mem")):
+                        # Skip intrinsic slots
+                        continue
+                    device_plugin = self.computers[dev_name].instance
+                    attached_devices = await device_plugin.get_attached_devices(device_alloc)
+                    mem_per_device: list[str] = []
+                    mem_per_device_tf: list[str] = []
+                    # proc_items = []  # (unused yet)
+                    for local_idx, dev_info in enumerate(attached_devices):
+                        mem = BinarySize(dev_info["data"].get("mem", 0))
+                        # Keep backward-compatibility with the CUDA plugin ("smp")
+                        mem_per_device.append(f"{local_idx}:{mem:s}")
+                        mem_in_megibytes = f"{mem:m}"[:-1]
+                        mem_per_device_tf.append(f"{local_idx}:{mem_in_megibytes}")
+                        # The processor count is not used yet!
+                        # proc = dev_info["data"].get("proc", dev_info["data"].get("smp", 0))
+                        # proc_items.append(f"{local_idx}:{proc}")
+                    if attached_devices:
+                        first_gpu_model_name = attached_devices[0]["model_name"]
+                    else:
+                        first_gpu_model_name = ""
+                    # proc_str = ",".join(proc_items)  # (unused yet)
+                    environ["GPU_TYPE"] = dev_name
+                    environ["GPU_MODEL_NAME"] = first_gpu_model_name
+                    environ["GPU_COUNT"] = str(len(attached_devices))
+                    environ["N_GPUS"] = str(len(attached_devices))
+                    environ["GPU_CONFIG"] = ",".join(mem_per_device)
+                    environ["TF_GPU_MEMORY_ALLOC"] = ",".join(mem_per_device_tf)
+                    has_gpu_config = True
+                if not has_gpu_config:
+                    environ["GPU_COUNT"] = "0"
+                    environ["N_GPUS"] = "0"
 
                 exposed_ports = [2000, 2001]
                 service_ports: List[ServicePort] = []
@@ -2069,6 +2109,7 @@ class AbstractAgent(
 
                 # Store information required for restarts.
                 # NOTE: kconfig may be updated after restarts.
+                kernel_config["environ"] = environ
                 resource_spec.freeze()
                 await self.restart_kernel__store_config(
                     kernel_id,

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -334,7 +334,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         raise NotImplementedError
 
     @abstractmethod
-    async def spawn(
+    async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
         environ: Mapping[str, str],
@@ -2087,7 +2087,7 @@ class AbstractAgent(
                         "kernel starting with resource spec: \n{0}",
                         pretty(attrs.asdict(resource_spec)),
                     )
-                kernel_obj: KernelObjectType = await ctx.spawn(
+                kernel_obj: KernelObjectType = await ctx.prepare_container(
                     resource_spec,
                     environ,
                     service_ports,

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1958,15 +1958,13 @@ class AbstractAgent(
 
                 # Generate GPU config env-vars
                 has_gpu_config = False
-                for dev_name, device_alloc in attached_devices.items():
+                for dev_name, attached_accelerators in attached_devices.items():
                     if has_gpu_config:
                         # Generate GPU config for the first-seen accelerator only
                         continue
                     if dev_name in (DeviceName("cpu"), DeviceName("mem")):
                         # Skip intrinsic slots
                         continue
-                    device_plugin = self.computers[dev_name].instance
-                    attached_accelerators = await device_plugin.get_attached_devices(device_alloc)
                     mem_per_device: list[str] = []
                     mem_per_device_tf: list[str] = []
                     # proc_items = []  # (unused yet)

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -337,7 +337,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: Mapping[str, str],
+        environ: MutableMapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> KernelObjectType:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1958,7 +1958,7 @@ class AbstractAgent(
 
                 # Generate GPU config env-vars
                 has_gpu_config = False
-                for dev_name, device_alloc in resource_spec.allocations.items():
+                for dev_name, device_alloc in attached_devices.items():
                     if has_gpu_config:
                         # Generate GPU config for the first-seen accelerator only
                         continue
@@ -1966,11 +1966,11 @@ class AbstractAgent(
                         # Skip intrinsic slots
                         continue
                     device_plugin = self.computers[dev_name].instance
-                    attached_devices = await device_plugin.get_attached_devices(device_alloc)
+                    attached_accelerators = await device_plugin.get_attached_devices(device_alloc)
                     mem_per_device: list[str] = []
                     mem_per_device_tf: list[str] = []
                     # proc_items = []  # (unused yet)
-                    for local_idx, dev_info in enumerate(attached_devices):
+                    for local_idx, dev_info in enumerate(attached_accelerators):
                         mem = BinarySize(dev_info["data"].get("mem", 0))
                         # Keep backward-compatibility with the CUDA plugin ("smp")
                         mem_per_device.append(f"{local_idx}:{mem:s}")
@@ -1979,15 +1979,15 @@ class AbstractAgent(
                         # The processor count is not used yet!
                         # proc = dev_info["data"].get("proc", dev_info["data"].get("smp", 0))
                         # proc_items.append(f"{local_idx}:{proc}")
-                    if attached_devices:
-                        first_gpu_model_name = attached_devices[0]["model_name"]
+                    if attached_accelerators:
+                        first_gpu_model_name = attached_accelerators[0]["model_name"]
                     else:
                         first_gpu_model_name = ""
                     # proc_str = ",".join(proc_items)  # (unused yet)
                     environ["GPU_TYPE"] = dev_name
                     environ["GPU_MODEL_NAME"] = first_gpu_model_name
-                    environ["GPU_COUNT"] = str(len(attached_devices))
-                    environ["N_GPUS"] = str(len(attached_devices))
+                    environ["GPU_COUNT"] = str(len(attached_accelerators))
+                    environ["N_GPUS"] = str(len(attached_accelerators))
                     environ["GPU_CONFIG"] = ",".join(mem_per_device)
                     environ["TF_GPU_MEMORY_ALLOC"] = ",".join(mem_per_device_tf)
                     has_gpu_config = True

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1970,11 +1970,11 @@ class AbstractAgent(
                     # proc_items = []  # (unused yet)
                     for local_idx, dev_info in enumerate(attached_accelerators):
                         mem = BinarySize(dev_info["data"].get("mem", 0))
-                        # Keep backward-compatibility with the CUDA plugin ("smp")
                         mem_per_device.append(f"{local_idx}:{mem:s}")
                         mem_in_megibytes = f"{mem // (2**20):d}"[:-1]
                         mem_per_device_tf.append(f"{local_idx}:{mem_in_megibytes}")
                         # The processor count is not used yet!
+                        # NOTE: Keep backward-compatibility with the CUDA plugin ("smp")
                         # proc = dev_info["data"].get("proc", dev_info["data"].get("smp", 0))
                         # proc_items.append(f"{local_idx}:{proc}")
                     if attached_accelerators:

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1614,12 +1614,10 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         loop = current_loop()
         scratch_dir = (self.local_config["container"]["scratch-root"] / str(kernel_id)).resolve()
         config_dir = scratch_dir / "config"
-        data = await loop.run_in_executor(
+        return await loop.run_in_executor(
             None,
             (config_dir / name).read_bytes,
         )
-        log.debug("restart_kernel(k:{}): load config {}", kernel_id, data)
-        return data
 
     async def restart_kernel__store_config(
         self,
@@ -1630,7 +1628,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         loop = current_loop()
         scratch_dir = (self.local_config["container"]["scratch-root"] / str(kernel_id)).resolve()
         config_dir = scratch_dir / "config"
-        log.debug("restart_kernel(k:{}): store config {}", kernel_id, data)
         return await loop.run_in_executor(
             None,
             (config_dir / name).write_bytes,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -677,7 +677,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 for local_idx, dev_info in enumerate(attached_devices):
                     mem = BinarySize(dev_info["data"].get("mem", 0))
                     # Keep backward-compatibility with the CUDA plugin ("smp")
-                    mem_per_device.append(f"{local_idx}:{mem: }")
+                    mem_per_device.append(f"{local_idx}:{mem:s}")
                     mem_in_megibytes = f"{mem:m}"[:-1]
                     mem_per_device_tf.append(f"{local_idx}:{mem_in_megibytes}")
                     # The processor count is not used yet!
@@ -691,11 +691,13 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 environ["GPU_TYPE"] = dev_name
                 environ["GPU_MODEL_NAME"] = first_gpu_model_name
                 environ["GPU_COUNT"] = str(len(attached_devices))
+                environ["N_GPUS"] = str(len(attached_devices))
                 environ["GPU_CONFIG"] = ",".join(mem_per_device)
                 environ["TF_GPU_MEMORY_ALLOC"] = ",".join(mem_per_device_tf)
                 has_gpu_config = True
             if not has_gpu_config:
                 environ["GPU_COUNT"] = "0"
+                environ["N_GPUS"] = "0"
 
             with StringIO() as buf:
                 for k, v in environ.items():

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -638,7 +638,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: MutableMapping[str, str],
+        environ: Mapping[str, str],
         service_ports: List[ServicePort],
         cluster_info: ClusterInfo,
     ) -> DockerKernel:
@@ -666,7 +666,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 accel_envs = self.computer_docker_args.get("Env", [])
                 for env in accel_envs:
                     buf.write(f"{env}\n")
-
                 await loop.run_in_executor(
                     None,
                     (self.config_dir / "environ.txt").write_bytes,
@@ -680,7 +679,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     kvpairs = await device_plugin.generate_resource_data(device_alloc)
                     for k, v in kvpairs.items():
                         buf.write(f"{k}={v}\n")
-
                 await loop.run_in_executor(
                     None,
                     (self.config_dir / "resource.txt").write_bytes,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -634,7 +634,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         src_path.mkdir()
         return await computer.generate_mounts(src_path, device_alloc)
 
-    async def spawn(
+    async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
         environ: Mapping[str, str],

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -40,6 +40,7 @@ import aiohttp
 import aiotools
 import pkg_resources
 import zmq
+import zmq.asyncio
 from aiodocker.docker import Docker, DockerContainer
 from aiodocker.exceptions import DockerError
 from aiodocker.types import PortInfo
@@ -665,7 +666,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 if has_gpu_config:
                     # Generate GPU config for the first-seen accelerator only
                     continue
-                if dev_name in ("cpu", "mem"):
+                if dev_name in (DeviceName("cpu"), DeviceName("mem")):
                     # Skip intrinsic slots
                     continue
                 device_plugin = self.computers[dev_name].instance

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -278,7 +278,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             current_resource_slots.set(known_slot_types)
             slots = slots.normalize_slots(ignore_unknown=True)
             resource_spec = KernelResourceSpec(
-                container_id="",
                 allocations={},
                 slots={**slots},  # copy
                 mounts=[],
@@ -976,19 +975,11 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 )
                 assert container is not None
                 cid = cast(str, container._id)
-                resource_spec.container_id = cid
-                # Write resource.txt again to update the container id.
-                with open(self.config_dir / "resource.txt", "w") as f:
-                    await loop.run_in_executor(None, resource_spec.write_to_file, f)
                 async with AsyncFileWriter(
                     target_filename=self.config_dir / "resource.txt",
                     access_mode="a",
                 ) as writer:
-                    for dev_name, device_alloc in resource_spec.allocations.items():
-                        computer_ctx = self.computers[dev_name]
-                        kvpairs = await computer_ctx.instance.generate_resource_data(device_alloc)
-                        for k, v in kvpairs.items():
-                            await writer.write(f"{k}={v}\n")
+                    await writer.write(f"CID={cid}\n")
 
             except asyncio.CancelledError:
                 if container is not None:

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -160,7 +160,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
     ):
         return Mount(MountTypes.BIND, Path(), Path())
 
-    async def spawn(
+    async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
         environ: Mapping[str, str],

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -98,7 +98,6 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
         current_resource_slots.set(known_slot_types)
         slots = slots.normalize_slots(ignore_unknown=True)
         resource_spec = KernelResourceSpec(
-            container_id="",
             allocations={},
             slots={**slots},  # copy
             mounts=[],

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -163,7 +163,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: Mapping[str, str],
+        environ: MutableMapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> DummyKernel:

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -163,7 +163,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: MutableMapping[str, str],
+        environ: Mapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> DummyKernel:

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -182,7 +182,6 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             current_resource_slots.set(known_slot_types)
             slots = slots.normalize_slots(ignore_unknown=True)
             resource_spec = KernelResourceSpec(
-                container_id="",
                 allocations={},
                 slots={**slots},  # copy
                 mounts=[],

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -523,7 +523,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: MutableMapping[str, str],
+        environ: Mapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> KubernetesKernel:

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -523,7 +523,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
     async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
-        environ: Mapping[str, str],
+        environ: MutableMapping[str, str],
         service_ports,
         cluster_info: ClusterInfo,
     ) -> KubernetesKernel:

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -520,7 +520,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             },
         }
 
-    async def spawn(
+    async def prepare_container(
         self,
         resource_spec: KernelResourceSpec,
         environ: Mapping[str, str],

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -81,9 +81,6 @@ class KernelResourceSpec:
     while kernel containers are running.
     """
 
-    container_id: str
-    """The container ID to refer inside containers."""
-
     slots: Mapping[SlotName, str]
     """Stores the original user-requested resource slots."""
 
@@ -114,7 +111,7 @@ class KernelResourceSpec:
         mounts_str = ",".join(map(str, self.mounts))
         slots_str = json.dumps({k: str(v) for k, v in self.slots.items()})
 
-        resource_str = f"CID={self.container_id}\n"
+        resource_str = ""
         resource_str += f"SCRATCH_SIZE={BinarySize(self.scratch_disk_size):m}\n"
         resource_str += f"MOUNTS={mounts_str}\n"
         resource_str += f"SLOTS={slots_str}\n"
@@ -180,7 +177,6 @@ class KernelResourceSpec:
                 allocations[device_name][slot_name] = per_device_alloc
         mounts = [Mount.from_str(m) for m in kvpairs["MOUNTS"].split(",") if m]
         return cls(
-            container_id=kvpairs.get("CID", "unknown"),
             scratch_disk_size=BinarySize.finite_from_str(kvpairs["SCRATCH_SIZE"]),
             allocations=dict(allocations),
             slots=ResourceSlot(json.loads(kvpairs["SLOTS"])),

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1057,10 +1057,15 @@ class ClusterSSHKeyPair(TypedDict):
     private_key: str  # PEM-encoded string
 
 
+class ComputedDeviceCapacity(TypedDict):
+    mem: NotRequired[BinarySize]
+    proc: NotRequired[int]
+
+
 class DeviceModelInfo(TypedDict):
     device_id: DeviceId | str
     model_name: str
-    data: Mapping[str, Any]
+    data: ComputedDeviceCapacity
 
 
 class KernelCreationResult(TypedDict):

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1065,7 +1065,7 @@ class ComputedDeviceCapacity(TypedDict):
 class DeviceModelInfo(TypedDict):
     device_id: DeviceId | str
     model_name: str
-    data: ComputedDeviceCapacity
+    data: ComputedDeviceCapacity  # name kept for backward compat with plugins
 
 
 class KernelCreationResult(TypedDict):

--- a/tests/agent/test_resources.py
+++ b/tests/agent/test_resources.py
@@ -222,7 +222,6 @@ async def test_allocate_rollback(monkeypatch):
     affinity_policy = AffinityPolicy.PREFER_SINGLE_NODE
 
     resource_spec = resources.KernelResourceSpec(
-        "a0001",
         ResourceSlot.from_json({
             "cpu": "1",
             "mem": "512",
@@ -242,7 +241,6 @@ async def test_allocate_rollback(monkeypatch):
         DeviceId("root")
     ] == Decimal(512)
     resource_spec = resources.KernelResourceSpec(
-        "a0001",
         ResourceSlot.from_json({
             "cpu": "1",
             "mem": "1024",  # should fail to allocate
@@ -273,7 +271,6 @@ async def test_allocate_rollback(monkeypatch):
     monkeypatch.setattr(resources.copy, "deepcopy", lambda o: o)
 
     resource_spec = resources.KernelResourceSpec(
-        "a0001",
         ResourceSlot.from_json({
             "cpu": "1",
             "mem": "512",
@@ -293,7 +290,6 @@ async def test_allocate_rollback(monkeypatch):
         DeviceId("root")
     ] == Decimal(512)
     resource_spec = resources.KernelResourceSpec(
-        "a0001",
         ResourceSlot.from_json({
             "cpu": "1",
             "mem": "1024",  # should fail to allocate


### PR DESCRIPTION
resolves #3269

This implementation is agnostic to the agent backend as long as they support the accelerator device plugins and those plugins provide proper `get_attached_devices()` implementation.

**Example execution:**
<img width="878" alt="image" src="https://github.com/user-attachments/assets/49b1d1aa-e6d3-4b5e-8074-86c2431db042" />

<img width="886" alt="image" src="https://github.com/user-attachments/assets/0466dda0-ceb6-47a6-94f9-0c9ea166e329" />

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
