### PR TITLE
ci: Change the job name to make sense

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -137,12 +137,12 @@ jobs:
 
 
   backport:
-    if: ${{ needs.backport-target-branch.outputs.matrix != '[]' }}
+    if: ${{ needs.get-backport-target-branch.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
-    needs: backport-target-branch
+    needs: get-backport-target-branch
     strategy:
       matrix:
-        milestone: ${{ fromJson(needs.backport-target-branch.outputs.matrix) }}
+        milestone: ${{ fromJson(needs.get-backport-target-branch.outputs.matrix) }}
     permissions:
       pull-requests: write
     steps:
@@ -151,26 +151,26 @@ jobs:
           ref: ${{ matrix.target_branch }}
       - name: Cherry-pick
         env:
-          COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
+          COMMIT_MESSAGE: ${{ needs.get-backport-target-branch.outputs.commit_message }}
         run: |
-          git config user.name "${{ needs.backport-target-branch.outputs.author }}"
-          git config user.email "${{ needs.backport-target-branch.outputs.author_email }}"
+          git config user.name "${{ needs.get-backport-target-branch.outputs.author }}"
+          git config user.email "${{ needs.get-backport-target-branch.outputs.author_email }}"
           git fetch origin main --depth=10
-          git cherry-pick --strategy=recursive --strategy-option=theirs ${{ needs.backport-target-branch.outputs.latest_commit }}
+          git cherry-pick --strategy=recursive --strategy-option=theirs ${{ needs.get-backport-target-branch.outputs.latest_commit }}
           git commit \
             --amend -m "${COMMIT_MESSAGE}" \
-            --trailer "Backported-from=main (${{ needs.backport-target-branch.outputs.latest_release }})" \
+            --trailer "Backported-from=main (${{ needs.get-backport-target-branch.outputs.latest_release }})" \
             --trailer "Backported-to=${{ matrix.target_branch }}" \
-            --trailer "Backport-of=${{ needs.backport-target-branch.outputs.pr_number }}"
+            --trailer "Backport-of=${{ needs.get-backport-target-branch.outputs.pr_number }}"
       - name: When cherry-pick is failed
         if: failure()
         run: |
-          gh pr comment ${{ needs.backport-target-branch.outputs.pr_number }} -b "Backport to ${{ matrix.target_branch }} is failed. Please backport manually."
+          gh pr comment ${{ needs.get-backport-target-branch.outputs.pr_number }} -b "Backport to ${{ matrix.target_branch }} is failed. Please backport manually."
         env:
           GH_TOKEN: ${{ github.token }}
       - id: commit_message
         env:
-          COMMIT_MESSAGE: ${{ needs.backport-target-branch.outputs.commit_message }}
+          COMMIT_MESSAGE: ${{ needs.get-backport-target-branch.outputs.commit_message }}
         run: |
           commit_header=$(echo "${COMMIT_MESSAGE}" | head -n 1)
           echo "commit_header=$commit_header" >> $GITHUB_OUTPUT
@@ -187,15 +187,15 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.OCTODOG }}
-          author: "${{ needs.backport-target-branch.outputs.author }} <${{ needs.backport-target-branch.outputs.author_email }}>"
+          author: "${{ needs.get-backport-target-branch.outputs.author }} <${{ needs.get-backport-target-branch.outputs.author_email }}>"
           title: "${{ steps.commit_message.outputs.commit_header }}"
-          body: "This is an auto-generated backport PR of #${{ needs.backport-target-branch.outputs.pr_number }} to the ${{ matrix.target_branch }} release."
-          branch: "backport/${{ needs.backport-target-branch.outputs.pr_number }}-to-${{ matrix.target_branch }}"
+          body: "This is an auto-generated backport PR of #${{ needs.get-backport-target-branch.pr_number }} to the ${{ matrix.target_branch }} release."
+          branch: "backport/${{ needs.get-backport-target-branch.outputs.pr_number }}-to-${{ matrix.target_branch }}"
           base: ${{ matrix.target_branch }}
           labels: |
             backport
             ${{ needs.backport-target-branch.outputs.labels }}
-          assignees: ${{ needs.backport-target-branch.outputs.author }}
+          assignees: ${{ needs.get-backport-target-branch.outputs.author }}
       - id: pr_id
         run: |
           pr_id=$(gh api graphql -f query='
@@ -212,11 +212,11 @@ jobs:
           GH_TOKEN: ${{ secrets.OCTODOG }}
       - id: commit_footer
         run: |
-          commit_footer="Co-authored-by: ${{ needs.backport-target-branch.outputs.author }} <${{ needs.backport-target-branch.outputs.author_email }}>
+          commit_footer="Co-authored-by: ${{ needs.get-backport-target-branch.outputs.author }} <${{ needs.get-backport-target-branch.outputs.author_email }}>
           ${{ steps.commit_message.outputs.commit_footer }}
-          Backported-from: main (${{ needs.backport-target-branch.outputs.latest_release }})
+          Backported-from: main (${{ needs.get-backport-target-branch.outputs.latest_release }})
           Backported-to: ${{ matrix.target_branch }}
-          Backport-of: ${{ needs.backport-target-branch.outputs.pr_number }}"
+          Backport-of: ${{ needs.get-backport-target-branch.outputs.pr_number }}"
           commit_footer=$(echo "$commit_footer" | grep '.')  # remove empty lines
           echo "commit_footer<<EOF" >> $GITHUB_OUTPUT
           echo "$commit_footer" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/backport.yml` file, primarily focusing on renaming the `backport-target-branch` to `get-backport-target-branch` in various sections of the workflow.

The most important changes include:

* Updated the `if` condition to use `needs.get-backport-target-branch.outputs.matrix` instead of `needs.backport-target-branch.outputs.matrix`.
* Changed the `needs` dependency from `backport-target-branch` to `get-backport-target-branch`.
* Modified the environment variables and commit message trailers to use `get-backport-target-branch` outputs instead of `backport-target-branch` outputs.
* Updated the author and PR details in the `create-pull-request` step to use `get-backport-target-branch` outputs.
* Adjusted the commit footer to reflect the new `get-backport-target-branch` naming convention.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
