### PR TITLE
fix(BA-912): GQL compute session node resolver misses kernel ORM object loading

### DIFF
--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -521,7 +521,7 @@ class ComputeSessionNode(graphene.ObjectType):
             cond = permission_ctx.query_condition
             if cond is None:
                 return ConnectionResolverResult([], cursor, pagination_order, page_size, 0)
-            query = query.where(cond)
+            query = query.where(cond).options(selectinload(SessionRow.kernels))
             cnt_query = cnt_query.where(cond)
             async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
                 session_rows = (await db_session.scalars(query)).all()


### PR DESCRIPTION
resolves #3896 (BA-912)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue