### PR TITLE
feat: Improvement redis keys command to scan_iter for manager cli

### DIFF
--- a/changes/5704.feature.md
+++ b/changes/5704.feature.md
@@ -1,0 +1,1 @@
+feat: Improvement redis keys command to scan_iter for manager cli


### PR DESCRIPTION
resolves #BA-2218

change keys to scan_iter for manager cli

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
