### PR TITLE
fix(BA-1032): `modify_compute_session` error caused by missing kernel loading option

### DIFF
--- a/changes/4032.fix.md
+++ b/changes/4032.fix.md
@@ -1,0 +1,1 @@
+Fix `modify_compute_session` GQL mutation error caused by missing kernel loading option.

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -621,6 +621,7 @@ class ModifyComputeSession(graphene.relay.ClientIDMutation):
             )
             _stmt = (
                 sa.select(SessionRow)
+                .options(selectinload(SessionRow.kernels))
                 .from_statement(_update_stmt)
                 .execution_options(populate_existing=True)
             )


### PR DESCRIPTION
Resolves #4031 (BA-1032).

FYI, The milestone is set to 24.09, when `ModifyComputeSession` was created.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
