### PR TITLE
fix(BA-1302): Add TypeError handling in redis_helper (#4339)

### DIFF
--- a/changes/4339.fix.md
+++ b/changes/4339.fix.md
@@ -1,0 +1,1 @@
+Add TypeError handling in redis_helper


### PR DESCRIPTION
This is an auto-generated backport PR of #4339 to the 25.6 release.