### PR TITLE
fix: Include endpoint loading in route retrieval for delete_route function

### DIFF
--- a/changes/4594.fix.md
+++ b/changes/4594.fix.md
@@ -1,0 +1,1 @@
+Include endpoint loading in route retrieval for delete_route function

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -990,7 +990,7 @@ async def delete_route(request: web.Request) -> SuccessResponseModel:
     )
     async with root_ctx.db.begin_readonly_session() as db_sess:
         try:
-            route = await RoutingRow.get(db_sess, route_id, load_session=True, load_endpoint=True)
+            route = await RoutingRow.get(db_sess, route_id, load_endpoint=True, load_session=True)
         except NoResultFound:
             raise ObjectNotFound
         if route.endpoint != service_id:

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -990,7 +990,7 @@ async def delete_route(request: web.Request) -> SuccessResponseModel:
     )
     async with root_ctx.db.begin_readonly_session() as db_sess:
         try:
-            route = await RoutingRow.get(db_sess, route_id, load_session=True)
+            route = await RoutingRow.get(db_sess, route_id, load_session=True, load_endpoint=True)
         except NoResultFound:
             raise ObjectNotFound
         if route.endpoint != service_id:


### PR DESCRIPTION
Follow-up of #4590 (BA-1498)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
