### PR TITLE
fix: Broken image rescanning on `HarborRegistry_v1` (#3821)

### DIFF
--- a/changes/3821.fix.md
+++ b/changes/3821.fix.md
@@ -1,0 +1,1 @@
+Broken image rescanning on `HarborRegistry_v1` due to type error of credential value.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -40,7 +40,7 @@ class HarborRegistry_v1(BaseContainerRegistry):
             rqst_args["auth"] = aiohttp.BasicAuth(
                 self.credentials["username"],
                 self.credentials["password"],
-            ).encode()
+            )
         project_list_url: Optional[yarl.URL]
         project_list_url = (api_url / "projects").with_query(
             {"page_size": "30"},


### PR DESCRIPTION
This is an auto-generated backport PR of #3821 to the 24.09 release.