### PR TITLE
fix(BA-438): Libc version not parsed on image without metadata label

### DIFF
--- a/changes/3341.fix.md
+++ b/changes/3341.fix.md
@@ -1,0 +1,1 @@
+Fix image without metadata label not working

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1351,8 +1351,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 "HostConfig": {
                     "Init": True,
                 },
-                "Entrypoint": "sh",
-                "Cmd": ["-c", "ldd", "--version"],
+                "Entrypoint": [""],
+                "Cmd": ["ldd", "--version"],
             }
 
             container = await docker.containers.create(container_config)


### PR DESCRIPTION
Follow-up PR of #3173 and #2582. On #3173 we forced `Entrypoint` value as `sh` to force override the value set from the image, but it caused another shell script evaluation error. Along with that it seems that we can just let container use docker system's default value by passing `[""]` as the `Entrypoint` config.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
