### PR TITLE
fix(BA-1752): Wrong indent in Agent container stat function (#4946)

### DIFF
--- a/changes/4946.fix.md
+++ b/changes/4946.fix.md
@@ -1,0 +1,1 @@
+Wrong indent in Agent container stat function

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1113,7 +1113,7 @@ class AbstractAgent(
                 if not kernel_obj.stats_enabled or kernel_obj.container_id is None:
                     continue
                 container_ids.append(ContainerId(kernel_obj.container_id))
-                await self.stat_ctx.collect_container_stat(container_ids)
+            await self.stat_ctx.collect_container_stat(container_ids)
         except asyncio.CancelledError:
             pass
         except Exception:


### PR DESCRIPTION
This is an auto-generated backport PR of #4946 to the 25.6 release.