### PR TITLE
feat(BA-2218): Improve clipboard support in ttyd + tmux mouse mode

### DIFF
--- a/changes/5688.feature.md
+++ b/changes/5688.feature.md
@@ -1,0 +1,1 @@
+The mouse-selected or copy-mode selected texts in the intrinsic ttyd app with tmux are now directly copied to the user-side clipboard, without needing to `set mouse=off` in the tmux session

--- a/scripts/agent/build-ttyd.sh
+++ b/scripts/agent/build-ttyd.sh
@@ -22,15 +22,17 @@ build_script=$(cat <<'EOF'
 # Download ttyd source.
 git clone https://github.com/tsl0922/ttyd.git
 cd ttyd
+git checkout eccebc6bb1dfbaf0c46f1fd9c53b89abc773784d
 
 # Apply custom patch.
 git apply /workspace/patch.diff
 
 # Run build script.
-./scripts/cross-build.sh
-
-# Check ttyd binary version.
+env BUILD_TARGET=x86_64 ./scripts/cross-build.sh
 ./build/ttyd --version
+mv ./build/ttyd ./build/ttyd_linux.x86_64.bin
+env BUILD_TARGET=aarch64 ./scripts/cross-build.sh
+mv ./build/ttyd ./build/ttyd_linux.aarch64.bin
 
 # The script requires sudo to bootstrap a crossbuild toolchain.
 chown -R ${BUILDER_UID}:${BUILDER_GID} .

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -592,14 +592,16 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
             _mount(MountTypes.BIND, resolved_path, target_path)
 
         mount_static_binary(f"su-exec.{arch}.bin", "/opt/kernel/su-exec")
+        # /opt/kernel is for private executables not exposed in the user's PATH.
+        # /usr/local/bin is for public executables to be exposed in the user's PATH.
         mount_versioned_binary(f"libbaihook.*.{arch}.so", "/opt/kernel/libbaihook.so")
         mount_static_binary(f"dropbearmulti.{arch}.bin", "/opt/kernel/dropbearmulti")
         mount_static_binary(f"sftp-server.{arch}.bin", "/opt/kernel/sftp-server")
         mount_static_binary(f"tmux.{arch}.bin", "/opt/kernel/tmux")
+        mount_static_binary(f"ttyd_linux.{arch}.bin", "/opt/kernel/ttyd")
+        mount_static_binary("yank.sh", "/opt/kernel/yank.sh")
         mount_static_binary(f"all-smi.{arch}.bin", "/usr/local/bin/all-smi")
         mount_static_binary("all-smi.1", "/usr/local/share/man/man1/all-smi.1", skip_missing=True)
-        mount_static_binary(f"ttyd_linux.{arch}.bin", "/opt/kernel/ttyd")
-        mount_static_binary("yank.sh", "/usr/local/bin/yank.sh")
 
         jail_path: Optional[Path]
         if self.local_config.container.sandbox_type == ContainerSandboxType.JAIL:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -598,7 +598,8 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         mount_static_binary(f"tmux.{arch}.bin", "/opt/kernel/tmux")
         mount_static_binary(f"all-smi.{arch}.bin", "/usr/local/bin/all-smi")
         mount_static_binary("all-smi.1", "/usr/local/share/man/man1/all-smi.1", skip_missing=True)
-        mount_static_binary("yank.sh", "/opt/kernel/yank.sh")
+        mount_static_binary(f"ttyd_linux.{arch}.bin", "/opt/kernel/ttyd")
+        mount_static_binary("yank.sh", "/usr/local/bin/yank.sh")
 
         jail_path: Optional[Path]
         if self.local_config.container.sandbox_type == ContainerSandboxType.JAIL:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -598,6 +598,7 @@ class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
         mount_static_binary(f"tmux.{arch}.bin", "/opt/kernel/tmux")
         mount_static_binary(f"all-smi.{arch}.bin", "/usr/local/bin/all-smi")
         mount_static_binary("all-smi.1", "/usr/local/share/man/man1/all-smi.1", skip_missing=True)
+        mount_static_binary("yank.sh", "/opt/kernel/yank.sh")
 
         jail_path: Optional[Path]
         if self.local_config.container.sandbox_type == ContainerSandboxType.JAIL:

--- a/src/ai/backend/appproxy/worker/proxy/backend/base.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/base.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 import time
 from dataclasses import dataclass
 from typing import Any, final
 
-import aiohttp
+from aiohttp.streams import AsyncStreamIterator
 from yarl import URL
 
 from ai.backend.appproxy.common.types import RouteInfo
@@ -19,7 +21,7 @@ class HttpRequest:
     method: str
     path: str | URL
     headers: dict[str, Any]
-    body: aiohttp.StreamReader
+    body: AsyncStreamIterator[bytes] | None
 
 
 class BaseBackend:

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -6,7 +6,7 @@ import random
 import time
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import AsyncIterator, Final, override
+from typing import AsyncIterator, override
 
 import aiohttp
 import aiotools
@@ -26,8 +26,17 @@ from .base import BaseBackend, HttpRequest
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
-CHUNK_SIZE = 1 * 1024 * 1024  # 1 KiB
-SKIP_HEADERS: Final[set[str]] = {"connection"}
+HOP_ONLY_HEADERS: frozenset[str] = frozenset([
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "proxy-connection",
+])
 
 
 class HTTPBackend(BaseBackend):
@@ -47,7 +56,7 @@ class HTTPBackend(BaseBackend):
             partial(
                 tcp_client_session_factory,
                 timeout=client_timeout,
-                auto_decompress=False,
+                auto_decompress=False,  # transparently pass the response body
             ),
             cleanup_interval_seconds=cleanup_interval,
         )
