### PR TITLE
feat(BA-1607): Add runtime_variant parameter to Service creation SDK function

### DIFF
--- a/changes/4749.feature.md
+++ b/changes/4749.feature.md
@@ -1,0 +1,1 @@
+Add `runtime_variant` parameter to Service creation SDK function and CLI command

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -16,7 +16,7 @@ from ai.backend.client.compat import asyncio_run
 from ai.backend.client.session import AsyncSession, Session
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
 from ai.backend.common.bgtask.types import BgtaskStatus
-from ai.backend.common.types import ClusterMode
+from ai.backend.common.types import ClusterMode, RuntimeVariant
 
 from ..exceptions import BackendError
 from ..output.fields import routing_fields, service_fields
@@ -269,6 +269,16 @@ def info(ctx: CLIContext, service_name_or_id: str) -> None:
         "If set to true, no authentication will be required to access the endpoint."
     ),
 )
+@click.option(
+    "--runtime-variant",
+    metavar="RUNTIME_VARIANT",
+    type=click.Choice([*RuntimeVariant], case_sensitive=False),
+    default=RuntimeVariant.CUSTOM,
+    help=(
+        "Runtime variant of the service. "
+        "Control which runtime environment is used for the service. Default is `custom`."
+    ),
+)
 def create(
     ctx: CLIContext,
     image: str,
@@ -294,6 +304,7 @@ def create(
     owner: Optional[str],
     model_definition_path: Optional[str],
     public: bool,
+    runtime_variant: RuntimeVariant,
 ) -> None:
     """
     Create a service endpoint with a backing inference session.
@@ -324,6 +335,7 @@ def create(
         "scaling_group": scaling_group,
         "expose_to_public": public,
         "model_definition_path": model_definition_path,
+        "runtime_variant": runtime_variant,
     }
     if model_mount_destination:
         body["model_mount_destination"] = model_mount_destination

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -113,6 +113,7 @@ class Service(BaseFunction):
         owner_access_key: Optional[str] = None,
         model_definition_path: Optional[str] = None,
         expose_to_public: bool = False,
+        runtime_variant: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Creates an inference service.
@@ -142,6 +143,7 @@ class Service(BaseFunction):
         :param model_definition_path: Relative path to model definition file. Defaults to `model-definition.yaml`.
         :param expose_to_public: Visibility of API Endpoint which serves inference workload.
             If set to true, no authentication will be required to access the endpoint.
+        :param runtime_variant: The runtime variant to use for the service.
 
         :returns: The :class:`ComputeSession` instance.
         """
@@ -201,6 +203,7 @@ class Service(BaseFunction):
             "bootstrap_script": bootstrap_script,
             "owner_access_key": owner_access_key,
             "open_to_public": expose_to_public,
+            "runtime_variant": runtime_variant,
             "config": model_config,
         })
         async with rqst.fetch() as resp:

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -7,6 +7,7 @@ from typing_extensions import deprecated
 
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
 from ai.backend.common.typed_validators import SESSION_NAME_MAX_LENGTH
+from ai.backend.common.types import RuntimeVariant
 
 from ..exceptions import BackendClientError
 from ..output.fields import service_fields
@@ -113,7 +114,7 @@ class Service(BaseFunction):
         owner_access_key: Optional[str] = None,
         model_definition_path: Optional[str] = None,
         expose_to_public: bool = False,
-        runtime_variant: Optional[str] = None,
+        runtime_variant: Optional[RuntimeVariant] = None,
     ) -> dict[str, Any]:
         """
         Creates an inference service.


### PR DESCRIPTION
resolves #4748 (BA-1607)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
