### PR TITLE
fix: Nested app-proxy pkgs missing in the entrypoint glob

### DIFF
--- a/src/ai/backend/plugin/entrypoint.py
+++ b/src/ai/backend/plugin/entrypoint.py
@@ -85,11 +85,11 @@ _optimized_glob_search_patterns = {
     # These patterns only apply to scanning BUILD files in dev setups and pex distributions.
     # They do not affect standard package entrypoint searches.
     # NOTE: most entrypoint declaration in BUILD files are in the package's top-level only!
-    "backendai_cli_v10": ["ai/backend/*"],
+    "backendai_cli_v10": ["ai/backend/*", "ai/backend/appproxy/*"],
     "backendai_network_manager_v1": ["ai/backend/*"],
-    "backendai_event_dispatcher_v20": ["ai/backend/*"],
-    "backendai_stats_monitor_v20": ["ai/backend/*"],
-    "backendai_error_monitor_v20": ["ai/backend/*"],
+    "backendai_event_dispatcher_v20": ["ai/backend/*", "ai/backend/appproxy/*"],
+    "backendai_stats_monitor_v20": ["ai/backend/*", "ai/backend/appproxy/*"],
+    "backendai_error_monitor_v20": ["ai/backend/*", "ai/backend/appproxy/*"],
     "backendai_hook_v20": ["ai/backend/*"],
     "backendai_webapp_v20": ["ai/backend/*"],
     "backendai_scheduler_v10": ["ai/backend/manager"],


### PR DESCRIPTION
Follow-up fix to #5377 and #5379
