### PR TITLE
fix(BA-887): Rescan all tags in `HarborRegistryV2` (#3871)

### DIFF
--- a/changes/3871.fix.md
+++ b/changes/3871.fix.md
@@ -1,0 +1,1 @@
+Fix rescan only the latest tag in `HarborRegistryV2`.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -260,24 +260,26 @@ class HarborRegistry_v2(BaseContainerRegistry):
                             if not image_info["tags"] or len(image_info["tags"]) == 0:
                                 skip_reason = "no tag"
                                 continue
-                            tag = image_info["tags"][0]["name"]
-                            match image_info["manifest_media_type"]:
-                                case self.MEDIA_TYPE_OCI_INDEX:
-                                    await self._process_oci_index(
-                                        tg, sess, rqst_args, image, tag, image_info
-                                    )
-                                case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
-                                    await self._process_docker_v2_multiplatform_image(
-                                        tg, sess, rqst_args, image, tag, image_info
-                                    )
-                                case self.MEDIA_TYPE_DOCKER_MANIFEST:
-                                    await self._process_docker_v2_image(
-                                        tg, sess, rqst_args, image, tag, image_info
-                                    )
-                                case _ as media_type:
-                                    raise RuntimeError(
-                                        f"Unsupported artifact media-type: {media_type}"
-                                    )
+                            tags = [item["name"] for item in image_info["tags"]]
+
+                            for tag in tags:
+                                match image_info["manifest_media_type"]:
+                                    case self.MEDIA_TYPE_OCI_INDEX:
+                                        await self._process_oci_index(
+                                            tg, sess, rqst_args, image, tag, image_info
+                                        )
+                                    case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
+                                        await self._process_docker_v2_multiplatform_image(
+                                            tg, sess, rqst_args, image, tag, image_info
+                                        )
+                                    case self.MEDIA_TYPE_DOCKER_MANIFEST:
+                                        await self._process_docker_v2_image(
+                                            tg, sess, rqst_args, image, tag, image_info
+                                        )
+                                    case _ as media_type:
+                                        raise RuntimeError(
+                                            f"Unsupported artifact media-type: {media_type}"
+                                        )
                         finally:
                             if skip_reason:
                                 log.warning("Skipped image - {}:{} ({})", image, tag, skip_reason)
@@ -314,8 +316,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             resp.raise_for_status()
             resp_json = await resp.json()
             async with aiotools.TaskGroup() as tg:
-                tag = resp_json["tags"][0]["name"]
-
                 match resp_json["manifest_media_type"]:
                     case self.MEDIA_TYPE_OCI_INDEX:
                         await self._process_oci_index(tg, sess, rqst_args, image, tag, resp_json)


### PR DESCRIPTION
This is an auto-generated backport PR of #3871 to the 24.09 release.