### PR TITLE
fix(BA-585): Empty tag image scan error in docker registry

### DIFF
--- a/changes/3513.fix.md
+++ b/changes/3513.fix.md
@@ -1,0 +1,1 @@
+Fix empty tag image scan error in docker registry.

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -234,9 +234,11 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         while tag_list_url is not None:
             async with sess.get(tag_list_url, **rqst_args) as resp:
                 data = json.loads(await resp.read())
-                if "tags" in data:
-                    # sometimes there are dangling image names in the hub.
-                    tags.extend(data["tags"])
+                tags_data = data.get("tags", [])
+                if not tags_data:
+                    break
+
+                tags.extend(tags_data)
                 tag_list_url = None
                 next_page_link = resp.links.get("next")
                 if next_page_link:

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -235,6 +235,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             async with sess.get(tag_list_url, **rqst_args) as resp:
                 data = json.loads(await resp.read())
                 tags_data = data.get("tags", [])
+                # sometimes there are dangling image names in the hub.
                 if not tags_data:
                     break
 

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -160,7 +160,9 @@ class AsyncContextCoroutineMock(AsyncMock):
         pass
 
 
-def mock_multi_responses(mock_responses: list[Any]) -> Callable[..., CallbackResult]:
+def mock_aioresponses_sequential_payloads(
+    mock_responses: list[Any],
+) -> Callable[..., CallbackResult]:
     """
     Returns CallbackResult for aioresponses that sequentially returns mock responses.
     On each invocation, it returns the next mock response from the 'mock_value' list.
@@ -171,12 +173,11 @@ def mock_multi_responses(mock_responses: list[Any]) -> Callable[..., CallbackRes
     def _callback(*args, **kwargs) -> CallbackResult:
         nonlocal cb_call_counter
 
-        if cb_call_counter < len(mock_responses):
-            data = mock_responses[cb_call_counter]
-            cb_call_counter += 1
-        else:
+        if cb_call_counter >= len(mock_responses):
             raise Exception("No more mock responses left")
 
+        data = mock_responses[cb_call_counter]
+        cb_call_counter += 1
         return CallbackResult(status=200, payload=data)
 
     return _callback

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -164,8 +164,8 @@ def mock_aioresponses_sequential_payloads(
     mock_responses: list[Any],
 ) -> Callable[..., CallbackResult]:
     """
-    Returns CallbackResult for aioresponses that sequentially returns mock responses.
-    On each invocation, it returns the next mock response from the 'mock_value' list.
+    Creates a callback function for aioresponses that sequentially returns mock responses.
+    On each invocation, the callback function returns the next mock response from the 'mock_value' list.
     If the number of calls exceeds the length of 'mock_value', it raises an Exception to indicate that no more responses are available.
     """
     cb_call_counter = 0

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -160,7 +160,7 @@ class AsyncContextCoroutineMock(AsyncMock):
         pass
 
 
-def mock_multi_responses(mock_responses: list[Any]) -> Callable[[Any, Any], CallbackResult]:
+def mock_multi_responses(mock_responses: list[Any]) -> Callable[..., CallbackResult]:
     """
     Returns CallbackResult for aioresponses that sequentially returns mock responses.
     On each invocation, it returns the next mock response from the 'mock_value' list.
