### PR TITLE
fix(BA-585): Empty tag image scan error in docker registry (#3533)

### DIFF
--- a/changes/3513.fix.md
+++ b/changes/3513.fix.md
@@ -1,0 +1,1 @@
+Fix empty tag image scan error in docker registry.

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -185,9 +185,12 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         while tag_list_url is not None:
             async with sess.get(tag_list_url, **rqst_args) as resp:
                 data = json.loads(await resp.read())
-                if "tags" in data:
-                    # sometimes there are dangling image names in the hub.
-                    tags.extend(data["tags"])
+                tags_data = data.get("tags", [])
+                # sometimes there are dangling image names in the hub.
+                if not tags_data:
+                    break
+
+                tags.extend(tags_data)
                 tag_list_url = None
                 next_page_link = resp.links.get("next")
                 if next_page_link:

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -1,5 +1,8 @@
+from typing import Any, Callable
 from unittest import mock
 from unittest.mock import AsyncMock
+
+from aioresponses import CallbackResult
 
 
 def mock_corofunc(return_value):
@@ -155,3 +158,26 @@ class AsyncContextCoroutineMock(AsyncMock):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
+
+
+def mock_aioresponses_sequential_payloads(
+    mock_responses: list[Any],
+) -> Callable[..., CallbackResult]:
+    """
+    Creates a callback function for aioresponses that sequentially returns mock responses.
+    On each invocation, the callback function returns the next mock response from the 'mock_value' list.
+    If the number of calls exceeds the length of 'mock_value', it raises an Exception to indicate that no more responses are available.
+    """
+    cb_call_counter = 0
+
+    def _callback(*args, **kwargs) -> CallbackResult:
+        nonlocal cb_call_counter
+
+        if cb_call_counter >= len(mock_responses):
+            raise Exception("No more mock responses left")
+
+        data = mock_responses[cb_call_counter]
+        cb_call_counter += 1
+        return CallbackResult(status=200, payload=data)
+
+    return _callback

--- a/src/ai/backend/testutils/mock.py
+++ b/src/ai/backend/testutils/mock.py
@@ -1,8 +1,5 @@
-from typing import Any, Callable
 from unittest import mock
 from unittest.mock import AsyncMock
-
-from aioresponses import CallbackResult
 
 
 def mock_corofunc(return_value):
@@ -158,26 +155,3 @@ class AsyncContextCoroutineMock(AsyncMock):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
-
-
-def mock_aioresponses_sequential_payloads(
-    mock_responses: list[Any],
-) -> Callable[..., CallbackResult]:
-    """
-    Creates a callback function for aioresponses that sequentially returns mock responses.
-    On each invocation, the callback function returns the next mock response from the 'mock_value' list.
-    If the number of calls exceeds the length of 'mock_value', it raises an Exception to indicate that no more responses are available.
-    """
-    cb_call_counter = 0
-
-    def _callback(*args, **kwargs) -> CallbackResult:
-        nonlocal cb_call_counter
-
-        if cb_call_counter >= len(mock_responses):
-            raise Exception("No more mock responses left")
-
-        data = mock_responses[cb_call_counter]
-        cb_call_counter += 1
-        return CallbackResult(status=200, payload=data)
-
-    return _callback


### PR DESCRIPTION
Backported-from: main
Backported-to: 23.09
Backported-of: 3533

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

