### PR TITLE
fix(BA-2008): Add missing db transaction retry when setting network ID of new sessions (#5329)

### DIFF
--- a/changes/5329.fix.md
+++ b/changes/5329.fix.md
@@ -1,0 +1,1 @@
+Add missing database transaction retry logic when setting network ID of new sessions

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1666,7 +1666,8 @@ class AgentRegistry:
         log.debug("ssh connection info mapping: {}", cluster_ssh_port_mapping)
 
         if scheduled_session.network_type == NetworkType.VOLATILE:
-            async with self.db.begin_session() as db_sess:
+
+            async def _update_network_id(db_sess: AsyncSession) -> None:
                 query = (
                     sa.update(SessionRow)
                     .values({
@@ -1675,6 +1676,9 @@ class AgentRegistry:
                     .where(SessionRow.id == scheduled_session.id)
                 )
                 await db_sess.execute(query)
+
+            async with self.db.connect() as db_conn:
+                await execute_with_txn_retry(_update_network_id, self.db.begin_session, db_conn)
 
         keyfunc = lambda binding: binding.kernel.cluster_role
         replicas = {


### PR DESCRIPTION
This is an auto-generated backport PR of #5329 to the 25.6 release.