### PR TITLE
ci: Allow `releases` with pr prefix

### DIFF
--- a/.github/workflows/pr-prefix.yml
+++ b/.github/workflows/pr-prefix.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$TITLE" | tr ':' '\n' | head -n 1 | grep -qE '^(feat|fix|docs?|refactor|ci|chore|deps)(\([^)]+\))?$';
+          if echo "$TITLE" | tr ':' '\n' | head -n 1 | grep -qE '^(feat|fix|docs?|refactor|ci|chore|release|deps)(\([^)]+\))?$';
           then
             echo "PR title is valid."
           else
@@ -25,6 +25,7 @@ jobs:
             echo "  refactor:   (for refactoring and revisions on how things are related)"
             echo "  ci:         (for changes related to CI/CD workflows)"
             echo "  chore:      (for changes related to repo/build configs, tool dependencies, etc.)"
+            echo "  release:    (for changes related to versioning and release management)"
             echo "  deps:       (for changes related to upstream dependencies, etc.)"
             echo "following the conventional commit style."
             echo ""


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
