### PR TITLE
fix(BA-913): GQL vfolder_node type does not resolve permissions field

### DIFF
--- a/changes/3900.fix.md
+++ b/changes/3900.fix.md
@@ -1,0 +1,1 @@
+GQL `vfolder_node` query does not resolve `permissions` field

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -2421,6 +2421,15 @@ class VFolderPermissionContext(
                     if perm in _STORAGE_HOST_PERMISSION_TO_VFOLDER_PERMISSION_MAP
                 }
 
+        match vfolder_row.permission:
+            case (
+                VFolderPermission.OWNER_PERM
+                | VFolderPermission.RW_DELETE
+                | VFolderPermission.READ_WRITE
+            ):
+                pass
+            case VFolderPermission.READ_ONLY:
+                permissions -= {VFolderRBACPermission.MOUNT_RW, VFolderRBACPermission.MOUNT_WD}
         return frozenset(permissions)
 
 


### PR DESCRIPTION
resolves #3899 (BA-913)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
