### PR TITLE
fix(BA-1543): Update container ports validation to prevent potential `IndexError`

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Update container ports validation to catch omitted or empty list cases, preventing potential `IndexError`

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1189,7 +1189,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 await network.connect({"Container": container._id})
 
             kernel_obj.container_id = container._id
-            container_network_info: ContainerNetworkInfo | None = None
+            container_network_info: Optional[ContainerNetworkInfo] = None
             if (mode := cluster_info["network_config"].get("mode")) and mode != "bridge":
                 try:
                     plugin = self.network_plugin_ctx.plugins[mode]
@@ -1229,8 +1229,8 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 stdin_port = 0
                 stdout_port = 0
                 for idx, port in enumerate(exposed_ports):
-                    ports: list[PortInfo] | None = await container.port(port)
-                    if ports is None:
+                    ports: Optional[list[PortInfo]] = await container.port(port)
+                    if not ports:
                         raise ContainerCreationError(
                             container_id=cid, message="Container port not found"
                         )
@@ -1436,7 +1436,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             self.local_config, {name: cctx.instance for name, cctx in self.computers.items()}
         )
 
-    async def extract_image_command(self, image: str) -> str | None:
+    async def extract_image_command(self, image: str) -> Optional[str]:
         async with closing_async(Docker()) as docker:
             result = await docker.images.get(image)
             return result["Config"].get("Cmd")
@@ -1675,7 +1675,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         image_ref: ImageRef,
         registry_conf: ImageRegistry,
         *,
-        timeout: float | None | Sentinel = Sentinel.TOKEN,
+        timeout: Optional[float] | Sentinel = Sentinel.TOKEN,
     ) -> None:
         if image_ref.is_local:
             return
@@ -1707,7 +1707,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         image_ref: ImageRef,
         registry_conf: ImageRegistry,
         *,
-        timeout: float | None,
+        timeout: Optional[float],
     ) -> None:
         auth_config = None
         reg_user = registry_conf.get("username")


### PR DESCRIPTION
Follow-up of #1645 and resolves #4655 (BA-1543)

This pull request includes updates to improve type annotations and error handling in the codebase. The most important changes include updating container ports validation to prevent potential runtime errors.

### Type Annotation Improvements:
* Replaced `list[PortInfo] | None` with `Optional[list[PortInfo]]` in `_rollback_container_creation` to improve type clarity and ensure consistent handling of `None` values.
* Updated `str | None` to `Optional[str]` in `extract_image_command` to align with Python's standard type annotations.
* Changed `float | None | Sentinel` to `Optional[float] | Sentinel` in `push_image` and `float | None` to `Optional[float]` in `pull_image` for better readability. [[1]](diffhunk://#diff-4abe32fc0ac4d92071c86246bf16680a26548ebef7cbbb78e8d28514e5513f77L1678-R1678) [[2]](diffhunk://#diff-4abe32fc0ac4d92071c86246bf16680a26548ebef7cbbb78e8d28514e5513f77L1710-R1710)
* Replaced `ContainerNetworkInfo | None` with `Optional[ContainerNetworkInfo]` in `_rollback_container_creation` to maintain consistency in type annotations.

### Error Handling Enhancements:
* Updated container ports validation to catch omitted or empty list cases, preventing potential `IndexError` during runtime.

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
