### PR TITLE
fix(BA-788): Cannot query session in rename API handler (#3746)

### DIFF
--- a/changes/3746.fix.md
+++ b/changes/3746.fix.md
@@ -1,0 +1,1 @@
+Fix compute session rename API handler to query DB correctly

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1323,7 +1323,6 @@ async def rename_session(request: web.Request, params: Any) -> web.Response:
             session_name,
             owner_access_key,
             allow_stale=True,
-            for_update=True,
             kernel_loading_strategy=KernelLoadingStrategy.ALL_KERNELS,
         )
         if compute_session.status != SessionStatus.RUNNING:


### PR DESCRIPTION
This is an auto-generated backport PR of #3746 to the 24.03 release.