### PR TITLE
feat(BA-992): Offload health check capability to AppProxy

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2999,15 +2999,11 @@ class AbstractAgent(
             # if everything went well then krunner itself will report the status via zmq
             await self.anycast_and_broadcast_event(
                 ModelServiceStatusAnycastEvent(
-                    kernel_obj.kernel_id,
                     kernel_obj.session_id,
-                    model["name"],
                     ModelServiceStatus.UNHEALTHY,
                 ),
                 ModelServiceStatusBroadcastEvent(
-                    kernel_obj.kernel_id,
                     kernel_obj.session_id,
-                    model["name"],
                     ModelServiceStatus.UNHEALTHY,
                 ),
             )

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -50,15 +50,11 @@ from ai.backend.common.events.dispatcher import (
 from ai.backend.common.events.event_types.kernel.types import (
     KernelLifecycleEventReason,
 )
-from ai.backend.common.events.event_types.model_serving.anycast import (
-    ModelServiceStatusAnycastEvent,
-)
 from ai.backend.common.json import load_json
 from ai.backend.common.types import (
     AgentId,
     CommitStatus,
     KernelId,
-    ModelServiceStatus,
     ServicePort,
     SessionId,
     SessionTypes,
@@ -1129,18 +1125,8 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
                         case b"model-service-result":
                             await self.model_service_queue.put(msg_data)
                         case b"model-service-status":
-                            response = load_json(msg_data)
-                            event = ModelServiceStatusAnycastEvent(
-                                self.kernel_id,
-                                self.session_id,
-                                response["model_name"],
-                                (
-                                    ModelServiceStatus.HEALTHY
-                                    if response["is_healthy"]
-                                    else ModelServiceStatus.UNHEALTHY
-                                ),
-                            )
-                            await self.event_producer.anycast_event(event)
+                            # no-op
+                            pass
                         case b"apps-result":
                             await self.service_apps_info_queue.put(msg_data)
                         case b"stdout":

--- a/src/ai/backend/common/data/config/types.py
+++ b/src/ai/backend/common/data/config/types.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, Field
 
 from ai.backend.common.typed_validators import HostPortPair
 
@@ -10,3 +12,15 @@ class EtcdConfigData:
     addr: HostPortPair
     user: Optional[str]
     password: Optional[str]
+
+
+class HealthCheckConfig(BaseModel):
+    """
+    Health check configuration matching model-definition.yaml schema
+    """
+
+    interval: Annotated[float, Field(default=10.0, ge=0)] = 10.0
+    path: str
+    max_retries: Annotated[int, Field(default=10, ge=1)] = 10
+    max_wait_time: Annotated[float, Field(default=15.0, ge=0)] = 15.0
+    expected_status_code: Annotated[int, Field(default=200, ge=100, le=599)] = 200

--- a/src/ai/backend/common/events/event_types/model_serving/__init__.py
+++ b/src/ai/backend/common/events/event_types/model_serving/__init__.py
@@ -1,0 +1,39 @@
+import uuid
+from dataclasses import dataclass
+from typing import Optional, override
+
+from ai.backend.common.events.types import AbstractEvent, EventDomain
+from ai.backend.common.events.user_event.user_event import UserEvent
+from ai.backend.common.types import ModelServiceStatus, SessionId
+
+
+@dataclass
+class ModelServiceStatusEventArgs(AbstractEvent):
+    session_id: SessionId
+    new_status: ModelServiceStatus
+
+    def serialize(self) -> tuple:
+        return (
+            str(self.session_id),
+            self.new_status.value,
+        )
+
+    @classmethod
+    def deserialize(cls, value: tuple):
+        return cls(
+            session_id=SessionId(uuid.UUID(value[0])),
+            new_status=ModelServiceStatus(value[1]),
+        )
+
+    @classmethod
+    @override
+    def event_domain(cls) -> EventDomain:
+        return EventDomain.MODEL_SERVING
+
+    @override
+    def domain_id(self) -> Optional[str]:
+        return None
+
+    @override
+    def user_event(self) -> Optional[UserEvent]:
+        return None

--- a/src/ai/backend/common/events/event_types/model_serving/anycast.py
+++ b/src/ai/backend/common/events/event_types/model_serving/anycast.py
@@ -4,48 +4,11 @@ from typing import Optional, override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.types import KernelId, ModelServiceStatus, SessionId
+
+from . import ModelServiceStatusEventArgs
 
 
-@dataclass
-class ModelServiceStatusEventArgs(AbstractAnycastEvent):
-    kernel_id: KernelId
-    session_id: SessionId
-    model_name: str
-    new_status: ModelServiceStatus
-
-    def serialize(self) -> tuple:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.model_name,
-            self.new_status.value,
-        )
-
-    @classmethod
-    def deserialize(cls, value: tuple):
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            model_name=value[2],
-            new_status=ModelServiceStatus(value[3]),
-        )
-
-    @classmethod
-    @override
-    def event_domain(cls) -> EventDomain:
-        return EventDomain.MODEL_SERVING
-
-    @override
-    def domain_id(self) -> Optional[str]:
-        return None
-
-    @override
-    def user_event(self) -> Optional[UserEvent]:
-        return None
-
-
-class ModelServiceStatusAnycastEvent(ModelServiceStatusEventArgs):
+class ModelServiceStatusAnycastEvent(ModelServiceStatusEventArgs, AbstractAnycastEvent):
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -82,3 +45,40 @@ class RouteCreatedAnycastEvent(RouteCreationEvent):
     @override
     def event_name(cls) -> str:
         return "route_created"
+
+
+class RouteTerminatingEvent(RouteCreationEvent):
+    @classmethod
+    @override
+    def event_name(cls) -> str:
+        return "route_terminating"
+
+
+@dataclass
+class EndpointRouteListUpdatedEvent(AbstractAnycastEvent):
+    endpoint_id: uuid.UUID
+
+    def serialize(self) -> tuple:
+        return (str(self.endpoint_id),)
+
+    @classmethod
+    def deserialize(cls, value: tuple):
+        return cls(uuid.UUID(value[0]))
+
+    @classmethod
+    @override
+    def event_name(cls) -> str:
+        return "endpoint_route_list_updated"
+
+    @classmethod
+    @override
+    def event_domain(cls) -> EventDomain:
+        return EventDomain.MODEL_ROUTE
+
+    @override
+    def domain_id(self) -> Optional[str]:
+        return str(self.endpoint_id)
+
+    @override
+    def user_event(self) -> Optional[UserEvent]:
+        return None

--- a/src/ai/backend/common/events/event_types/model_serving/broadcast.py
+++ b/src/ai/backend/common/events/event_types/model_serving/broadcast.py
@@ -1,51 +1,11 @@
-import uuid
-from dataclasses import dataclass
-from typing import Optional, override
+from typing import override
 
-from ai.backend.common.events.types import AbstractBroadcastEvent, EventDomain
-from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.types import KernelId, ModelServiceStatus, SessionId
+from ai.backend.common.events.types import AbstractBroadcastEvent
+
+from . import ModelServiceStatusEventArgs
 
 
-@dataclass
-class ModelServiceStatusEventArgs(AbstractBroadcastEvent):
-    kernel_id: KernelId
-    session_id: SessionId
-    model_name: str
-    new_status: ModelServiceStatus
-
-    def serialize(self) -> tuple:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.model_name,
-            self.new_status.value,
-        )
-
-    @classmethod
-    def deserialize(cls, value: tuple):
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            model_name=value[2],
-            new_status=ModelServiceStatus(value[3]),
-        )
-
-    @classmethod
-    @override
-    def event_domain(cls) -> EventDomain:
-        return EventDomain.MODEL_SERVING
-
-    @override
-    def domain_id(self) -> Optional[str]:
-        return None
-
-    @override
-    def user_event(self) -> Optional[UserEvent]:
-        return None
-
-
-class ModelServiceStatusBroadcastEvent(ModelServiceStatusEventArgs):
+class ModelServiceStatusBroadcastEvent(ModelServiceStatusEventArgs, AbstractBroadcastEvent):
     @classmethod
     @override
     def event_name(cls) -> str:

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -30,6 +30,7 @@ from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
     RuntimeVariant,
