### PR TITLE
chore: Add "kubernetes" to the known 3rd-party list for Ruff isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore = ["E203","E731","E501"]
 [tool.ruff.lint.isort]
 known-first-party = ["ai.backend"]
 known-local-folder = ["src"]
-known-third-party = ["alembic", "redis"]
+known-third-party = ["alembic", "redis", "kubernetes"]
 split-on-trailing-comma = true
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
This is to resolve bogus CI failures with a corner case:
```shell
pants lint src/ai/backend/agent/kubernetes::
```
