### PR TITLE
fix: Wrong session download-single API result

### DIFF
--- a/changes/4276.fix.md
+++ b/changes/4276.fix.md
@@ -1,0 +1,1 @@
+Fix wrong value of Session download-single file API result

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1507,7 +1507,7 @@ async def download_single(request: web.Request, params: Any) -> web.Response:
             file=file,
         )
     )
-    return web.Response(body=result, status=HTTPStatus.OK)
+    return web.Response(body=result.result, status=HTTPStatus.OK)
 
 
 @server_status_required(READ_ALLOWED)


### PR DESCRIPTION
<!-- resolves #NNN (BA-MMM) -->

follow up #4061 

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue