### PR TITLE
fix(BA-1487): Correct the worker process ID and names in the server logs (#4572)

### DIFF
--- a/changes/4572.fix.md
+++ b/changes/4572.fix.md
@@ -1,0 +1,1 @@
+Correct the worker process ID and names in the server log outputs, which had been unintentionally overriden as the main process information

--- a/src/ai/backend/logging/handler/intrinsic.py
+++ b/src/ai/backend/logging/handler/intrinsic.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import traceback
 from typing import TYPE_CHECKING, Optional, override
 
 import msgpack
+import psutil
 import zmq
 
 if TYPE_CHECKING:
@@ -20,6 +22,8 @@ class RelayHandler(logging.Handler):
         self.endpoint = endpoint
         self.msgpack_options = msgpack_options
         self._zctx = zmq.Context[zmq.Socket]()
+        self._pid = os.getpid()
+        self._process_name = psutil.Process().name()
         # We should use PUSH-PULL socket pairs to avoid
         # lost of synchronization sentinel messages.
         if endpoint:
@@ -54,6 +58,8 @@ class RelayHandler(logging.Handler):
                 "msg": record.getMessage(),
                 "levelno": record.levelno,
                 "levelname": record.levelname,
+                "process": self._pid,
+                "processName": self._process_name,
             }
             if record.exc_info:
                 log_body["exc_info"] = traceback.format_exception(*record.exc_info)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -363,7 +363,61 @@ async def shared_config_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     )
     await root_ctx.shared_config.reload()
     yield
-    await root_ctx.shared_config.close()
+    await root_ctx.etcd.close()
+
+
+@actxmgr
+async def config_provider_ctx(
+    root_ctx: RootContext,
+    log_level: LogLevel,
+    config_path: Optional[Path] = None,
+    extra_config: Optional[Mapping[str, Any]] = None,
+) -> AsyncIterator[ManagerConfigProvider]:
+    loaders: list[AbstractConfigLoader] = []
+
+    if config_path:
+        toml_config_loader = TomlConfigLoader(config_path, "manager")
+        loaders.append(toml_config_loader)
+    else:
+        log.warning("No config file path specified. Skipped loading toml config file...")
+
+    legacy_etcd_loader = LegacyEtcdLoader(root_ctx.etcd)
+    loaders.append(legacy_etcd_loader)
+    loaders.append(LegacyEtcdVolumesLoader(root_ctx.etcd))
+    loaders.append(EtcdCommonConfigLoader(root_ctx.etcd))
+    loaders.append(EtcdManagerConfigLoader(root_ctx.etcd))
+
+    overrides: list[tuple[tuple[str, ...], Any]] = [
+        (("debug", "enabled"), log_level == LogLevel.DEBUG),
+    ]
+    if log_level != LogLevel.NOTSET:
+        overrides += [
+            (("logging", "level"), log_level),
+            (("logging", "pkg-ns", "ai.backend"), log_level),
+            (("logging", "pkg-ns", "aiohttp"), log_level),
+        ]
+
+    loaders.append(ConfigOverrider(overrides))
+
+    unified_config_loader = LoaderChain(loaders, base_config=extra_config)
+    etcd_watcher = EtcdConfigWatcher(root_ctx.etcd)
+
+    config_provider: Optional[ManagerConfigProvider] = None
+    try:
+        config_provider = await ManagerConfigProvider.create(
+            unified_config_loader,
+            etcd_watcher,
+            legacy_etcd_loader,
+        )
+        root_ctx.config_provider = config_provider
+
+        if config_provider.config.debug.enabled and root_ctx.pidx == 0:
+            print("== Manager configuration ==", file=sys.stderr)
+            print(pformat(config_provider.config), file=sys.stderr)
+        yield root_ctx.config_provider
+    finally:
+        if config_provider:
+            await config_provider.terminate()
 
 
 @actxmgr
@@ -1116,7 +1170,12 @@ async def server_main_logwrapper(
     _args: List[Any],
 ) -> AsyncIterator[None]:
     setproctitle(f"backend.ai: manager worker-{pidx}")
-    log_endpoint = _args[1]
+    args = ServerMainArgs(
+        bootstrap_cfg=tuple_args[0],
+        bootstrap_cfg_path=tuple_args[1],
+        log_endpoint=tuple_args[2],
+        log_level=tuple_args[3],
+    )
     logger = Logger(
         _args[0]["logging"],
         is_master=False,


### PR DESCRIPTION
This is an auto-generated backport PR of #4572 to the 25.6 release.