### PR TITLE
fix(BA-2110): Skip saving session for failed login attempts

### DIFF
--- a/changes/5473.fix.md
+++ b/changes/5473.fix.md
@@ -1,0 +1,1 @@
+Fix not store session and cookies when the request fails

--- a/changes/5473.fix.md
+++ b/changes/5473.fix.md
@@ -1,1 +1,1 @@
-Fix not store session and cookies when the request fails
+Fixed session being incorrectly set on failed login attempts and ensured `X-BackendAI-SessionID` header is always included when login succeeds

--- a/src/ai/backend/common/web/session/__init__.py
+++ b/src/ai/backend/common/web/session/__init__.py
@@ -251,7 +251,7 @@ def session_middleware(storage: "AbstractStorage") -> Middleware:
         if response.prepared:
             raise RuntimeError("Cannot save session data into prepared response")
         session = request.get(SESSION_KEY)
-        if session is not None:
+        if (session is not None) and (raise_response is False):
             if session._changed:
                 await storage.save_session(request=request, response=response, session=session)
         if raise_response:

--- a/src/ai/backend/common/web/session/redis_storage.py
+++ b/src/ai/backend/common/web/session/redis_storage.py
@@ -110,6 +110,7 @@ class RedisStorage(AbstractStorage):
                 # response.headers.set('X-BackendAI-SessionID', "")
             else:
                 key = str(key)
+                response._headers["X-BackendAI-SessionID"] = key
                 self.save_cookie(
                     response=response,
                     cookie_data=key,

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -283,7 +283,7 @@ async def login_handler(request: web.Request) -> web.Response:
     stats.active_login_handlers.add(asyncio.current_task())  # type: ignore
     session = await get_session(request)
     if session.get("authenticated", False):
-        return web.HTTPBadRequest(
+        raise web.HTTPBadRequest(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/generic-bad-request",
                 "title": "You have already logged in.",
@@ -304,7 +304,7 @@ async def login_handler(request: web.Request) -> web.Response:
         log.error("Login: JSON decoding error: {}", e)
         creds = {}
     if "username" not in creds or not creds["username"]:
-        return web.HTTPBadRequest(
+        raise web.HTTPBadRequest(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/invalid-api-params",
                 "title": "You must provide the username field.",
@@ -312,7 +312,7 @@ async def login_handler(request: web.Request) -> web.Response:
             content_type="application/problem+json",
         )
     if "password" not in creds or not creds["password"]:
-        return web.HTTPBadRequest(
+        raise web.HTTPBadRequest(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/invalid-api-params",
                 "title": "You must provide the password field.",
@@ -370,7 +370,7 @@ async def login_handler(request: web.Request) -> web.Response:
             client_ip,
         )
         await _set_login_history(last_login_attempt, login_fail_count)
-        return web.HTTPTooManyRequests(
+        raise web.HTTPTooManyRequests(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/too-many-requests",
                 "title": "Too many failed login attempts",


### PR DESCRIPTION
resolves #5473 (BA-2110)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
