### PR TITLE
fix: Wait `BgtaskDone` event in VFolder clone test

### DIFF
--- a/src/ai/backend/test/testcases/vfolder/clone.py
+++ b/src/ai/backend/test/testcases/vfolder/clone.py
@@ -1,5 +1,7 @@
+from ai.backend.common.bgtask.types import BgtaskStatus
 from ai.backend.test.contexts.client_session import ClientSessionContext
 from ai.backend.test.contexts.vfolder import CreatedVFolderMetaContext
+from ai.backend.test.templates.session.utils import verify_bgtask_events
 from ai.backend.test.templates.template import TestCode
 from ai.backend.test.templates.vfolder.utils import retrieve_all_files
 
@@ -10,7 +12,16 @@ class VFolderCloneSuccess(TestCode):
         vfolder_meta = CreatedVFolderMetaContext.current()
 
         new_vfolder_name = vfolder_meta.name + "_cloned"
-        await client_session.VFolder(vfolder_meta.name).clone(target_name=new_vfolder_name)
+        response = await client_session.VFolder(vfolder_meta.name).clone(
+            target_name=new_vfolder_name
+        )
+
+        await verify_bgtask_events(
+            client_session,
+            response["bgtask_id"],
+            BgtaskStatus.DONE,
+            {BgtaskStatus.FAILED, BgtaskStatus.CANCELLED, BgtaskStatus.PARTIAL_SUCCESS},
+        )
 
         old_vfolder_files = await retrieve_all_files(client_session, vfolder_meta.name)
         new_vfolder_files = await retrieve_all_files(client_session, new_vfolder_name)


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
