### PR TITLE
fix(BA-1720): Clean up endpoints when purge group

### DIFF
--- a/changes/4917.fix.md
+++ b/changes/4917.fix.md
@@ -1,0 +1,1 @@
+Ensure endpoints are properly cleaned up during group purge operations

--- a/src/ai/backend/manager/services/group/actions/purge_group.py
+++ b/src/ai/backend/manager/services/group/actions/purge_group.py
@@ -65,7 +65,7 @@ class PurgeGroupActionVFoldersMountedToActiveKernelsError(BackendAIError):
 
 
 class PurgeGroupActionActiveEndpointsError(BackendAIError):
-    error_type = "https://api.backend.ai/probs/group-has-active-endpoints"
+    error_type = "https://api.backend.ai/probs/group-active-endpoints"
     error_title = "Group has active endpoints."
 
     @classmethod

--- a/src/ai/backend/manager/services/group/actions/purge_group.py
+++ b/src/ai/backend/manager/services/group/actions/purge_group.py
@@ -2,6 +2,13 @@ import uuid
 from dataclasses import dataclass
 from typing import Optional, override
 
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.services.group.actions.base import GroupAction
 from ai.backend.manager.services.group.types import GroupData
@@ -29,3 +36,42 @@ class PurgeGroupActionResult(BaseActionResult):
     @override
     def entity_id(self) -> Optional[str]:
         return str(self.data.id) if self.data is not None else None
+
+
+class PurgeGroupActionActiveKernelsError(BackendAIError):
+    error_type = "https://api.backend.ai/probs/group-active-kernels"
+    error_title = "Group has active kernels."
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.GROUP,
+            operation=ErrorOperation.HARD_DELETE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class PurgeGroupActionVFoldersMountedToActiveKernelsError(BackendAIError):
+    error_type = "https://api.backend.ai/probs/group-vfolders-mounted-to-active-kernels"
+    error_title = "Group has vfolders mounted to active kernels."
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.GROUP,
+            operation=ErrorOperation.HARD_DELETE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class PurgeGroupActionActiveEndpointsError(BackendAIError):
+    error_type = "https://api.backend.ai/probs/group-has-active-endpoints"
+    error_title = "Group has active endpoints."
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.GROUP,
+            operation=ErrorOperation.HARD_DELETE,
+            error_detail=ErrorDetail.CONFLICT,
+        )

--- a/src/ai/backend/manager/services/group/service.py
+++ b/src/ai/backend/manager/services/group/service.py
@@ -332,18 +332,20 @@ class GroupService:
         if len(endpoint_ids) == 0:
             return
 
-        active_endpoint = await db_conn.scalar(
-            sa.select(EndpointRow.id).where(
-                (EndpointRow.project == group_id)
-                & (
-                    EndpointRow.lifecycle_stage
-                    in (EndpointLifecycle.CREATED, EndpointLifecycle.DESTROYING)
+        active_endpoints = (
+            await db_conn.scalars(
+                sa.select(EndpointRow.id).where(
+                    (EndpointRow.project == group_id)
+                    & (
+                        EndpointRow.lifecycle_stage
+                        in (EndpointLifecycle.CREATED, EndpointLifecycle.DESTROYING)
+                    )
                 )
             )
-        )
-        if active_endpoint is not None:
+        ).all()
+        if len(active_endpoints) > 0:
             log.error(
-                f"Cannot delete group {group_id} because it has an active endpoint {active_endpoint}. Please delete the endpoint first."
+                f"Cannot delete group {group_id} because it has active endpoints {active_endpoints}. Please delete the endpoints first."
             )
             raise PurgeGroupActionActiveEndpointsError()
 


### PR DESCRIPTION
resolves #4897 (BA-1720)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
