### PR TITLE
feat(BA-2040): Add serialization alias for `pkg_ns` in logging config

### DIFF
--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -404,6 +404,7 @@ class LoggingConfig(BaseSchema):
             description="Override default log level for specific scope of package",
             default=default_pkg_ns,
             validation_alias=AliasChoices("pkg_ns", "pkg-ns"),
+            serialization_alias="pkg-ns",
         ),
     ]
     drivers: Annotated[

--- a/src/ai/backend/logging/config_pydantic.py
+++ b/src/ai/backend/logging/config_pydantic.py
@@ -124,4 +124,5 @@ class LoggingConfig(BaseConfigModel):
         description="Override default log level for specific scope of package",
         default=default_pkg_ns,
         validation_alias=AliasChoices("pkg_ns", "pkg-ns"),
+        serialization_alias="pkg-ns",
     )


### PR DESCRIPTION
resolves #5369 (BA-2040)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
