### PR TITLE
refactor: Resolve some pyright errors

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -326,7 +326,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         type: MountTypes,
         src: Union[str, Path],
         target: Union[str, Path],
-        perm: Literal["ro", "rw"] = "ro",
+        perm: MountPermission = MountPermission.READ_ONLY,
         opts: Optional[Mapping[str, Any]] = None,
     ):
         """
@@ -428,7 +428,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
                     type,
                     src,
                     dst,
-                    MountPermission("ro"),
+                    MountPermission.READ_ONLY,
                 ),
             )
 
@@ -2781,6 +2781,7 @@ async def handle_volume_umount(
     volume_mount_prefix = context.local_config["agent"]["mount-path"]
     real_path = Path(volume_mount_prefix, event.dir_name)
     err_msg: str | None = None
+    did_umount = False
     try:
         did_umount = await umount(
             str(real_path),

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1101,8 +1101,8 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     )
                     sport["host_ports"] = created_host_ports
 
-        assert repl_in_port != 0, "repl_in_port should have bee assigned."
-        assert repl_out_port != 0, "repl_out_port should have bee assigned."
+        assert repl_in_port != 0, "repl_in_port should have been assigned."
+        assert repl_out_port != 0, "repl_out_port should have been assigned."
         return {
             "container_id": container._id,
             "kernel_host": kernel_host,

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -24,7 +24,6 @@ from typing import (
     Final,
     FrozenSet,
     List,
-    Literal,
     MutableMapping,
     Optional,
     Sequence,
@@ -500,7 +499,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         type: MountTypes,
         src: Union[str, Path],
         target: Union[str, Path],
-        perm: Literal["ro", "rw"] = "ro",
+        perm: MountPermission = MountPermission.READ_ONLY,
         opts: Optional[Mapping[str, Any]] = None,
     ) -> Mount:
         return Mount(
@@ -1050,6 +1049,8 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     )
 
             created_host_ports: Tuple[int, ...]
+            repl_in_port = 0
+            repl_out_port = 0
             if container_network_info:
                 kernel_host = container_network_info.container_host
                 port_map = container_network_info.services
@@ -1100,6 +1101,8 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     )
                     sport["host_ports"] = created_host_ports
 
+        assert repl_in_port != 0, "repl_in_port should have bee assigned."
+        assert repl_out_port != 0, "repl_out_port should have bee assigned."
         return {
             "container_id": container._id,
             "kernel_host": kernel_host,
@@ -1265,6 +1268,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 cgroup = f"docker/{container_id}"
             case "systemd":
                 cgroup = f"system.slice/docker-{container_id}.scope"
+            case _:
+                raise ValueError(f"Unsupported cgroup driver: {driver!r}")
         return mount_point / cgroup
 
     async def load_resources(self) -> Mapping[DeviceName, AbstractComputePlugin]:

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -28,6 +28,7 @@ from ai.backend.common.types import (
     ImageRegistry,
     KernelCreationConfig,
     KernelId,
+    MountPermission,
     MountTypes,
     ResourceSlot,
     ServicePort,
@@ -155,7 +156,7 @@ class DummyKernelCreationContext(AbstractKernelCreationContext[DummyKernel]):
         type: MountTypes,
         src: str | Path,
         target: str | Path,
-        perm: Literal["ro", "rw"] = "ro",
+        perm: MountPermission = MountPermission.READ_ONLY,
         opts: Optional[Mapping[str, Any]] = None,
     ):
         return Mount(MountTypes.BIND, Path(), Path())

--- a/src/ai/backend/agent/dummy/kernel.py
+++ b/src/ai/backend/agent/dummy/kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import secrets
 from collections import OrderedDict
 from typing import Any, Dict, FrozenSet, Mapping, Sequence, override
 
@@ -316,7 +317,12 @@ class DummyFakeCodeRunner(AbstractCodeRunner):
         return
 
     async def get_next_result(self, api_ver=2, flush_timeout=2.0) -> NextResult:
-        return {}
+        return {
+            "runId": f"run-{secrets.token_urlsafe(8)}",
+            "status": "finished",
+            "exitCode": 0,
+            "options": {},
+        }
 
     async def attach_output_queue(self, run_id: str | None) -> None:
         return

--- a/src/ai/backend/agent/dummy/kernel.py
+++ b/src/ai/backend/agent/dummy/kernel.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import secrets
 from collections import OrderedDict
 from typing import Any, Dict, FrozenSet, Mapping, Sequence, override
 
@@ -318,10 +317,10 @@ class DummyFakeCodeRunner(AbstractCodeRunner):
 
     async def get_next_result(self, api_ver=2, flush_timeout=2.0) -> NextResult:
         return {
-            "runId": f"run-{secrets.token_urlsafe(8)}",
+            "runId": self.current_run_id,
             "status": "finished",
-            "exitCode": 0,
-            "options": {},
+            "exitCode": None,
+            "options": None,
         }
 
     async def attach_output_queue(self, run_id: str | None) -> None:

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -20,6 +20,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NotRequired,
     Optional,
     Sequence,
     Set,
@@ -146,18 +147,18 @@ class ResultRecord:
     data: Optional[str] = None
 
 
-class NextResult(TypedDict, total=False):
+class NextResult(TypedDict):
     runId: Optional[str]
     status: ResultType
     exitCode: Optional[int]
     options: Optional[Mapping[str, Any]]
     # v1
-    stdout: Optional[str]
-    stderr: Optional[str]
-    media: Optional[Sequence[Any]]
-    html: Optional[Sequence[Any]]
+    stdout: NotRequired[str]
+    stderr: NotRequired[str]
+    media: NotRequired[Sequence[Any]]
+    html: NotRequired[Sequence[Any]]
     # v2
-    console: Optional[Sequence[Any]]
+    console: NotRequired[Sequence[Any]]
 
 
 class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
@@ -816,9 +817,9 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
     async def get_next_result(self, api_ver=2, flush_timeout=2.0) -> NextResult:
         # Context: per API request
         has_continuation = ClientFeatures.CONTINUATION in self.client_features
+        records = []
+        result: NextResult
         try:
-            records = []
-            result: NextResult
             assert self.output_queue is not None
             with timeout(flush_timeout if has_continuation else None):
                 while True:

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -153,8 +153,8 @@ class NextResult(TypedDict):
     exitCode: Optional[int]
     options: Optional[Mapping[str, Any]]
     # v1
-    stdout: NotRequired[str]
-    stderr: NotRequired[str]
+    stdout: NotRequired[Optional[str]]
+    stderr: NotRequired[Optional[str]]
     media: NotRequired[Sequence[Any]]
     html: NotRequired[Sequence[Any]]
     # v2

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -16,7 +16,6 @@ from typing import (
     Any,
     FrozenSet,
     List,
-    Literal,
     Mapping,
     MutableMapping,
     Optional,
@@ -412,7 +411,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
         type: MountTypes,
         src: Union[str, Path],
         target: Union[str, Path],
-        perm: Literal["ro", "rw"] = "ro",
+        perm: MountPermission = MountPermission.READ_ONLY,
         opts: Optional[Mapping[str, Any]] = None,
     ) -> Mount:
         return Mount(

--- a/src/ai/backend/common/enum_extension.pyi
+++ b/src/ai/backend/common/enum_extension.pyi
@@ -1,6 +1,6 @@
 import enum
 
-class StringSetFlag(enum.Flag):
+class StringSetFlag(enum.StrEnum):
     def __eq__(self, other: object) -> bool: ...
     def __hash__(self) -> int: ...
     def __or__(  # type: ignore[override]

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -121,7 +121,7 @@ class aobject(object):
     """
 
     @classmethod
-    async def new(cls: Type[T_aobj], *args, **kwargs) -> T_aobj:
+    async def new(cls: Type[Self], *args, **kwargs) -> Self:
         """
         We can do ``await SomeAObject(...)``, but this makes mypy
         to complain about its return type with ``await`` statement.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -101,8 +101,6 @@ if TYPE_CHECKING:
     from .docker import ImageRef
 
 
-T_aobj = TypeVar("T_aobj", bound="aobject")
-
 current_resource_slots: ContextVar[Mapping[SlotName, SlotTypes]] = ContextVar(
     "current_resource_slots"
 )


### PR DESCRIPTION
resolves #3298 (BA-412).

- Fix type definition mismatch of `common/enum_extenion.{py,pyi}`
- Fix possibly unbound variables in multiple places
- Use explicit enum types when possible and fix inconsistent use of enum/str values for `MountPermission` in `get_runner_mount()`
- Use `typing.Self` in `aobject.new()`

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
