### PR TITLE
fix(BA-2100): NUMA-aware allocation with existing allocations of the first-seen device type (#5454)

### DIFF
--- a/changes/5454.fix.md
+++ b/changes/5454.fix.md
@@ -1,0 +1,1 @@
+Fix NUMA-aware affinity allocation to find the larged connected component with the most remaining resource capacity when grouping devices per NUMA node

--- a/src/ai/backend/agent/affinity_map.py
+++ b/src/ai/backend/agent/affinity_map.py
@@ -20,6 +20,13 @@ class AffinityPolicy(enum.Enum):
 
 @attr.define()
 class AffinityHint:
+    """
+    Represents the affinity hint for realization of an entire resource slot for a single kernel.
+
+    The devices field starts with None and gets replaced with the devices allocated in the prior resource slot
+    as the allocation proceeds with the next resource slot.
+    """
+
     devices: Optional[Sequence[AbstractComputeDevice]]
     affinity_map: AffinityMap
     policy: AffinityPolicy

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -125,15 +125,31 @@ class AbstractAllocMap(metaclass=ABCMeta):
         self, affinity_hint: Optional[AffinityHint], slot_name: SlotName
     ) -> Sequence[tuple[DeviceId, Decimal]]:
         device_name = DeviceName(slot_name.partition(".")[0])
-        if affinity_hint is None or not affinity_hint.devices:  # for legacy
+
+        if affinity_hint is None:  # for legacy
             return sorted(
                 self.allocations[slot_name].items(),  # k: slot_name, v: per-device alloc
                 key=lambda pair: self.device_slots[pair[0]].amount - pair[1],
                 reverse=True,
             )
-        primary_sets, secondary_set = affinity_hint.affinity_map.get_distance_ordered_neighbors(
-            affinity_hint.devices, device_name
-        )
+
+        def sort_to_prefer_remaining_alloc_per_node(device_set: Sequence[AbstractComputeDevice]):
+            # the device set is already a set within a numa node.
+            alloc_per_numa_node = Decimal(0)
+            for device in device_set:
+                alloc_per_numa_node += self.allocations[slot_name][device.device_id]
+            return alloc_per_numa_node
+
+        if not affinity_hint.devices:
+            primary_sets = affinity_hint.affinity_map.get_device_clusters_with_lowest_distance(
+                device_name
+            )
+            secondary_set: Sequence[AbstractComputeDevice] = []
+        else:
+            primary_sets, secondary_set = affinity_hint.affinity_map.get_distance_ordered_neighbors(
+                affinity_hint.devices, device_name
+            )
+        primary_sets = sorted(primary_sets, key=sort_to_prefer_remaining_alloc_per_node)
 
         def convert_to_sorted_dev_alloc(device_set: Iterable[AbstractComputeDevice]):
             device_ids = {d.device_id for d in device_set}


### PR DESCRIPTION
This is an auto-generated backport PR of #5454 to the 24.09 release.