### PR TITLE
chore: Ensure uv is added to PATH after install

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -282,9 +282,11 @@ fi
 show_info "Checking the uv installation..."
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
-  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
-  append_to_profiles "$uv_init_script"
-  eval "$uv_init_script"
+  if [ $SHELL = "/bin/fish" ]; then
+    source $HOME/.local/bin/env.fish
+  else
+    source $HOME/.local/bin/env
+  fi
   show_info "uv is installed."
 else
   show_info "uv is already installed."

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -279,6 +279,17 @@ else
   exit 1
 fi
 
+show_info "Checking the uv installation..."
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
+  append_to_profiles "$uv_init_script"
+  eval "$uv_init_script"
+  show_info "uv is installed."
+else
+  show_info "uv is already installed."
+fi
+
 show_info "Checking the bootstrapper Python version..."
 scripts/python.sh -c 'import sys; print(sys.version_info)'
 

--- a/scripts/pyscript.sh
+++ b/scripts/pyscript.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 PYVER="3.13.7"
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
+  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
+  append_to_profiles "$uv_init_script"
+  eval "$uv_init_script"
 fi
 # This variant auto-manages the script dependency caches in ~/.cache/uv and run the script using the cached venv.
 # e.g., `scripts/pyscript.sh scripts/do-something.py ...`

--- a/scripts/pyscript.sh
+++ b/scripts/pyscript.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 PYVER="3.13.7"
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
-  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
-  append_to_profiles "$uv_init_script"
-  eval "$uv_init_script"
+  if [ $SHELL = "/bin/fish" ]; then
+    source $HOME/.local/bin/env.fish
+  else
+    source $HOME/.local/bin/env
+  fi
 fi
 # This variant auto-manages the script dependency caches in ~/.cache/uv and run the script using the cached venv.
 # e.g., `scripts/pyscript.sh scripts/do-something.py ...`

--- a/scripts/python.sh
+++ b/scripts/python.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 PYVER="3.13.7"
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
-  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
-  append_to_profiles "$uv_init_script"
-  eval "$uv_init_script"
+  if [ $SHELL = "/bin/fish" ]; then
+    source $HOME/.local/bin/env.fish
+  else
+    source $HOME/.local/bin/env
+  fi
 fi
 # This variant transparently runs the python command without creating virtualenvs.
 # e.g., `scripts/python.sh -c '...'`

--- a/scripts/python.sh
+++ b/scripts/python.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 PYVER="3.13.7"
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
+  uv_init_script="export PATH=\"\$HOME/.local/bin:\$PATH\""
+  append_to_profiles "$uv_init_script"
+  eval "$uv_init_script"
 fi
 # This variant transparently runs the python command without creating virtualenvs.
 # e.g., `scripts/python.sh -c '...'`


### PR DESCRIPTION
Updates install-dev.sh, pyscript.sh, and python.sh to export $HOME/.local/bin to PATH after installing uv, ensuring the uv command is immediately available in the current session and future shells.
