### PR TITLE
ci: Add error handling to build scripts

### DIFF
--- a/scripts/build-scies.sh
+++ b/scripts/build-scies.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
+set -e
+
 pants --tag='scie' --tag='lazy' package '::'
 # NOTE: 'pants run' does not support parallelization
 pants list --filter-tag-regex='checksum' '::' | xargs -n 1 pants run

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -1,3 +1,6 @@
+#! /bin/bash
+set -e
+
 # Normalize the package version
 PKGVER=$(python -c "import packaging.version,pathlib; print(str(packaging.version.Version(pathlib.Path('VERSION').read_text())))")
 # Build non-platform-specific wheels


### PR DESCRIPTION
Updated `build-scies.sh` and `build-wheels.sh` to include `set -e` for error handling, ensuring the scripts exit immediately on failure. Also added a shebang to `build-wheels.sh` for consistency.
