### PR TITLE
fix: Missing cases where sudo is required to run docker

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -706,7 +706,7 @@ wait_for_docker() {
       exit 1
   fi
 
-  until docker info >/dev/null 2>&1
+  until $docker_sudo docker info >/dev/null 2>&1
   do
       count=$((count+1))
       if [ "$count" -ge "$max_wait" ]; then


### PR DESCRIPTION
By default, install-dev.sh uses the $docker_sudo variable to handle cases where sudo is required to run docker commands.
Only in the wait_for_docker() function is that logic missing, so we add it.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
