### PR TITLE
chore: Update gitignore and editorconfig (#3280)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,10 @@ indent_size = 4
 max_line_length = 0
 trim_trailing_whitespace = false
 
+[*.diff]
+max_line_length = 0
+trim_trailing_whitespace = false
+
 [*.rst]
 max_line_length = 0
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ ENV/
 /.exrc
 .ripgreprc
 .neoconf.json
+/.zed
+/.ropeproject
+pyrightconfig.json
 
 # Pants
 /.pants.d/


### PR DESCRIPTION
This is an auto-generated backport PR of # to the 24.03 release.