### PR TITLE
fix(BA-1488): Gracefully handle missing `Config.Labels` in Docker image inspection (#4576)

### DIFF
--- a/changes/4576.fix.md
+++ b/changes/4576.fix.md
@@ -1,0 +1,1 @@
+Fix Backend.AI agent to gracefully handle missing `Config.Labels` field in Docker image inspection


### PR DESCRIPTION
This is an auto-generated backport PR of #4576 to the 25.6 release.