### PR TITLE
chore: Describe the extension of the config file to use TOML (#2906)

### DIFF
--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -968,7 +968,7 @@ async def server_main(
     "--config",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     default=None,
-    help="The config file path. (default: ./agent.conf and /etc/backend.ai/agent.conf)",
+    help="The config file path. (default: ./agent.toml and /etc/backend.ai/agent.toml)",
 )
 @click.option(
     "--debug",

--- a/src/ai/backend/agent/watcher.py
+++ b/src/ai/backend/agent/watcher.py
@@ -323,7 +323,7 @@ async def watcher_server(loop, pidx, args):
     "--config",
     type=click.Path(exists=True, dir_okay=False),
     default=None,
-    help="The config file path. (default: ./agent.conf and /etc/backend.ai/agent.conf)",
+    help="The config file path. (default: ./agent.toml and /etc/backend.ai/agent.toml)",
 )
 @click.option(
     "--debug",


### PR DESCRIPTION
This is an auto-generated backport PR of #2906 to the 24.09 release.