### PR TITLE
test(BA-2181): Add Bgtask unit tests

### DIFF
--- a/changes/5625.test.md
+++ b/changes/5625.test.md
@@ -1,0 +1,1 @@
+Add Backgroundtask unit tests

--- a/tests/common/bgtask/BUILD
+++ b/tests/common/bgtask/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/common/bgtask/test_bgtask.py
+++ b/tests/common/bgtask/test_bgtask.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from ai.backend.common.bgtask.bgtask import (
+    BackgroundTaskManager,
+    BackgroundTaskObserver,
+    BgTaskInfo,
+    NopBackgroundTaskObserver,
+)
+from ai.backend.common.bgtask.reporter import ProgressReporter
+from ai.backend.common.bgtask.task.base import BaseBackgroundTaskArgs, BaseBackgroundTaskHandler
+from ai.backend.common.bgtask.task.registry import BackgroundTaskHandlerRegistry
+from ai.backend.common.bgtask.types import BackgroundTaskMetadata, BgtaskStatus, TaskID
+from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
+from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.events.event_types.bgtask.broadcast import (
+    BgtaskDoneEvent,
+    BgtaskFailedEvent,
+    BgtaskPartialSuccessEvent,
+)
+from ai.backend.common.exception import BgtaskFailedError
+from ai.backend.common.types import DispatchResult
+
+# Use actual TaskName enum values as string constants to avoid direct enum references
+MOCK_TASK = "clone_vfolder"  # Matches TaskName.CLONE_VFOLDER value
+MOCK_TASK_ONE = "clone_vfolder"
+MOCK_TASK_TWO = "push_image"  # Matches TaskName.PUSH_IMAGE value
+
+
+class MockBackgroundTaskArgs(BaseBackgroundTaskArgs):
+    def __init__(self, test_value: str = "test"):
+        self.test_value = test_value
+
+    def to_metadata_body(self) -> dict[str, Any]:
+        return {"test_value": self.test_value}
+
+    @classmethod
+    def from_metadata_body(cls, body: Mapping[str, Any]) -> MockBackgroundTaskArgs:
+        return cls(test_value=body.get("test_value", "test"))
+
+
+class MockBackgroundTaskHandler(BaseBackgroundTaskHandler[MockBackgroundTaskArgs]):
+    async def execute(
+        self, reporter: ProgressReporter, args: MockBackgroundTaskArgs
+    ) -> DispatchResult:
+        await reporter.update(1, "Starting mock task")
+        return DispatchResult(result={"result": "success"})
+
+    @classmethod
+    def name(cls) -> str:  # type: ignore[override]
+        return MOCK_TASK
+
+    @classmethod
+    def args_type(cls) -> type[MockBackgroundTaskArgs]:
+        return MockBackgroundTaskArgs
+
+
+@pytest.fixture
+def mock_event_producer() -> AsyncMock:
+    producer = AsyncMock(spec=EventProducer)
+    producer.broadcast_event_with_cache = AsyncMock()
+    return producer
+
+
+@pytest.fixture
+def mock_valkey_client() -> AsyncMock:
+    client = AsyncMock(spec=ValkeyBgtaskClient)
+    client.register_task = AsyncMock()
+    client.unregister_task = AsyncMock()
+    client.heartbeat = AsyncMock()
+    client.list_timeout_tasks_by_server_id = AsyncMock(return_value=[])
+    client.list_timeout_tasks_by_tags = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.fixture
+def mock_task_registry() -> BackgroundTaskHandlerRegistry:
+    registry = BackgroundTaskHandlerRegistry()
+    registry.register(MockBackgroundTaskHandler())
+    return registry
+
+
+@pytest.fixture
+def mock_observer() -> Mock:
+    observer = Mock(spec=BackgroundTaskObserver)
+    observer.observe_bgtask_started = Mock()
+    observer.observe_bgtask_done = Mock()
+    return observer
+
+
+@pytest.fixture
+async def background_task_manager(
+    mock_event_producer: AsyncMock,
+    mock_valkey_client: AsyncMock,
+    mock_task_registry: BackgroundTaskHandlerRegistry,
+    mock_observer: Mock,
+):
+    manager = BackgroundTaskManager(
+        mock_event_producer,
+        task_registry=mock_task_registry,
+        valkey_client=mock_valkey_client,
+        server_id="test-server",
+        tags={"test-tag"},
+        bgtask_observer=mock_observer,
+    )
+    yield manager
+    await manager.shutdown()
+
+
+class TestBgTaskInfo:
+    def test_started(self) -> None:
+        info = BgTaskInfo.started("Starting task")
+        assert info.status == BgtaskStatus.STARTED
+        assert info.msg == "Starting task"
+        assert info.current == "0"
+        assert info.total == "0"
+        assert float(info.started_at) > 0
+        assert info.started_at == info.last_update
+
+    def test_finished(self) -> None:
+        info = BgTaskInfo.finished(BgtaskStatus.DONE, "Task completed")
+        assert info.status == BgtaskStatus.DONE
+        assert info.msg == "Task completed"
+        assert info.started_at == "0"
+        assert float(info.last_update) > 0
+        assert info.current == "0"
+        assert info.total == "0"
+
+    def test_to_dict(self) -> None:
+        info = BgTaskInfo.started("Test")
+        data = info.to_dict()
+        assert "status" in data
+        assert "msg" in data
+        assert "started_at" in data
+        assert "last_update" in data
+        assert "current" in data
+        assert "total" in data
+        assert data["status"] == str(BgtaskStatus.STARTED)
+        assert data["msg"] == "Test"
+
+
+class TestNopBackgroundTaskObserver:
+    def test_nop_observer(self) -> None:
+        observer = NopBackgroundTaskObserver()
+        observer.observe_bgtask_started(task_name="test")
+        observer.observe_bgtask_done(task_name="test", status="done", duration=1.0, error_code=None)
+
+
+class TestBackgroundTaskManager:
+    @pytest.mark.asyncio
+    async def test_init(
+        self, mock_event_producer: AsyncMock, mock_valkey_client: AsyncMock
+    ) -> None:
+        manager = BackgroundTaskManager(
+            mock_event_producer,
+            valkey_client=mock_valkey_client,
+            server_id="test-server",
+        )
+        assert manager._server_id == "test-server"
+        assert manager._tags == set()
+        assert manager._ongoing_tasks == {}
+        await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_init_with_tags(
+        self, mock_event_producer: AsyncMock, mock_valkey_client: AsyncMock
+    ) -> None:
+        manager = BackgroundTaskManager(
+            mock_event_producer,
+            valkey_client=mock_valkey_client,
+            server_id="test-server",
+            tags=["tag1", "tag2"],
+        )
+        assert manager._tags == {"tag1", "tag2"}
+        await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_start_simple_task(self, background_task_manager: BackgroundTaskManager) -> None:
+        async def simple_task(reporter: ProgressReporter, value: str) -> str:
+            await reporter.update(1, "Processing")
+            return f"Result: {value}"
+
+        task_id = await background_task_manager.start(simple_task, name="simple", value="test")
+        assert isinstance(task_id, uuid.UUID)
+        assert TaskID(task_id) in background_task_manager._ongoing_tasks
+
+        await asyncio.sleep(0.1)
+        assert TaskID(task_id) not in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_start_task_with_exception(
+        self, background_task_manager: BackgroundTaskManager, mock_observer: Mock
+    ) -> None:
+        async def failing_task(reporter: ProgressReporter) -> None:
+            raise ValueError("Test error")
+
+        await background_task_manager.start(failing_task, name="failing")
+        await asyncio.sleep(0.1)
+
+        mock_observer.observe_bgtask_started.assert_called_with(task_name="failing")
+        mock_observer.observe_bgtask_done.assert_called()
+        call_args = mock_observer.observe_bgtask_done.call_args
+        assert call_args.kwargs["status"] == BgtaskStatus.FAILED
+        assert call_args.kwargs["task_name"] == "failing"
+
+    @pytest.mark.asyncio
+    async def test_start_task_with_backend_error(
+        self, background_task_manager: BackgroundTaskManager, mock_observer: Mock
+    ) -> None:
+        async def backend_error_task(reporter: ProgressReporter) -> None:
+            raise BgtaskFailedError("Backend error")
+
+        await background_task_manager.start(backend_error_task, name="backend_error")
+        await asyncio.sleep(0.1)
+
+        mock_observer.observe_bgtask_done.assert_called()
+        call_args = mock_observer.observe_bgtask_done.call_args
+        assert call_args.kwargs["status"] == BgtaskStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_start_task_cancelled(
+        self, background_task_manager: BackgroundTaskManager, mock_observer: Mock
+    ) -> None:
+        cancel_event = asyncio.Event()
+
+        async def long_task(reporter: ProgressReporter) -> None:
+            cancel_event.set()  # Signal that we're ready to be cancelled
+            await asyncio.sleep(10)
+
+        task_id = await background_task_manager.start(long_task, name="long")
+
+        # Wait for the task to be ready
+        await cancel_event.wait()
+
+        task = background_task_manager._ongoing_tasks[TaskID(task_id)]
+        task.cancel()
+
+        # Wait for the cancellation to propagate
+        await asyncio.sleep(0.1)
+
+        mock_observer.observe_bgtask_done.assert_called()
+        call_args = mock_observer.observe_bgtask_done.call_args
+        assert call_args.kwargs["status"] == BgtaskStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_start_retriable(self, background_task_manager: BackgroundTaskManager) -> None:
+        args = MockBackgroundTaskArgs("test_value")
+        task_id = await background_task_manager.start_retriable(
+            MOCK_TASK,  # type: ignore[arg-type]
+            args,
+            tags=["test-tag"],
+        )
+
+        assert isinstance(task_id, uuid.UUID)
+        assert task_id in background_task_manager._ongoing_tasks
+
+        await asyncio.sleep(0.1)
+        assert task_id not in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_convert_bgtask_to_event(
+        self, background_task_manager: BackgroundTaskManager
+    ) -> None:
+        task_id = uuid.uuid4()
+
+        event = background_task_manager._convert_bgtask_to_event(task_id, None)
+        assert isinstance(event, BgtaskDoneEvent)
+        assert event.task_id == task_id
+        assert event.message is None
+
+        event = background_task_manager._convert_bgtask_to_event(task_id, "Success")
+        assert isinstance(event, BgtaskDoneEvent)
+        assert event.message == "Success"
+
+        result = DispatchResult(result={"test": "data"})
+        event = background_task_manager._convert_bgtask_to_event(task_id, result)
+        assert isinstance(event, BgtaskDoneEvent)
+
+        result_with_error = DispatchResult(result={"test": "data"}, errors=["test error"])
+        event = background_task_manager._convert_bgtask_to_event(task_id, result_with_error)
+        assert isinstance(event, BgtaskPartialSuccessEvent)
+        assert event.errors == ["test error"]
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop(
+        self, background_task_manager: BackgroundTaskManager, mock_valkey_client: AsyncMock
+    ) -> None:
+        # The heartbeat loop runs periodically - we'll just check that the task starts
+        async def long_task(reporter: ProgressReporter) -> None:
+            await asyncio.sleep(0.01)
+
+        task_id = await background_task_manager.start(long_task)
+
+        # Task should be in ongoing_tasks initially
+        assert TaskID(task_id) in background_task_manager._ongoing_tasks
+
+        # Wait for task to complete
+        await asyncio.sleep(0.1)
+
+        # Task should be removed after completion
+        assert TaskID(task_id) not in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_retry_loop_server_tasks(
+        self,
+        background_task_manager: BackgroundTaskManager,
+        mock_valkey_client: AsyncMock,
+        mock_task_registry: BackgroundTaskHandlerRegistry,
+    ) -> None:
+        metadata = BackgroundTaskMetadata.create(
+            task_id=TaskID(uuid.uuid4()),
+            task_name=MOCK_TASK,  # type: ignore[arg-type]
+            body={"test_value": "retry"},
+            server_id="old-server",
+        )
+        mock_valkey_client.list_timeout_tasks_by_server_id.return_value = [metadata]
+
+        await background_task_manager._check_server_tasks()
+
+        assert metadata.task_id in background_task_manager._ongoing_tasks
+        assert metadata.server_id == "test-server"
+
+    @pytest.mark.asyncio
+    async def test_retry_loop_tagged_tasks(
+        self, background_task_manager: BackgroundTaskManager, mock_valkey_client: AsyncMock
+    ) -> None:
+        metadata = BackgroundTaskMetadata.create(
+            task_id=TaskID(uuid.uuid4()),
+            task_name=MOCK_TASK,  # type: ignore[arg-type]
+            body={"test_value": "retry"},
+            server_id="old-server",
+            tags=["test-tag"],
+        )
+        mock_valkey_client.list_timeout_tasks_by_tags.return_value = [metadata]
+
+        await background_task_manager._check_tagged_tasks()
+
+        assert metadata.task_id in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_retry_task_not_registered(
+        self, background_task_manager: BackgroundTaskManager, mock_valkey_client: AsyncMock
+    ) -> None:
+        metadata = BackgroundTaskMetadata.create(
+            task_id=TaskID(uuid.uuid4()),
+            task_name=MOCK_TASK_TWO,  # type: ignore[arg-type]
+            body={"test": "data"},
+            server_id="old-server",
+        )
+
+        await background_task_manager._retry_bgtask(metadata)
+        assert metadata.task_id not in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_shutdown(
+        self, mock_event_producer: AsyncMock, mock_valkey_client: AsyncMock
+    ) -> None:
+        manager = BackgroundTaskManager(
+            mock_event_producer,
+            valkey_client=mock_valkey_client,
+            server_id="test-server",
+        )
+
+        async def long_task(reporter: ProgressReporter) -> None:
+            await asyncio.sleep(10)
+
+        task_id = await manager.start(long_task)
+        assert TaskID(task_id) in manager._ongoing_tasks
+
+        await manager.shutdown()
+
+        # All tasks should be cancelled or done
+        for task in manager._ongoing_tasks.values():
+            assert task.done() or task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_task_with_dispatch_result(
+        self, background_task_manager: BackgroundTaskManager
+    ) -> None:
+        async def task_with_result(reporter: ProgressReporter) -> DispatchResult:
+            await reporter.update(1, "Processing")
+            return DispatchResult(result={"result": "success"})
+
+        task_id = await background_task_manager.start(task_with_result, name="result_task")
+        await asyncio.sleep(0.1)
+
+        assert TaskID(task_id) not in background_task_manager._ongoing_tasks
+
+    @pytest.mark.asyncio
+    async def test_observe_retriable_bgtask_with_exception(
+        self, background_task_manager: BackgroundTaskManager, mock_observer: Mock
+    ) -> None:
+        class FailingHandler(BaseBackgroundTaskHandler[MockBackgroundTaskArgs]):
+            async def execute(
+                self, reporter: ProgressReporter, args: MockBackgroundTaskArgs
+            ) -> DispatchResult:
+                raise ValueError("Test error")
+
+            @classmethod
+            def name(cls) -> str:  # type: ignore[override]
+                return MOCK_TASK
+
+            @classmethod
+            def args_type(cls) -> type[MockBackgroundTaskArgs]:
+                return MockBackgroundTaskArgs
+
+        handler = FailingHandler()
+        args = MockBackgroundTaskArgs()
+        metadata = BackgroundTaskMetadata.create(
+            task_id=TaskID(uuid.uuid4()),
+            task_name=MOCK_TASK,  # type: ignore[arg-type]
+            body=args.to_metadata_body(),
+            server_id="test-server",
+        )
+
+        event = await background_task_manager._observe_retriable_bgtask(handler, args, metadata)
+
+        assert isinstance(event, BgtaskFailedEvent)
+        assert event.message is not None
+        assert "ValueError" in event.message

