### PR TITLE
fix(BA-1631): Skip kernel termination future set if already (#4791)

### DIFF
--- a/changes/4791.fix.md
+++ b/changes/4791.fix.md
@@ -1,0 +1,1 @@
+Fix invalid state error when setting kernel termination future

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1186,8 +1186,7 @@ class AbstractAgent(
                                     reason=KernelLifecycleEventReason.ALREADY_TERMINATED,
                                 ),
                             )
-                        if ev.done_future is not None:
-                            ev.done_future.set_result(None)
+                        ev.set_done_future_result(None)
                         return
                 else:
                     kernel_obj.state = KernelLifecycleStatus.TERMINATING
@@ -1198,8 +1197,7 @@ class AbstractAgent(
                 try:
                     await self.destroy_kernel(ev.kernel_id, ev.container_id)
                 except Exception as e:
-                    if ev.done_future is not None:
-                        ev.done_future.set_exception(e)
+                    ev.set_done_future_exception(e)
                     raise
                 else:
                     log.info("Kernel {0} destroyed", ev.kernel_id)
@@ -1248,8 +1246,7 @@ class AbstractAgent(
                 )
             except Exception as e:
                 log.exception("unhandled exception while processing CLEAN event: {0}", repr(e))
-                if ev.done_future is not None:
-                    ev.done_future.set_exception(e)
+                ev.set_done_future_exception(e)
                 await self.produce_error_event()
             else:
                 log.info("Kernel {0} cleaned", ev.kernel_id)
@@ -1280,8 +1277,7 @@ class AbstractAgent(
                     # Notify cleanup waiters after all state updates.
                     if kernel_obj is not None and kernel_obj.clean_event is not None:
                         kernel_obj.clean_event.set_result(None)
-                    if ev.done_future is not None and not ev.done_future.done():
-                        ev.done_future.set_result(None)
+                    ev.set_done_future_result(None)
         log.info(
             "Handled clean event for kernel {0} with container {1}", ev.kernel_id, ev.container_id
         )

--- a/src/ai/backend/agent/types.py
+++ b/src/ai/backend/agent/types.py
@@ -118,6 +118,22 @@ class ContainerLifecycleEvent:
             f"reason:{self.reason!r})"
         )
 
+    def set_done_future_result(self, result: Any):
+        if self.done_future is not None:
+            try:
+                self.done_future.set_result(result)
+            except asyncio.InvalidStateError:
+                # The future is already done, ignore the error
+                pass
+
+    def set_done_future_exception(self, exception: Exception):
+        if self.done_future is not None:
+            try:
+                self.done_future.set_exception(exception)
+            except asyncio.InvalidStateError:
+                # The future is already done, ignore the error
+                pass
+
 
 @dataclass
 class KernelOwnershipData:


### PR DESCRIPTION
This is an auto-generated backport PR of #4791 to the 25.6 release.