### PR TITLE
fix(BA-1722): Check daemon process before query docker netstat (#4929)

### DIFF
--- a/changes/4929.fix.md
+++ b/changes/4929.fix.md
@@ -1,0 +1,1 @@
+Check if Agent is daemon process before query docker netstat


### PR DESCRIPTION
This is an auto-generated backport PR of #4929 to the 25.6 release.