### PR TITLE
fix(BA-438): Libc version not parsed on image without metadata label (#3341)

### DIFF
--- a/changes/3341.fix.md
+++ b/changes/3341.fix.md
@@ -1,0 +1,1 @@
+Fix image without metadata label not working

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1311,8 +1311,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 "HostConfig": {
                     "Init": True,
                 },
-                "Entrypoint": "sh",
-                "Cmd": ["-c", "ldd", "--version"],
+                "Entrypoint": [""],
+                "Cmd": ["ldd", "--version"],
             }
 
             container = await docker.containers.create(container_config)


### PR DESCRIPTION
This is an auto-generated backport PR of #3341 to the 24.09 release.