### PR TITLE
misc: Unify the agent RPC mock naming convention in session tests

### DIFF
--- a/tests/manager/services/session/actions/test_check_and_transit_status.py
+++ b/tests/manager/services/session/actions/test_check_and_transit_status.py
@@ -47,7 +47,6 @@ def mock_session_lifecycle_dependencies(mocker):
 
 @pytest.fixture
 def mock_trigger_batch_execution_rpc(mocker):
-    # Mock potential agent RPC calls that could be triggered during status transitions
     mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.trigger_batch_execution",
         new_callable=AsyncMock,

--- a/tests/manager/services/session/actions/test_commit_session.py
+++ b/tests/manager/services/session/actions/test_commit_session.py
@@ -19,7 +19,7 @@ from ..fixtures import (
 
 
 @pytest.fixture
-def mock_agent_commit_session_rpc(mocker, mock_agent_response_result):
+def mock_commit_session_to_file_rpc(mocker, mock_agent_response_result):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.commit_session_to_file",
         new_callable=AsyncMock,
@@ -64,7 +64,7 @@ COMMIT_SESSION_ACTION = CommitSessionAction(
     ],
 )
 async def test_commit_session(
-    mock_agent_commit_session_rpc,
+    mock_commit_session_to_file_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[CommitSessionAction, CommitSessionActionResult],
 ):

--- a/tests/manager/services/session/actions/test_complete.py
+++ b/tests/manager/services/session/actions/test_complete.py
@@ -20,7 +20,7 @@ from ..fixtures import (
 
 
 @pytest.fixture
-def mock_agent_complete_session_rpc(mocker, mock_agent_response_result):
+def mock_complete_session_rpc(mocker, mock_agent_response_result):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.get_completions",
         new_callable=AsyncMock,
@@ -30,7 +30,7 @@ def mock_agent_complete_session_rpc(mocker, mock_agent_response_result):
 
 
 @pytest.fixture
-def mock_session_service_complete(mocker, mock_agent_response_result):
+def mock_increment_session_usage_rpc(mocker, mock_agent_response_result):
     mock_increment_usage = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
         new_callable=AsyncMock,
@@ -81,8 +81,8 @@ COMPLETE_ACTION = CompleteAction(
     ],
 )
 async def test_complete_session(
-    mock_session_service_complete,
-    mock_agent_complete_session_rpc,
+    mock_increment_session_usage_rpc,
+    mock_complete_session_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[CompleteAction, CompleteActionResult],
 ):
@@ -97,5 +97,5 @@ async def test_complete_session(
     assert result.result == COMPLETE_SESSION_MOCK
 
     # Verify the mocks were called
-    mock_session_service_complete.assert_called_once()
-    mock_agent_complete_session_rpc.assert_called_once()
+    mock_increment_session_usage_rpc.assert_called_once()
+    mock_complete_session_rpc.assert_called_once()

--- a/tests/manager/services/session/actions/test_convert_session_to_image.py
+++ b/tests/manager/services/session/actions/test_convert_session_to_image.py
@@ -28,8 +28,7 @@ SESSION_FIXTURE_DICT = {**SESSION_FIXTURE_DICT, "group_id": GROUP_FIXTURE_DATA["
 
 
 @pytest.fixture
-def mock_agent_commit_session_rpc(mocker):
-    # Mock the commit_session agent RPC call
+def mock_commit_session_rpc(mocker):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.commit_session",
         new_callable=AsyncMock,
@@ -39,7 +38,7 @@ def mock_agent_commit_session_rpc(mocker):
 
 
 @pytest.fixture
-def mock_agent_push_image_rpc(mocker):
+def mock_push_image_rpc(mocker):
     # Mock the push_image agent RPC call
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.push_image",
@@ -68,8 +67,8 @@ PUSH_IMAGE_MOCK_TASK_ID = uuid4()
     ],
 )
 async def test_convert_session_to_image(
-    mock_agent_commit_session_rpc,
-    mock_agent_push_image_rpc,
+    mock_commit_session_rpc,
+    mock_push_image_rpc,
     processors: SessionProcessors,
     session_repository,
 ):
@@ -97,7 +96,3 @@ async def test_convert_session_to_image(
     assert result.session_data.id == SESSION_FIXTURE_DATA.id
     assert result.session_data.name == SESSION_FIXTURE_DATA.name
     assert result.session_data.access_key == SESSION_FIXTURE_DATA.access_key
-
-    # Verify the agent RPC calls were made correctly
-    # mock_agent_commit_session_rpc.assert_called_once()
-    # mock_agent_push_image_rpc.assert_called_once()

--- a/tests/manager/services/session/actions/test_download_files.py
+++ b/tests/manager/services/session/actions/test_download_files.py
@@ -19,7 +19,7 @@ from ..fixtures import (
 
 
 @pytest.fixture
-def mock_agent_download_files_rpc(mocker, mock_agent_response_result):
+def mock_download_file_rpc(mocker, mock_agent_response_result):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.download_file",
         new_callable=AsyncMock,
@@ -29,8 +29,7 @@ def mock_agent_download_files_rpc(mocker, mock_agent_response_result):
 
 
 @pytest.fixture
-def mock_session_service_download_files(mocker, mock_agent_response_result):
-    # Only mock the AgentRegistry increment_session_usage method
+def mock_increment_session_usage_rpc(mocker, mock_agent_response_result):
     mock_increment_usage = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
         new_callable=AsyncMock,
@@ -75,8 +74,8 @@ DOWNLOAD_FILES_ACTION = DownloadFilesAction(
     ],
 )
 async def test_download_files(
-    mock_session_service_download_files,
-    mock_agent_download_files_rpc,
+    mock_increment_session_usage_rpc,
+    mock_download_file_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[DownloadFilesAction, DownloadFilesActionResult],
 ):
@@ -90,5 +89,5 @@ async def test_download_files(
     assert result.result is not None  # MultipartWriter should be present
 
     # Verify the mocks were called correctly
-    mock_session_service_download_files.assert_called_once()
-    mock_agent_download_files_rpc.assert_called()
+    mock_increment_session_usage_rpc.assert_called_once()
+    mock_download_file_rpc.assert_called()

--- a/tests/manager/services/session/actions/test_execute_session.py
+++ b/tests/manager/services/session/actions/test_execute_session.py
@@ -33,8 +33,7 @@ def mock_agent_execute_rpc(mocker, mock_agent_response_result):
 
 
 @pytest.fixture
-def mock_increment_session_usage(mocker):
-    """Mock AgentRegistry increment_session_usage method"""
+def mock_increment_session_usage_rpc(mocker):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
         new_callable=AsyncMock,
@@ -130,7 +129,7 @@ EXECUTE_SESSION_ERROR_MOCK = {"result": EXECUTE_SESSION_ERROR_RESULT}
 )
 async def test_execute_session(
     mock_agent_execute_rpc,
-    mock_increment_session_usage,
+    mock_increment_session_usage_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[ExecuteSessionAction, ExecuteSessionActionResult],
     session_repository,

--- a/tests/manager/services/session/actions/test_get_abusing_report.py
+++ b/tests/manager/services/session/actions/test_get_abusing_report.py
@@ -20,7 +20,7 @@ from ..fixtures import (
 
 
 @pytest.fixture
-def mock_agent_get_abusing_report_rpc(mocker, mock_agent_response_result):
+def mock_get_abusing_report_rpc(mocker, mock_agent_response_result):
     mock = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.get_abusing_report",
         new_callable=AsyncMock,
@@ -61,7 +61,7 @@ AGENT_GET_ABUSING_REPORT_RPC_RESP = AbuseReport(kernel=str(KERNEL_FIXTURE_DATA.i
     ],
 )
 async def test_get_abusing_report(
-    mock_agent_get_abusing_report_rpc,
+    mock_get_abusing_report_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[GetAbusingReportAction, GetAbusingReportActionResult],
 ):

--- a/tests/manager/services/session/actions/test_restart_session.py
+++ b/tests/manager/services/session/actions/test_restart_session.py
@@ -21,11 +21,17 @@ from ..fixtures import (
 @pytest.fixture
 def mock_restart_session_rpc(mocker, mock_agent_response_result):
     mocker.patch(
-        "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
+        "ai.backend.manager.registry.AgentRegistry.restart_session",
         new_callable=AsyncMock,
     )
+
+    return mock_agent_response_result
+
+
+@pytest.fixture
+def mock_increment_session_usage_rpc(mocker, mock_agent_response_result):
     mocker.patch(
-        "ai.backend.manager.registry.AgentRegistry.restart_session",
+        "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
         new_callable=AsyncMock,
     )
 
@@ -65,6 +71,7 @@ RESTART_SESSION_MOCK = None
 )
 async def test_restart_session(
     mock_restart_session_rpc,
+    mock_increment_session_usage_rpc,
     processors: SessionProcessors,
     test_scenario: TestScenario[RestartSessionAction, RestartSessionActionResult],
 ):

--- a/tests/manager/services/session/actions/test_upload_files.py
+++ b/tests/manager/services/session/actions/test_upload_files.py
@@ -20,8 +20,7 @@ from ..fixtures import (
 
 
 @pytest.fixture
-def mock_upload_files_rpc(mocker):
-    """Mock agent RPC calls for upload_files operation"""
+def mock_upload_file_rpc(mocker):
     # Mock increment_session_usage
     mock_increment_usage = mocker.patch(
         "ai.backend.manager.registry.AgentRegistry.increment_session_usage",
@@ -115,7 +114,7 @@ UPLOAD_FILES_MOCK = {"uploaded": True, "files": ["test_file1.txt", "test_file2.t
     ],
 )
 async def test_upload_files(
-    mock_upload_files_rpc,
+    mock_upload_file_rpc,
     mock_simple_file_reader,
     processors: SessionProcessors,
     test_scenario: TestScenario[UploadFilesAction, UploadFilesActionResult],
@@ -138,5 +137,5 @@ async def test_upload_files(
     assert result.session_data.access_key == SESSION_FIXTURE_DATA.access_key
 
     # Verify that agent RPC calls were made
-    mock_upload_files_rpc["increment_usage"].assert_called_once()
-    mock_upload_files_rpc["upload_file"].assert_called_once()
+    mock_upload_file_rpc["increment_usage"].assert_called_once()
+    mock_upload_file_rpc["upload_file"].assert_called_once()


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
