### PR TITLE
fix(BA-1016): Wrong uuid parse in list presets API handler

### DIFF
--- a/changes/4006.fix.md
+++ b/changes/4006.fix.md
@@ -1,0 +1,1 @@
+Fix wrong JSON serialization for response of list presets API handler

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -103,7 +103,7 @@ async def list_presets(request: web.Request) -> web.Response:
             row = cast(ResourcePresetRow, row)
             preset_slots = row.resource_slots.normalize_slots(ignore_unknown=True)
             resp["presets"].append({
-                "id": row.id,
+                "id": str(row.id),
                 "name": row.name,
                 "shared_memory": str(row.shared_memory) if row.shared_memory else None,
                 "resource_slots": preset_slots.to_json(),


### PR DESCRIPTION
resolves #4005 (BA-1016)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue