### PR TITLE
fix: 'DockerKernel' object has no attribute 'network_driver'

### DIFF
--- a/changes/3286.feature.md
+++ b/changes/3286.feature.md
@@ -1,0 +1,1 @@
+Fix container cleanup process failing with error `AttributeError: 'DockerKernel' object has no attribute 'network_driver'`

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -83,6 +83,8 @@ class DockerKernel(AbstractKernel):
         return props
 
     def __setstate__(self, props):
+        if "network_driver" not in props:
+            props["network_driver"] = "bridge"
         super().__setstate__(props)
 
     async def create_code_runner(


### PR DESCRIPTION
Follow-up PR of #2100. Fixes cleanup process of kernels created before #2100 failing since `clean_kernel()` function tries to access `network_driver` variable on a rebuilt `DockerKernel` object, which has yet no reference to the variable (ref: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/agent/docker/agent.py#L1763-L1770). This PR resolves the pitfall by setting up the `network_driver` value as `bridge` when deserializing dated `DockerKernel` object. By doing so, the `clean_kernel()` function will skip all network plugin-specific cleanup feature, which was not an interest on previous implementations anyways.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
