### PR TITLE
chore(BA-1082): Replace aiodataloader package to the managed upstream one

### DIFF
--- a/changes/4098.fix.md
+++ b/changes/4098.fix.md
@@ -1,0 +1,1 @@
+Replace aiodataloader-ng (a fork based on 0.2.1) with the managed upstream aiodataloader package (0.4.2)

--- a/python.lock
+++ b/python.lock
@@ -13,7 +13,7 @@
 //     "PyJWT~=2.0",
 //     "PyYAML~=6.0",
 //     "SQLAlchemy[postgresql_asyncpg]~=1.4.54",
-//     "aiodataloader-ng~=0.2.1",
+//     "aiodataloader~=0.4.2",
 //     "aiodns>=3.2",
 //     "aiodocker==0.24.0",
 //     "aiofiles~=24.1.0",
@@ -153,29 +153,33 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c705656ae8cab12f8d313ddac4d68d6036bafe403f172c9687ece027cde21acc",
-              "url": "https://files.pythonhosted.org/packages/d4/f7/9b837b7893d2db59c21df28434f31637a37884ce6b9e29b92d4dd1e68435/aiodataloader_ng-0.2.1-py3-none-any.whl"
+              "hash": "3c9780867631326a2ae931c322fac5e2a2ad5a48bf7646e5250834630536ef57",
+              "url": "https://files.pythonhosted.org/packages/ef/20/8700336be44dcccab78741f2513b1b1474ba4070134e8c2b5a50865f07bd/aiodataloader-0.4.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f655efa53d72f9887617443161e7920eaa10b79ba6710326223bf9de395515ec",
-              "url": "https://files.pythonhosted.org/packages/e0/09/9d11e527dcd81e770526a32c95e207fa6ef0aeb92de6b31b418573ebfd0b/aiodataloader-ng-0.2.1.tar.gz"
+              "hash": "c92f6f2fb7ee13939ffd68274895aca44ccc0294a1275179bfb8af2b29b788e1",
+              "url": "https://files.pythonhosted.org/packages/bc/3b/405fe771e782054509f976db2a29c69bb6250be8bde16ac1fa93755070c6/aiodataloader-0.4.2.tar.gz"
             }
           ],
-          "project_name": "aiodataloader-ng",
+          "project_name": "aiodataloader",
           "requires_dists": [
+            "black; extra == \"lint\"",
             "coveralls; extra == \"test\"",
-            "flake8>=3.9.0; extra == \"lint\"",
+            "flake8-import-order; extra == \"lint\"",
+            "flake8; extra == \"lint\"",
+            "hatch; extra == \"build\"",
+            "hatch; extra == \"lint\"",
+            "hatch; extra == \"test\"",
             "mock; extra == \"test\"",
-            "mypy>=0.930; extra == \"typecheck\"",
+            "mypy; extra == \"lint\"",
             "pytest-asyncio; extra == \"test\"",
             "pytest-cov; extra == \"test\"",
-            "pytest>=6.2.5; extra == \"test\"",
-            "twine>=3.7.1; extra == \"build\"",
-            "wheel>=0.37.1; extra == \"build\""
+            "pytest>=3.6; extra == \"test\"",
+            "typing-extensions>=4.1.1"
           ],
-          "requires_python": null,
-          "version": "0.2.1"
+          "requires_python": ">=3.7",
+          "version": "0.4.2"
         },
         {
           "artifacts": [
@@ -259,19 +263,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "147ec992cf873d74f5062644332c539fcd42956dc69453fe5204195e560517e1",
-              "url": "https://files.pythonhosted.org/packages/44/4c/03fb05f56551828ec67ceb3665e5dc51638042d204983a03b0a1541475b6/aiohappyeyeballs-2.4.6-py3-none-any.whl"
+              "hash": "f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8",
+              "url": "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b05052f9042985d32ecbe4b59a77ae19c006a78f1344d7fdad69d28ded3d0b0",
-              "url": "https://files.pythonhosted.org/packages/08/07/508f9ebba367fc3370162e53a3cfd12f5652ad79f0e0bfdf9f9847c6f159/aiohappyeyeballs-2.4.6.tar.gz"
+              "hash": "c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558",
+              "url": "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz"
             }
           ],
           "project_name": "aiohappyeyeballs",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "2.4.6"
+          "version": "2.6.1"
         },
         {
           "artifacts": [
@@ -366,22 +370,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e",
-              "url": "https://files.pythonhosted.org/packages/13/e7/e436a0c0eb5127d8b491a9b83ecd2391c6ff7dcd5548dfaec2080a2340fd/aiohttp_cors-0.7.0-py3-none-any.whl"
+              "hash": "3180cf304c5c712d626b9162b195b1db7ddf976a2a25172b35bb2448b890a80d",
+              "url": "https://files.pythonhosted.org/packages/98/3b/40a68de458904bcc143622015fff2352b6461cd92fd66d3527bf1c6f5716/aiohttp_cors-0.8.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d",
-              "url": "https://files.pythonhosted.org/packages/44/9e/6cdce7c3f346d8fd487adf68761728ad8cd5fbc296a7b07b92518350d31f/aiohttp-cors-0.7.0.tar.gz"
+              "hash": "ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403",
+              "url": "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz"
             }
           ],
           "project_name": "aiohttp-cors",
           "requires_dists": [
-            "aiohttp>=1.1",
-            "typing; python_version < \"3.5\""
+            "aiohttp>=3.9"
           ],
-          "requires_python": null,
-          "version": "0.7.0"
+          "requires_python": ">=3.9",
+          "version": "0.8.1"
         },
         {
           "artifacts": [
@@ -798,13 +801,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a",
-              "url": "https://files.pythonhosted.org/packages/fc/30/d4986a882011f9df997a55e6becd864812ccfcd821d64aac8570ee39f719/attrs-25.1.0-py3-none-any.whl"
+              "hash": "427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+              "url": "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
-              "url": "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz"
+              "hash": "75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b",
+              "url": "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz"
             }
           ],
           "project_name": "attrs",
@@ -848,10 +851,10 @@
             "sphinx-notfound-page; extra == \"docs\"",
             "sphinx; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
-            "towncrier<24.7; extra == \"docs\""
+            "towncrier; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "25.1.0"
+          "version": "25.3.0"
         },
         {
           "artifacts": [
@@ -1046,36 +1049,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "41fb90a516995946563ec91b9d891e2516c58617e9556d5e86dfa62da3fdebe6",
-              "url": "https://files.pythonhosted.org/packages/36/0d/cc521e7b0ffe37b099f9183ced90e8f93e75910611c8b9b10968a30a2715/boto3-1.36.25-py3-none-any.whl"
+              "hash": "439c2cd18c79386b1b9d5fdc4a4e7e418e57ac50431bdf9421c60f09807f40fb",
+              "url": "https://files.pythonhosted.org/packages/b7/23/19fbca3ca1614c69b7bc1aa15839ef355b8ccf434e1ad8b190f7ebfdc261/boto3-1.37.27-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a057c19adffb48737c192bdb10f9d85e0d9dcecd21327f51520c15db9022a835",
-              "url": "https://files.pythonhosted.org/packages/0d/4d/1ea0720c173814f2055bf9ac6937a74b559169fa66602be7f37e809dda1e/boto3-1.36.25.tar.gz"
+              "hash": "ccdeee590902e6f4fb30cec6d3a88668545817fccfd3e5cb9cbc166c4a0000d4",
+              "url": "https://files.pythonhosted.org/packages/e5/3f/03033eaacd043e5c905c74f9067ebcf3a4a24fb852fa3f4745f87327f0e7/boto3-1.37.27.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.37.0,>=1.36.25",
+            "botocore<1.38.0,>=1.37.27",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.12.0,>=0.11.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.36.25"
+          "version": "1.37.27"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "04c8ff03531e8d92baa8c98d1850bdf01668a805467f4222b65e5325f94aa8af",
-              "url": "https://files.pythonhosted.org/packages/b5/e9/107e5ab6b0b02c3d766a850238741c02723ae249dcfe76c72b9c76d7b67b/botocore-1.36.25-py3-none-any.whl"
+              "hash": "a86d1ffbe344bfb183d9acc24de3428118fc166cb89d0f1ce1d412857edfacd7",
+              "url": "https://files.pythonhosted.org/packages/c3/48/f2670866a36d2dd68f7c93897fb9ec6c693bca1bb73cb867a173c2ad92c3/botocore-1.37.27-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b0a857d2621c336fb82a36cb6da4b6e062d346451ac46d110b074e5e5fd7cfc",
-              "url": "https://files.pythonhosted.org/packages/17/e7/3d93e2b5be18486a9c14fc3fda1597c5f3835a9766eb7f2ba9f144fca73f/botocore-1.36.25.tar.gz"
+              "hash": "143fd7cdb0d73f43aa1f14799124de7b857da7d7ab996af5c89a49e3032a9e66",
+              "url": "https://files.pythonhosted.org/packages/53/3f/597ca9de62d00556a2c387261293441d9e84fa196a7031ec656deffe8aee/botocore-1.37.27.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1087,7 +1090,7 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.36.25"
+          "version": "1.37.27"
         },
         {
           "artifacts": [
@@ -1156,13 +1159,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0",
-              "url": "https://files.pythonhosted.org/packages/c8/d5/867e75361fc45f6de75fe277dd085627a9db5ebb511a87f27dc1396b5351/cattrs-24.1.2-py3-none-any.whl"
+              "hash": "adf957dddd26840f27ffbd060a6c4dd3b2192c5b7c2c0525ef1bd8131d8a83f5",
+              "url": "https://files.pythonhosted.org/packages/3c/ee/d68a3de23867a9156bab7e0a22fb9a0305067ee639032a22982cf7f725e7/cattrs-24.1.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85",
-              "url": "https://files.pythonhosted.org/packages/64/65/af6d57da2cb32c076319b7489ae0958f746949d407109e3ccf4d115f147c/cattrs-24.1.2.tar.gz"
+              "hash": "981a6ef05875b5bb0c7fb68885546186d306f10f0f6718fe9b96c226e68821ff",
+              "url": "https://files.pythonhosted.org/packages/29/7b/da4aa2f95afb2f28010453d03d6eedf018f9e085bd001f039e15731aba89/cattrs-24.1.3.tar.gz"
             }
           ],
           "project_name": "cattrs",
@@ -1180,7 +1183,7 @@
             "ujson>=5.7.0; extra == \"ujson\""
           ],
           "requires_python": ">=3.8",
