### PR TITLE
fix: Improve handling of process termination races in the krunner's OOM logger (#4008)

### DIFF
--- a/changes/4008.fix.md
+++ b/changes/4008.fix.md
@@ -1,0 +1,1 @@
+Fix a potential race condition error in the kernel runner's OOM logger

--- a/src/ai/backend/kernel/utils.py
+++ b/src/ai/backend/kernel/utils.py
@@ -88,8 +88,11 @@ def scan_proc_stats() -> dict[int, dict]:
     for p in Path("/proc").iterdir():
         if p.name.isdigit():
             pid = int(p.name)
-            stat = parse_proc_stat(pid)
-            pid_set[pid] = stat
+            try:
+                stat = parse_proc_stat(pid)
+                pid_set[pid] = stat
+            except IOError:
+                pass
     return pid_set
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #4008 to the 24.03 release.