### PR TITLE
ci: Fix the newlines of changelog between versions

### DIFF
--- a/changes/template.md
+++ b/changes/template.md
@@ -36,3 +36,7 @@ No significant changes.
 No significant changes.
   {%- endif %}
 {%- endfor %}
+
+
+
+{# NOTE: keep trailing newlines #}


### PR DESCRIPTION
This PR adds the required newlines to the end of `changes/template.md` with an explicit comment to prevent accidental removal of them.

The backport target is set to 24.03 which shares the same towncrier version (`~=24.8`).

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
