### PR TITLE
fix: Make log-level/debug flag handling consistent in all components

### DIFF
--- a/changes/5366.fix.md
+++ b/changes/5366.fix.md
@@ -1,0 +1,1 @@
+Make `--log-level` and `--debug` flag behavior and description consistent across all `start-server` commands

--- a/src/ai/backend/account_manager/cli/context.py
+++ b/src/ai/backend/account_manager/cli/context.py
@@ -3,7 +3,7 @@ from typing import Self
 
 import click
 
-from ai.backend.logging import AbstractLogger, LocalLogger
+from ai.backend.logging import AbstractLogger, LocalLogger, LogLevel
 
 from ..config import ServerConfig
 from ..config import load as load_config
@@ -13,7 +13,7 @@ class CLIContext:
     _local_config: ServerConfig | None
     _logger: AbstractLogger
 
-    def __init__(self, config_path: Path, log_level: str) -> None:
+    def __init__(self, config_path: Path, log_level: LogLevel) -> None:
         self.config_path = config_path
         self.log_level = log_level
         self._local_config = None

--- a/src/ai/backend/account_manager/config.py
+++ b/src/ai/backend/account_manager/config.py
@@ -23,6 +23,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticUndefined, core_schema
 
 from ai.backend.common import config
+from ai.backend.logging import LogLevel
 
 from .types import EventLoopType
 from .utils import config_key_to_snake_case
@@ -397,14 +398,14 @@ class ServerConfig(BaseSchema):
     # logging
 
 
-def load(config_path: Path | None = None, log_level: str = "INFO") -> ServerConfig:
+def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET) -> ServerConfig:
     # Determine where to read configuration.
     raw_cfg, _ = config.read_from_file(config_path, "account-manager")
 
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level.upper())
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogLevel.DEBUG)
+    if log_level != LogLevel.NOTSET:
+        config.override_key(raw_cfg, ("logging", "level"), log_level)
+        config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/account_manager/server.py
+++ b/src/ai/backend/account_manager/server.py
@@ -415,24 +415,25 @@ async def server_main_logwrapper(
 @click.option(
     "--debug",
     is_flag=True,
-    help="This option will soon change to --log-level TEXT option.",
+    help="A shortcut to set `--log-level=DEBUG`",
 )
 @click.option(
     "--log-level",
     type=click.Choice([*LogLevel], case_sensitive=False),
-    default=LogLevel.INFO,
+    default=LogLevel.NOTSET,
     help="Set the logging verbosity level",
 )
 @click.pass_context
 def main(
     ctx: click.Context,
-    config_path: Path,
+    config_path: Optional[Path],
+    debug: bool,
     log_level: LogLevel,
-    debug: bool = False,
 ) -> None:
     """
     Start the account-manager service as a foreground process.
     """
+    log_level = LogLevel.DEBUG if debug else log_level
     cfg = load_config(config_path, log_level)
 
     if ctx.invoked_subcommand is None:

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -1430,7 +1430,7 @@ async def server_main(
 @click.option(
     "--debug",
     is_flag=True,
-    help="Set the logging level to DEBUG",
+    help="A shortcut to set `--log-level=DEBUG`",
 )
 @click.option(
     "--log-level",

--- a/src/ai/backend/appproxy/coordinator/cli/context.py
+++ b/src/ai/backend/appproxy/coordinator/cli/context.py
@@ -4,7 +4,7 @@ from typing import Optional, Self
 import click
 
 from ai.backend.common.config import find_config_file
-from ai.backend.logging import AbstractLogger, LocalLogger
+from ai.backend.logging import AbstractLogger, LocalLogger, LogLevel
 
 from ..config import ServerConfig
 from ..config import load as load_config
@@ -14,7 +14,7 @@ class CLIContext:
     _local_config: ServerConfig | None
     _logger: AbstractLogger
 
-    def __init__(self, config_path: Optional[Path], log_level: str) -> None:
+    def __init__(self, config_path: Optional[Path], log_level: LogLevel) -> None:
         self.config_path = config_path
         self.log_level = log_level
         self._local_config = None

--- a/src/ai/backend/appproxy/coordinator/config.py
+++ b/src/ai/backend/appproxy/coordinator/config.py
@@ -25,6 +25,7 @@ from ai.backend.appproxy.common.exceptions import ConfigValidationError
 from ai.backend.appproxy.common.types import EventLoopType
 from ai.backend.common import config
 from ai.backend.common.types import ServiceDiscoveryType
+from ai.backend.logging import LogLevel
 
 _file_perm = (Path(__file__).parent / "server.py").stat()
 
@@ -303,14 +304,13 @@ class ServerConfig(BaseSchema):
     ]
 
 
-def load(config_path: Path | None = None, log_level: str = "INFO") -> ServerConfig:
+def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET) -> ServerConfig:
     # Determine where to read configuration.
     raw_cfg, _ = config.read_from_file(config_path, "app-proxy-coordinator")
 
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level.upper())
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogLevel.DEBUG)
+    if log_level != LogLevel.NOTSET:
+        config.override_key(raw_cfg, ("logging", "pkg_ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/appproxy/coordinator/config.py
+++ b/src/ai/backend/appproxy/coordinator/config.py
@@ -310,7 +310,8 @@ def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET)
 
     config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogLevel.DEBUG)
     if log_level != LogLevel.NOTSET:
