### PR TITLE
feat(BA-2158): Add Valkey Client TLS configuration

### DIFF
--- a/changes/5573.feature.md
+++ b/changes/5573.feature.md
@@ -1,0 +1,1 @@
+Add Valkey Client TLS configuration

--- a/src/ai/backend/common/clients/valkey_client/client.py
+++ b/src/ai/backend/common/clients/valkey_client/client.py
@@ -38,6 +38,10 @@ _DEFAULT_REQUEST_TIMEOUT = 1_000  # Default request timeout in milliseconds
 Logger.init(LogLevel.OFF)  # Disable Glide logging by default
 
 
+SSL_CERT_NONE = "none"
+SSL_CERT_REQUIRED = "required"
+
+
 @dataclass
 class ValkeyStandaloneTarget:
     address: str
@@ -167,7 +171,6 @@ class ValkeyStandaloneClient(AbstractValkeyClient):
             addresses,
             credentials=credentials,
             database_id=self._db_id,
-            use_tls=self._target.use_tls,
             request_timeout=self._target.request_timeout or _DEFAULT_REQUEST_TIMEOUT,
             pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
                 channels_and_patterns={
@@ -178,6 +181,7 @@ class ValkeyStandaloneClient(AbstractValkeyClient):
             )
             if self._pubsub_channels
             else None,
+            use_tls=self._target.use_tls,
             advanced_config=AdvancedGlideClientConfiguration(
                 tls_config=TlsAdvancedConfiguration(
                     use_insecure_tls=self._target.tls_skip_verify,
@@ -292,9 +296,9 @@ class ValkeySentinelClient(AbstractValkeyClient):
 
         sentinel_kwargs: dict[str, Any] = {
             "password": target.password,
+            "ssl": target.use_tls,
+            "ssl_cert_reqs": SSL_CERT_NONE if target.tls_skip_verify else SSL_CERT_REQUIRED,
         }
-        if target.use_tls:
-            sentinel_kwargs["ssl"] = True
         self._sentinel = Sentinel(
             sentinel_addrs,
             sentinel_kwargs=sentinel_kwargs,
@@ -351,7 +355,6 @@ class ValkeySentinelClient(AbstractValkeyClient):
             addresses,
             credentials=credentials,
             database_id=self._db_id,
-            use_tls=self._target.use_tls,
             client_name=self._target.service_name,
             request_timeout=self._target.request_timeout or _DEFAULT_REQUEST_TIMEOUT,
             pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
@@ -363,6 +366,7 @@ class ValkeySentinelClient(AbstractValkeyClient):
             )
             if self._pubsub_channels
             else None,
+            use_tls=self._target.use_tls,
             advanced_config=AdvancedGlideClientConfiguration(
                 tls_config=TlsAdvancedConfiguration(
                     use_insecure_tls=self._target.tls_skip_verify,

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -78,6 +78,8 @@ redis_default_config = {
     "service_name": None,
     "password": None,
     "redis_helper_config": redis_helper_default_config,
+    "use_tls": False,
+    "tls_skip_verify": False,
 }
 
 redis_config_iv = t.Dict({
@@ -87,6 +89,8 @@ redis_config_iv = t.Dict({
     ): t.Null | tx.DelimiterSeperatedList(tx.HostPortPair),
     t.Key("service_name", default=redis_default_config["service_name"]): t.Null | t.String,
     t.Key("password", default=redis_default_config["password"]): t.Null | t.String,
+    t.Key("use_tls", default=redis_default_config["use_tls"]): t.Bool,
+    t.Key("tls_skip_verify", default=redis_default_config["tls_skip_verify"]): t.Bool,
     t.Key(
         "redis_helper_config",
         default=redis_helper_default_config,
@@ -101,6 +105,8 @@ redis_config_iv = t.Dict({
             ): t.Null | tx.DelimiterSeperatedList(tx.HostPortPair),
             t.Key("service_name", default=redis_default_config["service_name"]): t.Null | t.String,
             t.Key("password", default=redis_default_config["password"]): t.Null | t.String,
+            t.Key("use_tls", default=redis_default_config["use_tls"]): t.Bool,
+            t.Key("tls_skip_verify", default=redis_default_config["tls_skip_verify"]): t.Bool,
             t.Key(
                 "redis_helper_config",
                 default=redis_helper_default_config,

--- a/src/ai/backend/common/configs/redis.py
+++ b/src/ai/backend/common/configs/redis.py
@@ -114,6 +114,20 @@ class SingleRedisConfig(BaseModel):
         validation_alias=AliasChoices("redis_helper_config", "redis-helper-config"),
         serialization_alias="redis-helper-config",
     )
+    use_tls: bool = Field(
+        default=False,
+        description="""
+        Whether to use TLS for Redis connections.""",
+        validation_alias=AliasChoices("use_tls", "use-tls"),
+    )
+    tls_skip_verify: bool = Field(
+        default=False,
+        description="""
+        Whether to skip TLS certificate verification.
+        Set to True for self-signed certificates or development environments.
+        """,
+        validation_alias=AliasChoices("tls_skip_verify", "tls-skip-verify"),
+    )
 
     @field_validator("sentinel", mode="before")
     @classmethod

--- a/src/ai/backend/common/redis_helper.py
+++ b/src/ai/backend/common/redis_helper.py
@@ -20,7 +20,14 @@ from typing import (
 
 import redis.exceptions
 import yarl
-from glide import GlideClient, GlideClientConfiguration, NodeAddress, ServerCredentials
+from glide import (
+    AdvancedGlideClientConfiguration,
+    GlideClient,
+    GlideClientConfiguration,
+    NodeAddress,
+    ServerCredentials,
+    TlsAdvancedConfiguration,
+)
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import Pipeline
 from redis.asyncio.sentinel import MasterNotFoundError, Sentinel, SlaveNotFoundError
@@ -303,6 +310,12 @@ async def create_valkey_client(
         raise ValueError("At least one Redis address is required to create a GlideClient.")
     config = GlideClientConfiguration(
         addresses,
+        use_tls=valkey_target.use_tls,
+        advanced_config=AdvancedGlideClientConfiguration(
+            tls_config=TlsAdvancedConfiguration(
+                use_insecure_tls=valkey_target.tls_skip_verify,
+            ),
+        ),
         credentials=credentials,
         database_id=db,
         client_name=name,

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1476,6 +1476,8 @@ class ValkeyTarget:
     service_name: Optional[str] = None
     password: Optional[str] = None
     request_timeout: Optional[int] = None
+    use_tls: bool = False
+    tls_skip_verify: bool = False
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)
@@ -1497,6 +1499,8 @@ class RedisTarget:
     service_name: Optional[str] = None
     password: Optional[str] = None
     redis_helper_config: Optional[RedisHelperConfig] = None
+    use_tls: bool = False
+    tls_skip_verify: bool = False
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)
@@ -1517,6 +1521,8 @@ class RedisTarget:
             service_name=self.service_name,
             password=self.password,
             redis_helper_config=self.redis_helper_config,
+            use_tls=self.use_tls,
+            tls_skip_verify=self.tls_skip_verify,
         )
 
     def to_valkey_target(self) -> ValkeyTarget:
@@ -1538,6 +1544,8 @@ class RedisTarget:
             service_name=self.service_name,
             password=self.password,
             request_timeout=None,
+            use_tls=self.use_tls,
+            tls_skip_verify=self.tls_skip_verify,
         )
 
 
@@ -1586,6 +1594,8 @@ class RedisProfileTarget:
         password: Optional[str] = None,
         redis_helper_config: Optional[RedisHelperConfig] = None,
         override_targets: Optional[Mapping[str, RedisTarget]] = None,
+        use_tls: bool = False,
+        tls_skip_verify: bool = False,
     ) -> None:
         self._base_target = RedisTarget(
             addr=addr,
@@ -1593,6 +1603,8 @@ class RedisProfileTarget:
             service_name=service_name,
             password=password,
             redis_helper_config=redis_helper_config,
+            use_tls=use_tls,
+            tls_skip_verify=tls_skip_verify,
         )
         self._override_targets = override_targets
 


### PR DESCRIPTION
resolves #5577 (BA-2158)

related to #5571

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
