### PR TITLE
fix(BA-1003): Wrong error message logging when `model_path` does not exist

### DIFF
--- a/changes/3990.fix.md
+++ b/changes/3990.fix.md
@@ -1,0 +1,1 @@
+Fix wrong error message logging when `model_path` does not exist.

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -815,6 +815,14 @@ class BaseRunner(metaclass=ABCMeta):
                     _cwd = Path.cwd()
                     if cwd:
                         _cwd = Path(cwd)
+
+                    if not _cwd.exists():
+                        error_reason = f"the model directory does not exist: {cwd}"
+                        return {
+                            "status": "failed",
+                            "error": error_reason,
+                        }
+
                     cmdargs: Optional[Sequence[Union[str, os.PathLike]]]
                     env: Mapping[str, str]
                     cmdargs, env = None, {}

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -817,7 +817,7 @@ class BaseRunner(metaclass=ABCMeta):
                         _cwd = Path(cwd)
 
                     if not _cwd.exists():
-                        error_reason = f"the model directory does not exist: {cwd}"
+                        error_reason = f"the model directory does not exist: {_cwd}"
                         return {
                             "status": "failed",
                             "error": error_reason,


### PR DESCRIPTION
Resolves #3991 (BA-1003)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->


**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

