### PR TITLE
fix: scaling group check failing

### DIFF
--- a/changes/5706.fix.md
+++ b/changes/5706.fix.md
@@ -1,0 +1,1 @@
+Fix session creation failing with `not allowed scaling group` error

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1371,7 +1371,7 @@ class ScheduleDBSource:
         allowed_sgroups = await query_allowed_sgroups(
             db_sess,
             domain_name,
-            group_id,
+            UUID(group_id),
             access_key,
         )
 


### PR DESCRIPTION
This PR fixes `ScheduleDBSource. _query_allowed_scaling_groups()` excluding resource groups allowed by project settings. This issue is caused by `ai.backend.manager.models.group._build_group_query` ([ref](https://github.com/lablup/backend.ai/blob/7fc621cb5e857c6ddfdb374a991f211098bd75c8/src/ai/backend/manager/models/group.py#L386)) assuming target parameter as a reference of group ID only if the parameter type is `UUID`.