### PR TITLE
fix(BA-1708): Allow update users main_access_key (#4879)

### DIFF
--- a/changes/4879.fix.md
+++ b/changes/4879.fix.md
@@ -1,0 +1,1 @@
+Allow GQL modify_user mutation to update users `main_access_key`

--- a/src/ai/backend/manager/services/user/actions/modify_user.py
+++ b/src/ai/backend/manager/services/user/actions/modify_user.py
@@ -43,6 +43,7 @@ class UserModifier(PartialModifier):
         self.totp_activated.update_dict(to_update, "totp_activated")
         self.resource_policy.update_dict(to_update, "resource_policy")
         self.sudo_session_enabled.update_dict(to_update, "sudo_session_enabled")
+        self.main_access_key.update_dict(to_update, "main_access_key")
         self.container_uid.update_dict(to_update, "container_uid")
         self.container_main_gid.update_dict(to_update, "container_main_gid")
         self.container_gids.update_dict(to_update, "container_gids")


### PR DESCRIPTION
This is an auto-generated backport PR of #4879 to the 25.6 release.