### PR TITLE
chore: Correct script name from build-wheel.sh to build-wheels.sh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To build:
 
 ```bash
 # Build wheels or SCIE packages
-./scripts/build-wheel.sh
+./scripts/build-wheels.sh
 ./scripts/build-scies.sh
 ```
 

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Normalize the package version
-PKGVER=$(python -c "import packaging.version,pathlib; print(str(packaging.version.Version(pathlib.Path('VERSION').read_text())))")
+PKGVER=$(./py -c "import packaging.version,pathlib; print(str(packaging.version.Version(pathlib.Path('VERSION').read_text())))")
 # Build non-platform-specific wheels
 pants --platform-specific-resources-target=linux_x86_64 --tag="wheel" --tag="-platform-specific" package '::'
 # Build x86_64 wheels


### PR DESCRIPTION
This PR resolves minor typo issue and using a proper python version when operating `./scripts/build-wheels.sh`.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
