### PR TITLE
ci: Merge checksum files into one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
         pants list --filter-tag-regex='checksum' '::' | xargs -n 1 pants run
         # Merge checksums into a single file
         cat dist/*.sha256 > dist/checksum.txt
-        sort -u dist/checksum.txt -o dist/checksum.txt
+        mv dist/checksum.txt dist/checksum-${platform_suffix}.txt
         rm dist/*.sha256
     - name: Upload scies
       uses: actions/upload-artifact@v4
@@ -501,6 +501,10 @@ jobs:
         pattern: scies-*
         path: dist
         merge-multiple: true
+    - name: Merge checksum files into one
+      run: |
+        cat dist/checksum-*.txt > dist/checksum.txt
+        sort -u -k2 dist/checksum.txt -o dist/checksum.txt
     - name: Download SBOM report
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
#3575 (BA-635)

Since the build-scies job runs as a matrix, it will be overwritten by checksum.txt when uploading the artifact with all the same names.
We need to keep all the values, so we use platform-suffix to separate the files and have them merged into one file in the final step.
