### PR TITLE
fix: Remove limit for short help string and allow `None` for unlimited width

### DIFF
--- a/changes/3333.fix.md
+++ b/changes/3333.fix.md
@@ -1,0 +1,1 @@
+Remove limit for short help string and allow `None` for unlimited width.

--- a/src/ai/backend/cli/__main__.py
+++ b/src/ai/backend/cli/__main__.py
@@ -1,5 +1,3 @@
-import shutil
-
 from .loader import load_entry_points
 
 main = load_entry_points()
@@ -7,4 +5,4 @@ main = load_entry_points()
 
 if __name__ == "__main__":
     # Execute right away if the module is directly called from CLI.
-    main(max_content_width=shutil.get_terminal_size().columns - 2)
+    main(max_content_width=None)

--- a/src/ai/backend/cli/extensions.py
+++ b/src/ai/backend/cli/extensions.py
@@ -138,7 +138,7 @@ class AliasGroupMixin(click.Group):
             rows = []
             limit = (
                 ctx.parent.max_content_width
-                if ctx.parent.max_content_width is not None
+                if ctx.parent and ctx.parent.max_content_width is not None
                 else sys.maxsize
             )
 

--- a/src/ai/backend/cli/extensions.py
+++ b/src/ai/backend/cli/extensions.py
@@ -135,8 +135,13 @@ class AliasGroupMixin(click.Group):
 
         # allow for 3 times the default spacing
         if len(commands):
-            limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
             rows = []
+            limit = (
+                ctx.parent.max_content_width
+                if ctx.parent.max_content_width is not None
+                else sys.maxsize
+            )
+
             for subcommand, cmd in commands:
                 help = cmd.get_short_help_str(limit)
                 rows.append((subcommand, help))


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Fixes https://github.com/lablup/giftbox/issues/655 ([BA-429](https://lablup.atlassian.net/browse/BA-429)) ([GF-64](https://lablup.atlassian.net/browse/GF-64)).

The current `AliasGroupMixin.format_commands()` logic for truncating help text when it is too long is hardcoded. 
This PR updates the code to allow the injection of a `max_content_width` setting, enabling customization of this behavior. Additionally, when this value is set to `None`, no truncation will be applied.

## Example

![2024-12-31_10-47-33](https://github.com/user-attachments/assets/649a92b4-9eef-4da5-a305-502e9b9b75fa)

---

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue


[BA-429]: https://lablup.atlassian.net/browse/BA-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GF-64]: https://lablup.atlassian.net/browse/GF-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