### PR TITLE
fix(BA-1746): Skip kernel destroy when agent shutdown (#4923)

### DIFF
--- a/changes/4923.fix.md
+++ b/changes/4923.fix.md
@@ -1,0 +1,1 @@
+Skip kernel destroy when agent shutdown

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -893,8 +893,6 @@ class AbstractAgent(
                     await kernel_obj.runner.close()
                 await kernel_obj.close()
             await self.save_last_registry(force=True)
-            if stop_signal == signal.SIGTERM:
-                await self.clean_all_kernels(blocking=True)
 
         # Stop timers.
         cancel_results = await cancel_tasks(self.timer_tasks)
@@ -1675,25 +1673,6 @@ class AbstractAgent(
         await redis_helper.execute(
             self.redis_stat_pool, lambda r: r.set(f"container_count.{self.id}", container_count)
         )
-
-    async def clean_all_kernels(self, blocking: bool = False) -> None:
-        kernel_ids = [*self.kernel_registry.keys()]
-        clean_events = {}
-        loop = asyncio.get_running_loop()
-        if blocking:
-            for kernel_id in kernel_ids:
-                clean_events[kernel_id] = loop.create_future()
-        for kernel_id in kernel_ids:
-            await self.inject_container_lifecycle_event(
-                kernel_id,
-                self.kernel_registry[kernel_id].session_id,
-                LifecycleEvent.DESTROY,
-                KernelLifecycleEventReason.AGENT_TERMINATION,
-                done_future=clean_events[kernel_id] if blocking else None,
-            )
-        if blocking:
-            waiters = [clean_events[kernel_id] for kernel_id in kernel_ids]
-            await asyncio.gather(*waiters)
 
     @abstractmethod
     def get_cgroup_path(self, controller: str, container_id: str) -> Path:

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -203,7 +203,7 @@ async def update_manager_status(request: web.Request, params: Any) -> web.Respon
         # It supposed to kill all running sessions and kernels
         # but there is no RPC to do that.
         pass
-    await root_ctx.config_provider.legacy_etcd_config_loader.update_manager_status(status)
+    await root_ctx.shared_config.update_manager_status(status)
 
     return web.Response(status=HTTPStatus.NO_CONTENT)
 

--- a/src/ai/backend/manager/api/manager.py
+++ b/src/ai/backend/manager/api/manager.py
@@ -200,8 +200,10 @@ async def update_manager_status(request: web.Request, params: Any) -> web.Respon
         raise InvalidAPIParameters(extra_msg=str(e.args[0]))
 
     if force_kill:
-        await root_ctx.registry.kill_all_sessions()
-    await root_ctx.shared_config.update_manager_status(status)
+        # It supposed to kill all running sessions and kernels
+        # but there is no RPC to do that.
+        pass
+    await root_ctx.config_provider.legacy_etcd_config_loader.update_manager_status(status)
 
     return web.Response(status=HTTPStatus.NO_CONTENT)
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -200,7 +200,6 @@ from .models.utils import (
     execute_with_retry,
     execute_with_txn_retry,
     is_db_retry_error,
-    reenter_txn,
     reenter_txn_session,
     sql_json_merge,
 )
@@ -2995,25 +2994,6 @@ class AgentRegistry:
     ) -> None:
         # noop for performance reasons
         pass
-
-    async def kill_all_sessions_in_agent(self, agent_id, agent_addr):
-        async with self.agent_cache.rpc_context(agent_id) as rpc:
-            coro = rpc.call.clean_all_kernels("manager-freeze-force-kill")
-            return await coro
-
-    async def kill_all_sessions(self, conn=None):
-        async with reenter_txn(self.db, conn, {"postgresql_readonly": True}) as conn:
-            query = sa.select([agents.c.id, agents.c.addr]).where(
-                agents.c.status == AgentStatus.ALIVE
-            )
-            result = await conn.execute(query)
-            rows = result.fetchall()
-        tasks = []
-        for row in rows:
-            tasks.append(
-                self.kill_all_sessions_in_agent(row["id"], row["addr"]),
-            )
-        await asyncio.gather(*tasks, return_exceptions=True)
 
     async def handle_heartbeat(self, agent_id, agent_info):
         now = datetime.now(tzutc())


### PR DESCRIPTION
This is an auto-generated backport PR of #4923 to the 25.6 release.