### PR TITLE
chore(ci): Ensure removal of renamed news fragment files

### DIFF
--- a/.github/workflows/assign-pr-number.yml
+++ b/.github/workflows/assign-pr-number.yml
@@ -35,12 +35,11 @@ jobs:
       id: assign_pr_number
       run: |
         pip install tomlkit
-        python scripts/pr-number-assign.py ${{ github.event.pull_request.number }}
+        python scripts/assign-pr-number.py ${{ github.event.pull_request.number }}
 
     - name: Make commit message for changing change log file
       if: ${{ steps.assign_pr_number.outputs.has_renamed_pairs == 'true' }}
       run: |
-        git add changes/*.md
         author_name=$(git show -q --pretty='format:%an')
         author_email=$(git show -q --pretty='format:%ae')
         git config user.email "$author_email"

--- a/scripts/assign-pr-number.py
+++ b/scripts/assign-pr-number.py
@@ -2,12 +2,14 @@
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 import tomlkit
 
 exempted_files = ["README.md", "template.md"]
+
 
 def read_news_types() -> set[str]:
     with open("./pyproject.toml", "r") as f:
@@ -50,6 +52,18 @@ def main(pr_number: str) -> None:
             )
 
     if renamed_pairs:
+        subprocess.run(
+            ["git", "rm", *(base_path / pair[0] for pair in renamed_pairs)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+        subprocess.run(
+            ["git", "add", *(base_path / pair[1] for pair in renamed_pairs)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=None,
+        )
         with open(os.getenv("GITHUB_OUTPUT", os.devnull), "a") as ghoutput:
             rename_results = [f"{pair[0]} -> {pair[1]}" for pair in renamed_pairs]
             print(f"rename_results={json.dumps(rename_results)}", file=ghoutput)


### PR DESCRIPTION
This hotfix PR ensures git-removal of renamed news fragments files.
