### PR TITLE
fix(BA-1150): Broken single image rescan on `HarborRegistryV2` (#4161)

### DIFF
--- a/changes/4161.fix.md
+++ b/changes/4161.fix.md
@@ -1,0 +1,1 @@
+Fix broken single image rescan on `HarborRegistryV2`.


### PR DESCRIPTION
This is an auto-generated backport PR of #4161 to the 23.09 release.