### PR TITLE
ci: Bump twine from 5 to 6 (#4302)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
         pip install -U -r tools/towncrier-requirements.txt
     - name: Install local dependencies for packaging
       run: |
-        pip install -U 'twine~=5.0' 'packaging>=21.3'
+        pip install -U 'twine~=6.0'
     - name: Extract the release changelog
       run: |
         python ./scripts/extract-release-changelog.py


### PR DESCRIPTION
This is an auto-generated backport PR of #4302 to the 24.09 release.