### PR TITLE
fix(BA-1282): Use label's items for making resource info (#4341)

### DIFF
--- a/changes/4341.fix.md
+++ b/changes/4341.fix.md
@@ -1,0 +1,1 @@
+Use label's items for making resource info

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -688,7 +688,9 @@ class ImageRow(Base):
             "mem": {"min": INTRINSIC_SLOTS_MIN[SlotName("mem")], "max": None},
         }
 
-        for k, v in filter(lambda pair: pair[0].startswith(RESOURCE_LABEL_PREFIX), self.labels):
+        for k, v in filter(
+            lambda pair: pair[0].startswith(RESOURCE_LABEL_PREFIX), self.labels.items()
+        ):
             res_key = k[len(RESOURCE_LABEL_PREFIX) :]
             resources[res_key] = {"min": v}
 


### PR DESCRIPTION
This is an auto-generated backport PR of #4341 to the 25.6 release.