### PR TITLE
chore: Update subagents to use pipe-optimized pants options

### DIFF
--- a/.claude/agents/linter.md
+++ b/.claude/agents/linter.md
@@ -31,20 +31,27 @@ The pants commands accept target arguments:
 - Files changed after last commit: `--changed-since=HEAD~1`
 - Files changed and their dependents: `--changed-since=HEAD~1 --changed-dependents=transitive`
 
+### Global Options
+To ensure readable output when piped, always add these options:
+- `--no-colors`: Avoid using terminal color sequences
+- `--no-dynamic-ui`: Avoid using dynamically updated progress animation
+
+The global options must be put after `pants` and before other subcommands like `lint`.
+
 ### Pants Command Examples
 ```bash
-pants lint ::                      # Lint all files
-pants lint src/ai/backend/manager/example.py  # Lint a specific file
-pants lint src/ai/backend/manager::           # Lint all files in a directory
-pants lint --changed-since=HEAD~1 --changed-dependents=transitive  # Lint changed files and their dependent files
+pants --no-colors --no-dynamic-ui lint ::                      # Lint all files
+pants --no-colors --no-dynamic-ui lint src/ai/backend/manager/example.py  # Lint a specific file
+pants --no-colors --no-dynamic-ui lint src/ai/backend/manager::           # Lint all files in a directory
+pants --no-colors --no-dynamic-ui lint --changed-since=HEAD~1 --changed-dependents=transitive  # Lint changed files and their dependent files
 
-pants fix ::                       # Auto-fix linting issues in all files
-pants fix src/ai/backend/manager/example.py  # Auto-fix a specific file
-pants fix src/ai/backend/manager::           # Auto-fix all files in a directory
-pants fix --changed-since=HEAD~1   # Auto-fix linting issues in files changed since the last commit
+pants --no-colors --no-dynamic-ui fix ::                       # Auto-fix linting issues in all files
+pants --no-colors --no-dynamic-ui fix src/ai/backend/manager/example.py  # Auto-fix a specific file
+pants --no-colors --no-dynamic-ui fix src/ai/backend/manager::           # Auto-fix all files in a directory
+pants --no-colors --no-dynamic-ui fix --changed-since=HEAD~1   # Auto-fix linting issues in files changed since the last commit
 
-pants fmt ::                       # Auto-format all files
-pants fmt src/ai/backend/manager/example.py  # Auto-format a specific file
-pants fmt src/ai/backend/manager::           # Auto-format all files in a directory
-pants fmt --changed-since=HEAD~1   # Auto-format files changed since the last commit
+pants --no-colors --no-dynamic-ui fmt ::                       # Auto-format all files
+pants --no-colors --no-dynamic-ui fmt src/ai/backend/manager/example.py  # Auto-format a specific file
+pants --no-colors --no-dynamic-ui fmt src/ai/backend/manager::           # Auto-format all files in a directory
+pants --no-colors --no-dynamic-ui fmt --changed-since=HEAD~1   # Auto-format files changed since the last commit
 ```

--- a/.claude/agents/linter.md
+++ b/.claude/agents/linter.md
@@ -22,7 +22,7 @@ When invoked:
 
 Always run `pants lint` first and then apply `pants fix` and `pants fmt` as appropriate.
 
-## Testing Commands and Target Arguments
+## Pants Command Arguments and Options
 
 ### Target Arguments
 The pants commands accept target arguments:

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -36,17 +36,24 @@ The pants commands accept target arguments:
 - Test modules affected by files changed after last commit: `--changed-since=HEAD~1`
 - Test modules affected by files changed and their dependents: `--changed-since=HEAD~1 --changed-dependents=transitive`
 
+### Global Options
+To ensure readable output when piped, always add these options:
+- `--no-colors`: Avoid using terminal color sequences
+- `--no-dynamic-ui`: Avoid using dynamically updated progress animation
+
+The global options must be put after `pants` and before other subcommands like `lint`.
+
 ### Pants Command Examples
 ```bash
 # Testing with summary output
-pants test {targets}               # Run designated test targets
-pants test ::                      # Run all tests
-pants test tests/common::          # Run specific test directory in test suite
-pants test tests/agent/test_affinity_map.py  # Run a specific test module
-pants test --changed-since=HEAD~1 --changed-dependents=transitive  # Test changed files and dependents
+pants --no-colors --no-dynamic-ui test {targets}               # Run designated test targets
+pants --no-colors --no-dynamic-ui test ::                      # Run all tests
+pants --no-colors --no-dynamic-ui test tests/common::          # Run specific test directory in test suite
+pants --no-colors --no-dynamic-ui test tests/agent/test_affinity_map.py  # Run a specific test module
+pants --no-colors --no-dynamic-ui test --changed-since=HEAD~1 --changed-dependents=transitive  # Test changed files and dependents
 
 # Testing with full console output (debug mode)
-pants test --debug {targets}       # Run tests with full output
+pants --no-colors --no-dynamic-ui test --debug {targets}       # Run tests with full output
 ```
 
 ### Advanced Option Combinations
@@ -56,8 +63,8 @@ pants test --debug {targets}       # Run tests with full output
 
 ### Advanced Pants Command Examples
 ```bash
-pants test --debug {targets} -- -k {test-case-filter} -v -s               # Debug mode with pytest args
-pants test --debug {targets} -- -k {test-case-filter} --print-stacktrace  # Debug mode with stacktrace
+pants --no-colors --no-dynamic-ui test --debug {targets} -- -k {test-case-filter} -v -s               # Debug mode with pytest args
+pants --no-colors --no-dynamic-ui test --debug {targets} -- -k {test-case-filter} --print-stacktrace  # Debug mode with stacktrace
 ```
 
 ### Important Rules

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -26,7 +26,7 @@ When inovked:
 Always ensure BUILD files exist in test directories before running tests.
 Focus on fixing the underlying issue, not just symptoms.
 
-## Pants Commands and Target Arguments
+## Pants Command Arguments and Options
 
 ### Target Arguments
 The pants commands accept target arguments:

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -41,7 +41,7 @@ To ensure readable output when piped, always add these options:
 - `--no-colors`: Avoid using terminal color sequences
 - `--no-dynamic-ui`: Avoid using dynamically updated progress animation
 
-The global options must be put after `pants` and before other subcommands like `lint`.
+The global options must be put after `pants` and before other subcommands like `test`.
 
 ### Pants Command Examples
 ```bash

--- a/.claude/agents/typechecker.md
+++ b/.claude/agents/typechecker.md
@@ -29,10 +29,17 @@ The pants commands accept target arguments:
 - Files changed after last commit: `--changed-since=HEAD~1`
 - Files changed and their dependents: `--changed-since=HEAD~1 --changed-dependents=transitive`
 
+### Global Options
+To ensure readable output when piped, always add these options:
+- `--no-colors`: Avoid using terminal color sequences
+- `--no-dynamic-ui`: Avoid using dynamically updated progress animation
+
+The global options must be put after `pants` and before other subcommands like `lint`.
+
 ### Pants Command Examples
 ```bash
-pants check ::                      # Typecheck all files
-pants check src/ai/backend/manager/example.py  # Typecheck a specific file
-pants check src/ai/backend/manager::           # Typecheck all files in a directory
-pants check --changed-since=HEAD~1 --changed-dependents=transitive  # Typecheck changed files and their dependent files
+pants --no-colors --no-dynamic-ui check ::                      # Typecheck all files
+pants --no-colors --no-dynamic-ui check src/ai/backend/manager/example.py  # Typecheck a specific file
+pants --no-colors --no-dynamic-ui check src/ai/backend/manager::           # Typecheck all files in a directory
+pants --no-colors --no-dynamic-ui check --changed-since=HEAD~1 --changed-dependents=transitive  # Typecheck changed files and their dependent files
 ```

--- a/.claude/agents/typechecker.md
+++ b/.claude/agents/typechecker.md
@@ -34,7 +34,7 @@ To ensure readable output when piped, always add these options:
 - `--no-colors`: Avoid using terminal color sequences
 - `--no-dynamic-ui`: Avoid using dynamically updated progress animation
 
-The global options must be put after `pants` and before other subcommands like `lint`.
+The global options must be put after `pants` and before other subcommands like `check`.
 
 ### Pants Command Examples
 ```bash

--- a/.claude/agents/typechecker.md
+++ b/.claude/agents/typechecker.md
@@ -20,7 +20,7 @@ When invoked:
 2. Identify failing typecheck errors
 3. Updates the releated codes by adding missing annotations, applying generics with proper type variables, and referring to existing typing patterns in similar codes
 
-## Pants Commands and Target Arguments
+## Pants Command Arguments and Options
 
 ### Target Arguments
 The pants commands accept target arguments:


### PR DESCRIPTION
Let Claude Code subagents use pipe-friendly output options in pants commands regardless of user configuration (e.g., `~/.pants.rc`).
