### PR TITLE
fix(BA-1599): Allow None type of session id in RouteInfo

### DIFF
--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -186,7 +186,9 @@ class RouteInfoModel(BaseFieldModel):
             " relationship with the inference session."
         )
     )
-    session_id: uuid.UUID = Field(description="Unique ID referencing the inference session.")
+    session_id: Optional[uuid.UUID] = Field(
+        description="Unique ID referencing the inference session."
+    )
     traffic_ratio: NonNegativeFloat
 
 

--- a/src/ai/backend/manager/services/model_serving/types.py
+++ b/src/ai/backend/manager/services/model_serving/types.py
@@ -56,7 +56,7 @@ class MountOption:
 @dataclass
 class RouteInfo:
     route_id: uuid.UUID
-    session_id: uuid.UUID
+    session_id: Optional[uuid.UUID]
     traffic_ratio: float
 
 


### PR DESCRIPTION
resolves #4735 (BA-1599)

If you call the ModelService's `get_info` before the session that maps to the model service's routings has been created, you will get a type error because of the pydantic constraint that the session id must be of type uuid. However, as you mentioned, the session that maps to the routings may not have been created yet, so it could easily be None (the session column in `RoutingRow` is also set to nullable).

Therefore, we relax the `session_id` constraint in `RoutingInfo` to Optional[str]