### PR TITLE
chore: Add dev environment start/stop scripts

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -4,9 +4,6 @@ tmux new-session -d -s backendai-manager-dev \
 tmux new-session -d -s backendai-agent-dev \
     "./backend.ai ag start-server --debug"
 
-tmux new-session -d -s backendai-storage-proxy-dev \
-    "./backend.ai storage-proxy start-server --debug"
-
 tmux new-session -d -s backendai-storage-dev \
     "./backend.ai storage start-server --debug"
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,23 @@
+tmux new-session -d -s backendai-manager-dev \
+    "./backend.ai mgr start-server --debug"
+
+tmux new-session -d -s backendai-agent-dev \
+    "./backend.ai ag start-server --debug"
+
+tmux new-session -d -s backendai-storage-proxy-dev \
+    "./backend.ai storage-proxy start-server --debug"
+
+tmux new-session -d -s backendai-storage-dev \
+    "./backend.ai storage start-server --debug"
+
+tmux new-session -d -s backendai-webserver-dev \
+    "./backend.ai web start-server --debug"
+
+tmux new-session -d -s backendai-appproxy-dev \
+    "./backend.ai app-proxy start-server --debug"
+
+tmux new-window -t backendai-appproxy-dev -n "coordinator"
+tmux send-keys "./backend.ai app-proxy-coordinator start-server --debug" C-m
+
+tmux new-window -t backendai-appproxy-dev -n "worker"
+tmux send-keys "./backend.ai app-proxy-worker start-server --debug" C-m

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -13,8 +13,7 @@ tmux new-session -d -s backendai-storage-dev \
 tmux new-session -d -s backendai-webserver-dev \
     "./backend.ai web start-server --debug"
 
-tmux new-session -d -s backendai-appproxy-dev \
-    "./backend.ai app-proxy start-server --debug"
+tmux new-session -d -s backendai-appproxy-dev
 
 tmux new-window -t backendai-appproxy-dev -n "coordinator"
 tmux send-keys "./backend.ai app-proxy-coordinator start-server --debug" C-m

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,6 +1,5 @@
 tmux kill-session -t backendai-manager-dev
 tmux kill-session -t backendai-agent-dev
-tmux kill-session -t backendai-storage-proxy-dev
 tmux kill-session -t backendai-storage-dev
 tmux kill-session -t backendai-webserver-dev
 tmux kill-session -t backendai-appproxy-dev

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,0 +1,6 @@
+tmux kill-session -t backendai-manager-dev
+tmux kill-session -t backendai-agent-dev
+tmux kill-session -t backendai-storage-proxy-dev
+tmux kill-session -t backendai-storage-dev
+tmux kill-session -t backendai-webserver-dev
+tmux kill-session -t backendai-appproxy-dev


### PR DESCRIPTION
Introduces start-dev.sh and stop-dev.sh scripts to automate launching and terminating multiple Backend.AI components in tmux sessions for development purposes.
