### PR TITLE
deps: Update all-smi binaries to v0.6.3

### DIFF
--- a/changes/.deps.md
+++ b/changes/.deps.md
@@ -1,0 +1,1 @@
+Update all-smi binaries to v0.6.3

--- a/src/ai/backend/runner/all-smi.aarch64.bin
+++ b/src/ai/backend/runner/all-smi.aarch64.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc9fa6f48d45d4dc66543339f94ec7ce5f76133efd61b71a0961de13f0032623
-size 17193160
+oid sha256:692cbf969d07698f61cda379b10f614072fb7a5d9e35b480f16efbbb6fb9276f
+size 17128288

--- a/src/ai/backend/runner/all-smi.x86_64.bin
+++ b/src/ai/backend/runner/all-smi.x86_64.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06d8276650220b1d6dddb65c3a720552be4117c9b9cf7e5c4e45c59b97980a84
-size 18668344
+oid sha256:55fe8cc2e98cf92c0b9d1f197cf32ffedde453e10653fdfd40d4b9020e135713
+size 18573936


### PR DESCRIPTION
This PR updates the all-smi binaries (musl variant) for both aarch64 and x86_64 architectures to version v0.6.3.

Source: https://github.com/inureyes/all-smi/releases/tag/v0.6.3

This update was triggered by:
- Event: workflow_dispatch
- Manual workflow dispatch