### PR TITLE
refactor(BA-696): Change Absolute Imports to Relative Imports in Storage-Proxy (#3656)

### DIFF
--- a/changes/3685.enhance.md
+++ b/changes/3685.enhance.md
@@ -1,0 +1,1 @@
+Change Absolute Imports to Relative Imports in Storage-Proxy

--- a/src/ai/backend/common/dto/storage/response.py
+++ b/src/ai/backend/common/dto/storage/response.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from pydantic import Field
 
-from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.dto.storage.field import VFolderMetaField, VolumeMetaField
+from ...api_handlers import BaseResponseModel
+from .field import VFolderMetaField, VolumeMetaField
 
 
 class GetVolumeResponse(BaseResponseModel):

--- a/src/ai/backend/common/lock.py
+++ b/src/ai/backend/common/lock.py
@@ -28,10 +28,11 @@ from tenacity import (
     wait_random,
 )
 
-from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.etcd_etcetra import AsyncEtcd as EtcetraAsyncEtcd
-from ai.backend.common.types import RedisConnectionInfo
 from ai.backend.logging import BraceStyleAdapter
+
+from .etcd import AsyncEtcd
+from .etcd_etcetra import AsyncEtcd as EtcetraAsyncEtcd
+from .types import RedisConnectionInfo
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -45,11 +45,10 @@ from ai.backend.common.events import (
 from ai.backend.common.metrics.http import build_api_metric_middleware
 from ai.backend.common.types import AgentId, BinarySize, ItemResult, QuotaScopeID, ResultSet
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import ExecutionError
-from ai.backend.storage.watcher import ChownTask, MountTask, UmountTask
 
 from .. import __version__
 from ..exception import (
+    ExecutionError,
     ExternalError,
     InvalidQuotaConfig,
     InvalidSubpathError,
@@ -60,6 +59,7 @@ from ..exception import (
 )
 from ..types import QuotaConfig, VFolderID
 from ..utils import check_params, log_manager_api_entry
+from ..watcher import ChownTask, MountTask, UmountTask
 
 if TYPE_CHECKING:
     from ..context import RootContext

--- a/src/ai/backend/storage/plugin.py
+++ b/src/ai/backend/storage/plugin.py
@@ -6,8 +6,9 @@ from typing import Iterator, Optional
 from aiohttp import web
 
 from ai.backend.common.plugin import AbstractPlugin, BasePluginContext
-from ai.backend.storage.api.types import CORSOptions, WebMiddleware
-from ai.backend.storage.volumes.abc import AbstractVolume
+
+from .api.types import CORSOptions, WebMiddleware
+from .volumes.abc import AbstractVolume
 
 
 class AbstractStoragePlugin(AbstractPlugin, metaclass=ABCMeta):

--- a/src/ai/backend/storage/volumes/abc.py
+++ b/src/ai/backend/storage/volumes/abc.py
@@ -20,7 +20,6 @@ from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.watcher import WatcherClient
 
 from ..exception import InvalidSubpathError, VFolderNotFoundError
 from ..types import (
@@ -32,6 +31,7 @@ from ..types import (
     TreeUsage,
     VFolderID,
 )
+from ..watcher import WatcherClient
 
 # Available capabilities of a volume implementation
 CAP_VFOLDER: Final = "vfolder"  # ability to create vfolder

--- a/src/ai/backend/storage/volumes/cephfs/__init__.py
+++ b/src/ai/backend/storage/volumes/cephfs/__init__.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, FrozenSet, List
 import aiofiles.os
 
 from ai.backend.common.types import BinarySize, QuotaScopeID
-from ai.backend.storage.exception import QuotaScopeNotFoundError
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import CapacityUsage, Optional, QuotaConfig, QuotaUsage, TreeUsage
 
+from ...exception import QuotaScopeNotFoundError
+from ...subproc import run
+from ...types import CapacityUsage, Optional, QuotaConfig, QuotaUsage, TreeUsage
 from ..abc import (
     CAP_FAST_SIZE,
     CAP_QUOTA,

--- a/src/ai/backend/storage/volumes/ddn/__init__.py
+++ b/src/ai/backend/storage/volumes/ddn/__init__.py
@@ -8,10 +8,10 @@ import aiofiles.os
 
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.types import QuotaScopeID
-from ai.backend.storage.exception import QuotaScopeAlreadyExists, QuotaScopeNotFoundError
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import Optional, QuotaConfig, QuotaUsage
 
+from ...exception import QuotaScopeAlreadyExists, QuotaScopeNotFoundError
+from ...subproc import run
+from ...types import Optional, QuotaConfig, QuotaUsage
 from ..abc import CAP_QUOTA, CAP_VFOLDER, AbstractQuotaModel
 from ..vfs import BaseQuotaModel, BaseVolume
 

--- a/src/ai/backend/storage/volumes/dellemc/__init__.py
+++ b/src/ai/backend/storage/volumes/dellemc/__init__.py
@@ -9,9 +9,9 @@ import aiofiles.os
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.types import HardwareMetadata, QuotaScopeID
-from ai.backend.storage.exception import NotEmptyError
-from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaConfig, QuotaUsage
 
+from ...exception import NotEmptyError
+from ...types import CapacityUsage, FSPerfMetric, QuotaConfig, QuotaUsage
 from ..abc import CAP_FAST_FS_SIZE, CAP_METRIC, CAP_QUOTA, CAP_VFOLDER, AbstractQuotaModel
 from ..vfs import BaseQuotaModel, BaseVolume
 from .config import config_iv

--- a/src/ai/backend/storage/volumes/gpfs/__init__.py
+++ b/src/ai/backend/storage/volumes/gpfs/__init__.py
@@ -7,8 +7,8 @@ from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.types import CapacityUsage, FSPerfMetric
 
+from ...types import CapacityUsage, FSPerfMetric
 from ..abc import (
     CAP_FAST_FS_SIZE,
     CAP_METRIC,

--- a/src/ai/backend/storage/volumes/gpfs/gpfs_client.py
+++ b/src/ai/backend/storage/volumes/gpfs/gpfs_client.py
@@ -18,8 +18,8 @@ from tenacity import (
 
 from ai.backend.common.types import BinarySize
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import ExternalError
 
+from ...exception import ExternalError
 from .exceptions import (
     GPFSAPIError,
     GPFSInvalidBodyError,

--- a/src/ai/backend/storage/volumes/netapp/__init__.py
+++ b/src/ai/backend/storage/volumes/netapp/__init__.py
@@ -29,14 +29,15 @@ from tenacity import (
 
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import (
+
+from ...exception import (
     ExecutionError,
     InvalidQuotaScopeError,
     NotEmptyError,
     QuotaScopeNotFoundError,
 )
-from ai.backend.storage.subproc import spawn_and_watch
-from ai.backend.storage.types import (
+from ...subproc import spawn_and_watch
+from ...types import (
     SENTINEL,
     CapacityUsage,
     DirEntry,
@@ -48,8 +49,7 @@ from ai.backend.storage.types import (
     Stat,
     TreeUsage,
 )
-from ai.backend.storage.utils import fstime2datetime
-
+from ...utils import fstime2datetime
 from ..abc import (
     CAP_FAST_FS_SIZE,
     CAP_FAST_SIZE,

--- a/src/ai/backend/storage/volumes/netapp/netappclient.py
+++ b/src/ai/backend/storage/volumes/netapp/netappclient.py
@@ -75,8 +75,8 @@ from typing import (
 
 import aiohttp
 
-from ai.backend.storage.exception import ExternalError
-from ai.backend.storage.types import QuotaConfig, QuotaUsage
+from ...exception import ExternalError
+from ...types import QuotaConfig, QuotaUsage
 
 StorageID: TypeAlias = uuid.UUID
 VolumeID: TypeAlias = uuid.UUID

--- a/src/ai/backend/storage/volumes/purestorage/__init__.py
+++ b/src/ai/backend/storage/volumes/purestorage/__init__.py
@@ -8,8 +8,8 @@ from typing import FrozenSet
 
 from ai.backend.common.types import HardwareMetadata
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.types import CapacityUsage, FSPerfMetric
 
+from ...types import CapacityUsage, FSPerfMetric
 from ..abc import (
     CAP_FAST_FS_SIZE,
     CAP_FAST_SCAN,

--- a/src/ai/backend/storage/volumes/purestorage/rapidfiles.py
+++ b/src/ai/backend/storage/volumes/purestorage/rapidfiles.py
@@ -6,10 +6,10 @@ from subprocess import CalledProcessError
 from typing import AsyncIterator
 
 from ai.backend.common.types import BinarySize
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import DirEntry, DirEntryType, Stat, TreeUsage
-from ai.backend.storage.utils import fstime2datetime
 
+from ...subproc import run
+from ...types import DirEntry, DirEntryType, Stat, TreeUsage
+from ...utils import fstime2datetime
 from ..vfs import BaseFSOpModel
 
 

--- a/src/ai/backend/storage/volumes/purestorage/rapidfiles_v2.py
+++ b/src/ai/backend/storage/volumes/purestorage/rapidfiles_v2.py
@@ -5,10 +5,9 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import AsyncIterator
 
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import DirEntry, DirEntryType, Stat, TreeUsage
-from ai.backend.storage.utils import fstime2datetime
-
+from ...subproc import run
+from ...types import DirEntry, DirEntryType, Stat, TreeUsage
+from ...utils import fstime2datetime
 from .rapidfiles import RapidFileToolsFSOpModel
 
 

--- a/src/ai/backend/storage/volumes/vast/__init__.py
+++ b/src/ai/backend/storage/volumes/vast/__init__.py
@@ -13,14 +13,14 @@ from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.types import HardwareMetadata, QuotaConfig, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import (
+
+from ...exception import (
     ExternalError,
     InvalidQuotaConfig,
     QuotaScopeNotFoundError,
     StorageProxyError,
 )
-from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaUsage
-
+from ...types import CapacityUsage, FSPerfMetric, QuotaUsage
 from ..abc import CAP_FAST_FS_SIZE, CAP_FAST_SIZE, CAP_METRIC, CAP_QUOTA, CAP_VFOLDER
 from ..vfs import BaseQuotaModel, BaseVolume
 from .config import config_iv

--- a/src/ai/backend/storage/volumes/vast/vastdata_client.py
+++ b/src/ai/backend/storage/volumes/vast/vastdata_client.py
@@ -13,9 +13,9 @@ import jwt
 from yarl import URL
 
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import ExternalError, QuotaScopeAlreadyExists
-from ai.backend.storage.types import CapacityUsage
 
+from ...exception import ExternalError, QuotaScopeAlreadyExists
+from ...types import CapacityUsage
 from .config import APIVersion
 from .exceptions import (
     VASTAPIError,

--- a/src/ai/backend/storage/volumes/vfs/__init__.py
+++ b/src/ai/backend/storage/volumes/vfs/__init__.py
@@ -19,15 +19,16 @@ import trafaret as t
 from ai.backend.common.defs import DEFAULT_VFOLDER_PERMISSION_MODE
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import (
+
+from ...exception import (
     ExecutionError,
     InvalidAPIParameters,
     InvalidQuotaScopeError,
     NotEmptyError,
     QuotaScopeNotFoundError,
 )
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import (
+from ...subproc import run
+from ...types import (
     SENTINEL,
     CapacityUsage,
     DirEntry,
@@ -40,7 +41,6 @@ from ai.backend.storage.types import (
     TreeUsage,
     VFolderID,
 )
-
 from ...utils import fstime2datetime
 from ...watcher import DeletePathTask, WatcherClient
 from ..abc import CAP_VFOLDER, AbstractFSOpModel, AbstractQuotaModel, AbstractVolume

--- a/src/ai/backend/storage/volumes/weka/__init__.py
+++ b/src/ai/backend/storage/volumes/weka/__init__.py
@@ -12,8 +12,8 @@ from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.types import HardwareMetadata, QuotaConfig, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaUsage
 
+from ...types import CapacityUsage, FSPerfMetric, QuotaUsage
 from ..abc import CAP_FAST_FS_SIZE, CAP_METRIC, CAP_QUOTA, CAP_VFOLDER, AbstractQuotaModel
 from ..vfs import BaseQuotaModel, BaseVolume
 from .exceptions import WekaAPIError, WekaInitError, WekaNoMetricError, WekaNotFoundError

--- a/src/ai/backend/storage/volumes/xfs/__init__.py
+++ b/src/ai/backend/storage/volumes/xfs/__init__.py
@@ -17,14 +17,14 @@ import aiofiles.os
 from ai.backend.common.lock import FileLock
 from ai.backend.common.types import QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.storage.exception import InvalidQuotaScopeError, NotEmptyError
-from ai.backend.storage.subproc import run
-from ai.backend.storage.types import (
+
+from ...exception import InvalidQuotaScopeError, NotEmptyError
+from ...subproc import run
+from ...types import (
     QuotaConfig,
     QuotaUsage,
 )
-from ai.backend.storage.volumes.abc import CAP_QUOTA, CAP_VFOLDER
-
+from ...volumes.abc import CAP_QUOTA, CAP_VFOLDER
 from ..abc import AbstractQuotaModel
 from ..vfs import BaseQuotaModel, BaseVolume
 


### PR DESCRIPTION
resolves #3656  (BA-696)

To follow the import convention:
- Use **relative** imports when importing modules within the **same package**.
- Use **absolute** imports when importing modules from a **different package**.

Files are changed:
- `common/dto/storage/*.py`
- `storage/api/vfolder/handler.py`
- `storage/services/service.py`
- `storage/volumes/*.py` _(includes cephfs, ddn, etc.)_

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
