### PR TITLE
feat(BA-1504): Add Etcd, Redis, and PostgreSQL exporters, scraper configs

### DIFF
--- a/changes/4604.misc.md
+++ b/changes/4604.misc.md
@@ -1,1 +1,0 @@
-Add Etcd scraper to local development environment's Prometheus config

--- a/changes/4604.misc.md
+++ b/changes/4604.misc.md
@@ -1,0 +1,1 @@
+Add Etcd scraper to local development environment's Prometheus config

--- a/changes/4606.misc.md
+++ b/changes/4606.misc.md
@@ -1,0 +1,1 @@
+Add Etcd, Redis, and PostgreSQL exporters/scrapers in local development environment's Prometheus config

--- a/changes/4606.misc.md
+++ b/changes/4606.misc.md
@@ -1,1 +1,1 @@
-Add Etcd, Redis, and PostgreSQL exporters/scrapers in local development environment's Prometheus config
+Add Etcd, Redis, and PostgreSQL exporters/scrapers in local development environment configuration.

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -26,4 +26,9 @@ scrape_configs:
           - backendai-half-etcd:2379
   - job_name: 'redis-exporter'
     static_configs:
-      - targets: ['backendai-half-redis-exporter:9121']
+      - targets:
+          - backendai-half-redis-exporter:9121
+  - job_name: 'postgres-exporter'
+    static_configs:
+      - targets:
+          - backendai-half-db-exporter:9187

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -24,3 +24,6 @@ scrape_configs:
     static_configs:
       - targets:
           - backendai-half-etcd:2379
+  - job_name: 'redis-exporter'
+    static_configs:
+      - targets: ['backendai-half-redis-exporter:9121']

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -18,7 +18,7 @@ scrape_configs:
     http_sd_configs:
       - url: 'http://host.docker.internal:18080/metrics/service_discovery'
         refresh_interval: "60s"
-  - job_name: 'etcd-scraper'
+  - job_name: 'etcd'
     scrape_interval: 10s
     metrics_path: /metrics
     static_configs:

--- a/configs/prometheus/prometheus.yaml
+++ b/configs/prometheus/prometheus.yaml
@@ -16,5 +16,11 @@ scrape_configs:
   - job_name: 'http-sd'
     scheme: 'http'
     http_sd_configs:
-      - url: 'http://host.docker.internal:18080/metrics/service_discovery' 
+      - url: 'http://host.docker.internal:18080/metrics/service_discovery'
         refresh_interval: "60s"
+  - job_name: 'etcd-scraper'
+    scrape_interval: 10s
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - backendai-half-etcd:2379

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -59,6 +59,7 @@ services:
       --initial-cluster-state new
       --enable-v2=true
       --auto-compaction-retention 1
+      --metrics=extensive
     healthcheck:
       test: ["CMD", "etcdctl", "endpoint", "health"]
       interval: 5s
@@ -103,6 +104,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yaml'
     ports:
       - "9090:9090"
+
   backendai-half-otel-collector:
     image: otel/opentelemetry-collector-contrib:0.126.0
     networks:

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -19,6 +19,18 @@ services:
       timeout: 3s
       retries: 10
 
+  backendai-half-db-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.17.1
+    restart: unless-stopped
+    networks:
+      - half
+    environment:
+      - DATA_SOURCE_URI=backendai-half-db:5432/backend?sslmode=disable
+      - DATA_SOURCE_USER=postgres
+      - DATA_SOURCE_PASS=develove
+    ports:
+      - "9187:9187"
+
   backendai-half-redis:
     image: redis:7.2.4-alpine
     restart: unless-stopped

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -49,6 +49,19 @@ services:
       timeout: 3s
       retries: 10
 
+  backendai-half-redis-exporter:
+    image: oliver006/redis_exporter:v1.73.0
+    restart: unless-stopped
+    networks:
+      - half
+    command: >
+      --redis.addr redis://backendai-half-redis:6379
+      --include-system-metrics
+      --include-config-metrics
+      --include-modules-metrics
+    ports:
+      - "9121:9121"
+
   backendai-half-etcd:
     image: quay.io/coreos/etcd:v3.5.14
     restart: unless-stopped
@@ -77,19 +90,6 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-
-  backendai-half-redis-exporter:
-    image: oliver006/redis_exporter:v1.73.0
-    restart: unless-stopped
-    networks:
-      - half
-    command: >
-      --redis.addr redis://backendai-half-redis:6379
-      --include-system-metrics
-      --include-config-metrics
-      --include-modules-metrics
-    ports:
-      - "9121:9121"
 
   backendai-half-grafana:
     image: grafana/grafana-enterprise:11.4.0

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -67,7 +67,7 @@ services:
       retries: 10
 
   backendai-half-redis-exporter:
-    image: oliver006/redis_exporter:v1.62.0
+    image: oliver006/redis_exporter:v1.73.0
     restart: unless-stopped
     networks: [half]
     command: >

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -69,7 +69,8 @@ services:
   backendai-half-redis-exporter:
     image: oliver006/redis_exporter:v1.73.0
     restart: unless-stopped
-    networks: [half]
+    networks:
+      - half
     command: >
       --redis.addr redis://backendai-half-redis:6379
       --include-system-metrics

--- a/docker-compose.halfstack-2409.yml
+++ b/docker-compose.halfstack-2409.yml
@@ -66,6 +66,18 @@ services:
       timeout: 3s
       retries: 10
 
+  backendai-half-redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    restart: unless-stopped
+    networks: [half]
+    command: >
+      --redis.addr redis://backendai-half-redis:6379
+      --include-system-metrics
+      --include-config-metrics
+      --include-modules-metrics
+    ports:
+      - "9121:9121"
+
   backendai-half-grafana:
     image: grafana/grafana-enterprise:11.4.0
     restart: unless-stopped


### PR DESCRIPTION
Resolves #4603 (BA-1504).
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

## Example Usage

- Import the desired Grafana dashboard.
(For example, you can use 3070 for Etcd or 736 for Redis, 9628 for PostgreSQL DB)

![스크린샷 2025-06-04 오후 3 03 46](https://github.com/user-attachments/assets/663bf8d3-6fdd-4328-b465-47bd81804879)

![2025-06-04_17-39-15](https://github.com/user-attachments/assets/9616b846-d9f5-4881-be05-4ad51f4b54f9)

![2025-06-04_17-39-36](https://github.com/user-attachments/assets/43e403df-6cab-490b-bc8c-a93c71ddcac1)




**Checklist:** (if applicable)

- [x] Mention to the original issue

