### PR TITLE
ci: Modify to accommodate the changed release naming convention (#2914)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - 'main'
-      - '[0-9][0-9].0[39]'
+      - '[0-9][0-9].[0-9]'
+      - '[0-9][0-9].[0-9][0-9]'
     tags:
-      - '[0-9][0-9].0[39].*'
+      - '[0-9][0-9].[0-9].*'
+      - '[0-9][0-9].[0-9][0-9].*'
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:


### PR DESCRIPTION
This is an auto-generated backport PR of # to the 24.03 release.