### PR TITLE
ci: Using a self-hosted runner (#3818)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,8 +367,8 @@ jobs:
         # ubuntu-22.04: x86-64
         # ubuntu-22.04-arm64: aarch64
         # macos-14-large: intel
-        # macos-14-xlarge: apple silicon
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-xlarge, macos-14-large]
+        # self-hosted-macos-14: apple silicon
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted-macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out the revision


### PR DESCRIPTION
This is an auto-generated backport PR of #3818 to the 24.09 release.