### PR TITLE
fix(BA-1487): Correct the worker process ID and names in the server logs (#4572)

### DIFF
--- a/changes/4572.fix.md
+++ b/changes/4572.fix.md
@@ -1,0 +1,1 @@
+Correct the worker process ID and names in the server log outputs, which had been unintentionally overriden as the main process information

--- a/src/ai/backend/logging/handler/intrinsic.py
+++ b/src/ai/backend/logging/handler/intrinsic.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import traceback
 from typing import TYPE_CHECKING, Optional, override
 
 import msgpack
+import psutil
 import zmq
 
 if TYPE_CHECKING:
@@ -20,6 +22,8 @@ class RelayHandler(logging.Handler):
         self.endpoint = endpoint
         self.msgpack_options = msgpack_options
         self._zctx = zmq.Context[zmq.Socket]()
+        self._pid = os.getpid()
+        self._process_name = psutil.Process().name()
         # We should use PUSH-PULL socket pairs to avoid
         # lost of synchronization sentinel messages.
         if endpoint:
@@ -54,6 +58,8 @@ class RelayHandler(logging.Handler):
                 "msg": record.getMessage(),
                 "levelno": record.levelno,
                 "levelname": record.levelname,
+                "process": self._pid,
+                "processName": self._process_name,
             }
             if record.exc_info:
                 log_body["exc_info"] = traceback.format_exception(*record.exc_info)


### PR DESCRIPTION
This is an auto-generated backport PR of #4572 to the 24.09 release.