### PR TITLE
fix: Add missing validator to Redis Sentinel Config

### DIFF
--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -1428,7 +1428,8 @@ class InterContainerNetworkConfig(BaseModel):
         examples=[True, False],
     )
     # TODO: Write description
-    plugin: Optional[str] = Field(
+    # Need to investigate what kind of setting or type it is.
+    plugin: Optional[Any] = Field(
         default=None,
         description="""
         """,

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -432,6 +432,7 @@ async def config_provider_ctx(
     unified_config_loader = LoaderChain(loaders, base_config=extra_config)
     etcd_watcher = EtcdConfigWatcher(root_ctx.etcd)
 
+    config_provider: Optional[ManagerConfigProvider] = None
     try:
         config_provider = await ManagerConfigProvider.create(
             unified_config_loader,
@@ -445,7 +446,8 @@ async def config_provider_ctx(
             print(pformat(config_provider.config), file=sys.stderr)
         yield root_ctx.config_provider
     finally:
-        await config_provider.terminate()
+        if config_provider:
+            await config_provider.terminate()
 
 
 @actxmgr


### PR DESCRIPTION
Hotfix to #4317.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