-        config.override_key(raw_cfg, ("logging", "pkg_ns", "ai.backend"), log_level)
+        config.override_key(raw_cfg, ("logging", "level"), log_level)
+        config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -1006,16 +1006,22 @@ async def server_main_logwrapper(
     ),
 )
 @click.option(
+    "--debug",
+    is_flag=True,
+    help="A shortcut to set `--log-level=DEBUG`",
+)
+@click.option(
     "--log-level",
-    type=click.Choice([*LogLevel.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogLevel], case_sensitive=False),
+    default=LogLevel.NOTSET,
     help="Set the logging verbosity level",
 )
 @click.pass_context
-def main(ctx: click.Context, config_path: Path, log_level: str) -> None:
+def main(ctx: click.Context, config_path: Path, debug: bool, log_level: LogLevel) -> None:
     """
     Start the proxy-coordinator service as a foreground process.
     """
+    log_level = LogLevel.DEBUG if debug else log_level
     cfg = load_config(config_path, log_level)
 
     if ctx.invoked_subcommand is None:

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -387,7 +387,8 @@ def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET)
 
     config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogLevel.DEBUG)
     if log_level != LogLevel.NOTSET:
-        config.override_key(raw_cfg, ("logging", "pkg_ns", "ai.backend"), log_level)
+        config.override_key(raw_cfg, ("logging", "level"), log_level)
+        config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -12,6 +12,7 @@ from pydantic import AnyUrl, Field, FilePath, ValidationError
 from ai.backend.appproxy.common.exceptions import ConfigValidationError
 from ai.backend.common import config
 from ai.backend.common.types import ServiceDiscoveryType
+from ai.backend.logging import LogLevel
 
 from ..common.config import (
     BaseSchema,
@@ -380,14 +381,13 @@ class ServerConfig(BaseSchema):
     ]
 
 
-def load(config_path: Path | None = None, log_level: str = "INFO") -> ServerConfig:
+def load(config_path: Path | None = None, log_level: LogLevel = LogLevel.NOTSET) -> ServerConfig:
     # Determine where to read configuration.
     raw_cfg, _ = config.read_from_file(config_path, "app-proxy-worker")
 
-    config.override_key(raw_cfg, ("debug", "enabled"), log_level == "DEBUG")
-    config.override_key(raw_cfg, ("logging", "level"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level.upper())
-    config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level.upper())
+    config.override_key(raw_cfg, ("debug", "enabled"), log_level == LogLevel.DEBUG)
+    if log_level != LogLevel.NOTSET:
+        config.override_key(raw_cfg, ("logging", "pkg_ns", "ai.backend"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)

--- a/src/ai/backend/appproxy/worker/server.py
+++ b/src/ai/backend/appproxy/worker/server.py
@@ -887,16 +887,22 @@ async def server_main_logwrapper(
     ),
 )
 @click.option(
+    "--debug",
+    is_flag=True,
+    help="A shortcut to set `--log-level=DEBUG`",
+)
+@click.option(
     "--log-level",
-    type=click.Choice([*LogLevel.__members__.keys()], case_sensitive=False),
-    default="INFO",
+    type=click.Choice([*LogLevel], case_sensitive=False),
+    default=LogLevel.NOTSET,
     help="Set the logging verbosity level",
 )
 @click.pass_context
-def main(ctx: click.Context, config_path: Path, log_level: str) -> None:
+def main(ctx: click.Context, config_path: Path, debug: bool, log_level: LogLevel) -> None:
     """
     Start the proxy-worker service as a foreground process.
     """
