### PR TITLE
fix(BA-926): Properly handle zero-value unknown resource limits when creating session (#3925)

### DIFF
--- a/changes/3925.fix.md
+++ b/changes/3925.fix.md
@@ -1,0 +1,1 @@
+Properly handle zero-value unknown resource limits when creating session.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -784,17 +784,19 @@ class ResourceSlot(UserDict):
         obj: Mapping[str, Any],
         slot_types: Optional[Mapping[SlotName, SlotTypes]],
     ) -> "ResourceSlot":
+        pruned_obj = {k: v for k, v in obj.items() if v != 0}
+
         try:
             if slot_types is None:
                 data = {
                     k: cls._normalize_value(k, v, cls._guess_slot_type(k))
-                    for k, v in obj.items()
+                    for k, v in pruned_obj.items()
                     if v is not None
                 }
             else:
                 data = {
                     k: cls._normalize_value(k, v, slot_types[SlotName(k)])
-                    for k, v in obj.items()
+                    for k, v in pruned_obj.items()
                     if v is not None
                 }
                 # fill missing

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1131,7 +1131,7 @@ class AgentRegistry:
             if (resources := creation_config.get("resources")) is not None:
                 # Sanitize user input: does it have "known" resource slots only?
                 for slot_key, slot_value in resources.items():
-                    if slot_key not in known_slot_types:
+                    if slot_value != 0 and slot_key not in known_slot_types:
                         raise InvalidAPIParameters(f"Unknown requested resource slot: {slot_key}")
                 try:
                     requested_slots = ResourceSlot.from_user_input(resources, known_slot_types)


### PR DESCRIPTION
This is an auto-generated backport PR of #3925 to the 24.03 release.