--- a/tests/common/bgtask/test_reporter.py
+++ b/tests/common/bgtask/test_reporter.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai.backend.common.bgtask.reporter import ProgressReporter
+from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.events.event_types.bgtask.broadcast import BgtaskUpdatedEvent
+from ai.backend.common.events.types import EventCacheDomain
+
+
+@pytest.fixture
+def mock_event_producer() -> AsyncMock:
+    producer = AsyncMock(spec=EventProducer)
+    producer.broadcast_event_with_cache = AsyncMock()
+    return producer
+
+
+@pytest.fixture
+def task_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def progress_reporter(mock_event_producer: AsyncMock, task_id: uuid.UUID) -> ProgressReporter:
+    return ProgressReporter(
+        event_producer=mock_event_producer,
+        task_id=task_id,
+        current_progress=0,
+        total_progress=100,
+    )
+
+
+class TestProgressReporter:
+    def test_init(self, mock_event_producer: AsyncMock, task_id: uuid.UUID) -> None:
+        reporter = ProgressReporter(mock_event_producer, task_id)
+        assert reporter._event_producer == mock_event_producer
+        assert reporter._task_id == task_id
+        assert reporter.current_progress == 0
+        assert reporter.total_progress == 0
+
+    def test_init_with_progress(self, mock_event_producer: AsyncMock, task_id: uuid.UUID) -> None:
+        reporter = ProgressReporter(
+            mock_event_producer,
+            task_id,
+            current_progress=10,
+            total_progress=100,
+        )
+        assert reporter.current_progress == 10
+        assert reporter.total_progress == 100
+
+    @pytest.mark.asyncio
+    async def test_update_without_message(
+        self,
+        progress_reporter: ProgressReporter,
+        mock_event_producer: AsyncMock,
+        task_id: uuid.UUID,
+    ) -> None:
+        await progress_reporter.update(increment=10)
+
+        assert progress_reporter.current_progress == 10
+        mock_event_producer.broadcast_event_with_cache.assert_called_once()
+
+        call_args = mock_event_producer.broadcast_event_with_cache.call_args
+        assert call_args[0][0] == EventCacheDomain.BGTASK.cache_id(str(task_id))
+
+        event = call_args[0][1]
+        assert isinstance(event, BgtaskUpdatedEvent)
+        assert event.task_id == task_id
+        assert event.message is None
+        assert event.current_progress == 10
+        assert event.total_progress == 100
+
+    @pytest.mark.asyncio
+    async def test_update_with_message(
+        self,
+        progress_reporter: ProgressReporter,
+        mock_event_producer: AsyncMock,
+        task_id: uuid.UUID,
+    ) -> None:
+        await progress_reporter.update(increment=25, message="Processing batch 1")
+
+        assert progress_reporter.current_progress == 25
+        mock_event_producer.broadcast_event_with_cache.assert_called_once()
+
+        call_args = mock_event_producer.broadcast_event_with_cache.call_args
+        event = call_args[0][1]
+        assert isinstance(event, BgtaskUpdatedEvent)
+        assert event.message == "Processing batch 1"
+        assert event.current_progress == 25
+        assert event.total_progress == 100
+
+    @pytest.mark.asyncio
+    async def test_multiple_updates(
+        self, progress_reporter: ProgressReporter, mock_event_producer: AsyncMock
+    ) -> None:
+        await progress_reporter.update(increment=10, message="Step 1")
+        await progress_reporter.update(increment=20, message="Step 2")
+        await progress_reporter.update(increment=30, message="Step 3")
+
+        assert progress_reporter.current_progress == 60
+        assert mock_event_producer.broadcast_event_with_cache.call_count == 3
+
+        last_call = mock_event_producer.broadcast_event_with_cache.call_args_list[-1]
+        event = last_call[0][1]
+        assert event.current_progress == 60
+        assert event.message == "Step 3"
+
+    @pytest.mark.asyncio
+    async def test_update_with_float_increment(
+        self, progress_reporter: ProgressReporter, mock_event_producer: AsyncMock
+    ) -> None:
+        await progress_reporter.update(increment=10.5)
+        assert progress_reporter.current_progress == 10.5
+
+        await progress_reporter.update(increment=20.3)
+        assert progress_reporter.current_progress == 30.8
+
+    @pytest.mark.asyncio
+    async def test_update_with_zero_increment(
+        self, progress_reporter: ProgressReporter, mock_event_producer: AsyncMock
+    ) -> None:
+        await progress_reporter.update(increment=0, message="Status update")
+
+        assert progress_reporter.current_progress == 0
+        mock_event_producer.broadcast_event_with_cache.assert_called_once()
+
+        call_args = mock_event_producer.broadcast_event_with_cache.call_args
+        event = call_args[0][1]
+        assert event.current_progress == 0
+        assert event.message == "Status update"
+
+    @pytest.mark.asyncio
+    async def test_update_with_negative_increment(
+        self, progress_reporter: ProgressReporter
+    ) -> None:
+        progress_reporter.current_progress = 50
+        await progress_reporter.update(increment=-10)
+
+        assert progress_reporter.current_progress == 40
+
+    @pytest.mark.asyncio
+    async def test_concurrent_updates(self, progress_reporter: ProgressReporter) -> None:
+        async def update_task(increment: int, message: str):
+            await progress_reporter.update(increment=increment, message=message)
+
+        tasks = [
+            update_task(10, "Task 1"),
+            update_task(20, "Task 2"),
+            update_task(30, "Task 3"),
+        ]
+
+        await asyncio.gather(*tasks)
+        assert progress_reporter.current_progress == 60
+
+    def test_progress_state_persistence(self, progress_reporter: ProgressReporter) -> None:
+        progress_reporter.current_progress = 50
+        progress_reporter.total_progress = 200
+
+        assert progress_reporter.current_progress == 50
+        assert progress_reporter.total_progress == 200
+
+    @pytest.mark.asyncio
+    async def test_cache_id_usage(self, mock_event_producer: AsyncMock, task_id: uuid.UUID) -> None:
+        reporter = ProgressReporter(mock_event_producer, task_id)
+        await reporter.update(increment=1)
+
+        expected_cache_id = EventCacheDomain.BGTASK.cache_id(str(task_id))
+        call_args = mock_event_producer.broadcast_event_with_cache.call_args
+        assert call_args[0][0] == expected_cache_id

