### PR TITLE
fix(BA-1671): GQL image node has wrong query filter definition (#4843)

### DIFF
--- a/changes/4843.fix.md
+++ b/changes/4843.fix.md
@@ -1,0 +1,1 @@
+Fix incorrect query filter definition in GQL image node

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Backend.AI Manager API",
     "description": "Backend.AI Manager REST API specification",
-    "version": "25.6.11",
+    "version": "25.6.11a",
     "contact": {
       "name": "Lablup Inc.",
       "url": "https://docs.backend.ai",

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -34,6 +34,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
+from ai.backend.manager.models.minilang import EnumFieldItem
 from ai.backend.manager.models.minilang.ordering import ColumnMapType, QueryOrderParser
 from ai.backend.manager.models.minilang.queryfilter import (
     FieldSpecType,
@@ -126,6 +127,9 @@ __all__ = (
 _queryfilter_fieldspec: FieldSpecType = {
     "id": ("id", None),
     "name": ("name", None),
+    "namespace": ("image", None),
+    "tag": ("tag", None),
+    "status": (EnumFieldItem("status", ImageStatus), None),
     "project": ("project", None),
     "image": ("image", None),
     "created_at": ("created_at", dtparse),
@@ -133,7 +137,7 @@ _queryfilter_fieldspec: FieldSpecType = {
     "registry_id": ("registry_id", None),
     "architecture": ("architecture", None),
     "is_local": ("is_local", None),
-    "type": ("session_type", ImageType),
+    "type": (EnumFieldItem("type", ImageType), None),
     "accelerators": ("accelerators", None),
 }
 


### PR DESCRIPTION
This is an auto-generated backport PR of #4843 to the 25.6 release.