### PR TITLE
feat(BA-1214): Add environment variables for distributed training

### DIFF
--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,0 +1,1 @@
+Add environment variables (`WORLD_SIZE`, `WORLD_RANK`, `LOCAL_RANK`, `MASTER_ADDR`, `MASTER_PORT`, `TF_CONFIG`) for distributed training

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1723,7 +1723,6 @@ class AgentRegistry:
                 if scheduled_session.main_kernel.preopen_ports is not None
                 else ""
             ),
-            # TODO
         })
 
         # Aggregate by agents to minimize RPC calls
@@ -1894,7 +1893,7 @@ class AgentRegistry:
                                 "WORLD_SIZE": str(binding.kernel.cluster_size),
                                 "WORLD_RANK": str(scheduled_session.kernels.index(binding.kernel)),
                                 "LOCAL_RANK": str(binding.kernel.local_rank),
-                                "MASTER_ADDR": str(binding.kernel.cluster_hostname),
+                                "MASTER_ADDR": str(scheduled_session.main_kernel.cluster_hostname),
                                 "MASTER_PORT": "12345",
                                 # TensorFlow
                                 "TF_CONFIG": dump_json_str({


### PR DESCRIPTION
resolves #4243 (BA-1214)

This pull request introduces support for distributed training by adding environment variables for PyTorch and TensorFlow configurations. It also includes a minor import addition to support JSON serialization.

### Distributed training support:

* Added environment variables (`WORLD_SIZE`, `WORLD_RANK`, `LOCAL_RANK`, `MASTER_ADDR`, `MASTER_PORT`, `TF_CONFIG`) to facilitate distributed training for PyTorch and TensorFlow. These variables are configured based on the cluster and kernel details in the `get_image_conf` function. (`src/ai/backend/manager/registry.py`, [src/ai/backend/manager/registry.pyR1892-R1912](diffhunk://#diff-2a44366d1a056952fd0e9ea782c130eb92efe47fd1258ee35f609147c456e4fcR1892-R1912))

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
