### PR TITLE
fix(BA-901): remove `show_kernel_list` configuration

### DIFF
--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -71,8 +71,6 @@ is_directory_size_visible = true
 # enable_model_store = True
 # enable_extend_login_session = False
 # If false, directory size in folder explorer will show `-`. default value is set to true.
-# If true, the kernel list will be shown in the session detail panel.
-show_kernel_list = false
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -72,7 +72,6 @@ config_iv = t.Dict({
         t.Key("enable_model_store", default=True): t.ToBool(),
         t.Key("enable_extend_login_session", default=False): t.ToBool(),
         t.Key("is_directory_size_visible", default=True): t.ToBool(),
-        t.Key("show_kernel_list", default=False): t.ToBool(),
     }).allow_extra("*"),
     t.Key("security", default=_default_security_config): t.Dict({
         t.Key("request_policies", default=[]): t.List(t.String),

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -33,7 +33,6 @@ connectionMode = "SESSION"
 {% toml_field "eduAppNamePrefix" config["service"]["edu_appname_prefix"] %}
 {% toml_field "enableModelStore" config["service"]["enable_model_store"] %}
 {% toml_field "enableExtendLoginSession" config["service"]["enable_extend_login_session"] %}
-{% toml_field "showKernelList" config["service"]["show_kernel_list"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
resolves #3886 (BA-901)

Removes the `show_kernel_list` configuration option as it is no longer used in the codebase. This option previously controlled the visibility of kernel information in the session detail panel.

**Checklist:**

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations