### PR TITLE
fix(BA-2229): Delete sessions and kernels records when purge user

### DIFF
--- a/changes/5691.fix.md
+++ b/changes/5691.fix.md
@@ -1,0 +1,1 @@
+Delete session and kernel records when user records are purged

--- a/src/ai/backend/manager/repositories/user/admin_repository.py
+++ b/src/ai/backend/manager/repositories/user/admin_repository.py
@@ -63,6 +63,8 @@ class AdminUserRepository:
             await self._delete_keypairs(conn, user_uuid)
             await self._delete_vfolder_permissions(conn, user_uuid)
             await self._clear_user_groups(conn, user_uuid)
+            await self._delete_kernels(conn, user_uuid)
+            await self._delete_sessions(conn, user_uuid)
 
             # Finally delete the user
             await conn.execute(sa.delete(users).where(users.c.email == email))
@@ -210,6 +212,16 @@ class AdminUserRepository:
                 association_groups_users.c.user_id == user_uuid
             )
         )
+
+    async def _delete_kernels(self, conn: SAConnection, user_uuid: UUID) -> int:
+        """Private method to delete user's kernels."""
+        result = await conn.execute(sa.delete(kernels).where(kernels.c.user_uuid == user_uuid))
+        return result.rowcount
+
+    async def _delete_sessions(self, conn: SAConnection, user_uuid: UUID) -> int:
+        """Private method to delete user's sessions."""
+        result = await conn.execute(sa.delete(SessionRow).where(SessionRow.user_uuid == user_uuid))
+        return result.rowcount
 
     async def _user_vfolder_mounted_to_active_kernels(
         self,


### PR DESCRIPTION
resolves #5692 (BA-2229)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