-          "version": "24.1.2"
+          "version": "24.1.3"
         },
         {
           "artifacts": [
@@ -1397,108 +1400,108 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7",
-              "url": "https://files.pythonhosted.org/packages/3d/cb/afff48ceaed15531eab70445abe500f07f8f96af2bb35d98af6bfa89ebd4/cryptography-44.0.1-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4",
+              "url": "https://files.pythonhosted.org/packages/b3/9f/6a3e0391957cc0c5f84aef9fbdd763035f2b52e998a53f99345e3ac69312/cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62",
-              "url": "https://files.pythonhosted.org/packages/07/ef/77c74d94a8bfc1a8a47b3cafe54af3db537f081742ee7a8a9bd982b62774/cryptography-44.0.1-cp39-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639",
+              "url": "https://files.pythonhosted.org/packages/06/88/638865be7198a84a7713950b1db7343391c6066a20e614f8fa286eb178ed/cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864",
-              "url": "https://files.pythonhosted.org/packages/0f/10/cf91691064a9e0a88ae27e31779200b1505d3aee877dbe1e4e0d73b4f155/cryptography-44.0.1-cp37-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea",
+              "url": "https://files.pythonhosted.org/packages/16/32/051f7ce79ad5a6ef5e26a92b37f172ee2d6e1cce09931646eef8de1e9827/cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3",
-              "url": "https://files.pythonhosted.org/packages/25/ba/e00d5ad6b58183829615be7f11f55a7b6baa5a06910faabdc9961527ba44/cryptography-44.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843",
+              "url": "https://files.pythonhosted.org/packages/26/e4/ba680f0b35ed4a07d87f9e98f3ebccb05091f3bf6b5a478b943253b3bbd5/cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69",
-              "url": "https://files.pythonhosted.org/packages/28/01/604508cd34a4024467cd4105887cf27da128cba3edd435b54e2395064bfb/cryptography-44.0.1-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
+              "hash": "bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb",
+              "url": "https://files.pythonhosted.org/packages/27/61/72e3afdb3c5ac510330feba4fc1faa0fe62e070592d6ad00c40bb69165e5/cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f",
-              "url": "https://files.pythonhosted.org/packages/34/b9/4d1fa8d73ae6ec350012f89c3abfbff19fc95fe5420cf972e12a8d182986/cryptography-44.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c",
+              "url": "https://files.pythonhosted.org/packages/27/7b/664ea5e0d1eab511a10e480baf1c5d3e681c7d91718f60e149cec09edf01/cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41",
-              "url": "https://files.pythonhosted.org/packages/6d/b9/8be0ff57c4592382b77406269b1e15650c9f1a167f9e34941b8515b97159/cryptography-44.0.1-cp39-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a",
+              "url": "https://files.pythonhosted.org/packages/2a/07/79554a9c40eb11345e1861f46f845fa71c9e25bf66d132e123d9feb8e7f9/cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2",
-              "url": "https://files.pythonhosted.org/packages/6e/57/371a9f3f3a4500807b5fcd29fec77f418ba27ffc629d88597d0d1049696e/cryptography-44.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1",
+              "url": "https://files.pythonhosted.org/packages/30/ec/7ea7c1e4c8fc8329506b46c6c4a52e2f20318425d48e0fe597977c71dbce/cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009",
-              "url": "https://files.pythonhosted.org/packages/72/27/5e3524053b4c8889da65cf7814a9d0d8514a05194a25e1e34f46852ee6eb/cryptography-44.0.1-cp37-abi3-macosx_10_9_universal2.whl"
+              "hash": "6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181",
+              "url": "https://files.pythonhosted.org/packages/53/7b/aafe60210ec93d5d7f552592a28192e51d3c6b6be449e7fd0a91399b5d07/cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b",
-              "url": "https://files.pythonhosted.org/packages/78/e1/4b6ac5f4100545513b0847a4d276fe3c7ce0eacfa73e3b5ebd31776816ee/cryptography-44.0.1-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9",
+              "url": "https://files.pythonhosted.org/packages/72/97/430e56e39a1356e8e8f10f723211a0e256e11895ef1a135f30d7d40f2540/cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008",
-              "url": "https://files.pythonhosted.org/packages/9f/f1/676e69c56a9be9fd1bffa9bc3492366901f6e1f8f4079428b05f1414e65c/cryptography-44.0.1-cp39-abi3-macosx_10_9_universal2.whl"
+              "hash": "b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699",
+              "url": "https://files.pythonhosted.org/packages/78/2b/999b2a1e1ba2206f2d3bca267d68f350beb2b048a41ea827e08ce7260098/cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7",
-              "url": "https://files.pythonhosted.org/packages/b3/45/690a02c748d719a95ab08b6e4decb9d81e0ec1bac510358f61624c86e8a3/cryptography-44.0.1-cp39-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23",
+              "url": "https://files.pythonhosted.org/packages/89/33/c1cf182c152e1d262cac56850939530c05ca6c8d149aa0dcee490b417e99/cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862",
-              "url": "https://files.pythonhosted.org/packages/ba/9f/1775600eb69e72d8f9931a104120f2667107a0ee478f6ad4fe4001559345/cryptography-44.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7",
+              "url": "https://files.pythonhosted.org/packages/92/ef/83e632cfa801b221570c5f58c0369db6fa6cef7d9ff859feab1aae1a8a0f/cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0",
-              "url": "https://files.pythonhosted.org/packages/c1/17/f5282661b57301204cbf188254c1a0267dbd8b18f76337f0a7ce1038888c/cryptography-44.0.1-cp37-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5",
+              "url": "https://files.pythonhosted.org/packages/9c/e8/44ae3e68c8b6d1cbc59040288056df2ad7f7f03bbcaca6b503c737ab8e73/cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911",
-              "url": "https://files.pythonhosted.org/packages/c5/1d/5b77815e7d9cf1e3166988647f336f87d5634a5ccecec2ffbe08ef8dd481/cryptography-44.0.1-cp37-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3",
+              "url": "https://files.pythonhosted.org/packages/9e/be/7a26142e6d0f7683d8a382dd963745e65db895a79a280a30525ec92be890/cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026",
-              "url": "https://files.pythonhosted.org/packages/c6/3d/d3c55d4f1d24580a236a6753902ef6d8aafd04da942a1ee9efb9dc8fd0cb/cryptography-44.0.1-cp37-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688",
+              "url": "https://files.pythonhosted.org/packages/b2/80/62df41ba4916067fa6b125aa8c14d7e9181773f0d5d0bd4dcef580d8b7c6/cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14",
-              "url": "https://files.pythonhosted.org/packages/c7/67/545c79fe50f7af51dbad56d16b23fe33f63ee6a5d956b3cb68ea110cbe64/cryptography-44.0.1.tar.gz"
+              "hash": "f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308",
+              "url": "https://files.pythonhosted.org/packages/bb/6d/858e356a49a4f0b591bd6789d821427de18432212e137290b6d8a817e9bf/cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c",
-              "url": "https://files.pythonhosted.org/packages/e1/e7/cfb18011821cc5f9b21efb3f94f3241e3a658d267a3bf3a0f45543858ed8/cryptography-44.0.1-cp39-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0",
+              "url": "https://files.pythonhosted.org/packages/cd/25/4ce80c78963834b8a9fd1cc1266be5ed8d1840785c0f2e1b73b8d128d505/cryptography-44.0.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a",
-              "url": "https://files.pythonhosted.org/packages/e6/50/bf8d090911347f9b75adc20f6f6569ed6ca9b9bff552e6e390f53c2a1233/cryptography-44.0.1-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
+              "hash": "9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd",
+              "url": "https://files.pythonhosted.org/packages/d7/fc/99fe639bcdf58561dfad1faa8a7369d1dc13f20acd78371bb97a01613585/cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd",
-              "url": "https://files.pythonhosted.org/packages/ea/a6/44d63950c8588bfa8594fd234d3d46e93c3841b8e84a066649c566afb972/cryptography-44.0.1-cp37-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922",
+              "url": "https://files.pythonhosted.org/packages/e1/99/87cf26d4f125380dc674233971069bc28d19b07f7755b29861570e513650/cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf",
-              "url": "https://files.pythonhosted.org/packages/f3/68/abbae29ed4f9d96596687f3ceea8e233f65c9645fbbec68adb7c756bb85a/cryptography-44.0.1-cp37-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7",
+              "url": "https://files.pythonhosted.org/packages/f3/cd/2558cc08f7b1bb40683f99ff4327f8dcfc7de3affc669e9065e14824511b/cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -1509,7 +1512,7 @@
             "cffi>=1.12; platform_python_implementation != \"PyPy\"",
             "check-sdist; python_version >= \"3.8\" and extra == \"pep8test\"",
             "click>=8.0.1; extra == \"pep8test\"",
-            "cryptography-vectors==44.0.1; extra == \"test\"",
+            "cryptography-vectors==44.0.2; extra == \"test\"",
             "mypy>=1.4; extra == \"pep8test\"",
             "nox>=2024.4.15; extra == \"nox\"",
             "nox[uv]>=2024.3.2; python_version >= \"3.8\" and extra == \"nox\"",
@@ -1527,7 +1530,7 @@
             "sphinxcontrib-spelling>=7.3.1; extra == \"docstest\""
           ],
           "requires_python": "!=3.9.0,!=3.9.1,>=3.7",
-          "version": "44.0.1"
+          "version": "44.0.2"
         },
         {
           "artifacts": [
@@ -2202,13 +2205,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86014ca5c52675dffa1d404491952f1f5bf03b07c175a51891a343daebf01fea",
-              "url": "https://files.pythonhosted.org/packages/32/30/5ef5994b090398f9284d2662f56853e5183ae2cb5d8e3db67e4f4cfea407/humanize-4.12.1-py3-none-any.whl"
+              "hash": "e4e44dced598b7e03487f3b1c6fd5b1146c30ea55a110e71d5d4bca3e094259e",
+              "url": "https://files.pythonhosted.org/packages/55/c7/6f89082f619c76165feb633446bd0fee32b0e0cbad00d22480e5aea26ade/humanize-4.12.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1338ba97415c96556758a6e2f65977ed406dddf4620d4c6db9bbdfd07f0f1232",
-              "url": "https://files.pythonhosted.org/packages/5b/8c/4f2f0784d08a383b5de3d3b1d65a6f204cc5dc487621c91c550388d756af/humanize-4.12.1.tar.gz"
+              "hash": "ce0715740e9caacc982bb89098182cf8ded3552693a433311c6a4ce6f4e12a2c",
+              "url": "https://files.pythonhosted.org/packages/e0/84/ae8e64a6ffe3291105e9688f4e28fa65eba7924e0fe6053d85ca00556385/humanize-4.12.2.tar.gz"
             }
           ],
           "project_name": "humanize",
