### PR TITLE
ci: Using a self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,8 @@ jobs:
         # ubuntu-22.04: x86-64
         # ubuntu-22.04-arm64: aarch64
         # macos-14-large: intel
-        # macos-14-xlarge: apple silicon
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-xlarge, macos-14-large]
+        # self-hosted: apple silicon
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted]
     runs-on: ${{ matrix.os }}
     env:
       SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,8 @@ jobs:
         # ubuntu-22.04: x86-64
         # ubuntu-22.04-arm64: aarch64
         # macos-14-large: intel
-        # self-hosted: apple silicon
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted]
+        # self-hosted-macos-14: apple silicon
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted-macos-14]
     runs-on: ${{ matrix.os }}
     env:
       SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the recent release, the release is failing due to github api rate limit issue when building scie on arm mac.
It is speculated that the lack of github hosted arm runner is the cause, so we will change to using self hosted r
unner. 
Also, I think that using self hosted runner will save cost.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
