### PR TITLE
chore(BA-1841): Improve DX for IDEs using Pyright as the default LSP (#5088)

### DIFF
--- a/changes/5088.misc.md
+++ b/changes/5088.misc.md
@@ -1,0 +1,1 @@
+Add `[tool.pyright]` section to `pyproject.toml` so that IDEs using Pyright as the default LSP works out of the box by detecting Pants-specific configurations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,22 @@ explicit_package_bases = true
 python_executable = "dist/export/python/virtualenvs/python-default/3.13.3/bin/python"
 disable_error_code = ["typeddict-unknown-key"]
 
+[tool.pyright]
+pythonVersion = "3.13"
+include = [
+    "src",
+    "tools/pants-plugins",
+]
+stubPath = "stubs"
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "src/ai/backend/webui",
+    "src/ai/backend/web/static",
+]
+venvPath = "dist/export/python/virtualenvs/python-default"
+venv = "3.13.3"
+
 [tool.pydantic-mypy]
 init_forbid_extra = true
 init_typed = true


### PR DESCRIPTION
This is an auto-generated backport PR of #5088 to the 25.6 release.