### PR TITLE
fix: Missing all-smi manpage in the package

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Add missing all-smi manpage file in the wheel packages

--- a/src/ai/backend/runner/BUILD
+++ b/src/ai/backend/runner/BUILD
@@ -57,6 +57,7 @@ resources(
         ".zshrc",
         ".tmux.conf",
         ".vimrc",
+        "all-smi.1",
         "terminfo.alpine3.8/**/*",
     ],
 )


### PR DESCRIPTION
- **fix: Missing all-smi manpage in the packaged wheels**
- **doc: Add news fragment**

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
