### PR TITLE
fix: Broken input validation for session creation from templates

### DIFF
--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -296,7 +296,9 @@ creation_config_v6_template = t.Dict({
     tx.AliasedKey(["resource_opts", "resourceOpts"], default=undefined): (
         UndefChecker | t.Null | t.Mapping(t.String, t.Any)
     ),
-    tx.AliasedKey(["attach_network", "attachNetwork"], default=None): t.Null | tx.UUID,
+    tx.AliasedKey(["attach_network", "attachNetwork"], default=undefined): (
+        UndefChecker | t.Null | tx.UUID
+    ),
 })
 
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -125,11 +125,12 @@ VALID_VERSIONS: Final = frozenset([
     "v8.20240315",
     # added session priority and Relay-compliant ComputeSessioNode, KernelNode queries
     # added dependents/dependees/graph query fields to ComputeSessioNode
+    "v8.20240915",
+    # added explicit attach_network option to session creation config
+    # <future>
+    # TODO: replaced keypair-based resource policies to user-based resource policies
     # TODO: began SSO support using per-external-service keypairs (e.g., for FastTrack)
     # TODO: added an initial version of RBAC for projects and vfolders
-    "v8.20240915",
-    # TODO: replaced keypair-based resource policies to user-based resource policies
-    # <future>
 ])
 LATEST_REV_DATES: Final = {
     1: "20160915",


### PR DESCRIPTION
A hotfix follow-up to #3291 (refs #3290).

- Also update the API version history
- In this case (#3290), creation_config_v5 and v6 are compatible as the
  added field is an optional one with a default value.
  We do not need to bump the API version from v8 to v9.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
