### PR TITLE
fix(BA-1049): Remove wrong `Accept` header from Image rescanning logic 

### DIFF
--- a/changes/4066.fix.md
+++ b/changes/4066.fix.md
@@ -1,0 +1,1 @@
+Remove wrong `Accept` header from Image rescanning logic.

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1626,6 +1626,12 @@ class DispatchResult(Generic[ResultType]):
     def error(cls, error_message: str) -> DispatchResult[ResultType]:
         return cls(errors=[error_message])
 
+    @classmethod
+    def partial_success(
+        cls, result_type: ResultType, errors: list[str]
+    ) -> DispatchResult[ResultType]:
+        return cls(result=result_type, errors=errors)
+
 
 class PurgeImageResult(TypedDict):
     image: str

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -366,8 +366,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**rqst_args}
-        rqst_args["headers"] = rqst_args.get("headers") or {}
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -401,9 +399,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**rqst_args}
-        rqst_args["headers"] = rqst_args.get("headers") or {}
-
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
 
@@ -468,8 +463,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**rqst_args}
-        rqst_args["headers"] = rqst_args.get("headers") or {}
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -503,8 +496,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**rqst_args}
-        rqst_args["headers"] = rqst_args.get("headers") or {}
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
         tg.create_task(
@@ -519,7 +510,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_per_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: dict[str, Any],
+        rqst_args: Mapping[str, Any],
         image: str,
         *,
         digest: str,
@@ -576,7 +567,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_single_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: dict[str, Any],
+        rqst_args: Mapping[str, Any],
         image: str,
         tag: str,
     ) -> None:

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -368,7 +368,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
     ) -> None:
         rqst_args = {**rqst_args}
         rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"].update({"Accept": "application/vnd.oci.image.manifest.v1+json"})
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -404,7 +403,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
     ) -> None:
         rqst_args = {**rqst_args}
         rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_OCI_MANIFEST
 
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
@@ -472,9 +470,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
     ) -> None:
         rqst_args = {**rqst_args}
         rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"].update({
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        })
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -510,9 +505,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
     ) -> None:
         rqst_args = {**rqst_args}
         rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"].update({
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        })
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
         tg.create_task(
@@ -595,7 +587,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         """
         manifests = {}
         async with concurrency_sema.get():
-            rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
             # Harbor does not provide architecture information for a single-arch tag reference.
             # We heuristically detect the architecture using the tag name pattern.
             if tag.endswith("-arm64") or tag.endswith("-aarch64"):

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -950,7 +950,7 @@ class RescanImages(graphene.Mutation):
                 )
                 loaded_registries = registries.registries
 
-            rescaned_images = []
+            rescanned_images = []
             errors = []
             for registry_data in loaded_registries:
                 action_result = (
@@ -967,11 +967,11 @@ class RescanImages(graphene.Mutation):
                     log.error(error)
 
                 errors.extend(action_result.errors)
-                rescaned_images.extend(action_result.images)
+                rescanned_images.extend(action_result.images)
 
             if errors:
-                return DispatchResult.partial_success(rescaned_images, errors)
-            return DispatchResult.success(rescaned_images)
+                return DispatchResult.partial_success(rescanned_images, errors)
+            return DispatchResult.success(rescanned_images)
 
         task_id = await ctx.background_task_manager.start(_bg_task)
         return RescanImages(ok=True, msg="", task_id=task_id)

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -1255,7 +1255,11 @@ class PurgeImages(graphene.Mutation):
                         log.error(result.error)
                         total_result.errors.append(result.error)
 
-            return DispatchResult.success(total_result)
+            if total_result.errors:
+                return DispatchResult.partial_success(
+                    total_result.purged_images, total_result.errors
+                )
+            return DispatchResult.success(total_result.purged_images)
 
         task_id = await ctx.background_task_manager.start(_bg_task)
         return PurgeImagesPayload(task_id=task_id)

--- a/tests/manager/conftest.py
+++ b/tests/manager/conftest.py
@@ -93,6 +93,30 @@ here = Path(__file__).parent
 log = logging.getLogger("tests.manager.conftest")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rescan-cr-backend-ai",
+        action="store_true",
+        default=False,
+        help="Enable tests marked as rescan_cr_backend_ai",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "rescan_cr_backend_ai: mark test to run only when --rescan-cr-backend-ai is set",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--rescan-cr-backend-ai"):
+        skip_flag = pytest.mark.skip(reason="--rescan-cr-backend-ai not set")
+        for item in items:
+            if "rescan_cr_backend_ai" in item.keywords:
+                item.add_marker(skip_flag)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def test_id():
     return secrets.token_hex(12)

--- a/tests/manager/models/test_image.py
+++ b/tests/manager/models/test_image.py
@@ -325,3 +325,90 @@ async def test_image_rescan_on_docker_registry(
             res = await db_session.execute(sa.select(ImageRow.image, ImageRow.tag))
             populated_img_names = res.fetchall()
             assert set(populated_img_names) == test_case["expected_result"]["images"]
+
+
+@pytest.mark.rescan_cr_backend_ai
+@pytest.mark.timeout(60)
+async def test_image_rescan_on_cr_backend_ai(
+    client: Client,
+    etcd_fixture,
+    database_fixture,
+    create_app_and_client,
+):
+    app, _ = await create_app_and_client(
+        [
+            shared_config_ctx,
+            database_ctx,
+            monitoring_ctx,
+            hook_plugin_ctx,
+            redis_ctx,
+            event_dispatcher_ctx,
+            services_ctx,
+            network_plugin_ctx,
+            storage_manager_ctx,
+            agent_registry_ctx,
+            background_task_ctx,
+            distributed_lock_ctx,
+            idle_checker_ctx,
+            processors_ctx,
+        ],
+        [".events", ".auth"],
+    )
+    root_ctx: RootContext = app["_root.context"]
+    dispatcher: EventDispatcher = root_ctx.event_dispatcher
+    done_handler_ctx = {}
+    done_event = asyncio.Event()
+
+    async def done_sub(
+        context: web.Application,
+        source: AgentId,
+        event: BgtaskDoneEvent,
+    ) -> None:
+        done_handler_ctx["event_name"] = event.name
+        update_body = attr.asdict(event)  # type: ignore
+        done_handler_ctx.update(**update_body)
+        done_event.set()
+
+    async def fail_sub(
+        context: web.Application,
+        source: AgentId,
+        event: BgtaskFailedEvent,
+    ) -> None:
+        assert False, "Background task failed"
+
+    async def cancel_sub(
+        context: web.Application,
+        source: AgentId,
+        event: BgtaskCancelledEvent,
+    ) -> None:
+        assert False, "Background task was cancelled"
+
+    dispatcher.subscribe(BgtaskDoneEvent, app, done_sub)
+    dispatcher.subscribe(BgtaskFailedEvent, app, fail_sub)
+    dispatcher.subscribe(BgtaskCancelledEvent, app, cancel_sub)
+
+    context = get_graphquery_context(
+        root_ctx.background_task_manager,
+        root_ctx.services_ctx,
+        root_ctx.processors,
+        root_ctx.db,
+    )
+    image_rescan_query = """
+        mutation ($registry: String, $project: String) {
+            rescan_images(registry: $registry, project: $project) {
+                ok
+                msg
+                task_id
+            }
+        }
+    """
+    variables = {
+        "registry": "cr.backend.ai",
+        "project": "stable",
+    }
+
+    res = await client.execute_async(image_rescan_query, context=context, variables=variables)
+    assert res["data"]["rescan_images"]["ok"]
+    await done_event.wait()
+    errors = done_handler_ctx.get("errors", None)
+    assert not errors, f"Rescan task failed with errors: {errors}"


### PR DESCRIPTION
Resolves #4054 (BA-1049).

To run the image rescanning test on cr.backend.ai,

```
pants test --pytest-args="--rescan-cr-backend-ai" ./tests/manager/models/test_image.py
```

<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
