### PR TITLE
fix(BA-1501): Replace assert statements in `load_model_definition` with raising exception (#4599)

### DIFF
--- a/changes/4599.fix.md
+++ b/changes/4599.fix.md
@@ -1,0 +1,1 @@
+Replace assert statements in `load_model_definition` with raising exception

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2308,7 +2308,10 @@ class AbstractAgent(
             raise AgentError(
                 "image should have its own command when runtime variant is set to values other than CUSTOM!"
             )
-        assert len(model_folders) > 0
+
+        if len(model_folders) == 0:
+            raise AgentError("At least one model virtual folder must be specified.")
+
         model_folder: VFolderMount = model_folders[0]
 
         match runtime_variant:
@@ -2392,7 +2395,10 @@ class AbstractAgent(
                     raise AgentError(f"Invalid YAML syntax: {e}") from e
         try:
             model_definition = model_definition_iv.check(raw_definition)
-            assert model_definition is not None
+            if model_definition is None:
+                raise AgentError(
+                    "Model definition is empty. Please check your model definition file"
+                )
             for model in model_definition["models"]:
                 if "BACKEND_MODEL_NAME" not in environ:
                     environ["BACKEND_MODEL_NAME"] = model["name"]


### PR DESCRIPTION
This is an auto-generated backport PR of #4599 to the 24.09 release.