### PR TITLE
fix(BA-1585): Broken `untag_image_from_registry` SDK method (#4720)

### DIFF
--- a/changes/4720.fix.md
+++ b/changes/4720.fix.md
@@ -1,0 +1,1 @@
+Fix broken `untag_image_from_registry` SDK method

--- a/src/ai/backend/client/func/image.py
+++ b/src/ai/backend/client/func/image.py
@@ -161,14 +161,14 @@ class Image(BaseFunction):
     @classmethod
     async def untag_image_from_registry(cls, id: str):
         q = _d("""
-            mutation($id: String!) {
-                untag_image_from_registry(id: $id) {
+            mutation($image_id: String!) {
+                untag_image_from_registry(image_id: $image_id) {
                     ok msg
                 }
             }
         """)
         variables = {
-            "id": id,
+            "image_id": id,
         }
         data = await api_session.get().Admin._query(q, variables)
         return data["untag_image_from_registry"]


### PR DESCRIPTION
This is an auto-generated backport PR of #4720 to the 25.6 release.