### PR TITLE
fix(BA-749): Handle `None` arguments properly in `ContainerRegistryNode` GQL API

### DIFF
--- a/changes/3697.feature.md
+++ b/changes/3697.feature.md
@@ -1,0 +1,1 @@
+Handle `None` arguments properly in `ContainerRegistryNode` GQL API.

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -331,12 +331,12 @@ class CreateContainerRegistryNode(graphene.Mutation):
         url: str,
         type: ContainerRegistryType,
         registry_name: str,
-        is_global: bool | UndefinedType = Undefined,
-        project: str | UndefinedType = Undefined,
-        username: str | UndefinedType = Undefined,
-        password: str | UndefinedType = Undefined,
-        ssl_verify: bool | UndefinedType = Undefined,
-        extra: dict | UndefinedType = Undefined,
+        is_global: bool | UndefinedType | None = Undefined,
+        project: str | UndefinedType | None = Undefined,
+        username: str | UndefinedType | None = Undefined,
+        password: str | UndefinedType | None = Undefined,
+        ssl_verify: bool | UndefinedType | None = Undefined,
+        extra: dict | UndefinedType | None = Undefined,
     ) -> CreateContainerRegistryNode:
         ctx: GraphQueryContext = info.context
 
@@ -402,15 +402,15 @@ class ModifyContainerRegistryNode(graphene.Mutation):
         root,
         info: graphene.ResolveInfo,
         id: str,
-        url: str | UndefinedType = Undefined,
-        type: ContainerRegistryType | UndefinedType = Undefined,
-        registry_name: str | UndefinedType = Undefined,
-        is_global: bool | UndefinedType = Undefined,
-        project: str | UndefinedType = Undefined,
-        username: str | UndefinedType = Undefined,
-        password: str | UndefinedType = Undefined,
-        ssl_verify: bool | UndefinedType = Undefined,
-        extra: dict | UndefinedType = Undefined,
+        url: str | UndefinedType | None = Undefined,
+        type: ContainerRegistryType | UndefinedType | None = Undefined,
+        registry_name: str | UndefinedType | None = Undefined,
+        is_global: bool | UndefinedType | None = Undefined,
+        project: str | UndefinedType | None = Undefined,
+        username: str | UndefinedType | None = Undefined,
+        password: str | UndefinedType | None = Undefined,
+        ssl_verify: bool | UndefinedType | None = Undefined,
+        extra: dict | UndefinedType | None = Undefined,
     ) -> ModifyContainerRegistryNode:
         ctx: GraphQueryContext = info.context
 

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -347,7 +347,7 @@ class CreateContainerRegistryNode(graphene.Mutation):
         }
 
         def _set_if_set(name: str, val: Any) -> None:
-            if val is not Undefined:
+            if val is not Undefined and val is not None:
                 input_config[name] = val
 
         _set_if_set("project", project)
@@ -417,7 +417,7 @@ class ModifyContainerRegistryNode(graphene.Mutation):
         input_config: dict[str, Any] = {}
 
         def _set_if_set(name: str, val: Any) -> None:
-            if val is not Undefined:
+            if val is not Undefined and val is not None:
                 input_config[name] = val
 
         _set_if_set("url", url)

--- a/src/ai/backend/manager/models/gql_models/container_registry_v2.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry_v2.py
@@ -77,7 +77,7 @@ class CreateContainerRegistryNodeV2(graphene.Mutation):
         }
 
         def _set_if_set(name: str, val: Any) -> None:
-            if val is not Undefined:
+            if val is not Undefined and val is not None:
                 input_config[name] = val
 
         _set_if_set("project", props.project)
@@ -149,7 +149,7 @@ class ModifyContainerRegistryNodeV2(graphene.Mutation):
         input_config: dict[str, Any] = {}
 
         def _set_if_set(name: str, val: Any) -> None:
-            if val is not Undefined:
+            if val is not Undefined and val is not None:
                 input_config[name] = val
 
         _set_if_set("url", props.url)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Resolves #3698 ([BA-749](https://lablup.atlassian.net/browse/BA-749)).

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue


[BA-749]: https://lablup.atlassian.net/browse/BA-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