### PR TITLE
fix(BA-1567): Fix Session Rename API to prevent duplicate names

### DIFF
--- a/changes/4690.fix.md
+++ b/changes/4690.fix.md
@@ -1,0 +1,1 @@
+Fix Session Rename API to block duplicate session names for the same user

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1437,15 +1437,15 @@ class SessionService:
         new_name = action.new_name
 
         async with self._db.begin_session() as db_sess:
-            session_exists = await SessionRow.get_session(
+            session_with_new_name = await SessionRow.get_session(
                 db_sess,
                 new_name,
                 owner_access_key,
                 kernel_loading_strategy=KernelLoadingStrategy.NONE,
                 allow_stale=True,
             )
-            if session_exists:
-                raise InvalidAPIParameters("Session with new name already exists")
+            if session_with_new_name is not None:
+                raise InvalidAPIParameters(f"Session name of '{new_name}' already exists")
             compute_session = await SessionRow.get_session(
                 db_sess,
                 session_name,

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1447,7 +1447,6 @@ class SessionService:
             except SessionNotFound:
                 pass
             else:
-                print(f"Session with name {new_name} already exists")
                 raise InvalidAPIParameters(
                     f"Duplicate session name. Session(id:{sess.id}) already has name({sess.name})"
                 )

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1437,6 +1437,15 @@ class SessionService:
         new_name = action.new_name
 
         async with self._db.begin_session() as db_sess:
+            session_exists = await SessionRow.get_session(
+                db_sess,
+                new_name,
+                owner_access_key,
+                kernel_loading_strategy=KernelLoadingStrategy.NONE,
+                allow_stale=True,
+            )
+            if session_exists:
+                raise InvalidAPIParameters("Session with new name already exists")
             compute_session = await SessionRow.get_session(
                 db_sess,
                 session_name,

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1442,7 +1442,6 @@ class SessionService:
                 new_name,
                 owner_access_key,
                 kernel_loading_strategy=KernelLoadingStrategy.NONE,
-                allow_stale=True,
             )
             if session_with_new_name is not None:
                 raise InvalidAPIParameters(f"Session name of '{new_name}' already exists")


### PR DESCRIPTION
resolves #4689 (BA-1567)
