### PR TITLE
ci: Fixes behavior that was preventing proper comparison due to typos (#2907)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
       - name: labeler
-        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'syncrhonize'
+        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
         uses: lablup/auto-labeler@main   # actions/labeler, lablup/size-label-action, lablup/auto-label-in-issue
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of # to the 23.09 release.