### PR TITLE
fix(BA-584): Remove foreign key constraint from `EndpointRow.image` column

### DIFF
--- a/changes/3599.fix.md
+++ b/changes/3599.fix.md
@@ -1,0 +1,1 @@
+Remove foreign key constraint from `EndpointRow.image` column.

--- a/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
@@ -20,6 +20,11 @@ depends_on = None
 def upgrade() -> None:
     op.drop_constraint("fk_endpoints_image_images", "endpoints", type_="foreignkey")
     op.alter_column("endpoints", "image", existing_type=GUID, nullable=True)
+    op.create_check_constraint(
+        constraint_name="ck_image_required_unless_destroyed",
+        table_name="endpoints",
+        condition="lifecycle_stage = 'destroyed' OR image IS NOT NULL",
+    )
 
 
 def downgrade() -> None:
@@ -27,3 +32,6 @@ def downgrade() -> None:
         "fk_endpoints_image_images", "endpoints", "images", ["image"], ["id"], ondelete="RESTRICT"
     )
     op.alter_column("endpoints", "image", existing_type=GUID, nullable=False)
+    op.drop_constraint(
+        constraint_name="ck_image_required_unless_destroyed", table_name="endpoints", type_="check"
+    )

--- a/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
@@ -1,0 +1,29 @@
+"""Remove foreign key constraint from endpoints.image column
+
+Revision ID: ecc9f6322be4
+Revises: f6ca2f2d04c1
+Create Date: 2025-02-07 00:58:05.211395
+
+"""
+
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "ecc9f6322be4"
+down_revision = "f6ca2f2d04c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("fk_endpoints_image_images", "endpoints", type_="foreignkey")
+    op.alter_column("endpoints", "image", existing_type=GUID, nullable=True)
+
+
+def downgrade() -> None:
+    op.create_foreign_key(
+        "fk_endpoints_image_images", "endpoints", "images", ["image"], ["id"], ondelete="RESTRICT"
+    )
+    op.alter_column("endpoints", "image", existing_type=GUID, nullable=False)

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -132,7 +132,10 @@ class EndpointRow(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "lifecycle_stage = 'destroyed' OR image IS NOT NULL",
+            sa.or_(
+                sa.column("lifecycle_stage") == EndpointLifecycle.DESTROYED,
+                sa.column("image").isnot(None),
+            ),
             name="ck_image_required_unless_destroyed",
         ),
     )
@@ -147,7 +150,7 @@ class EndpointRow(Base):
     )
     # minus session count means this endpoint is requested for removal
     replicas = sa.Column("replicas", sa.Integer, nullable=False, default=0, server_default="0")
-    image = sa.Column("image", GUID, nullable=True)
+    image = sa.Column("image", GUID)
     model = sa.Column(
         "model",
         GUID,

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -133,7 +133,7 @@ class EndpointRow(Base):
     __table_args__ = (
         CheckConstraint(
             sa.or_(
-                sa.column("lifecycle_stage") == EndpointLifecycle.DESTROYED,
+                sa.column("lifecycle_stage") == EndpointLifecycle.DESTROYED.value,
                 sa.column("image").isnot(None),
             ),
             name="ck_image_required_unless_destroyed",


### PR DESCRIPTION
Resolves #3509 ([BA-584](https://lablup.atlassian.net/browse/BA-584)).

This PR prevents issues like #3509 by removing the foreign key constraint on `EndpointRow.image`.
It also modifies the `EndpointRow.image` column to be conditionally nullable.
`EndpointRow.image` can only be null when in the "Destroyed" state.
This prevents the creation of a new session with an empty image when `EndpointRow.replicas` is modified.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue


[BA-584]: https://lablup.atlassian.net/browse/BA-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