### PR TITLE
feat(BA-1699): Add vfolder share test

### DIFF
--- a/changes/4971.feature.md
+++ b/changes/4971.feature.md
@@ -1,0 +1,1 @@
+Add VFolder share test verifying shared project vfolder has override permission to shared user

--- a/configs/tester/tester.toml
+++ b/configs/tester/tester.toml
@@ -60,3 +60,4 @@ group = "default"
 usage_mode = "general"
 permission = "rw"
 cloneable = true
+share-permission = "ro"

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -34,6 +34,8 @@ __all__ = (
     "api_session",
 )
 
+from contextlib import asynccontextmanager as actxmgr
+
 from ..common.types import SSLContextType
 
 api_session: ContextVar[BaseSession] = ContextVar("api_session")
@@ -536,3 +538,13 @@ class AsyncSession(BaseSession):
     async def __aexit__(self, *exc_info) -> Literal[False]:
         await self.close()
         return False  # raise up the inner exception
+
+
+# TODO: Remove this after refactoring session management with contextvars
+@actxmgr
+async def set_api_context(session):
+    token = api_session.set(session)
+    try:
+        yield
+    finally:
+        api_session.reset(token)

--- a/src/ai/backend/test/contexts/context.py
+++ b/src/ai/backend/test/contexts/context.py
@@ -35,10 +35,14 @@ class ContextName(enum.StrEnum):
     SESSION_IMAGIFY = "session_imagify"
     TEST_ERROR_OUTPUT_DIRECTORY = "test_error_output_directory"
     SESSION_DEPENDENCY = "session_dependency"
+
     VFOLDER = "vfolder"
     VFOLDER_UPLOAD_FILES = "vfolder_upload_files"
-
+    VFOLDER_SHARE_META = "vfolder_share_meta"
+    VFOLDER_INVITATION = "vfolder_invitation"
+    VFOLDER_INVITATION_PERMISSION = "vfolder_invitation_permission"
     VFOLDER_UPLOADED_FILES_META = "vfolder_uploaded_files_meta"
+
     CREATED_VFOLDER_META = "created_vfolder_meta"
     CREATED_SESSION_META = "created_session_meta"
     CREATED_SESSION_TEMPLATE_ID = "created_session_template_id"
@@ -47,8 +51,6 @@ class ContextName(enum.StrEnum):
     CREATED_USER_CONTEXT = "created_user_context"
     CREATED_USER_CLIENT_SESSION = "created_user_client_session"
     CREATED_GROUP = "created_group"
-    VFOLDER_INVITATION = "vfolder_invitation"
-    VFOLDER_INVITATION_PERMISSION = "vfolder_invitation_permission"
 
 
 class BaseTestContext(Generic[T]):

--- a/src/ai/backend/test/contexts/vfolder.py
+++ b/src/ai/backend/test/contexts/vfolder.py
@@ -1,7 +1,12 @@
 from typing import override
 
 from ai.backend.test.contexts.context import BaseTestContext, ContextName
-from ai.backend.test.data.vfolder import UploadedFilesMeta, VFolderInvitationMeta, VFolderMeta
+from ai.backend.test.data.vfolder import (
+    UploadedFilesMeta,
+    VFolderInvitationMeta,
+    VFolderMeta,
+    VFolderShareMeta,
+)
 from ai.backend.test.tester.dependency import UploadFileDep, VFolderDep
 
 
@@ -46,3 +51,10 @@ class VFolderInvitationPermissionContext(BaseTestContext[str]):
     @classmethod
     def name(cls) -> ContextName:
         return ContextName.VFOLDER_INVITATION_PERMISSION
+
+
+class VFolderShareContext(BaseTestContext[VFolderShareMeta]):
+    @override
+    @classmethod
+    def name(cls) -> ContextName:
+        return ContextName.VFOLDER_SHARE_META

--- a/src/ai/backend/test/data/vfolder.py
+++ b/src/ai/backend/test/data/vfolder.py
@@ -24,3 +24,9 @@ class UploadedFilesMeta:
 @dataclass
 class VFolderInvitationMeta:
     invited_user_emails: list[str]
+
+
+@dataclass
+class VFolderShareMeta:
+    override_permission: str
+    user_emails: list[str]

--- a/src/ai/backend/test/templates/vfolder/share.py
+++ b/src/ai/backend/test/templates/vfolder/share.py
@@ -1,0 +1,52 @@
+from contextlib import asynccontextmanager as actxmgr
+from typing import AsyncIterator, override
+
+from ai.backend.test.contexts.client_session import ClientSessionContext
+from ai.backend.test.contexts.user import CreatedUserContext
+from ai.backend.test.contexts.vfolder import (
+    CreatedVFolderMetaContext,
+    VFolderContext,
+    VFolderShareContext,
+)
+from ai.backend.test.data.vfolder import VFolderShareMeta
+from ai.backend.test.templates.template import WrapperTestTemplate
+from ai.backend.test.utils.exceptions import UnexpectedFailure
+
+
+class ShareVFolderTemplate(WrapperTestTemplate):
+    @property
+    def name(self) -> str:
+        return "share_vfolder"
+
+    @override
+    @actxmgr
+    async def _context(self) -> AsyncIterator[None]:
+        vfolder_meta = CreatedVFolderMetaContext.current()
+        client_session = ClientSessionContext.current()
+        created_user_meta = CreatedUserContext.current()
+        vfolder_dep = VFolderContext.current()
+        override_permission = vfolder_dep.share_permission
+
+        vfolder_info = await client_session.VFolder(name=vfolder_meta.name).info()
+        # TODO: Move VFolderOwnershipType to common package
+        if vfolder_info["type"] != "group":
+            raise UnexpectedFailure("VFolder type should be 'group' for sharing.")
+
+        try:
+            await client_session.VFolder(name=vfolder_meta.name).share(
+                perm=override_permission, emails=[created_user_meta.email]
+            )
+            with VFolderShareContext.with_current(
+                VFolderShareMeta(
+                    override_permission=override_permission, user_emails=[created_user_meta.email]
+                )
+            ):
+                yield
+        finally:
+            await client_session.VFolder(name=vfolder_meta.name).unshare(
+                emails=[created_user_meta.email]
+            )
+            vfolder_info = await client_session.VFolder(name=vfolder_meta.name).info()
+            assert vfolder_info["permission"] == vfolder_dep.permission, (
+                f"VFolder permission should be reverted to '{vfolder_dep.permission}' after unsharing."
+            )

--- a/src/ai/backend/test/testcases/vfolder/share.py
+++ b/src/ai/backend/test/testcases/vfolder/share.py
@@ -1,0 +1,42 @@
+from ai.backend.client.session import set_api_context
+from ai.backend.test.contexts.client_session import (
+    ClientSessionContext,
+    CreatedUserClientSessionContext,
+)
+from ai.backend.test.contexts.vfolder import (
+    CreatedVFolderMetaContext,
+    VFolderContext,
+    VFolderShareContext,
+)
+from ai.backend.test.templates.template import TestCode
+from ai.backend.test.utils.exceptions import UnexpectedFailure
+
+
+class VFolderSharePermissionOverrideSuccess(TestCode):
+    async def test(self) -> None:
+        vfolder_meta = CreatedVFolderMetaContext.current()
+        # The session of the user who shared the vfolder
+        sharing_user_session = ClientSessionContext.current()
+        # The session of the user who received the share
+        shared_user_session = CreatedUserClientSessionContext.current()
+
+        vfolder_share_dep = VFolderContext.current()
+        vfolder_share_meta = VFolderShareContext.current()
+
+        if vfolder_share_dep.permission == vfolder_share_meta.override_permission:
+            raise UnexpectedFailure(
+                "VFolder share permission should not match the override permission for test purposes."
+            )
+
+        # TODO: Refactor 'set_api_context' after refactoring AsyncSession(session management with contextvars)
+        async with set_api_context(sharing_user_session):
+            sharing_user_vfolder_info = await sharing_user_session.VFolder(
+                name=vfolder_meta.name
+            ).info()
+            assert sharing_user_vfolder_info["permission"] == vfolder_share_dep.permission
+
+        async with set_api_context(shared_user_session):
+            shared_user_vfolder_info = await shared_user_session.VFolder(
+                name=vfolder_meta.name
+            ).info()
+            assert shared_user_vfolder_info["permission"] == vfolder_share_meta.override_permission

