### PR TITLE
ci(BA-1182): Remove the skip-git option from the osv scanner

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -36,7 +36,6 @@ jobs:
       # Example of specifying custom arguments
       scan-args: |-
         -r
-        --skip-git
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
@@ -45,5 +44,4 @@ jobs:
       # Example of specifying custom arguments
       scan-args: |-
         -r
-        --skip-git
         ./


### PR DESCRIPTION
resolves #4206 (BA-1182)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

https://github.com/google/osv-scanner/pull/1584
The skip-git option is now included as a default behavior in osv scanner.

**Checklist:** (if applicable)

- [x] Mention to the original issue