### PR TITLE
fix: Print warning message when `bootstrap.sh` is not executable

### DIFF
--- a/src/ai/backend/runner/entrypoint.sh
+++ b/src/ai/backend/runner/entrypoint.sh
@@ -35,10 +35,14 @@ if [ $USER_ID -eq 0 ]; then
   export HOME="/home/work"
 
   # Invoke image-specific bootstrap hook.
-  if [ -x "/opt/container/bootstrap.sh" ]; then
-    echo 'Executing image bootstrap... '
-    . /opt/container/bootstrap.sh
-    echo 'Image bootstrap executed.'
+  if [ -f "/opt/container/bootstrap.sh" ]; then
+    if [ -x "/opt/container/bootstrap.sh" ]; then
+      echo 'Executing image bootstrap…'
+      . /opt/container/bootstrap.sh
+      echo 'Image bootstrap executed.'
+    else
+      echo 'WARNING: /opt/container/bootstrap.sh exists but is not executable; bootstrap.sh excution was skipped.'
+    fi
   fi
 
   # Extract dotfiles


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
