### PR TITLE
ci(BA-416): Fix invalid variable usage

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -191,7 +191,7 @@ jobs:
           token: ${{ secrets.OCTODOG }}
           author: "${{ needs.get-backport-target-branch.outputs.author }} <${{ needs.get-backport-target-branch.outputs.author_email }}>"
           title: "${{ steps.commit_message.outputs.commit_header }}"
-          body: "This is an auto-generated backport PR of #${{ needs.get-backport-target-branch.pr_number }} to the ${{ matrix.target_branch }} release."
+          body: "This is an auto-generated backport PR of #${{ needs.get-backport-target-branch.outputs.pr_number }} to the ${{ matrix.target_branch }} release."
           branch: "backport/${{ needs.get-backport-target-branch.outputs.pr_number }}-to-${{ matrix.target_branch }}"
           base: ${{ matrix.target_branch }}
           labels: |


### PR DESCRIPTION
https://github.com/lablup/backend.ai/pull/3289/files#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L192
Revert 'outputs' after accidentally deleting it while renaming a variable.

This pull request includes a small but important change to the `.github/workflows/backport.yml` file. The change corrects the reference to the pull request number in the auto-generated backport PR body.

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L194-R194): Corrected the reference from `needs.get-backport-target-branch.pr_number` to `needs.get-backport-target-branch.outputs.pr_number` in the `body` field of the auto-generated backport PR.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version

