### PR TITLE
fix(BA-484): Missing architceture name lookup in LocalRegistry (#3420)

### DIFF
--- a/changes/3420.fix.md
+++ b/changes/3420.fix.md
@@ -1,0 +1,1 @@
+Fix missing CPU architecture name lookup in `LocalRegistry` to directly scan and load container images from the local Docker daemon in dev setups

--- a/src/ai/backend/manager/container_registry/local.py
+++ b/src/ai/backend/manager/container_registry/local.py
@@ -9,7 +9,7 @@ import aiohttp
 import sqlalchemy as sa
 import yarl
 
-from ai.backend.common.docker import get_docker_connector
+from ai.backend.common.docker import arch_name_aliases, get_docker_connector
 from ai.backend.logging import BraceStyleAdapter
 
 from ..models.image import ImageRow
@@ -71,13 +71,13 @@ class LocalRegistry(BaseContainerRegistry):
                 self.registry_url / "images" / f"{image}:{digest}" / "json"
             ) as response:
                 data = await response.json()
-            architecture = data["Architecture"]
+            architecture = arch_name_aliases.get(data["Architecture"], data["Architecture"])
             summary = {
                 "Id": data["Id"],
                 "RepoDigests": data.get("RepoDigests", []),
                 "Config.Image": data["Config"]["Image"],
                 "ContainerConfig.Image": data.get("ContainerConfig", {}).get("Image", None),
-                "Architecture": data["Architecture"],
+                "Architecture": architecture,
             }
             log.debug("scanned image info: {}:{}\n{}", image, digest, json.dumps(summary, indent=2))
             already_exists = 0


### PR DESCRIPTION
This is an auto-generated backport PR of #3420 to the 24.09 release.