### PR TITLE
fix(BA-2108): Avoid producing error event in Agent heartbeat (#5468)

### DIFF
--- a/changes/5469.fix.md
+++ b/changes/5469.fix.md
@@ -1,0 +1,1 @@
+Prevent the Agent from producing error events in the heartbeat loop to avoid loop termination due to Redis connection failures

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1041,7 +1041,6 @@ class AbstractAgent(
             log.warning("event dispatch timeout: instance_heartbeat")
         except Exception:
             log.exception("instance_heartbeat failure")
-            await self.produce_error_event()
 
     async def collect_logs(
         self,


### PR DESCRIPTION
This is an auto-generated backport PR of #5468 to the 25.6 release.