### PR TITLE
fix(BA-1645): Wrong Accept Header on `HarborRegistryV2._process_oci_index` (#4807)

### DIFF
--- a/changes/4807.fix.md
+++ b/changes/4807.fix.md
@@ -1,0 +1,1 @@
+Fix wrong `Accept` Header on `HarborRegistryV2._process_oci_index()`

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -376,7 +376,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
     ) -> None:
         rqst_args = copy.deepcopy(rqst_args)
         rqst_args["headers"] = rqst_args.get("headers") or {}
-        rqst_args["headers"].update({"Accept": self.MEDIA_TYPE_OCI_INDEX})
+        rqst_args["headers"].update({
+            "Accept": ", ".join([self.MEDIA_TYPE_OCI_INDEX, self.MEDIA_TYPE_OCI_MANIFEST])
+        })
 
         digests: list[tuple[str, str]] = []
         for reference in image_info["references"]:


### PR DESCRIPTION
This is an auto-generated backport PR of #4807 to the 25.6 release.