### PR TITLE
feature: restart model service process

### DIFF
--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -151,6 +151,10 @@ class DockerKernel(AbstractKernel):
         assert self.runner is not None
         await self.runner.feed_shutdown_service(service)
 
+    async def shutdown_model_service(self, model_service: Mapping[str, Any]):
+        assert self.runner is not None
+        await self.runner.feed_shutdown_model_service(model_service)
+
     async def get_service_apps(self):
         assert self.runner is not None
         result = await self.runner.feed_service_apps()

--- a/src/ai/backend/agent/dummy/config.py
+++ b/src/ai/backend/agent/dummy/config.py
@@ -55,6 +55,7 @@ dummy_local_config = t.Dict({
             t.Key("start-service", default=0.1): tx.Delay,
             t.Key("start-model-service", default=0.1): tx.Delay,
             t.Key("shutdown-service", default=0.1): tx.Delay,
+            t.Key("shutdown-model-service", default=0.1): tx.Delay,
             t.Key("commit", default=5.0): tx.Delay,
             t.Key("get-service-apps", default=0.1): tx.Delay,
             t.Key("accept-file", default=0.1): tx.Delay,

--- a/src/ai/backend/agent/dummy/kernel.py
+++ b/src/ai/backend/agent/dummy/kernel.py
@@ -115,6 +115,11 @@ class DummyKernel(AbstractKernel):
         delay = self.dummy_kernel_cfg["delay"]["shutdown-service"]
         await asyncio.sleep(delay)
 
+    async def shutdown_model_service(self, model_service: Mapping[str, Any]):
+        delay = self.dummy_kernel_cfg["delay"]["shutdown-model-service"]
+        await asyncio.sleep(delay)
+        return {}
+
     async def check_duplicate_commit(self, kernel_id, subdir) -> CommitStatus:
         if self.is_commiting:
             return CommitStatus.ONGOING

--- a/src/ai/backend/agent/kubernetes/kernel.py
+++ b/src/ai/backend/agent/kubernetes/kernel.py
@@ -209,6 +209,10 @@ class KubernetesKernel(AbstractKernel):
         assert self.runner is not None
         await self.runner.feed_shutdown_service(service)
 
+    async def shutdown_model_service(self, model_service: Mapping[str, Any]):
+        assert self.runner is not None
+        await self.runner.feed_shutdown_model_service(model_service)
+
     async def get_service_apps(self):
         assert self.runner is not None
         result = await self.runner.feed_service_apps()

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -695,6 +695,12 @@ class AgentRPCServer(aobject):
 
     @rpc_function
     @collect_error
+    async def restart_model_service(self, kernel_id: str):
+        log.info("rpc::restart_model_service(k:{0})", kernel_id)
+        return await self.agent.restart_model_service(KernelId(UUID(kernel_id)))
+
+    @rpc_function
+    @collect_error
     async def execute(
         self,
         session_id: str,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3678,6 +3678,14 @@ class AgentRegistry:
             "abuse_report": result,
         }
 
+    async def restart_model_service(
+        self,
+        agent_id: AgentId,
+        kernel_id: KernelId,
+    ) -> None:
+        async with self.agent_cache.rpc_context(agent_id) as rpc:
+            await rpc.call.restart_model_service(kernel_id)
+
     async def update_appproxy_endpoint_routes(
         self, db_sess: AsyncSession, endpoint: EndpointRow, active_routes: list[RoutingRow]
     ) -> None:


### PR DESCRIPTION
This PR enhances model service reloading experience by enabling user to restart model process only, not the whole container. Since this only stops and reloads the process itself, any changes applied to container spec (e.g. image, resource request, env var, ...) will not be effective.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
