### PR TITLE
feat(BA-528): Update GQL user mutation to allow set uid/gid

### DIFF
--- a/changes/3352.feature.md
+++ b/changes/3352.feature.md
@@ -1,0 +1,1 @@
+Enable per-user UID/GID set for containers via user creation and update GraphQL APIs

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -732,6 +732,21 @@ type UserNode implements Node {
   totp_activated: Boolean
   totp_activated_at: DateTime
   sudo_session_enabled: Boolean
+
+  """
+  Added in 25.2.0. The user ID (UID) assigned to processes running inside the container.
+  """
+  container_uid: Int
+
+  """
+  Added in 25.2.0. The primary group ID (GID) assigned to processes running inside the container.
+  """
+  container_main_gid: Int
+
+  """
+  Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.
+  """
+  container_gids: [Int]
 }
 
 """Added in 24.03.0"""
@@ -835,6 +850,21 @@ type User implements Item {
   Added in 24.03.0. Used as the default authentication credential for password-based logins and sets the user's total resource usage limit. User's main_access_key cannot be deleted, and only super-admin can replace main_access_key.
   """
   main_access_key: String
+
+  """
+  Added in 25.2.0. The user ID (UID) assigned to processes running inside the container.
+  """
+  container_uid: Int
+
+  """
+  Added in 25.2.0. The primary group ID (GID) assigned to processes running inside the container.
+  """
+  container_main_gid: Int
+
+  """
+  Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.
+  """
+  container_gids: [Int]
   groups: [UserGroup]
 }
 
@@ -2131,6 +2161,21 @@ input UserInput {
   totp_activated: Boolean = false
   resource_policy: String = "default"
   sudo_session_enabled: Boolean = false
+
+  """
+  Added in 25.2.0. The user ID (UID) assigned to processes running inside the container.
+  """
+  container_uid: Int
+
+  """
+  Added in 25.2.0. The primary group ID (GID) assigned to processes running inside the container.
+  """
+  container_main_gid: Int
+
+  """
+  Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.
+  """
+  container_gids: [Int]
 }
 
 type ModifyUser {
@@ -2155,6 +2200,21 @@ input ModifyUserInput {
   resource_policy: String
   sudo_session_enabled: Boolean
   main_access_key: String
+
+  """
+  Added in 25.2.0. The user ID (UID) assigned to processes running inside the container.
+  """
+  container_uid: Int
+
+  """
+  Added in 25.2.0. The primary group ID (GID) assigned to processes running inside the container.
+  """
+  container_main_gid: Int
+
+  """
+  Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.
+  """
+  container_gids: [Int]
 }
 
 """

--- a/src/ai/backend/manager/models/gql_models/user.py
+++ b/src/ai/backend/manager/models/gql_models/user.py
@@ -52,6 +52,16 @@ class UserNode(graphene.ObjectType):
     totp_activated = graphene.Boolean()
     totp_activated_at = GQLDateTime()
     sudo_session_enabled = graphene.Boolean()
+    container_uid = graphene.Int(
+        description="Added in 25.2.0. The user ID (UID) assigned to processes running inside the container."
+    )
+    container_main_gid = graphene.Int(
+        description="Added in 25.2.0. The primary group ID (GID) assigned to processes running inside the container."
+    )
+    container_gids = graphene.List(
+        lambda: graphene.Int,
+        description="Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.",
+    )
 
     @classmethod
     def from_row(cls, ctx: GraphQueryContext, row: UserRow) -> Self:
@@ -74,6 +84,9 @@ class UserNode(graphene.ObjectType):
             totp_activated=row.totp_activated,
             totp_activated_at=row.totp_activated_at,
             sudo_session_enabled=row.sudo_session_enabled,
+            container_uid=row.container_uid,
+            container_main_gid=row.container_main_gid,
+            container_gids=row.container_gids,
         )
 
     @classmethod


### PR DESCRIPTION
resolves #3478 (BA-528)

```graphql
mutation ModifyUser {
    modify_user (
        email: "admin@lablup.com",
        props: {
            container_uid: 1101,
            container_main_gid: 1102,
            container_gids: [1103,1104]
        }
    ){
        ok
        msg
        user {
            username
            container_uid
            container_main_gid
            container_gids
        }
    }
}
```

The fields are described as follows:

- container_uid: The user ID (UID) assigned to processes running inside the container. Integer type, nullable.
- container_main_gid: The primary group ID (GID) assigned to processes running inside the container. Integer type, nullable.
- container_gids: Supplementary group IDs assigned to processes running inside the container. Array of integers, nullable.

When connecting to a container created with container_uid = 1100, container_main_gid = 1101, and container_gids = [1102, 1103], the id values should be displayed as follows:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/a2304f75-91f3-42c1-9b75-74ad015daddd" />


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3352.org.readthedocs.build/en/3352/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3352.org.readthedocs.build/ko/3352/

<!-- readthedocs-preview sorna-ko end -->