### PR TITLE
chore: Sync init-pants action of coverage workflow to reduce actions cache pressure

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,9 +29,8 @@ jobs:
         python-version: ${{ env.PROJECT_PYTHON_VERSION }}
         cache: pip
     - name: Bootstrap Pants
-      uses: pantsbuild/actions/init-pants@v8
+      uses: ./actions/init-pants
       with:
-        gha-cache-key: pants-cache-main-1-coverage-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
     - name: Run the full test suite


### PR DESCRIPTION
Inspecting Github Actions cache, the coverage workflow excessively occupies the cache capacity.
Let's fix this.
