### PR TITLE
ci: Add manual backport trigger via workflow_dispatch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,15 @@ jobs:
         run: |
           git clone --filter=blob:none --no-checkout https://github.com/${{ github.repository }}.git .
           pr_number=${{ github.event.inputs.pr_number }}
-          commits=$(git rev-list main --grep="(#${pr_number})" -n 1 | jq -Rc '[.]')
+          pr_number=${{ github.event.inputs.pr_number }}
+          commit=$(git rev-list main --grep="(#${pr_number})" -n 1)
+
+          if [ -z "$commit" ]; then
+            echo "Error: Could not find PR #${pr_number} in main branch commits" >&2
+            exit 1
+          fi
+
+          commits=$(echo "$commit" | jq -Rc '[.]')
           echo "commits=$commits" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to backport'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,15 +17,24 @@ jobs:
   backport-commits:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.commits.outputs.commits }}
+      matrix: ${{ steps.push.outputs.commits || steps.dispatch.outputs.commits }}
     steps:
-      - name: Get all commits in the push event
-        id: commits
+      - if: ${{ github.event_name == 'push' }}
+        name: Get all commits in the push event
+        id: push
         env:
           COMMITS: ${{ toJson(github.event.commits) }}
         run: |
           commits_json=$(echo "$COMMITS" | jq -c '[.[].id]')
           echo "commits=${commits_json}" >> $GITHUB_OUTPUT
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: Get the commit from the PR
+        id: dispatch
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/${{ github.repository }}.git .
+          pr_number=${{ github.event.inputs.pr_number }}
+          commits=$(git rev-list main --grep="(#${pr_number})" -n 1 | jq -Rc '[.]')
+          echo "commits=$commits" >> $GITHUB_OUTPUT
 
 
   backport-target-branch:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,15 +6,15 @@ on:
       - 'main'
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: 'PR number to backport'
+      commit_hash:
+        description: 'The commit hash to backport'
         required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  backport-commits:
+  get-backport-commits:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.push.outputs.commits || steps.dispatch.outputs.commits }}
@@ -31,25 +31,16 @@ jobs:
         name: Get the commit from the PR
         id: dispatch
         run: |
-          git clone --filter=blob:none --no-checkout https://github.com/${{ github.repository }}.git .
-          pr_number=${{ github.event.inputs.pr_number }}
-          commit=$(git rev-list main --grep="(#${pr_number})" -n 1)
-
-          if [ -z "$commit" ]; then
-            echo "Error: Could not find PR #${pr_number} in main branch commits" >&2
-            exit 1
-          fi
-
-          commits=$(echo "$commit" | jq -Rc '[.]')
+          commits=$(echo '${{ github.event.inputs.commit_hash }}' | jq -Rc '[.]')
           echo "commits=$commits" >> $GITHUB_OUTPUT
 
 
-  backport-target-branch:
+  get-backport-target-branch:
     runs-on: ubuntu-latest
-    needs: backport-commits
+    needs: get-backport-commits
     strategy:
       matrix:
-        commits: ${{ fromJson(needs.backport-commits.outputs.matrix) }}
+        commits: ${{ fromJson(needs.get-backport-commits.outputs.matrix) }}
     outputs:
       matrix: ${{ steps.milestones.outputs.matrix }}
       latest_commit: ${{ steps.commit.outputs.latest_commit }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           git clone --filter=blob:none --no-checkout https://github.com/${{ github.repository }}.git .
           pr_number=${{ github.event.inputs.pr_number }}
-          pr_number=${{ github.event.inputs.pr_number }}
           commit=$(git rev-list main --grep="(#${pr_number})" -n 1)
 
           if [ -z "$commit" ]; then


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflow to support manual dispatch for backporting pull requests. The most important changes include adding inputs for the `workflow_dispatch` event and modifying the `jobs` section to handle commits based on the event type.

Enhancements to workflow dispatch:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491R7-R11): Added `workflow_dispatch` event with an input for `pr_number` to allow manual triggering of the backport workflow.

Modifications to job steps:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L15-R37): Updated the `matrix` output to handle commits from either the `push` or `workflow_dispatch` events.
* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L15-R37): Added conditional steps to get commits based on whether the event is a `push` or `workflow_dispatch`.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
