### PR TITLE
fix(BA-450): do not set timeout on docker push API execution

### DIFF
--- a/changes/3391.fix.md
+++ b/changes/3391.fix.md
@@ -1,0 +1,1 @@
+Fix certain customized images not being pushed to registry properly

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1610,7 +1610,12 @@ class AbstractAgent(
         self.images = await self.scan_images()
 
     @abstractmethod
-    async def push_image(self, image_ref: ImageRef, registry_conf: ImageRegistry) -> None:
+    async def push_image(
+        self,
+        image_ref: ImageRef,
+        registry_conf: ImageRegistry,
+        timeout: float | None | Sentinel = Sentinel.TOKEN,
+    ) -> None:
         """
         Push the given image to the given registry.
         """

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1614,6 +1614,7 @@ class AbstractAgent(
         self,
         image_ref: ImageRef,
         registry_conf: ImageRegistry,
+        *,
         timeout: float | None | Sentinel = Sentinel.TOKEN,
     ) -> None:
         """

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1512,6 +1512,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         self,
         image_ref: ImageRef,
         registry_conf: ImageRegistry,
+        *,
         timeout: float | None | Sentinel = Sentinel.TOKEN,
     ) -> None:
         if image_ref.is_local:

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -31,6 +31,7 @@ from ai.backend.common.types import (
     MountPermission,
     MountTypes,
     ResourceSlot,
+    Sentinel,
     ServicePort,
     SessionId,
     SlotName,
@@ -293,7 +294,13 @@ class DummyAgent(
         delay = self.dummy_agent_cfg["delay"]["pull-image"]
         await asyncio.sleep(delay)
 
-    async def push_image(self, image_ref: ImageRef, registry_conf: ImageRegistry) -> None:
+    async def push_image(
+        self,
+        image_ref: ImageRef,
+        registry_conf: ImageRegistry,
+        *,
+        timeout: float | None | Sentinel = Sentinel.TOKEN,
+    ) -> None:
         delay = self.dummy_agent_cfg["delay"]["push-image"]
         await asyncio.sleep(delay)
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -819,6 +819,7 @@ class AgentRPCServer(aobject):
             await self.agent.push_image(
                 image_ref,
                 registry_conf,
+                timeout=None,
             )
 
         task_id = await bgtask_mgr.start(_push_image)


### PR DESCRIPTION
Resolves https://github.com/lablup/backend.ai-internal/issues/118.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