@@ -85,14 +94,7 @@ class HTTPBackend(BaseBackend):
     ) -> AsyncIterator[aiohttp.ClientResponse]:
         metrics = self.root_context.metrics
         remote = f"{route.kernel_host}:{route.kernel_port}"
-        headers = dict(request.headers)
-
-        if headers.get("Transfer-Encoding", "").lower() == "chunked":
-            del headers["Transfer-Encoding"]
-
-        metrics.proxy.observe_upstream_http_request(
-            remote=remote, total_bytes_size=request.body.total_bytes
-        )
+        metrics.proxy.observe_upstream_http_request(remote=remote, total_bytes_size=0)
         client_key = ClientKey(
             endpoint=f"http://{route.kernel_host}:{route.kernel_port}",
             domain=str(route.route_id),
@@ -101,12 +103,13 @@ class HTTPBackend(BaseBackend):
         async with client_session.request(
             request.method,
             request.path,
-            headers=headers,
+            headers=request.headers,
+            allow_redirects=False,
             data=request.body,
+            auto_decompress=False,  # transparently pass the response body
+            compress=None,  # transparently pass the request body
         ) as response:
-            metrics.proxy.observe_upstream_http_response(
-                remote=remote, total_bytes_size=response.content.total_bytes
-            )
+            metrics.proxy.observe_upstream_http_response(remote=remote, total_bytes_size=0)
             yield response
 
     @asynccontextmanager
@@ -118,72 +121,99 @@ class HTTPBackend(BaseBackend):
             domain=str(route.route_id),
         )
         client_session = self.client_pool.load_client_session(client_key)
-        log.debug("connecting to {}", URL(client_key.endpoint).with_path(request.path))
+        log.trace("connecting to {}", URL(client_key.endpoint).with_path(request.path))
         async with client_session.ws_connect(request.rel_url, protocols=protocols) as ws:
-            log.debug("connected")
             yield ws
 
-    async def proxy_http(self, request: web.Request) -> web.StreamResponse:
-        protocol = self.get_x_forwarded_proto(request)
-        host = self.get_x_forwarded_host(request)
+    async def proxy_http(self, frontend_request: web.Request) -> web.StreamResponse:
+        protocol = self.get_x_forwarded_proto(frontend_request)
+        host = self.get_x_forwarded_host(frontend_request)
         remote_host, remote_port = (
-            request.transport.get_extra_info("peername") if request.transport else None,
+            frontend_request.transport.get_extra_info("peername")
+            if frontend_request.transport
+            else None,
             None,
         )
-        headers = {
-            "x-forwarded-proto": protocol,
-        }
+        backend_rqst_hdrs = {}
+        # copy frontend request headers without hop-by-hop headers
+        for key, value in frontend_request.headers.items():
+            if key.lower() not in HOP_ONLY_HEADERS:
+                backend_rqst_hdrs[key] = value
+        # overwrite proxy-related headers
+        backend_rqst_hdrs["x-forwarded-proto"] = protocol
         if self.circuit.app == "rstudio":
