### PR TITLE
feat(BA-624): Add vfolder repository layer in manager

### DIFF
--- a/src/ai/backend/common/dto/manager/field.py
+++ b/src/ai/backend/common/dto/manager/field.py
@@ -47,8 +47,8 @@ class VFolderItemField(BaseModel):
     cloneable: bool
     status: VFolderOperationStatusField
     is_owner: bool
-    user_email: str
-    group_name: str
+    user_email: Optional[str]
+    group_name: Optional[str]
     type: str  # legacy
     max_files: int
     cur_size: int

--- a/src/ai/backend/common/dto/manager/request.py
+++ b/src/ai/backend/common/dto/manager/request.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import AliasChoices, BaseModel, Field
 
 from ai.backend.common import typed_validators as tv
-from ai.backend.common.dto.manager.dto import VFolderPermissionDTO
+from ai.backend.common.dto.manager.field import VFolderPermissionField
 from ai.backend.common.types import VFolderUsageMode
 
 
@@ -17,7 +17,7 @@ class VFolderCreateReq(BaseModel):
         default=None,
     )
     usage_mode: VFolderUsageMode = Field(default=VFolderUsageMode.GENERAL)
-    permission: VFolderPermissionDTO = Field(default=VFolderPermissionDTO.READ_WRITE)
+    permission: VFolderPermissionField = Field(default=VFolderPermissionField.READ_WRITE)
     unmanaged_path: Optional[str] = Field(
         validation_alias=AliasChoices("unmanaged_path", "unmanagedPath"),
         default=None,

--- a/src/ai/backend/manager/api/vfolders/repositories.py
+++ b/src/ai/backend/manager/api/vfolders/repositories.py
@@ -1,0 +1,414 @@
+import uuid
+from contextlib import AbstractAsyncContextManager as AbstractAsyncCtxMgr
+from typing import Any, Awaitable, Callable, Iterable, Optional, ParamSpec, TypeVar
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
+from sqlalchemy.orm import selectinload
+
+from ai.backend.manager.api.exceptions import GroupNotFound, UserNotFound
+from ai.backend.manager.data.vfolder.dto import (
+    UserIdentity,
+    VFolderItem,
+    VFolderMetadataToCreate,
+    VFolderResourceLimit,
+)
+from ai.backend.manager.models import (
+    HARD_DELETED_VFOLDER_STATUSES,
+    ProjectType,
+    UserRole,
+    VFolderOperationStatus,
+    VFolderOwnershipType,
+    VFolderPermission,
+    VFolderStatusSet,
+    vfolder_status_map,
+)
+from ai.backend.manager.models.group import AssocGroupUserRow
+from ai.backend.manager.models.utils import (
+    ExtendedAsyncSAEngine,
+    execute_with_txn_retry,
+)
+from ai.backend.manager.models.vfolder import (
+    GroupRow,
+    UserRow,
+    VFolderInvitationRow,
+    VFolderPermissionRow,
+    VFolderRow,
+)
+
+_P = ParamSpec("_P")
+_TQueryResult = TypeVar("_TQueryResult")
+
+
+class VFolderRepository:
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    async def get_group_type(self, group_id: uuid.UUID) -> ProjectType:
+        async with self._db.begin_session() as sess:
+            query = sa.select(GroupRow).where(GroupRow.id == group_id)
+            group_row = await sess.scalar(query)
+
+            if group_row is None:
+                raise GroupNotFound(extra_data=group_id)
+
+        return group_row.type
+
+    async def get_user_container_id(self, user_id: uuid.UUID) -> Optional[int]:
+        async with self._db.begin_session() as sess:
+            query = sa.select(UserRow.container_uid).where(UserRow.uuid == user_id)
+            result = await sess.scalar(query)
+        return result
+
+    async def get_created_vfolder_count(
+        self, owner_id: uuid.UUID, ownership_type: VFolderOwnershipType
+    ) -> int:
+        async with self._db.begin_session() as sess:
+            if ownership_type == VFolderOwnershipType.USER:
+                ownership_type_caluse = VFolderRow.user == owner_id
+            else:
+                ownership_type_caluse = VFolderRow.group == owner_id
+
+            query = (
+                sa.select([sa.func.count()])
+                .select_from(VFolderRow)
+                .where(
+                    (ownership_type_caluse)
+                    & (VFolderRow.status.not_in(HARD_DELETED_VFOLDER_STATUSES))
+                )
+            )
+            result = await sess.scalar(query)
+
+        return result
+
+    async def get_user_vfolder_resource_limit(
+        self, user_identity: UserIdentity
+    ) -> VFolderResourceLimit:
+        async with self._db.begin_session() as sess:
+            query = (
+                sa.select(UserRow)
+                .where(UserRow.uuid == user_identity.user_uuid)
+                .options(selectinload(UserRow.resource_policy_row))
+            )
+            user_row = await sess.scalar(query)
+
+            if user_row is None:
+                raise UserNotFound(extra_data=user_identity.user_uuid)
+
+            max_vfolder_count = user_row.resource_policy_row.max_vfolder_count
+            max_quota_scope_size = user_row.resource_policy_row.max_quota_scope_size
+
+        return VFolderResourceLimit(
+            max_vfolder_count=max_vfolder_count,
+            max_quota_scope_size=max_quota_scope_size,
+        )
+
+    async def get_group_vfolder_resource_limit(
+        self, user_identity: UserIdentity, group_id: uuid.UUID
+    ) -> VFolderResourceLimit:
+        async with self._db.begin_session() as sess:
+            query = (
+                sa.select(GroupRow)
+                .where(
+                    (GroupRow.domain_name == user_identity.domain_name) & (GroupRow.id == group_id)
+                )
+                .options(selectinload(GroupRow.resource_policy_row))
+            )
+            group_row = await sess.scalar(query)
+
+            if group_row is None:
+                raise GroupNotFound(extra_data=group_id)
+
+            max_vfolder_count = group_row.resource_policy_row.max_vfolder_count
+            max_quota_scope_size = group_row.resource_policy_row.max_quota_scope_size
+
+        return VFolderResourceLimit(
+            max_vfolder_count=max_vfolder_count,
+            max_quota_scope_size=max_quota_scope_size,
+        )
+
+    async def persist_vfolder_metadata(self, metadata: VFolderMetadataToCreate) -> VFolderItem:
+        async with self._db.begin_session() as sess:
+            query = sa.insert(VFolderRow).values(metadata.to_dict()).returning(VFolderRow)
+            vfolder: VFolderRow = await sess.scalar(query)
+            vfolder_item = VFolderItem.from_orm(orm=vfolder, is_owner=True)
+        return vfolder_item
+
+    async def create_vfolder_permission(
+        self,
+        user_id: uuid.UUID,
+        vfolder_id: uuid.UUID,
+        permission: VFolderPermission = VFolderPermission.OWNER_PERM,
+    ) -> None:
+        async with self._db.begin_session() as sess:
+            insert_value: dict[str, Any] = {
+                "user": user_id,
+                "vfolder": vfolder_id.hex,
+                "permission": permission,
+            }
+
+            stmt = sa.insert(VFolderPermissionRow).values(insert_value)
+            await sess.execute(stmt)
+
+    async def get_accessible_folders(
+        self,
+        user_identity: UserIdentity,
+        allowed_vfolder_types: list[str],
+        group_id: Optional[uuid.UUID] = None,
+    ) -> list[VFolderItem]:
+        all_entries: list[VFolderItem] = []
+        if "user" in allowed_vfolder_types:
+            owned_vfolders = await self.query_owned_vfolders(
+                user_identity=user_identity, group_id=group_id
+            )
+            all_entries.extend(owned_vfolders)
+
+            shared_vfolders = await self.query_shared_vfolders(user_identity=user_identity)
+            all_entries.extend(shared_vfolders)
+
+        if "group" in allowed_vfolder_types:
+            if group_id is not None:
+                group_vfolders = await self._query_specific_group_vfolders(user_identity, group_id)
+            else:
+                group_vfolders = await self._query_all_accessible_group_vfolders(user_identity)
+
+            all_entries.extend(group_vfolders)
+
+        return all_entries
+
+    async def _query_specific_group_vfolders(
+        self,
+        user_identity: UserIdentity,
+        group_id: uuid.UUID,
+    ) -> list[VFolderItem]:
+        async with self._db.begin_session() as sess:
+            if user_identity.is_admin:
+                # check if group belongs to admin's domain
+                domain_check_query = (
+                    sa.select(GroupRow.id)
+                    .select_from(GroupRow)
+                    .where(
+                        (GroupRow.id == group_id)
+                        & (GroupRow.domain_name == user_identity.domain_name)
+                    )
+                )
+                if await sess.scalar(domain_check_query) is None:
+                    raise GroupNotFound(
+                        extra_msg=f"group {group_id} does not belong to domain {user_identity.domain_name}"
+                    )
+
+            if user_identity.is_normal_user:
+                # check if user is in the group
+                membership_query = (
+                    sa.select(AssocGroupUserRow.group_id)
+                    .select_from(AssocGroupUserRow)
+                    .where(
+                        (AssocGroupUserRow.user_id == user_identity.user_uuid)
+                        & (AssocGroupUserRow.group_id == group_id)
+                    )
+                )
+                if await sess.scalar(membership_query) is None:
+                    raise GroupNotFound(
+                        extra_msg=f"user {user_identity.user_uuid} is not a member of group {group_id}"
+                    )
+
+            query = (
+                sa.select(VFolderRow)
+                .select_from(VFolderRow.join(GroupRow, VFolderRow.group == GroupRow.id))
+                .where(
+                    (
+                        (VFolderRow.group == group_id)
+                        | (VFolderRow.user.isnot(None))
+                        & VFolderRow.status.not_in(
+                            vfolder_status_map[VFolderStatusSet.INACCESSIBLE]
+                        )
+                    )
+                )
+            )
+            vfolders: list[VFolderRow] = (await sess.scalars(query)).all()
+
+        entries = [
+            VFolderItem.from_orm(
+                orm=vfolder,
+                is_owner=user_identity.has_privilege_role,
+                include_relations=True,
+                override_with_group_member_permission=True,
+            )
+            for vfolder in vfolders
+        ]
+
+        return entries
+
+    async def _query_all_accessible_group_vfolders(
+        self,
+        user_identity: UserIdentity,
+    ) -> list[VFolderItem]:
+        async with self._db.begin_session() as sess:
+            base_query = (
+                sa.select(VFolderRow)
+                .select_from(VFolderRow.join(GroupRow, VFolderRow.group == GroupRow.id))
+                .where(VFolderRow.status.not_in(vfolder_status_map[VFolderStatusSet.INACCESSIBLE]))
+            )
+
+            if user_identity.is_superadmin:
+                query = base_query
+            elif user_identity.is_admin:
+                query = (
+                    sa.select(GroupRow.id)
+                    .select_from(GroupRow)
+                    .where(GroupRow.domain_name == user_identity.domain_name)
+                )
+                group_ids = await sess.scalars(query)
+                query = base_query.where(VFolderRow.group.in_(group_ids))
+            else:
+                query = (
+                    sa.select(AssocGroupUserRow.group_id)
+                    .select_from(
+                        AssocGroupUserRow.join(UserRow, AssocGroupUserRow.user_id == UserRow.uuid)
+                    )
+                    .where(AssocGroupUserRow.user_id == user_identity.user_uuid)
+                )
+                group_ids = await sess.scalars(query)
+                query = base_query.where(VFolderRow.group.in_(group_ids))
+
+            vfolders: list[VFolderRow] = (await sess.scalars(query)).all()
+            entries = [
+                VFolderItem.from_orm(
+                    orm=vfolder, is_owner=user_identity.has_privilege_role, include_relations=True
+                )
+                for vfolder in vfolders
+            ]
+
+        return entries
+
+    async def query_owned_vfolders(
+        self, user_identity: UserIdentity, group_id: Optional[uuid.UUID] = None
+    ) -> list[VFolderItem]:
+        async with self._db.begin_session() as sess:
+            user_join = VFolderRow.join(UserRow, VFolderRow.user == UserRow.uuid)
+
+            query = (
+                sa.select(VFolderRow)
+                .select_from(user_join)
+                .where(VFolderRow.status.not_in(vfolder_status_map[VFolderStatusSet.INACCESSIBLE]))
+            )
+            # If group id is provided, filter user owned vfolders that are in certain group
+            if group_id is not None:
+                query = query.where((VFolderRow.group == group_id) | (VFolderRow.user.isnot(None)))
+
+            if user_identity.user_role not in (UserRole.ADMIN, UserRole.SUPERADMIN):
+                query = query.where(VFolderRow.user == user_identity.user_uuid)
+
+            vfolders: list[VFolderRow] = (await sess.scalars(query)).all()
+            entries = [
+                VFolderItem.from_orm(orm=vfolder, is_owner=True, include_relations=True)
+                for vfolder in vfolders
+            ]
+
+        return entries
+
+    async def query_shared_vfolders(
+        self,
+        user_identity: UserIdentity,
+    ) -> list[VFolderItem]:
+        async with self._db.begin_session() as sess:
+            shared_join = VFolderRow.join(
+                VFolderPermissionRow,
+                VFolderRow.id == VFolderPermissionRow.vfolder,
+                isouter=True,
+            ).join(
+                UserRow,
+                VFolderRow.user == UserRow.uuid,
+                isouter=True,
+            )
+
+            query = (
+                sa.select(VFolderRow)
+                .select_from(shared_join)
+                .where(
+                    (VFolderPermissionRow.user == user_identity.user_uuid)
+                    & (VFolderRow.ownership_type == VFolderOwnershipType.USER)
+                    & (VFolderRow.status.not_in(vfolder_status_map[VFolderStatusSet.INACCESSIBLE]))
+                )
+            )
+
+            vfolders: list[VFolderRow] = (await sess.scalars(query)).all()
+            entries = [
+                VFolderItem.from_orm(orm=vfolder, is_owner=False, include_relations=True)
+                for vfolder in vfolders
+            ]
+
+        return entries
+
+    async def patch_vFolder_name(self, vfolder_id: uuid.UUID, new_name: str) -> None:
+        async with self._db.begin_session() as sess:
+            stmt = sa.update(VFolderRow).where(VFolderRow.id == vfolder_id).values(name=new_name)
+            await sess.execute(stmt)
+
+    async def _delete_vfolder_permission_rows(
+        self,
+        db_session: SASession,
+        vfolder_row_ids: Iterable[uuid.UUID],
+    ) -> None:
+        stmt = sa.delete(VFolderInvitationRow).where(
+            VFolderInvitationRow.vfolder.in_(vfolder_row_ids)
+        )
+        await db_session.execute(stmt)
+
+    async def _retry(
+        self,
+        func: Callable[[SASession], Awaitable[_TQueryResult]],
+        db_session: Callable[..., AbstractAsyncCtxMgr],
+    ) -> None:
+        await execute_with_txn_retry(
+            txn_func=func, begin_trx=db_session, connection=self._db.connect()
+        )
+
+    async def _delete_vfolder_invitation_rows(
+        self,
+        db_session: SASession,
+        vfolder_row_ids: Iterable[uuid.UUID],
+    ) -> None:
+        stmt = sa.delete(VFolderPermissionRow).where(
+            VFolderPermissionRow.vfolder.in_(vfolder_row_ids)
+        )
+        await db_session.execute(stmt)
+
+    async def _delete_vfolder_relation_rows(
+        self,
+        db_session: SASession,
+        vfolder_row_ids: Iterable[uuid.UUID],
+    ) -> None:
+        async def _delete(db_session: SASession) -> None:
+            await self._delete_vfolder_invitation_rows(
+                db_session=db_session, vfolder_row_ids=vfolder_row_ids
+            )
+            await self._delete_vfolder_permission_rows(
+                db_session=db_session, vfolder_row_ids=vfolder_row_ids
+            )
+
+        await self._retry(func=_delete, db_session=db_session)
+
+    async def _update_vfolder_status(
+        self,
+        db_session: SASession,
+        vfolder_id: uuid.UUID,
+        vfolder_status: VFolderOperationStatus,
+    ) -> None:
+        stmt = sa.update(VFolderRow).where(VFolderRow.id == vfolder_id).value(status=vfolder_status)
+        await db_session.execute(stmt)
+
+    async def delete_vFolder_by_id(
+        self,
+        vfolder_id: uuid.UUID,
+    ) -> None:
+        vfolder_ids = [vfolder_id]
+        async with self._db.begin_session() as sess:
+            await self._delete_vfolder_relation_rows(db_session=sess, vfolder_row_ids=vfolder_ids)
+            await self._update_vfolder_status(
+                db_session=sess,
+                vfolder_id=vfolder_id,
+                vfolder_status=VFolderOperationStatus.DELETE_PENDING,
+            )

--- a/src/ai/backend/manager/api/vfolders/repositories.py
+++ b/src/ai/backend/manager/api/vfolders/repositories.py
@@ -160,12 +160,12 @@ class VFolderRepository:
     ) -> list[VFolderItem]:
         all_entries: list[VFolderItem] = []
         if "user" in allowed_vfolder_types:
