### PR TITLE
fix(BA-641): Check intrinsic time files exist before mount (#3583)

### DIFF
--- a/changes/3583.fix.md
+++ b/changes/3583.fix.md
@@ -1,0 +1,1 @@
+Check intrinsic time files exist before mount

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -378,22 +378,26 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             )
         # /etc/localtime and /etc/timezone mounts
         if sys.platform.startswith("linux"):
-            mounts.append(
-                Mount(
-                    type=MountTypes.BIND,
-                    source=Path("/etc/localtime"),
-                    target=Path("/etc/localtime"),
-                    permission=MountPermission.READ_ONLY,
+            localtime_file = Path("/etc/localtime")
+            timezone_file = Path("/etc/timezone")
+            if localtime_file.exists():
+                mounts.append(
+                    Mount(
+                        type=MountTypes.BIND,
+                        source=localtime_file,
+                        target=localtime_file,
+                        permission=MountPermission.READ_ONLY,
+                    )
                 )
-            )
-            mounts.append(
-                Mount(
-                    type=MountTypes.BIND,
-                    source=Path("/etc/timezone"),
-                    target=Path("/etc/timezone"),
-                    permission=MountPermission.READ_ONLY,
+            if timezone_file.exists():
+                mounts.append(
+                    Mount(
+                        type=MountTypes.BIND,
+                        source=timezone_file,
+                        target=timezone_file,
+                        permission=MountPermission.READ_ONLY,
+                    )
                 )
-            )
         # lxcfs mounts
         lxcfs_root = Path("/var/lib/lxcfs")
         if lxcfs_root.is_dir():


### PR DESCRIPTION
This is an auto-generated backport PR of #3583 to the 24.09 release.