### PR TITLE
fix(BA-1438): Skip processing messages with None data in RedisQueue (#4559)

### DIFF
--- a/changes/4559.fix.md
+++ b/changes/4559.fix.md
@@ -1,0 +1,1 @@
+Skip processing messages with None data in RedisQueue

--- a/src/ai/backend/common/message_queue/redis_queue.py
+++ b/src/ai/backend/common/message_queue/redis_queue.py
@@ -146,6 +146,8 @@ class RedisQueue(AbstractMessageQueue):
             return autoclaim_start_id, False
         autoclaim_start_id = reply[0]
         for msg_id, msg_data in reply[1]:
+            if msg_data is None:
+                continue
             msg = MQMessage(msg_id, msg_data)
             if msg.retry():
                 await self._retry_message(msg)


### PR DESCRIPTION
This is an auto-generated backport PR of #4559 to the 25.6 release.