### PR TITLE
chore: Add "kubernetes" to the known 3rd-party list for Ruff isort (#5541)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ ignore = ["E203","E731","E501"]
 [tool.ruff.lint.isort]
 known-first-party = ["ai.backend"]
 known-local-folder = ["src"]
-known-third-party = ["alembic", "redis"]
+known-third-party = ["alembic", "redis", "kubernetes"]
 split-on-trailing-comma = true
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
This is an auto-generated backport PR of #5541 to the 24.09 release.