@@ -2218,7 +2221,7 @@
             "pytest; extra == \"tests\""
           ],
           "requires_python": ">=3.9",
-          "version": "4.12.1"
+          "version": "4.12.2"
         },
         {
           "artifacts": [
@@ -2265,19 +2268,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
-              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
+              "hash": "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760",
+              "url": "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
-              "url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz"
+              "hash": "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+              "url": "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz"
             }
           ],
           "project_name": "iniconfig",
           "requires_dists": [],
-          "requires_python": ">=3.7",
-          "version": "2.0.0"
+          "requires_python": ">=3.8",
+          "version": "2.1.0"
         },
         {
           "artifacts": [
@@ -2325,13 +2328,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb",
-              "url": "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl"
+              "hash": "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67",
+              "url": "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
-              "url": "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz"
+              "hash": "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+              "url": "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz"
             }
           ],
           "project_name": "jinja2",
@@ -2340,7 +2343,7 @@
             "MarkupSafe>=2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "3.1.5"
+          "version": "3.1.6"
         },
         {
           "artifacts": [
@@ -2818,86 +2821,86 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "48e171e52d1c4d33888e529b999e5900356b9ae588c2f09a52dcefb158b27506",
-              "url": "https://files.pythonhosted.org/packages/99/b7/b9e70fde2c0f0c9af4cc5277782a89b66d35948ea3369ec9f598358c3ac5/multidict-6.1.0-py3-none-any.whl"
+              "hash": "71409d4579f716217f23be2f5e7afca5ca926aaeb398aa11b72d793bff637a1f",
+              "url": "https://files.pythonhosted.org/packages/aa/c1/7832c95a50641148b567b5366dd3354489950dcfd01c8fc28472bec63b9a/multidict-6.3.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "50b3a2710631848991d0bf7de077502e8994c804bb805aeb2925a981de58ec2e",
-              "url": "https://files.pythonhosted.org/packages/47/e9/604bb05e6e5bce1e6a5cf80a474e0f072e80d8ac105f1b994a53e0b28c42/multidict-6.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "643e57b403d3e240045a3681f9e6a04d35a33eddc501b4cbbbdbc9c70122e7bc",
+              "url": "https://files.pythonhosted.org/packages/1f/67/64b18180e8f559cc93efaaaac2fe0746b9c978560866b6fdd626d3237129/multidict-6.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "76f364861c3bfc98cbbcbd402d83454ed9e01a5224bb3a28bf70002a230f73e2",
-              "url": "https://files.pythonhosted.org/packages/5b/46/73697ad7ec521df7de5531a32780bbfd908ded0643cbe457f981a701457c/multidict-6.1.0-cp312-cp312-musllinux_1_2_i686.whl"
+              "hash": "9d17b37b9715b30605b5bab1460569742d0c309e5c20079263b440f5d7746e7e",
+              "url": "https://files.pythonhosted.org/packages/21/f6/e81a8e4817c2d32787b33ae58c72dc3fe08e0ba8e56e660a225df3cb8619/multidict-6.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3ec660d19bbc671e3a6443325f07263be452c453ac9e512f5eb935e7d4ac28b3",
-              "url": "https://files.pythonhosted.org/packages/77/00/8538f11e3356b5d95fa4b024aa566cde7a38aa7a5f08f4912b32a037c5dc/multidict-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "68acd51fa94e63312b8ddf84bfc9c3d3442fe1f9988bbe1b6c703043af8867fe",
+              "url": "https://files.pythonhosted.org/packages/3e/e8/44ca66758df031a8119483cf5385e2ff3b09b9c6df8f3396d626c325b553/multidict-6.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b58c621844d55e71c1b7f7c498ce5aa6985d743a1a59034c57a905b3f153c1ef",
-              "url": "https://files.pythonhosted.org/packages/7e/13/9efa50801785eccbf7086b3c83b71a4fb501a4d43549c2f2f80b8787d69f/multidict-6.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "029bbd7d782251a78975214b78ee632672310f9233d49531fc93e8e99154af25",
+              "url": "https://files.pythonhosted.org/packages/59/e0/a0a9247c32f385ac4c1afefe9c3f2271fb8e235aad72332d42384c41b9cb/multidict-6.3.2-cp312-cp312-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6180c0ae073bddeb5a97a38c03f30c233e0a4d39cd86166251617d1bbd0af436",
-              "url": "https://files.pythonhosted.org/packages/94/3d/37d1b8893ae79716179540b89fc6a0ee56b4a65fcc0d63535c6f5d96f217/multidict-6.1.0-cp312-cp312-macosx_10_9_x86_64.whl"
+              "hash": "e4d3f8e57027dcda84a1aa181501c15c45eab9566eb6fcc274cbd1e7561224f8",
+              "url": "https://files.pythonhosted.org/packages/63/37/f5a6ea10dab96491b7300be940f86a5490dc474d18473c438f2550b78da3/multidict-6.3.2-cp312-cp312-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "071120490b47aa997cca00666923a83f02c7fbb44f71cf7f136df753f7fa8761",
-              "url": "https://files.pythonhosted.org/packages/a2/12/adb6b3200c363062f805275b4c1e656be2b3681aada66c80129932ff0bae/multidict-6.1.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "d1e0ba1ce1b8cc79117196642d95f4365e118eaf5fb85f57cdbcc5a25640b2a4",
+              "url": "https://files.pythonhosted.org/packages/83/ae/bd7518193b4374484c04ba0f6522d0572dc17fcd53d238deb3cb3643c858/multidict-6.3.2-cp312-cp312-macosx_10_13_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55b6d90641869892caa9ca42ff913f7ff1c5ece06474fbd32fb2cf6834726c95",
-              "url": "https://files.pythonhosted.org/packages/bf/0f/93808b765192780d117814a6dfcc2e75de6dcc610009ad408b8814dca3ba/multidict-6.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "1fcab18e65cc555ac29981a581518c23311f2b1e72d8f658f9891590465383be",
+              "url": "https://files.pythonhosted.org/packages/87/35/3bcc3616cb54d3a327b1d26dbec284c3eb7b179e8a78a6075852dbb51dac/multidict-6.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10a9b09aba0c5b48c53761b7c720aaaf7cf236d5fe394cd399c7ba662d5f9966",
-              "url": "https://files.pythonhosted.org/packages/ca/0c/fc85b439014d5a58063e19c3a158a889deec399d47b5269a0f3b6a2e28bc/multidict-6.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "347eea2852ab7f697cc5ed9b1aae96b08f8529cca0c6468f747f0781b1842898",
+              "url": "https://files.pythonhosted.org/packages/93/76/d2faabbac582dc100a4d7ecf7d0ab8dd2aadf7f10d5d5a19e9932cf63a2e/multidict-6.3.2-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "820c661588bd01a0aa62a1283f20d2be4281b086f80dad9e955e690c75fb54a2",
-              "url": "https://files.pythonhosted.org/packages/cd/ed/51f060e2cb0e7635329fa6ff930aa5cffa17f4c7f5c6c3ddc3500708e2f2/multidict-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl"
+              "hash": "0d50eff89aa4d145a5486b171a2177042d08ea5105f813027eb1050abe91839f",
+              "url": "https://files.pythonhosted.org/packages/b8/c3/17ddbfd6fc3eed9ab7326a43651e1a97da73f7acc69b78a7bb04b59c073d/multidict-6.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4b820514bfc0b98a30e3d85462084779900347e4d49267f747ff54060cc33925",
-              "url": "https://files.pythonhosted.org/packages/d3/c8/529101d7176fe7dfe1d99604e48d69c5dfdcadb4f06561f465c8ef12b4df/multidict-6.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "d7db41e3b56817d9175264e5fe00192fbcb8e1265307a59f53dede86161b150e",
+              "url": "https://files.pythonhosted.org/packages/c3/fa/8c23cdd4492d59bea0e762662285f2163766e69e5ea715fe6a03a8670660/multidict-6.3.2-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a",
-              "url": "https://files.pythonhosted.org/packages/d6/be/504b89a5e9ca731cd47487e91c469064f8ae5af93b7259758dcfc2b9c848/multidict-6.1.0.tar.gz"
+              "hash": "430120c6ce3715a9c6075cabcee557daccbcca8ba25a9fedf05c7bf564532f2d",
+              "url": "https://files.pythonhosted.org/packages/c6/3a/0a3488be2e5a6499f512e748d31e8fb90b753eb35793ecf390b9d8548e66/multidict-6.3.2-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e16bf3e5fc9f44632affb159d30a437bfe286ce9e02754759be5536b169b305",
-              "url": "https://files.pythonhosted.org/packages/db/46/d4416eb20176492d2258fbd47b4abe729ff3b6e9c829ea4236f93c865089/multidict-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "7cafdafb44c4e646118410368307693e49d19167e5f119cbe3a88697d2d1a636",
+              "url": "https://files.pythonhosted.org/packages/cd/f2/badedad94e1731debe56d076c9e61a1658c5e9d65dfa9c1ee74d1e3d31d7/multidict-6.3.2-cp312-cp312-musllinux_1_2_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e5f362e895bc5b9e67fe6e4ded2492d8124bdf817827f33c5b46c2fe3ffaca6",
-              "url": "https://files.pythonhosted.org/packages/df/9e/ee7d1954b1331da3eddea0c4e08d9142da5f14b1321c7301f5014f49d492/multidict-6.1.0-cp312-cp312-musllinux_1_2_s390x.whl"
+              "hash": "9ca57a841ffcf712e47875d026aa49d6e67f9560624d54b51628603700d5d287",
+              "url": "https://files.pythonhosted.org/packages/d4/b1/2c32b684763b69becbaaa61b7af8a45a6f757fc82d9b4b123ca90cb69f75/multidict-6.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b04772ed465fa3cc947db808fa306d79b43e896beb677a56fb2347ca1a49c1fa",
-              "url": "https://files.pythonhosted.org/packages/fd/16/92057c74ba3b96d5e211b553895cd6dc7cc4d1e43d9ab8fafc727681ef71/multidict-6.1.0-cp312-cp312-macosx_10_9_universal2.whl"
+              "hash": "c1035eea471f759fa853dd6e76aaa1e389f93b3e1403093fa0fd3ab4db490678",
+              "url": "https://files.pythonhosted.org/packages/fa/2d/6e0d6771cadd5ad14d13193cc8326dc0b341cc1659c306cbfce7a5058fff/multidict-6.3.2.tar.gz"
             }
           ],
           "project_name": "multidict",
           "requires_dists": [
             "typing-extensions>=4.1.0; python_version < \"3.11\""
           ],
