### PR TITLE
fix(BA-2008): Add missing db transaction retry when setting network ID of new sessions

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Add missing database transaction retry logic when setting network ID of new sessions


### PR DESCRIPTION
resolves #5328 (BA-2008)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
