### PR TITLE
fix(BA-1141): Wrong project-id parsing when creating project vfolder (#4144)

### DIFF
--- a/changes/4144.fix.md
+++ b/changes/4144.fix.md
@@ -1,0 +1,1 @@
+Fix wrong project-id parsing when creating project vfolders


### PR DESCRIPTION
This is an auto-generated backport PR of #4144 to the 25.6 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--4381.org.readthedocs.build/en/4381/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--4381.org.readthedocs.build/ko/4381/

<!-- readthedocs-preview sorna-ko end -->