### PR TITLE
fix(BA-1609): Skip gathering metric of non-existent process (#4753)

### DIFF
--- a/changes/4753.fix.md
+++ b/changes/4753.fix.md
@@ -1,0 +1,1 @@
+Skip gathering metrics of non-existent processes

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1110,15 +1110,11 @@ class AbstractAgent(
         if self.local_config["debug"]["log-stats"]:
             log.debug("collecting container statistics")
         try:
-            container_ids = []
-            async with self.registry_lock:
-                for kernel_id, kernel_obj in [*self.kernel_registry.items()]:
-                    if (
-                        not kernel_obj.stats_enabled
-                        or kernel_obj.state != KernelLifecycleStatus.RUNNING
-                    ):
-                        continue
-                    container_ids.append(kernel_obj["container_id"])
+            container_ids: list[ContainerId] = []
+            for kernel_obj in [*self.kernel_registry.values()]:
+                if not kernel_obj.stats_enabled or kernel_obj.container_id is None:
+                    continue
+                container_ids.append(ContainerId(kernel_obj.container_id))
                 await self.stat_ctx.collect_container_stat(container_ids)
         except asyncio.CancelledError:
             pass
@@ -1130,18 +1126,12 @@ class AbstractAgent(
         if self.local_config["debug"]["log-stats"]:
             log.debug("collecting process statistics in container")
         try:
-            updated_kernel_ids = []
             container_ids = []
-            async with self.registry_lock:
-                for kernel_id, kernel_obj in [*self.kernel_registry.items()]:
-                    if (
-                        not kernel_obj.stats_enabled
-                        or kernel_obj.state != KernelLifecycleStatus.RUNNING
-                    ):
-                        continue
-                    updated_kernel_ids.append(kernel_id)
-                    container_ids.append(kernel_obj["container_id"])
-                await self.stat_ctx.collect_per_container_process_stat(container_ids)
+            for kernel_obj in [*self.kernel_registry.values()]:
+                if not kernel_obj.stats_enabled or kernel_obj.container_id is None:
+                    continue
+                container_ids.append(ContainerId(kernel_obj.container_id))
+            await self.stat_ctx.collect_per_container_process_stat(container_ids)
         except asyncio.CancelledError:
             pass
         except Exception:
@@ -1164,7 +1154,6 @@ class AbstractAgent(
         async with self.registry_lock:
             kernel_obj = self.kernel_registry.get(ev.kernel_id)
             if kernel_obj is not None:
-                kernel_obj.stats_enabled = True
                 kernel_obj.state = KernelLifecycleStatus.RUNNING
         log.info("Kernel {0} started", ev.kernel_id)
 
@@ -1202,7 +1191,6 @@ class AbstractAgent(
                         return
                 else:
                     kernel_obj.state = KernelLifecycleStatus.TERMINATING
-                    kernel_obj.stats_enabled = False
                     kernel_obj.termination_reason = ev.reason
                     if kernel_obj.runner is not None:
                         await kernel_obj.runner.close()

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -173,7 +173,6 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
     last_used: float
     termination_reason: Optional[KernelLifecycleEventReason]
     clean_event: Optional[asyncio.Future]
-    stats_enabled: bool
     # FIXME: apply TypedDict to data in Python 3.8
     environ: Mapping[str, Any]
     state: KernelLifecycleStatus
@@ -211,7 +210,6 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         self.last_used = time.monotonic()
         self.termination_reason = None
         self.clean_event = None
-        self.stats_enabled = False
         self.environ = environ
         self.runner = None
         self.container_id = None
@@ -254,6 +252,9 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
             )
         if "session_type" not in props:
             props["session_type"] = SessionTypes.INTERACTIVE
+        if "stats_enabled" in props:
+            # stats_enabled is a property, not an attribute.
+            del props["stats_enabled"]
         self.__dict__.update(props)
         # agent_config is set by the pickle.loads() caller.
         self.clean_event = None
@@ -279,6 +280,13 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         """
         for accel_key, accel_alloc in self.resource_spec.allocations.items():
             computer_ctxs[accel_key].alloc_map.free(accel_alloc)
+
+    @property
+    def stats_enabled(self) -> bool:
+        """
+        Returns True if the kernel supports statistics gathering.
+        """
+        return self.state == KernelLifecycleStatus.RUNNING
 
     @abstractmethod
     async def create_code_runner(

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -629,6 +629,33 @@ class StatContext:
 
         await redis_helper.execute(self.agent.redis_stat_pool, _pipe_builder)
 
+    async def _get_processes(
+        self, container_id: ContainerId, docker: aiodocker.Docker
+    ) -> list[PID]:
+        """
+        Get the list of PIDs for the given container ID.
+        """
+        return_val: list[PID] = []
+        try:
+            result = await docker._query_json(f"containers/{container_id}/top", method="GET")
+            procs = result["Processes"]
+        except (KeyError, aiodocker.exceptions.DockerError):
+            log.debug(
+                "collect_per_container_process_stat(): cannot find container {}", container_id
+            )
+            return return_val
+
+        for proc in procs:
+            try:
+                return_val.append(PID(int(proc[1])))
+            except (ValueError, KeyError):
+                log.debug(
+                    "collect_per_container_process_stat(): cannot parse PID from {}",
+                    proc,
+                )
+                continue
+        return return_val
+
     async def collect_per_container_process_stat(
         self,
         container_ids: Sequence[ContainerId],
@@ -643,26 +670,25 @@ class StatContext:
             return
 
         async with self._lock:
-            pid_map = {}
-            pids = []
+            pid_map: dict[PID, ContainerId] = {}
             async with aiodocker.Docker() as docker:
                 for cid in container_ids:
-                    try:
-                        result = await docker._query_json(f"containers/{cid}/top", method="GET")
-                        procs = result["Processes"]
-                        pids = [PID(int(proc[1])) for proc in procs]
-                        unused_pids = set(self.process_metrics[cid].keys()) - set(pids)
-                    except (KeyError, aiodocker.exceptions.DockerError):
-                        log.debug(
-                            "collect_per_container_process_stat(): cannot found container {}", cid
-                        )
-                    else:
-                        for unused_pid in unused_pids:
-                            log.debug("removing pid_metric for {}: {}", cid, unused_pid)
-                            self.process_metrics[cid].pop(unused_pid, None)
-                    for pid in pids:
-                        pid_map[pid] = cid
-
+                    active_pids = await self._get_processes(cid, docker)
+                    if cid in self.process_metrics:
+                        unused_pids = set(self.process_metrics[cid].keys()) - set(active_pids)
+                        if unused_pids:
+                            log.debug(
+                                "removing pid_metric for {}: {}",
+                                cid,
+                                ", ".join([str(p) for p in unused_pids]),
+                            )
+                            self.process_metrics[cid] = {
+                                pid_: metric
+                                for pid_, metric in self.process_metrics[cid].items()
+                                if pid_ in active_pids
+                            }
+                    for pid_ in active_pids:
+                        pid_map[pid_] = cid
             # Here we use asyncio.gather() instead of aiotools.TaskGroup
             # to keep methods of other plugins running when a plugin raises an error
             # instead of cancelling them.


### PR DESCRIPTION
This is an auto-generated backport PR of #4753 to the 25.6 release.