### PR TITLE
fix(BA-970): Prevent `image forget` CLI from deleting registry image

### DIFF
--- a/src/ai/backend/client/cli/image.py
+++ b/src/ai/backend/client/cli/image.py
@@ -75,15 +75,14 @@ def forget(reference_or_id, arch):
     with Session() as session:
         try:
             image_id = get_image_id(session, reference_or_id, architecture=arch)
-        except BackendAPIError:
-            print_fail("Could not find image.")
+        except BackendAPIError as e:
+            print_fail(f"Could not find image. Error: {e}")
             if not arch:
                 print_warn(
                     "`arch` parameter not passed. If you are trying to resolve image via its canonical string you have to specify which architecture are you trying to manipulate with."
                 )
             sys.exit(ExitCode.FAILURE)
         try:
-            result = session.Image.untag_image_from_registry(image_id)
             result = session.Image.forget_image_by_id(image_id)
         except Exception as e:
             print_error(e)

--- a/src/ai/backend/client/func/image.py
+++ b/src/ai/backend/client/func/image.py
@@ -66,7 +66,7 @@ class Image(BaseFunction):
         q = _d("""
             query($reference: String!, $architecture: String!) {
                 image(reference: $reference, architecture: $architecture) {
-                    $fields"
+                    $fields
                 }
             }
         """)


### PR DESCRIPTION
Resolves #3950 (BA-970).

**Checklist:** (if applicable)

- [x] Mention to the original issue