### PR TITLE
fix(BA-1173): Add missing `application/vnd.oci.image.manifest.v1` type handling on HarborRegistryV2's single image rescan

### DIFF
--- a/changes/4188.fix.md
+++ b/changes/4188.fix.md
@@ -1,0 +1,1 @@
+Add missing `application/vnd.oci.image.manifest.v1` type handling on HarborRegistryV2's single image rescan.

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -341,6 +341,15 @@ class HarborRegistry_v2(BaseContainerRegistry):
                             await self._process_oci_index(
                                 tg, sess, rqst_args, image, tag, resp_json
                             )
+                        case self.MEDIA_TYPE_OCI_MANIFEST:
+                            await self._process_oci_manifest(
+                                tg,
+                                sess,
+                                rqst_args,
+                                image,
+                                tag,
+                                resp_json,
+                            )
                         case self.MEDIA_TYPE_DOCKER_MANIFEST_LIST:
                             await self._process_docker_v2_multiplatform_image(
                                 tg, sess, rqst_args, image, tag, resp_json


### PR DESCRIPTION
Follow-up to #3814.

Resolves #4187 (BA-1173).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue