### PR TITLE
fix(BA-1150): Broken single image rescan on `HarborRegistryV2` (#4161)

### DIFF
--- a/changes/4161.fix.md
+++ b/changes/4161.fix.md
@@ -1,0 +1,1 @@
+Fix broken single image rescan on `HarborRegistryV2`.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -282,7 +282,8 @@ class HarborRegistry_v2(BaseContainerRegistry):
             urllib.parse.urlencode({"": x})[1:] for x in [project, repository, tag]
         ]
         api_url = self.registry_url / "api" / "v2.0"
-        rqst_args["headers"] = {}
+        if "Accept" in rqst_args["headers"]:
+            del rqst_args["headers"]["Accept"]
         async with sess.get(
             api_url / "projects" / project / "repositories" / repository / "artifacts" / tag,
             **rqst_args,


### PR DESCRIPTION
This is an auto-generated backport PR of #4161 to the 24.03 release.