### PR TITLE
feat(BA-858): Set Docker container timezone using TZ env

### DIFF
--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -431,28 +431,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     MountPermission.READ_WRITE,
                 )
             )
-        # /etc/localtime and /etc/timezone mounts
-        if sys.platform.startswith("linux"):
-            localtime_file = Path("/etc/localtime")
-            timezone_file = Path("/etc/timezone")
-            if localtime_file.exists():
-                mounts.append(
-                    Mount(
-                        type=MountTypes.BIND,
-                        source=localtime_file,
-                        target=localtime_file,
-                        permission=MountPermission.READ_ONLY,
-                    )
-                )
-            if timezone_file.exists():
-                mounts.append(
-                    Mount(
-                        type=MountTypes.BIND,
-                        source=timezone_file,
-                        target=timezone_file,
-                        permission=MountPermission.READ_ONLY,
-                    )
-                )
         # lxcfs mounts
         lxcfs_root = Path("/var/lib/lxcfs")
         if lxcfs_root.is_dir():

--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -21,6 +21,21 @@ if [ ! -f "/usr/bin/scp" ]; then
   ln -s /opt/kernel/dropbearmulti /usr/bin/scp
 fi
 
+# set timezone configuration
+TARGET_TZ=${TZ:-"Etc/UTC"}
+ZONEINFO_DIR="/usr/share/zoneinfo"
+DEFAULT_ZONEINFO="${ZONEINFO_DIR}/Etc/UTC"
+TARGET_ZONEINFO="${ZONEINFO_DIR}/${TARGET_TZ}"
+if [ -f "$TARGET_ZONEINFO" ]; then
+    ln -sf "$TARGET_ZONEINFO" /etc/localtime
+    echo "$TARGET_TZ" > /etc/timezone
+    echo "Timezone set to: $TARGET_TZ"
+else
+    ln -sf "$DEFAULT_ZONEINFO" /etc/localtime
+    echo "$DEFAULT_TZ" > /etc/timezone
+    echo "Invalid TZ. Timezone set to default: Etc/UTC"
+fi
+
 if [ $USER_ID -eq 0 ]; then
 
   echo "WARNING: Running the user codes as root is not recommended."


### PR DESCRIPTION
Set Docker container timezone using TZ env
 - configure Docker container timezone consistently across any Linux distributions & Mac hosts
 - implement platform-independent solution using environment variables (e.g. ENV TZ=Asia/Seoul )

Ref1: Synchronize timezone from host to container
https://forums.docker.com/t/synchronize-timezone-from-host-to-container/39116/1

resolves #2300 #3841  

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [V] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
