### PR TITLE
fix(BA-1870): Relax stats serialization (#5143)

### DIFF
--- a/changes/5142.fix.md
+++ b/changes/5142.fix.md
@@ -1,0 +1,1 @@
+Relax Decimal serialization of Agent stats

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -179,6 +179,20 @@ class ProcessMeasurement:
     unit_hint: str = "count"
 
 
+def _to_serializable_value(value: Decimal, *, exponent: Decimal = Decimal("0.000")) -> str:
+    """
+    Convert a Decimal value to a string without scientific notation.
+    """
+    try:
+        quantized = value.quantize(exponent)
+    except DecimalException:
+        return str(value)
+    try:
+        return str(remove_exponent(quantized))
+    except DecimalException:
+        return str(quantized)
+
+
 class MovingStatistics:
     __slots__ = (
         "_sum",


### PR DESCRIPTION
This is an auto-generated backport PR of #5143 to the 25.6 release.