### PR TITLE
fix(BA-1839): Finish Agent execution task event correctly (#5112)

### DIFF
--- a/changes/5112.fix.md
+++ b/changes/5112.fix.md
@@ -1,0 +1,1 @@
+Enable continuous code execution tasks to work properly in Agent

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -403,6 +403,13 @@ class AbstractKernel(UserDict, aobject, metaclass=ABCMeta):
         assert self.runner is not None
         self._tasks.add(myself)
         try:
+            log.info(
+                "kernel.execute(k:{0}, run_id:{1}, mode:{2}, opts:{3})",
+                self.kernel_id,
+                run_id,
+                mode,
+                opts,
+            )
             await self.runner.attach_output_queue(run_id)
             try:
                 if mode == "batch":
@@ -953,7 +960,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
                 "options": None,
             }
             type(self).aggregate_console(result, records, api_ver)
-            self.resume_output_queue()
+            self.next_output_queue()
             return result
         except BuildFinished as e:
             result = {
@@ -963,7 +970,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
                 "options": None,
             }
             type(self).aggregate_console(result, records, api_ver)
-            self.resume_output_queue()
+            self.next_output_queue()
             return result
         except RunFinished as e:
             result = {
@@ -1011,6 +1018,12 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             self.pending_queues[run_id] = (activated, q)
         else:
             activated, q = self.pending_queues[run_id]
+        log.info(
+            "CodeRunner.attach_output_queue(k:{0}, run_id:{1}, is running event set:{2})",
+            self.kernel_id,
+            run_id,
+            activated.is_set(),
+        )
         if self.output_queue is None:
             self.output_queue = q
         else:


### PR DESCRIPTION
This is an auto-generated backport PR of #5112 to the 24.09 release.