### PR TITLE
fix(BA-1174): Remove misleading representation of VFolder deletion permissions for invited users

### DIFF
--- a/changes/4190.fix.md
+++ b/changes/4190.fix.md
@@ -1,0 +1,1 @@
+Fix the representation that shows invited VFolder users having VFolder deletion permissions

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -651,7 +651,11 @@ def invitations():
                     perm = "read-only"
                 else:
                     perm = inv["perm"]
-                print("[{}] {}, {}, {}".format(cnt + 1, inv["inviter"], inv["vfolder_id"], perm))
+                print(
+                    "[{}] {}, {}, {}".format(
+                        cnt + 1, inv["inviter_user_email"], inv["vfolder_id"], perm
+                    )
+                )
 
             selection = input("Choose invitation number to manage: ")
             if selection.isdigit():

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -2300,7 +2300,6 @@ LEGACY_PERMISSION_TO_RBAC_PERMISSION_MAP: Mapping[
     VFolderPermission.READ_WRITE: frozenset([
         VFolderRBACPermission.READ_ATTRIBUTE,
         VFolderRBACPermission.UPDATE_ATTRIBUTE,
-        VFolderRBACPermission.DELETE_VFOLDER,
         VFolderRBACPermission.READ_CONTENT,
         VFolderRBACPermission.WRITE_CONTENT,
         VFolderRBACPermission.DELETE_CONTENT,
@@ -2310,7 +2309,6 @@ LEGACY_PERMISSION_TO_RBAC_PERMISSION_MAP: Mapping[
     VFolderPermission.RW_DELETE: frozenset([
         VFolderRBACPermission.READ_ATTRIBUTE,
         VFolderRBACPermission.UPDATE_ATTRIBUTE,
-        VFolderRBACPermission.DELETE_VFOLDER,
         VFolderRBACPermission.READ_CONTENT,
         VFolderRBACPermission.WRITE_CONTENT,
         VFolderRBACPermission.DELETE_CONTENT,


### PR DESCRIPTION
resolves #4189 (BA-1174)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue