### PR TITLE
fix(BA-1488): Gracefully handle missing `Config.Labels` in Docker image inspection (#4576)

### DIFF
--- a/changes/4576.fix.md
+++ b/changes/4576.fix.md
@@ -1,0 +1,1 @@
+Fix Backend.AI agent to gracefully handle missing `Config.Labels` field in Docker image inspection

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1555,7 +1555,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                         continue
 
                     img_detail = await docker.images.inspect(repo_tag)
-                    labels = img_detail["Config"]["Labels"]
+                    labels = img_detail.get("Config", {}).get("Labels")
                     if labels is None:
                         continue
                     kernelspec = int(labels.get("ai.backend.kernelspec", "1"))


### PR DESCRIPTION
This is an auto-generated backport PR of #4576 to the 25.6 release.