### PR TITLE
fix(BA-788): Cannot query session in rename API handler (#3746)

### DIFF
--- a/changes/3746.fix.md
+++ b/changes/3746.fix.md
@@ -1,0 +1,1 @@
+Fix compute session rename API handler to query DB correctly

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Backend.AI Manager API",
     "description": "Backend.AI Manager REST API specification",
-    "version": "24.09.6",
+    "version": "24.09.7",
     "contact": {
       "name": "Lablup Inc.",
       "url": "https://docs.backend.ai",

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1417,7 +1417,6 @@ async def rename_session(request: web.Request, params: Any) -> web.Response:
             session_name,
             owner_access_key,
             allow_stale=True,
-            for_update=True,
             kernel_loading_strategy=KernelLoadingStrategy.ALL_KERNELS,
         )
         if compute_session.status != SessionStatus.RUNNING:


### PR DESCRIPTION
This is an auto-generated backport PR of #3746 to the 24.09 release.