### PR TITLE
fix(BA-1999): Handle None user when request context setup in auth middleware

### DIFF
--- a/changes/5327.fix.md
+++ b/changes/5327.fix.md
@@ -1,0 +1,1 @@
+Handle None user when request context setup in auth middleware

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -553,11 +553,11 @@ async def auth_middleware(request: web.Request, handler) -> web.StreamResponse:
                         )
                     )
                 )
-            stack.enter_context(
-                with_log_context_fields({
-                    "user_id": str(user_id),
-                })
-            )
+                stack.enter_context(
+                    with_log_context_fields({
+                        "user_id": str(user_id),
+                    })
+                )
         # No matter if authenticated or not, pass-through to the handler.
         # (if it's required, `auth_required` decorator will handle the situation.)
         return await handler(request)

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -538,20 +538,21 @@ async def auth_middleware(request: web.Request, handler) -> web.StreamResponse:
         request.update(auth_result)
 
     with ExitStack() as stack:
-        user_id = request.get("user", {}).get("uuid")
-        if user_id is not None:
-            stack.enter_context(
-                with_user(
-                    UserData(
-                        user_id=user_id,
-                        is_authorized=request.get("is_authorized", False),
-                        is_admin=request.get("is_admin", False),
-                        is_superadmin=request.get("is_superadmin", False),
-                        role=request["user"]["role"],
-                        domain_name=request["user"]["domain_name"],
+        if user := request.get("user"):
+            user_id = user.get("uuid")
+            if user_id is not None:
+                stack.enter_context(
+                    with_user(
+                        UserData(
+                            user_id=user_id,
+                            is_authorized=request.get("is_authorized", False),
+                            is_admin=request.get("is_admin", False),
+                            is_superadmin=request.get("is_superadmin", False),
+                            role=request["user"]["role"],
+                            domain_name=request["user"]["domain_name"],
+                        )
                     )
                 )
-            )
             stack.enter_context(
                 with_log_context_fields({
                     "user_id": str(user_id),


### PR DESCRIPTION
resolves #5323 (BA-1999)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
