### PR TITLE
fix(BA-1744): Handle NoSuchProcess properly when gather process stat (#4922)

### DIFF
--- a/changes/4922.fix.md
+++ b/changes/4922.fix.md
@@ -1,0 +1,1 @@
+Handle `NoSuchProcess` properly when gather process memory stat

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -306,10 +306,10 @@ class CPUPlugin(AbstractComputePlugin):
         async def psutil_impl(pid: int, cid: str) -> Optional[Decimal]:
             try:
                 p = psutil.Process(pid)
+                cpu_times = p.cpu_times()
             except psutil.NoSuchProcess:
                 log.debug("Process not found for CPU stats (pid:{0}, container id:{1})", pid, cid)
             else:
-                cpu_times = p.cpu_times()
                 cpu_used = Decimal(cpu_times.user + cpu_times.system) * 1000
                 return cpu_used
             return None
@@ -811,6 +811,7 @@ class MemoryPlugin(AbstractComputePlugin):
         ) -> tuple[Optional[int], Optional[int], Optional[int]]:
             try:
                 p = psutil.Process(pid)
+                stats = p.as_dict(attrs=["memory_info", "io_counters"])
             except psutil.NoSuchProcess:
                 log.debug(
                     "Process not found for memory stats (pid:{0}, container id:{1})",
@@ -818,7 +819,6 @@ class MemoryPlugin(AbstractComputePlugin):
                     cid,
                 )
             else:
-                stats = p.as_dict(attrs=["memory_info", "io_counters"])
                 mem_cur_bytes = io_read_bytes = io_write_bytes = None
                 if stats["memory_info"] is not None:
                     mem_cur_bytes = stats["memory_info"].rss


### PR DESCRIPTION
This is an auto-generated backport PR of #4922 to the 25.6 release.