--- a/tests/common/bgtask/test_task_base.py
+++ b/tests/common/bgtask/test_task_base.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Mapping
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai.backend.common.bgtask.reporter import ProgressReporter
+from ai.backend.common.bgtask.task.base import BaseBackgroundTaskArgs, BaseBackgroundTaskHandler
+from ai.backend.common.types import DispatchResult
+
+
+# Mock task name enum for testing - using actual TaskName values
+class MockTaskName(StrEnum):
+    MOCK_TASK_ONE = "clone_vfolder"  # Matches TaskName.CLONE_VFOLDER
+    MOCK_TASK_TWO = "push_image"  # Matches TaskName.PUSH_IMAGE
+
+
+class ConcreteTaskArgs(BaseBackgroundTaskArgs):
+    def __init__(self, value: str, count: int = 0) -> None:
+        self.value = value
+        self.count = count
+
+    def to_metadata_body(self) -> dict[str, Any]:
+        return {
+            "value": self.value,
+            "count": self.count,
+        }
+
+    @classmethod
+    def from_metadata_body(cls, body: Mapping[str, Any]) -> ConcreteTaskArgs:
+        return cls(
+            value=body.get("value", ""),
+            count=body.get("count", 0),
+        )
+
+
+class ConcreteTaskHandler(BaseBackgroundTaskHandler[ConcreteTaskArgs]):
+    async def execute(self, reporter: ProgressReporter, args: ConcreteTaskArgs) -> DispatchResult:
+        await reporter.update(1, f"Processing {args.value}")
+        result = {"processed": args.value, "count": args.count}
+        return DispatchResult(result=result)
+
+    @classmethod
+    def name(cls) -> MockTaskName:  # type: ignore[override]
+        return MockTaskName.MOCK_TASK_ONE
+
+    @classmethod
+    def args_type(cls) -> type[ConcreteTaskArgs]:
+        return ConcreteTaskArgs
+
+
+class TestBaseBackgroundTaskArgs:
+    def test_concrete_implementation(self) -> None:
+        args = ConcreteTaskArgs(value="test", count=5)
+        assert args.value == "test"
+        assert args.count == 5
+
+    def test_to_metadata_body(self) -> None:
+        args = ConcreteTaskArgs(value="hello", count=10)
+        body = args.to_metadata_body()
+
+        assert isinstance(body, dict)
+        assert body["value"] == "hello"
+        assert body["count"] == 10
+
+    def test_from_metadata_body(self) -> None:
+        body = {"value": "world", "count": 20}
+        args = ConcreteTaskArgs.from_metadata_body(body)
+
+        assert isinstance(args, ConcreteTaskArgs)
+        assert args.value == "world"
+        assert args.count == 20
+
+    def test_from_metadata_body_with_missing_fields(self) -> None:
+        body = {"value": "partial"}
+        args = ConcreteTaskArgs.from_metadata_body(body)
+
+        assert args.value == "partial"
+        assert args.count == 0
+
+    def test_from_metadata_body_empty(self) -> None:
+        body: dict[str, Any] = {}
+        args = ConcreteTaskArgs.from_metadata_body(body)
+
+        assert args.value == ""
+        assert args.count == 0
+
+    def test_round_trip_serialization(self) -> None:
+        original = ConcreteTaskArgs(value="round-trip", count=42)
+        body = original.to_metadata_body()
+        restored = ConcreteTaskArgs.from_metadata_body(body)
+
+        assert restored.value == original.value
+        assert restored.count == original.count
+
+
+class TestBaseBackgroundTaskHandler:
+    @pytest.mark.asyncio
+    async def test_concrete_handler_execute(self) -> None:
+        handler = ConcreteTaskHandler()
+        args = ConcreteTaskArgs(value="test-value", count=3)
+
+        reporter = AsyncMock(spec=ProgressReporter)
+        reporter.update = AsyncMock()
+
+        result = await handler.execute(reporter, args)
+
+        assert isinstance(result, DispatchResult)
+        assert result.result is not None
+        assert result.result["processed"] == "test-value"
+        assert result.result["count"] == 3
+
+        reporter.update.assert_called_once_with(1, "Processing test-value")
+
+    def test_handler_name(self) -> None:
+        assert ConcreteTaskHandler.name() == MockTaskName.MOCK_TASK_ONE
+
+    def test_handler_args_type(self) -> None:
+        assert ConcreteTaskHandler.args_type() == ConcreteTaskArgs
+
+    def test_handler_generic_typing(self) -> None:
+        handler = ConcreteTaskHandler()
+        assert isinstance(handler, BaseBackgroundTaskHandler)
+
+    @pytest.mark.asyncio
+    async def test_handler_with_empty_args(self) -> None:
+        from unittest.mock import AsyncMock
+
+        handler = ConcreteTaskHandler()
+        args = ConcreteTaskArgs(value="", count=0)
+
+        reporter = AsyncMock(spec=ProgressReporter)
+        reporter.update = AsyncMock()
+
+        result = await handler.execute(reporter, args)
+
+        assert result.result is not None
+        assert result.result["processed"] == ""
+        assert result.result["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_handler_with_error_result(self) -> None:
+        from unittest.mock import AsyncMock
+
+        class ErrorTaskHandler(BaseBackgroundTaskHandler[ConcreteTaskArgs]):
+            async def execute(
+                self, reporter: ProgressReporter, args: ConcreteTaskArgs
+            ) -> DispatchResult:
+                return DispatchResult(
+                    result={"status": "partial"},
+                    errors=["Something went wrong"],
+                )
+
+            @classmethod
+            def name(cls) -> MockTaskName:  # type: ignore[override]
+                return MockTaskName.MOCK_TASK_TWO
+
+            @classmethod
+            def args_type(cls) -> type[ConcreteTaskArgs]:
+                return ConcreteTaskArgs
+
+        handler = ErrorTaskHandler()
+        args = ConcreteTaskArgs(value="error-test", count=1)
+
+        reporter = AsyncMock(spec=ProgressReporter)
+        result = await handler.execute(reporter, args)
+
+        assert result.has_error()
+        assert len(result.errors) == 1
+        assert result.errors[0] == "Something went wrong"

--- a/tests/common/bgtask/test_task_registry.py
+++ b/tests/common/bgtask/test_task_registry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai.backend.common.bgtask.reporter import ProgressReporter
+from ai.backend.common.bgtask.task.base import BaseBackgroundTaskArgs, BaseBackgroundTaskHandler
+from ai.backend.common.bgtask.task.registry import BackgroundTaskHandlerRegistry
+from ai.backend.common.exception import BgtaskNotRegisteredError
+from ai.backend.common.types import DispatchResult
+
+# Mock task names for testing - using actual TaskName values
+MOCK_TASK_ONE = "clone_vfolder"  # Matches TaskName.CLONE_VFOLDER
+MOCK_TASK_TWO = "push_image"  # Matches TaskName.PUSH_IMAGE
+
+
+class MockTaskArgs(BaseBackgroundTaskArgs):
+    def __init__(self, data: str = "") -> None:
+        self.data = data
+
+    def to_metadata_body(self) -> dict[str, Any]:
+        return {"data": self.data}
+
+    @classmethod
+    def from_metadata_body(cls, body: Mapping[str, Any]) -> MockTaskArgs:
+        return cls(data=body.get("data", ""))
+
+
+class MockTaskOneHandler(BaseBackgroundTaskHandler[MockTaskArgs]):
+    async def execute(self, reporter: ProgressReporter, args: MockTaskArgs) -> DispatchResult:
+        return DispatchResult(result={"result": f"processed_one: {args.data}"})
+
+    @classmethod
+    def name(cls) -> str:  # type: ignore[override]
+        return MOCK_TASK_ONE
+
+    @classmethod
+    def args_type(cls) -> type[MockTaskArgs]:
+        return MockTaskArgs
+
+
+class MockTaskTwoHandler(BaseBackgroundTaskHandler[MockTaskArgs]):
+    async def execute(self, reporter: ProgressReporter, args: MockTaskArgs) -> DispatchResult:
+        return DispatchResult(result={"result": f"processed_two: {args.data}"})
+
+    @classmethod
+    def name(cls) -> str:  # type: ignore[override]
+        return MOCK_TASK_TWO
+
+    @classmethod
+    def args_type(cls) -> type[MockTaskArgs]:
+        return MockTaskArgs
+
+
+class TestBackgroundTaskHandlerRegistry:
+    def test_init(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+        assert hasattr(registry, "_registry")
+        assert registry._registry == {}
+
+    def test_register_single_task(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+        handler = MockTaskOneHandler()
+
+        registry.register(handler)
+
+        assert MOCK_TASK_ONE in registry._registry
+        assert registry._registry[MOCK_TASK_ONE] == handler  # type: ignore[index]
+
+    def test_register_multiple_tasks(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+        handler_one = MockTaskOneHandler()
+        handler_two = MockTaskTwoHandler()
+
+        registry.register(handler_one)
+        registry.register(handler_two)
+
+        assert len(registry._registry) == 2
+        assert registry._registry[MOCK_TASK_ONE] == handler_one  # type: ignore[index]
+        assert registry._registry[MOCK_TASK_TWO] == handler_two  # type: ignore[index]
+
+    def test_get_registered_task(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+        handler = MockTaskOneHandler()
+        registry.register(handler)
+
+        retrieved_handler = registry.get_task(MOCK_TASK_ONE)  # type: ignore[arg-type]
+
+        assert retrieved_handler == handler
+        assert retrieved_handler.name() == MOCK_TASK_ONE
+
+    def test_get_unregistered_task(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+
+        with pytest.raises(BgtaskNotRegisteredError):
+            registry.get_task(MOCK_TASK_ONE)  # type: ignore[arg-type]
+
+    def test_override_registered_task(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+
+        class CustomTaskOneHandler(BaseBackgroundTaskHandler[MockTaskArgs]):
+            async def execute(
+                self, reporter: ProgressReporter, args: MockTaskArgs
+            ) -> DispatchResult:
+                return DispatchResult(result={"result": "custom task one"})
+
+            @classmethod
+            def name(cls) -> str:  # type: ignore[override]
+                return MOCK_TASK_ONE
+
+            @classmethod
+            def args_type(cls) -> type[MockTaskArgs]:
+                return MockTaskArgs
+
+        original_handler = MockTaskOneHandler()
+        custom_handler = CustomTaskOneHandler()
+
+        registry.register(original_handler)
+        assert registry._registry[MOCK_TASK_ONE] == original_handler  # type: ignore[index]
+
+        registry.register(custom_handler)
+        assert registry._registry[MOCK_TASK_ONE] == custom_handler  # type: ignore[index]
+
+    def test_get_task_after_override(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+
+        original_handler = MockTaskOneHandler()
+        registry.register(original_handler)
+
+        handler_two = MockTaskTwoHandler()
+        registry.register(handler_two)
+
+        retrieved_one = registry.get_task(MOCK_TASK_ONE)  # type: ignore[arg-type]
+        retrieved_two = registry.get_task(MOCK_TASK_TWO)  # type: ignore[arg-type]
+
+        assert retrieved_one == original_handler
+        assert retrieved_two == handler_two
+
+    def test_registry_isolation(self) -> None:
+        registry1 = BackgroundTaskHandlerRegistry()
+        registry2 = BackgroundTaskHandlerRegistry()
+
+        handler1 = MockTaskOneHandler()
+        handler2 = MockTaskTwoHandler()
+
+        registry1.register(handler1)
+        registry2.register(handler2)
+
+        assert MOCK_TASK_ONE in registry1._registry
+        assert MOCK_TASK_ONE not in registry2._registry
+
+        assert MOCK_TASK_TWO not in registry1._registry
+        assert MOCK_TASK_TWO in registry2._registry
+
+    @pytest.mark.asyncio
+    async def test_registered_handler_execution(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+        handler = MockTaskOneHandler()
+        registry.register(handler)
+
+        retrieved_handler = registry.get_task(MOCK_TASK_ONE)  # type: ignore[arg-type]
+        args = MockTaskArgs(data="test-data")
+        reporter = AsyncMock(spec=ProgressReporter)
+
+        result = await retrieved_handler.execute(reporter, args)
+
+        assert result.result is not None
+        assert result.result["result"] == "processed_one: test-data"
+
+    def test_get_multiple_unregistered_tasks(self) -> None:
+        registry = BackgroundTaskHandlerRegistry()
+
+        with pytest.raises(BgtaskNotRegisteredError):
+            registry.get_task(MOCK_TASK_ONE)  # type: ignore[arg-type]
+
+        with pytest.raises(BgtaskNotRegisteredError):
+            registry.get_task(MOCK_TASK_TWO)  # type: ignore[arg-type]

--- a/tests/common/bgtask/test_types.py
+++ b/tests/common/bgtask/test_types.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+from ai.backend.common.bgtask.types import (
+    BackgroundTaskMetadata,
+    BgtaskStatus,
+    TaskID,
+    TaskName,
+)
+
+
+class TestBgtaskStatus:
+    def test_status_values(self) -> None:
+        assert BgtaskStatus.STARTED == "bgtask_started"
+        assert BgtaskStatus.UPDATED == "bgtask_updated"
+        assert BgtaskStatus.DONE == "bgtask_done"
+        assert BgtaskStatus.CANCELLED == "bgtask_cancelled"
+        assert BgtaskStatus.FAILED == "bgtask_failed"
+        assert BgtaskStatus.PARTIAL_SUCCESS == "bgtask_partial_success"
+
+    def test_finished(self) -> None:
+        assert BgtaskStatus.DONE.finished() is True
+        assert BgtaskStatus.CANCELLED.finished() is True
+        assert BgtaskStatus.FAILED.finished() is True
+        assert BgtaskStatus.PARTIAL_SUCCESS.finished() is True
+
+        assert BgtaskStatus.STARTED.finished() is False
+        assert BgtaskStatus.UPDATED.finished() is False
+
+    def test_string_conversion(self) -> None:
+        assert str(BgtaskStatus.STARTED) == "bgtask_started"
+        assert str(BgtaskStatus.DONE) == "bgtask_done"
+
+
+class TestTaskName:
+    def test_task_names(self) -> None:
+        assert TaskName.CLONE_VFOLDER == "clone_vfolder"
+        assert TaskName.PUSH_IMAGE == "push_image"
+
+    def test_string_conversion(self) -> None:
+        assert str(TaskName.CLONE_VFOLDER) == "clone_vfolder"
+        assert str(TaskName.PUSH_IMAGE) == "push_image"
+
+
+class TestTaskID:
+    def test_task_id_creation(self) -> None:
+        uuid_value = uuid.uuid4()
+        task_id = TaskID(uuid_value)
+        assert task_id == uuid_value
+        assert isinstance(task_id, uuid.UUID)
+
+    def test_task_id_equality(self) -> None:
+        uuid_value = uuid.uuid4()
+        task_id1 = TaskID(uuid_value)
+        task_id2 = TaskID(uuid_value)
+        assert task_id1 == task_id2
+
+    def test_task_id_hash(self) -> None:
+        uuid_value = uuid.uuid4()
+        task_id = TaskID(uuid_value)
+        assert hash(task_id) == hash(uuid_value)
+
+        task_ids = {task_id}
+        assert task_id in task_ids
+
+
+class TestBackgroundTaskMetadata:
+    def test_create(self) -> None:
+        task_id = TaskID(uuid.uuid4())
+        metadata = BackgroundTaskMetadata.create(
+            task_id=task_id,
+            task_name=TaskName.CLONE_VFOLDER,
+            body={"key": "value"},
+            server_id="server-1",
+        )
+
+        assert metadata.task_id == task_id
+        assert metadata.task_name == TaskName.CLONE_VFOLDER
+        assert metadata.body == {"key": "value"}
+        assert metadata.server_id == "server-1"
+        assert metadata.tags == set()
+
+    def test_create_with_tags(self) -> None:
+        task_id = TaskID(uuid.uuid4())
+        tags = ["tag1", "tag2", "tag3"]
+        metadata = BackgroundTaskMetadata.create(
+            task_id=task_id,
+            task_name=TaskName.PUSH_IMAGE,
+            body={"data": "test"},
+            server_id="server-2",
+            tags=tags,
+        )
+
+        assert metadata.tags == {"tag1", "tag2", "tag3"}
+
+    def test_create_with_none_tags(self) -> None:
+        task_id = TaskID(uuid.uuid4())
+        metadata = BackgroundTaskMetadata.create(
+            task_id=task_id,
+            task_name=TaskName.CLONE_VFOLDER,
+            body={},
+            server_id="server-3",
+            tags=None,
+        )
+
+        assert metadata.tags == set()
+
+    def test_json_serialization_deserialization(self) -> None:
+        # Test to_json and from_json together since they are a pair for DB storage
+        task_id = TaskID(uuid.uuid4())
+        original_metadata = BackgroundTaskMetadata.create(
+            task_id=task_id,
+            task_name=TaskName.CLONE_VFOLDER,
+            body={"test": "data", "number": 42, "nested": {"key": "value"}},
+            server_id="server-1",
+            tags=["tag1", "tag2"],
+        )
+
+        # Serialize to JSON
+        json_str = original_metadata.to_json()
+
+        # Verify the JSON structure
+        data = json.loads(json_str)
+        assert data["task_id"] == str(task_id)
+        assert data["task_name"] == "clone_vfolder"
+        assert data["body"]["test"] == "data"
+        assert data["body"]["number"] == 42
+        assert data["server_id"] == "server-1"
+        assert set(data["tags"]) == {"tag1", "tag2"}
+
+        # Deserialize from JSON
+        restored_metadata = BackgroundTaskMetadata.from_json(json_str)
+
+        # Verify the restored object matches the original
+        assert str(restored_metadata.task_id) == str(original_metadata.task_id)
+        assert restored_metadata.task_name == original_metadata.task_name
+        assert restored_metadata.body == original_metadata.body
+        assert restored_metadata.server_id == original_metadata.server_id
+        assert restored_metadata.tags == original_metadata.tags
+
+    def test_json_serialization_with_bytes_input(self) -> None:
+        # Test that from_json can handle bytes input (common in DB operations)
+        task_id = TaskID(uuid.uuid4())
+        json_data = json.dumps({
+            "task_id": str(task_id),
+            "task_name": "clone_vfolder",
+            "body": {"data": "test"},
+            "server_id": "server-3",
+            "tags": [],
+        }).encode("utf-8")
+
+        metadata = BackgroundTaskMetadata.from_json(json_data)
+
+        assert str(metadata.task_id) == str(task_id)
+        assert metadata.task_name == TaskName.CLONE_VFOLDER
+        assert metadata.body == {"data": "test"}
+        assert metadata.server_id == "server-3"
+        assert metadata.tags == set()
+
+    def test_json_serialization_with_complex_data(self) -> None:
+        # Test serialization/deserialization with more complex nested structures
+        task_id = TaskID(uuid.uuid4())
+        complex_body = {
+            "nested": {"deeply": {"nested": "value"}},
+            "list": [1, 2, 3],
+            "mixed": [{"key": "value"}, {"another": "item"}],
+            "boolean": True,
+            "null": None,
+        }
+
+        original = BackgroundTaskMetadata.create(
+            task_id=task_id,
+            task_name=TaskName.PUSH_IMAGE,
+            body=complex_body,
+            server_id="server-complex",
+            tags=["tag1", "tag2", "tag3"],
+        )
+
+        # Round-trip serialization
+        json_str = original.to_json()
+        restored = BackgroundTaskMetadata.from_json(json_str)
+
+        assert str(restored.task_id) == str(original.task_id)
+        assert restored.task_name == original.task_name
+        assert restored.body == original.body
+        assert restored.body["nested"]["deeply"]["nested"] == "value"
+        assert restored.body["list"] == [1, 2, 3]
+        assert restored.server_id == original.server_id
+        assert restored.tags == original.tags


### PR DESCRIPTION
resolves #5620 (BA-2181)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
