### PR TITLE
chore(scripts): Update diff-releases.py to recognize auto-backported PRs

### DIFF
--- a/scripts/diff-release.py
+++ b/scripts/diff-release.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 rx_oneline = re.compile(
-    r"^(?P<commit>[a-f0-9]{40}) (?P<msg>.*?)(\(#(?P<orig_pr>\d+)\)\s*)?(\(#(?P<pr>\d+)\))?$"
+    r"^(?P<commit>[a-f0-9]{40}) (?P<msg>.*?)(\(#(?P<orig_pr>\d+)\)\s*)?(\(#(?P<backport_pr>\d+)\))?$"
 )
 
 
@@ -53,17 +53,17 @@ def do_diff_release(ref_old, ref_new):
 
     old_pr_set = set()
     for rev in old_rev_list:
-        if (m := rx_oneline.search(rev.strip())) is not None and (pr := m.group("pr")) is not None:
-            if (orig_pr := m.group("orig_pr")) is not None:
-                pr = orig_pr
+        if (m := rx_oneline.search(rev.strip())) is not None and (
+            pr := m.group("orig_pr")
+        ) is not None:
             old_pr_set.add(int(pr))
             pr_desc_map[int(pr)] = m.group("msg")
 
     new_pr_set = set()
     for rev in new_rev_list:
-        if (m := rx_oneline.search(rev.strip())) is not None and (pr := m.group("pr")) is not None:
-            if (orig_pr := m.group("orig_pr")) is not None:
-                pr = orig_pr
+        if (m := rx_oneline.search(rev.strip())) is not None and (
+            pr := m.group("orig_pr")
+        ) is not None:
             new_pr_set.add(int(pr))
             pr_desc_map[int(pr)] = m.group("msg")
 

--- a/scripts/diff-release.py
+++ b/scripts/diff-release.py
@@ -11,10 +11,6 @@ def do_diff_release(ref_old, ref_new):
     # To ensure latest information from the repository, first fetch all branches
     # and use the "origin" refspec prefix.
     subprocess.run(["git", "fetch"], capture_output=True)
-    if not ref_old.startswith("origin/"):
-        ref_old = "origin/" + ref_old
-    if not ref_new.startswith("origin/"):
-        ref_new = "origin/" + ref_new
 
     proc = subprocess.run(
         [
@@ -87,6 +83,9 @@ def do_diff_release(ref_old, ref_new):
     print(f"PRs only in the {ref_old} branch:")
     for pr in sorted(old_pr_set - new_pr_set, reverse=True):
         print(f"  {pr} {pr_desc_map[pr]}")
+
+    print()
+    print("WARNING: Ensure that you have made the local branches up-to-date.")
 
 
 if __name__ == "__main__":

--- a/scripts/diff-release.py
+++ b/scripts/diff-release.py
@@ -2,53 +2,70 @@ import re
 import subprocess
 import sys
 
-rx_oneline = re.compile(r"^(?P<commit>[a-f0-9]{40}) (?P<msg>.*?)(\(#(?P<pr>\d+)\))?$")
+rx_oneline = re.compile(
+    r"^(?P<commit>[a-f0-9]{40}) (?P<msg>.*?)(\(#(?P<orig_pr>\d+)\)\s*)?(\(#(?P<pr>\d+)\))?$"
+)
 
 
 def do_diff_release(ref_old, ref_new):
-
     # To ensure latest information from the repository, first fetch all branches
     # and use the "origin" refspec prefix.
-    subprocess.run(['git', 'fetch'], capture_output=True)
-    if not ref_old.startswith('origin/'):
-        ref_old = 'origin/' + ref_old
-    if not ref_new.startswith('origin/'):
-        ref_new = 'origin/' + ref_new
+    subprocess.run(["git", "fetch"], capture_output=True)
+    if not ref_old.startswith("origin/"):
+        ref_old = "origin/" + ref_old
+    if not ref_new.startswith("origin/"):
+        ref_new = "origin/" + ref_new
 
-    proc = subprocess.run([
-        'git', 'merge-base', ref_old, ref_new,
-    ], capture_output=True)
+    proc = subprocess.run(
+        [
+            "git",
+            "merge-base",
+            ref_old,
+            ref_new,
+        ],
+        capture_output=True,
+    )
     common_ancestor = proc.stdout.strip().decode()
 
-    proc = subprocess.run([
-        'git', 'rev-list', '--pretty=oneline', f'{common_ancestor}..{ref_old}',
-    ], capture_output=True)
+    proc = subprocess.run(
+        [
+            "git",
+            "rev-list",
+            "--pretty=oneline",
+            f"{common_ancestor}..{ref_old}",
+        ],
+        capture_output=True,
+    )
     old_rev_list = proc.stdout.decode().splitlines()
 
-    proc = subprocess.run([
-        'git', 'rev-list', '--pretty=oneline', f'{common_ancestor}..{ref_new}',
-    ], capture_output=True)
+    proc = subprocess.run(
+        [
+            "git",
+            "rev-list",
+            "--pretty=oneline",
+            f"{common_ancestor}..{ref_new}",
+        ],
+        capture_output=True,
+    )
     new_rev_list = proc.stdout.decode().splitlines()
 
     pr_desc_map = {}
 
     old_pr_set = set()
     for rev in old_rev_list:
-        if (
-            (m := rx_oneline.search(rev.strip())) is not None and
-            (pr := m.group('pr')) is not None
-        ):
+        if (m := rx_oneline.search(rev.strip())) is not None and (pr := m.group("pr")) is not None:
+            if (orig_pr := m.group("orig_pr")) is not None:
+                pr = orig_pr
             old_pr_set.add(int(pr))
-            pr_desc_map[int(pr)] = m.group('msg')
+            pr_desc_map[int(pr)] = m.group("msg")
 
     new_pr_set = set()
     for rev in new_rev_list:
-        if (
-            (m := rx_oneline.search(rev.strip())) is not None and
-            (pr := m.group('pr')) is not None
-        ):
+        if (m := rx_oneline.search(rev.strip())) is not None and (pr := m.group("pr")) is not None:
+            if (orig_pr := m.group("orig_pr")) is not None:
+                pr = orig_pr
             new_pr_set.add(int(pr))
-            pr_desc_map[int(pr)] = m.group('msg')
+            pr_desc_map[int(pr)] = m.group("msg")
 
     print()
     print(f"The common ancestor commit:\n{common_ancestor}")


### PR DESCRIPTION
Since auto-backported PRs have two references to the PR numbers in their merge-commit titles, we need to override the last PR number with the second-last PR number if present.
