### PR TITLE
fix(BA-1457): Broken `Keypair` SDK methods (#4547)

### DIFF
--- a/changes/4547.fix.md
+++ b/changes/4547.fix.md
@@ -1,0 +1,1 @@
+Fix broken `Keypair` SDK methods (`activate`, `deactivate`)

--- a/src/ai/backend/client/func/keypair.py
+++ b/src/ai/backend/client/func/keypair.py
@@ -241,9 +241,6 @@ class KeyPair(BaseFunction):
             "access_key": access_key,
             "input": {
                 "is_active": True,
-                "is_admin": None,
-                "resource_policy": None,
-                "rate_limit": None,
             },
         }
         data = await api_session.get().Admin._query(q, variables)
@@ -269,9 +266,6 @@ class KeyPair(BaseFunction):
             "access_key": access_key,
             "input": {
                 "is_active": False,
-                "is_admin": None,
-                "resource_policy": None,
-                "rate_limit": None,
             },
         }
         data = await api_session.get().Admin._query(q, variables)


### PR DESCRIPTION
This is an auto-generated backport PR of #4547 to the 25.6 release.