### PR TITLE
fix(BA-1615): Prevent cleaning PULLING kernels

### DIFF
--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -120,6 +120,7 @@ class KernelStatus(CIStrEnum):
     @classmethod
     def having_containers(cls) -> set[KernelStatus]:
         return {
+            cls.PULLING,
             cls.CREATING,
             cls.RUNNING,
         }


### PR DESCRIPTION
resolves #4762 (BA-1615)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