-          "requires_python": ">=3.8",
-          "version": "6.1.0"
+          "requires_python": ">=3.9",
+          "version": "6.3.2"
         },
         {
           "artifacts": [
@@ -3040,13 +3043,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb",
-              "url": "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl"
+              "hash": "a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94",
+              "url": "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
-              "url": "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz"
+              "hash": "eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351",
+              "url": "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz"
             }
           ],
           "project_name": "platformdirs",
@@ -3054,16 +3057,16 @@
             "appdirs==1.4.4; extra == \"test\"",
             "covdefaults>=2.3; extra == \"test\"",
             "furo>=2024.8.6; extra == \"docs\"",
-            "mypy>=1.11.2; extra == \"type\"",
+            "mypy>=1.14.1; extra == \"type\"",
             "proselint>=0.14; extra == \"docs\"",
-            "pytest-cov>=5; extra == \"test\"",
+            "pytest-cov>=6; extra == \"test\"",
             "pytest-mock>=3.14; extra == \"test\"",
-            "pytest>=8.3.2; extra == \"test\"",
-            "sphinx-autodoc-typehints>=2.4; extra == \"docs\"",
-            "sphinx>=8.0.2; extra == \"docs\""
+            "pytest>=8.3.4; extra == \"test\"",
+            "sphinx-autodoc-typehints>=3; extra == \"docs\"",
+            "sphinx>=8.1.3; extra == \"docs\""
           ],
-          "requires_python": ">=3.8",
-          "version": "4.3.6"
+          "requires_python": ">=3.9",
+          "version": "4.3.7"
         },
         {
           "artifacts": [
@@ -3262,21 +3265,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd",
-              "url": "https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl"
+              "hash": "29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a",
+              "url": "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c",
-              "url": "https://files.pythonhosted.org/packages/1d/67/6afbf0d507f73c32d21084a79946bfcfca5fbc62a72057e9c23797a737c9/pyasn1_modules-0.4.1.tar.gz"
+              "hash": "677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6",
+              "url": "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz"
             }
           ],
           "project_name": "pyasn1-modules",
           "requires_dists": [
-            "pyasn1<0.7.0,>=0.4.6"
+            "pyasn1<0.7.0,>=0.6.1"
           ],
           "requires_python": ">=3.8",
