### PR TITLE
fix(BA-459): password based SSH login not working (#3387)

### DIFF
--- a/changes/3387.fix.md
+++ b/changes/3387.fix.md
@@ -1,0 +1,1 @@
+Fix password based SSH login not working on sessions based on certain images

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -55,7 +55,7 @@ if [ $USER_ID -eq 0 ]; then
     /opt/backend.ai/bin/python -s /opt/kernel/fantompass.py > "$HOME/.password"
     export ALPHA_NUMERIC_VAL=$(cat $HOME/.password)
     chmod 0644 "$HOME/.password"
-    echo "work:$ALPHA_NUMERIC_VAL" | chpasswd
+    echo "work:$ALPHA_NUMERIC_VAL" | chpasswd -c SHA512
   fi
 
   echo "Executing the main program..."
@@ -132,7 +132,7 @@ else
     /opt/kernel/su-exec $USER_ID:$GROUP_ID /opt/backend.ai/bin/python -s /opt/kernel/fantompass.py > "$HOME/.password"
     export ALPHA_NUMERIC_VAL=$(cat $HOME/.password)
     chmod 0644 "$HOME/.password"
-    echo "$USER_NAME:$ALPHA_NUMERIC_VAL" | chpasswd
+    echo "$USER_NAME:$ALPHA_NUMERIC_VAL" | chpasswd -c SHA512
   fi
 
   # The gid 42 is a reserved gid for "shadow" to allow passwrd-based SSH login. (lablup/backend.ai#751)


### PR DESCRIPTION
This is an auto-generated backport PR of #3387 to the 24.09 release.