### PR TITLE
fix(BA-1457): Broken `Keypair` SDK methods

### DIFF
--- a/changes/4547.fix.md
+++ b/changes/4547.fix.md
@@ -1,0 +1,1 @@
+Fix broken `Keypair` SDK methods (`activate`, `deactivate`)

--- a/src/ai/backend/client/func/keypair.py
+++ b/src/ai/backend/client/func/keypair.py
@@ -241,9 +241,6 @@ class KeyPair(BaseFunction):
             "access_key": access_key,
             "input": {
                 "is_active": True,
-                "is_admin": None,
-                "resource_policy": None,
-                "rate_limit": None,
             },
         }
         data = await api_session.get().Admin._query(q, variables)
@@ -269,9 +266,6 @@ class KeyPair(BaseFunction):
             "access_key": access_key,
             "input": {
                 "is_active": False,
-                "is_admin": None,
-                "resource_policy": None,
-                "rate_limit": None,
             },
         }
         data = await api_session.get().Admin._query(q, variables)


### PR DESCRIPTION
resolves #NNN (BA-1457).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

## Example

```
async def test():
    async with AsyncSession() as session:
        r = await session.KeyPair.activate("AKIAIOSFODNN7EXAMPLE")
        print(r)
```

## Result

```
{'ok': False, 'msg': 'integrity error: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class \'asyncpg.exceptions.NotNullViolationError\'>: null value in column "resource_policy" of relation "keypairs" violates not-null constraint\nDETAIL:  Failing row contains (admin@lablup.com, AKIAIOSFODNN7EXAMPLE, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY, t, null, 2025-05-15 04:20:51.421069+00, 2025-05-29 03:27:57.697798+00, null, null, 0, null, null, f38dea23-50fa-42a0-b5ae-338f5f4693f4, null, \\x90, ).\n[SQL: UPDATE keypairs SET is_active=%s, is_admin=%s, modified_at=CURRENT_TIMESTAMP, rate_limit=%s, resource_policy=%s WHERE keypairs.access_key = %s]\n[parameters: (True, None, None, None, \'AKIAIOSFODNN7EXAMPLE\')]\n(Background on this error at: https://sqlalche.me/e/14/gkpj)'}
```

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue