### PR TITLE
fix: Skip cleaning non-running kernels

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1395,11 +1395,11 @@ class AbstractAgent(
             try:
                 alive_containers = await self.enumerate_containers()
                 alive_kernel_ids = {kid for kid, _ in alive_containers}
-                registered_kernel_ids = set([
+                registered_kernel_ids = {
                     kid
                     for kid, kernel in self.kernel_registry.items()
                     if kernel.state == KernelLifecycleStatus.RUNNING
-                ])
+                }
                 dangling_kernel_ids = registered_kernel_ids - alive_kernel_ids
                 log.info("found dangling kernels in registry: {}", dangling_kernel_ids)
                 asyncio.create_task(

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1395,7 +1395,11 @@ class AbstractAgent(
             try:
                 alive_containers = await self.enumerate_containers()
                 alive_kernel_ids = {kid for kid, _ in alive_containers}
-                registered_kernel_ids = set(self.kernel_registry.keys())
+                registered_kernel_ids = set([
+                    kid
+                    for kid, kernel in self.kernel_registry.items()
+                    if kernel.state == KernelLifecycleStatus.RUNNING
+                ])
                 dangling_kernel_ids = registered_kernel_ids - alive_kernel_ids
                 log.info("found dangling kernels in registry: {}", dangling_kernel_ids)
                 asyncio.create_task(


### PR DESCRIPTION
resolves #NNN (BA-MMM)

follow-up #4710

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
