### PR TITLE
fix(BA-1032): `modify_compute_session` error caused by missing kernel loading option (#4032)

### DIFF
--- a/changes/4032.fix.md
+++ b/changes/4032.fix.md
@@ -1,0 +1,1 @@
+Fix `modify_compute_session` GQL mutation error caused by missing kernel loading option.

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -581,6 +581,7 @@ class ModifyComputeSession(graphene.relay.ClientIDMutation):
             )
             _stmt = (
                 sa.select(SessionRow)
+                .options(selectinload(SessionRow.kernels))
                 .from_statement(_update_stmt)
                 .execution_options(populate_existing=True)
             )


### PR DESCRIPTION
This is an auto-generated backport PR of #4032 to the 24.09 release.