### PR TITLE
feat(BA-1668): Add the `default_file_browser_image` option to the webserver configuration.

### DIFF
--- a/changes/4836.feature.md
+++ b/changes/4836.feature.md
@@ -1,0 +1,1 @@
+Add a new webserver configuration option `default_file_browser_image` to specify a default file browser image.

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -73,6 +73,8 @@ is_directory_size_visible = true
 # If true, display the "Sign in with a different account" button on the interactive login page.
 # If false, hide the "Sign in with a different account" button from the interactive login page.
 enable_interactive_login_account_switch = true
+# Default file browser image. If not specified, an arbitrary installed file browser image will be used.
+# default_file_browser_image = ""
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config.py
+++ b/src/ai/backend/web/config.py
@@ -72,6 +72,7 @@ config_iv = t.Dict({
         t.Key("enable_extend_login_session", default=False): t.ToBool(),
         t.Key("is_directory_size_visible", default=True): t.ToBool(),
         t.Key("enable_interactive_login_account_switch", default=True): t.ToBool(),
+        t.Key("default_file_browser_image", default=""): t.String(allow_blank=True),
     }).allow_extra("*"),
     t.Key("security", default=_default_security_config): t.Dict({
         t.Key("request_policies", default=[]): t.List(t.String),

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -31,6 +31,7 @@ connectionMode = "SESSION"
 {% toml_field "eduAppNamePrefix" config["service"]["edu_appname_prefix"] %}
 {% toml_field "enableExtendLoginSession" config["service"]["enable_extend_login_session"] %}
 {% toml_field "enableInteractiveLoginAccountSwitch" config["service"]["enable_interactive_login_account_switch"] %}
+{% toml_field "defaultFileBrowserImage" config["service"]["default_file_browser_image"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open_port_to_public"] %}


### PR DESCRIPTION
Resolves #4836 ([BA-1668](https://lablup.atlassian.net/browse/BA-1668))

# Add default file browser image configuration option

This PR adds a new configuration option `default_file_browser_image` to specify a default file browser image. When not specified, a random installed file browser image will be used as before.

The changes include:
- Adding the new configuration option to the sample config file with documentation
- Adding the option to the config schema validation
- Exposing the setting in the frontend config template as `defaultFileBrowserImage`

**Checklist:**

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations

[BA-1668]: https://lablup.atlassian.net/browse/BA-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