### PR TITLE
chore(BA-941): clean up unused configuration of webserver.conf

### DIFF
--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -50,7 +50,6 @@ endpoint = "http://127.0.0.1:9500"
 frontend-endpoint = "http://127.0.0.1:3000"
 
 [ui]
-brand = "Lablup Cloud"
 menu_blocklist = "pipeline"
 
 [api]

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -68,7 +68,6 @@ directory_based_usage = false
 is_directory_size_visible = true
 # edu_appname_prefix = "" 
 # If false, the model store will be disabled.
-# enable_model_store = True
 # enable_extend_login_session = False
 # If false, directory size in folder explorer will show `-`. default value is set to true.
 # If true, display the "Sign in with a different account" button on the interactive login page.
@@ -141,7 +140,6 @@ show_non_installed_images = false
 #frontend-endpoint = "http://127.0.0.1:3000"
 
 [ui]
-brand = "Lablup Cloud"
 # Default environment to show on session launcher
 # default_environment = 'index.docker.io/lablup/python-tensorflow'
 # Default environment to import GitHub repositories / notebooks
@@ -151,7 +149,6 @@ menu_blocklist = "pipeline"
 # Comma-separated sidebar menu pages to disable
 #menu_inactivelist = "statistics"
 # Enable/disable the LLM Playground tab in the service page
-# enable_LLM_playground = false
 
 [api]
 domain = "default"

--- a/docs/install/install-from-package/install-webserver.rst
+++ b/docs/install/install-from-package/install-webserver.rst
@@ -66,7 +66,6 @@ would be:
    # allowlist = ""
 
    [ui]
-   brand = "Backend.AI"
    menu_blocklist = "pipeline"
 
    [api]

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -69,7 +69,6 @@ config_iv = t.Dict({
         t.Key("directory_based_usage", default=False): t.ToBool(),
         t.Key("allow_custom_resource_allocation", default=True): t.ToBool(),
         t.Key("edu_appname_prefix", default=""): t.String(allow_blank=True),
-        t.Key("enable_model_store", default=True): t.ToBool(),
         t.Key("enable_extend_login_session", default=False): t.ToBool(),
         t.Key("is_directory_size_visible", default=True): t.ToBool(),
         t.Key("enable_interactive_login_account_switch", default=True): t.ToBool(),
@@ -124,13 +123,11 @@ config_iv = t.Dict({
         },
     ).allow_extra("*"),
     t.Key("ui"): t.Dict({
-        t.Key("brand"): t.String,
         t.Key("default_environment", default=None): t.Null | t.String,
         t.Key("default_import_environment", default=None): t.Null | t.String,
         t.Key("menu_blocklist", default=None): t.Null | tx.StringList(empty_str_as_empty_list=True),
         t.Key("menu_inactivelist", default=None): t.Null
         | tx.StringList(empty_str_as_empty_list=True),
-        t.Key("enable_LLM_playground", default=False): t.ToBool,
     }).allow_extra("*"),
     t.Key("api"): t.Dict({
         t.Key("domain"): t.String,

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -3,8 +3,6 @@
 {% toml_field "apiEndpointText" config["api"]["text"] %}
 {% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
 {% toml_field "defaultImportEnvironment" config["ui"]["default_import_environment"] %}
-{% toml_field "siteDescription" config["ui"]["brand"] %}
-{% toml_field "enableLLMPlayground" config["ui"]["enable_LLM_playground"] %}
 connectionMode = "SESSION"
 {% toml_field "signupSupport" config["service"]["enable_signup"] %}
 {% toml_field "allowChangeSigninMode" config["service"]["allow_change_signin_mode"] %}
@@ -31,7 +29,6 @@ connectionMode = "SESSION"
 {% toml_field "allowCustomResourceAllocation" config["service"]["allow_custom_resource_allocation"] %}
 {% toml_field "isDirectorySizeVisible" config["service"]["is_directory_size_visible"] %}
 {% toml_field "eduAppNamePrefix" config["service"]["edu_appname_prefix"] %}
-{% toml_field "enableModelStore" config["service"]["enable_model_store"] %}
 {% toml_field "enableExtendLoginSession" config["service"]["enable_extend_login_session"] %}
 {% toml_field "enableInteractiveLoginAccountSwitch" config["service"]["enable_interactive_login_account_switch"] %}
 

--- a/src/ai/backend/web/templates/config_ini.toml.j2
+++ b/src/ai/backend/web/templates/config_ini.toml.j2
@@ -2,8 +2,6 @@
 {% toml_field "apiEndpoint" endpoint_url %}
 {% toml_field "apiEndpointText" config["api"]["text"] %}
 {% toml_field "defaultSessionEnvironment" config["ui"]["default_environment"] %}
-{% toml_field "siteDescription" config["ui"]["brand"] %}
-{% toml_field "enableLLMPlayground" config["ui"]["enable_LLM_playground"] %}
 connectionMode = "SESSION"
 
 [environments]


### PR DESCRIPTION
resolves #nnn (BA-941)

Related PR : https://github.com/lablup/backend.ai-webui/pull/3325

Removes unused configuration options from the web server:
- Removes `brand` field from UI section
- Removes `enable_model_store` from service section
- Removes `enable_LLM_playground` from UI section

**Checklist:**
- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--3934.org.readthedocs.build/en/3934/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--3934.org.readthedocs.build/ko/3934/

<!-- readthedocs-preview sorna-ko end -->