### PR TITLE
fix: CLI test failures caused by `yarl.URL._val` type change (#3235)

### DIFF
--- a/changes/3235.fix.md
+++ b/changes/3235.fix.md
@@ -1,0 +1,1 @@
+Fix CLI test failures caused by `yarl.URL._val` type change.

--- a/src/ai/backend/client/auth.py
+++ b/src/ai/backend/client/auth.py
@@ -41,7 +41,7 @@ def generate_signature(
     Generates the API request signature from the given parameters.
     """
     hash_type = hash_type
-    hostname = endpoint._val.netloc  # type: ignore
+    hostname = endpoint.raw_authority
     body_hash = hashlib.new(hash_type, b"").hexdigest()
 
     sign_str = "{}\n{}\n{}\nhost:{}\ncontent-type:{}\nx-backendai-version:{}\n{}".format(  # noqa


### PR DESCRIPTION
Backported-from: main
Backported-to: 23.09
Backported-of: 3235

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->