+    log_level = LogLevel.DEBUG if debug else log_level
     cfg = load_config(config_path, log_level)
 
     if ctx.invoked_subcommand is None:

--- a/src/ai/backend/logging/config_pydantic.py
+++ b/src/ai/backend/logging/config_pydantic.py
@@ -10,9 +10,8 @@ from .types import LogFormat, LogLevel
 
 default_pkg_ns = {
     "": LogLevel.WARNING,
-    "ai.backend": LogLevel.DEBUG,
+    "ai.backend": LogLevel.INFO,
     "tests": LogLevel.DEBUG,
-    "aiohttp": LogLevel.INFO,
 }
 
 

--- a/src/ai/backend/manager/config/bootstrap.py
+++ b/src/ai/backend/manager/config/bootstrap.py
@@ -90,7 +90,6 @@ class BootstrapConfig(BaseModel):
             overrides += [
                 (("logging", "level"), log_level),
                 (("logging", "pkg-ns", "ai.backend"), log_level),
-                (("logging", "pkg-ns", "aiohttp"), log_level),
             ]
 
         file_loader = TomlConfigLoader(config_path, "manager")

--- a/src/ai/backend/manager/config_legacy.py
+++ b/src/ai/backend/manager/config_legacy.py
@@ -451,7 +451,6 @@ def load(
     if log_level != LogLevel.NOTSET:
         config.override_key(raw_cfg, ("logging", "level"), log_level)
         config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
-        config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-compatible)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -1436,7 +1436,7 @@ async def server_main_logwrapper(
 @click.option(
     "--debug",
     is_flag=True,
-    help="This option will soon change to --log-level TEXT option.",
+    help="A shortcut to set `--log-level=DEBUG`",
 )
 @click.option(
     "--log-level",

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -462,7 +462,6 @@ async def config_provider_ctx(
         overrides += [
             (("logging", "level"), log_level),
             (("logging", "pkg-ns", "ai.backend"), log_level),
-            (("logging", "pkg-ns", "aiohttp"), log_level),
         ]
 
     loaders.append(ConfigOverrider(overrides))
@@ -1447,9 +1446,9 @@ async def server_main_logwrapper(
 @click.pass_context
 def main(
     ctx: click.Context,
+    config_path: Optional[Path],
+    debug: bool,
     log_level: LogLevel,
-    config_path: Optional[Path] = None,
-    debug: bool = False,
 ) -> None:
     """
     Start the manager service as a foreground process.

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -384,7 +384,7 @@ async def _make_message_queue(
 @click.option(
     "--debug",
     is_flag=True,
-    help="Set the logging level to DEBUG",
+    help="A shortcut to set `--log-level=DEBUG`",
 )
 @click.option(
     "--log-level",

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -871,7 +871,7 @@ async def server_main(
     "--debug",
     is_flag=True,
     default=False,
-    help="Set the logging level to DEBUG",
+    help="A shortcut to set `--log-level=DEBUG`",
 )
 @click.option(
     "--log-level",

--- a/src/ai/backend/wsproxy/config.py
+++ b/src/ai/backend/wsproxy/config.py
@@ -299,7 +299,6 @@ def load(config_path: Optional[Path] = None, log_level: LogLevel = LogLevel.NOTS
     if log_level != LogLevel.NOTSET:
         config.override_key(raw_cfg, ("logging", "level"), log_level)
         config.override_key(raw_cfg, ("logging", "pkg-ns", "ai.backend"), log_level)
-        config.override_key(raw_cfg, ("logging", "pkg-ns", "aiohttp"), log_level)
 
     # Validate and fill configurations
     # (allow_extra will make configs to be forward-copmatible)


### PR DESCRIPTION
Make `--log-level` and `--debug` flag behavior and description consistent across all daemon services.

Now the log-level CLI option ONLY overrides:
- the global log-level filter (`[logging].level` in toml files)
- the log-level of "ai.backend" namespace (`[logging.pkg-ns]` in toml files)

The default `[logging.pkg-ns]` is also unified to:
```
[logging.pkg-ns]
"" = "WARNING"
"ai.backend" = "INFO"
"tests" = "DEBUG"
```

> [!NOTE]
> If you have relied on the previous behavior that synchronizes the log-level of `aiohttp` with `ai.backend`, you need to specify the aiohttp log-level explicitly:
> ```
> [logging.pkg-ns]
> ...
> "aiohttp" = "INFO"  # aiohttp access logs are INFO level.
> ```