### PR TITLE
fix(BA-1175): Wrong `Accept` header handling in image rescanning (#4191)

### DIFF
--- a/changes/4191.fix.md
+++ b/changes/4191.fix.md
@@ -1,0 +1,1 @@
+Fix wrong `Accept` header handling in image rescanning.

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import logging
 from abc import ABCMeta, abstractmethod
 from contextlib import asynccontextmanager as actxmgr
@@ -418,69 +419,6 @@ class BaseContainerRegistry(metaclass=ABCMeta):
         rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_OCI_MANIFEST
 
         await self._read_manifest_list(sess, manifest_list, rqst_args, image, tag)
-
-    async def _process_oci_manifest(
-        self,
-        tg: aiotools.TaskGroup,
-        sess: aiohttp.ClientSession,
-        rqst_args: dict[str, Any],
-        image: str,
-        tag: str,
-        image_info: Mapping[str, Any],
-    ) -> None:
-        rqst_args = copy.deepcopy(rqst_args)
-        rqst_args["headers"] = rqst_args.get("headers", {})
-        rqst_args["headers"].update({
-            "Accept": self.MEDIA_TYPE_OCI_MANIFEST,
-        })
-
-        if (reporter := progress_reporter.get()) is not None:
-            reporter.total_progress += 1
-
-        async with concurrency_sema.get():
-            config_digest = image_info["config"]["digest"]
-            size_bytes = (
-                sum(layer["size"] for layer in image_info["layers"]) + image_info["config"]["size"]
-            )
-
-            async with sess.get(
-                self.registry_url / f"v2/{image}/blobs/{config_digest}",
-                **rqst_args,
-            ) as resp:
-                resp.raise_for_status()
-                config_data = await read_json(resp)
-
-        labels = {}
-        if _config_labels := config_data.get("config", {}).get("Labels"):
-            labels = _config_labels
-        elif _container_config_labels := config_data.get("container_config", {}).get("Labels"):
-            labels = _container_config_labels
-
-        if not labels:
-            log.warning(
-                "The image {}:{} has no metadata labels -> treating as vanilla image",
-                image,
-                tag,
-            )
-            labels = {}
-
-        architecture = config_data.get("architecture")
-        if architecture:
-            architecture = arch_name_aliases.get(architecture, architecture)
-        else:
-            if tag.endswith("-arm64") or tag.endswith("-aarch64"):
-                architecture = "aarch64"
-            else:
-                architecture = "x86_64"
-
-        manifests = {
-            architecture: {
-                "size": size_bytes,
-                "labels": labels,
-                "digest": config_digest,
-            }
-        }
-        await self._read_manifest(image, tag, manifests)
 
     async def _process_docker_v2_multiplatform_image(
         self,

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import json
+import copy
 import logging
 import urllib.parse
 from typing import Any, AsyncIterator, Mapping, Optional, cast, override
@@ -313,8 +313,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
             urllib.parse.urlencode({"": x})[1:] for x in [project, repository, tag]
         ]
         api_url = self.registry_url / "api" / "v2.0"
-        if "Accept" in rqst_args["headers"]:
-            del rqst_args["headers"]["Accept"]
         async with sess.get(
             api_url / "projects" / project / "repositories" / repository / "artifacts" / tag,
             **rqst_args,
@@ -353,11 +351,15 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = copy.deepcopy(rqst_args)
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_INDEX})
+
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -382,15 +384,87 @@ class HarborRegistry_v2(BaseContainerRegistry):
             )
 
     @override
-    async def _process_docker_v2_multiplatform_image(
+    async def _process_oci_manifest(
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = copy.deepcopy(rqst_args)
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_MANIFEST})
+
+        if (reporter := progress_reporter.get()) is not None:
+            reporter.total_progress += 1
+
+        async with concurrency_sema.get():
+            async with sess.get(
+                self.registry_url / f"v2/{image}/manifests/{tag}", **rqst_args
+            ) as resp:
+                resp.raise_for_status()
+                manifest_data = await resp.json()
+
+            config_digest = manifest_data["config"]["digest"]
+            size_bytes = (
+                sum(layer["size"] for layer in manifest_data["layers"])
+                + manifest_data["config"]["size"]
+            )
+
+            async with sess.get(
+                self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
+            ) as resp:
+                resp.raise_for_status()
+                config_data = await read_json(resp)
+
+        labels = {}
+        if _config_labels := config_data.get("config", {}).get("Labels"):
+            labels = _config_labels
+        elif _container_config_labels := config_data.get("container_config", {}).get("Labels"):
+            labels = _container_config_labels
+
+        if not labels:
+            log.warning(
+                "The image {}:{} has no metadata labels -> treating as vanilla image",
+                image,
+                tag,
+            )
+            labels = {}
+
+        architecture = config_data.get("architecture")
+        if architecture:
+            architecture = arch_name_aliases.get(architecture, architecture)
+        else:
+            if tag.endswith("-arm64") or tag.endswith("-aarch64"):
+                architecture = "aarch64"
+            else:
+                architecture = "x86_64"
+
+        manifests = {
+            architecture: {
+                "size": size_bytes,
+                "labels": labels,
+                "digest": config_digest,
+            }
+        }
+        await self._read_manifest(image, tag, manifests)
+
+    @override
+    async def _process_docker_v2_multiplatform_image(
+        self,
+        tg: aiotools.TaskGroup,
+        sess: aiohttp.ClientSession,
+        rqst_args: dict[str, Any],
+        image: str,
+        tag: str,
+        image_info: Mapping[str, Any],
+    ) -> None:
+        rqst_args = copy.deepcopy(rqst_args)
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST_LIST})
+
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:
             if (
@@ -419,11 +493,15 @@ class HarborRegistry_v2(BaseContainerRegistry):
         self,
         tg: aiotools.TaskGroup,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
         image_info: Mapping[str, Any],
     ) -> None:
