### PR TITLE
fix(BA-433): Misuse of the walrus operator when taking ModifyEndpoint input

### DIFF
--- a/changes/3337.fix.md
+++ b/changes/3337.fix.md
@@ -1,0 +1,1 @@
+Fix a regression that modifying a model service endpoint's replica count always sets it to 1 regardless of the user input

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1217,6 +1217,16 @@ class ModifyEndpoint(graphene.Mutation):
                         raise InvalidAPIParameters(f"Unsupported runtime {_newval}")
 
                 if (
+                    (_legacy_replicas := props.desired_session_count) is not None
+                    and _legacy_replicas is not Undefined
+                    and (_new_replicas := props.replicas) is not None
+                    and _new_replicas is not Undefined
+                ):
+                    raise InvalidAPIParameters(
+                        "Cannot set both desired_session_count and replicas. Use replicas for future use."
+                    )
+
+                if (
                     _newval := props.desired_session_count
                 ) is not None and _newval is not Undefined:
                     endpoint_row.replicas = _newval

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1216,10 +1216,12 @@ class ModifyEndpoint(graphene.Mutation):
                     except KeyError:
                         raise InvalidAPIParameters(f"Unsupported runtime {_newval}")
 
-                if _newval := props.desired_session_count is not None and _newval is not Undefined:
-                    endpoint_row.desired_session_count = _newval
+                if (
+                    _newval := props.desired_session_count
+                ) is not None and _newval is not Undefined:
+                    endpoint_row.replicas = _newval
 
-                if _newval := props.replicas is not None and _newval is not Undefined:
+                if (_newval := props.replicas) is not None and _newval is not Undefined:
                     endpoint_row.replicas = _newval
 
                 if (_newval := props.resource_group) and _newval is not Undefined:


### PR DESCRIPTION
resolves #3336 (BA-433)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
