### PR TITLE
hotfix: Use relative URLs in manager.wsproxy HTTP clients

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Fix manager.wsproxy's HTTP requests to use relative URLs as the default factory sets `base_url` of `aiohttp.ClientSession` instances

--- a/src/ai/backend/common/clients/http_client/client_pool.py
+++ b/src/ai/backend/common/clients/http_client/client_pool.py
@@ -29,6 +29,14 @@ def tcp_client_session_factory(
     timeout: Optional[aiohttp.ClientTimeout] = None,
     **kwargs,
 ) -> aiohttp.ClientSession:
+    """
+    The default TCP-based ClientSession factory.
+    It creates ClientSession instances with base_url set from the endpoint of
+    client keys, so all HTTP requests must use relative URL paths.
+
+    All custom keyword arguments are passed to the ClientSession constructor,
+    while ssl, limit, limit_per_host are passed to the TCPConnector consctructor.
+    """
     connector = aiohttp.TCPConnector(
         ssl=ssl,
         limit=limit,

--- a/src/ai/backend/manager/clients/wsproxy/client.py
+++ b/src/ai/backend/manager/clients/wsproxy/client.py
@@ -26,7 +26,7 @@ class WSProxyClient:
         body: Mapping[str, Any],
     ) -> dict[str, Any]:
         async with self._client_session.post(
-            f"{self._address}/v2/endpoints/{endpoint_id}",
+            f"/v2/endpoints/{endpoint_id}",
             json=body,
             headers={
                 "X-BackendAI-Token": self._token,
@@ -41,7 +41,7 @@ class WSProxyClient:
         endpoint_id: UUID,
     ) -> None:
         async with self._client_session.delete(
-            f"{self._address}/v2/endpoints/{endpoint_id}",
+            f"/v2/endpoints/{endpoint_id}",
             headers={
                 "X-BackendAI-Token": self._token,
             },


### PR DESCRIPTION
This is an urgent hotfix following up BA-1942 and BA-1983.
