### PR TITLE
feat: populate `BACKEND_MODEL_NAME` environment variable automatically

### DIFF
--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,0 +1,1 @@
+Populate `BACKEND_MODEL_NAME` environment variable automatically on inference session

--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,1 +1,0 @@
-Populate `BACKEND_MODEL_NAME` environment variable automatically on inference session

--- a/changes/3281.feature.md
+++ b/changes/3281.feature.md
@@ -1,0 +1,1 @@
+Populate `BACKEND_MODEL_NAME` environment variable automatically on inference session


### PR DESCRIPTION
This PR updates model service session creation logic to automatically populate `BACKEND_MODEL_NAME` as name of the model folder. Handing out the model name as environment variable will help inference runtimes understand the model better.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
