### PR TITLE
fix(BA-1511): `rpc_auth_manager_keypair` not found error in `generate-rpc-keypair`

### DIFF
--- a/changes/4612.fix.md
+++ b/changes/4612.fix.md
@@ -1,0 +1,1 @@
+Resolve `generate-rpc-keypair` failure due to `rpc_auth_manager_keypair` not found error

--- a/changes/4612.fix.md
+++ b/changes/4612.fix.md
@@ -1,1 +1,1 @@
-Resolve `generate-rpc-keypair` failure due to `rpc_auth_manager_keypair` not found error
+Resolve `generate-rpc-keypair` CLI command failure due to `rpc_auth_manager_keypair` not found error

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -488,7 +488,7 @@ class ManagerConfig(BaseModel):
         validation_alias=AliasChoices("internal-addr", "internal_addr"),
         serialization_alias="internal-addr",
     )
-    rpc_auth_manager_keypair: FilePath = Field(
+    rpc_auth_manager_keypair: Path = Field(
         default=Path("fixtures/manager/manager.key_secret"),
         description="""
         Path to the keypair file used for RPC authentication.
@@ -838,6 +838,16 @@ class ManagerConfig(BaseModel):
         if self.aiomonitor_port is not None:
             return self.aiomonitor_port
         return self.aiomonitor_termui_port
+
+    @field_validator("rpc_auth_manager_keypair", mode="before")
+    @classmethod
+    def _parse_rpc_auth_manager_keypair(cls, v: str) -> str:
+        if not Path(v).exists():
+            log.warning(
+                f'RPC authentication keypair file does not exist: "{v}".',
+            )
+            return v
+        return v
 
 
 # Deprecated: v20.09

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -846,7 +846,6 @@ class ManagerConfig(BaseModel):
             log.warning(
                 f'RPC authentication keypair file does not exist: "{v}".',
             )
-            return v
         return v
 
 


### PR DESCRIPTION
Resolves #4611 (BA-1511)

**Checklist:** (if applicable)

- [x] Mention to the original issue