### PR TITLE
fix(BA-1632): Cool down redis error log (#4795)

### DIFF
--- a/changes/4795.fix.md
+++ b/changes/4795.fix.md
@@ -1,0 +1,1 @@
+Cool down Redis error logs `AttributeError: 'NoneType' object has no attribute 'get'`

--- a/src/ai/backend/common/message_queue/redis_queue.py
+++ b/src/ai/backend/common/message_queue/redis_queue.py
@@ -117,14 +117,16 @@ class RedisQueue(AbstractMessageQueue):
                 next_start_id, claimed = await self._auto_claim(
                     autoclaim_start_id, autoclaim_idle_timeout
                 )
-                if not claimed:
-                    await asyncio.sleep(_DEFAULT_AUTOCLAIM_INTERVAL / 1000)
+                if claimed:
+                    autoclaim_start_id = next_start_id
                     continue
-                autoclaim_start_id = next_start_id
             except redis.exceptions.ResponseError as e:
                 await self._failover_consumer(e)
+            except AttributeError:
+                pass
             except Exception as e:
                 log.exception("Error while auto claiming messages: {}", e)
+            await asyncio.sleep(_DEFAULT_AUTOCLAIM_INTERVAL / 1000)
 
     async def _auto_claim(
         self, autoclaim_start_id: str, autoclaim_idle_timeout: int


### PR DESCRIPTION
This is an auto-generated backport PR of #4795 to the 25.6 release.