### PR TITLE
chore: Changed the number of CPUs in the dev environment to one

### DIFF
--- a/configs/storage-proxy/halfstack.toml
+++ b/configs/storage-proxy/halfstack.toml
@@ -8,7 +8,7 @@ password = ""				    # env: BACKEND_ETCD_PASSWORD
 [storage-proxy]
 # An identifier of this storage proxy, which must be unique in a cluster.
 node-id = "i-storage-proxy-local"
-num-proc = 4
+num-proc = 1
 # pid-file = "./storage-proxy.pid"
 event-loop = "uvloop"
 


### PR DESCRIPTION
All other components are using only 1 CPU by default in the development environment.
Change the default setting to 1 for compatibility in smaller environments.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
