### PR TITLE
fix(BA-1854): Handle scratch already cleaned before destroy container

### DIFF
--- a/changes/5118.fix.md
+++ b/changes/5118.fix.md
@@ -1,0 +1,1 @@
+Enable Agent starts if scratch already cleaned before destroy container

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2007,10 +2007,20 @@ class AbstractAgent(
                     # Restore compute resources.
                     async with self.resource_lock:
                         for computer_ctx in self.computers.values():
-                            await computer_ctx.instance.restore_from_container(
-                                container,
-                                computer_ctx.alloc_map,
-                            )
+                            try:
+                                await computer_ctx.instance.restore_from_container(
+                                    container,
+                                    computer_ctx.alloc_map,
+                                )
+                            except FileNotFoundError:
+                                log.warning(
+                                    "scan_running_kernels(): "
+                                    "failed to read kernel resource info; "
+                                    "maybe already terminated (k:{}, c:{})",
+                                    kernel_id,
+                                    container.id,
+                                )
+                                continue
                     await self.inject_container_lifecycle_event(
                         kernel_id,
                         session_id,

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -103,6 +103,7 @@ async def get_resource_spec_from_container(container_info) -> Optional[KernelRes
     for mount in container_info["HostConfig"]["Mounts"]:
         if mount["Target"] == "/home/config":
             async with aiofiles.open(Path(mount["Source"]) / "resource.txt", "r") as f:  # type: ignore
+                raise FileNotFoundError("Fucking resource.txt not found")
                 return await KernelResourceSpec.aread_from_file(f)
     else:
         return None

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -103,7 +103,6 @@ async def get_resource_spec_from_container(container_info) -> Optional[KernelRes
     for mount in container_info["HostConfig"]["Mounts"]:
         if mount["Target"] == "/home/config":
             async with aiofiles.open(Path(mount["Source"]) / "resource.txt", "r") as f:  # type: ignore
-                raise FileNotFoundError("Fucking resource.txt not found")
                 return await KernelResourceSpec.aread_from_file(f)
     else:
         return None


### PR DESCRIPTION
resolves #5117 (BA-1854)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
