### PR TITLE
fix(BA-1768): Remove the incorrect warning logs that `BgtaskUpdated` is not supported

### DIFF
--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -23,6 +23,7 @@ from ai.backend.common.bgtask.types import BgtaskStatus
 from ai.backend.common.docker import DEFAULT_KERNEL_FEATURE, ImageRef, KernelFeatures, LabelName
 from ai.backend.common.events.event_types.bgtask.broadcast import (
     BaseBgtaskDoneEvent,
+    BgtaskUpdatedEvent,
 )
 from ai.backend.common.events.fetcher import EventFetcher
 from ai.backend.common.events.hub.hub import EventHub
@@ -466,6 +467,8 @@ class SessionService:
             try:
                 cache_id = EventCacheDomain.BGTASK.cache_id(bgtask_id)
                 async for event in propagator.receive(cache_id):
+                    if isinstance(event, BgtaskUpdatedEvent):
+                        continue
                     if not isinstance(event, BaseBgtaskDoneEvent):
                         log.warning("unexpected event: {}", event)
                         continue
@@ -504,6 +507,8 @@ class SessionService:
                 try:
                     cache_id = EventCacheDomain.BGTASK.cache_id(bgtask_id)
                     async for event in propagator.receive(cache_id):
+                        if isinstance(event, BgtaskUpdatedEvent):
+                            continue
                         if not isinstance(event, BaseBgtaskDoneEvent):
                             log.warning("unexpected event: {}", event)
                             continue

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -23,7 +23,7 @@ from ai.backend.common.bgtask.types import BgtaskStatus
 from ai.backend.common.docker import DEFAULT_KERNEL_FEATURE, ImageRef, KernelFeatures, LabelName
 from ai.backend.common.events.event_types.bgtask.broadcast import (
     BaseBgtaskDoneEvent,
-    BgtaskUpdatedEvent,
+    BaseBgtaskEvent,
 )
 from ai.backend.common.events.fetcher import EventFetcher
 from ai.backend.common.events.hub.hub import EventHub
@@ -467,9 +467,7 @@ class SessionService:
             try:
                 cache_id = EventCacheDomain.BGTASK.cache_id(bgtask_id)
                 async for event in propagator.receive(cache_id):
-                    if isinstance(event, BgtaskUpdatedEvent):
-                        continue
-                    if not isinstance(event, BaseBgtaskDoneEvent):
+                    if not isinstance(event, BaseBgtaskEvent):
                         log.warning("unexpected event: {}", event)
                         continue
                     match event.status():
@@ -478,9 +476,13 @@ class SessionService:
                             await reporter.update(increment=1, message="Committed image")
                             break
                         case BgtaskStatus.FAILED:
-                            raise BgtaskFailedError(extra_msg=event.message)
+                            raise BgtaskFailedError(
+                                extra_msg=cast(BaseBgtaskDoneEvent, event).message
+                            )
                         case BgtaskStatus.CANCELLED:
                             raise BgtaskCancelledError(extra_msg="Operation cancelled")
+                        case BgtaskStatus.UPDATED:
+                            continue
                         case _:
                             log.warning("unexpected bgtask done event: {}", event)
             finally:
@@ -507,18 +509,20 @@ class SessionService:
                 try:
                     cache_id = EventCacheDomain.BGTASK.cache_id(bgtask_id)
                     async for event in propagator.receive(cache_id):
-                        if isinstance(event, BgtaskUpdatedEvent):
-                            continue
-                        if not isinstance(event, BaseBgtaskDoneEvent):
+                        if not isinstance(event, BaseBgtaskEvent):
                             log.warning("unexpected event: {}", event)
                             continue
                         match event.status():
                             case BgtaskStatus.DONE | BgtaskStatus.PARTIAL_SUCCESS:
                                 break
                             case BgtaskStatus.FAILED:
-                                raise BgtaskFailedError(extra_msg=event.message)
+                                raise BgtaskFailedError(
+                                    extra_msg=cast(BaseBgtaskDoneEvent, event).message
+                                )
                             case BgtaskStatus.CANCELLED:
                                 raise BgtaskCancelledError(extra_msg="Operation cancelled")
+                            case BgtaskStatus.UPDATED:
+                                continue
                             case _:
                                 log.warning("unexpected bgtask done event: {}", event)
                 finally:


### PR DESCRIPTION
resolves #4974 (BA-1768)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
