### PR TITLE
Refresh worker after flush in update_worker

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Added an explicit call to await sess.refresh(worker) after flushing the session in update_worker. This ensures the worker object is up-to-date with the database state before proceeding

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -238,6 +238,7 @@ async def update_worker(
             )
             sess.add(worker)
             await sess.flush()
+            await sess.refresh(worker)
 
         for filter in params.app_filters:
             try:


### PR DESCRIPTION
Added an explicit call to await sess.refresh(worker) after flushing the session in update_worker. This ensures the worker object is up-to-date with the database state before proceeding.
