### PR TITLE
fix(BA-1024): Fix wrong parse of auto-mount vfolders inputs

### DIFF
--- a/changes/4025.fix.md
+++ b/changes/4025.fix.md
@@ -1,0 +1,1 @@
+Fix wrong parse of auto-mount vfolders inputs

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -986,8 +986,8 @@ async def prepare_vfolder_mounts(
     # and requested_vfolder_subpath
     for _vfolder in accessible_vfolders:
         if _vfolder["name"].startswith("."):
-            requested_vfolder_names.setdefault(_vfolder["name"], _vfolder["name"])
-            requested_vfolder_subpaths.setdefault(_vfolder["name"], ".")
+            requested_vfolder_names.setdefault(_vfolder["id"], _vfolder["name"])
+            requested_vfolder_subpaths.setdefault(_vfolder["id"], ".")
 
     # for vfolder in accessible_vfolders:
     accessible_vfolders_map = {vfolder["name"]: vfolder for vfolder in accessible_vfolders}


### PR DESCRIPTION
resolves #4023 (BA-1024)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue