### PR TITLE
fix(BA-2008): Add missing db transaction retry when setting network ID of new sessions (#5329)

### DIFF
--- a/changes/5329.fix.md
+++ b/changes/5329.fix.md
@@ -1,0 +1,1 @@
+Add missing database transaction retry logic when setting network ID of new sessions


### PR DESCRIPTION
This is an auto-generated backport PR of #5329 to the 24.09 release.