### PR TITLE
fix(BA-1389): vfolder ls cmd not working (#4426)

### DIFF
--- a/changes/4425.fix.md
+++ b/changes/4425.fix.md
@@ -1,0 +1,1 @@
+Fix `vfolder ls` CLI command which referred deprecated response schema fields.

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -585,13 +585,13 @@ def ls(name, path):
             if "error_msg" in result and result["error_msg"]:
                 print_fail(result["error_msg"])
                 return
-            files = json.loads(result["files"])
+            files = result["items"]
             table = []
             headers = ["file name", "size", "modified", "mode"]
             for file in files:
-                mdt = datetime.fromtimestamp(file["mtime"])
+                mdt = datetime.fromisoformat(file["modified"])
                 mtime = mdt.strftime("%b %d %Y %H:%M:%S")
-                row = [file["filename"], file["size"], mtime, file["mode"]]
+                row = [file["name"], file["size"], mtime, file["mode"]]
                 table.append(row)
             print_done("Retrieved.")
             print(tabulate(table, headers=headers))


### PR DESCRIPTION
This is an auto-generated backport PR of #4426 to the 25.6 release.