-          "version": "0.4.1"
+          "version": "0.4.2"
         },
         {
           "artifacts": [
@@ -3376,54 +3379,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93",
-              "url": "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "d21c1eda2f42211f18a25db4eaf8056c94a8563cd39da3683f89fe0d881fb772",
+              "url": "https://files.pythonhosted.org/packages/b8/2a/25e0be2b509c28375c7f75c7e8d8d060773f2cce4856a1654276e3202339/pycryptodome-3.22.0-cp37-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f7787e0d469bdae763b876174cf2e6c0f7be79808af26b1da96f1a64bcf47297",
-              "url": "https://files.pythonhosted.org/packages/13/52/13b9db4a913eee948152a079fe58d035bd3d1a519584155da8e786f767e6/pycryptodome-3.21.0.tar.gz"
+              "hash": "009e1c80eea42401a5bd5983c4bab8d516aef22e014a4705622e24e6d9d703c6",
+              "url": "https://files.pythonhosted.org/packages/1f/65/a05831c3e4bcd1bf6c2a034e399f74b3d6f30bb4e37e36b9c310c09dc8c0/pycryptodome-3.22.0-cp37-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d85c1b613121ed3dbaa5a97369b3b757909531a959d229406a75b912dd51dd1",
-              "url": "https://files.pythonhosted.org/packages/2c/2b/152c330732a887a86cbf591ed69bd1b489439b5464806adb270f169ec139/pycryptodome-3.21.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "f6cf6aa36fcf463e622d2165a5ad9963b2762bebae2f632d719dfb8544903cf5",
+              "url": "https://files.pythonhosted.org/packages/3d/f9/a4f8a83384626098e3f55664519bec113002b9ef751887086ae63a53135a/pycryptodome-3.22.0-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "932c905b71a56474bff8a9c014030bc3c882cee696b448af920399f730a650c2",
-              "url": "https://files.pythonhosted.org/packages/39/1f/c74288f54d80a20a78da87df1818c6464ac1041d10988bb7d982c4153fbc/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_i686.whl"
+              "hash": "fd7ab568b3ad7b77c908d7c3f7e167ec5a8f035c64ff74f10d47a4edd043d723",
+              "url": "https://files.pythonhosted.org/packages/44/e6/099310419df5ada522ff34ffc2f1a48a11b37fc6a76f51a6854c182dbd3e/pycryptodome-3.22.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "8898a66425a57bcf15e25fc19c12490b87bd939800f39a03ea2de2aea5e3611a",
-              "url": "https://files.pythonhosted.org/packages/55/92/517c5c498c2980c1b6d6b9965dffbe31f3cd7f20f40d00ec4069559c5902/pycryptodome-3.21.0-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "3b76fa80daeff9519d7e9f6d9e40708f2fce36b9295a847f00624a08293f4f00",
+              "url": "https://files.pythonhosted.org/packages/5c/76/ff3c2e7a60d17c080c4c6120ebaf60f38717cd387e77f84da4dcf7f64ff0/pycryptodome-3.22.0-cp37-abi3-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de18954104667f565e2fbb4783b56667f30fb49c4d79b346f52a29cb198d5b6b",
-              "url": "https://files.pythonhosted.org/packages/66/e1/8f28cd8cf7f7563319819d1e172879ccce2333781ae38da61c28fe22d6ff/pycryptodome-3.21.0-cp36-abi3-macosx_10_9_x86_64.whl"
+              "hash": "aec7b40a7ea5af7c40f8837adf20a137d5e11a6eb202cde7e588a48fb2d871a8",
+              "url": "https://files.pythonhosted.org/packages/88/65/e5f8c3a885f70a6e05c84844cd5542120576f4369158946e8cfc623a464d/pycryptodome-3.22.0-cp37-abi3-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2de4b7263a33947ff440412339cb72b28a5a4c769b5c1ca19e33dd6cd1dcec6e",
-              "url": "https://files.pythonhosted.org/packages/6a/c1/f75a1aaff0c20c11df8dc8e2bf8057e7f73296af7dfd8cbb40077d1c930d/pycryptodome-3.21.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a0092fd476701eeeb04df5cc509d8b739fa381583cda6a46ff0a60639b7cd70d",
+              "url": "https://files.pythonhosted.org/packages/92/65/35f5063e68790602d892ad36e35ac723147232a9084d1999630045c34593/pycryptodome-3.22.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2480ec2c72438430da9f601ebc12c518c093c13111a5c1644c82cdfc2e50b1e4",
-              "url": "https://files.pythonhosted.org/packages/a7/88/5e83de10450027c96c79dc65ac45e9d0d7a7fef334f39d3789a191f33602/pycryptodome-3.21.0-cp36-abi3-macosx_10_9_universal2.whl"
+              "hash": "18d5b0ddc7cf69231736d778bd3ae2b3efb681ae33b64b0c92fb4626bb48bb89",
+              "url": "https://files.pythonhosted.org/packages/cc/67/46acdd35b1081c3dbc72dc466b1b95b80d2f64cad3520f994a9b6c5c7d00/pycryptodome-3.22.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0714206d467fc911042d01ea3a1847c847bc10884cf674c82e12915cfe1649f8",
-              "url": "https://files.pythonhosted.org/packages/ea/66/6f2b7ddb457b19f73b82053ecc83ba768680609d56dd457dbc7e902c41aa/pycryptodome-3.21.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "a31fa5914b255ab62aac9265654292ce0404f6b66540a065f538466474baedbc",
+              "url": "https://files.pythonhosted.org/packages/cc/7f/cc5d6da0dbc36acd978d80a72b228e33aadaec9c4f91c93221166d8bdc05/pycryptodome-3.22.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pycryptodome",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "3.21.0"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7",
+          "version": "3.22.0"
         },
         {
           "artifacts": [
@@ -3619,13 +3622,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6",
-              "url": "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl"
+              "hash": "c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
+              "url": "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761",
-              "url": "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz"
+              "hash": "f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845",
+              "url": "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -3646,7 +3649,7 @@
             "xmlschema; extra == \"dev\""
           ],
           "requires_python": ">=3.8",
-          "version": "8.3.4"
+          "version": "8.3.5"
         },
         {
           "artifacts": [
@@ -3676,13 +3679,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3",
-              "url": "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl"
+              "hash": "7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0",
+              "url": "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a",
-              "url": "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz"
+              "hash": "c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f",
+              "url": "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz"
             }
           ],
           "project_name": "pytest-asyncio",
@@ -3691,10 +3694,11 @@
             "hypothesis>=5.7.1; extra == \"testing\"",
             "pytest<9,>=8.2",
             "sphinx-rtd-theme>=1; extra == \"docs\"",
-            "sphinx>=5.3; extra == \"docs\""
+            "sphinx>=5.3; extra == \"docs\"",
+            "typing-extensions>=4.12; python_version < \"3.10\""
           ],
           "requires_python": ">=3.9",
-          "version": "0.25.3"
+          "version": "0.26.0"
         },
         {
           "artifacts": [
@@ -3844,61 +3848,56 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "91e2bfb8e9a29f709d51b208dd5f441dc98eb412c8fe75c24ea464734ccdb48e",
-              "url": "https://files.pythonhosted.org/packages/d9/c4/b3edb7d0ae82ad6fb1a8cdb191a4113c427a01e85139906f3b655b07f4f8/pyzmq-26.2.1-cp312-cp312-musllinux_1_1_x86_64.whl"
+              "hash": "ba698c7c252af83b6bba9775035263f0df5f807f0404019916d4b71af8161f66",
+              "url": "https://files.pythonhosted.org/packages/6b/36/7c570698127a43398ed1b1832dada59496e633115016addbce5eda9938a6/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "17d72a74e5e9ff3829deb72897a175333d3ef5b5413948cae3cf7ebf0b02ecca",
-              "url": "https://files.pythonhosted.org/packages/5a/e3/8d0382cb59feb111c252b54e8728257416a38ffcb2243c4e4775a3c990fe/pyzmq-26.2.1.tar.gz"
+              "hash": "943a22ebb3daacb45f76a9bcca9a7b74e7d94608c0c0505da30af900b998ca8d",
+              "url": "https://files.pythonhosted.org/packages/02/ad/afcb8484b65ceacd1609f709c2caeed31bd6c49261a7507cd5c175cc105f/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a6549ecb0041dafa55b5932dcbb6c68293e0bd5980b5b99f5ebb05f9a3b8a8f3",
-              "url": "https://files.pythonhosted.org/packages/9c/b9/260a74786f162c7f521f5f891584a51d5a42fd15f5dcaa5c9226b2865fcc/pyzmq-26.2.1-cp312-cp312-macosx_10_15_universal2.whl"
+              "hash": "f1cd68b8236faab78138a8fc703f7ca0ad431b17a3fcac696358600d4e6243b3",
+              "url": "https://files.pythonhosted.org/packages/3a/ed/c3876f3b3e8beba336214ce44e1efa1792dd537027cef24192ac2b077d7c/pyzmq-26.3.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d88ba221a07fc2c5581565f1d0fe8038c15711ae79b80d9462e080a1ac30435",
-              "url": "https://files.pythonhosted.org/packages/a1/d1/6fda77a034d02034367b040973fd3861d945a5347e607bd2e98c99f20599/pyzmq-26.2.1-cp312-cp312-manylinux_2_28_x86_64.whl"
+              "hash": "7a4ac2ffa34f1212dd586af90f4ba894e424f0cabb3a49cdcff944925640f6ac",
+              "url": "https://files.pythonhosted.org/packages/5a/56/29dcd3647a39e933eb489fda261a1e2700a59d4a9432889a85166e15651c/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c84c1297ff9f1cd2440da4d57237cb74be21fdfe7d01a10810acba04e79371a",
-              "url": "https://files.pythonhosted.org/packages/ad/81/48f7fd8a71c427412e739ce576fc1ee14f3dc34527ca9b0076e471676183/pyzmq-26.2.1-cp312-cp312-musllinux_1_1_aarch64.whl"
+              "hash": "e281a8071a06888575a4eb523c4deeefdcd2f5fe4a2d47e02ac8bf3a5b49f695",
+              "url": "https://files.pythonhosted.org/packages/74/6a/63db856e93e3a3c3dc98a1de28a902cf1b21c7b0d3856cd5931d7cfd30af/pyzmq-26.3.0-cp312-cp312-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0250c94561f388db51fd0213cdccbd0b9ef50fd3c57ce1ac937bf3034d92d72e",
-              "url": "https://files.pythonhosted.org/packages/bf/73/8a0757e4b68f5a8ccb90ddadbb76c6a5f880266cdb18be38c99bcdc17aaa/pyzmq-26.2.1-cp312-cp312-macosx_10_9_x86_64.whl"
+              "hash": "6e317ee1d4528a03506cb1c282cd9db73660a35b3564096de37de7350e7d87a7",
+              "url": "https://files.pythonhosted.org/packages/74/f3/908b17f9111cdc764aef1de3d36026a2984c46ed90c3c2c85f28b66142f0/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "786dd8a81b969c2081b31b17b326d3a499ddd1856e06d6d79ad41011a25148da",
-              "url": "https://files.pythonhosted.org/packages/c3/25/0b4824596f261a3cc512ab152448b383047ff5f143a6906a36876415981c/pyzmq-26.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c80653332c6136da7f4d4e143975e74ac0fa14f851f716d90583bc19e8945cea",
+              "url": "https://files.pythonhosted.org/packages/7b/03/7170c3814bb9106c1bca67700c731aaf1cd990fd2f0097c754acb600330e/pyzmq-26.3.0-cp312-cp312-macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "46d4ebafc27081a7f73a0f151d0c38d4291656aa134344ec1f3d0199ebfbb6d4",
-              "url": "https://files.pythonhosted.org/packages/c7/d8/818f15c6ef36b5450e435cbb0d3a51599fc884a5d2b27b46b9c00af68ef1/pyzmq-26.2.1-cp312-cp312-musllinux_1_1_i686.whl"
+              "hash": "3fc9e71490d989144981ea21ef4fdfaa7b6aa84aff9632d91c736441ce2f6b00",
+              "url": "https://files.pythonhosted.org/packages/a1/b5/4eeeae0aaaa6ef0c74cfa8b2273b53382bd858df6d99485f2fc8211e7002/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36ee4297d9e4b34b5dc1dd7ab5d5ea2cbba8511517ef44104d2915a917a56dc8",
-              "url": "https://files.pythonhosted.org/packages/cf/de/f02ec973cd33155bb772bae33ace774acc7cc71b87b25c4829068bec35de/pyzmq-26.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c2a9cb17fd83b7a3a3009901aca828feaf20aa2451a8a487b035455a86549c09",
-              "url": "https://files.pythonhosted.org/packages/d1/80/8fc583085f85ac91682744efc916888dd9f11f9f75a31aef1b78a5486c6c/pyzmq-26.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "be77efd735bb1064605be8dec6e721141c1421ef0b115ef54e493a64e50e9a52",
+              "url": "https://files.pythonhosted.org/packages/e1/ce/d522c9b46ee3746d4b98c81969c568c2c6296e931a65f2c87104b645654c/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_aarch64.whl"
             }
           ],
           "project_name": "pyzmq",
           "requires_dists": [
             "cffi; implementation_name == \"pypy\""
           ],
