### PR TITLE
fix: Extend VFolderAlreadyExists exception to inherit from web.HTTPConflict

### DIFF
--- a/src/ai/backend/manager/services/vfolder/exceptions.py
+++ b/src/ai/backend/manager/services/vfolder/exceptions.py
@@ -1,3 +1,8 @@
+from aiohttp import web
+
+from ai.backend.common.exception import BackendError
+
+
 class VFolderServiceException(Exception):
     pass
 
@@ -10,7 +15,7 @@ class VFolderCreationFailure(VFolderServiceException):
     pass
 
 
-class VFolderAlreadyExists(VFolderServiceException):
+class VFolderAlreadyExists(BackendError, web.HTTPConflict):
     pass
 
 

--- a/src/ai/backend/manager/services/vfolder/services/invite.py
+++ b/src/ai/backend/manager/services/vfolder/services/invite.py
@@ -116,7 +116,7 @@ class VFolderInviteService:
             count = await db_session.scalar(count_query)
             if count > 0:
                 raise VFolderAlreadyExists(
-                    "Invitation to this VFolder already sent out to target user"
+                    extra_msg="Invitation to this VFolder already sent out to target user"
                 )
 
             # Create invitation.


### PR DESCRIPTION
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
