### PR TITLE
fix(BA-1763): Modify configs to avoid resource creation timeouts

### DIFF
--- a/configs/tester/tester.toml
+++ b/configs/tester/tester.toml
@@ -41,7 +41,7 @@ name = "cr.backend.ai/multiarch/python:3.13-ubuntu24.04"
 architecture = "x86_64"
 
 [context.session]
-resources = { cpu = 1, mem = "512mb" }
+resources = { cpu = 1, mem = "320mb" }
 
 [context.session-imagify]
 new-image-name = "new-customized-image"

--- a/src/ai/backend/test/templates/model_service/endpoint.py
+++ b/src/ai/backend/test/templates/model_service/endpoint.py
@@ -26,7 +26,7 @@ from ai.backend.test.templates.template import (
 )
 from ai.backend.test.utils.exceptions import DependencyNotSet
 
-_ENDPOINT_CREATION_TIMEOUT = 30
+_ENDPOINT_CREATION_TIMEOUT = 60
 
 
 class _BaseEndpointTemplate(WrapperTestTemplate):


### PR DESCRIPTION
resolves #4966 (BA-1763)
When running tests that create multiple multi-container sessions, there were cases where the session creation would pend due to exhausting the computing resources of the test environment and lack of time creating multi-kernel routes. This can be avoided by setting the memory value on session creation to minimum (320mb), which is set in the test default config, so we want to modify the config value and timeouts

- Changed session resource memory size to 320mb(minimum resource to commit session image)
- Doubled timeout limit waiting model service creation

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
