### PR TITLE
fix(BA-1227): Destroy kernels that fail during initialization

### DIFF
--- a/changes/4264.fix.md
+++ b/changes/4264.fix.md
@@ -1,0 +1,1 @@
+Fix kernel cleanup by ensuring kernels and their containers are properly destroyed during initialization failures

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2382,9 +2382,7 @@ class AbstractAgent(
                         KernelLifecycleEventReason.FAILED_TO_START,
                         container_id=ContainerId(container_data["container_id"]),
                     )
-                    raise AgentError(
-                        f"Container startup failed (k:{str(ctx.kernel_id)}, container:{container_data['container_id']}, e:{repr(e)})"
-                    )
+                    raise
                 finally:
                     self._pending_creation_tasks[kernel_id].remove(current_task)
                     if not self._pending_creation_tasks[kernel_id]:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2369,12 +2369,19 @@ class AbstractAgent(
                     raise AgentError(
                         f"Cancelled waiting of container startup (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
                     )
-                except Exception:
+                except BaseException as e:
                     log.exception(
-                        "unexpected error while waiting container startup (k:{})", kernel_id
+                        f"unexpected error while waiting container startup (k: {kernel_id}, e: {repr(e)})"
                     )
-                    raise RuntimeError(
-                        "cancelled waiting of container startup due to initialization failure",
+                    await self.inject_container_lifecycle_event(
+                        kernel_id,
+                        session_id,
+                        LifecycleEvent.DESTROY,
+                        KernelLifecycleEventReason.FAILED_TO_START,
+                        container_id=ContainerId(container_data["container_id"]),
+                    )
+                    raise AgentError(
+                        f"Container startup failed (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
                     )
                 finally:
                     self._pending_creation_tasks[kernel_id].remove(current_task)

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2381,7 +2381,7 @@ class AbstractAgent(
                         container_id=ContainerId(container_data["container_id"]),
                     )
                     raise AgentError(
-                        f"Container startup failed (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
+                        f"Container startup failed (k:{str(ctx.kernel_id)}, container:{container_data['container_id']}, e:{repr(e)})"
                     )
                 finally:
                     self._pending_creation_tasks[kernel_id].remove(current_task)

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2371,7 +2371,9 @@ class AbstractAgent(
                     )
                 except BaseException as e:
                     log.exception(
-                        f"unexpected error while waiting container startup (k: {kernel_id}, e: {repr(e)})"
+                        "unexpected error while waiting container startup (k: {}, e: {})",
+                        kernel_id,
+                        repr(e),
                     )
                     await self.inject_container_lifecycle_event(
                         kernel_id,


### PR DESCRIPTION
resolves #4263 (BA-1227)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue