### PR TITLE
fix(BA-1049): Remove wrong `Accept` header from Image rescanning logic (#4066)

### DIFF
--- a/changes/4066.fix.md
+++ b/changes/4066.fix.md
@@ -1,0 +1,1 @@
+Remove wrong `Accept` header from Image rescanning logic.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -320,7 +320,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         rqst_args = dict(_rqst_args)
         if not rqst_args.get("headers"):
             rqst_args["headers"] = {}
-        rqst_args["headers"].update({"Accept": "application/vnd.oci.image.manifest.v1+json"})
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -356,9 +355,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         rqst_args = dict(_rqst_args)
         if not rqst_args.get("headers"):
             rqst_args["headers"] = {}
-        rqst_args["headers"].update({
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        })
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -394,9 +390,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         rqst_args = dict(_rqst_args)
         if not rqst_args.get("headers"):
             rqst_args["headers"] = {}
-        rqst_args["headers"].update({
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-        })
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
         async with aiotools.TaskGroup() as tg:
@@ -474,7 +467,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
         """
         manifests = {}
         async with concurrency_sema.get():
-            rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
             # Harbor does not provide architecture information for a single-arch tag reference.
             # We heuristically detect the architecture using the tag name pattern.
             if tag.endswith("-arm64") or tag.endswith("-aarch64"):


### PR DESCRIPTION
Backported-from: main
Backported-to: 24.03
Backported-of: #4066