### PR TITLE
feat(BA-675): Implement `Image` status filtering logics

### DIFF
--- a/changes/3647.feature.md
+++ b/changes/3647.feature.md
@@ -1,1 +1,1 @@
-Implement `Image` status filtering logics. (e.g. adding an optional argument to the `Image`, `ImageNode` GQL resolvers allowing query DELETED images as well)
+Implement `Image` status filtering logics. (e.g. adding an optional argument to the `Image`, `ImageNode` GQL resolvers to enable querying deleted images as well.)

--- a/changes/3647.feature.md
+++ b/changes/3647.feature.md
@@ -1,0 +1,1 @@
+Implement `Image` status filtering logics. (e.g. adding an optional argument to the `Image`, `ImageNode` GQL resolvers allowing query DELETED images as well)

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -93,7 +93,7 @@ type Queries {
     is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null.")
 
     """Added in 25.3.1."""
-    load_only_active: Boolean = true
+    filter_by_statuses: [ImageStatus] = [ALIVE]
 
     """
     Added in 24.03.8. Allowed values are: [general, operational, customized]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.
@@ -126,7 +126,7 @@ type Queries {
     permission: ImagePermissionValueField = "read_attribute"
 
     """Added in 25.3.1."""
-    load_only_active: Boolean = true
+    filter_by_statuses: [ImageStatus] = [ALIVE]
     filter: String
     order: String
     offset: Int
@@ -909,6 +909,12 @@ type Image {
   installed: Boolean
   installed_agents: [String]
   hash: String
+}
+
+"""Added in 25.3.1."""
+enum ImageStatus {
+  ALIVE
+  DELETED
 }
 
 """Added in 25.3.0."""

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -92,7 +92,7 @@ type Queries {
     is_installed: Boolean
     is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null.")
 
-    """Added in 25.3.1."""
+    """Added in 25.4.0."""
     filter_by_statuses: [ImageStatus] = [ALIVE]
 
     """
@@ -125,7 +125,7 @@ type Queries {
     """Default is read_attribute."""
     permission: ImagePermissionValueField = "read_attribute"
 
-    """Added in 25.3.1."""
+    """Added in 25.4.0."""
     filter_by_statuses: [ImageStatus] = [ALIVE]
     filter: String
     order: String
@@ -911,7 +911,7 @@ type Image {
   hash: String
 }
 
-"""Added in 25.3.1."""
+"""Added in 25.4.0."""
 enum ImageStatus {
   ALIVE
   DELETED

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -92,7 +92,7 @@ type Queries {
     is_installed: Boolean
     is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null.")
 
-    """Added in 25.3.0."""
+    """Added in 25.3.1."""
     load_only_active: Boolean = true
 
     """
@@ -125,7 +125,7 @@ type Queries {
     """Default is read_attribute."""
     permission: ImagePermissionValueField = "read_attribute"
 
-    """Added in 25.3.0."""
+    """Added in 25.3.1."""
     load_only_active: Boolean = true
     filter: String
     order: String

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -92,6 +92,9 @@ type Queries {
     is_installed: Boolean
     is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null.")
 
+    """Added in 25.3.0."""
+    load_only_active: Boolean = true
+
     """
     Added in 24.03.8. Allowed values are: [general, operational, customized]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by callee). To resolve images owned by user only call `customized_images`.
     """

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -124,6 +124,9 @@ type Queries {
 
     """Default is read_attribute."""
     permission: ImagePermissionValueField = "read_attribute"
+
+    """Added in 25.3.0."""
+    load_only_active: Boolean = true
     filter: String
     order: String
     offset: Int

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -51,7 +51,7 @@ from sqlalchemy.sql.expression import null, true
 from ai.backend.common.bgtask import ProgressReporter
 from ai.backend.common.docker import ImageRef
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.image import ImageIdentifier, rescan_images
+from ai.backend.manager.models.image import ImageIdentifier, ImageStatus, rescan_images
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
@@ -1261,6 +1261,7 @@ async def convert_session_to_image(
                             == f"{params.image_visibility.value}:{image_owner_id}"
                         )
                     )
+                    .where(ImageRow.status == ImageStatus.ALIVE)
                 )
                 existing_image_count = await sess.scalar(query)
 
@@ -1277,16 +1278,20 @@ async def convert_session_to_image(
                     )
 
                 # check if image with same name exists and reuse ID it if is
-                query = sa.select(ImageRow).where(
-                    ImageRow.name.like(f"{new_canonical}%")
-                    & (
-                        ImageRow.labels["ai.backend.customized-image.owner"].as_string()
-                        == f"{params.image_visibility.value}:{image_owner_id}"
+                query = (
+                    sa.select(ImageRow)
+                    .where(
+                        ImageRow.name.like(f"{new_canonical}%")
+                        & (
+                            ImageRow.labels["ai.backend.customized-image.owner"].as_string()
+                            == f"{params.image_visibility.value}:{image_owner_id}"
+                        )
+                        & (
+                            ImageRow.labels["ai.backend.customized-image.name"].as_string()
+                            == params.image_name
+                        )
                     )
-                    & (
-                        ImageRow.labels["ai.backend.customized-image.name"].as_string()
-                        == params.image_name
-                    )
+                    .where(ImageRow.status == ImageStatus.ALIVE)
                 )
                 existing_row = await sess.scalar(query)
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1278,20 +1278,15 @@ async def convert_session_to_image(
                     )
 
                 # check if image with same name exists and reuse ID it if is
-                query = (
-                    sa.select(ImageRow)
-                    .where(
-                        ImageRow.name.like(f"{new_canonical}%")
-                        & (
-                            ImageRow.labels["ai.backend.customized-image.owner"].as_string()
-                            == f"{params.image_visibility.value}:{image_owner_id}"
-                        )
-                        & (
-                            ImageRow.labels["ai.backend.customized-image.name"].as_string()
-                            == params.image_name
-                        )
+                query = sa.select(ImageRow).where(
+                    sa.and_(
+                        ImageRow.name.like(f"{new_canonical}%"),
+                        ImageRow.labels["ai.backend.customized-image.owner"].as_string()
+                        == f"{params.image_visibility.value}:{image_owner_id}",
+                        ImageRow.labels["ai.backend.customized-image.name"].as_string()
+                        == params.image_name,
+                        ImageRow.status == ImageStatus.ALIVE,
                     )
-                    .where(ImageRow.status == ImageStatus.ALIVE)
                 )
                 existing_row = await sess.scalar(query)
 

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -138,7 +138,7 @@ async def purge_image(cli_ctx, canonical_or_alias, architecture):
                     ImageIdentifier(canonical_or_alias, architecture),
                     ImageAlias(canonical_or_alias),
                 ],
-                load_only_active=False,
+                filter_by_statuses=None,
             )
             await session.delete(image_row)
         except UnknownImageReference:

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -16,7 +16,7 @@ from ai.backend.common.exception import UnknownImageReference
 from ai.backend.common.types import ImageAlias
 from ai.backend.logging import BraceStyleAdapter
 
-from ..models.image import ImageAliasRow, ImageIdentifier, ImageRow
+from ..models.image import ImageAliasRow, ImageIdentifier, ImageRow, ImageStatus
 from ..models.image import rescan_images as rescan_images_func
 from ..models.utils import connect_database
 from .context import CLIContext, redis_ctx
@@ -263,9 +263,9 @@ async def validate_image_canonical(
                     print(value)
             else:
                 rows = await session.scalars(
-                    sa.select(ImageRow)
-                    .where(ImageRow.name == canonical)
-                    .where(ImageRow.status == ImageStatus.ALIVE)
+                    sa.select(ImageRow).where(
+                        sa.and_(ImageRow.name == canonical, ImageRow.status == ImageStatus.ALIVE)
+                    )
                 )
                 image_rows = rows.fetchall()
                 if not image_rows:

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -33,7 +33,7 @@ async def list_images(cli_ctx, short, installed_only):
     ):
         displayed_items = []
         try:
-            # Idea: Add `deleted` option to include deleted images.
+            # Idea: Add `--include-deleted` option to include deleted images?
             items = await ImageRow.list(session)
             # NOTE: installed/installed_agents fields are no longer provided in CLI,
             #       until we finish the epic refactoring of image metadata db.

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -33,7 +33,6 @@ async def list_images(cli_ctx, short, installed_only):
     ):
         displayed_items = []
         try:
-            # TODO QUESTION: Should we display deleted image here?
             # Idea: Add `deleted` option to include deleted images.
             items = await ImageRow.list(session)
             # NOTE: installed/installed_agents fields are no longer provided in CLI,
@@ -252,7 +251,6 @@ async def validate_image_canonical(
                 if current:
                     architecture = architecture or CURRENT_ARCH
 
-                # TODO QUESTION: Should we use deleted image here?
                 assert architecture is not None
                 image_row = await ImageRow.resolve(
                     session, [ImageIdentifier(canonical, architecture)]
@@ -264,7 +262,6 @@ async def validate_image_canonical(
                         value = f"{', '.join(value)}"
                     print(value)
             else:
-                # TODO QUESTION: Should we use deleted image here?
                 rows = await session.scalars(
                     sa.select(ImageRow)
                     .where(ImageRow.name == canonical)

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -194,24 +194,22 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                             await reporter.update(1, message=progress_msg)
                         continue
 
-                    session.add(
-                        ImageRow(
-                            name=parsed_img.canonical,
-                            project=self.registry_info.project,
-                            registry=parsed_img.registry,
-                            registry_id=self.registry_info.id,
-                            image=join_non_empty(parsed_img.project, parsed_img.name, sep="/"),
-                            tag=parsed_img.tag,
-                            architecture=image_identifier.architecture,
-                            is_local=is_local,
-                            config_digest=update["config_digest"],
-                            size_bytes=update["size_bytes"],
-                            type=ImageType.COMPUTE,
-                            accelerators=update.get("accels"),
-                            labels=update["labels"],
-                            resources=update["resources"],
-                            status=ImageStatus.ALIVE,
-                        )
+                    image_row = ImageRow(
+                        name=parsed_img.canonical,
+                        project=self.registry_info.project,
+                        registry=parsed_img.registry,
+                        registry_id=self.registry_info.id,
+                        image=join_non_empty(parsed_img.project, parsed_img.name, sep="/"),
+                        tag=parsed_img.tag,
+                        architecture=image_identifier.architecture,
+                        is_local=is_local,
+                        config_digest=update["config_digest"],
+                        size_bytes=update["size_bytes"],
+                        type=ImageType.COMPUTE,
+                        accelerators=update.get("accels"),
+                        labels=update["labels"],
+                        resources=update["resources"],
+                        status=ImageStatus.ALIVE,
                     )
                     session.add(image_row)
                     scanned_images.append(image_row)

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -150,7 +150,6 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         else:
             image_identifiers = [(k.canonical, k.architecture) for k in _all_updates.keys()]
             async with self.db.begin_session() as session:
-                # TODO QUESTION: Should we filter out deleted image here?
                 existing_images = await session.scalars(
                     sa.select(ImageRow)
                     .where(

--- a/src/ai/backend/manager/container_registry/local.py
+++ b/src/ai/backend/manager/container_registry/local.py
@@ -81,6 +81,7 @@ class LocalRegistry(BaseContainerRegistry):
             already_exists = 0
             config_digest = data["Id"]
             async with self.db.begin_readonly_session() as db_session:
+                # TODO QUESTION: Should we use deleted image here?
                 already_exists = await db_session.scalar(
                     sa.select([sa.func.count(ImageRow.id)]).where(
                         ImageRow.config_digest == config_digest,

--- a/src/ai/backend/manager/container_registry/local.py
+++ b/src/ai/backend/manager/container_registry/local.py
@@ -82,12 +82,13 @@ class LocalRegistry(BaseContainerRegistry):
             config_digest = data["Id"]
             async with self.db.begin_readonly_session() as db_session:
                 already_exists = await db_session.scalar(
-                    sa.select([sa.func.count(ImageRow.id)])
-                    .where(
-                        ImageRow.config_digest == config_digest,
-                        ImageRow.is_local == sa.false(),
-                    )
-                    .where(ImageRow.status == ImageStatus.ALIVE),
+                    sa.select([sa.func.count(ImageRow.id)]).where(
+                        sa.and_(
+                            ImageRow.config_digest == config_digest,
+                            ImageRow.is_local == sa.false(),
+                            ImageRow.status == ImageStatus.ALIVE,
+                        )
+                    ),
                 )
             if already_exists > 0:
                 return {}, "already synchronized from a remote registry"

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -618,6 +618,7 @@ class Queries(graphene.ObjectType):
             default_value=ImagePermission.READ_ATTRIBUTE,
             description=f"Default is {ImagePermission.READ_ATTRIBUTE.value}.",
         ),
+        load_only_active=graphene.Boolean(default_value=True, description="Added in 25.3.0."),
     )
 
     user = graphene.Field(
@@ -1754,6 +1755,7 @@ class Queries(graphene.ObjectType):
         info: graphene.ResolveInfo,
         *,
         scope_id: ScopeType,
+        load_only_active: bool = True,
         permission: ImagePermission = ImagePermission.READ_ATTRIBUTE,
         filter: Optional[str] = None,
         order: Optional[str] = None,
@@ -1767,6 +1769,7 @@ class Queries(graphene.ObjectType):
             info,
             scope_id,
             permission,
+            load_only_active,
             filter_expr=filter,
             order_expr=order,
             offset=offset,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -583,7 +583,7 @@ class Queries(graphene.ObjectType):
         ),
         load_only_active=graphene.Boolean(
             default_value=True,
-            description="Added in 25.3.0.",
+            description="Added in 25.3.1.",
         ),
         load_filters=graphene.List(
             graphene.String,
@@ -618,7 +618,10 @@ class Queries(graphene.ObjectType):
             default_value=ImagePermission.READ_ATTRIBUTE,
             description=f"Default is {ImagePermission.READ_ATTRIBUTE.value}.",
         ),
-        load_only_active=graphene.Boolean(default_value=True, description="Added in 25.3.0."),
+        load_only_active=graphene.Boolean(
+            default_value=True,
+            description="Added in 25.3.1.",
+        ),
     )
 
     user = graphene.Field(

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -586,7 +586,7 @@ class Queries(graphene.ObjectType):
         filter_by_statuses=graphene.List(
             ImageStatusType,
             default_value=[ImageStatus.ALIVE],
-            description="Added in 25.3.1.",
+            description="Added in 25.4.0.",
         ),
         load_filters=graphene.List(
             graphene.String,
@@ -624,7 +624,7 @@ class Queries(graphene.ObjectType):
         filter_by_statuses=graphene.List(
             ImageStatusType,
             default_value=[ImageStatus.ALIVE],
-            description="Added in 25.3.1.",
+            description="Added in 25.4.0.",
         ),
     )
 

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -124,7 +124,7 @@ _queryorder_colmap: ColumnMapType = {
     "accelerators": ("accelerators", None),
 }
 
-ImageStatusType = graphene.Enum.from_enum(ImageStatus, description="Added in 25.3.1.")
+ImageStatusType = graphene.Enum.from_enum(ImageStatus, description="Added in 25.4.0.")
 
 
 class Image(graphene.ObjectType):

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -1070,7 +1070,6 @@ class ImagePermissionContextBuilder(
             sa.select(ImageRow)
             .join(ImageRow.registry_row)
             .options(load_only(ImageRow.id, ImageRow.registry))
-            .where(ImageRow.status == ImageStatus.ALIVE)
             .where(ContainerRegistryRow.is_global == true())
         )
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #3618 ([BA-675](https://lablup.atlassian.net/browse/BA-675)).

Images marked as "DELETED" cannot be used in CLI commands by default (e.g., `inspect`).
Similarly, "DELETED" images are not retrieved in GQL by default.

**Checklist:** (if applicable)

- [x] Mention to the original issue


[BA-675]: https://lablup.atlassian.net/browse/BA-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3647.org.readthedocs.build/en/3647/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3647.org.readthedocs.build/ko/3647/

<!-- readthedocs-preview sorna-ko end -->