### PR TITLE
chore(BA-469): Rename variables `api_rqst` to `api_request` for clarity (#3404)

### DIFF
--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -57,8 +57,8 @@ class WSProxy:
         if len(self.envs.keys()) > 0:
             params["envs"] = json.dumps(self.envs)
 
-        api_rqst = Request("GET", path, b"", params=params, content_type="application/json")
-        async with api_rqst.connect_websocket() as ws:
+        api_request = Request("GET", path, b"", params=params, content_type="application/json")
+        async with api_request.connect_websocket() as ws:
 
             async def downstream() -> None:
                 try:

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -121,18 +121,18 @@ async def web_handler(request):
     try:
         # We treat all requests and responses as streaming universally
         # to be a transparent proxy.
-        api_rqst = Request(
+        api_request = Request(
             request.method,
             path,
             request.content,
             params=request.query,
         )
-        _translate_headers(api_rqst, request)
+        _translate_headers(api_request, request)
         if "Content-Type" in request.headers:
-            api_rqst.content_type = request.content_type  # set for signing
+            api_request.content_type = request.content_type  # set for signing
         # Uploading request body happens at the entering of the block,
         # and downloading response body happens in the read loop inside.
-        async with api_rqst.fetch() as up_resp:
+        async with api_request.fetch() as up_resp:
             down_resp = web.StreamResponse()
             down_resp.set_status(up_resp.status, up_resp.reason)
             down_resp.headers.update(up_resp.headers)
@@ -164,15 +164,15 @@ async def web_handler(request):
 async def websocket_handler(request):
     path = re.sub(r"^/?v(\d+)/", "/", request.path)
     try:
-        api_rqst = Request(
+        api_request = Request(
             request.method,
             path,
             request.content,
             params=request.query,
             content_type=request.content_type,
         )
-        _translate_headers(api_rqst, request)
-        async with api_rqst.connect_websocket() as up_conn:
+        _translate_headers(api_request, request)
+        async with api_request.connect_websocket() as up_conn:
             down_conn = web.WebSocketResponse()
             await down_conn.prepare(request)
             web_socket_proxy = WebSocketProxy(up_conn, down_conn)

--- a/src/ai/backend/client/cli/session/app.py
+++ b/src/ai/backend/client/cli/session/app.py
@@ -55,8 +55,8 @@ class WSProxy:
         if len(self.envs.keys()) > 0:
             params["envs"] = json.dumps(self.envs)
 
-        api_rqst = Request("GET", path, b"", params=params, content_type="application/json")
-        async with api_rqst.connect_websocket() as ws:
+        api_request = Request("GET", path, b"", params=params, content_type="application/json")
+        async with api_request.connect_websocket() as ws:
 
             async def downstream() -> None:
                 try:

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1041,12 +1041,12 @@ class ComputeSession(BaseFunction):
             params["owner_access_key"] = self.owner_access_key
         prefix = get_naming(api_session.get().api_version, "path")
         id_or_name = get_id_or_name(api_session.get().api_version, self)
-        api_rqst = Request(
+        api_request = Request(
             "GET",
             f"/stream/{prefix}/{id_or_name}/apps",
             params=params,
         )
-        async with api_rqst.fetch() as resp:
+        async with api_request.fetch() as resp:
             return await resp.json()
 
     @api_function

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -188,7 +188,7 @@ async def web_handler(request: web.Request, *, is_anonymous=False) -> web.Stream
             api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
             # We treat all requests and responses as streaming universally
             # to be a transparent proxy.
-            api_rqst = Request(
+            api_request = Request(
                 request.method,
                 path,
                 payload,
@@ -196,37 +196,23 @@ async def web_handler(request: web.Request, *, is_anonymous=False) -> web.Stream
                 override_api_version=request_api_version,
             )
             if "Content-Type" in request.headers:
-                api_rqst.content_type = request.content_type  # set for signing
-                api_rqst.headers["Content-Type"] = request.headers[
+                api_request.content_type = request.content_type  # set for signing
+                api_request.headers["Content-Type"] = request.headers[
                     "Content-Type"
                 ]  # preserve raw value
             if "Content-Length" in request.headers and not secure_context:
-                api_rqst.headers["Content-Length"] = request.headers["Content-Length"]
+                api_request.headers["Content-Length"] = request.headers["Content-Length"]
             if "Content-Length" in request.headers and secure_context:
-                api_rqst.headers["Content-Length"] = str(decrypted_payload_length)
-            for hdr in HTTP_HEADERS_TO_FORWARD:
+                api_request.headers["Content-Length"] = str(decrypted_payload_length)
+            for hdr in {*HTTP_HEADERS_TO_FORWARD, *http_headers_to_forward_extra}:
+                # Prevent malicious or accidental modification of critical headers.
+                if hdr in api_request.headers:
+                    continue
                 if request.headers.get(hdr) is not None:
-                    api_rqst.headers[hdr] = request.headers[hdr]
-            if proxy_path == "pipeline":
-                session_id = request.headers.get("X-BackendAI-SessionID", "")
-                if not (sso_token := request.headers.get("X-BackendAI-SSO")):
-                    jwt_secret = config["pipeline"]["jwt"]["secret"]
-                    now = datetime.now().astimezone()
-                    payload = {
-                        # Registered claims
-                        "exp": now + timedelta(seconds=config["session"]["max_age"]),
-                        "iss": "Backend.AI Webserver",
-                        "iat": now,
-                        # Private claims
-                        "aiohttp_session": session_id,
-                        "access_key": api_session.config.access_key,  # since 23.03.10
-                    }
-                    sso_token = jwt.encode(payload, key=jwt_secret, algorithm="HS256")
-                api_rqst.headers["X-BackendAI-SSO"] = sso_token
-                api_rqst.headers["X-BackendAI-SessionID"] = session_id
+                    api_request.headers[hdr] = request.headers[hdr]
             # Uploading request body happens at the entering of the block,
             # and downloading response body happens in the read loop inside.
-            async with api_rqst.fetch() as up_resp:
+            async with api_request.fetch() as up_resp:
                 down_resp = web.StreamResponse()
                 down_resp.set_status(up_resp.status, up_resp.reason)
                 down_resp.headers.update(up_resp.headers)
@@ -294,7 +280,7 @@ async def web_plugin_handler(request, *, is_anonymous=False) -> web.StreamRespon
             fill_forwarding_hdrs_to_api_session(request, api_session)
             # Deliver cookie for token-based authentication.
             api_session.aiohttp_session.cookie_jar.update_cookies(request.cookies)
-            api_rqst = Request(
+            api_request = Request(
                 request.method,
                 path,
                 content,
@@ -304,8 +290,8 @@ async def web_plugin_handler(request, *, is_anonymous=False) -> web.StreamRespon
             )
             for hdr in HTTP_HEADERS_TO_FORWARD:
                 if request.headers.get(hdr) is not None:
-                    api_rqst.headers[hdr] = request.headers[hdr]
-            async with api_rqst.fetch() as up_resp:
+                    api_request.headers[hdr] = request.headers[hdr]
+            async with api_request.fetch() as up_resp:
                 down_resp = web.StreamResponse()
                 down_resp.set_status(up_resp.status, up_resp.reason)
                 down_resp.headers.update(up_resp.headers)
@@ -385,7 +371,7 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
         async with api_session:
             request_api_version = request.headers.get("X-BackendAI-Version", None)
             fill_forwarding_hdrs_to_api_session(request, api_session)
-            api_rqst = Request(
+            api_request = Request(
                 request.method,
                 path,
                 request.content,
@@ -393,7 +379,7 @@ async def websocket_handler(request, *, is_anonymous=False) -> web.StreamRespons
                 content_type=request.content_type,
                 override_api_version=request_api_version,
             )
-            async with api_rqst.connect_websocket() as up_conn:
+            async with api_request.connect_websocket() as up_conn:
                 down_conn = web.WebSocketResponse()
                 await down_conn.prepare(request)
                 web_socket_proxy = WebSocketProxy(up_conn.raw_websocket, down_conn)


### PR DESCRIPTION
This is an auto-generated backport PR of #3404 to the 24.09 release.