### PR TITLE
feat(BA-2066): Add TTL support to Redis key operations in AppProxy

### DIFF
--- a/changes/5416.feature.md
+++ b/changes/5416.feature.md
@@ -1,0 +1,1 @@
+Add TTL support to Redis key operations in AppProxy

--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -497,12 +497,9 @@ def generate_example_json(
         raise UnsupportedTypeError(str(schema))
 
 
-DEFAULT_REDIS_TTL_SECONDS = 2 * 24 * 60 * 60  # 2 days in seconds
-
-
 def get_default_redis_key_ttl() -> int:
     """
     Returns the default TTL for Redis keys.
     This is used to set the expiration time for keys in Redis.
     """
-    return DEFAULT_REDIS_TTL_SECONDS
+    return 2 * 24 * 60 * 60  # 2 days in seconds

--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -495,3 +495,11 @@ def generate_example_json(
         return res
     else:
         raise UnsupportedTypeError(str(schema))
+
+
+def get_default_redis_key_ttl() -> int:
+    """
+    Returns the default TTL for Redis keys.
+    This is used to set the expiration time for keys in Redis.
+    """
+    return 172800  # 2 days in seconds

--- a/src/ai/backend/appproxy/common/config.py
+++ b/src/ai/backend/appproxy/common/config.py
@@ -497,9 +497,12 @@ def generate_example_json(
         raise UnsupportedTypeError(str(schema))
 
 
+DEFAULT_REDIS_TTL_SECONDS = 2 * 24 * 60 * 60  # 2 days in seconds
+
+
 def get_default_redis_key_ttl() -> int:
     """
     Returns the default TTL for Redis keys.
     This is used to set the expiration time for keys in Redis.
     """
-    return 172800  # 2 days in seconds
+    return DEFAULT_REDIS_TTL_SECONDS

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -14,6 +14,7 @@ from aiohttp import web
 from dateutil.tz import tzutc
 from pydantic import BaseModel, Field
 
+from ai.backend.appproxy.common.config import get_default_redis_key_ttl
 from ai.backend.appproxy.common.events import DoCheckWorkerLostEvent, WorkerLostEvent
 from ai.backend.appproxy.common.exceptions import ObjectNotFound
 from ai.backend.appproxy.common.logging_utils import BraceStyleAdapter
@@ -43,6 +44,8 @@ from .types import CircuitListResponseModel, SlotModel, StubResponseModel
 from .utils import auth_required
 
 if TYPE_CHECKING:
+    from redis.asyncio import Redis
+    from redis.asyncio.client import Pipeline
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))  # type: ignore[name-defined]
@@ -295,10 +298,18 @@ async def heartbeat_worker(request: web.Request) -> PydanticResponse[WorkerRespo
         result["slots"] = [
             SlotModel(**dataclasses.asdict(s)) for s in (await worker.list_slots(sess))
         ]
+
         # Update "last seen" timestamp for liveness tracking
+        def _hset_with_expiration(r: Redis) -> Pipeline:
+            pipe = r.pipeline(transaction=False)
+            pipe.hset("proxy-worker.last_seen", worker.authority, now.timestamp())
+            ttl = get_default_redis_key_ttl()
+            pipe.expire("proxy-worker.last_seen", ttl)
+            return pipe
+
         await redis_helper.execute(
             root_ctx.redis_live,
-            lambda r: r.hset("proxy-worker.last_seen", worker.authority, now.timestamp()),
+            _hset_with_expiration,
         )
         return result
 

--- a/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
@@ -132,7 +132,7 @@ class AbstractTraefikFrontend(Generic[TCircuitKey], AbstractFrontend[TraefikBack
                 self.redis_keys = {}
 
             async def mset_then_set_expiry(r: Redis) -> Pipeline:
-                pipe = r.pipeline()
+                pipe = r.pipeline(transaction=False)
                 ttl = get_default_redis_key_ttl()
                 pipe.mset(cast(MSetType, keys))
                 for key in keys:

--- a/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
@@ -132,11 +132,11 @@ class AbstractTraefikFrontend(Generic[TCircuitKey], AbstractFrontend[TraefikBack
 
             ttl = get_default_redis_key_ttl()
 
-            async def _batch_set_expiry(r: Redis) -> None:
+            async def _set_keys_with_expiry(r: Redis) -> None:
                 for k, v in keys.items():
                     await r.set(k, v, ex=ttl)
 
-            await redis_helper.execute(self.root_context.redis_live, _batch_set_expiry)
+            await redis_helper.execute(self.root_context.redis_live, _set_keys_with_expiry)
 
             log.debug("Wrote {} keys", len(keys))
         except Exception:


### PR DESCRIPTION
resolves #5410 (BA-2066)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
