### PR TITLE
fix(BA-694): Number of concurrent sftp session queried incorrectly (#3654)

### DIFF
--- a/changes/3654.fix.md
+++ b/changes/3654.fix.md
@@ -1,0 +1,1 @@
+Correct the number of concurrent SFTP sessions queried from DB

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -1500,7 +1500,7 @@ async def recalc_concurrency_used(
             .where(
                 (KernelRow.access_key == access_key)
                 & (KernelRow.status.in_(USER_RESOURCE_OCCUPYING_KERNEL_STATUSES))
-                & (KernelRow.session_type.not_in(PRIVATE_SESSION_TYPES))
+                & (KernelRow.session_type.in_(PRIVATE_SESSION_TYPES))
             ),
         )
         sftp_concurrency_used = result.scalar()


### PR DESCRIPTION
This is an auto-generated backport PR of #3654 to the 24.03 release.