### PR TITLE
fix(BA-1205): `ImageAliasData` type not found in `ImageAliasData.to_dataclass()` (#4232)

### DIFF
--- a/changes/4232.fix.md
+++ b/changes/4232.fix.md
@@ -1,0 +1,1 @@
+Resolve `ImageAliasData` type not found issue in `ImageAliasData.to_dataclass()`.


### PR DESCRIPTION
This is an auto-generated backport PR of #4232 to the 24.09 release.