### PR TITLE
fix(BA-1921): `status_data` not initialized properly when creating single node session

### DIFF
--- a/changes/5217.fix.md
+++ b/changes/5217.fix.md
@@ -1,1 +1,1 @@
-`status_data` not initialized properly in single node session
+`status_data` not initialized properly when creating single node session

--- a/changes/5217.fix.md
+++ b/changes/5217.fix.md
@@ -1,0 +1,1 @@
+`status_data` not initialized properly in single node session

--- a/src/ai/backend/manager/repositories/schedule/repository.py
+++ b/src/ai/backend/manager/repositories/schedule/repository.py
@@ -505,13 +505,19 @@ class ScheduleRepository:
 
             for kernel in session_row.kernels:
                 kernel.set_status(
-                    KernelStatus.SCHEDULED, status_info="scheduled", status_changed_at=now
+                    KernelStatus.SCHEDULED,
+                    status_info="scheduled",
+                    status_data={},
+                    status_changed_at=now,
                 )
                 kernel.agent = agent_alloc_ctx.agent_id
                 kernel.agent_addr = agent_alloc_ctx.agent_addr
                 kernel.scaling_group = sgroup_name
             session_row.set_status(
-                SessionStatus.SCHEDULED, status_info="scheduled", status_changed_at=now
+                SessionStatus.SCHEDULED,
+                status_info="scheduled",
+                status_data={},
+                status_changed_at=now,
             )
             if agent_alloc_ctx.agent_id is not None:
                 agent_ids.append(agent_alloc_ctx.agent_id)


### PR DESCRIPTION
resolves #NNN (BA-1921)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue