### PR TITLE
ci(BA-434): Graceful exit if committed directly to main

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -137,7 +137,7 @@ jobs:
 
 
   backport:
-    if: ${{ needs.get-backport-target-branch.outputs.matrix != '[]' }}
+    if: ${{ needs.get-backport-target-branch.outputs.matrix != '[]' && needs.get-backport-target-branch.outputs.matrix != '' }}
     runs-on: ubuntu-latest
     needs: get-backport-target-branch
     strategy:


### PR DESCRIPTION
close #3350 
This pull request includes a small change to the `jobs:` section in the `.github/workflows/backport.yml` file. The change ensures that the backport job only runs if the `matrix` output is not empty or an empty string.

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491L140-R140): Modified the condition in the `if` statement to check that `matrix` is not empty and not an empty string.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
