### PR TITLE
feat(BA-1917): Add chown util for Agent volume mount

### DIFF
--- a/changes/5213.feature.md
+++ b/changes/5213.feature.md
@@ -1,0 +1,1 @@
+Add chown feature to Agent to allow change owner of mount path

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -196,6 +196,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.common.utils import (
     cancel_tasks,
+    chown,
     current_loop,
     mount,
     umount,
@@ -3415,6 +3416,12 @@ async def handle_volume_mount(
             event.fstab_path,
             mount_prefix,
         )
+        if context.local_config.agent.mount_path_uid_gid is not None:
+            await chown(
+                real_path,
+                context.local_config.agent.mount_path_uid_gid,
+                mount_prefix=mount_prefix,
+            )
     except VolumeMountFailed as e:
         err_msg = str(e)
     await context.event_producer.broadcast_event(

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -562,6 +562,13 @@ class AgentConfig(BaseModel):
         validation_alias=AliasChoices("docker-mode", "docker_mode"),
         serialization_alias="docker-mode",
     )
+    mount_path_uid_gid: Optional[str] = Field(
+        default=None,
+        description="Owner uid:gid of the mount directory",
+        examples=["root:root", "bai:bai"],
+        validation_alias=AliasChoices("mount-path-uid-gid", "mount_path_uid_gid"),
+        serialization_alias="mount-path-uid-gid",
+    )
 
     def real_mount_path(self, directory_path: str) -> Path:
         if self.mount_path is None:


### PR DESCRIPTION
resolves #5212 (BA-1917)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
