### PR TITLE
feat(BA-595): Add `row_id` field to UserNode GQL schema

### DIFF
--- a/changes/3525.feature.md
+++ b/changes/3525.feature.md
@@ -1,0 +1,1 @@
+Add a `row_id` field to the `UserNode` GraphQL schema to enable querying and mutating users by ID.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -704,6 +704,9 @@ type UserNode implements Node {
   """The ID of the object"""
   id: ID!
 
+  """Added in 25.1.0. The undecoded id value stored in DB."""
+  row_id: UUID
+
   """Unique username of the user."""
   username: String
 

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -704,7 +704,7 @@ type UserNode implements Node {
   """The ID of the object"""
   id: ID!
 
-  """Added in 25.1.0. The undecoded id value stored in DB."""
+  """Added in 25.2.0. The undecoded id value stored in DB."""
   row_id: UUID
 
   """Unique username of the user."""

--- a/src/ai/backend/manager/models/gql_models/user.py
+++ b/src/ai/backend/manager/models/gql_models/user.py
@@ -29,6 +29,7 @@ class UserNode(graphene.ObjectType):
     class Meta:
         interfaces = (AsyncNode,)
 
+    row_id = graphene.UUID(description="Added in 25.1.0. The undecoded id value stored in DB.")
     username = graphene.String(description="Unique username of the user.")
     email = graphene.String(description="Unique email of the user.")
     need_password_change = graphene.Boolean()
@@ -57,6 +58,7 @@ class UserNode(graphene.ObjectType):
     def from_row(cls, ctx: GraphQueryContext, row: UserRow) -> Self:
         return cls(
             id=row.uuid,
+            row_id=row.uuid,
             username=row.username,
             email=row.email,
             need_password_change=row.need_password_change,
@@ -87,7 +89,7 @@ class UserNode(graphene.ObjectType):
             return cls.from_row(graph_ctx, user_row)
 
     _queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
-        "uuid": ("uuid", None),
+        "row_id": ("id", None),
         "username": ("username", None),
         "email": ("email", None),
         "need_password_change": ("need_password_change", None),
@@ -109,7 +111,7 @@ class UserNode(graphene.ObjectType):
     }
 
     _queryorder_colmap: Mapping[str, OrderSpecItem] = {
-        "uuid": ("uuid", None),
+        "row_id": ("id", None),
         "username": ("username", None),
         "email": ("email", None),
         "need_password_change": ("need_password_change", None),

--- a/src/ai/backend/manager/models/gql_models/user.py
+++ b/src/ai/backend/manager/models/gql_models/user.py
@@ -29,7 +29,7 @@ class UserNode(graphene.ObjectType):
     class Meta:
         interfaces = (AsyncNode,)
 
-    row_id = graphene.UUID(description="Added in 25.1.0. The undecoded id value stored in DB.")
+    row_id = graphene.UUID(description="Added in 25.2.0. The undecoded id value stored in DB.")
     username = graphene.String(description="Unique username of the user.")
     email = graphene.String(description="Unique email of the user.")
     need_password_change = graphene.Boolean()


### PR DESCRIPTION
resolves #3524  (BA-595)

Adds a `row_id` field to the `UserNode` GraphQL schema, enabling direct querying and mutation of users by their database ID. This field represents the undecoded UUID value stored in the database and was introduced in version 25.2.0.

The change updates the query filter and order specifications to use `row_id` instead of `uuid` for consistency with the new field naming.

**Checklist:**

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3525.org.readthedocs.build/en/3525/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3525.org.readthedocs.build/ko/3525/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3525.org.readthedocs.build/en/3525/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3525.org.readthedocs.build/ko/3525/

<!-- readthedocs-preview sorna-ko end -->