### PR TITLE
fix(BA-669): Change ports using ephemeral ports

### DIFF
--- a/changes/3614.fix.md
+++ b/changes/3614.fix.md
@@ -1,0 +1,1 @@
+Change port numbers using ephemeral ports

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -87,8 +87,8 @@ metadata-server-bind-host = "0.0.0.0"
 metadata-server-port = 40128
 
 # The port number for aiomonitor.
-# aiomonitor-termui-port = 48200
-# aiomonitor-webui-port = 49200
+# aiomonitor-termui-port = 38200
+# aiomonitor-webui-port = 39200
 
 # Explicitly set allowed(or blocked) compute plugins to avoid conflicts of mock &
 # open-source CUDA plugins in the mono-repo source installation.

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -148,8 +148,8 @@ importer-image = "lablup/importer:manylinux2010"
 # The starting port number for aiomonitor.
 # Since the manager is composed of multiple processes, each process will be exposed
 # via the port number of this base port number + pidx.
-# aiomonitor-termui-port = 48100
-# aiomonitor-webui-port = 49100
+# aiomonitor-termui-port = 38100
+# aiomonitor-webui-port = 39100
 
 
 [docker-registry]

--- a/configs/storage-proxy/halfstack.toml
+++ b/configs/storage-proxy/halfstack.toml
@@ -32,8 +32,8 @@ session-expire = "1d"
 # The starting port number for aiomonitor.
 # Since the storage-proxy is composed of multiple processes, each process will be exposed
 # via the port number of this base port number + pidx.
-# aiomonitor-termui-port = 48300
-# aiomonitor-webui-port = 49300
+# aiomonitor-termui-port = 38300
+# aiomonitor-webui-port = 39300
 
 
 # The socket fd path prefix to communicate with storage proxy watcher

--- a/configs/storage-proxy/sample.toml
+++ b/configs/storage-proxy/sample.toml
@@ -43,8 +43,8 @@ session-expire = "1d"
 # The starting port number for aiomonitor.
 # Since the storage-proxy is composed of multiple processes, each process will be exposed
 # via the port number of this base port number + pidx.
-# aiomonitor-termui-port = 48300
-# aiomonitor-webui-port = 49300
+# aiomonitor-termui-port = 38300
+# aiomonitor-webui-port = 39300
 
 
 # The socket fd path prefix to communicate with storage proxy watcher

--- a/configs/wsproxy/sample.toml
+++ b/configs/wsproxy/sample.toml
@@ -24,8 +24,8 @@ jwt_encrypt_key = "50M3G00DL00KING53CR3T"
 permit_hash_key = "50M3G00DL00KING53CR3T"
 api_secret = "50M3G00DL00KING53CR3T"
 
-aiomonitor_termui_port = 48500
-aiomonitor_webui_port = 49500
+aiomonitor_termui_port = 38500
+aiomonitor_webui_port = 39500
 
 [pyroscope]
 enabled = true

--- a/src/ai/backend/account_manager/config.py
+++ b/src/ai/backend/account_manager/config.py
@@ -356,13 +356,13 @@ class AccountManagerConfig(BaseSchema):
     aiomonitor_termui_port: Annotated[
         int,
         Field(
-            gt=0, lt=65536, description="Port number for aiomonitor termui server.", default=48500
+            gt=0, lt=65536, description="Port number for aiomonitor termui server.", default=38500
         ),
     ]
     aiomonitor_webui_port: Annotated[
         int,
         Field(
-            gt=0, lt=65536, description="Port number for aiomonitor webui server.", default=49500
+            gt=0, lt=65536, description="Port number for aiomonitor webui server.", default=39500
         ),
     ]
 

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -64,10 +64,10 @@ agent_local_config_iv = (
             ),
             t.Key("event-loop", default="asyncio"): t.Enum("asyncio", "uvloop"),
             t.Key("skip-manager-detection", default=False): t.ToBool,
-            tx.AliasedKey(["aiomonitor-termui-port", "aiomonitor-port"], default=48200): t.ToInt[
+            tx.AliasedKey(["aiomonitor-termui-port", "aiomonitor-port"], default=38200): t.ToInt[
                 1:65535
             ],
-            t.Key("aiomonitor-webui-port", default=49200): t.ToInt[1:65535],
+            t.Key("aiomonitor-webui-port", default=39200): t.ToInt[1:65535],
             t.Key("metadata-server-bind-host", default="0.0.0.0"): t.String,
             t.Key("metadata-server-port", default=40128): t.ToInt[1:65535],
             t.Key("allow-compute-plugins", default=None): t.Null | tx.ToSet,

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -295,10 +295,10 @@ manager_local_config_iv = (
             ): t.List(t.String),
             t.Key("importer-image", default="lablup/importer:manylinux2010"): t.String,
             t.Key("max-wsmsg-size", default=16 * (2**20)): t.ToInt,  # default: 16 MiB
-            tx.AliasedKey(["aiomonitor-termui-port", "aiomonitor-port"], default=48100): t.ToInt[
+            tx.AliasedKey(["aiomonitor-termui-port", "aiomonitor-port"], default=38100): t.ToInt[
                 1:65535
             ],
-            t.Key("aiomonitor-webui-port", default=49100): t.ToInt[1:65535],
+            t.Key("aiomonitor-webui-port", default=39100): t.ToInt[1:65535],
             t.Key("use-experimental-redis-event-dispatcher", default=False): t.ToBool,
             t.Key("status-update-interval", default=None): t.Null | t.ToFloat[0:],  # second
             t.Key("status-lifetime", default=None): t.Null | t.ToInt[0:],  # second

--- a/src/ai/backend/storage/config.py
+++ b/src/ai/backend/storage/config.py
@@ -63,9 +63,9 @@ local_config_iv = (
                         default_gid=_default_gid,
                     ),
                     tx.AliasedKey(
-                        ["aiomonitor-termui-port", "aiomonitor-port"], default=48300
+                        ["aiomonitor-termui-port", "aiomonitor-port"], default=38300
                     ): t.ToInt[1:65535],
-                    t.Key("aiomonitor-webui-port", default=49300): t.ToInt[1:65535],
+                    t.Key("aiomonitor-webui-port", default=39300): t.ToInt[1:65535],
                     t.Key("watcher-insock-path-prefix", default=None): t.Null
                     | t.String(allow_blank=False),
                     t.Key("watcher-outsock-path-prefix", default=None): t.Null

--- a/src/ai/backend/wsproxy/config.py
+++ b/src/ai/backend/wsproxy/config.py
@@ -424,13 +424,13 @@ class WSProxyConfig(BaseSchema):
     aiomonitor_termui_port: Annotated[
         int,
         Field(
-            gt=0, lt=65536, description="Port number for aiomonitor termui server.", default=48500
+            gt=0, lt=65536, description="Port number for aiomonitor termui server.", default=38500
         ),
     ]
     aiomonitor_webui_port: Annotated[
         int,
         Field(
-            gt=0, lt=65536, description="Port number for aiomonitor webui server.", default=49500
+            gt=0, lt=65536, description="Port number for aiomonitor webui server.", default=39500
         ),
     ]
 


### PR DESCRIPTION
resolves #3614 (BA-669)
As aiomonitor in wsproxy, manager, agent, halfstack use port number included in Ephemeral ports, It needs to be changed. 

I've changed port number around 38000~39000, and confirmed it not used by other protocol or services

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
