### PR TITLE
fix(BA-754): ContainerRegistry per-project API misc bugs

### DIFF
--- a/changes/3701.fix.md
+++ b/changes/3701.fix.md
@@ -1,0 +1,1 @@
+Fix ContainerRegistry per-project API misc bugs.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20,6 +20,386 @@
       }
     },
     "schemas": {
+      "AllowedGroupsModel": {
+        "properties": {
+          "add": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Add",
+            "type": "array"
+          },
+          "remove": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Remove",
+            "type": "array"
+          }
+        },
+        "title": "AllowedGroupsModel",
+        "type": "object"
+      },
+      "ContainerRegistryType": {
+        "enum": [
+          "docker",
+          "harbor",
+          "harbor2",
+          "github",
+          "gitlab",
+          "ecr",
+          "ecr-public",
+          "local"
+        ],
+        "title": "ContainerRegistryType",
+        "type": "string"
+      },
+      "PatchContainerRegistryRequestModel": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Id"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Url"
+          },
+          "registry_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Registry Name"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContainerRegistryType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Username"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Password"
+          },
+          "ssl_verify": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ssl Verify"
+          },
+          "is_global": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Is Global"
+          },
+          "extra": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Extra"
+          },
+          "allowed_groups": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedGroupsModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "title": "PatchContainerRegistryRequestModel",
+        "type": "object"
+      },
+      "PatchContainerRegistryResponseModel": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Id"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Url"
+          },
+          "registry_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Registry Name"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContainerRegistryType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Username"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Password"
+          },
+          "ssl_verify": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ssl Verify"
+          },
+          "is_global": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Is Global"
+          },
+          "extra": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Extra"
+          }
+        },
+        "title": "PatchContainerRegistryResponseModel",
+        "type": "object"
+      },
+      "EventData": {
+        "properties": {
+          "resources": {
+            "description": "List of related artifacts involved in the event",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "title": "Resources",
+            "type": "array"
+          },
+          "repository": {
+            "$ref": "#/components/schemas/Repository",
+            "description": "Repository details"
+          }
+        },
+        "required": [
+          "resources",
+          "repository"
+        ],
+        "title": "EventData",
+        "type": "object"
+      },
+      "Repository": {
+        "properties": {
+          "namespace": {
+            "description": "Harbor project (namespace)",
+            "title": "Namespace",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the repository",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "namespace",
+          "name"
+        ],
+        "title": "Repository",
+        "type": "object"
+      },
+      "Resource": {
+        "properties": {
+          "resource_url": {
+            "description": "URL of the artifact",
+            "title": "Resource Url",
+            "type": "string"
+          },
+          "tag": {
+            "description": "Tag of the artifact",
+            "title": "Tag",
+            "type": "string"
+          }
+        },
+        "required": [
+          "resource_url",
+          "tag"
+        ],
+        "title": "Resource",
+        "type": "object"
+      },
+      "HarborWebhookRequestModel": {
+        "properties": {
+          "type": {
+            "description": "Type of the webhook event triggered by Harbor. See Harbor documentation for details.",
+            "title": "Type",
+            "type": "string"
+          },
+          "event_data": {
+            "$ref": "#/components/schemas/EventData",
+            "description": "Event details"
+          }
+        },
+        "required": [
+          "type",
+          "event_data"
+        ],
+        "title": "HarborWebhookRequestModel",
+        "type": "object"
+      },
       "VFolderPermission": {
         "description": "Permissions for a virtual folder given to a specific access key.\nRW_DELETE includes READ_WRITE and READ_WRITE includes READ_ONLY.",
         "enum": [
@@ -1216,6 +1596,75 @@
         ],
         "parameters": [],
         "description": "\n**Preconditions:**\n* User privilege required.\n* Manager status required: RUNNING\n"
+      }
+    },
+    "/container-registries/{registry_id}": {
+      "patch": {
+        "operationId": "container-registries.patch_container_registry",
+        "tags": [
+          "container-registries"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PatchContainerRegistryResponseModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchContainerRegistryRequestModel"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "registry_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "\n**Preconditions:**\n* Superadmin privilege required.\n* Manager status required: one of FROZEN, RUNNING\n"
+      }
+    },
+    "/container-registries/webhook/harbor": {
+      "post": {
+        "operationId": "container-registries.harbor_webhook_handler",
+        "tags": [
+          "container-registries"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HarborWebhookRequestModel"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "\n**Preconditions:**\n* Manager status required: RUNNING\n"
       }
     },
     "/config/resource-slots": {

--- a/src/ai/backend/manager/api/container_registry.py
+++ b/src/ai/backend/manager/api/container_registry.py
@@ -27,11 +27,10 @@ from ai.backend.manager.models.container_registry import (
 from ai.backend.manager.models.gql_models.container_registry_v2 import handle_allowed_groups_update
 
 from .exceptions import (
-    ContainerRegistryGroupsAssociationNotFound,
-    ContainerRegistryNotFound,
     GenericBadRequest,
     HarborWebhookContainerRegistryRowNotFound,
     InternalServerError,
+    ObjectNotFound,
 )
 
 if TYPE_CHECKING:
@@ -73,7 +72,7 @@ async def patch_container_registry(
 
         if params.allowed_groups:
             await handle_allowed_groups_update(root_ctx.db, registry_id, params.allowed_groups)
-    except (ContainerRegistryNotFound, ContainerRegistryGroupsAssociationNotFound) as e:
+    except ObjectNotFound as e:
         raise e
     except IntegrityError as e:
         raise GenericBadRequest(f"Failed to update allowed groups! Details: {str(e)}")

--- a/src/ai/backend/manager/api/container_registry.py
+++ b/src/ai/backend/manager/api/container_registry.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.container_registry import (
 from ai.backend.manager.models.gql_models.container_registry_v2 import handle_allowed_groups_update
 
 from .exceptions import (
+    ContainerRegistryGroupsAssociationNotFound,
     ContainerRegistryNotFound,
     GenericBadRequest,
     HarborWebhookContainerRegistryRowNotFound,
@@ -72,7 +73,7 @@ async def patch_container_registry(
 
         if params.allowed_groups:
             await handle_allowed_groups_update(root_ctx.db, registry_id, params.allowed_groups)
-    except ContainerRegistryNotFound as e:
+    except (ContainerRegistryNotFound, ContainerRegistryGroupsAssociationNotFound) as e:
         raise e
     except IntegrityError as e:
         raise GenericBadRequest(f"Failed to update allowed groups! Details: {str(e)}")

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -260,6 +260,10 @@ class ContainerRegistryNotFound(ObjectNotFound):
     object_name = "container_registry"
 
 
+class ContainerRegistryGroupsAssociationNotFound(ObjectNotFound):
+    object_name = "association of container_registry and group"
+
+
 class TooManySessionsMatched(BackendError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/too-many-sessions-matched"
     error_title = "Too many sessions matched."

--- a/src/ai/backend/manager/client/container_registry/harbor.py
+++ b/src/ai/backend/manager/client/container_registry/harbor.py
@@ -40,7 +40,7 @@ class AbstractPerProjectRegistryQuotaClient(abc.ABC):
     ) -> None:
         raise NotImplementedError
 
-    async def read_quota(self, project_info: HarborProjectInfo) -> int:
+    async def read_quota(self, project_info: HarborProjectInfo, auth_args: HarborAuthArgs) -> int:
         raise NotImplementedError
 
 
@@ -94,10 +94,10 @@ class PerProjectHarborQuotaClient(AbstractPerProjectRegistryQuotaClient):
             return HarborProjectQuotaInfo(previous_quota=previous_quota, quota_id=quota_id)
 
     @override
-    async def read_quota(self, project_info: HarborProjectInfo) -> int:
+    async def read_quota(self, project_info: HarborProjectInfo, auth_args: HarborAuthArgs) -> int:
         connector = aiohttp.TCPConnector(ssl=project_info.ssl_verify)
         async with aiohttp.ClientSession(connector=connector) as sess:
-            rqst_args: dict[str, Any] = {}
+            rqst_args = _get_harbor_auth_args(auth_args)
             quota_info = await self._get_quota_info(sess, project_info, rqst_args)
             previous_quota = quota_info["previous_quota"]
             if previous_quota == -1:

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -13,7 +13,7 @@ from graphql import Undefined, UndefinedType
 from ai.backend.common.container_registry import AllowedGroupsModel, ContainerRegistryType
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.exceptions import (
-    ContainerRegistryNotFound,
+    ContainerRegistryGroupsAssociationNotFound,
 )
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.gql_models.fields import ScopeField
@@ -295,7 +295,7 @@ async def handle_allowed_groups_update(
             )
             result = await db_sess.execute(delete_query)
             if result.rowcount == 0:
-                raise ContainerRegistryNotFound()
+                raise ContainerRegistryGroupsAssociationNotFound()
 
 
 class CreateContainerRegistryNode(graphene.Mutation):

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -295,7 +295,9 @@ async def handle_allowed_groups_update(
             )
             result = await db_sess.execute(delete_query)
             if result.rowcount == 0:
-                raise ContainerRegistryGroupsAssociationNotFound()
+                raise ContainerRegistryGroupsAssociationNotFound(
+                    f"Tried to remove non-existing associations for registry_id: {registry_id}, group_ids: {allowed_group_updates.remove}"
+                )
 
 
 class CreateContainerRegistryNode(graphene.Mutation):

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -182,6 +182,7 @@ public_interface_objs: MutableMapping[str, Any] = {}
 
 global_subapp_pkgs: Final[list[str]] = [
     ".acl",
+    ".container_registry",
     ".etcd",
     ".events",
     ".auth",

--- a/src/ai/backend/manager/service/container_registry/harbor.py
+++ b/src/ai/backend/manager/service/container_registry/harbor.py
@@ -144,4 +144,7 @@ class PerProjectContainerRegistryQuotaService(AbstractPerProjectContainerRegistr
         registry_info = await self._repository.fetch_container_registry_row(scope_id)
         client = self._client_pool.make_client(registry_info.type)
         project_info = self._registry_row_to_harbor_project_info(registry_info)
-        return await client.read_quota(project_info)
+        credential = HarborAuthArgs(
+            username=registry_info.username, password=registry_info.password
+        )
+        return await client.read_quota(project_info, credential)


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Follow-up of #3090, #3116.

Resolves #3702 ([BA-754](https://lablup.atlassian.net/browse/BA-754)).

The following bugs have been fixed.
- [x] 401 error occurs when calling the `read_quota` in the Harbor registry CRUD API. Credentials are required to retrieve the Harbor project quota.
- [x] The `container_registry.py` is not registered in `global_subapp_pkgs`, causing a 404 error when a Harbor registry webhook request is received.
- [x] In `modify_container_registry_node_v2`, when removing specific `allowed_groups`, a `ContainerRegistryNotFound` error occurs if the association does not exist. However, the missing object is an association, not a `ContainerRegistry`.
- [x] Fixed a bug where an `ImageNode` accessible by a user from a non-global registry not associated with the domain was being queried when querying ImageRBAC with `DomainScope`.
- [x] `openapi.json` updates
---

**Checklist:** (if applicable)

- [x] Mention to the original issue


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3701.org.readthedocs.build/en/3701/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3701.org.readthedocs.build/ko/3701/

<!-- readthedocs-preview sorna-ko end -->

[BA-754]: https://lablup.atlassian.net/browse/BA-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