+        rqst_args = copy.deepcopy(rqst_args)
+        rqst_args["headers"] = rqst_args.get("headers") or {}
+        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_DOCKER_MANIFEST})
+
         if (reporter := progress_reporter.get()) is not None:
             reporter.total_progress += 1
         tg.create_task(
@@ -438,7 +516,7 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_per_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         *,
         digest: str,
@@ -495,12 +573,12 @@ class HarborRegistry_v2(BaseContainerRegistry):
     async def _harbor_scan_tag_single_arch(
         self,
         sess: aiohttp.ClientSession,
-        rqst_args: Mapping[str, Any],
+        rqst_args: dict[str, Any],
         image: str,
         tag: str,
     ) -> None:
         """
-        Scan 'image:tag' which has been pusehd as a single architecture tag.
+        Scan 'image:tag' which has been pushed as a single architecture tag.
         In this case, Harbor does not provide explicit methods to determine the architecture.
         We infer the architecture from the tag naming patterns ("-arm64" for instance).
         """

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging
 import urllib.parse
 from typing import Any, AsyncIterator, Mapping, Optional, cast, override
@@ -382,74 +383,6 @@ class HarborRegistry_v2(BaseContainerRegistry):
                     architecture=architecture,
                 )
             )
-
-    @override
-    async def _process_oci_manifest(
-        self,
-        tg: aiotools.TaskGroup,
-        sess: aiohttp.ClientSession,
-        rqst_args: dict[str, Any],
-        image: str,
-        tag: str,
-        image_info: Mapping[str, Any],
-    ) -> None:
-        rqst_args = copy.deepcopy(rqst_args)
-        rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_MANIFEST})
-
-        if (reporter := progress_reporter.get()) is not None:
-            reporter.total_progress += 1
-
-        async with concurrency_sema.get():
-            async with sess.get(
-                self.registry_url / f"v2/{image}/manifests/{tag}", **rqst_args
-            ) as resp:
-                resp.raise_for_status()
-                manifest_data = await resp.json()
-
-            config_digest = manifest_data["config"]["digest"]
-            size_bytes = (
-                sum(layer["size"] for layer in manifest_data["layers"])
-                + manifest_data["config"]["size"]
-            )
-
-            async with sess.get(
-                self.registry_url / f"v2/{image}/blobs/{config_digest}", **rqst_args
-            ) as resp:
-                resp.raise_for_status()
-                config_data = await read_json(resp)
-
-        labels = {}
-        if _config_labels := config_data.get("config", {}).get("Labels"):
-            labels = _config_labels
-        elif _container_config_labels := config_data.get("container_config", {}).get("Labels"):
-            labels = _container_config_labels
-
-        if not labels:
-            log.warning(
-                "The image {}:{} has no metadata labels -> treating as vanilla image",
-                image,
-                tag,
-            )
-            labels = {}
-
-        architecture = config_data.get("architecture")
-        if architecture:
-            architecture = arch_name_aliases.get(architecture, architecture)
-        else:
-            if tag.endswith("-arm64") or tag.endswith("-aarch64"):
-                architecture = "aarch64"
-            else:
-                architecture = "x86_64"
-
-        manifests = {
-            architecture: {
-                "size": size_bytes,
-                "labels": labels,
-                "digest": config_digest,
-            }
-        }
-        await self._read_manifest(image, tag, manifests)
 
     @override
     async def _process_docker_v2_multiplatform_image(


### PR DESCRIPTION
This is an auto-generated backport PR of #4191 to the 24.09 release.