### PR TITLE
fix(BA-1847): Wrong `service ports` field name of Session creation response (#5047)

### DIFF
--- a/changes/5047.fix.md
+++ b/changes/5047.fix.md
@@ -1,0 +1,1 @@
+Wrong `service ports` field name of Session creation response

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -527,7 +527,8 @@ class AgentRegistry:
                 "sessionId": str(sess.id),
                 "sessionName": str(sess.name),
                 "status": sess.status.name,
-                "service_ports": sess.main_kernel.service_ports,
+                "service_ports": sess.main_kernel.service_ports,  # deprecated, left for compatibility.
+                "servicePorts": sess.main_kernel.service_ports,
                 "created": False,
             }
         except SessionNotFound:


### PR DESCRIPTION
This is an auto-generated backport PR of #5047 to the 24.09 release.