### PR TITLE
ci: Reflect what's missing from the rename

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -194,7 +194,7 @@ jobs:
           base: ${{ matrix.target_branch }}
           labels: |
             backport
-            ${{ needs.backport-target-branch.outputs.labels }}
+            ${{ needs.get-backport-target-branch.outputs.labels }}
           assignees: ${{ needs.get-backport-target-branch.outputs.author }}
       - id: pr_id
         run: |


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/backport.yml` file. The change updates the reference to the output labels of a GitHub Actions job.

Workflow file update:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L197-R197): Changed the reference from `needs.backport-target-branch.outputs.labels` to `needs.get-backport-target-branch.outputs.labels` to correct the job dependency.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
