### PR TITLE
fix(BA-1379): Truncate generated session name in service creation to max allowed length (#4450)

### DIFF
--- a/changes/4450.fix.md
+++ b/changes/4450.fix.md
@@ -1,0 +1,1 @@
+Fixed `Service.create()` in client SDK to truncate the default generated session name to the maximum allowed length

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -6,6 +6,7 @@ from faker import Faker
 from typing_extensions import deprecated
 
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
+from ai.backend.common.typed_validators import SESSION_NAME_MAX_LENGTH
 
 from ..exceptions import BackendClientError
 from ..output.fields import service_fields
@@ -146,7 +147,7 @@ class Service(BaseFunction):
         """
         if service_name is None:
             faker = Faker()
-            service_name = f"bai-serve-{faker.user_name()}"
+            service_name = f"bai-serve-{faker.user_name()}"[:SESSION_NAME_MAX_LENGTH]
 
         extra_mount_body = {}
         if extra_mounts:
@@ -269,7 +270,7 @@ class Service(BaseFunction):
         """
         if service_name is None:
             faker = Faker()
-            service_name = f"bai-serve-{faker.user_name()}"
+            service_name = f"bai-serve-{faker.user_name()}"[:SESSION_NAME_MAX_LENGTH]
 
         rqst = Request("POST", "/services/_/try")
         rqst.set_json({

--- a/src/ai/backend/common/typed_validators.py
+++ b/src/ai/backend/common/typed_validators.py
@@ -1,6 +1,9 @@
 import datetime
 import re
-from typing import Annotated, Any, TypeAlias
+from collections.abc import Mapping, Sequence
+from datetime import tzinfo
+from pathlib import Path
+from typing import Annotated, Any, ClassVar, Final, Optional, TypeAlias, TypeVar
 
 from dateutil.relativedelta import relativedelta
 from pydantic import (
@@ -150,8 +153,10 @@ TimeDuration = Annotated[
 NaiveTimeDuration = Annotated[TVariousDelta, _NaiveTimeDurationPydanticAnnotation]
 """Time duration validator which also accepts negative value"""
 
-
-SESSION_NAME_MATCHER = re.compile(r"^(?=.{4,24}$)\w[\w.-]*\w$", re.ASCII)
+SESSION_NAME_MAX_LENGTH: Final[int] = 24
+SESSION_NAME_MATCHER = re.compile(
+    r"^(?=.{4,%d}$)\w[\w.-]*\w$" % (SESSION_NAME_MAX_LENGTH,), re.ASCII
+)
 
 
 def session_name_validator(s: str) -> str:

--- a/src/ai/backend/common/typed_validators.py
+++ b/src/ai/backend/common/typed_validators.py
@@ -1,9 +1,8 @@
 import datetime
 import re
-from collections.abc import Mapping, Sequence
 from datetime import tzinfo
 from pathlib import Path
-from typing import Annotated, Any, ClassVar, Final, Optional, TypeAlias, TypeVar
+from typing import Annotated, Any, Final, TypeAlias
 
 from dateutil.relativedelta import relativedelta
 from pydantic import (

--- a/src/ai/backend/common/typed_validators.py
+++ b/src/ai/backend/common/typed_validators.py
@@ -1,7 +1,5 @@
 import datetime
 import re
-from datetime import tzinfo
-from pathlib import Path
 from typing import Annotated, Any, Final, TypeAlias
 
 from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
This is an auto-generated backport PR of #4450 to the 25.6 release.