### PR TITLE
fix(BA-1854): Handle scratch already cleaned before destroy container (#5118)

### DIFF
--- a/changes/5118.fix.md
+++ b/changes/5118.fix.md
@@ -1,0 +1,1 @@
+Enable Agent starts if scratch already cleaned before destroy container

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1939,10 +1939,20 @@ class AbstractAgent(
                     # Restore compute resources.
                     async with self.resource_lock:
                         for computer_ctx in self.computers.values():
-                            await computer_ctx.instance.restore_from_container(
-                                container,
-                                computer_ctx.alloc_map,
-                            )
+                            try:
+                                await computer_ctx.instance.restore_from_container(
+                                    container,
+                                    computer_ctx.alloc_map,
+                                )
+                            except FileNotFoundError:
+                                log.warning(
+                                    "scan_running_kernels(): "
+                                    "failed to read kernel resource info; "
+                                    "maybe already terminated (k:{}, c:{})",
+                                    kernel_id,
+                                    container.id,
+                                )
+                                continue
                     await self.inject_container_lifecycle_event(
                         kernel_id,
                         session_id,


### PR DESCRIPTION
This is an auto-generated backport PR of #5118 to the 25.6 release.