-          "requires_python": ">=3.7",
-          "version": "26.2.1"
+          "requires_python": ">=3.8",
+          "version": "26.3.0"
         },
         {
           "artifacts": [
@@ -4058,79 +4057,79 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "be6ecb39fadd986ef1701097771f87e4d2f821f27f6071c872143884d2950fbc",
-              "url": "https://files.pythonhosted.org/packages/1b/ac/e7dc469e49048dc57f62e0c555d2ee3117fa30813d2a1a2962cce3a2a82a/s3transfer-0.11.2-py3-none-any.whl"
+              "hash": "ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d",
+              "url": "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f",
-              "url": "https://files.pythonhosted.org/packages/62/45/2323b5928f86fd29f9afdcef4659f68fa73eaa5356912b774227f5cf46b5/s3transfer-0.11.2.tar.gz"
+              "hash": "559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679",
+              "url": "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz"
             }
           ],
           "project_name": "s3transfer",
           "requires_dists": [
-            "botocore<2.0a.0,>=1.36.0",
-            "botocore[crt]<2.0a.0,>=1.36.0; extra == \"crt\""
+            "botocore<2.0a.0,>=1.37.4",
+            "botocore[crt]<2.0a.0,>=1.37.4; extra == \"crt\""
           ],
           "requires_python": ">=3.8",
-          "version": "0.11.2"
+          "version": "0.11.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "726aee40357d4bdb70115442cb85ccc8e8bc554fc0bbbaa3a57cbe81df42287d",
-              "url": "https://files.pythonhosted.org/packages/b0/76/9b4877850c9c5f41c4bacae441285dead7c192bebf4fcbf3b3eb0e8033cc/setproctitle-1.3.4-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "f3b5e2eacd572444770026c9dd3ddc7543ce427cdf452d40a408d1e95beefb30",
+              "url": "https://files.pythonhosted.org/packages/6e/08/13b561085d2de53b9becfa5578545d99114e9ff2aa3dc151bcaadf80b17e/setproctitle-1.3.5-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a88e466fcaee659679c1d64dcb2eddbcb4bfadffeb68ba834d9c173a25b6184",
-              "url": "https://files.pythonhosted.org/packages/25/b2/8dff0d2a72076e5535f117f33458d520538b5a0900b90a9f59a278f0d3f6/setproctitle-1.3.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "50cfbf86b9c63a2c2903f1231f0a58edeb775e651ae1af84eec8430b0571f29b",
+              "url": "https://files.pythonhosted.org/packages/13/ee/e1f27bf52d2bec7060bb6311ab0ccede8de98ed5394e3a59e7a14a453fb5/setproctitle-1.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1bba0a866f5895d5b769d8c36b161271c7fd407e5065862ab80ff91c29fbe554",
-              "url": "https://files.pythonhosted.org/packages/26/ab/bbde90ea0ed6a062ef94fe1c609b68077f7eb586133a62fa62d0c8dd9f8c/setproctitle-1.3.4-cp312-cp312-musllinux_1_2_i686.whl"
+              "hash": "0b91e68e6685998e6353f296100ecabc313a6cb3e413d66a03d74b988b61f5ff",
+              "url": "https://files.pythonhosted.org/packages/15/13/167cdd55e00a8e10b36aad79646c3bf3c23fba0c08a9b8db9b74622c1b13/setproctitle-1.3.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "97f1f861998e326e640708488c442519ad69046374b2c3fe9bcc9869b387f23c",
-              "url": "https://files.pythonhosted.org/packages/36/0e/817be9934eda4cf63c96c694c3383cb0d2e5d019a2871af7dbd2202f7a58/setproctitle-1.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl"
+              "hash": "523424b9be4dea97d95b8a584b183f35c7bab2d0a3d995b01febf5b8a8de90e4",
+              "url": "https://files.pythonhosted.org/packages/2b/19/04755958495de57e4891de50f03e77b3fe9ca6716a86de00faa00ad0ee5a/setproctitle-1.3.5-cp312-cp312-macosx_10_13_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0855006261635e8669646c7c304b494b6df0a194d2626683520103153ad63cc9",
-              "url": "https://files.pythonhosted.org/packages/45/b7/04f5d221cbdcff35d6cdf74e2a852e69dc8d8e746eb1b314be6b57b79c41/setproctitle-1.3.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "ea6c505264275a43e9b2acd2acfc11ac33caf52bc3167c9fced4418a810f6b1c",
+              "url": "https://files.pythonhosted.org/packages/36/d6/e90e23b4627e016a4f862d4f892be92c9765dd6bf1e27a48e52cd166d4a3/setproctitle-1.3.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f963b6ed8ba33eda374a98d979e8a0eaf21f891b6e334701693a2c9510613c4c",
-              "url": "https://files.pythonhosted.org/packages/4b/cf/4f19cdc7fdff3eaeb3064ce6eeb27c63081dba3123fbf904ac6bf0de440c/setproctitle-1.3.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "828727d220e46f048b82289018300a64547b46aaed96bf8810c05fe105426b41",
+              "url": "https://files.pythonhosted.org/packages/52/79/78b05c7d792c9167b917acdab1773b1ff73b016560f45d8155be2baa1a82/setproctitle-1.3.5-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb5fefb53b9d9f334a5d9ec518a36b92a10b936011ac8a6b6dffd60135f16459",
-              "url": "https://files.pythonhosted.org/packages/86/ed/8031871d275302054b2f1b94b7cf5e850212cc412fe968f0979e64c1b838/setproctitle-1.3.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "6d8a411e752e794d052434139ca4234ffeceeb8d8d8ddc390a9051d7942b2726",
+              "url": "https://files.pythonhosted.org/packages/72/e7/b394c55934b89f00c2ef7d5e6f18cca5d8dfa26ef628700c4de0c85e3f3d/setproctitle-1.3.5-cp312-cp312-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d06990dcfcd41bb3543c18dd25c8476fbfe1f236757f42fef560f6aa03ac8dfc",
-              "url": "https://files.pythonhosted.org/packages/94/1f/02fb3c6038c819d86765316d2a911281fc56c7dd3a9355dceb3f26a5bf7b/setproctitle-1.3.4-cp312-cp312-macosx_10_13_universal2.whl"
+              "hash": "bc1fda208ae3a2285ad27aeab44c41daf2328abe58fa3270157a739866779199",
+              "url": "https://files.pythonhosted.org/packages/9b/22/574a110527df133409a75053b7d6ff740993ccf30b8713d042f26840d351/setproctitle-1.3.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "122c2e05697fa91f5d23f00bbe98a9da1bd457b32529192e934095fadb0853f1",
-              "url": "https://files.pythonhosted.org/packages/9b/a7/5f9c3c70dc5573f660f978fb3bb4847cd26ede95a5fc294d3f1cf6779800/setproctitle-1.3.4-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "83b016221cf80028b2947be20630faa14e3e72a403e35f0ba29550b4e856767b",
+              "url": "https://files.pythonhosted.org/packages/b0/62/4509735be062129694751ac55d5e1fbb6d86fa46a8689b7d5e2c23dae5b0/setproctitle-1.3.5-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b40d32a3e1f04e94231ed6dfee0da9e43b4f9c6b5450d53e6dd7754c34e0c50",
-              "url": "https://files.pythonhosted.org/packages/ae/4e/b09341b19b9ceb8b4c67298ab4a08ef7a4abdd3016c7bb152e9b6379031d/setproctitle-1.3.4.tar.gz"
+              "hash": "b6ec1d86c1b4d7b5f2bdceadf213310cf24696b82480a2a702194b8a0bfbcb47",
+              "url": "https://files.pythonhosted.org/packages/b9/3d/2ca9df5aa49b975296411dcbbe272cdb1c5e514c43b8be7d61751bb71a46/setproctitle-1.3.5-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "317218c9d8b17a010ab2d2f0851e8ef584077a38b1ba2b7c55c9e44e79a61e73",
-              "url": "https://files.pythonhosted.org/packages/b8/0c/d69e1f91c8f3d3aa74394e9e6ebb818f7d323e2d138ce1127e9462d09ebc/setproctitle-1.3.4-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "1e6eaeaf8a734d428a95d8c104643b39af7d247d604f40a7bebcf3960a853c5e",
+              "url": "https://files.pythonhosted.org/packages/c4/4d/6a840c8d2baa07b57329490e7094f90aac177a1d5226bc919046f1106860/setproctitle-1.3.5.tar.gz"
             }
           ],
           "project_name": "setproctitle",