-            owned_vfolders = await self.query_owned_vfolders(
+            owned_vfolders = await self._query_owned_vfolders(
                 user_identity=user_identity, group_id=group_id
             )
             all_entries.extend(owned_vfolders)
 
-            shared_vfolders = await self.query_shared_vfolders(user_identity=user_identity)
+            shared_vfolders = await self._query_shared_vfolders(user_identity=user_identity)
             all_entries.extend(shared_vfolders)
 
         if "group" in allowed_vfolder_types:
@@ -283,7 +283,7 @@ class VFolderRepository:
 
         return entries
 
-    async def query_owned_vfolders(
+    async def _query_owned_vfolders(
         self, user_identity: UserIdentity, group_id: Optional[uuid.UUID] = None
     ) -> list[VFolderItem]:
         async with self._db.begin_session() as sess:
@@ -309,7 +309,7 @@ class VFolderRepository:
 
         return entries
 
-    async def query_shared_vfolders(
+    async def _query_shared_vfolders(
         self,
         user_identity: UserIdentity,
     ) -> list[VFolderItem]:


### PR DESCRIPTION
resolves #3558 (BA-624)

Implemented repository layer for vfolder api in manager. Repository layer use `database_engine (ExtendedAsyncSAEngine)` created in `/manager/models/utils`

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
