### PR TITLE
fix(BA-1460): Broken `Resource.usage_per_month` SDK method

### DIFF
--- a/changes/4546.fix.md
+++ b/changes/4546.fix.md
@@ -1,1 +1,1 @@
-Fix broken `Resource.usage_per_month` method in the SDK
+Fix broken `usage_per_month` method in Resource SDK

--- a/changes/4546.fix.md
+++ b/changes/4546.fix.md
@@ -1,0 +1,1 @@
+Fix broken `Resource.usage_per_month` method in the SDK

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -7427,7 +7427,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "List of items separated by a delimiter (default: comma). Items may contain spaces, but not the delimiter."
             },
             "required": false,
             "in": "query"

--- a/src/ai/backend/client/func/resource.py
+++ b/src/ai/backend/client/func/resource.py
@@ -68,11 +68,15 @@ class Resource(BaseFunction):
         :param month: The month you want to get the statistics (yyyymm).
         :param group_ids: Groups IDs to be included in the result.
         """
-        rqst = Request("GET", "/resource/usage/month")
-        rqst.set_json({
-            "month": month,
-            "group_ids": group_ids,
-        })
+        rqst = Request(
+            "GET",
+            "/resource/usage/month",
+            params={
+                "group_ids": ",".join(group_ids),
+                "month": month,
+            },
+        )
+
         async with rqst.fetch() as resp:
             return await resp.json()
 

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -170,6 +170,7 @@ async def usage_per_month(request: web.Request, params: Any) -> web.Response:
     """
     log.info("USAGE_PER_MONTH (g:[{}], month:{})", ",".join(params["group_ids"]), params["month"])
     root_ctx: RootContext = request.app["_root.context"]
+
     result = await root_ctx.processors.group.usage_per_month.wait_for_complete(
         UsagePerMonthAction(
             group_ids=params["group_ids"],

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -155,7 +155,7 @@ async def recalculate_usage(request: web.Request) -> web.Response:
 @superadmin_required
 @check_api_params(
     t.Dict({
-        tx.MultiKey("group_ids"): t.List(t.String) | t.Null,
+        t.Key("group_ids"): tx.DelimiterSeperatedList[str](t.String) | t.Null,
         t.Key("month"): t.Regexp(r"^\d{6}", re.ASCII),
     }),
     loads=_json_loads,
@@ -170,7 +170,6 @@ async def usage_per_month(request: web.Request, params: Any) -> web.Response:
     """
     log.info("USAGE_PER_MONTH (g:[{}], month:{})", ",".join(params["group_ids"]), params["month"])
     root_ctx: RootContext = request.app["_root.context"]
-
     result = await root_ctx.processors.group.usage_per_month.wait_for_complete(
         UsagePerMonthAction(
             group_ids=params["group_ids"],

--- a/src/ai/backend/manager/openapi.py
+++ b/src/ai/backend/manager/openapi.py
@@ -75,6 +75,15 @@ def _traverse(scheme: t.Trafaret) -> dict:
     if isinstance(scheme, t.Enum):
         enum_values = scheme.variants  # type: ignore[attr-defined]
         return {"type": "string", "enum": enum_values}
+    if isinstance(scheme, tx.DelimiterSeperatedList):
+        return {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "List of items separated by a delimiter (default: comma). "
+                "Items may contain spaces, but not the delimiter."
+            ),
+        }
     if isinstance(scheme, t.Float):
         resp = {"type": "integer"}
         if gte := scheme.gte:  # type: ignore[attr-defined]


### PR DESCRIPTION
resolves #4525 (BA-1460).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

## Example code

```python
async def test():
    async with AsyncSession() as session:
        r = await session.Resource.usage_per_month("202505", ["2de2b969-1d04-48a6-af16-0bc8adb3c831", "8e32dd28-d319-4e3b-8851-ea37837699a5"])
        print(r)
```

## Result
```
{'result': {'PENDING': '2025-05-29T02:11:56.602497+00:00', 'RUNNING': '2025-05-29T02:11:59.551399+00:00', 'CREATING': '2025-05-29T02:11:57.351795+00:00', 'PREPARED': '2025-05-29T02:11:57.342391+00:00', 'PREPARING': '2025-05-29T02:11:57.306649+00:00', 'SCHEDULED': '2025-05-29T02:11:57.297149+00:00'}}
```

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--4546.org.readthedocs.build/en/4546/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--4546.org.readthedocs.build/ko/4546/

<!-- readthedocs-preview sorna-ko end -->