-            headers["x-rstudio-proto"] = protocol
+            backend_rqst_hdrs["x-rstudio-proto"] = protocol
         if host:
-            headers["forwarded"] = f"host={host};proto={protocol}"
-            headers["x-forwarded-host"] = host
+            backend_rqst_hdrs["forwarded"] = f"host={host};proto={protocol}"
+            backend_rqst_hdrs["x-forwarded-host"] = host
             if self.circuit.app == "rstudio":
-                headers["x-rstudio-request"] = f"{protocol}://{host}{request.path or ''}"
+                backend_rqst_hdrs["x-rstudio-request"] = (
+                    f"{protocol}://{host}{frontend_request.path or ''}"
+                )
             split = host.split(":")
             if len(split) >= 2:
-                headers["x-forwarded-port"] = split[1]
+                backend_rqst_hdrs["x-forwarded-port"] = split[1]
             elif remote_port:
-                headers["x-forwarded-port"] = remote_port
+                backend_rqst_hdrs["x-forwarded-port"] = remote_port
         if remote_host:
-            headers["x-forwarded-for"] = f"{remote_host[0]}:{remote_host[1]}"
-        headers_to_skip = set(headers.keys()) | SKIP_HEADERS
-        for key, value in request.headers.items():
-            if key.lower() not in headers_to_skip:
-                headers[key] = value
-        upstream_request = HttpRequest(
-            request.method,
-            request.rel_url,
-            headers,
-            request.content,
+            backend_rqst_hdrs["x-forwarded-for"] = f"{remote_host[0]}:{remote_host[1]}"
+        if frontend_request.body_exists:
+            backend_rqst_body = frontend_request.content.iter_any()
+        else:
+            backend_rqst_body = None
+        backend_request = HttpRequest(
+            frontend_request.method,
+            frontend_request.rel_url,
+            backend_rqst_hdrs,
+            backend_rqst_body,
         )
         route = self.selected_route
         await self.mark_last_used_time(route)
         await self.increase_request_counter()
-        log.debug(
-            "Proxying {} {} HTTP Request to {}:{}",
-            request.method,
-            request.rel_url,
+        log.trace(
+            "proxying {} {} HTTP Request to {}:{}",
+            frontend_request.method,
+            frontend_request.rel_url,
             route.kernel_host,
             route.kernel_port,
         )
-
         try:
-            async with self.request_http(route, upstream_request) as backend_response:
-                response = web.StreamResponse(
+            async with self.request_http(route, backend_request) as backend_response:
+                frontend_resp_hdrs = {}
+                for key, value in backend_response.headers.items():
+                    if key.lower() not in HOP_ONLY_HEADERS:
+                        frontend_resp_hdrs[key] = value
+                frontend_resp_hdrs["Access-Control-Allow-Origin"] = "*"
+                frontend_response = web.StreamResponse(
                     status=backend_response.status,
-                    headers={**backend_response.headers, "Access-Control-Allow-Origin": "*"},
+                    reason=backend_response.reason,
+                    headers=frontend_resp_hdrs,
                 )
-                await response.prepare(request)
-                async for data in backend_response.content.iter_chunked(CHUNK_SIZE):
-                    await response.write(data)
-                return response
+                if "Content-Length" not in backend_response.headers:
+                    frontend_response.enable_chunked_encoding()
+                await frontend_response.prepare(frontend_request)
+                recv_len = 0
+                try:
+                    async for data in backend_response.content.iter_any():
+                        recv_len += len(data)
+                        await frontend_response.write(data)
+                except aiohttp.ClientPayloadError as e:
+                    log.exception(
+                        "{!r} (recv-len: {}, content-length: {}, headers: {!r})",
+                        e,
+                        recv_len,
+                        backend_response.content_length,
+                        frontend_resp_hdrs,
+                    )
+                finally:
+                    await frontend_response.write_eof()
+                return frontend_response
         except ConnectionResetError:
             raise asyncio.CancelledError()
         except aiohttp.ClientOSError as e:
             raise ContainerConnectionRefused from e
         except:
-            log.exception("")
+            log.exception("Unhandled exception while proxying HTTP request")
             raise
 
     async def proxy_ws(self, request: web.Request) -> web.WebSocketResponse:
@@ -238,7 +268,7 @@ class HTTPBackend(BaseBackend):
             await self.mark_last_used_time(route)
 
         route = self.selected_route
-        log.debug(
+        log.trace(
             "Proxying {} {} WS Request to {}:{}",
             request.method,
             request.path or "/",
@@ -273,16 +303,15 @@ class HTTPBackend(BaseBackend):
                         log.debug("created tasks, now waiting until one of two tasks end")
                         await stop_event.wait()
                 finally:
-                    log.debug("tasks ended")
                     marker_task.cancel()
                     await marker_task
                     if not downstream_ws.closed:
                         await downstream_ws.close()
                     if not upstream_ws.closed:
                         await upstream_ws.close()
-            log.debug("websocket connection closed")
+            log.trace("websocket connection closed")
         except ClientConnectorError:
-            log.debug("upstream connection closed")
+            log.trace("upstream connection closed")
             if not downstream_ws.closed:
                 await downstream_ws.close()
         finally:

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -162,7 +162,7 @@ async def prepare_ttyd_service(service_info):
     elif Path("/bin/ash").exists():
         shell = "ash"
 
-    cmdargs = ["/opt/kernel/ttyd", "-p", service_info["port"], f"/bin/{shell}"]
-    if shell != "ash":  # Currently Alpine-based containers are not supported.
+    cmdargs = ["/opt/kernel/ttyd", "-W", "-p", service_info["port"], f"/bin/{shell}"]
+    if shell != "ash":  # Currently prebuilt tmux in Alpine-based containers are not supported.
         cmdargs += ["-c", f"export SHELL=/bin/{shell}; /opt/kernel/tmux -2 attach"]
     return cmdargs, {}

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -163,7 +163,6 @@ async def prepare_ttyd_service(service_info):
         shell = "ash"
 
     cmdargs = ["/opt/kernel/ttyd", "-W", "-p", service_info["port"], f"/bin/{shell}"]
-    # cmdargs = ["/opt/backend.ai/bin/ttyd", "-p", service_info["port"], f"/bin/{shell}"]
-    if shell != "ash":  # Currently prebuilt tmux in Alpine-based containers are not supported.
+    if shell != "ash":  # Currently prebuilt tmux in Alpine-based containers is not supported.
         cmdargs += ["-c", f"export SHELL=/bin/{shell}; /opt/kernel/tmux -2 attach"]
     return cmdargs, {}

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -163,6 +163,7 @@ async def prepare_ttyd_service(service_info):
         shell = "ash"
 
     cmdargs = ["/opt/kernel/ttyd", "-W", "-p", service_info["port"], f"/bin/{shell}"]
+    # cmdargs = ["/opt/backend.ai/bin/ttyd", "-p", service_info["port"], f"/bin/{shell}"]
     if shell != "ash":  # Currently prebuilt tmux in Alpine-based containers are not supported.
         cmdargs += ["-c", f"export SHELL=/bin/{shell}; /opt/kernel/tmux -2 attach"]
     return cmdargs, {}

--- a/src/ai/backend/kernel/intrinsic.py
+++ b/src/ai/backend/kernel/intrinsic.py
@@ -162,7 +162,7 @@ async def prepare_ttyd_service(service_info):
     elif Path("/bin/ash").exists():
         shell = "ash"
 
-    cmdargs = ["/opt/backend.ai/bin/ttyd", "-p", service_info["port"], f"/bin/{shell}"]
+    cmdargs = ["/opt/kernel/ttyd", "-p", service_info["port"], f"/bin/{shell}"]
     if shell != "ash":  # Currently Alpine-based containers are not supported.
         cmdargs += ["-c", f"export SHELL=/bin/{shell}; /opt/kernel/tmux -2 attach"]
     return cmdargs, {}

--- a/src/ai/backend/runner/.tmux.conf
+++ b/src/ai/backend/runner/.tmux.conf
@@ -58,8 +58,6 @@ yank="/opt/kernel/yank.sh"
 # M-w -> copy-selection-and-cancel
 unbind-key -T copy-mode MouseDragEnd1Pane
 unbind-key -T copy-mode y
-# bind-key -T copy-mode y send-keys -X copy-selection
-# bind-key -T copy-mode enter send-keys -X copy-selection-and-cancel
 bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "$yank"
 bind-key -T copy-mode y                 send-keys -X copy-pipe "$yank"
 bind-key -T copy-mode enter             send-keys -X copy-pipe-and-cancel "$yank"

--- a/src/ai/backend/runner/.tmux.conf
+++ b/src/ai/backend/runner/.tmux.conf
@@ -58,8 +58,10 @@ yank="/opt/kernel/yank.sh"
 # M-w -> copy-selection-and-cancel
 unbind-key -T copy-mode MouseDragEnd1Pane
 unbind-key -T copy-mode y
+unbind-key -T copy-mode M-w
 bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "$yank"
 bind-key -T copy-mode y                 send-keys -X copy-pipe "$yank"
+bind-key -T copy-mode M-w               send-keys -X copy-pipe-and-cancel "$yank"
 bind-key -T copy-mode enter             send-keys -X copy-pipe-and-cancel "$yank"
 bind-key -T copy-mode space             send-keys -X begin-selection
 

--- a/src/ai/backend/runner/.tmux.conf
+++ b/src/ai/backend/runner/.tmux.conf
@@ -26,7 +26,8 @@ run-shell "if [ -x /bin/zsh ]; then /opt/kernel/tmux set-option -g default-shell
 # override inner $TERM
 set-option -g default-terminal "xterm-256color"
 # override outer $TERM for true-color support (tmux 2.3+)
-set-option -as terminal-overrides ",xterm-256color:Tc,gnome*:RGB"
+set-option -as terminal-features ',xterm-256color:Tc:RGB:clipboard'
+
 
 # Enable mouse features
 set -g mouse on
@@ -46,11 +47,36 @@ bind _ split-window -v
 set-option -g base-index 1
 set-option -g set-titles on
 set-option -g visual-activity on
-# set-window-option -g mode-keys vi
+
+set-option -g set-clipboard on
+set-option -g allow-passthrough on
+
+yank="/opt/kernel/yank.sh"
+
+# Original key bindings for copy-mode (default style)
+# C-space -> begin-selection
+# M-w -> copy-selection-and-cancel
+unbind-key -T copy-mode MouseDragEnd1Pane
+unbind-key -T copy-mode y
+# bind-key -T copy-mode y send-keys -X copy-selection
+# bind-key -T copy-mode enter send-keys -X copy-selection-and-cancel
+bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "$yank"
+bind-key -T copy-mode y                 send-keys -X copy-pipe "$yank"
+bind-key -T copy-mode enter             send-keys -X copy-pipe-and-cancel "$yank"
+bind-key -T copy-mode space             send-keys -X begin-selection
+
+# Original key bindings for copy-mode (vi style)
+# space -> begin-selection
+# enter -> copy-selection-and-cancel
+unbind-key -T copy-mode-vi MouseDragEnd1Pane
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "$yank"
+bind-key -T copy-mode-vi y                 send-keys -X copy-pipe "$yank"
+bind-key -T copy-mode-vi enter             send-keys -X copy-pipe-and-cancel "$yank"
+
+
 # set-window-option -g automatic-rename
 # set-window-option -g monitor-activity on
 # set-window-option -g aggressive-resize on
-# set -g status off
 
 set-option -g history-limit 5000
 

--- a/src/ai/backend/runner/BUILD
+++ b/src/ai/backend/runner/BUILD
@@ -58,6 +58,7 @@ resources(
         ".tmux.conf",
         ".vimrc",
         "all-smi.1",
+        "yank.sh",
         "terminfo.alpine3.8/**/*",
     ],
 )

--- a/src/ai/backend/runner/ttyd_linux.aarch64.bin
+++ b/src/ai/backend/runner/ttyd_linux.aarch64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c442ad9adaab27e062dd9f46f35ca0afe67a15f8eb344e21a1a0a557da57f1
+size 1372880

--- a/src/ai/backend/runner/ttyd_linux.x86_64.bin
+++ b/src/ai/backend/runner/ttyd_linux.x86_64.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5ef0c94c22e86232966b257bed3f34a903a0fb41bae1b29a18baffc13d510cf
+size 1364824

--- a/src/ai/backend/runner/yank.sh
+++ b/src/ai/backend/runner/yank.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This is a simplified and modified version of https://github.com/samoshkin/tmux-config/blob/af2efd9/tmux/yank.sh
+# to make it working with no-clear, no-cancel variants of the tmux copy-pipe commands
+set -eu
+
+# get data either form stdin or from file
+buf=$(cat "$@")
+
+# Copy via OSC 52 ANSI escape sequence to controlling terminal
+buflen=$( printf %s "$buf" | wc -c )
+
+# https://sunaku.github.io/tmux-yank-osc52.html
+# The maximum length of an OSC 52 escape sequence is 100_000 bytes, of which
+# 7 bytes are occupied by a "\033]52;c;" header, 1 byte by a "\a" footer, and
+# 99_992 bytes by the base64-encoded result of 74_994 bytes of copyable text
+maxlen=74994
+
+# warn if exceeds maxlen
+if [ "$buflen" -gt "$maxlen" ]; then
+  printf "yank.sh: input is too long (%d bytes, max: ${max_len} bytes)" "$(( buflen - maxlen ))" >&2
+fi
+
+# build up OSC 52 ANSI escape sequence
+esc="\033]52;c;$( printf %s "$buf" | head -c $maxlen | base64 | tr -d '\r\n' )\a"
+
+# resolve target terminal to send escape sequence
+pane_active_tty=$(tmux list-panes -F "#{pane_active} #{pane_tty}" | awk '$1=="1" { print $2 }')
+target_tty="${SSH_TTY:-$pane_active_tty}"
+
+printf "$esc" > "$target_tty"

--- a/src/ai/backend/runner/yank.sh
+++ b/src/ai/backend/runner/yank.sh
@@ -19,7 +19,7 @@ maxlen=74994
 
 # warn if exceeds maxlen
 if [ "$buflen" -gt "$maxlen" ]; then
-  printf "yank.sh: input is too long (%d bytes, max: ${max_len} bytes)" "$(( buflen - maxlen ))" >&2
+  printf "yank.sh: input is too long (%d bytes, max: $maxlen bytes)" "$(( buflen - maxlen ))" >&2
 fi
 
 # build up OSC 52 ANSI escape sequence

--- a/src/ai/backend/runner/yank.sh
+++ b/src/ai/backend/runner/yank.sh
@@ -3,6 +3,8 @@
 # to make it working with no-clear, no-cancel variants of the tmux copy-pipe commands
 set -eu
 
+tmux=/opt/kernel/tmux
+
 # get data either form stdin or from file
 buf=$(cat "$@")
 
@@ -24,7 +26,7 @@ fi
 esc="\033]52;c;$( printf %s "$buf" | head -c $maxlen | base64 | tr -d '\r\n' )\a"
 
 # resolve target terminal to send escape sequence
-pane_active_tty=$(tmux list-panes -F "#{pane_active} #{pane_tty}" | awk '$1=="1" { print $2 }')
+pane_active_tty=$("$tmux" list-panes -F "#{pane_active} #{pane_tty}" | awk '$1=="1" { print $2 }')
 target_tty="${SSH_TTY:-$pane_active_tty}"
 
 printf "$esc" > "$target_tty"


### PR DESCRIPTION
resolves #5687 (BA-2218)

* Update ttyd to the latest source version to enable **the xterm.js clipboard plugin** which handles OSC 52 sequences.
  - Previously, ttyd was imported from `backend.ai-krunner-static-gnu` package, but now it is embedded in `backend.ai-kernel-binary` package with the automated build script: `scripts/agent/build-ttyd.sh`.
* Update `.tmux.conf` to use the new `/opt/kernel/yank.sh` script for copying the buffer selection.
  - Explicitly enable the clipboard support and allow-passthrough option in the tmux config.
  - `yank.sh` transforms the piped text into a base64-encoded OSC 52 sequence and prints it into the tty device used by the tmux pane.
* Fix the app proxy's aiohttp worker NOT to send empty HTTP bodies when the frontend request does not have the body at all, by checking `.body_exists` attribute.
  - This hidden bug caused premature connection shutdown from the updated libwebsockets in ttyd as it no longer accepts HTTP bodies with GET/HEAD requests (saying `lws_read_h1: Unhandled state 282` error).

**Checklist:** (if applicable)

- [x] Mention to the original issue
