### PR TITLE
fix(BA-1722): Check daemon process before query docker netstat

### DIFF
--- a/changes/4929.fix.md
+++ b/changes/4929.fix.md
@@ -1,0 +1,1 @@
+Check if Agent is daemon process before query docker netstat


### PR DESCRIPTION
resolves #4901 (BA-1722)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
