### PR TITLE
fix(BA-1042): fix typo in keypair resource policy affecting `max_concurrent_sftp_sessions`

### DIFF
--- a/changes/4050.feature.md
+++ b/changes/4050.feature.md
@@ -1,0 +1,1 @@
+Fix typo in keypair resource policy affecting `max_concurrent_sftp_sessions`

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Backend.AI Manager API",
     "description": "Backend.AI Manager REST API specification",
-    "version": "25.5.0",
+    "version": "25.5.1",
     "contact": {
       "name": "Lablup Inc.",
       "url": "https://docs.backend.ai",

--- a/src/ai/backend/manager/models/resource_policy.py
+++ b/src/ai/backend/manager/models/resource_policy.py
@@ -369,7 +369,7 @@ class CreateKeyPairResourcePolicy(graphene.Mutation):
             "total_resource_slots": ResourceSlot.from_user_input(props.total_resource_slots, None),
             "max_session_lifetime": props.max_session_lifetime,
             "max_concurrent_sessions": props.max_concurrent_sessions,
-            "max_concurrent_sftp_sessions": props.max_concurrent_sessions,
+            "max_concurrent_sftp_sessions": props.max_concurrent_sftp_sessions,
             "max_containers_per_session": props.max_containers_per_session,
             "idle_timeout": props.idle_timeout,
             "allowed_vfolder_hosts": props.allowed_vfolder_hosts,


### PR DESCRIPTION
## Fix typo in keypair resource policy affecting `max_concurrent_sftp_sessions`

resolves https://github.com/lablup/backend.ai/issues/4049 (BA-1042)

This PR fixes a typo in the resource policy mutation function where `max_concurrent_sftp_sessions` was incorrectly assigned the value of `max_concurrent_sessions` instead of its own property value. The fix ensures that the correct value is used for SFTP session limits.

Also updates the API version to 25.5.1 in the OpenAPI specification.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--4050.org.readthedocs.build/en/4050/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--4050.org.readthedocs.build/ko/4050/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--4050.org.readthedocs.build/en/4050/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--4050.org.readthedocs.build/ko/4050/

<!-- readthedocs-preview sorna-ko end -->