### PR TITLE
fix(BA-1522): Support more Accept headers in `BaseContainerRegistry.scan_tag` (#4627)

### DIFF
--- a/changes/4627.fix.md
+++ b/changes/4627.fix.md
@@ -1,0 +1,1 @@
+Support more Accept headers in `BaseContainerRegistry.scan_tag`

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -307,7 +307,15 @@ class BaseContainerRegistry(metaclass=ABCMeta):
     ) -> None:
         async with concurrency_sema.get():
             rqst_args = copy.deepcopy(rqst_args)
-            rqst_args["headers"]["Accept"] = self.MEDIA_TYPE_DOCKER_MANIFEST_LIST
+            acceptables = [
+                self.MEDIA_TYPE_DOCKER_MANIFEST_LIST,
+                self.MEDIA_TYPE_DOCKER_MANIFEST,
+                self.MEDIA_TYPE_OCI_INDEX,
+                self.MEDIA_TYPE_OCI_MANIFEST,
+                self.MEDIA_TYPE_DOCKER_MANIFEST_V1_JSON,
+                self.MEDIA_TYPE_DOCKER_MANIFEST_V1_PRETTY_JWS,
+            ]
+            rqst_args["headers"]["Accept"] = ",".join(acceptables)
             async with sess.get(
                 self.registry_url / f"v2/{image}/manifests/{tag}", **rqst_args
             ) as resp:


### PR DESCRIPTION
This is an auto-generated backport PR of #4627 to the 25.6 release.