### PR TITLE
refactor(BA-657): Remove assignment of `pyroscope.configure()` return value

### DIFF
--- a/src/ai/backend/account_manager/server.py
+++ b/src/ai/backend/account_manager/server.py
@@ -285,7 +285,7 @@ async def server_main(
     Profiler(
         pyroscope_args=PyroscopeArgs(
             enabled=local_cfg.pyroscope.enabled,
-            app_name=local_cfg.pyroscope.app_name,
+            application_name=local_cfg.pyroscope.app_name,
             server_address=local_cfg.pyroscope.server_addr,
             sample_rate=local_cfg.pyroscope.sample_rate,
         )

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -998,7 +998,7 @@ async def server_main(
     Profiler(
         pyroscope_args=PyroscopeArgs(
             enabled=local_config["pyroscope"]["enabled"],
-            app_name=local_config["pyroscope"]["app-name"],
+            application_name=local_config["pyroscope"]["app-name"],
             server_address=local_config["pyroscope"]["server-addr"],
             sample_rate=local_config["pyroscope"]["sample-rate"],
         )

--- a/src/ai/backend/common/metrics/profiler.py
+++ b/src/ai/backend/common/metrics/profiler.py
@@ -14,7 +14,7 @@ class PyroscopeArgs:
 class Profiler:
     def __init__(self, pyroscope_args: PyroscopeArgs) -> None:
         if pyroscope_args.enabled:
-            self._pyroscope = pyroscope.configure(
+            pyroscope.configure(
                 app_name=pyroscope_args.app_name,
                 server_address=pyroscope_args.server_address,
                 sample_rate=pyroscope_args.sample_rate,

--- a/src/ai/backend/common/metrics/profiler.py
+++ b/src/ai/backend/common/metrics/profiler.py
@@ -6,7 +6,7 @@ import pyroscope
 @dataclass
 class PyroscopeArgs:
     enabled: bool
-    app_name: str
+    application_name: str
     server_address: str
     sample_rate: int
 
@@ -15,7 +15,7 @@ class Profiler:
     def __init__(self, pyroscope_args: PyroscopeArgs) -> None:
         if pyroscope_args.enabled:
             pyroscope.configure(
-                app_name=pyroscope_args.app_name,
+                application_name=pyroscope_args.application_name,
                 server_address=pyroscope_args.server_address,
                 sample_rate=pyroscope_args.sample_rate,
             )

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -817,7 +817,7 @@ def build_root_app(
     Profiler(
         pyroscope_args=PyroscopeArgs(
             enabled=local_config["pyroscope"]["enabled"],
-            app_name=local_config["pyroscope"]["app-name"],
+            application_name=local_config["pyroscope"]["app-name"],
             server_address=local_config["pyroscope"]["server-addr"],
             sample_rate=local_config["pyroscope"]["sample-rate"],
         )

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -95,7 +95,7 @@ async def server_main(
     Profiler(
         pyroscope_args=PyroscopeArgs(
             enabled=local_config["pyroscope"]["enabled"],
-            app_name=local_config["pyroscope"]["app-name"],
+            application_name=local_config["pyroscope"]["app-name"],
             server_address=local_config["pyroscope"]["server-addr"],
             sample_rate=local_config["pyroscope"]["sample-rate"],
         )

--- a/src/ai/backend/wsproxy/server.py
+++ b/src/ai/backend/wsproxy/server.py
@@ -242,7 +242,7 @@ def build_root_app(
     Profiler(
         pyroscope_args=PyroscopeArgs(
             enabled=local_config.pyroscope.enabled,
-            app_name=local_config.pyroscope.app_name,
+            application_name=local_config.pyroscope.app_name,
             server_address=local_config.pyroscope.server_addr,
             sample_rate=local_config.pyroscope.sample_rate,
         )


### PR DESCRIPTION
Follow-up of #3459 and resolves #3600 (BA-657)

According to the pyroscope implementation, `pyroscope.configure()` always returns `None`. Therefore, this pull request suggests to remove meaningless assignment for the return value of `pyroscope.configure()`.

https://github.com/grafana/pyroscope-rs/blob/9f71fd08a314518119d33e7a3a8bcfb9f60ba868/pyroscope_ffi/python/pyroscope/__init__.py#L10-L59%7Csmart-link

This pull request includes a modification to the `Profiler` class in the `src/ai/backend/common/metrics/profiler.py` file. The change removes the assignment of the `pyroscope.configure` call to the `_pyroscope` attribute, simplifying the initialization process.

* [`src/ai/backend/common/metrics/profiler.py`](diffhunk://#diff-48e98260c65436406f498f4b4f6ec43152355668366d333f9ccc7c567bc0dbb9L17-R17): Removed the assignment of the `pyroscope.configure` call to the `_pyroscope` attribute in the `Profiler` class initialization.

**Checklist:** (if applicable)

- [x] Mention to the original issue
