### PR TITLE
ci: Remove graphite-specific workflow details (#5390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       pull-requests: write
     outputs:
       skip: ${{ steps.check_skip.outputs.SKIP_CI }}
-      graphite-labels: ${{ steps.graphite_labels.outputs.GRAPHITE_LABELS }}
       release: ${{ steps.release.outputs.IS_RELEASE }}
       alembic: ${{ steps.alembic.outputs.ALEMBIC }}
     steps:
@@ -64,30 +63,12 @@ jobs:
         id: labeler
         if: github.event_name == 'pull_request'
         uses: lablup/auto-labeler@main   # actions/labeler, lablup/size-label-action, lablup/auto-label-in-issue
-      - name: Optimize CI
-        id: check_stacked_pr
-        run: |
-          echo "NON_TOP_BOTTOM=false" >> $GITHUB_OUTPUT
-          BASE_BRANCH=${{ github.event.pull_request.base.ref }}
-          if [[ "$BASE_BRANCH" != "main" && ! "$BASE_BRANCH" =~ ^[0-9]{2}\.[0-9]{1,2}$ ]]; then
-            response=$(curl -s -o /dev/null -w "%{http_code}" -X GET "${{ secrets.KVSTORE_URL }}/?key=base_${{ github.event.pull_request.head }}" \
-            -H "Authorization: Bearer ${{ secrets.KVSTORE_TOKEN }}")
-            if [ "$response" == "200" ]; then
-              echo "NON_TOP_BOTTOM=true" >> $GITHUB_OUTPUT
-            fi
-          fi
       - name: Skip CI
         id: check_skip
         if: |
           contains(toJSON(github.event.head_commit.message), 'skip:ci')
           || contains(github.event.pull_request.labels.*.name, 'skip:ci')
-          || steps.check_stacked_pr.outputs.NON_TOP_BOTTOM == 'true'
         run: echo "SKIP_CI=true" >> $GITHUB_OUTPUT
-      - name: Graphite labels
-        id: graphite_labels
-        if: contains(fromJSON('["flow:merge-queue", "flow:hotfix"]'), github.event.pull_request.labels.*.name)
-        run: |
-          echo "GRAPHITE_LABELS=true" >> $GITHUB_OUTPUT
       - name: Release
         id: release
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
@@ -105,7 +86,6 @@ jobs:
   lint:
     if: |
       needs.optimize-ci.outputs.skip != 'true'
-      && needs.optimize-ci.outputs.graphite-labels != 'true'
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:
@@ -182,8 +162,6 @@ jobs:
         || needs.optimize-ci.outputs.release == 'true'
       )
       && needs.optimize-ci.outputs.skip != 'true'
-      && needs.optimize-ci.outputs.graphite-labels !=
-      'true'
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:
@@ -237,7 +215,6 @@ jobs:
   typecheck:
     if: |
       needs.optimize-ci.outputs.skip != 'true'
-      && needs.optimize-ci.outputs.graphite-labels != 'true'
     needs: [optimize-ci]
     runs-on: ubuntu-latest
     steps:
@@ -305,7 +282,6 @@ jobs:
   test:
     if: |
       needs.optimize-ci.outputs.skip != 'true'
-      && needs.optimize-ci.outputs.graphite-labels != 'true'
     needs: [optimize-ci]
     runs-on: [ubuntu-latest-8-cores]
     steps:


### PR DESCRIPTION
This is an auto-generated backport PR of #5390 to the 25.6 release.