### PR TITLE
feat(BA-468): Add timeout conf for image push

### DIFF
--- a/changes/3412.feature.md
+++ b/changes/3412.feature.md
@@ -1,0 +1,1 @@
+Add timeout configuration for Docker image push

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -150,10 +150,9 @@ default_container_logs_config = {
 }
 
 DEFAULT_PULL_TIMEOUT = 2 * 60 * 60  # 2 hours
+DEFAULT_PUSH_TIMEOUT = None  # Infinite
 
-default_api_config = {
-    "pull-timeout": DEFAULT_PULL_TIMEOUT,
-}
+default_api_config = {"pull-timeout": DEFAULT_PULL_TIMEOUT, "push-timeout": DEFAULT_PUSH_TIMEOUT}
 
 agent_etcd_config_iv = t.Dict({
     t.Key("container-logs", default=default_container_logs_config): t.Dict({
@@ -163,6 +162,10 @@ agent_etcd_config_iv = t.Dict({
     t.Key("api", default=default_api_config): t.Dict({
         t.Key("pull-timeout", default=default_api_config["pull-timeout"]): tx.ToNone
         | t.ToFloat[0:],  # Set the image pull timeout in seconds
+        t.Key("push-timeout", default=default_api_config["push-timeout"]): tx.ToNone
+        | t.ToFloat[
+            0:
+        ],  # Set the image push timeout in seconds. 'None' indicates an infinite timeout.
     }).allow_extra("*"),
 }).allow_extra("*")
 

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -815,11 +815,15 @@ class AgentRPCServer(aobject):
         log.info("rpc::push_image(c:{})", image_ref.canonical)
         bgtask_mgr = self.agent.background_task_manager
 
+        image_push_timeout = cast(
+            Optional[float], self.local_config["agent"]["api"]["push-timeout"]
+        )
+
         async def _push_image(reporter: ProgressReporter) -> None:
             await self.agent.push_image(
                 image_ref,
                 registry_conf,
-                timeout=None,
+                timeout=image_push_timeout,
             )
 
         task_id = await bgtask_mgr.start(_push_image)


### PR DESCRIPTION
resolves #3401 

The default timeout value is `None`, which means infinite timeout

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
