### PR TITLE
fix(BA-932): Unload removed docker images from Redis

### DIFF
--- a/changes/3923.fix.md
+++ b/changes/3923.fix.md
@@ -1,1 +1,1 @@
-Remove redis cache for images deleted in the `PurgeImage` mutation, and add logic to detect the removal of docker agent images.
+Unload images that have been purged from the agents in the manager.

--- a/changes/3923.fix.md
+++ b/changes/3923.fix.md
@@ -1,0 +1,1 @@
+Remove redis cache for images deleted in the `PurgeImage` mutation, and add logic to detect the removal of docker agent images.

--- a/changes/3923.fix.md
+++ b/changes/3923.fix.md
@@ -1,1 +1,1 @@
-Unload the removed images from Redis cache.
+Unload the removed docker images from Redis cache.

--- a/changes/3923.fix.md
+++ b/changes/3923.fix.md
@@ -1,1 +1,1 @@
-Unload images that have been purged from the agents in the manager.
+Unload the removed images from Redis cache.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -227,10 +227,16 @@ def update_additional_gids(environ: MutableMapping[str, str], gids: Iterable[int
     environ["ADDITIONAL_GIDS"] = ",".join(map(str, additional_gids))
 
 
+ImageCanonical = str
+ImageDigest = str
+
+ScannedImage = Mapping[ImageCanonical, ImageDigest]
+
+
 @dataclass
 class ScanImagesResult:
-    scanned_images: Mapping[str, str]
-    removed_images: Mapping[str, str]
+    scanned_images: ScannedImage
+    removed_images: ScannedImage
 
 
 class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1703,9 +1703,10 @@ class AbstractAgent(
     async def _scan_images_wrapper(self, interval: float) -> None:
         result = await self.scan_images()
         self.images = result.scanned_images
-        await self.produce_event(
-            AgentImagesRemoveEvent(image_canonicals=list(result.removed_images.keys()))
-        )
+        if result.removed_images:
+            await self.produce_event(
+                AgentImagesRemoveEvent(image_canonicals=list(result.removed_images.keys()))
+            )
 
     @abstractmethod
     async def push_image(

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -230,13 +230,11 @@ def update_additional_gids(environ: MutableMapping[str, str], gids: Iterable[int
 ImageCanonical = str
 ImageDigest = str
 
-ScannedImage = Mapping[ImageCanonical, ImageDigest]
-
 
 @dataclass
 class ScanImagesResult:
-    scanned_images: ScannedImage
-    removed_images: ScannedImage
+    scanned_images: Mapping[ImageCanonical, ImageDigest]
+    removed_images: Mapping[ImageCanonical, ImageDigest]
 
 
 class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -80,7 +80,7 @@ from ai.backend.common.events import (
     AbstractEvent,
     AgentErrorEvent,
     AgentHeartbeatEvent,
-    AgentPurgeImagesEvent,
+    AgentImagesRemoveEvent,
     AgentStartedEvent,
     AgentTerminatedEvent,
     DoAgentResourceCheckEvent,
@@ -1702,7 +1702,7 @@ class AbstractAgent(
         result = await self.scan_images()
         self.images = result.scanned_images
         await self.produce_event(
-            AgentPurgeImagesEvent(image_canonicals=list(result.removed_images.keys()))
+            AgentImagesRemoveEvent(image_canonicals=list(result.removed_images.keys()))
         )
 
     @abstractmethod

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -14,7 +14,7 @@ import traceback
 import weakref
 import zlib
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
+from collections import UserDict, defaultdict
 from collections.abc import (
     AsyncGenerator,
     Awaitable,
@@ -227,14 +227,17 @@ def update_additional_gids(environ: MutableMapping[str, str], gids: Iterable[int
     environ["ADDITIONAL_GIDS"] = ",".join(map(str, additional_gids))
 
 
-ImageCanonical = str
-ImageDigest = str
+class ImageCanonicalDigestDict(UserDict):
+    def __setitem__(self, image_canonical: str, image_digest: str) -> None:
+        if not isinstance(image_canonical, str) or not isinstance(image_digest, str):
+            raise TypeError("image_canonical, image_digest must be str")
+        super().__setitem__(image_canonical, image_digest)
 
 
 @dataclass
 class ScanImagesResult:
-    scanned_images: Mapping[ImageCanonical, ImageDigest]
-    removed_images: Mapping[ImageCanonical, ImageDigest]
+    scanned_images: ImageCanonicalDigestDict
+    removed_images: ImageCanonicalDigestDict
 
 
 class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -14,7 +14,7 @@ import traceback
 import weakref
 import zlib
 from abc import ABCMeta, abstractmethod
-from collections import UserDict, defaultdict
+from collections import defaultdict
 from collections.abc import (
     AsyncGenerator,
     Awaitable,
@@ -227,17 +227,16 @@ def update_additional_gids(environ: MutableMapping[str, str], gids: Iterable[int
     environ["ADDITIONAL_GIDS"] = ",".join(map(str, additional_gids))
 
 
-class ImageCanonicalDigestDict(UserDict):
-    def __setitem__(self, image_canonical: str, image_digest: str) -> None:
-        if not isinstance(image_canonical, str) or not isinstance(image_digest, str):
-            raise TypeError("image_canonical, image_digest must be str")
-        super().__setitem__(image_canonical, image_digest)
+@dataclass
+class ScannedImage:
+    canonical: str
+    digest: str
 
 
 @dataclass
 class ScanImagesResult:
-    scanned_images: ImageCanonicalDigestDict
-    removed_images: ImageCanonicalDigestDict
+    scanned_images: Mapping[str, ScannedImage]
+    removed_images: Mapping[str, ScannedImage]
 
 
 class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
@@ -647,7 +646,7 @@ class AbstractAgent(
     local_instance_id: str
     kernel_registry: MutableMapping[KernelId, AbstractKernel]
     computers: MutableMapping[DeviceName, ComputerContext]
-    images: Mapping[str, str]
+    images: Mapping[str, ScannedImage]
     port_pool: set[int]
 
     redis: Redis
@@ -691,7 +690,7 @@ class AbstractAgent(
         self.agent_public_key = agent_public_key
         self.kernel_registry = {}
         self.computers = {}
-        self.images = {}  # repoTag -> digest
+        self.images = {}
         self.restarting_kernels = {}
         self.stat_ctx = StatContext(
             self,

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -786,7 +786,8 @@ class AbstractAgent(
         self.affinity_map = AffinityMap.build(all_devices)
 
         if not self._skip_initial_scan:
-            self.images = (await self.scan_images()).scanned_images
+            scan_images_result = await self.scan_images()
+            self.images = scan_images_result.scanned_images
             self.timer_tasks.append(aiotools.create_timer(self._scan_images_wrapper, 20.0))
             await self.scan_running_kernels()
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -89,7 +89,13 @@ from ai.backend.common.utils import (
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.logging.formatter import pretty
 
-from ..agent import ACTIVE_STATUS_SET, AbstractAgent, AbstractKernelCreationContext, ComputerContext
+from ..agent import (
+    ACTIVE_STATUS_SET,
+    AbstractAgent,
+    AbstractKernelCreationContext,
+    ComputerContext,
+    ScanImagesResult,
+)
 from ..exception import ContainerCreationError, UnsupportedResource
 from ..fs import create_scratch_filesystem, destroy_scratch_filesystem
 from ..kernel import AbstractKernel
@@ -1526,10 +1532,10 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             )
             return distro
 
-    async def scan_images(self) -> Mapping[str, str]:
+    async def scan_images(self) -> ScanImagesResult:
         async with closing_async(Docker()) as docker:
             all_images = await docker.images.list()
-            updated_images = {}
+            scanned_images, removed_images = {}, {}
             for image in all_images:
                 if image["RepoTags"] is None:
                     continue
@@ -1554,12 +1560,18 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                         continue
                     kernelspec = int(labels.get("ai.backend.kernelspec", "1"))
                     if MIN_KERNELSPEC <= kernelspec <= MAX_KERNELSPEC:
-                        updated_images[repo_tag] = img_detail["Id"]
-            for added_image in updated_images.keys() - self.images.keys():
+                        scanned_images[repo_tag] = img_detail["Id"]
+            for added_image in scanned_images.keys() - self.images.keys():
                 log.debug("found kernel image: {0}", added_image)
-            for removed_image in self.images.keys() - updated_images.keys():
+
+            for removed_image in self.images.keys() - scanned_images.keys():
                 log.debug("removed kernel image: {0}", removed_image)
-            return updated_images
+                removed_images[removed_image] = self.images[removed_image]
+
+            return ScanImagesResult(
+                scanned_images=scanned_images,
+                removed_images=removed_images,
+            )
 
     async def handle_agent_socket(self):
         """

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1265,7 +1265,6 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     monitor_docker_task: asyncio.Task
     agent_sockpath: Path
     agent_sock_task: asyncio.Task
-    scan_images_timer: asyncio.Task
     metadata_server: MetadataServer
     docker_ptask_group: aiotools.PersistentTaskGroup
     gwbridge_subnet: Optional[str]

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -94,6 +94,7 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
+    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import ContainerCreationError, UnsupportedResource
@@ -1535,7 +1536,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     async def scan_images(self) -> ScanImagesResult:
         async with closing_async(Docker()) as docker:
             all_images = await docker.images.list()
-            scanned_images, removed_images = {}, {}
+            scanned_images, removed_images = ImageCanonicalDigestDict(), ImageCanonicalDigestDict()
             for image in all_images:
                 if image["RepoTags"] is None:
                     continue

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -94,7 +94,6 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
-    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import ContainerCreationError, UnsupportedResource
@@ -1536,7 +1535,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     async def scan_images(self) -> ScanImagesResult:
         async with closing_async(Docker()) as docker:
             all_images = await docker.images.list()
-            scanned_images, removed_images = ImageCanonicalDigestDict(), ImageCanonicalDigestDict()
+            scanned_images, removed_images = {}, {}
             for image in all_images:
                 if image["RepoTags"] is None:
                     continue

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -44,6 +44,7 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
+    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import UnsupportedResource
@@ -283,7 +284,9 @@ class DummyAgent(
     async def scan_images(self) -> ScanImagesResult:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
-        return ScanImagesResult(scanned_images={}, removed_images={})
+        return ScanImagesResult(
+            scanned_images=ImageCanonicalDigestDict(), removed_images=ImageCanonicalDigestDict()
+        )
 
     async def pull_image(
         self,

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -39,7 +39,13 @@ from ai.backend.common.types import (
     current_resource_slots,
 )
 
-from ..agent import ACTIVE_STATUS_SET, AbstractAgent, AbstractKernelCreationContext, ComputerContext
+from ..agent import (
+    ACTIVE_STATUS_SET,
+    AbstractAgent,
+    AbstractKernelCreationContext,
+    ComputerContext,
+    ScanImagesResult,
+)
 from ..exception import UnsupportedResource
 from ..kernel import AbstractKernel
 from ..resources import AbstractComputePlugin, KernelResourceSpec, Mount, known_slot_types
@@ -274,10 +280,10 @@ class DummyAgent(
         await asyncio.sleep(delay)
         return "cr.backend.ai/stable/python:3.9-ubuntu20.04"
 
-    async def scan_images(self) -> Mapping[str, str]:
+    async def scan_images(self) -> ScanImagesResult:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
-        return {}
+        return ScanImagesResult(scanned_images={}, removed_images={})
 
     async def pull_image(
         self,

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -44,7 +44,6 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
-    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import UnsupportedResource
@@ -284,9 +283,7 @@ class DummyAgent(
     async def scan_images(self) -> ScanImagesResult:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
-        return ScanImagesResult(
-            scanned_images=ImageCanonicalDigestDict(), removed_images=ImageCanonicalDigestDict()
-        )
+        return ScanImagesResult(scanned_images={}, removed_images={})
 
     async def pull_image(
         self,

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -63,7 +63,6 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
-    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import K8sError, UnsupportedResource
@@ -1010,9 +1009,7 @@ class KubernetesAgent(
 
     async def scan_images(self) -> ScanImagesResult:
         # Retrieving image label from registry api is not possible
-        return ScanImagesResult(
-            scanned_images=ImageCanonicalDigestDict(), removed_images=ImageCanonicalDigestDict()
-        )
+        return ScanImagesResult(scanned_images={}, removed_images={})
 
     async def handle_agent_socket(self):
         # TODO: Add support for remote agent socket mechanism

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -63,6 +63,7 @@ from ..agent import (
     AbstractAgent,
     AbstractKernelCreationContext,
     ComputerContext,
+    ImageCanonicalDigestDict,
     ScanImagesResult,
 )
 from ..exception import K8sError, UnsupportedResource
@@ -1009,7 +1010,9 @@ class KubernetesAgent(
 
     async def scan_images(self) -> ScanImagesResult:
         # Retrieving image label from registry api is not possible
-        return ScanImagesResult(scanned_images={}, removed_images={})
+        return ScanImagesResult(
+            scanned_images=ImageCanonicalDigestDict(), removed_images=ImageCanonicalDigestDict()
+        )
 
     async def handle_agent_socket(self):
         # TODO: Add support for remote agent socket mechanism

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -58,7 +58,13 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging import BraceStyleAdapter
 
-from ..agent import ACTIVE_STATUS_SET, AbstractAgent, AbstractKernelCreationContext, ComputerContext
+from ..agent import (
+    ACTIVE_STATUS_SET,
+    AbstractAgent,
+    AbstractKernelCreationContext,
+    ComputerContext,
+    ScanImagesResult,
+)
 from ..exception import K8sError, UnsupportedResource
 from ..kernel import AbstractKernel
 from ..resources import AbstractComputePlugin, KernelResourceSpec, Mount, known_slot_types
@@ -1001,9 +1007,9 @@ class KubernetesAgent(
             return distro
         raise NotImplementedError
 
-    async def scan_images(self) -> Mapping[str, str]:
+    async def scan_images(self) -> ScanImagesResult:
         # Retrieving image label from registry api is not possible
-        return {}
+        return ScanImagesResult(scanned_images={}, removed_images={})
 
     async def handle_agent_socket(self):
         # TODO: Add support for remote agent socket mechanism

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -199,6 +199,19 @@ class AgentHeartbeatEvent(AbstractEvent):
 
 
 @attrs.define(slots=True, frozen=True)
+class AgentPurgeImagesEvent(AbstractEvent):
+    name = "agent_purge_images"
+    image_canonicals: list[str] = attrs.field()
+
+    def serialize(self) -> tuple:
+        return (self.image_canonicals,)
+
+    @classmethod
+    def deserialize(cls, value: tuple):
+        return cls(value[0])
+
+
+@attrs.define(slots=True, frozen=True)
 class DoAgentResourceCheckEvent(AbstractEvent):
     name = "do_agent_resource_check"
 

--- a/src/ai/backend/common/events.py
+++ b/src/ai/backend/common/events.py
@@ -199,8 +199,8 @@ class AgentHeartbeatEvent(AbstractEvent):
 
 
 @attrs.define(slots=True, frozen=True)
-class AgentPurgeImagesEvent(AbstractEvent):
-    name = "agent_purge_images"
+class AgentImagesRemoveEvent(AbstractEvent):
+    name = "agent_images_remove"
     image_canonicals: list[str] = attrs.field()
 
     def serialize(self) -> tuple:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3163,7 +3163,7 @@ class AgentRegistry:
             # Update the mapping of kernel images to agents.
             loaded_images = msgpack.unpackb(zlib.decompress(agent_info["images"]))
             loaded_image_canonicals = set(img_info[0] for img_info in loaded_images)
-            old_image_canonicals = self.agent_installed_images.get(agent_id, set())
+            prev_image_canonicals = self.agent_installed_images.get(agent_id, set())
 
             async def _pipe_builder(r: Redis):
                 pipe = r.pipeline()
@@ -3171,7 +3171,7 @@ class AgentRegistry:
                     await pipe.sadd(image, agent_id)
 
                 # Remove old images that are not in the new list.
-                for image in old_image_canonicals - loaded_image_canonicals:
+                for image in prev_image_canonicals - loaded_image_canonicals:
                     await pipe.srem(image, agent_id)
                 return pipe
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3170,7 +3170,6 @@ class AgentRegistry:
                 for image in image_canonicals:
                     await pipe.sadd(image, agent_id)
 
-                # Remove old images that are not in the new list.
                 for image in prev_image_canonicals - image_canonicals:
                     await pipe.srem(image, agent_id)
                 return pipe

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3166,8 +3166,8 @@ class AgentRegistry:
 
             async def _pipe_builder(r: Redis):
                 pipe = r.pipeline()
-                for image in image_canonicals:
-                    await pipe.sadd(image, agent_id)
+                for image_canonical in image_canonicals:
+                    await pipe.sadd(image_canonical, agent_id)
                 return pipe
 
             await redis_helper.execute(self.redis_image, _pipe_builder)
@@ -3182,8 +3182,8 @@ class AgentRegistry:
     ) -> None:
         async def _pipe_builder(r: Redis):
             pipe = r.pipeline()
-            for image in image_canonicals:
-                await pipe.srem(image, agent_id)
+            for image_canonical in image_canonicals:
+                await pipe.srem(image_canonical, agent_id)
             return pipe
 
         await redis_helper.execute(self.redis_image, _pipe_builder)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -373,7 +373,7 @@ class AgentRegistry:
         evd.consume(AgentStartedEvent, self, handle_agent_lifecycle)
         evd.consume(AgentTerminatedEvent, self, handle_agent_lifecycle)
         evd.consume(AgentHeartbeatEvent, self, handle_agent_heartbeat)
-        evd.consume(AgentImagesRemoveEvent, self, handle_agent_purge_images)
+        evd.consume(AgentImagesRemoveEvent, self, handle_agent_images_remove)
         evd.consume(RouteCreatedEvent, self, handle_route_creation)
 
         evd.consume(VFolderDeletionSuccessEvent, self, handle_vfolder_deletion_success)
@@ -3177,7 +3177,9 @@ class AgentRegistry:
             (agent_id, sgroup, available_slots),
         )
 
-    async def handle_purge_images(self, agent_id: AgentId, image_canonicals: list[str]) -> None:
+    async def handle_agent_images_remove(
+        self, agent_id: AgentId, image_canonicals: list[str]
+    ) -> None:
         async def _pipe_builder(r: Redis):
             pipe = r.pipeline()
             for image in image_canonicals:
@@ -4224,12 +4226,12 @@ async def handle_agent_heartbeat(
     await context.handle_heartbeat(source, event.agent_info)
 
 
-async def handle_agent_purge_images(
+async def handle_agent_images_remove(
     context: AgentRegistry,
     source: AgentId,
     event: AgentImagesRemoveEvent,
 ) -> None:
-    await context.handle_purge_images(source, event.image_canonicals)
+    await context.handle_agent_images_remove(source, event.image_canonicals)
 
 
 async def handle_route_creation(

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -61,7 +61,7 @@ from ai.backend.common.dto.agent.response import PurgeImageResp, PurgeImagesResp
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
 from ai.backend.common.events import (
     AgentHeartbeatEvent,
-    AgentPurgeImagesEvent,
+    AgentImagesRemoveEvent,
     AgentStartedEvent,
     AgentTerminatedEvent,
     DoAgentResourceCheckEvent,
@@ -373,7 +373,7 @@ class AgentRegistry:
         evd.consume(AgentStartedEvent, self, handle_agent_lifecycle)
         evd.consume(AgentTerminatedEvent, self, handle_agent_lifecycle)
         evd.consume(AgentHeartbeatEvent, self, handle_agent_heartbeat)
-        evd.consume(AgentPurgeImagesEvent, self, handle_agent_purge_images)
+        evd.consume(AgentImagesRemoveEvent, self, handle_agent_purge_images)
         evd.consume(RouteCreatedEvent, self, handle_route_creation)
 
         evd.consume(VFolderDeletionSuccessEvent, self, handle_vfolder_deletion_success)
@@ -4227,7 +4227,7 @@ async def handle_agent_heartbeat(
 async def handle_agent_purge_images(
     context: AgentRegistry,
     source: AgentId,
-    event: AgentPurgeImagesEvent,
+    event: AgentImagesRemoveEvent,
 ) -> None:
     await context.handle_purge_images(source, event.image_canonicals)
 


### PR DESCRIPTION
Resolves #3924 (BA-927, BA-932)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

Previously, there was no feature to remove images, so the absence of the Unload logic does not seem like a bug. 
So I think we don't need to backport this PR. So I will set the milestone to 25Q1.

**Checklist:** (if applicable)

- [x] Mention to the original issue
