### PR TITLE
fix(BA-1976): Make AsyncEtcd an explicit async context manager

### DIFF
--- a/src/ai/backend/cli/__main__.py
+++ b/src/ai/backend/cli/__main__.py
@@ -1,5 +1,4 @@
 import shutil
-import time
 
 from .loader import load_entry_points
 
@@ -8,8 +7,4 @@ main = load_entry_points()
 
 if __name__ == "__main__":
     # Execute right away if the module is directly called from CLI.
-    try:
-        main(max_content_width=shutil.get_terminal_size().columns - 2)
-    finally:
-        # Workaround for tokio/pyo3-async-runtimes shutdown race (BA-1976)
-        time.sleep(0.1)
+    main(max_content_width=shutil.get_terminal_size().columns - 2)

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -78,17 +78,16 @@ async def etcd(etcd_container, test_ns):  # noqa: F811
             ConfigScopes.NODE: "node/i-test",
         },
     )
-    try:
-        await etcd.delete_prefix("", scope=ConfigScopes.GLOBAL)
-        await etcd.delete_prefix("", scope=ConfigScopes.SGROUP)
-        await etcd.delete_prefix("", scope=ConfigScopes.NODE)
-        yield etcd
-    finally:
-        await etcd.delete_prefix("", scope=ConfigScopes.GLOBAL)
-        await etcd.delete_prefix("", scope=ConfigScopes.SGROUP)
-        await etcd.delete_prefix("", scope=ConfigScopes.NODE)
-        await etcd.close()
-        del etcd
+    async with etcd:
+        try:
+            await etcd.delete_prefix("", scope=ConfigScopes.GLOBAL)
+            await etcd.delete_prefix("", scope=ConfigScopes.SGROUP)
+            await etcd.delete_prefix("", scope=ConfigScopes.NODE)
+            yield etcd
+        finally:
+            await etcd.delete_prefix("", scope=ConfigScopes.GLOBAL)
+            await etcd.delete_prefix("", scope=ConfigScopes.SGROUP)
+            await etcd.delete_prefix("", scope=ConfigScopes.NODE)
 
 
 @pytest.fixture


### PR DESCRIPTION
resolves #xxx (BA-1976)

But.. this still does not resolve the issue. T_T

See also: lablup/etcd-client-py#14

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