@@ -4138,7 +4137,7 @@
             "pytest; extra == \"test\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.3.4"
+          "version": "1.3.5"
         },
         {
           "artifacts": [
@@ -4352,13 +4351,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539",
-              "url": "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl"
+              "hash": "f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138",
+              "url": "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b",
-              "url": "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz"
+              "hash": "1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb",
+              "url": "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz"
             }
           ],
           "project_name": "tenacity",
@@ -4369,8 +4368,8 @@
             "tornado>=4.5; extra == \"test\"",
             "typeguard; extra == \"test\""
           ],
-          "requires_python": ">=3.8",
-          "version": "9.0.0"
+          "requires_python": ">=3.9",
+          "version": "9.1.2"
         },
         {
           "artifacts": [
@@ -4586,13 +4585,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c37795eaba19f73f3e1a905ef3f4f0cab660dc7617126e8ae99391e25c755416",
-              "url": "https://files.pythonhosted.org/packages/74/93/0944bb5ade972a5ef2dd9211a20730081ed2833024239171807d7a9bd4b0/treelib-1.7.0-py3-none-any.whl"
+              "hash": "69aa12559c603273c77580cc86089021756654a754a7c674038de20f9daeafde",
+              "url": "https://files.pythonhosted.org/packages/01/da/66fb7b0f91a4329d5e0dd49a7464a1ced62a9d495362ae4c5cc055f268ba/treelib-1.7.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9bff1af416b9e642a6cd0e0431d15edf26a24b8d0c8ae68afbd3801b5e30fb61",
-              "url": "https://files.pythonhosted.org/packages/d8/ec/962387a2bd7ece011f47cfa08f06f832fc9fd41b31f4f0007b8b7948eb93/treelib-1.7.0.tar.gz"
+              "hash": "a2b57ba38290f7da6af97b41de8ff7be98e7a8c00815f95d0782241f77503952",
+              "url": "https://files.pythonhosted.org/packages/ad/e2/aae318906d39f160eb5b1046119da6706588d14f0a2d0fe202c9a0db46dd/treelib-1.7.1.tar.gz"
             }
           ],
           "project_name": "treelib",
@@ -4600,7 +4599,7 @@
             "six"
           ],
           "requires_python": null,
-          "version": "1.7.0"
+          "version": "1.7.1"
         },
         {
           "artifacts": [
@@ -4634,19 +4633,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "11d4e102af0627c02e8c1d17736caa3c39de1058bea37e2f4de6ef11a5b652ab",
-              "url": "https://files.pythonhosted.org/packages/ff/da/77902220df98ce920444cf3611fa0b1cf0dc2cfa5a137c55e93829aa458e/types_aiofiles-24.1.0.20241221-py3-none-any.whl"
+              "hash": "dfb58c9aa18bd449e80fb5d7f49dc3dd20d31de920a46223a61798ee4a521a70",
+              "url": "https://files.pythonhosted.org/packages/0e/18/1016ffd4c7775f24371f6a0309483dc5597e8245b5add67924e54ea3b83a/types_aiofiles-24.1.0.20250326-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c40f6c290b0af9e902f7f3fa91213cf5bb67f37086fb21dc0ff458253586ad55",
-              "url": "https://files.pythonhosted.org/packages/ab/5e/f984b9ddc7eecdf31e683e692d933f3672276ed95aad6adb9aea9ecbdc29/types_aiofiles-24.1.0.20241221.tar.gz"
+              "hash": "c4bbe432fd043911ba83fb635456f5cc54f6d05fda2aadf6bef12a84f07a6efe",
+              "url": "https://files.pythonhosted.org/packages/8d/25/c76a9ee91eefac376ed8905b029272e27c44739e3f148faf5c00afe71e43/types_aiofiles-24.1.0.20250326.tar.gz"
             }
           ],
           "project_name": "types-aiofiles",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "24.1.0.20241221"
+          "requires_python": ">=3.9",
+          "version": "24.1.0.20250326"
         },
         {
           "artifacts": [
@@ -4670,21 +4669,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e5b76b4211d7a9185f6ab8d06a106d56c7eb80af7cdb8bfcb4186ade10fb112f",
-              "url": "https://files.pythonhosted.org/packages/00/ec/ebf35741fe824e66a57e7f35199b51021bff3aa4b01a7a2720c7f7668ee8/types_cffi-1.16.0.20241221-py3-none-any.whl"
+              "hash": "5af4ecd7374ae0d5fa9e80864e8d4b31088cc32c51c544e3af7ed5b5ed681447",
+              "url": "https://files.pythonhosted.org/packages/61/49/ce473d7fbc2c80931ef9f7530fd3ddf31b8a5bca56340590334ce6ffbfb1/types_cffi-1.17.0.20250326-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c96649618f4b6145f58231acb976e0b448be6b847f7ab733dabe62dfbff6591",
-              "url": "https://files.pythonhosted.org/packages/5e/00/ecd613293b6c41081b4e5c33bc42ba22a839c493bf8b6ee9480ce3b7a4e8/types_cffi-1.16.0.20241221.tar.gz"
+              "hash": "6c8fea2c2f34b55e5fb77b1184c8ad849d57cf0ddccbc67a62121ac4b8b32254",
+              "url": "https://files.pythonhosted.org/packages/3f/3b/d29491d754b9e42edd4890648311ffa5d4d000b7d97b92ac4d04faad40d8/types_cffi-1.17.0.20250326.tar.gz"
             }
           ],
           "project_name": "types-cffi",
           "requires_dists": [
             "types-setuptools"
           ],
-          "requires_python": ">=3.8",
-          "version": "1.16.0.20241221"
+          "requires_python": ">=3.9",
+          "version": "1.17.0.20250326"
         },
         {
           "artifacts": [
@@ -4767,19 +4766,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6",
-              "url": "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl"
+              "hash": "652348fa9e7a203d4b0d21066dfb00760d3cbd5a15ebb7cf8d33c88a49546681",
+              "url": "https://files.pythonhosted.org/packages/ed/56/1fe61db05685fbb512c07ea9323f06ea727125951f1eb4dff110b3311da3/types_pyyaml-6.0.12.20250402-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c",
-              "url": "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz"
+              "hash": "d7c13c3e6d335b6af4b0122a01ff1d270aba84ab96d1a1a1063ecba3e13ec075",
+              "url": "https://files.pythonhosted.org/packages/2d/68/609eed7402f87c9874af39d35942744e39646d1ea9011765ec87b01b2a3c/types_pyyaml-6.0.12.20250402.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "6.0.12.20241230"
+          "requires_python": ">=3.9",
+          "version": "6.0.12.20250402"
         },
         {
           "artifacts": [
@@ -4806,37 +4805,39 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a217d7b4d59be04c29e23d142c959a0f85e71292fd3fc4313f016ca11f0b56dc",
-              "url": "https://files.pythonhosted.org/packages/2d/b4/5978a63dac80d9a653fdb73f58e08b208486d303f9a3ee481f0c807630de/types_setuptools-75.8.0.20250210-py3-none-any.whl"
+              "hash": "ea47eab891afb506f470eee581dcde44d64dc99796665da794da6f83f50f6776",
+              "url": "https://files.pythonhosted.org/packages/7d/31/85d0264705d8ef47680d28f4dc9bb1e27d8cace785fbe3f8d009fad6cb88/types_setuptools-78.1.0.20250329-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c1547361b2441f07c94e25dce8a068e18c611593ad4b6fdd727b1a8f5d1fda33",
-              "url": "https://files.pythonhosted.org/packages/c3/20/794589df23b1e7d3c1a1f86285e749f2a83ef845d90f2461bc2912b8f989/types_setuptools-75.8.0.20250210.tar.gz"
+              "hash": "31e62950c38b8cc1c5114b077504e36426860a064287cac11b9666ab3a483234",
+              "url": "https://files.pythonhosted.org/packages/e9/6e/c54e6705e5fe67c3606e4c7c91123ecf10d7e1e6d7a9c11b52970cf2196c/types_setuptools-78.1.0.20250329.tar.gz"
             }
           ],
           "project_name": "types-setuptools",
-          "requires_dists": [],
+          "requires_dists": [
+            "setuptools"
+          ],
           "requires_python": ">=3.9",
-          "version": "75.8.0.20250210"
+          "version": "78.1.0.20250329"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a4947c2bdcd9ab69d44466a533a15839ff48ddc27223615cb8145d73ab805bc2",
-              "url": "https://files.pythonhosted.org/packages/96/c6/67812fcc6c4d6cb469a7f38a293ad6d6effcfb4b599eb0f1ba287878ec0f/types_six-1.17.0.20241205-py3-none-any.whl"
+              "hash": "0bbb20fc34a18163afe7cac70b85864bd6937e6d73413c5b8f424def28760ae8",
+              "url": "https://files.pythonhosted.org/packages/a6/d1/14a6a959a3f53105034ebe346a1f3c375296637292780f6e952fcf634974/types_six-1.17.0.20250403-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1f662347a8f3b2bf30517d629d82f591420df29811794b0bf3804e14d716f6e0",
-              "url": "https://files.pythonhosted.org/packages/ca/01/1e1088033a79faa46d1b0761b5b00f2d50e5f89c567a140d55b79d1f2658/types_six-1.17.0.20241205.tar.gz"
+              "hash": "82076f86e6e672a95adbf8b52625b1b3c72a8b9a893180344c1a02a6daabead6",
+              "url": "https://files.pythonhosted.org/packages/81/78/a711162eca091781522be07bf10694f2b731bbdbb885ec037a807e7658c5/types_six-1.17.0.20250403.tar.gz"
             }
           ],
           "project_name": "types-six",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "1.17.0.20241205"
