### PR TITLE
fix(BA-1560): Skip failure of code runner init (#4679)

### DIFF
--- a/changes/4679.fix.md
+++ b/changes/4679.fix.md
@@ -1,0 +1,1 @@
+Agent skips failure of code runner initialization

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1783,7 +1783,15 @@ class AbstractAgent(
             pass
         for kernel_obj in self.kernel_registry.values():
             kernel_obj.agent_config = self.local_config
-            await kernel_obj.init(self.event_producer)
+            try:
+                await kernel_obj.init(self.event_producer)
+            except Exception as e:
+                log.error(
+                    "Failed to initialize kernel {}: {}, skipping",
+                    kernel_obj.kernel_id,
+                    e,
+                )
+                continue
             if kernel_obj.runner is None:
                 log.warning("kernel {} has no runner, skipping", kernel_obj.kernel_id)
                 continue

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -225,9 +225,16 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
             default_api_version,
             default_client_features,
         )
-        self.runner = await self.create_code_runner(
-            event_producer, client_features=default_client_features, api_version=default_api_version
-        )
+        try:
+            self.runner = await self.create_code_runner(
+                event_producer,
+                client_features=default_client_features,
+                api_version=default_api_version,
+            )
+        except Exception as e:
+            log.error("kernel.init(k:{0}): failed to create code runner: {1}", self.kernel_id, e)
+            self.runner = None
+            raise
 
     def __getstate__(self) -> Mapping[str, Any]:
         props = self.__dict__.copy()


### PR DESCRIPTION
This is an auto-generated backport PR of #4679 to the 25.6 release.