### PR TITLE
fix(BA-2037): Add validation alias for `pkg_ns` in logging config

### DIFF
--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ByteSize,
     ConfigDict,
@@ -402,6 +403,7 @@ class LoggingConfig(BaseSchema):
         Field(
             description="Override default log level for specific scope of package",
             default=default_pkg_ns,
+            validation_alias=AliasChoices("pkg_ns", "pkg-ns"),
         ),
     ]
     drivers: Annotated[

--- a/src/ai/backend/logging/config_pydantic.py
+++ b/src/ai/backend/logging/config_pydantic.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Optional
 
-from pydantic import ByteSize, Field
+from pydantic import AliasChoices, ByteSize, Field
 
 from ai.backend.common.config import BaseConfigModel
 
@@ -123,4 +123,5 @@ class LoggingConfig(BaseConfigModel):
     pkg_ns: dict[str, LogLevel] = Field(
         description="Override default log level for specific scope of package",
         default=default_pkg_ns,
+        validation_alias=AliasChoices("pkg_ns", "pkg-ns"),
     )


### PR DESCRIPTION
resolves #5364 (BA-2037)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
