### PR TITLE
fix(BA-1746): Skip kernel destroy when agent shutdown

### DIFF
--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2953,11 +2953,6 @@ class AgentRegistry:
         # noop for performance reasons
         pass
 
-    async def kill_all_sessions_in_agent(self, agent_id, agent_addr):
-        async with self.agent_cache.rpc_context(agent_id) as rpc:
-            coro = rpc.call.clean_all_kernels("manager-freeze-force-kill")
-            return await coro
-
     async def kill_all_sessions(self, conn=None):
         async with reenter_txn(self.db, conn, {"postgresql_readonly": True}) as conn:
             query = sa.select([agents.c.id, agents.c.addr]).where(


### PR DESCRIPTION
resolves #4921 (BA-1746)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
