### PR TITLE
fix(BA-1073): Add missing `AuditLog` module import

### DIFF
--- a/changes/4079.fix.md
+++ b/changes/4079.fix.md
@@ -1,0 +1,1 @@
+Add missing `AuditLog` module import.

--- a/changes/4079.fix.md
+++ b/changes/4079.fix.md
@@ -1,1 +1,1 @@
-Add missing `AuditLog` module import.
+Add missing `AuditLog` module import to ensure AuditLog table created at initial installation.

--- a/src/ai/backend/manager/models/__init__.py
+++ b/src/ai/backend/manager/models/__init__.py
@@ -1,6 +1,7 @@
 from . import acl as _acl
 from . import agent as _agent
 from . import association_container_registries_groups as _association_container_registries_groups
+from . import audit_log as _auditlog
 from . import container_registry as _container_registry
 from . import domain as _domain
 from . import dotfile as _dotfile
@@ -31,6 +32,7 @@ from .gql_models import session as _relay_session
 __all__ = (
     "metadata",
     *_acl.__all__,
+    *_auditlog.__all__,
     *_agent.__all__,
     *_association_container_registries_groups.__all__,
     *_container_registry.__all__,
@@ -61,6 +63,7 @@ __all__ = (
 )
 
 from .acl import *  # noqa
+from .audit_log import *  # noqa
 from .agent import *  # noqa
 from .association_container_registries_groups import *  # noqa
 from .container_registry import *  # noqa

--- a/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
@@ -1,5 +1,4 @@
-"""Ensure AuditLogs table exist
-
+"""Ensure AuditLogs table exists
 Revision ID: c4ea15b77136
 Revises: 683ca0a32f41
 Create Date: 2025-04-04 01:11:07.003523

--- a/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
@@ -1,4 +1,5 @@
 """Ensure AuditLogs table exists
+
 Revision ID: c4ea15b77136
 Revises: 683ca0a32f41
 Create Date: 2025-04-04 01:11:07.003523

--- a/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
@@ -59,14 +59,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    inspector = sa.inspect(conn)
-
-    if "audit_logs" not in inspector.get_table_names():
-        return
-
-    op.drop_index(op.f("ix_audit_logs_created_at"), table_name="audit_logs")
-    op.drop_index(op.f("ix_audit_logs_entity_type"), table_name="audit_logs")
-    op.drop_index(op.f("ix_audit_logs_operation"), table_name="audit_logs")
-    op.drop_index(op.f("ix_audit_logs_entity_id"), table_name="audit_logs")
-    op.drop_table("audit_logs")
+    # Downgrade should be performed in 683ca0a32f41
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4ea15b77136_ensure_auditlogs_table_exist.py
@@ -23,6 +23,8 @@ depends_on = None
 logger = logging.getLogger("alembic.runtime.migration")
 
 
+# This migration script was intentionally created as a duplicate of 683ca0a32f41 to address an #4084.
+# See https://github.com/lablup/backend.ai/pull/4079.
 def upgrade() -> None:
     conn = op.get_bind()
     inspector = sa.inspect(conn)


### PR DESCRIPTION
Resolves #4084 (BA-1073).

The cause of the error is that the import of auditlog.py was missing in the `backend/manager/models/__init__.py` file.

Let's add the missing import to ensure that the `AuditLog` table is properly created during the initial installation, and also add a new duplicate migration script to guarantee that the `AuditLog` table definitely exists.


**Checklist:** (if applicable)
- [x] Mention to the original issue

