### PR TITLE
fix(BA-694): Number of concurrent sftp session queried incorrectly

### DIFF
--- a/changes/3654.fix.md
+++ b/changes/3654.fix.md
@@ -1,0 +1,1 @@
+Correct the number of concurrent SFTP sessions queried from DB

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1609,7 +1609,7 @@ async def recalc_concurrency_used(
             .where(
                 (KernelRow.access_key == access_key)
                 & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                & (KernelRow.session_type.not_in(PRIVATE_SESSION_TYPES))
+                & (KernelRow.session_type.in_(PRIVATE_SESSION_TYPES))
             ),
         )
         sftp_concurrency_used = result.scalar()


### PR DESCRIPTION
resolves #3653 (BA-694)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [x] API server-client counterparts (e.g., manager API -> client SDK)