### PR TITLE
fix(BA-871): Retry zmq socket from kernel

### DIFF
--- a/changes/3880.feature.md
+++ b/changes/3880.feature.md
@@ -1,0 +1,1 @@
+Add kernel bootstrap timeout config

--- a/changes/3880.fix.md
+++ b/changes/3880.fix.md
@@ -1,0 +1,1 @@
+Retry zmq socket connections from kernel

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2237,6 +2237,10 @@ class AbstractAgent(
                     float,
                     self.local_config["agent"]["kernel-lifecycles"]["init-polling-timeout-sec"],
                 )
+                kernel_init_timeout = cast(
+                    float,
+                    self.local_config["agent"]["kernel-lifecycles"]["init-timeout-sec"],
+                )
                 try:
                     async for attempt in AsyncRetrying(
                         wait=wait_fixed(0.3),
@@ -2250,10 +2254,11 @@ class AbstractAgent(
                             # Wait until bootstrap script is executed.
                             # - Main kernel runner is executed after bootstrap script, and
                             #   check_status is accessible only after kernel runner is loaded.
-                            await kernel_obj.check_status()
-                            # Update the service-ports metadata from the image labels
-                            # with the extended template metadata from the agent and krunner.
-                            live_services = await kernel_obj.get_service_apps()
+                            async with asyncio.timeout(kernel_init_timeout):
+                                await kernel_obj.check_status()
+                                # Update the service-ports metadata from the image labels
+                                # with the extended template metadata from the agent and krunner.
+                                live_services = await kernel_obj.get_service_apps()
                             if live_services["status"] != "failed":
                                 for live_service in live_services["data"]:
                                     for service_port in service_ports:
@@ -2262,6 +2267,17 @@ class AbstractAgent(
                                             break
                     if self.local_config["debug"]["log-kernel-config"]:
                         log.debug("service ports:\n{!r}", pretty(service_ports))
+                except asyncio.TimeoutError:
+                    await self.inject_container_lifecycle_event(
+                        kernel_id,
+                        session_id,
+                        LifecycleEvent.DESTROY,
+                        KernelLifecycleEventReason.BOOTSTRAP_TIMEOUT,
+                        container_id=ContainerId(container_data["container_id"]),
+                    )
+                    raise AgentError(
+                        f"Timeout during container bootstrap (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
+                    )
                 except asyncio.CancelledError:
                     log.warning("cancelled waiting of container startup (k:{})", kernel_id)
                     raise

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2272,15 +2272,23 @@ class AbstractAgent(
                         kernel_id,
                         session_id,
                         LifecycleEvent.DESTROY,
-                        KernelLifecycleEventReason.BOOTSTRAP_TIMEOUT,
+                        KernelLifecycleEventReason.FAILED_TO_START,
                         container_id=ContainerId(container_data["container_id"]),
                     )
                     raise AgentError(
-                        f"Timeout during container bootstrap (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
+                        f"Timeout during container startup (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
                     )
                 except asyncio.CancelledError:
-                    log.warning("cancelled waiting of container startup (k:{})", kernel_id)
-                    raise
+                    await self.inject_container_lifecycle_event(
+                        kernel_id,
+                        session_id,
+                        LifecycleEvent.DESTROY,
+                        KernelLifecycleEventReason.FAILED_TO_START,
+                        container_id=ContainerId(container_data["container_id"]),
+                    )
+                    raise AgentError(
+                        f"Cancelled waiting of container startup (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
+                    )
                 except Exception:
                     log.exception(
                         "unexpected error while waiting container startup (k:{})", kernel_id

--- a/src/ai/backend/agent/config.py
+++ b/src/ai/backend/agent/config.py
@@ -173,11 +173,13 @@ DEFAULT_PULL_TIMEOUT = 2 * 60 * 60  # 2 hours
 DEFAULT_PUSH_TIMEOUT = None  # Infinite
 DEFAULT_KERNEL_INIT_POLLING_ATTEMPT = 10
 DEFAULT_KERNEL_INIT_POLLING_TIMEOUT = 60.0  # 60 seconds
+DEFAULT_KERNEL_INIT_TIMEOUT = 60.0  # 60 seconds
 
 default_api_config = {"pull-timeout": DEFAULT_PULL_TIMEOUT, "push-timeout": DEFAULT_PUSH_TIMEOUT}
 default_kernel_lifecycles = {
     "init-polling-attempt": DEFAULT_KERNEL_INIT_POLLING_ATTEMPT,
     "init-polling-timeout-sec": DEFAULT_KERNEL_INIT_POLLING_TIMEOUT,
+    "init-timeout-sec": DEFAULT_KERNEL_INIT_TIMEOUT,
 }
 
 
@@ -202,6 +204,10 @@ agent_etcd_config_iv = t.Dict({
         t.Key(
             "init-polling-timeout-sec",
             default=default_kernel_lifecycles["init-polling-timeout-sec"],
+        ): t.ToFloat,
+        t.Key(
+            "init-timeout-sec",
+            default=default_kernel_lifecycles["init-timeout-sec"],
         ): t.ToFloat,
     }),
 }).allow_extra("*")

--- a/src/ai/backend/agent/exception.py
+++ b/src/ai/backend/agent/exception.py
@@ -98,3 +98,7 @@ class AgentError(RuntimeError):
     def __init__(self, *args, exc_repr: Optional[str] = None):
         super().__init__(*args)
         self.exc_repr = exc_repr
+
+
+class InvalidSocket(Exception):
+    pass

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -298,6 +298,7 @@ class KernelLifecycleEventReason(enum.StrEnum):
     FAILED_TO_CREATE = "failed-to-create"
     FAILED_TO_START = "failed-to-start"
     FORCE_TERMINATED = "force-terminated"
+    BOOTSTRAP_TIMEOUT = "bootstrap-timeout"
     HANG_TIMEOUT = "hang-timeout"
     IDLE_TIMEOUT = "idle-timeout"
     IDLE_SESSION_LIFETIME = "idle-session-lifetime"


### PR DESCRIPTION
resolves #3881 (BA-871)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