--- a/src/ai/backend/test/testcases/vfolder/testspecs.py
+++ b/src/ai/backend/test/testcases/vfolder/testspecs.py
@@ -17,6 +17,7 @@ from ai.backend.test.templates.vfolder.invite import (
     RejectInvitationTemplate,
     VFolderInviteTemplate,
 )
+from ai.backend.test.templates.vfolder.share import ShareVFolderTemplate
 from ai.backend.test.testcases.spec_manager import TestSpec, TestTag
 from ai.backend.test.testcases.vfolder.access import VFolderAccessFailure, VFolderAccessSuccess
 from ai.backend.test.testcases.vfolder.clone import VFolderCloneSuccess
@@ -32,6 +33,7 @@ from ai.backend.test.testcases.vfolder.invite_failures import (
 from ai.backend.test.testcases.vfolder.list_files import VFolderListFilesSuccess
 from ai.backend.test.testcases.vfolder.move import VFolderFileMoveSuccess
 from ai.backend.test.testcases.vfolder.rename_file import VFolderFileRenameSuccess
+from ai.backend.test.testcases.vfolder.share import VFolderSharePermissionOverrideSuccess
 from ai.backend.test.tester.dependency import UploadFileDep
 
 _TEST_FILE_CONTENT = "This is a test file for VFolder download."
@@ -367,6 +369,29 @@ VFOLDER_TEST_SPECS = {
                 ]
             ]
         },
+    ),
+    "shared_vfolder_permission_override": TestSpec(
+        name="shared_vfolder_permission_override",
+        description=textwrap.dedent("""\
+            Test for VFolder sharing functionality.
+            The test will:
+            1. Authenticate as admin and create a VFolder.
+            2. Create a test user.
+            3. Share the VFolder with the test user.
+            4. Login as the test user.
+            5. Verify that the test user can access the VFolder with the shared permission.
+            6. Unshare the VFolder from the test user.
+        """),
+        tags={TestTag.MANAGER, TestTag.VFOLDER},
+        template=BasicTestTemplate(VFolderSharePermissionOverrideSuccess()).with_wrappers(
+            # Run as admin(sharing user)
+            KeypairAuthTemplate,
+            ProjectVFolderTemplate,
+            UserTemplate,
+            ShareVFolderTemplate,
+            # Run as shared user
+            KeypairAuthAsCreatedUserTemplate,
+        ),
     ),
     **VFOLDER_INVITATION_TEST_SPECS,
 }

--- a/src/ai/backend/test/tester/dependency.py
+++ b/src/ai/backend/test/tester/dependency.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ai.backend.common.types import ClusterMode, RuntimeVariant
 
@@ -184,6 +184,17 @@ class VFolderDep(BaseDependencyModel):
     cloneable: bool = Field(
         description="Whether the vfolder is cloneable.",
     )
+    share_permission: str = Field(
+        default="ro",
+        description="The share permission for the vfolder.",
+        examples=["ro", "rw"],
+    )
+
+    @model_validator(mode="after")
+    def validate(self):
+        if self.permission == self.share_permission:
+            raise ValueError("permission and share_permission must be different")
+        return self
 
 
 class UploadFileDep(BaseDependencyModel):

--- a/src/ai/backend/test/utils/exceptions.py
+++ b/src/ai/backend/test/utils/exceptions.py
@@ -10,3 +10,10 @@ class UnexpectedSuccess(Exception):
 
     def __init__(self, message="Test succeeded unexpectedly."):
         super().__init__(message)
+
+
+class UnexpectedFailure(Exception):
+    """Raised when a test marked as expected to succeed actually fails."""
+
+    def __init__(self, message="Test failed unexpectedly."):
+        super().__init__(message)


### PR DESCRIPTION
resolves #4871 (BA-1699)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
