### PR TITLE
fix(BA-1345): Revert addition of `SessionStatus.ERROR` and `KernelStatus.ERROR` to dead status sets (#4384)

### DIFF
--- a/changes/4384.fix.md
+++ b/changes/4384.fix.md
@@ -1,0 +1,1 @@
+Revert addition of `SessionStatus.ERROR` and `KernelStatus.ERROR` to dead status sets

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -143,7 +143,6 @@ RESOURCE_USAGE_KERNEL_STATUSES = (
 DEAD_KERNEL_STATUSES = (
     KernelStatus.CANCELLED,
     KernelStatus.TERMINATED,
-    KernelStatus.ERROR,
 )
 
 LIVE_STATUS = (KernelStatus.RUNNING,)

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -181,13 +181,6 @@ LEADING_SESSION_STATUSES = tuple(
 DEAD_SESSION_STATUSES = frozenset([
     SessionStatus.CANCELLED,
     SessionStatus.TERMINATED,
-    SessionStatus.ERROR,
-])
-
-DEAD_KERNEL_STATUSES = frozenset([
-    KernelStatus.CANCELLED,
-    KernelStatus.TERMINATED,
-    KernelStatus.ERROR,
 ])
 
 # statuses to consider when calculating current resource usage

--- a/src/ai/backend/manager/sweeper/kernel.py
+++ b/src/ai/backend/manager/sweeper/kernel.py
@@ -14,7 +14,13 @@ from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
 
 from ..api.context import RootContext
-from ..models import DEAD_KERNEL_STATUSES, DEAD_SESSION_STATUSES, KernelRow, SessionRow
+from ..models import (
+    DEAD_KERNEL_STATUSES,
+    DEAD_SESSION_STATUSES,
+    KernelRow,
+    KernelStatus,
+    SessionRow,
+)
 from .base import DEFAULT_SWEEP_INTERVAL_SEC, AbstractSweeper
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -26,7 +32,7 @@ class KernelSweeper(AbstractSweeper):
         query = (
             sa.select(KernelRow)
             .join(SessionRow, KernelRow.session_id == SessionRow.id)
-            .where(KernelRow.status.not_in(DEAD_KERNEL_STATUSES))
+            .where(KernelRow.status.not_in({*DEAD_KERNEL_STATUSES, KernelStatus.ERROR}))
             .where(SessionRow.status.in_(DEAD_SESSION_STATUSES))
             .options(
                 noload("*"),


### PR DESCRIPTION
This is an auto-generated backport PR of #4384 to the 25.6 release.