### PR TITLE
fix(BA-1284): Agent retries to retrieve kernel service info when it fails (#4321)

### DIFF
--- a/changes/4321.fix.md
+++ b/changes/4321.fix.md
@@ -1,0 +1,1 @@
+Agent retries retrieving kernel service info if it fails during the kernel creation step

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -55,6 +55,8 @@ from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 from tenacity import (
     AsyncRetrying,
+    RetryError,
+    TryAgain,
     retry_if_exception_type,
     stop_after_attempt,
     stop_after_delay,
@@ -2328,7 +2330,10 @@ class AbstractAgent(
                             stop_after_attempt(kernel_init_polling_attempt)
                             | stop_after_delay(kernel_init_polling_timeout)
                         ),
-                        retry=retry_if_exception_type(zmq.error.ZMQError),
+                        retry=(
+                            retry_if_exception_type(zmq.error.ZMQError)
+                            | retry_if_exception_type(TryAgain)
+                        ),
                     ):
                         with attempt:
                             # Wait until bootstrap script is executed.
@@ -2345,6 +2350,13 @@ class AbstractAgent(
                                         if live_service["name"] == service_port["name"]:
                                             service_port.update(live_service)
                                             break
+                            else:
+                                log.warning(
+                                    "Failed to retrieve service app info, retrying (kernel:{}, container:{})",
+                                    kernel_id,
+                                    container_data["container_id"],
+                                )
+                                raise TryAgain
                     if self.local_config["debug"]["log-kernel-config"]:
                         log.debug("service ports:\n{!r}", pretty(service_ports))
                 except asyncio.TimeoutError:
@@ -2369,6 +2381,20 @@ class AbstractAgent(
                     raise AgentError(
                         f"Cancelled waiting of container startup (k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
                     )
+                except RetryError:
+                    await self.inject_container_lifecycle_event(
+                        kernel_id,
+                        session_id,
+                        LifecycleEvent.DESTROY,
+                        KernelLifecycleEventReason.FAILED_TO_START,
+                        container_id=ContainerId(container_data["container_id"]),
+                    )
+                    err_msg = (
+                        "Container startup failed, the container might be missing or failed to initialize "
+                        f"(k:{str(ctx.kernel_id)}, container:{container_data['container_id']})"
+                    )
+                    log.exception(err_msg)
+                    raise AgentError(err_msg)
                 except BaseException as e:
                     log.exception(
                         "unexpected error while waiting container startup (k: {}, e: {})",


### PR DESCRIPTION
This is an auto-generated backport PR of #4321 to the 25.6 release.