### PR TITLE
feat(BA-2212): Add rover cli installation in install-dev script

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -917,12 +917,6 @@ install_rover_cli() {
 
   export PATH="$HOME/.rover/bin:$PATH"
   export APOLLO_ELV2_LICENSE=accept
-
-  echo "Verifying Rover installation:"
-  echo "  PATH includes Rover: $(echo $PATH | grep -q ".rover/bin" && echo "✓ Yes" || echo "✗ No")"
-  echo "  License accepted: $APOLLO_ELV2_LICENSE"
-  echo "  Rover version: $(rover --version 2>/dev/null || echo "✗ Command not found")"
-  echo "  Rover binary location: $(which rover 2>/dev/null || echo "✗ Not in PATH")"
 }
 
 configure_backendai() {


### PR DESCRIPTION
resolves #5663 (BA-2213)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
