### PR TITLE
fix(BA-1584): Wrong exit code when `BaseRunner.query` fails

### DIFF
--- a/changes/4798.fix.md
+++ b/changes/4798.fix.md
@@ -1,0 +1,1 @@
+Fix wrong exit code when `BaseRunner.query()` fails

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -573,7 +573,7 @@ class BaseRunner(metaclass=ABCMeta):
             log.exception(str(e))
             return 127
         if exec_failed:
-            return -1
+            return 1
         return 0
 
     async def _complete(self, completion_data) -> None:

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -513,7 +513,7 @@ class BaseRunner(metaclass=ABCMeta):
                 if ename == "SystemExit":
                     try:
                         exit_code = int(evalue) if evalue not in (None, "") else 0
-                    except ValueError:
+                    except Exception:
                         exit_code = 1
                 else:
                     exit_code = 1

--- a/src/ai/backend/test/testcases/session/execution.py
+++ b/src/ai/backend/test/testcases/session/execution.py
@@ -53,8 +53,7 @@ class InteractiveSessionExecuteCodeFailureWrongCommand(TestCode):
         assert result["status"] == "finished", (
             f"Expected status to be finished, Actual status: {result['status']}"
         )
-        # TODO: Is 0 correct exitcode when the command fails?
-        assert result["exitCode"] == 0, (
+        assert result["exitCode"] == -1, (
             f"Expected exitCode to be 0, Actual exitCode: {result['exitCode']}"
         )
         assert result["console"][0][0] == "stderr", (

--- a/src/ai/backend/test/testcases/session/execution.py
+++ b/src/ai/backend/test/testcases/session/execution.py
@@ -54,7 +54,7 @@ class InteractiveSessionExecuteCodeFailureWrongCommand(TestCode):
             f"Expected status to be finished, Actual status: {result['status']}"
         )
         assert result["exitCode"] == 1, (
-            f"Expected exitCode to be 0, Actual exitCode: {result['exitCode']}"
+            f"Expected exitCode to be 1, Actual exitCode: {result['exitCode']}"
         )
         assert result["console"][0][0] == "stderr", (
             f"Expected stderr, Actual value: {result['console']}"
@@ -67,9 +67,31 @@ class InteractiveSessionExecuteCodeFailureWrongCommand(TestCode):
             assert result["status"] == "finished", (
                 f"Expected status to be finished, Actual status: {result['status']}"
             )
-            assert result["exitCode"] == 0, (
-                f"Expected exitCode to be 0, Actual exitCode: {result['exitCode']}"
+            assert result["exitCode"] == 1, (
+                f"Expected exitCode to be 1, Actual exitCode: {result['exitCode']}"
             )
             assert result["console"][0][0] == "stderr", (
                 f"Expected stderr, Actual value: {result['console']}"
             )
+
+
+class InteractiveSessionExecuteCodeFailureWithCustomExitCode(TestCode):
+    async def test(self) -> None:
+        client_session = ClientSessionContext.current()
+        session_meta = CreatedSessionMetaContext.current()
+        session_id = session_meta.id
+        CMD = "import sys; sys.exit(2)"
+
+        result = await client_session.ComputeSession(str(session_id)).execute(
+            code=CMD,
+        )
+
+        assert result["status"] == "finished", (
+            f"Expected status to be finished, Actual status: {result['status']}"
+        )
+        assert result["exitCode"] == 2, (
+            f"Expected exitCode to be 2, Actual exitCode: {result['exitCode']}"
+        )
+        assert result["console"][0][0] == "stderr", (
+            f"Expected stderr, Actual value: {result['console']}"
+        )

--- a/src/ai/backend/test/testcases/session/execution.py
+++ b/src/ai/backend/test/testcases/session/execution.py
@@ -53,7 +53,7 @@ class InteractiveSessionExecuteCodeFailureWrongCommand(TestCode):
         assert result["status"] == "finished", (
             f"Expected status to be finished, Actual status: {result['status']}"
         )
-        assert result["exitCode"] == -1, (
+        assert result["exitCode"] == 1, (
             f"Expected exitCode to be 0, Actual exitCode: {result['exitCode']}"
         )
         assert result["console"][0][0] == "stderr", (

--- a/src/ai/backend/test/testcases/session/testspecs.py
+++ b/src/ai/backend/test/testcases/session/testspecs.py
@@ -41,6 +41,7 @@ from ai.backend.test.testcases.session.creation_failure_wrong_command import (
     BatchSessionCreationFailureWrongCommand,
 )
 from ai.backend.test.testcases.session.execution import (
+    InteractiveSessionExecuteCodeFailureWithCustomExitCode,
     InteractiveSessionExecuteCodeFailureWrongCommand,
     InteractiveSessionExecuteCodeSuccess,
 )
@@ -236,6 +237,30 @@ INTERACTIVE_SESSION_TEST_SPECS = {
         tags={TestTag.MANAGER, TestTag.AGENT, TestTag.SESSION},
         template=BasicTestTemplate(
             InteractiveSessionExecuteCodeFailureWrongCommand()
+        ).with_wrappers(KeypairAuthTemplate, InteractiveSessionTemplate),
+        parametrizes={
+            ContextName.CLUSTER_CONFIG: [
+                ClusterDep(
+                    cluster_mode=ClusterMode.SINGLE_NODE,
+                    cluster_size=1,
+                ),
+            ],
+        },
+    ),
+    "execution_command_on_interactive_session_failure_with_custom_exitcode": TestSpec(
+        name="execution_command_on_interactive_session_failure_with_custom_exitcode",
+        description=textwrap.dedent("""\
+            Test for executing code in an interactive session.
+            This test verifies that code can be executed in an interactive session, and that the session transitions through the expected lifecycle events.
+            The test will:
+            1. Create an interactive session with the specified image and resources.
+            2. Execute a command in the session and verify the output.
+            3. Assert that the session is running after execution.
+            4. Destroy the session after the test is complete.
+        """),
+        tags={TestTag.MANAGER, TestTag.AGENT, TestTag.SESSION},
+        template=BasicTestTemplate(
+            InteractiveSessionExecuteCodeFailureWithCustomExitCode()
         ).with_wrappers(KeypairAuthTemplate, InteractiveSessionTemplate),
         parametrizes={
             ContextName.CLUSTER_CONFIG: [


### PR DESCRIPTION
resolves #4712 (BA-1584)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
