### PR TITLE
fix(BA-1136): Broken `UntagImageFromRegistry` GQL mutation

### DIFF
--- a/changes/4177.fix.md
+++ b/changes/4177.fix.md
@@ -1,0 +1,1 @@
+Fix Broken `UntagImageFromRegistry` GQL mutation.

--- a/src/ai/backend/manager/services/image/service.py
+++ b/src/ai/backend/manager/services/image/service.py
@@ -216,6 +216,8 @@ class ImageService:
             query = sa.select(ContainerRegistryRow).where(
                 ContainerRegistryRow.registry_name == image_row.image_ref.registry
             )
+            if image_row.image_ref.project:
+                query = query.where(ContainerRegistryRow.project == image_row.image_ref.project)
 
             registry_info = (await db_session.execute(query)).scalar()
 


### PR DESCRIPTION
resolves #4139 (BA-1136).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue

