### PR TITLE
chore: Add pyroscope and tempo data directories to setup

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -863,6 +863,8 @@ setup_environment() {
   mkdir -p "${HALFSTACK_VOLUME_PATH}/etcd-data"
   mkdir -p "${HALFSTACK_VOLUME_PATH}/redis-data"
   mkdir -p -m 757 "${HALFSTACK_VOLUME_PATH}/grafana-data"
+  mkdir -p "${HALFSTACK_VOLUME_PATH}/pyroscope-data"
+  mkdir -p "${HALFSTACK_VOLUME_PATH}/tempo-data"
 
   $docker_sudo docker compose -f "docker-compose.halfstack.current.yml" pull
 


### PR DESCRIPTION
The setup_environment function now creates directories for pyroscope-data and tempo-data under HALFSTACK_VOLUME_PATH to support new services or data storage requirements.

