### PR TITLE
fix: GQL log is not printing

### DIFF
--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -41,8 +41,8 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class GQLLoggingMiddleware:
     def resolve(self, next, root, info: graphene.ResolveInfo, **args) -> Any:
-        graph_ctx: GraphQueryContext = info.context
-        if len(info.path) == 1:
+        if info.path.prev is None:  # indicates the root query
+            graph_ctx = info.context
             log.info(
                 "ADMIN.GQL (ak:{}, {}:{}, op:{})",
                 graph_ctx.access_key,


### PR DESCRIPTION
resolves #NNN (BA-MMM)


Previously, it was determined that it was a Root Query based on the path length being 1, but you should determine that Prev was None based on the type of Path of ResolveInfo.


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
