### PR TITLE
feat(BA-988): Add Action Test Code for Group

### DIFF
--- a/changes/4051.feature.md
+++ b/changes/4051.feature.md
@@ -1,0 +1,1 @@
+Add Action Test Code for `Group`

--- a/tests/manager/services/test_group.py
+++ b/tests/manager/services/test_group.py
@@ -238,7 +238,7 @@ async def test_delete_group(
 
 
 @pytest.mark.asyncio
-async def test_delete_group_action_db_affect(
+async def test_delete_group_action_effect_in_db(
     processors: GroupProcessors,
     database_engine: ExtendedAsyncSAEngine,
 ) -> None:
@@ -269,11 +269,11 @@ async def test_purge_group(
             PurgeGroupAction(group_id)
         )
         assert result.data is None
-        assert result.success == True  # noqa: E712
+        assert result.success is True
 
 
 @pytest.mark.asyncio
-async def test_purge_group_action_result_in_db(
+async def test_purge_group_action_effect_in_db(
     processors: GroupProcessors,
     database_engine: ExtendedAsyncSAEngine,
 ) -> None:

--- a/tests/manager/services/test_group.py
+++ b/tests/manager/services/test_group.py
@@ -1,0 +1,288 @@
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any, AsyncGenerator, Optional
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.types import RedisConnectionInfo, ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.config import SharedConfig
+from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.storage import StorageSessionManager
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.services.group.actions.create_group import (
+    CreateGroupAction,
+    CreateGroupActionResult,
+)
+from ai.backend.manager.services.group.actions.delete_group import (
+    DeleteGroupAction,
+    DeleteGroupActionResult,
+)
+from ai.backend.manager.services.group.actions.modify_group import (
+    ModifyGroupAction,
+    ModifyGroupActionResult,
+)
+from ai.backend.manager.services.group.actions.purge_group import (
+    PurgeGroupAction,
+    PurgeGroupActionResult,
+)
+from ai.backend.manager.services.group.processors import GroupProcessors
+from ai.backend.manager.services.group.service import GroupService
+from ai.backend.manager.services.group.types import GroupCreator, GroupData, GroupModifier
+from ai.backend.manager.types import OptionalState, TriState
+
+from .test_utils import TestScenario
+
+
+@pytest.fixture
+def service_mock_args():
+    return {
+        "storage_manager": MagicMock(spec=StorageSessionManager),
+        "shared_config": MagicMock(spec=SharedConfig),
+        "redis_stat": MagicMock(spec=RedisConnectionInfo),
+    }
+
+
+@pytest.fixture
+def mock_action_monitor() -> ActionMonitor:
+    return MagicMock(spec=ActionMonitor)
+
+
+@pytest.fixture
+def processors(
+    database_fixture, database_engine, service_mock_args, mock_action_monitor
+) -> GroupProcessors:
+    group_service = GroupService(
+        db=database_engine,
+        storage_manager=service_mock_args["storage_manager"],
+        shared_config=service_mock_args["shared_config"],
+        redis_stat=service_mock_args["redis_stat"],
+    )
+    return GroupProcessors(group_service, [mock_action_monitor])
+
+
+@asynccontextmanager
+async def create_group(
+    database_engine: ExtendedAsyncSAEngine,
+    *,
+    domain_name: str,
+    name: str,
+    type: ProjectType = ProjectType.GENERAL,
+    resource_policy_name: str = "default",
+    description: str = "Test group",
+    is_active: bool = True,
+    total_resource_slots: ResourceSlot = ResourceSlot.from_user_input({}, None),
+    allowed_vfolder_hosts: VFolderHostPermissionMap = VFolderHostPermissionMap({}),
+) -> AsyncGenerator[Any, Any]:
+    # NOTICE: To use 'default' resource policy, you must use `database_fixture` concurrently in test function
+    async with database_engine.begin_session() as session:
+        group_id = uuid.uuid4()
+        group_data = {
+            "id": group_id,
+            "name": name,
+            "description": description,
+            "is_active": is_active,
+            "domain_name": domain_name,
+            "total_resource_slots": total_resource_slots,
+            "allowed_vfolder_hosts": allowed_vfolder_hosts,
+            "resource_policy": resource_policy_name,
+            "type": type,
+        }
+        await session.execute(sa.insert(GroupRow).values(group_data))
+
+    try:
+        yield group_id
+    finally:
+        async with database_engine.begin_session() as session:
+            await session.execute(sa.delete(GroupRow).where(GroupRow.id == group_id))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "test_scenario",
+    [
+        TestScenario.success(
+            "Create a group",
+            CreateGroupAction(
+                input=GroupCreator(
+                    name="test_create_group",
+                    type=ProjectType.GENERAL,
+                    description="test group description",
+                    resource_policy="default",
+                    total_resource_slots=ResourceSlot.from_user_input({}, None),
+                    domain_name="default",
+                    is_active=True,
+                ),
+            ),
+            CreateGroupActionResult(
+                data=GroupData(
+                    id=uuid.uuid4(),
+                    name="test_create_group",
+                    description="test group description",
+                    is_active=True,
+                    created_at=datetime.now(),
+                    modified_at=datetime.now(),
+                    integration_id=None,
+                    domain_name="default",
+                    total_resource_slots=ResourceSlot.from_user_input({}, None),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap({}),
+                    dotfiles=b"\x90",
+                    resource_policy="default",
+                    type=ProjectType.GENERAL,
+                    container_registry={},
+                ),
+                success=True,
+            ),
+        ),
+        # TODO: If business logic is implemented to raise exception instead of returning None
+        # we need to update TestScenario.failure
+        TestScenario.success(
+            "Create a group with duplicated name",
+            CreateGroupAction(
+                input=GroupCreator(
+                    name="default",
+                    type=ProjectType.GENERAL,
+                    description="duplicate group",
+                    resource_policy="default",
+                    total_resource_slots=ResourceSlot.from_user_input({}, None),
+                    domain_name="default",
+                ),
+            ),
+            CreateGroupActionResult(
+                data=None,
+                success=False,
+            ),
+        ),
+        TestScenario.success(
+            "Create a group without resource policy",
+            CreateGroupAction(
+                input=GroupCreator(
+                    name="test_create_group_without_resource_policy",
+                    type=ProjectType.GENERAL,
+                    description="test group description",
+                    resource_policy="",
+                    total_resource_slots=ResourceSlot.from_user_input({}, None),
+                    domain_name="default",
+                )
+            ),
+            CreateGroupActionResult(
+                data=None,
+                success=False,
+            ),
+        ),
+    ],
+)
+async def test_create_group(
+    processors: GroupProcessors,
+    test_scenario: TestScenario[CreateGroupAction, CreateGroupActionResult],
+) -> None:
+    await test_scenario.test(processors.create_group.wait_for_complete)
+
+
+@pytest.mark.asyncio
+async def test_modify_group(
+    processors: GroupProcessors,
+    database_engine: ExtendedAsyncSAEngine,
+) -> None:
+    async with create_group(
+        database_engine=database_engine, domain_name="default", name="test_modfiy_group"
+    ) as group_id:
+        action = ModifyGroupAction(
+            group_id=group_id,
+            modifier=GroupModifier(
+                name=OptionalState.update("modified_name"),
+                description=TriState.update("modified description"),
+                is_active=OptionalState.update(False),
+            ),
+        )
+        result: ModifyGroupActionResult = await processors.modify_group.wait_for_complete(action)
+        group_data: Optional[GroupData] = result.data
+
+        assert group_data is not None
+        assert group_data.name == "modified_name"
+        assert group_data.description == "modified description"
+        assert group_data.is_active == False  # noqa: E712
+
+
+async def test_modify_group_with_invalid_group_id(
+    processors: GroupProcessors,
+) -> None:
+    action = ModifyGroupAction(
+        group_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),
+        modifier=GroupModifier(
+            name=OptionalState.update("modified_name"),
+            description=TriState.update("modified description"),
+            is_active=OptionalState.update(False),
+        ),
+    )
+    result: ModifyGroupActionResult = await processors.modify_group.wait_for_complete(action)
+    assert result.data is None
+    assert result.success == False  # noqa
+
+
+@pytest.mark.asyncio
+async def test_delete_group(
+    processors: GroupProcessors,
+    database_engine: ExtendedAsyncSAEngine,
+) -> None:
+    async with create_group(
+        database_engine=database_engine, domain_name="default", name="test_delete_group"
+    ) as group_id:
+        action = DeleteGroupAction(group_id=group_id)
+        result: DeleteGroupActionResult = await processors.delete_group.wait_for_complete(action)
+        assert result.data is None
+        assert result.success == True  # noqa: E712
+
+
+@pytest.mark.asyncio
+async def test_delete_group_in_db(
+    processors: GroupProcessors,
+    database_engine: ExtendedAsyncSAEngine,
+) -> None:
+    async with create_group(
+        database_engine=database_engine, domain_name="default", name="test_delete_group_in_db"
+    ) as group_id:
+        action = DeleteGroupAction(group_id=group_id)
+        await processors.delete_group.wait_for_complete(action)
+        async with database_engine.begin_session() as session:
+            group = await session.scalar(sa.select(GroupRow).where(GroupRow.id == group_id))
+
+            assert group is not None
+            assert group.is_active == False  # noqa: E712
+            assert group.integration_id is None
+
+
+@pytest.mark.asyncio
+async def test_purge_group(
+    processors: GroupProcessors,
+    database_engine: ExtendedAsyncSAEngine,
+) -> None:
+    async with create_group(
+        database_engine=database_engine, domain_name="default", name="test_purge_group"
+    ) as group_id:
+        await processors.delete_group.wait_for_complete(DeleteGroupAction(group_id))
+
+        result: PurgeGroupActionResult = await processors.purge_group.wait_for_complete(
+            PurgeGroupAction(group_id)
+        )
+        assert result.data is None
+        assert result.success == True  # noqa: E712
+
+
+@pytest.mark.asyncio
+async def test_purge_group_in_db(
+    processors: GroupProcessors,
+    database_engine: ExtendedAsyncSAEngine,
+) -> None:
+    async with create_group(
+        database_engine=database_engine, domain_name="default", name="test_purge_group_in_db"
+    ) as group_id:
+        await processors.delete_group.wait_for_complete(DeleteGroupAction(group_id))
+        await processors.purge_group.wait_for_complete(PurgeGroupAction(group_id))
+
+        async with database_engine.begin_session() as session:
+            group = await session.scalar(sa.select(GroupRow).where(GroupRow.id == group_id))
+            assert group is None

--- a/tests/manager/services/test_group.py
+++ b/tests/manager/services/test_group.py
@@ -105,7 +105,7 @@ async def create_group(
     "test_scenario",
     [
         TestScenario.success(
-            "Create a group",
+            "When trigger create group action with valid data, group creation should be successful",
             CreateGroupAction(
                 input=GroupCreator(
                     name="test_create_group",
@@ -140,7 +140,7 @@ async def create_group(
         # TODO: If business logic is implemented to raise exception instead of returning None
         # we need to update TestScenario.failure
         TestScenario.success(
-            "Create a group with duplicated name",
+            "With duplicated name, group creation should be failed",
             CreateGroupAction(
                 input=GroupCreator(
                     name="default",
@@ -157,7 +157,7 @@ async def create_group(
             ),
         ),
         TestScenario.success(
-            "Create a group without resource policy",
+            "When trigger create group action with invalid resource policy, group creation should be failed",
             CreateGroupAction(
                 input=GroupCreator(
                     name="test_create_group_without_resource_policy",
@@ -204,7 +204,7 @@ async def test_modify_group(
         assert group_data is not None
         assert group_data.name == "modified_name"
         assert group_data.description == "modified description"
-        assert group_data.is_active == False  # noqa: E712
+        assert group_data.is_active is False
 
 
 async def test_modify_group_with_invalid_group_id(
@@ -220,7 +220,7 @@ async def test_modify_group_with_invalid_group_id(
     )
     result: ModifyGroupActionResult = await processors.modify_group.wait_for_complete(action)
     assert result.data is None
-    assert result.success == False  # noqa
+    assert result.success is False
 
 
 @pytest.mark.asyncio
@@ -234,11 +234,11 @@ async def test_delete_group(
         action = DeleteGroupAction(group_id=group_id)
         result: DeleteGroupActionResult = await processors.delete_group.wait_for_complete(action)
         assert result.data is None
-        assert result.success == True  # noqa: E712
+        assert result.success is True
 
 
 @pytest.mark.asyncio
-async def test_delete_group_in_db(
+async def test_delete_group_action_db_affect(
     processors: GroupProcessors,
     database_engine: ExtendedAsyncSAEngine,
 ) -> None:
@@ -251,7 +251,7 @@ async def test_delete_group_in_db(
             group = await session.scalar(sa.select(GroupRow).where(GroupRow.id == group_id))
 
             assert group is not None
-            assert group.is_active == False  # noqa: E712
+            assert group.is_active is False
             assert group.integration_id is None
 
 
@@ -273,7 +273,7 @@ async def test_purge_group(
 
 
 @pytest.mark.asyncio
-async def test_purge_group_in_db(
+async def test_purge_group_action_result_in_db(
     processors: GroupProcessors,
     database_engine: ExtendedAsyncSAEngine,
 ) -> None:


### PR DESCRIPTION
resolves #3968 (BA-988)

This pull request includes significant changes to the group management functionality in the backend manager. The changes focus on adding action test code, handling exceptions more effectively, and refactoring the group models and related classes to use new processor services.

### Group Management Enhancements:

* [`changes/4051.feature.md`](diffhunk://#diff-bab3863d1c2fa9ff7bafe229bc40ec907138d00f949b5c8399591030eae55a31R1): Added action test code for group management.

### Exception Handling Improvements:

* [`src/ai/backend/manager/actions/processor.py`](diffhunk://#diff-60a3be5c74c14445913aec0347d2556daff928538b3de0099cc1b2cf2c88797dR29-R39): Enhanced exception handling in the `_run` method by capturing exceptions in the `exc` variable and re-raising them if necessary. [[1]](diffhunk://#diff-60a3be5c74c14445913aec0347d2556daff928538b3de0099cc1b2cf2c88797dR29-R39) [[2]](diffhunk://#diff-60a3be5c74c14445913aec0347d2556daff928538b3de0099cc1b2cf2c88797dR49-R54)

### Processor Integration:

* `src/ai/backend/manager/api/admin.py`, `src/ai/backend/manager/api/context.py`, `src/ai/backend/manager/models/gql.py`: Integrated `Processors` into the GraphQL context and admin API to handle group-related actions. [[1]](diffhunk://#diff-30ae610d528da59654d1d989f9f0790c7dc8d3ae7ae248ad2fbadfc9ad80c010R95) [[2]](diffhunk://#diff-07fe68f8a86bab52b70ff2c52ab19dc793429ed30ecbf64d60a53a1c9eca9fc7R10) [[3]](diffhunk://#diff-07fe68f8a86bab52b70ff2c52ab19dc793429ed30ecbf64d60a53a1c9eca9fc7R65-R66) [[4]](diffhunk://#diff-56a2d9f1fc07827156313028f4414a518eb3f14bc56739d16d6bbb3e32956019R18) [[5]](diffhunk://#diff-56a2d9f1fc07827156313028f4414a518eb3f14bc56739d16d6bbb3e32956019R264)

### Group Model Refactoring:

* [`src/ai/backend/manager/models/group.py`](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L3): Refactored the group model to use new processor services for creating, modifying, deleting, and purging groups. This includes changes to the `CreateGroupAction`, `ModifyGroupAction`, `DeleteGroupAction`, and `PurgeGroupAction` classes, as well as the methods that handle these actions. [[1]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L3) [[2]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L13-R12) [[3]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L39-R38) [[4]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L60-L62) [[5]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L77-R92) [[6]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L432-R444) [[7]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3R614) [[8]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3R638-R662) [[9]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L668-L687) [[10]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L711-R737) [[11]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L794-R764) [[12]](diffhunk://#diff-1963ce781c363b494868f6a6eafaf15c6de1150ca91baaab04de13f274b482e3L830-R799)

### Service and Processor Updates:

* [`src/ai/backend/manager/server.py`](diffhunk://#diff-afbbd1783852837b204da4ea3041dadcd741e9c88a506725e40ad270b1ceda9eR77-R79): Added `GroupProcessors` and `GroupService` to the server context to manage group-related operations. [[1]](diffhunk://#diff-afbbd1783852837b204da4ea3041dadcd741e9c88a506725e40ad270b1ceda9eR77-R79) [[2]](diffhunk://#diff-afbbd1783852837b204da4ea3041dadcd741e9c88a506725e40ad270b1ceda9eR444-R450)
* [`src/ai/backend/manager/services/groups/actions/create_group.py`](diffhunk://#diff-58039426432b0fff137629afa913456c3238f390f32558c29987d23b84ab63e8L1-R1): Updated the `CreateGroupAction` class to include new fields with default values and a method to get insertion data for the group. [[1]](diffhunk://#diff-58039426432b0fff137629afa913456c3238f390f32558c29987d23b84ab63e8L1-R1) [[2]](diffhunk://#diff-58039426432b0fff137629afa913456c3238f390f32558c29987d23b84ab63e8L14-R24) [[3]](diffhunk://#diff-58039426432b0fff137629afa913456c3238f390f32558c29987d23b84ab63e8R37)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
