### PR TITLE
fix(BA-880): Aggregate multi-kernel session utilization in idle checker (#3861)

### DIFF
--- a/changes/3861.fix.md
+++ b/changes/3861.fix.md
@@ -1,0 +1,1 @@
+Aggregate multi-kernel session utilization in idle checker


### PR DESCRIPTION
This is an auto-generated backport PR of #3861 to the 24.03 release.