### PR TITLE
feat(BA-1321): Add force-delete support for VFolder in Python client SDK (#4353)

### DIFF
--- a/changes/4353.feature.md
+++ b/changes/4353.feature.md
@@ -1,0 +1,1 @@
+Add VFolder force-delete API to Python client SDK

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3853,7 +3853,7 @@
         "description": "\nDelete `delete-pending` vfolders in storage proxy\n\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
-    "/folders/{name}/force": {
+    "/folders/{folder_id}/force": {
       "delete": {
         "operationId": "folders.force_delete",
         "tags": [
@@ -3871,7 +3871,7 @@
         ],
         "parameters": [
           {
-            "name": "name",
+            "name": "folder_id",
             "in": "path",
             "required": true,
             "schema": {

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -298,6 +298,13 @@ class VFolderByName(BaseFunction):
             return {}
 
     @api_function
+    async def force_delete(self) -> dict[str, Any]:
+        await self.update_id_by_name()
+        rqst = Request("DELETE", "/folders/{0}/force".format(self.request_key))
+        async with rqst.fetch():
+            return {}
+
+    @api_function
     async def rename(self, new_name):
         await self.update_id_by_name()
         rqst = Request("POST", "/folders/{0}/rename".format(self.request_key))

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1858,7 +1858,7 @@ async def delete_from_trash_bin(
 async def force_delete(request: web.Request) -> web.Response:
     root_ctx: RootContext = request.app["_root.context"]
 
-    piece = request.match_info["name"]
+    piece = request.match_info["folder_id"]
     try:
         folder_id = uuid.UUID(piece)
     except ValueError:
@@ -2816,7 +2816,7 @@ def create_app(default_cors_options):
     cors.add(add_route("POST", r"/purge", purge))
     cors.add(add_route("POST", r"/restore-from-trash-bin", restore))
     cors.add(add_route("POST", r"/delete-from-trash-bin", delete_from_trash_bin))
-    cors.add(add_route("DELETE", r"/{name}/force", force_delete))
+    cors.add(add_route("DELETE", r"/{folder_id}/force", force_delete))
     cors.add(add_route("GET", r"/invitations/list-sent", list_sent_invitations))
     cors.add(add_route("GET", r"/invitations/list_sent", list_sent_invitations))  # legacy underbar
     cors.add(add_route("POST", r"/invitations/update/{inv_id}", update_invitation))

--- a/tests/client/test_vfolder.py
+++ b/tests/client/test_vfolder.py
@@ -269,3 +269,20 @@ def test_vfolder_clone():
         )
         resp = session.VFolder(source_vfolder_name).clone(target_vfolder_name)
         assert resp == payload
+
+
+def test_vfolder_force_delete() -> None:
+    with Session() as session, aioresponses() as m:
+        vfolder_uuid = UUID("c59395cd-ac91-4cd3-a1b0-3d2568aa2d04")
+        m.get(
+            build_url(session.config, "/folders/_/id"),
+            status=HTTPStatus.OK,
+            payload={"id": vfolder_uuid.hex},
+        )
+        m.delete(
+            build_url(session.config, "/folders/{}/force".format(vfolder_uuid.hex)),
+            status=HTTPStatus.NO_CONTENT,
+            payload={},
+        )
+        resp = session.VFolder("", id=vfolder_uuid).force_delete()
+    assert resp == {}


### PR DESCRIPTION
This is an auto-generated backport PR of #4353 to the 25.6 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--4420.org.readthedocs.build/en/4420/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--4420.org.readthedocs.build/ko/4420/

<!-- readthedocs-preview sorna-ko end -->