### PR TITLE
fix(BA-1334): Add missing `KernelStatus.ERROR` to dead kernel status set (#4371)

### DIFF
--- a/changes/4371.fix.md
+++ b/changes/4371.fix.md
@@ -1,0 +1,1 @@
+Add missing `KernelStatus.ERROR` to dead kernel status set

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -143,6 +143,7 @@ RESOURCE_USAGE_KERNEL_STATUSES = (
 DEAD_KERNEL_STATUSES = (
     KernelStatus.CANCELLED,
     KernelStatus.TERMINATED,
+    KernelStatus.ERROR,
 )
 
 LIVE_STATUS = (KernelStatus.RUNNING,)


### PR DESCRIPTION
This is an auto-generated backport PR of #4371 to the 25.6 release.