### PR TITLE
fix(BA-1741): Incorrect filetype check of `PureStorage` VFolder (#5018)

### DIFF
--- a/changes/5018.fix.md
+++ b/changes/5018.fix.md
@@ -1,0 +1,1 @@
+Fix incorrect filetype check of `PureStorage` VFolder

--- a/src/ai/backend/storage/volumes/purestorage/rapidfiles.py
+++ b/src/ai/backend/storage/volumes/purestorage/rapidfiles.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from pathlib import Path
+from stat import S_IFDIR, S_IFLNK
 from subprocess import CalledProcessError
 from typing import AsyncIterator
 
@@ -71,11 +72,12 @@ class RapidFileToolsFSOpModel(BaseFSOpModel):
                         break
                     line = line.rstrip(b"\n")
                     item = load_json(line)
+
                     item_path = Path(item["path"])
                     entry_type = DirEntryType.FILE
-                    if item["filetype"] == 40000:
+                    if item["filetype"] == S_IFDIR:
                         entry_type = DirEntryType.DIRECTORY
-                    if item["filetype"] == 120000:
+                    if item["filetype"] == S_IFLNK:
                         entry_type = DirEntryType.SYMLINK
                     yield DirEntry(
                         name=item_path.name,

--- a/src/ai/backend/storage/volumes/purestorage/rapidfiles_v2.py
+++ b/src/ai/backend/storage/volumes/purestorage/rapidfiles_v2.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from pathlib import Path
+from stat import S_IFDIR, S_IFLNK
 from subprocess import CalledProcessError
 from typing import AsyncIterator
 
@@ -59,11 +60,12 @@ class RapidFileToolsv2FSOpModel(RapidFileToolsFSOpModel):
                         break
                     line = line.rstrip(b"\n")
                     item = load_json(line)
+
                     item_path = Path(item["path"])
                     entry_type = DirEntryType.FILE
-                    if item["filetype"] == 40000:
+                    if item["filetype"] == S_IFDIR:
                         entry_type = DirEntryType.DIRECTORY
-                    if item["filetype"] == 120000:
+                    if item["filetype"] == S_IFLNK:
                         entry_type = DirEntryType.SYMLINK
                     yield DirEntry(
                         name=item_path.name,


### PR DESCRIPTION
This is an auto-generated backport PR of #5018 to the 25.6 release.