### PR TITLE
chore: Update gitignore and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,10 @@ indent_size = 4
 max_line_length = 0
 trim_trailing_whitespace = false
 
+[*.diff]
+max_line_length = 0
+trim_trailing_whitespace = false
+
 [*.rst]
 max_line_length = 0
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ ENV/
 /.exrc
 .ripgreprc
 .neoconf.json
+/.zed
+/.ropeproject
 
 # Pants
 /.pants.d/

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ ENV/
 .neoconf.json
 /.zed
 /.ropeproject
+pyrightconfig.json
 
 # Pants
 /.pants.d/


### PR DESCRIPTION
Add Zed-specific gitignore entries and let editors ignore line-length in diff files.
