### PR TITLE
fix(BA-714): Correct `mkdir` flag order for creating grafana-data

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -849,7 +849,7 @@ setup_environment() {
   mkdir -p "${HALFSTACK_VOLUME_PATH}/postgres-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/etcd-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/redis-data"
-  mkdir -p "${HALFSTACK_VOLUME_PATH}/grafana-data" -m 757
+  mkdir -m 757 -p "${HALFSTACK_VOLUME_PATH}/grafana-data"
 
   $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" pull
 


### PR DESCRIPTION
Follow-up of #3570 and resolves #3661 (BA-714)

This pull request includes a minor change to the `setup_environment` function in the `scripts/install-dev.sh` file. The change modifies the order of the `-m 757` and `-p` options in the `mkdir` command for creating the `grafana-data` directory.

* [`scripts/install-dev.sh`](diffhunk://#diff-fc14db900b51b907631d49f3f67ffbe5cde7849d23d9e3103e8a3577f903061cL852-R852): Changed the order of options in the `mkdir` command for the `grafana-data` directory to ensure the correct permissions are set.

**Checklist:** (if applicable)

- [x] Mention to the original issue