@@ -175,7 +175,7 @@ def mock_multi_responses(mock_responses: list[Any]) -> Callable[[Any, Any], Call
             data = mock_responses[cb_call_counter]
             cb_call_counter += 1
         else:
-            raise Exception("No more responses left")
+            raise Exception("No more mock responses left")
 
         return CallbackResult(status=200, payload=data)
 

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -1,5 +1,8 @@
+from typing import Any, Callable
 from unittest import mock
 from unittest.mock import AsyncMock
+
+from aioresponses import CallbackResult
 
 
 def mock_corofunc(return_value):
@@ -155,3 +158,25 @@ class AsyncContextCoroutineMock(AsyncMock):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
+
+
+def mock_multi_responses(mock_responses: list[Any]) -> Callable[[Any, Any], CallbackResult]:
+    """
+    Returns CallbackResult for aioresponses that sequentially returns mock responses.
+    On each invocation, it returns the next mock response from the 'mock_value' list.
+    If the number of calls exceeds the length of 'mock_value', it raises an Exception to indicate that no more responses are available.
+    """
+    cb_call_counter = 0
+
+    def _callback(*args, **kwargs) -> CallbackResult:
+        nonlocal cb_call_counter
+
+        if cb_call_counter < len(mock_responses):
+            data = mock_responses[cb_call_counter]
+            cb_call_counter += 1
+        else:
+            raise Exception("No more responses left")
+
+        return CallbackResult(status=200, payload=data)
+
+    return _callback

--- a/tests/manager/models/test_image.py
+++ b/tests/manager/models/test_image.py
@@ -30,7 +30,7 @@ from ai.backend.manager.server import (
     redis_ctx,
     shared_config_ctx,
 )
-from ai.backend.testutils.mock import mock_multi_responses
+from ai.backend.testutils.mock import mock_aioresponses_sequential_payloads
 
 
 @pytest.fixture(scope="module")
@@ -103,7 +103,7 @@ FIXTURES_DOCKER_REGISTRIES = [
                         "other/python",
                     ]
                 },
-                "get_tags": mock_multi_responses([
+                "get_tags": mock_aioresponses_sequential_payloads([
                     {"tags": ["latest"]},
                     {"tags": []},  # dangling image should be skipped
                     {"tags": None},  # dangling image should be skipped

--- a/tests/manager/models/test_image.py
+++ b/tests/manager/models/test_image.py
@@ -61,7 +61,7 @@ def get_graphquery_context(
     )
 
 
-FIXTURES_REGISTRIES = [
+FIXTURES_DOCKER_REGISTRIES = [
     {
         "container_registries": [
             {
@@ -85,7 +85,7 @@ FIXTURES_REGISTRIES = [
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(60)
-@pytest.mark.parametrize("extra_fixtures", FIXTURES_REGISTRIES)
+@pytest.mark.parametrize("extra_fixtures", FIXTURES_DOCKER_REGISTRIES)
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -94,7 +94,7 @@ FIXTURES_REGISTRIES = [
             "mock_dockerhub_responses": {
                 "get_token": {"token": "fake-token"},
                 "get_catalog": {"repositories": ["lablup/python", "other/python"]},
-                "get_tags": {"tags": ["latest", "latest"]},
+                "get_tags": {"tags": ["latest"]},
                 "get_manifest": {
                     "schemaVersion": 2,
                     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -119,7 +119,7 @@ FIXTURES_REGISTRIES = [
             "mock_dockerhub_responses": {
                 "get_token": {"token": "fake-token"},
                 "get_catalog": {"repositories": ["lablup/python", "other/python"]},
-                "get_tags": {"tags": ["latest", "latest"]},
+                "get_tags": {"tags": ["latest"]},
                 "get_manifest": {
                     "schemaVersion": 2,
                     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -171,7 +171,7 @@ FIXTURES_REGISTRIES = [
         "Rescan dangling images without tags",
     ],
 )
-async def test_image_rescan(
+async def test_image_rescan_on_docker_registry(
     client: Client,
     test_case,
     etcd_fixture,
@@ -233,7 +233,7 @@ async def test_image_rescan(
         mocked.get(
             f"{registry_url}/v2/",
             status=200,
-            payload=mock_dockerhub_responses["get_tags"],
+            payload=mock_dockerhub_responses["get_token"],
             repeat=True,
         )
 


### PR DESCRIPTION
Resolves #3513 ([BA-585](https://lablup.atlassian.net/browse/BA-585)).

This PR fixes an issue where an error occurs when rescanning images with empty tags (dangling images) in Docker registries.
After this PR, dangling images will be skipped, and only other valid images will be rescanned.

<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation



[BA-585]: https://lablup.atlassian.net/browse/BA-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