### PR TITLE
fix(BA-822): Wrong Python interpreter in the installer due to a missing build-macro reference

### DIFF
--- a/changes/3810.fix.md
+++ b/changes/3810.fix.md
@@ -1,0 +1,1 @@
+Fix wrong Python interpreter embedded in the installer scie builds

--- a/src/ai/backend/install/BUILD
+++ b/src/ai/backend/install/BUILD
@@ -42,10 +42,7 @@ python_distribution(
 
 pex_binary(
     name="backendai-install",
-    extra_build_args=["--scie", "lazy"],
-    tags=["scie", "lazy"],
-    entry_point="ai.backend.cli.__main__",
-    output_path="${target_name_normalized}",
+    **common_scie_config("lazy"),
     dependencies=[
         ":src",
         ":buildscript",
@@ -55,10 +52,7 @@ pex_binary(
 
 pex_binary(
     name="backendai-install-fat",
-    extra_build_args=["--scie", "eager"],
-    tags=["scie", "fat"],
-    entry_point="ai.backend.cli.__main__",
-    output_path="${target_name_normalized}",
+    **common_scie_config("eager"),
     dependencies=[
         ":src",
         ":buildscript",

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -105,6 +105,13 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     entrypoints = {}
     # Scan self-exported entrypoints when executed via pex.
     ai_backend_ns_path = Path(__file__).parent.parent
+    if os.environ.get("SCIE", None) is not None:
+        log.debug(
+            "scan_entrypoint_from_buildscript(%r): skipping when executed inside the SCIE environment",
+            group_name,
+        )
+        yield from []
+        return
     log.debug(
         "scan_entrypoint_from_buildscript(%r): Namespace path: %s", group_name, ai_backend_ns_path
     )

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -105,30 +105,31 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     entrypoints = {}
     # Scan self-exported entrypoints when executed via pex.
     ai_backend_ns_path = Path(__file__).parent.parent
-    if os.environ.get("SCIE", None) is not None:
-        log.debug(
-            "scan_entrypoint_from_buildscript(%r): skipping when executed inside the SCIE environment",
-            group_name,
-        )
-        yield from []
-        return
     log.debug(
         "scan_entrypoint_from_buildscript(%r): Namespace path: %s", group_name, ai_backend_ns_path
     )
     for buildscript_path in _glob(ai_backend_ns_path, "BUILD", _default_glob_excluded_patterns):
         for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
             entrypoints[entrypoint.name] = entrypoint
-    # Override with the entrypoints found in the current source directories,
-    try:
-        build_root = find_build_root()
-    except ValueError:
-        pass
+    if os.environ.get("SCIE", None) is not None:
+        log.debug(
+            "scan_entrypoint_from_buildscript(%r): skipping 'src' when executed inside the SCIE environment",
+            group_name,
+        )
     else:
-        src_path = build_root / "src"
-        log.debug("scan_entrypoint_from_buildscript(%r): current src: %s", group_name, src_path)
-        for buildscript_path in _glob(src_path, "BUILD", _default_glob_excluded_patterns):
-            for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
-                entrypoints[entrypoint.name] = entrypoint
+        # Override with the entrypoints found in the current source directories,
+        try:
+            build_root = find_build_root()
+        except ValueError:
+            pass
+        else:
+            src_path = build_root / "src"
+            log.debug("scan_entrypoint_from_buildscript(%r): current src: %s", group_name, src_path)
+            for buildscript_path in _glob(src_path, "BUILD", _default_glob_excluded_patterns):
+                for entrypoint in extract_entrypoints_from_buildscript(
+                    group_name, buildscript_path
+                ):
+                    entrypoints[entrypoint.name] = entrypoint
     yield from entrypoints.values()
 
 

--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -111,12 +111,7 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
     for buildscript_path in _glob(ai_backend_ns_path, "BUILD", _default_glob_excluded_patterns):
         for entrypoint in extract_entrypoints_from_buildscript(group_name, buildscript_path):
             entrypoints[entrypoint.name] = entrypoint
-    if os.environ.get("SCIE", None) is not None:
-        log.debug(
-            "scan_entrypoint_from_buildscript(%r): skipping 'src' when executed inside the SCIE environment",
-            group_name,
-        )
-    else:
+    if os.environ.get("SCIE", None) is None:
         # Override with the entrypoints found in the current source directories,
         try:
             build_root = find_build_root()
@@ -130,6 +125,11 @@ def scan_entrypoint_from_buildscript(group_name: str) -> Iterator[EntryPoint]:
                     group_name, buildscript_path
                 ):
                     entrypoints[entrypoint.name] = entrypoint
+    else:
+        log.debug(
+            "scan_entrypoint_from_buildscript(%r): skipping 'src' when executed inside the SCIE environment",
+            group_name,
+        )
     yield from entrypoints.values()
 
 


### PR DESCRIPTION
hotfix follow-up to #3791 (BA-822)
