### PR TITLE
fix(BA-1003): Wrong error message logging when `model_path` does not exist (#3990)

### DIFF
--- a/changes/3990.fix.md
+++ b/changes/3990.fix.md
@@ -1,0 +1,1 @@
+Fix wrong error message logging when `model_path` does not exist.

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -768,6 +768,14 @@ class BaseRunner(metaclass=ABCMeta):
                     _cwd = Path.cwd()
                     if cwd:
                         _cwd = Path(cwd)
+
+                    if not _cwd.exists():
+                        error_reason = f"the model directory does not exist: {_cwd}"
+                        return {
+                            "status": "failed",
+                            "error": error_reason,
+                        }
+
                     cmdargs: Optional[Sequence[Union[str, os.PathLike]]]
                     env: Mapping[str, str]
                     cmdargs, env = None, {}


### PR DESCRIPTION
This is an auto-generated backport PR of #3990 to the 23.09 release.