### PR TITLE
fix(BA-1041): Add newline at end of customized dotfiles (#4047)

### DIFF
--- a/changes/4047.fix.md
+++ b/changes/4047.fix.md
@@ -1,0 +1,1 @@
+Add missing newline at end of customized dotfiles.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -663,7 +663,11 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             else:
                 file_path = self.work_dir / dotfile["path"]
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            await loop.run_in_executor(None, file_path.write_text, dotfile["data"])
+
+            dotfile_content = dotfile["data"]
+            if not dotfile_content.endswith("\n"):
+                dotfile_content += "\n"
+            await loop.run_in_executor(None, file_path.write_text, dotfile_content)
 
             tmp = Path(file_path)
             while tmp != self.work_dir:


### PR DESCRIPTION
This is an auto-generated backport PR of #4047 to the 23.09 release.