### PR TITLE
feat(BA-1437): Add `EventDomain.WORKFLOW` enum value to support workflow-related events

### DIFF
--- a/changes/.feature.md
+++ b/changes/.feature.md
@@ -1,0 +1,1 @@
+Add `EventDomain.WORKFLOW` enum value to support workflow-related event categorization

--- a/src/ai/backend/agent/plugin/network.py
+++ b/src/ai/backend/agent/plugin/network.py
@@ -1,6 +1,6 @@
-import enum
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, Generic, Iterable, Mapping, Set, TypeVar
 
 from ai.backend.agent.kernel import AbstractKernel
@@ -10,7 +10,7 @@ from ai.backend.common.types import ClusterInfo, KernelCreationConfig
 TKernel = TypeVar("TKernel", bound=AbstractKernel)
 
 
-class ContainerNetworkCapability(str, enum.Enum):
+class ContainerNetworkCapability(StrEnum):
     GLOBAL = "global"
     """Referred when the network plugin replaces default bridge network and acts as a default route"""
 

--- a/src/ai/backend/common/data/session/types.py
+++ b/src/ai/backend/common/data/session/types.py
@@ -1,6 +1,6 @@
-import enum
+from enum import StrEnum
 
 
-class CustomizedImageVisibilityScope(str, enum.Enum):
+class CustomizedImageVisibilityScope(StrEnum):
     USER = "user"
     PROJECT = "project"

--- a/src/ai/backend/common/events/types.py
+++ b/src/ai/backend/common/events/types.py
@@ -23,6 +23,7 @@ class EventDomain(enum.StrEnum):
     VFOLDER = "vfolder"
     VOLUME = "volume"
     LOG = "log"
+    WORKFLOW = "workflow"
 
 
 class AbstractEvent(ABC):

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, tzinfo
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Mapping, Optional, Sequence
 from uuid import UUID
 
@@ -32,7 +32,7 @@ __all__: Sequence[str] = (
 )
 
 
-class ResourceGroupUnit(str, Enum):
+class ResourceGroupUnit(StrEnum):
     KERNEL = "kernel"
     SESSION = "session"
     PROJECT = "project"

--- a/src/ai/backend/wsproxy/config.py
+++ b/src/ai/backend/wsproxy/config.py
@@ -1,4 +1,3 @@
-import enum
 import os
 import pwd
 import socket
@@ -6,6 +5,7 @@ import sys
 import types
 import typing
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from pprint import pformat
 from typing import Annotated, Any
@@ -201,14 +201,14 @@ class GroupID:
         )
 
 
-class LogDriver(str, enum.Enum):
+class LogDriver(StrEnum):
     CONSOLE = "console"
     LOGSTASH = "logstash"
     FILE = "file"
     GRAYLOG = "graylog"
 
 
-class LogstashProtocol(str, enum.Enum):
+class LogstashProtocol(StrEnum):
     ZMQ_PUSH = "zmq.push"
     ZMQ_PUB = "zmq.pub"
     TCP = "tcp"

--- a/src/ai/backend/wsproxy/types.py
+++ b/src/ai/backend/wsproxy/types.py
@@ -1,8 +1,8 @@
 import dataclasses
-import enum
 import textwrap
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import (
     Annotated,
     Any,
@@ -25,11 +25,11 @@ from pydantic import AnyUrl, BaseModel, Field
 # FIXME: merge majority of common definitions to ai.backend.common when ready
 
 
-class FrontendMode(str, enum.Enum):
+class FrontendMode(StrEnum):
     PORT = "port"
 
 
-class ProxyProtocol(str, enum.Enum):
+class ProxyProtocol(StrEnum):
     HTTP = "http"
     GRPC = "grpc"
     HTTP2 = "h2"
@@ -37,7 +37,7 @@ class ProxyProtocol(str, enum.Enum):
     PREOPEN = "preopen"
 
 
-class AppMode(str, enum.Enum):
+class AppMode(StrEnum):
     INTERACTIVE = "interactive"
     INFERENCE = "inference"
 
@@ -50,12 +50,12 @@ class Slot:
     circuit_id: UUID | None
 
 
-class EventLoopType(str, enum.Enum):
+class EventLoopType(StrEnum):
     UVLOOP = "uvloop"
     ASYNCIO = "asyncio"
 
 
-class DigestModType(str, enum.Enum):
+class DigestModType(StrEnum):
     SHA1 = "sha1"
     SHA224 = "sha224"
     SHA256 = "sha256"


### PR DESCRIPTION
Follow-up of #4358 and resolves #4498 (BA-1437)

This pull request introduces two major updates: the addition of a new workflow-related event domain and the replacement of `enum.Enum` with `StrEnum` across multiple classes for consistency and improved string representation. Below is a breakdown of the key changes:

### Event Domain Updates:
* Added a new `WORKFLOW` value to the `EventDomain` enum to support categorization of workflow-related events. (`changes/.feature.md`, `src/ai/backend/common/events/types.py`) [[1]](diffhunk://#diff-631e0eb59499322a3837175e3a6831af651780f640f3a02d273dfd0b51a51f32R1) [[2]](diffhunk://#diff-a3c30163c84a784f1872667802816696e74b36e72440a36506b2eb1aaa8992bbR26)

### Migration to `StrEnum`:
* Replaced `enum.Enum` with `StrEnum` for the `ContainerNetworkCapability` class in `network.py` to enhance string handling. (`src/ai/backend/agent/plugin/network.py`) [[1]](diffhunk://#diff-1ab3f6724e20d9c7cfd1c72a1acbe3ba0b1a6eda8eaf1686fbb91ee8171e7d4cL1-R3) [[2]](diffhunk://#diff-1ab3f6724e20d9c7cfd1c72a1acbe3ba0b1a6eda8eaf1686fbb91ee8171e7d4cL13-R13)
* Updated `CustomizedImageVisibilityScope` to use `StrEnum` in `session/types.py`. (`src/ai/backend/common/data/session/types.py`)
* Converted `ResourceGroupUnit` to `StrEnum` in `resource_usage.py`. (`src/ai/backend/manager/models/resource_usage.py`) [[1]](diffhunk://#diff-d9a5c9d34d554b8d5d4e4e14c073ad84f35745248658acd0e2ab588d3b220f10L4-R4) [[2]](diffhunk://#diff-d9a5c9d34d554b8d5d4e4e14c073ad84f35745248658acd0e2ab588d3b220f10L35-R35)
* Migrated multiple enums (`LogDriver`, `LogstashProtocol`, etc.) in `config.py` and `types.py` to `StrEnum` for consistency. (`src/ai/backend/wsproxy/config.py`, `src/ai/backend/wsproxy/types.py`) [[1]](diffhunk://#diff-2023d76deb19afce6147b0dcfed5ffa4b23e08d3e43d88afe8e796d354014f0aL1-R8) [[2]](diffhunk://#diff-2023d76deb19afce6147b0dcfed5ffa4b23e08d3e43d88afe8e796d354014f0aL204-R211) [[3]](diffhunk://#diff-cc0ac467b83e852dd94eab2884759af8d82ba8422beeae8cdcaacf640bd09cc0L2-R5) [[4]](diffhunk://#diff-cc0ac467b83e852dd94eab2884759af8d82ba8422beeae8cdcaacf640bd09cc0L28-R40) [[5]](diffhunk://#diff-cc0ac467b83e852dd94eab2884759af8d82ba8422beeae8cdcaacf640bd09cc0L53-R58)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
