### PR TITLE
fix(BA-1175): Wrong `Accept` header handling in image rescanning

### DIFF
--- a/changes/4191.fix.md
+++ b/changes/4191.fix.md
@@ -1,0 +1,1 @@
+Fix wrong `Accept` header handling in image rescanning.

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 from abc import ABCMeta, abstractmethod
 from contextlib import asynccontextmanager as actxmgr
@@ -97,7 +98,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self.registry_url = yarl.URL(registry_info.url)
         self.max_concurrency_per_registry = max_concurrency_per_registry
         self.base_hdrs = {
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+            "Accept": self.MEDIA_TYPE_DOCKER_MANIFEST,
         }
         self.credentials = {}
         self.ssl_verify = ssl_verify
@@ -243,7 +244,6 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                     self.credentials,
                     f"repository:{project_and_image_name}:pull",
                 )
-                rqst_args["headers"].update(**self.base_hdrs)
                 await self._scan_tag(sess, rqst_args, project_and_image_name, tag)
             scanned_images = await self.commit_rescan_result()
             return RescanImagesResult(images=scanned_images)
@@ -305,6 +305,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         tag: str,
     ) -> None:
         async with concurrency_sema.get():
+            rqst_args = {**copy.deepcopy(rqst_args)}
             rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST_LIST
             async with sess.get(
                 self.registry_url / f"v2/{image}/manifests/{tag}", **rqst_args
@@ -446,6 +447,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             for item in image_info["manifests"]
             if "annotations" not in item  # skip attestation manifests
         ]
+        rqst_args = {**copy.deepcopy(rqst_args)}
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_OCI_MANIFEST
 
         await self._read_manifest_list(sess, manifest_list, rqst_args, image, tag)
@@ -459,7 +461,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**rqst_args}
+        rqst_args = {**copy.deepcopy(rqst_args)}
         rqst_args["headers"] = rqst_args.get("headers", {})
         rqst_args["headers"].update({
             "Accept": self.MEDIA_TYPE_OCI_MANIFEST,
@@ -523,6 +525,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         image_info: Mapping[str, Any],
     ) -> None:
         manifest_list = image_info["manifests"]
+        rqst_args = {**copy.deepcopy(rqst_args)}
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
 
         await self._read_manifest_list(
@@ -543,6 +546,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         image_info: Mapping[str, Any],
     ) -> None:
         config_digest = image_info["config"]["digest"]
+        rqst_args = {**copy.deepcopy(rqst_args)}
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
 
         async with sess.get(
@@ -583,6 +587,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             }
         ]
 
+        rqst_args = {**copy.deepcopy(rqst_args)}
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
         await self._read_manifest_list(sess, manifest_list, rqst_args, image, tag)
 

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -305,7 +305,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         tag: str,
     ) -> None:
         async with concurrency_sema.get():
-            rqst_args = {**copy.deepcopy(rqst_args)}
+            rqst_args = copy.deepcopy(rqst_args)
             rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST_LIST
             async with sess.get(
                 self.registry_url / f"v2/{image}/manifests/{tag}", **rqst_args
@@ -360,7 +360,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         sess: aiohttp.ClientSession,
         manifest_list: Sequence[Any],
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
     ) -> None:
@@ -402,7 +402,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         sess: aiohttp.ClientSession,
         manifest: Mapping[str, Any],
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
     ) -> dict[str, Any]:
         """
@@ -437,7 +437,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
@@ -447,7 +447,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             for item in image_info["manifests"]
             if "annotations" not in item  # skip attestation manifests
         ]
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_OCI_MANIFEST
 
         await self._read_manifest_list(sess, manifest_list, rqst_args, image, tag)
@@ -456,12 +456,12 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers", {})
         rqst_args["headers"].update({
             "Accept": self.MEDIA_TYPE_OCI_MANIFEST,
@@ -519,13 +519,13 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         manifest_list = image_info["manifests"]
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
 
         await self._read_manifest_list(
@@ -540,13 +540,13 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
         config_digest = image_info["config"]["digest"]
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
 
         async with sess.get(
@@ -568,7 +568,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
@@ -587,7 +587,7 @@ class BaseContainerRegistry(metaclass=ABCMeta):
             }
         ]
 
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST
         await self._read_manifest_list(sess, manifest_list, rqst_args, image, tag)
 

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -369,12 +369,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers") or {}
         rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_INDEX})
 
@@ -406,12 +406,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers") or {}
         rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_MANIFEST})
 
@@ -474,12 +474,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers") or {}
         rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST_LIST})
 
@@ -511,12 +511,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
-        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers") or {}
         rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST})
 
@@ -534,7 +534,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_per_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         *,
         digest: str,
@@ -591,12 +591,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_single_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
     ) -> None:
         """
-        Scan 'image:tag' which has been pusehd as a single architecture tag.
+        Scan 'image:tag' which has been pushed as a single architecture tag.
         In this case, Harbor does not provide explicit methods to determine the architecture.
         We infer the architecture from the tag naming patterns ("-arm64" for instance).
         """

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import urllib.parse
 from typing import Any, AsyncIterator, Mapping, Optional, cast, override
@@ -321,8 +322,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             urllib.parse.urlencode({"": x})[1:] for x in [project, repository, tag]
         ]
         api_url = self.registry_url / "api" / "v2.0"
-        if "Accept" in rqst_args["headers"]:
-            del rqst_args["headers"]["Accept"]
         async with sess.get(
             api_url / "projects" / project / "repositories" / repository / "artifacts" / tag,
             **rqst_args,
@@ -375,6 +374,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_INDEX})
+
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -408,6 +411,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_MANIFEST})
+
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
 
@@ -472,6 +479,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST_LIST})
+
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -505,6 +516,10 @@ class HarborRegistry_v2(BaseContainerRegistry):
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = {**copy.deepcopy(rqst_args)}
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST})
+
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
         tg.create_task(


### PR DESCRIPTION
Follow-up to #4066.
Revert #4066's change, and fix the correct `Accept` header wherever it is used.

Resolves #4192 (BA-1175).


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
