### PR TITLE
chore: Ensure that metrics is included in the common package

### DIFF
--- a/src/ai/backend/common/BUILD
+++ b/src/ai/backend/common/BUILD
@@ -25,6 +25,7 @@ python_distribution(
     name="dist",
     dependencies=[
         ":src",
+        "src/ai/backend/common/metrics:src",
         "src/ai/backend/common/plugin:src",
         "src/ai/backend/common/auth:src",
         "src/ai/backend/common/web/session:src",  # not auto-inferred


### PR DESCRIPTION
In #3475, the metrics module was added to the common package.
This was not explicitly added to the dependencies when packaging, causing issues when building wheel.
![CleanShot 2025-01-20 at 19 11 27@2x](https://github.com/user-attachments/assets/2ff86541-13ec-4b86-aa86-39dee7a5aab0)


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
