### PR TITLE
fix(BA-1192): Resolve `KeyError` in Client SDK's vfolder `mkdir` command

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fixed a `KeyError` in the Python Client SDK's vfolder `mkdir` command, caused by a missing "results" key in the API response

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -570,8 +570,7 @@ class VFolderByName(BaseFunction):
             "exist_ok": exist_ok,
         })
         async with rqst.fetch() as resp:
-            # reply: {'success': [{'msg': None, 'item': 'task-1'}], 'failed': []}
-            reply = await resp.json()  # {'results': {'success': [], 'failed': [{'msg': "FileExistsError(17, 'File exists')", 'item': 'task-0'}]}}
+            reply = await resp.json()
             return reply
 
     @api_function

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -570,8 +570,9 @@ class VFolderByName(BaseFunction):
             "exist_ok": exist_ok,
         })
         async with rqst.fetch() as resp:
-            reply = await resp.json()
-            return reply["results"]
+            # reply: {'success': [{'msg': None, 'item': 'task-1'}], 'failed': []}
+            reply = await resp.json()  # {'results': {'success': [], 'failed': [{'msg': "FileExistsError(17, 'File exists')", 'item': 'task-0'}]}}
+            return reply
 
     @api_function
     async def mkdir(


### PR DESCRIPTION
Follow-up of #4002 and resolves #4221 (BA-1192)

https://github.com/lablup/backend.ai/blob/aba0bffe0ae04fb6d1b387be384082db190f3cac/src/ai/backend/manager/api/vfolder.py#L1096

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
