### PR TITLE
chore: Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 .mypy_cache/
+.ruff_cache/
 
 # Translations
 *.mo
@@ -78,7 +79,7 @@ venv/
 ENV/
 
 # IDE/vim
-.idea
+.idea/
 .swp
 .swo
 .*.swp
@@ -90,7 +91,7 @@ ENV/
 /.exrc
 .ripgreprc
 .neoconf.json
-/.zed
+.zed/
 /.ropeproject
 pyrightconfig.json
 
@@ -103,13 +104,13 @@ pyrightconfig.json
 /tools/pants-src
 
 # Local configurations
-/account-manager.toml
-/manager.toml
-/agent.toml
-/storage-proxy.toml
-/webserver.conf
-/cuda-mock.toml
-/mock-accelerator.toml
+/account-manager*.toml
+/manager*.toml
+/agent*.toml
+/storage-proxy*.toml
+/webserver*.conf
+/cuda-mock*.toml
+/mock-accelerator*.toml
 /.pants.env
 /.pants.bootstrap
 /.pants.rc


### PR DESCRIPTION
- Update gitignore to exclude potentially locally crafted toml files: e.g., `agent.toml` -> `agent*.toml`.
- Let it exclude `.ruff_cache/` like `.mypy_cache/`.
- Let it exclude `.zed/` dirs even when they reside in subdirectories for pants/agent plugin development.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