+    VFolderID,
     VFolderMount,
     VFolderUsageMode,
 )
@@ -73,7 +74,7 @@ from ai.backend.manager.services.model_serving.types import (
 from ..defs import DEFAULT_IMAGE_ARCH
 from ..errors.exceptions import InvalidAPIParameters, VFolderNotFound
 from ..models import (
-    ModelServicePredicateChecker,
+    ModelServiceHelper,
     UserRole,
     UserRow,
     query_accessible_vfolders,
@@ -520,7 +521,7 @@ async def _validate(request: web.Request, params: NewServiceRequestModel) -> Val
         raise InvalidAPIParameters(f"Cannot spawn more than {_m} sessions for a single service")
 
     async with root_ctx.db.begin_readonly() as conn:
-        checked_scaling_group = await ModelServicePredicateChecker.check_scaling_group(
+        checked_scaling_group = await ModelServiceHelper.check_scaling_group(
             conn,
             params.config.scaling_group,
             owner_access_key,
@@ -578,7 +579,7 @@ async def _validate(request: web.Request, params: NewServiceRequestModel) -> Val
 
         model_id = folder_row["id"]
 
-        vfolder_mounts = await ModelServicePredicateChecker.check_extra_mounts(
+        vfolder_mounts = await ModelServiceHelper.check_extra_mounts(
             conn,
             root_ctx.config_provider.legacy_etcd_config_loader,
             root_ctx.storage_manager,
@@ -595,10 +596,18 @@ async def _validate(request: web.Request, params: NewServiceRequestModel) -> Val
         )
 
     if params.runtime_variant == RuntimeVariant.CUSTOM:
-        yaml_path = await ModelServicePredicateChecker.validate_model_definition(
+        vfid = VFolderID(folder_row["quota_scope_id"], folder_row["id"])
+        yaml_path = await ModelServiceHelper.validate_model_definition_file_exists(
             root_ctx.storage_manager,
-            folder_row,
+            folder_row["host"],
+            vfid,
             params.config.model_definition_path,
+        )
+        await ModelServiceHelper.validate_model_definition(
+            root_ctx.storage_manager,
+            folder_row["host"],
+            vfid,
+            yaml_path,
         )
     else:
         if (

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from collections.abc import (
     Container,
     Mapping,
@@ -15,6 +16,7 @@ from typing import (
     List,
     Optional,
     Self,
+    TypeAlias,
     cast,
 )
 from uuid import UUID, uuid4
@@ -74,7 +76,7 @@ from .image import ImageRow
 from .routing import RouteStatus
 from .scaling_group import scaling_groups
 from .user import UserRow
-from .vfolder import VFolderRow, prepare_vfolder_mounts
+from .vfolder import prepare_vfolder_mounts
 
 if TYPE_CHECKING:
     from ai.backend.manager.services.model_serving.types import EndpointTokenData
@@ -84,12 +86,14 @@ if TYPE_CHECKING:
 __all__ = (
     "EndpointRow",
     "EndpointLifecycle",
-    "ModelServicePredicateChecker",
+    "ModelServiceHelper",
     "EndpointStatistics",
     "EndpointTokenRow",
     "EndpointAutoScalingRuleRow",
 )
 
+
+ModelServiceSerializableConnectionInfo: TypeAlias = dict[str, list[dict[str, Any]]]
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore
 
@@ -532,6 +536,34 @@ class EndpointRow(Base):
         for session_row in session_rows:
             session_row.delegate_ownership(target_user_uuid, target_access_key)
 
+    async def generate_redis_route_info(
+        self, db_sess: AsyncSession
+    ) -> ModelServiceSerializableConnectionInfo:
+        from .kernel import KernelRow
+        from .routing import RoutingRow
+
+        active_routes = await RoutingRow.list(db_sess, self.id, load_session=True)
+        target_kernels = await KernelRow.batch_load_by_session_id(
+            db_sess,
+            [
+                r.session
+                for r in active_routes
+                if r.status in RouteStatus.active_route_statuses() and r.session
+            ],
+        )
+        session_id_to_route_map = {r.session: r for r in active_routes}
+        connection_info: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+        for kernel in target_kernels:
+            for port_info in kernel.service_ports:
+                if port_info["is_inference"]:
+                    connection_info[port_info["name"]].append({
+                        "session_id": str(kernel.session_id),
+                        "route_id": str(session_id_to_route_map[kernel.session_id].id),
+                        "kernel_host": kernel.kernel_host,
+                        "kernel_port": port_info["host_ports"][0],
+                    })
+        return connection_info
+
 
 class EndpointTokenRow(Base):
     __tablename__ = "endpoint_tokens"
@@ -728,7 +760,7 @@ class EndpointAutoScalingRuleRow(Base):
         await session.delete(self)
 
 
-class ModelServicePredicateChecker:
+class ModelServiceHelper:
     @staticmethod
     async def check_scaling_group(
         conn: AsyncConnection,
@@ -855,54 +887,55 @@ class ModelServicePredicateChecker:
             return await storage_resp.json()
 
     @staticmethod
-    async def validate_model_definition(
+    async def validate_model_definition_file_exists(
         storage_manager: StorageSessionManager,
-        model_vfolder_row: VFolderRow | Mapping[str, Any],
-        model_definition_path: str | None,
-    ) -> str | None:
+        folder_host: str,
+        vfid: VFolderID,
+        suggested_path: str | None,
+    ) -> str:
         """
-        Checks if model definition YAML exists and is syntactically perfect.
-        Returns relative path to customized model-definition.yaml (if any) or None.
+        Checks if model definition file exists in target model VFolder. Returns path to resolved model definition filename.
+        Since model service counts both `model-definition.yml` and `model-definition.yaml` as valid definition file name, this function ensures
+        at least one model definition file exists under the target VFolder and returns the matched filename.
         """
-        match model_vfolder_row:
-            case VFolderRow():
-                folder_name = model_vfolder_row.name
-                vfid = model_vfolder_row.vfid
-                folder_host = model_vfolder_row.host
-            case _:
-                folder_name = model_vfolder_row["name"]
-                vfid = VFolderID(model_vfolder_row["quota_scope_id"], model_vfolder_row["id"])
-                folder_host = model_vfolder_row["host"]
-
         proxy_name, volume_name = storage_manager.get_proxy_and_volume(folder_host)
 
-        if model_definition_path:
-            path = Path(model_definition_path)
-            storage_reply = await ModelServicePredicateChecker._listdir(
+        if suggested_path:
+            path = Path(suggested_path)
+            storage_reply = await ModelServiceHelper._listdir(
                 storage_manager, proxy_name, volume_name, vfid, path.parent.as_posix()
             )
             for item in storage_reply["items"]:
                 if item["name"] == path.name:
-                    yaml_name = model_definition_path
-                    break
+                    return suggested_path
             else:
                 raise InvalidAPIParameters(
-                    f"Model definition YAML file {model_definition_path} not found inside the model storage"
+                    f"Model definition YAML file {suggested_path} not found inside the model storage"
                 )
         else:
-            storage_reply = await ModelServicePredicateChecker._listdir(
+            storage_reply = await ModelServiceHelper._listdir(
                 storage_manager, proxy_name, volume_name, vfid, "."
             )
             model_definition_candidates = ["model-definition.yaml", "model-definition.yml"]
             for item in storage_reply["items"]:
                 if item["name"] in model_definition_candidates:
-                    yaml_name = item["name"]
-                    break
+                    return item["name"]
             else:
                 raise InvalidAPIParameters(
                     'Model definition YAML file "model-definition.yaml" or "model-definition.yml" not found inside the model storage'
                 )
 
+    @staticmethod
+    async def _read_model_definition(
+        storage_manager: StorageSessionManager,
+        folder_host: str,
+        vfid: VFolderID,
+        model_definition_filename: str,
+    ) -> dict[str, Any]:
+        """
+        Reads specified model definition file from target VFolder and returns
+        """
+        proxy_name, volume_name = storage_manager.get_proxy_and_volume(folder_host)
         chunks = bytes()
         async with storage_manager.request(
             proxy_name,
@@ -911,7 +944,7 @@ class ModelServicePredicateChecker:
             json={
                 "volume": volume_name,
                 "vfid": str(vfid),
-                "relpath": f"./{yaml_name}",
+                "relpath": f"./{model_definition_filename}",
             },
         ) as (client_api_url, storage_resp):
             while True:
@@ -921,19 +954,36 @@ class ModelServicePredicateChecker:
                 chunks += chunk
         model_definition_yaml = chunks.decode("utf-8")
         yaml = YAML()
-        model_definition_dict = yaml.load(model_definition_yaml)
+        return yaml.load(model_definition_yaml)
+
+    @staticmethod
+    async def validate_model_definition(
+        storage_manager: StorageSessionManager,
+        folder_host: str,
+        vfid: VFolderID,
+        model_definition_path: str,
+    ) -> dict[str, Any]:
+        """
+        Checks if model definition YAML exists and is syntactically perfect.
+        Returns validated model definition configuration.
+        """
+        raw_model_definition = await ModelServiceHelper._read_model_definition(
+            storage_manager,
+            folder_host,
+            vfid,
+            model_definition_path,
+        )
+
         try:
-            model_definition = model_definition_iv.check(model_definition_dict)
+            model_definition = model_definition_iv.check(raw_model_definition)
             assert model_definition is not None
+            return model_definition
         except t.DataError as e:
             raise InvalidAPIParameters(
-                f"Failed to validate model definition from vFolder {folder_name} (ID"
-                f" {vfid.folder_id}): {e}",
+                f"Failed to validate model definition from VFolder (ID {vfid.folder_id}): {e}",
             ) from e
         except YAMLError as e:
             raise InvalidAPIParameters(f"Invalid YAML syntax: {e}") from e
-
-        return yaml_name
 
 
 class EndpointStatistics:

--- a/src/ai/backend/manager/models/routing.py
+++ b/src/ai/backend/manager/models/routing.py
@@ -121,11 +121,8 @@ class RoutingRow(Base):
         db_sess: AsyncSession,
         endpoint_id: uuid.UUID,
         load_endpoint: bool = False,
-        status_filter: list[RouteStatus] = [
-            RouteStatus.HEALTHY,
-            RouteStatus.UNHEALTHY,
-            RouteStatus.PROVISIONING,
-        ],
+        load_session: bool = False,
+        status_filter: list[RouteStatus] = list(RouteStatus.active_route_statuses()),
         project: Optional[uuid.UUID] = None,
         domain: Optional[str] = None,
         user_uuid: Optional[uuid.UUID] = None,
@@ -141,6 +138,8 @@ class RoutingRow(Base):
         )
         if load_endpoint:
             query = query.options(selectinload(RoutingRow.endpoint_row))
+        if load_session:
+            query = query.options(selectinload(RoutingRow.session_row))
         if project:
             query = query.filter(RoutingRow.project == project)
         if domain:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import copy
 import itertools
+import json
 import logging
 import re
 import secrets
@@ -32,7 +33,6 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urlparse
 
 import aiodocker
 import aiohttp
@@ -55,6 +55,7 @@ from yarl import URL
 
 from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.asyncio import cancel_tasks
+from ai.backend.common.data.config.types import HealthCheckConfig
 from ai.backend.common.docker import ImageRef, LabelName
 from ai.backend.common.dto.agent.response import CodeCompletionResp, PurgeImageResp, PurgeImagesResp
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
@@ -82,6 +83,7 @@ from ai.backend.common.events.event_types.kernel.anycast import (
 )
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.events.event_types.model_serving.anycast import (
+    EndpointRouteListUpdatedEvent,
     ModelServiceStatusAnycastEvent,
     RouteCreatedAnycastEvent,
 )
@@ -107,6 +109,7 @@ from ai.backend.common.exception import AliasResolutionFailed
 from ai.backend.common.plugin.hook import ALL_COMPLETED, PASSED, HookPluginContext
 from ai.backend.common.service_ports import parse_service_ports
 from ai.backend.common.types import (
+    MODEL_SERVICE_RUNTIME_PROFILES,
     AbuseReport,
     AccessKey,
     AgentId,
@@ -129,6 +132,7 @@ from ai.backend.common.types import (
     ModelServiceStatus,
     RedisConnectionInfo,
     ResourceSlot,
+    RuntimeVariant,
     SessionEnqueueingConfig,
     SessionId,
     SessionTypes,
@@ -138,6 +142,7 @@ from ai.backend.common.types import (
 from ai.backend.common.utils import str_to_timedelta
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.models.endpoint import ModelServiceHelper
 from ai.backend.manager.models.image import ImageIdentifier
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.utils import query_userinfo
@@ -166,7 +171,6 @@ from .models import (
     USER_RESOURCE_OCCUPYING_SESSION_STATUSES,
     AgentRow,
     AgentStatus,
-    EndpointLifecycle,
     EndpointRow,
     ImageRow,
     KernelLoadingStrategy,
@@ -184,6 +188,7 @@ from .models import (
     SessionStatus,
     UserRole,
     UserRow,
+    VFolderRow,
     agents,
     domains,
     handle_session_exception,
@@ -211,7 +216,6 @@ from .models.utils import (
     ExtendedAsyncSAEngine,
     execute_with_retry,
     execute_with_txn_retry,
-    is_db_retry_error,
     reenter_txn_session,
     sql_json_merge,
 )
@@ -289,6 +293,7 @@ class AgentRegistry:
         self.session_lifecycle_mgr = SessionLifecycleManager(
             db,
             redis_stat,
+            redis_live,
             event_producer,
             hook_plugin_ctx,
             self,
@@ -3651,14 +3656,44 @@ class AgentRegistry:
             "abuse_report": result,
         }
 
-    async def update_appproxy_endpoint_routes(
-        self, db_sess: AsyncSession, endpoint: EndpointRow, active_routes: list[RoutingRow]
-    ) -> None:
-        target_sessions = await SessionRow.list_sessions(
-            db_sess,
-            [r.session for r in active_routes],
-            kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
-        )
+    async def get_health_check_info(
+        self, endpoint: EndpointRow, model: VFolderRow
+    ) -> HealthCheckConfig | None:
+        _info: HealthCheckConfig | None = None
+
+        if _path := MODEL_SERVICE_RUNTIME_PROFILES[endpoint.runtime_variant].health_check_endpoint:
+            _info = HealthCheckConfig(path=_path)
+        elif endpoint.runtime_variant == RuntimeVariant.CUSTOM:
+            model_definition_path = await ModelServiceHelper.validate_model_definition_file_exists(
+                self.storage_manager,
+                model.host,
+                model.vfid,
+                endpoint.model_definition_path,
+            )
+            model_definition = await ModelServiceHelper.validate_model_definition(
+                self.storage_manager,
+                model.host,
+                model.vfid,
+                model_definition_path,
+            )
+
+            for model_info in model_definition["models"]:
+                if health_check_info := model_info.get("service", {}).get("health_check"):
+                    _info = HealthCheckConfig(
+                        path=health_check_info["path"],
+                        interval=health_check_info["interval"],
+                        max_retries=health_check_info["max_retries"],
+                        max_wait_time=health_check_info["max_wait_time"],
+                        expected_status_code=health_check_info["expected_status_code"],
+                    )
+                    break
+        return _info
+
+    async def create_appproxy_endpoint(
+        self,
+        db_sess: AsyncSession,
+        endpoint: EndpointRow,
+    ) -> str:
         query = (
             sa.select([scaling_groups.c.wsproxy_addr, scaling_groups.c.wsproxy_api_token])
             .select_from(scaling_groups)
@@ -3670,29 +3705,15 @@ class AgentRegistry:
         wsproxy_addr = sgroup["wsproxy_addr"]
         wsproxy_api_token = sgroup["wsproxy_api_token"]
 
-        session_id_to_route_map = {r.session: r for r in active_routes}
-        inference_apps: defaultdict[str, list[dict[str, str]]] = defaultdict(list)
-        for target_session in target_sessions:
-            if target_session.main_kernel.kernel_host is None:
-                kernel_host = urlparse(target_session.main_kernel.agent_addr).hostname
-            else:
-                kernel_host = target_session.main_kernel.kernel_host
-            assert kernel_host is not None
-            for port_info in target_session.main_kernel.service_ports:
-                if not port_info["is_inference"]:
-                    continue
-                inference_apps[port_info["name"]].append({
-                    "session_id": str(target_session.id),
-                    "route_id": str(session_id_to_route_map[target_session.id].id),
-                    "kernel_host": kernel_host,
-                    "kernel_port": port_info["host_ports"][0],
-                    "traffic_ratio": session_id_to_route_map[target_session.id].traffic_ratio,
-                })
+        model = await VFolderRow.get(db_sess, endpoint.model)
+
+        health_check_information = await self.get_health_check_info(endpoint, model)
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"{wsproxy_addr}/v2/endpoints/{endpoint.id}",
                 json={
+                    "version": "v2",
                     "service_name": endpoint.name,
                     "tags": {
                         "session": {
@@ -3706,8 +3727,10 @@ class AgentRegistry:
                             "existing_url": str(endpoint.url) if endpoint.url else None,
                         },
                     },
-                    "apps": inference_apps,
                     "open_to_public": endpoint.open_to_public,
+                    "health_check": health_check_information.model_dump(mode="json")
+                    if health_check_information
+                    else None,
                 },  # TODO: support for multiple inference apps
                 headers={
                     "X-BackendAI-Token": wsproxy_api_token,
@@ -3715,13 +3738,7 @@ class AgentRegistry:
             ) as resp:
                 resp.raise_for_status()
                 endpoint_json = await resp.json()
-                async with self.db.begin_session() as db_sess:
-                    query = (
-                        sa.update(EndpointRow)
-                        .values({"url": endpoint_json["endpoint"]})
-                        .where(EndpointRow.id == endpoint.id)
-                    )
-                    await db_sess.execute(query)
+                return endpoint_json["endpoint"]
 
     async def delete_appproxy_endpoint(self, db_sess: AsyncSession, endpoint: EndpointRow) -> None:
         query = (
@@ -3743,6 +3760,21 @@ class AgentRegistry:
                 },
             ):
                 pass
+
+    async def notify_endpoint_route_update_to_appproxy(self, endpoint: EndpointRow) -> None:
+        async with self.db.begin_readonly_session() as db_sess:
+            connection_info = await endpoint.generate_redis_route_info(db_sess)
+
+        await redis_helper.execute(
+            self.redis_live,
+            lambda r: r.set(
+                f"endpoint.{endpoint.id}.route_connection_info",
+                json.dumps(connection_info),
+                ex=3600,
+            ),
+        )
+
+        await self.event_producer.anycast_event(EndpointRouteListUpdatedEvent(endpoint.id))
 
     async def purge_containers(
         self,
@@ -3956,24 +3988,6 @@ async def handle_model_service_status_update(
             query = sa.update(RoutingRow).values(data).where(RoutingRow.id == route.id)
             await db_sess.execute(query)
 
-            query = sa.select(RoutingRow).where(
-                (RoutingRow.endpoint == route.endpoint) & (RoutingRow.status == RouteStatus.HEALTHY)
-            )
-            result = await db_sess.execute(query)
-            latest_routes = result.fetchall()
-            latest_routes = await RoutingRow.list(
-                db_sess, route.endpoint, status_filter=[RouteStatus.HEALTHY]
-            )
-
-            try:
-                await context.update_appproxy_endpoint_routes(
-                    db_sess, route.endpoint_row, latest_routes
-                )
-            except Exception as e:
-                if is_db_retry_error(e):
-                    raise
-                log.exception("failed to communicate with AppProxy endpoint:")
-
     await execute_with_retry(_update)
 
 
@@ -4013,85 +4027,40 @@ async def invoke_session_callback(
         if session.session_type == SessionTypes.INFERENCE:
 
             async def _update() -> None:
-                new_routes: list[RoutingRow]
                 async with context.db.begin_session() as db_sess:
                     route = await RoutingRow.get_by_session(db_sess, session.id, load_endpoint=True)
                     endpoint = await EndpointRow.get(db_sess, route.endpoint, load_routes=True)
-                    if isinstance(event, SessionCancelledAnycastEvent):
-                        update_data: dict[str, Any] = {"status": RouteStatus.FAILED_TO_START}
-                        if "error" in session.status_data:
-                            if session.status_data["error"]["name"] == "MultiAgentError":
-                                errors = session.status_data["error"]["collection"]
-                            else:
-                                errors = [session.status_data["error"]]
-                            update_data["error_data"] = {
-                                "type": "session_cancelled",
-                                "errors": errors,
-                                "session_id": session.id,
-                            }
-                        query = (
-                            sa.update(RoutingRow)
-                            .values(update_data)
-                            .where(RoutingRow.id == route.id)
-                        )
-                        await db_sess.execute(query)
-                        query = (
-                            sa.update(EndpointRow)
-                            .values({"retries": endpoint.retries + 1})
-                            .where(EndpointRow.id == endpoint.id)
-                        )
-                        await db_sess.execute(query)
-                    elif isinstance(event, SessionTerminatedAnycastEvent):
-                        query = sa.delete(RoutingRow).where(RoutingRow.id == route.id)
-                        await db_sess.execute(query)
-                        if endpoint.lifecycle_stage == EndpointLifecycle.CREATED:
-                            new_routes = [
-                                r
-                                for r in endpoint.routings
-                                if r.id != route.id and r.status == RouteStatus.HEALTHY
-                            ]
-                            try:
-                                await context.update_appproxy_endpoint_routes(
-                                    db_sess, endpoint, new_routes
-                                )
-                            except Exception as e:
-                                if is_db_retry_error(e):
-                                    raise
-                                log.warning(
-                                    "failed to communicate with AppProxy endpoint: {}", str(e)
-                                )
-                        await db_sess.commit()
-                    else:
-                        new_route_status: Optional[RouteStatus] = None
-                        if isinstance(event, SessionTerminatingAnycastEvent):
-                            new_route_status = RouteStatus.TERMINATING
-
-                        if new_route_status:
+                    match event:
+                        case SessionCancelledAnycastEvent():
+                            update_data: dict[str, Any] = {"status": RouteStatus.FAILED_TO_START}
+                            if "error" in session.status_data:
+                                if session.status_data["error"]["name"] == "MultiAgentError":
+                                    errors = session.status_data["error"]["collection"]
+                                else:
+                                    errors = [session.status_data["error"]]
+                                update_data["error_data"] = {
+                                    "type": "session_cancelled",
+                                    "errors": errors,
+                                    "session_id": session.id,
+                                }
                             query = (
                                 sa.update(RoutingRow)
+                                .values(update_data)
                                 .where(RoutingRow.id == route.id)
-                                .values({"status": new_route_status})
                             )
                             await db_sess.execute(query)
-
-                            new_routes = [
-                                r
-                                for r in endpoint.routings
-                                if r.id != route.id and r.status == RouteStatus.HEALTHY
-                            ]
-                            if new_route_status == RouteStatus.HEALTHY:
-                                new_routes.append(route)
-                            try:
-                                await context.update_appproxy_endpoint_routes(
-                                    db_sess, endpoint, new_routes
-                                )
-                            except Exception as e:
-                                if is_db_retry_error(e):
-                                    raise
-                                log.warning(
-                                    "failed to communicate with AppProxy endpoint: {}", str(e)
-                                )
-                        await db_sess.commit()
+                            query = (
+                                sa.update(EndpointRow)
+                                .values({"retries": endpoint.retries + 1})
+                                .where(EndpointRow.id == endpoint.id)
+                            )
+                            await db_sess.execute(query)
+                        case SessionTerminatedAnycastEvent():
+                            query = sa.delete(RoutingRow).where(RoutingRow.id == route.id)
+                            await db_sess.execute(query)
+                        case SessionStartedAnycastEvent() | SessionTerminatingAnycastEvent():
+                            await context.notify_endpoint_route_update_to_appproxy(endpoint)
+                    await db_sess.commit()
 
             await execute_with_retry(_update)
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -647,6 +647,7 @@ async def processors_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
                 config_provider=root_ctx.config_provider,
                 storage_manager=root_ctx.storage_manager,
                 redis_stat=root_ctx.redis_stat,
+                redis_live=root_ctx.redis_live,
                 event_fetcher=root_ctx.event_fetcher,
                 background_task_manager=root_ctx.background_task_manager,
                 event_hub=root_ctx.event_hub,

--- a/src/ai/backend/manager/services/model_serving/types.py
+++ b/src/ai/backend/manager/services/model_serving/types.py
@@ -61,6 +61,13 @@ class RouteInfo:
 
 
 @dataclass
+class RouteConnectionInfo:
+    app: str
+    kernel_host: str
+    kernel_port: int
+
+
+@dataclass
 class ServiceConfig:
     model: str
     model_definition_path: Optional[str]

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -75,6 +75,7 @@ class ServiceArgs:
     config_provider: ManagerConfigProvider
     storage_manager: StorageSessionManager
     redis_stat: RedisConnectionInfo
+    redis_live: RedisConnectionInfo
     event_fetcher: EventFetcher
     background_task_manager: BackgroundTaskManager
     event_hub: EventHub
@@ -155,6 +156,7 @@ class Services:
             event_dispatcher=args.event_dispatcher,
             storage_manager=args.storage_manager,
             config_provider=args.config_provider,
+            redis_live=args.redis_live,
         )
         model_serving_auto_scaling = AutoScalingService(args.db)
         auth = AuthService(db=args.db, hook_plugin_ctx=args.hook_plugin_ctx)


### PR DESCRIPTION
Resolves https://github.com/lablup/backend.ai/issues/3051 (BA-992).

## Summary

- Refactor model service health check architecture to offload health checking to AppProxy
- Update API specifications for endpoint route management and health check configuration
- Implement separate model entity handling for health check configuration
- Add support for reading health check information from model-definition.yaml

## Breaking Changes

**Important**: This PR breaks health check capability on OSS AppProxy. Future work will restore support, but for now disable the health check feature in `model-definition.yaml` to use model service on Open Source Backend.AI.

## Changes

### API Specifications
- Updated model serving event types with new `ModelServiceStatusEventArgs` base class
- Added `EndpointRouteListUpdatedEvent` for endpoint route synchronization
- Refactored anycast/broadcast event structures for better separation of concerns

### Health Check System
- Added `ModelServiceHelper` class replacing `ModelServicePredicateChecker`
- Implemented health check configuration reading from model-definition.yaml
- Added health check configuration passing to AppProxy during endpoint creation
- Separated model definition validation into discrete functions

### Route Management
- Updated endpoint route generation to use Redis for AppProxy communication
- Modified session lifecycle handling for route status updates
- Added `generate_redis_route_info` method for serializable connection data
- Implemented `notify_endpoint_route_update_to_appproxy` for real-time updates

### Database Changes
- Enhanced endpoint model with Redis route info generation for AppProxy integration
- Updated routing status management in session callbacks
- Improved error handling and retry logic for route operations

## Technical Details

The health check system now reads configuration from either:
1. Runtime variant profiles for predefined endpoints
2. model-definition.yaml for custom runtime variants

Health check configuration is passed to AppProxy during endpoint creation, allowing AppProxy to handle health checking independently. Route connection information is stored in Redis for AppProxy consumption with the key pattern:
`endpoint.{endpoint_id}.route_connection_info`

## Testing

Existing tests should continue to pass. New functionality requires model service integration testing with AppProxy components.