### PR TITLE
fix(BA-2043): Image rescan exception handling where the image config is `None` (#5394)

### DIFF
--- a/changes/5394.fix.md
+++ b/changes/5394.fix.md
@@ -1,0 +1,1 @@
+Add Docker image rescan exception handling logic when the image config is `None`

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1566,10 +1566,11 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                         continue
 
                     img_detail = await docker.images.inspect(repo_tag)
-                    labels = img_detail.get("Config", {}).get("Labels")
+                    labels = (img_detail.get("Config") or {}).get("Labels")
                     if labels is None:
                         continue
-                    kernelspec = int(labels.get("ai.backend.kernelspec", "1"))
+
+                    kernelspec = int(labels.get(LabelName.KERNEL_SPEC, "1"))
                     if MIN_KERNELSPEC <= kernelspec <= MAX_KERNELSPEC:
                         scanned_images[repo_tag] = img_detail["Id"]
             for added_image in scanned_images.keys() - self.images.keys():

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1570,7 +1570,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     if labels is None:
                         continue
 
-                    kernelspec = int(labels.get(LabelName.KERNEL_SPEC, "1"))
+                    kernelspec = int(labels.get("ai.backend.kernelspec", "1"))
                     if MIN_KERNELSPEC <= kernelspec <= MAX_KERNELSPEC:
                         scanned_images[repo_tag] = img_detail["Id"]
             for added_image in scanned_images.keys() - self.images.keys():

--- a/src/ai/backend/manager/container_registry/base.py
+++ b/src/ai/backend/manager/container_registry/base.py
@@ -431,9 +431,9 @@ class BaseContainerRegistry(metaclass=ABCMeta):
 
         # we should favor `config` instead of `container_config` since `config` can contain additional datas
         # set when commiting image via `--change` flag
-        if _config_labels := data.get("config", {}).get("Labels"):
+        if _config_labels := (data.get("config") or {}).get("Labels"):
             labels = _config_labels
-        elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+        elif _container_config_labels := (data.get("container_config") or {}).get("Labels"):
             labels = _container_config_labels
 
         return {
@@ -493,9 +493,9 @@ class BaseContainerRegistry(metaclass=ABCMeta):
                 config_data = await read_json(resp)
 
         labels = {}
-        if _config_labels := config_data.get("config", {}).get("Labels"):
+        if _config_labels := (config_data.get("config") or {}).get("Labels"):
             labels = _config_labels
-        elif _container_config_labels := config_data.get("container_config", {}).get("Labels"):
+        elif _container_config_labels := (config_data.get("container_config") or {}).get("Labels"):
             labels = _container_config_labels
 
         if not labels:

--- a/src/ai/backend/manager/container_registry/harbor.py
+++ b/src/ai/backend/manager/container_registry/harbor.py
@@ -113,9 +113,11 @@ class HarborRegistry_v1(BaseContainerRegistry):
 
                     # we should favor `config` instead of `container_config` since `config` can contain additional datas
                     # set when commiting image via `--change` flag
-                    if _config_labels := data.get("config", {}).get("Labels"):
+                    if _config_labels := (data.get("config") or {}).get("Labels"):
                         labels = _config_labels
-                    elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+                    elif _container_config_labels := (data.get("container_config") or {}).get(
+                        "Labels"
+                    ):
                         labels = _container_config_labels
 
                     if not labels:
@@ -440,9 +442,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
                 config_data = await read_json(resp)
 
         labels = {}
-        if _config_labels := config_data.get("config", {}).get("Labels"):
+        if _config_labels := (config_data.get("config") or {}).get("Labels"):
             labels = _config_labels
-        elif _container_config_labels := config_data.get("container_config", {}).get("Labels"):
+        elif _container_config_labels := (config_data.get("container_config") or {}).get("Labels"):
             labels = _container_config_labels
 
         if not labels:
@@ -569,9 +571,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
                 resp.raise_for_status()
                 data = await read_json(resp)
             labels = {}
-            if _config_labels := data.get("config", {}).get("Labels"):
+            if _config_labels := (data.get("config") or {}).get("Labels"):
                 labels = _config_labels
-            elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+            elif _container_config_labels := (data.get("container_config") or {}).get("Labels"):
                 labels = _container_config_labels
 
             if not labels:
@@ -622,9 +624,9 @@ class HarborRegistry_v2(BaseContainerRegistry):
                 resp.raise_for_status()
                 data = await read_json(resp)
             labels = {}
-            if _config_labels := data.get("config", {}).get("Labels"):
+            if _config_labels := (data.get("config") or {}).get("Labels"):
                 labels = _config_labels
-            elif _container_config_labels := data.get("container_config", {}).get("Labels"):
+            elif _container_config_labels := (data.get("container_config") or {}).get("Labels"):
                 labels = _container_config_labels
 
             if not labels:


### PR DESCRIPTION
This is an auto-generated backport PR of #5394 to the 25.6 release.