### PR TITLE
fix(BA-1176): Chunk too big error of `admin image rescan` command

### DIFF
--- a/changes/4198.fix.md
+++ b/changes/4198.fix.md
@@ -1,0 +1,1 @@
+Fix `chunk too big` error of admin image rescan command.

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -972,9 +972,10 @@ class RescanImages(graphene.Mutation):
                 errors.extend(action_result.errors)
                 rescanned_images.extend(action_result.images)
 
+            rescanned_image_ids = [image.id for image in rescanned_images]
             if errors:
-                return DispatchResult.partial_success(rescanned_images, errors)
-            return DispatchResult.success(rescanned_images)
+                return DispatchResult.partial_success(rescanned_image_ids, errors)
+            return DispatchResult.success(rescanned_image_ids)
 
         task_id = await ctx.background_task_manager.start(_bg_task)
         return RescanImages(ok=True, msg="", task_id=task_id)


### PR DESCRIPTION
resolves #4193 (BA-1176).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
