### PR TITLE
chore: Add dev environment start/stop scripts to 25.6

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,14 @@
+tmux new-session -d -s backendai-manager-dev \
+    "./backend.ai mgr start-server --debug"
+
+tmux new-session -d -s backendai-agent-dev \
+    "./backend.ai ag start-server --debug"
+
+tmux new-session -d -s backendai-storage-dev \
+    "./backend.ai storage start-server --debug"
+
+tmux new-session -d -s backendai-webserver-dev \
+    "./backend.ai web start-server --debug"
+
+tmux new-session -d -s backendai-wsproxy-dev \
+    "./backend.ai wsproxy start-server --debug"

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,0 +1,5 @@
+tmux kill-session -t backendai-manager-dev
+tmux kill-session -t backendai-agent-dev
+tmux kill-session -t backendai-storage-dev
+tmux kill-session -t backendai-webserver-dev
+tmux kill-session -t backendai-wsproxy-dev


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
