### PR TITLE
refactor(BA-1466): Init device env vars with/without restart

### DIFF
--- a/changes/4585.enhance.md
+++ b/changes/4585.enhance.md
@@ -1,0 +1,1 @@
+Initialize device env vars with/without restart to make session restart successfully

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -296,6 +296,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         self.computers = computers
         self.restarting = restarting
         self.local_config = local_config
+        self.additional_allowed_syscalls = []
 
     @abstractmethod
     async def get_extra_envs(self) -> Mapping[str, str]:
@@ -610,7 +611,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
     async def inject_additional_device_env_vars(
         self, resource_spec: KernelResourceSpec, environ: MutableMapping[str, str]
     ) -> None:
-        # Inject ComputeDevice-specific env-varibles
+        # Inject ComputeDevice-specific env-variables
         additional_gid_set: set[int] = set()
         additional_allowed_syscalls_set: set[str] = set()
 


### PR DESCRIPTION
resolves #4529 (BA-1466)

When session restarts, `AttributeError` was raised due to `DockerKernelCreationContext `has no attirbute `additional_allowed_syscalls`. It is because `self.additional_allowed_syscalls` is initialized only when session first start. 

With @fregataa 's advice, I decoupled Device's added env vars initialization from `krunner_mount` and changed it to be called even if restarted