### PR TITLE
ci: Unify suffixes in release names the same way as before

### DIFF
--- a/scripts/get-platform-suffix.py
+++ b/scripts/get-platform-suffix.py
@@ -11,7 +11,13 @@ arch_name_aliases = {
     "i686": "x86",  # Windows
 }
 
-platform_kernel = sys.platform
+kernel_name_aliases = {
+    "linux": "linux",
+    "darwin": "macos",
+    "win32": "windows",
+}
+
+platform_kernel = kernel_name_aliases.get(sys.platform, sys.platform)
 platform_arch = arch_name_aliases.get(platform.machine(), platform.machine())
 
 print(f"{platform_kernel}-{platform_arch}")


### PR DESCRIPTION
resolves #3534 (BA-605)
I will also need to rename all of the release files for the 25.1.1 version that were incorrectly registered in this PR.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue