### PR TITLE
ci: Check alembic multi head in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
         run: echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
       - name: Alembic
         id: alembic
-        if: contains(github.event.pull_request.labels.*.name, 'comp:manager')
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'comp:manager')
+          || github.event_name == 'merge_group'
         run: echo "ALEMBIC=true" >> $GITHUB_OUTPUT
 
 


### PR DESCRIPTION
resolves #4014 (BA-1010)
Check alembic multihead in the merge queue to prevent multiheads from occurring even when merging multiple prs at the same time.
This will work when merging all PRs because it is hard to check for alembic related changes in the merge queue.

**Checklist:** (if applicable)

- [x] Mention to the original issue
