### PR TITLE
fix: Type error due to missing default type-var in zmq.Context (#3307)

### DIFF
--- a/src/ai/backend/logging/handler/intrinsic.py
+++ b/src/ai/backend/logging/handler/intrinsic.py
@@ -19,7 +19,7 @@ class RelayHandler(logging.Handler):
         super().__init__()
         self.endpoint = endpoint
         self.msgpack_options = msgpack_options
-        self._zctx = zmq.Context()
+        self._zctx = zmq.Context[zmq.Socket]()
         # We should use PUSH-PULL socket pairs to avoid
         # lost of synchronization sentinel messages.
         if endpoint:

--- a/src/ai/backend/logging/logger.py
+++ b/src/ai/backend/logging/logger.py
@@ -309,7 +309,7 @@ def log_worker(
         assert graylog_handler is not None
         graylog_handler.setFormatter(SerializedExceptionFormatter())
 
-    zctx = zmq.Context()
+    zctx = zmq.Context[zmq.Socket]()
     agg_sock = zctx.socket(zmq.PULL)
     agg_sock.bind(log_endpoint)
     ep_url = yarl.URL(log_endpoint)


### PR DESCRIPTION
This is an auto-generated backport PR of # to the 24.09 release.