### PR TITLE
fix(BA-584): Remove foreign key constraint from `EndpointRow.image` column (#3599)

### DIFF
--- a/changes/3599.fix.md
+++ b/changes/3599.fix.md
@@ -1,0 +1,1 @@
+Remove foreign key constraint from `EndpointRow.image` column.

--- a/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
@@ -1,0 +1,37 @@
+"""Remove foreign key constraint from endpoints.image column
+
+Revision ID: ecc9f6322be4
+Revises: f6ca2f2d04c1
+Create Date: 2025-02-07 00:58:05.211395
+
+"""
+
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "ecc9f6322be4"
+down_revision = "f6ca2f2d04c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("fk_endpoints_image_images", "endpoints", type_="foreignkey")
+    op.alter_column("endpoints", "image", existing_type=GUID, nullable=True)
+    op.create_check_constraint(
+        constraint_name="ck_image_required_unless_destroyed",
+        table_name="endpoints",
+        condition="lifecycle_stage = 'destroyed' OR image IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.create_foreign_key(
+        "fk_endpoints_image_images", "endpoints", "images", ["image"], ["id"], ondelete="RESTRICT"
+    )
+    op.alter_column("endpoints", "image", existing_type=GUID, nullable=False)
+    op.drop_constraint(
+        constraint_name="ck_image_required_unless_destroyed", table_name="endpoints", type_="check"
+    )

--- a/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc9f6322be4_remove_fk_constraint_from_endpoints_.py
@@ -1,7 +1,7 @@
 """Remove foreign key constraint from endpoints.image column
 
 Revision ID: ecc9f6322be4
-Revises: f6ca2f2d04c1
+Revises: 75ea2b136830
 Create Date: 2025-02-07 00:58:05.211395
 
 """
@@ -12,7 +12,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "ecc9f6322be4"
-down_revision = "f6ca2f2d04c1"
+down_revision = "75ea2b136830"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -23,11 +23,8 @@ import aiotools
 import graphene
 import sqlalchemy as sa
 import trafaret as t
-from graphql import Undefined
-from redis.asyncio import Redis
-from redis.asyncio.client import Pipeline
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import relationship, selectinload
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
+from sqlalchemy.orm import foreign, joinedload, load_only, relationship, selectinload
 
 from ai.backend.common import redis_helper
 from ai.backend.common.docker import ImageRef
@@ -149,6 +146,13 @@ class ImageType(enum.Enum):
     SERVICE = "service"
 
 
+# Defined for avoiding circular import
+def _get_image_endpoint_join_condition():
+    from ai.backend.manager.models.endpoint import EndpointRow
+
+    return ImageRow.id == foreign(EndpointRow.image)
+
+
 class ImageRow(Base):
     __tablename__ = "images"
     id = IDColumn("id")
@@ -191,8 +195,11 @@ class ImageRow(Base):
     )
     aliases: relationship
     # sessions = relationship("SessionRow", back_populates="image_row")
-    # kernels = relationship("KernelRow", back_populates="image_row")
-    endpoints = relationship("EndpointRow", back_populates="image_row")
+    endpoints = relationship(
+        "EndpointRow",
+        primaryjoin=_get_image_endpoint_join_condition,
+        back_populates="image_row",
+    )
 
     def __init__(
         self,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -23,8 +23,8 @@ import aiotools
 import graphene
 import sqlalchemy as sa
 import trafaret as t
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
-from sqlalchemy.orm import foreign, joinedload, load_only, relationship, selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import foreign, relationship, selectinload
 
 from ai.backend.common import redis_helper
 from ai.backend.common.docker import ImageRef
@@ -195,6 +195,7 @@ class ImageRow(Base):
     )
     aliases: relationship
     # sessions = relationship("SessionRow", back_populates="image_row")
+    # kernels = relationship("KernelRow", back_populates="image_row")
     endpoints = relationship(
         "EndpointRow",
         primaryjoin=_get_image_endpoint_join_condition,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -23,6 +23,9 @@ import aiotools
 import graphene
 import sqlalchemy as sa
 import trafaret as t
+from graphql import Undefined
+from redis.asyncio import Redis
+from redis.asyncio.client import Pipeline
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import foreign, relationship, selectinload
 


### PR DESCRIPTION
This is an auto-generated backport PR of #3599 to the 23.09 release.