### PR TITLE
fix(BA-1382): Initialize route session environment variables with fallback for `None` (#4447)

### DIFF
--- a/changes/4447.fix.md
+++ b/changes/4447.fix.md
@@ -1,0 +1,1 @@
+Fixed session environment variable init during route creation when `endpoint.environ` is `None`

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -2,17 +2,11 @@ import asyncio
 import logging
 import secrets
 import uuid
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from http import HTTPStatus
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Self,
-    Sequence,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any, Optional, Self
 
 import aiohttp
 import aiohttp_cors
@@ -308,7 +302,7 @@ class ServiceConfigModel(LegacyBaseRequestModel):
         default={},
     )
 
-    environ: dict[str, str] | None = Field(
+    environ: Optional[dict[str, str]] = Field(
         description="Environment variables to be set inside the inference session",
         default=None,
     )
@@ -1237,7 +1231,7 @@ async def shutdown(app: web.Application) -> None:
 
 def create_app(
     default_cors_options: CORSOptions,
-) -> Tuple[web.Application, Iterable[WebMiddleware]]:
+) -> tuple[web.Application, Iterable[WebMiddleware]]:
     app = web.Application()
     app["prefix"] = "services"
     app["api_versions"] = (4, 5)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -4284,7 +4284,7 @@ async def handle_route_creation(
                 ],
             )
 
-            environ = {**endpoint.environ}
+            environ = dict(endpoint.environ or {})
             if "BACKEND_MODEL_NAME" not in environ:
                 environ["BACKEND_MODEL_NAME"] = endpoint.model_row.name
 


### PR DESCRIPTION
This is an auto-generated backport PR of #4447 to the 25.6 release.