### PR TITLE
fix(BA-1630): Omission of status code in wsproxy exception middleware (#4788)

### DIFF
--- a/changes/4788.fix.md
+++ b/changes/4788.fix.md
@@ -1,0 +1,1 @@
+Status code is missing when the `Accept` header is not set to `application/json` in the wsproxy exception middleware

--- a/src/ai/backend/wsproxy/proxy/frontend/http/abc.py
+++ b/src/ai/backend/wsproxy/proxy/frontend/http/abc.py
@@ -109,6 +109,7 @@ class AbstractHTTPFrontend(Generic[TCircuitKey], AbstractFrontend[HTTPBackend, T
                     "error.jinja2",
                     request,
                     ex.body_dict,
+                    status=ex.status_code,
                 )
         return resp
 

--- a/src/ai/backend/wsproxy/server.py
+++ b/src/ai/backend/wsproxy/server.py
@@ -123,6 +123,7 @@ async def exception_middleware(
                 "error.jinja2",
                 request,
                 ex.body_dict,
+                status=ex.status_code,
             )
     except web.HTTPException as ex:
         if ex.status_code == 404:


### PR DESCRIPTION
This is an auto-generated backport PR of #4788 to the 24.09 release.