### PR TITLE
ci: Change the matrix variable to `target_branch`

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -142,7 +142,7 @@ jobs:
     needs: get-backport-target-branch
     strategy:
       matrix:
-        milestone: ${{ fromJson(needs.get-backport-target-branch.outputs.matrix) }}
+        target_branch: ${{ fromJson(needs.get-backport-target-branch.outputs.matrix) }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/backport.yml`. The change modifies the `jobs:` section to update the matrix strategy.

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L145-R145): Changed the matrix key from `milestone` to `target_branch` to correctly reflect the output from the `get-backport-target-branch` job.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

