### PR TITLE
fix(BA-725): Increase Backend.AI Kernel's app startup timeout (#3672)

### DIFF
--- a/changes/3679.fix.md
+++ b/changes/3679.fix.md
@@ -1,0 +1,1 @@
+Increase Backend.AI Kernel's app startup timeout

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -862,7 +862,7 @@ class BaseRunner(metaclass=ABCMeta):
                         self.services_running[service_info["name"]] = proc
                         asyncio.create_task(self._wait_service_proc(service_info["name"], proc))
                         if not do_not_wait:
-                            async with asyncio.timeout(20.0):
+                            async with asyncio.timeout(30.0):
                                 await wait_local_port_open(service_info["port"])
                         log.info(
                             "Service {} has started (pid: {}, port: {})",

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -862,7 +862,7 @@ class BaseRunner(metaclass=ABCMeta):
                         self.services_running[service_info["name"]] = proc
                         asyncio.create_task(self._wait_service_proc(service_info["name"], proc))
                         if not do_not_wait:
-                            async with asyncio.timeout(5.0):
+                            async with asyncio.timeout(20.0):
                                 await wait_local_port_open(service_info["port"])
                         log.info(
                             "Service {} has started (pid: {}, port: {})",


### PR DESCRIPTION
resolves #3672  (BA-725)

Increased the kernel-timeout value in `kernel/base.py`:
- prev: `5.0s`
- curr: `30.0s`

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