+          "requires_python": ">=3.9",
+          "version": "1.17.0.20250403"
         },
         {
           "artifacts": [
@@ -4860,19 +4861,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-              "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+              "hash": "4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69",
+              "url": "https://files.pythonhosted.org/packages/df/c5/e7a0b0f5ed69f94c8ab7379c599e6036886bffcde609969a5325f47f1332/typing_extensions-4.13.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
-              "url": "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
+              "hash": "98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff",
+              "url": "https://files.pythonhosted.org/packages/76/ad/cd3e3465232ec2416ae9b983f27b9e94dc8171d56ac99b345319a9475967/typing_extensions-4.13.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "4.12.2"
+          "version": "4.13.1"
         },
         {
           "artifacts": [
@@ -5180,7 +5181,7 @@
     "PyJWT~=2.0",
     "PyYAML~=6.0",
     "SQLAlchemy[postgresql_asyncpg]~=1.4.54",
-    "aiodataloader-ng~=0.2.1",
+    "aiodataloader~=0.4.2",
     "aiodns>=3.2",
     "aiodocker==0.24.0",
     "aiofiles~=24.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiodataloader-ng~=0.2.1
+aiodataloader~=0.4.2
 aiodocker==0.24.0
 aiofiles~=24.1.0
 aiohttp~=3.10.8

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -694,12 +694,12 @@ def ForeignKeyIDColumn(name, fk_field, nullable=True):
     return sa.Column(name, GUID, sa.ForeignKey(fk_field), nullable=nullable)
 
 
-ContextT = TypeVar("ContextT")
-LoaderKeyT = TypeVar("LoaderKeyT")
-LoaderResultT = TypeVar("LoaderResultT")
+TContext = TypeVar("TContext")
+TLoaderKey = TypeVar("TLoaderKey")
+TLoaderResult = TypeVar("TLoaderResult")
 
 
-class DataLoaderManager(Generic[ContextT, LoaderKeyT, LoaderResultT]):
+class DataLoaderManager(Generic[TContext, TLoaderKey, TLoaderResult]):
     """
     For every different combination of filtering conditions, we need to make a
     new DataLoader instance because it "batches" the database queries.
@@ -710,7 +710,7 @@ class DataLoaderManager(Generic[ContextT, LoaderKeyT, LoaderResultT]):
     for every incoming API request.
     """
 
-    cache: dict[int, DataLoader[LoaderKeyT, LoaderResultT]]
+    cache: dict[int, DataLoader[TLoaderKey, TLoaderResult]]
 
     def __init__(self) -> None:
         self.cache = {}
@@ -747,7 +747,9 @@ class DataLoaderManager(Generic[ContextT, LoaderKeyT, LoaderResultT]):
 
     @staticmethod
     def _get_func_key(
-        func: Callable[Concatenate[ContextT, Sequence[LoaderKeyT], ...], Awaitable[LoaderResultT]],
+        func: Callable[
+            Concatenate[TContext, Sequence[TLoaderKey], ...], Awaitable[Sequence[TLoaderResult]]
+        ],
         **kwargs,
     ) -> int:
         func_and_kwargs = (func, *[(k, kwargs[k]) for k in sorted(kwargs.keys())])
@@ -755,23 +757,24 @@ class DataLoaderManager(Generic[ContextT, LoaderKeyT, LoaderResultT]):
 
     def get_loader_by_func(
         self,
-        context: ContextT,
+        context: TContext,
         batch_load_func: Callable[
-            Concatenate[ContextT, Sequence[LoaderKeyT], ...], Awaitable[LoaderResultT]
+            Concatenate[TContext, Sequence[TLoaderKey], ...], Awaitable[Sequence[TLoaderResult]]
         ],
         # Using kwargs-only to prevent argument position confusion
         # when DataLoader calls `batch_load_func(keys)` which is `partial(batch_load_func, **kwargs)(keys)`.
         **kwargs,
-    ) -> DataLoader[LoaderKeyT, LoaderResultT]:
+    ) -> DataLoader[TLoaderKey, TLoaderResult]:
+        async def batch_load_wrapper(keys: Sequence[TLoaderKey]) -> list[TLoaderResult]:
+            # aiodataloader always converts the result via list(),
+            # so we can enforce type-casting here.
+            return cast(list[TLoaderResult], await batch_load_func(context, keys, **kwargs))
+
         key = self._get_func_key(batch_load_func, **kwargs)
         loader = self.cache.get(key)
         if loader is None:
             loader = DataLoader(
-                functools.partial(
-                    batch_load_func,
-                    context,
-                    **kwargs,
-                ),
+                batch_load_wrapper,
                 max_batch_size=128,
             )
             self.cache[key] = loader

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -699,7 +699,7 @@ LoaderKeyT = TypeVar("LoaderKeyT")
 LoaderResultT = TypeVar("LoaderResultT")
 
 
-class DataLoaderManager:
+class DataLoaderManager(Generic[ContextT, LoaderKeyT, LoaderResultT]):
     """
     For every different combination of filtering conditions, we need to make a
     new DataLoader instance because it "batches" the database queries.
@@ -710,7 +710,7 @@ class DataLoaderManager:
     for every incoming API request.
     """
 
-    cache: dict[int, DataLoader]
+    cache: dict[int, DataLoader[LoaderKeyT, LoaderResultT]]
 
     def __init__(self) -> None:
         self.cache = {}
@@ -762,7 +762,7 @@ class DataLoaderManager:
         # Using kwargs-only to prevent argument position confusion
         # when DataLoader calls `batch_load_func(keys)` which is `partial(batch_load_func, **kwargs)(keys)`.
         **kwargs,
-    ) -> DataLoader:
+    ) -> DataLoader[LoaderKeyT, LoaderResultT]:
         key = self._get_func_key(batch_load_func, **kwargs)
         loader = self.cache.get(key)
         if loader is None:

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -748,7 +748,8 @@ class DataLoaderManager(Generic[TContext, TLoaderKey, TLoaderResult]):
     @staticmethod
     def _get_func_key(
         func: Callable[
-            Concatenate[TContext, Sequence[TLoaderKey], ...], Awaitable[Sequence[TLoaderResult]]
+            Concatenate[TContext, Sequence[TLoaderKey], ...],
+            Awaitable[Sequence[TLoaderResult]],
         ],
         **kwargs,
     ) -> int:
@@ -759,7 +760,8 @@ class DataLoaderManager(Generic[TContext, TLoaderKey, TLoaderResult]):
         self,
         context: TContext,
         batch_load_func: Callable[
-            Concatenate[TContext, Sequence[TLoaderKey], ...], Awaitable[Sequence[TLoaderResult]]
+            Concatenate[TContext, Sequence[TLoaderKey], ...],
+            Awaitable[Sequence[TLoaderResult]],
         ],
         # Using kwargs-only to prevent argument position confusion
         # when DataLoader calls `batch_load_func(keys)` which is `partial(batch_load_func, **kwargs)(keys)`.


### PR DESCRIPTION
resolves #4095 (BA-1082)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version: to be included in the upcoming LTS
- [x] Mention to the original issue