### PR TITLE
fix(BA-1671): GQL image node has wrong query filter definition

### DIFF
--- a/changes/4843.fix.md
+++ b/changes/4843.fix.md
@@ -1,0 +1,1 @@
+Fix incorrect query filter definition in GQL image node

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -36,6 +36,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
+from ai.backend.manager.models.minilang import EnumFieldItem
 from ai.backend.manager.models.minilang.ordering import ColumnMapType, QueryOrderParser
 from ai.backend.manager.models.minilang.queryfilter import (
     FieldSpecType,
@@ -130,7 +131,7 @@ _queryfilter_fieldspec: FieldSpecType = {
     "name": ("name", None),
     "namespace": ("image", None),
     "tag": ("tag", None),
-    "status": ("status", ImageStatus),
+    "status": (EnumFieldItem("status", ImageStatus), None),
     "project": ("project", None),
     "image": ("image", None),
     "created_at": ("created_at", dtparse),
@@ -138,7 +139,7 @@ _queryfilter_fieldspec: FieldSpecType = {
     "registry_id": ("registry_id", None),
     "architecture": ("architecture", None),
     "is_local": ("is_local", None),
-    "type": ("session_type", ImageType),
+    "type": (EnumFieldItem("type", ImageType), None),
     "accelerators": ("accelerators", None),
 }
 


### PR DESCRIPTION
resolves #4842 (BA-1671)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
