### PR TITLE
fix: Missing cases where sudo is required to run docker (#3909)

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -701,7 +701,7 @@ wait_for_docker() {
       exit 1
   fi
 
-  until docker info >/dev/null 2>&1
+  until $docker_sudo docker info >/dev/null 2>&1
   do
       count=$((count+1))
       if [ "$count" -ge "$max_wait" ]; then


### PR DESCRIPTION
This is an auto-generated backport PR of #3909 to the 24.03 release.