### PR TITLE
ci: Fix the newlines of changelog between versions (#3364)

### DIFF
--- a/changes/template.md
+++ b/changes/template.md
@@ -36,3 +36,7 @@ No significant changes.
 No significant changes.
   {%- endif %}
 {%- endfor %}
+
+
+
+{# NOTE: keep trailing newlines #}


### PR DESCRIPTION
This is an auto-generated backport PR of #3364 to the 24.03 release.