### PR TITLE
fix: Relax required resource-preset GQL mutation fields to not-required

### DIFF
--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1991,8 +1991,8 @@ type Mutations {
   create_resource_preset(name: String!, props: CreateResourcePresetInput!): CreateResourcePreset
   modify_resource_preset(
     """Added in 25.4.0. ID of the resource preset."""
-    id: UUID!
-    name: String @deprecated(reason: "Deprecated since 25.4.0.")
+    id: UUID = null
+    name: String = null @deprecated(reason: "Deprecated since 25.4.0.")
     props: ModifyResourcePresetInput!
   ): ModifyResourcePreset
   delete_resource_preset(name: String!): DeleteResourcePreset


### PR DESCRIPTION


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [ ] API server-client counterparts (e.g., manager API -> client SDK)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3913.org.readthedocs.build/en/3913/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3913.org.readthedocs.build/ko/3913/

<!-- readthedocs-preview sorna-ko end -->