### PR TITLE
fix(BA-1609): Skip gathering metric of non-existent process (#4753)

### DIFF
--- a/changes/4753.fix.md
+++ b/changes/4753.fix.md
@@ -1,0 +1,1 @@
+Skip gathering metrics of non-existent processes

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -294,11 +294,11 @@ class CPUPlugin(AbstractComputePlugin):
     async def gather_process_measures(
         self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
-        async def psutil_impl(pid: int) -> Optional[Decimal]:
+        async def psutil_impl(pid: int, cid: str) -> Optional[Decimal]:
             try:
                 p = psutil.Process(pid)
             except psutil.NoSuchProcess:
-                log.warning("psutil cannot found process {0}", pid)
+                log.debug("Process not found for CPU stats (pid:{0}, container id:{1})", pid, cid)
             else:
                 cpu_times = p.cpu_times()
                 cpu_used = Decimal(cpu_times.user + cpu_times.system) * 1000
@@ -329,8 +329,8 @@ class CPUPlugin(AbstractComputePlugin):
                     results.extend(chunk)
             case _:
                 psutil_tasks = []
-                for pid, _ in pid_map_list:
-                    psutil_tasks.append(asyncio.create_task(psutil_impl(pid)))
+                for pid, cid in pid_map_list:
+                    psutil_tasks.append(asyncio.create_task(psutil_impl(pid, cid)))
                 results = await asyncio.gather(*psutil_tasks)
 
         for (pid, cid), cpu_used in zip(pid_map_list, results):
@@ -784,11 +784,17 @@ class MemoryPlugin(AbstractComputePlugin):
     async def gather_process_measures(
         self, ctx: StatContext, pid_map: Mapping[int, str]
     ) -> Sequence[ProcessMeasurement]:
-        async def psutil_impl(pid) -> tuple[Optional[int], Optional[int], Optional[int]]:
+        async def psutil_impl(
+            pid: int, cid: str
+        ) -> tuple[Optional[int], Optional[int], Optional[int]]:
             try:
                 p = psutil.Process(pid)
             except psutil.NoSuchProcess:
-                log.warning("psutil cannot found process {0}", pid)
+                log.debug(
+                    "Process not found for memory stats (pid:{0}, container id:{1})",
+                    pid,
+                    cid,
+                )
             else:
                 stats = p.as_dict(attrs=["memory_info", "io_counters"])
                 mem_cur_bytes = io_read_bytes = io_write_bytes = None
@@ -827,8 +833,8 @@ class MemoryPlugin(AbstractComputePlugin):
                     results.extend(chunk)
             case _:
                 psutil_tasks = []
-                for pid, _ in pid_map_list:
-                    psutil_tasks.append(asyncio.create_task(psutil_impl(pid)))
+                for pid, cid in pid_map_list:
+                    psutil_tasks.append(asyncio.create_task(psutil_impl(pid, cid)))
                 results = await asyncio.gather(*psutil_tasks)
 
         for (pid, _), result in zip(pid_map_list, results):

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -238,14 +238,6 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         # Used when a `Kernel` object is loaded from pickle data.
         if "state" not in props:
             props["state"] = KernelLifecycleStatus.RUNNING
-        if "ownership_data" not in props:
-            props["ownership_data"] = KernelOwnershipData(
-                props["kernel_id"],
-                props["session_id"],
-                props["agent_id"],
-            )
-        if "session_type" not in props:
-            props["session_type"] = SessionTypes.INTERACTIVE
         if "stats_enabled" in props:
             # stats_enabled is a property, not an attribute.
             del props["stats_enabled"]


### PR DESCRIPTION
This is an auto-generated backport PR of #4753 to the 24.09 release.