### PR TITLE
fix(BA-477): Logging and formatting exceptions raised from local process (#3410)

### DIFF
--- a/changes/3410.fix.md
+++ b/changes/3410.fix.md
@@ -1,0 +1,1 @@
+Fix formatting errors when logging exceptions raised from the current local process that did not pass our custom serialization step


### PR DESCRIPTION
This is an auto-generated backport PR of #3410 to the 24.09 release.