### PR TITLE
fix(BA-2242): Ensure chown id is int (#5713)

### DIFF
--- a/changes/5713.fix.md
+++ b/changes/5713.fix.md
@@ -1,0 +1,1 @@
+Ensure id parameter of chown function is an int

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -347,7 +347,20 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     stat = os.stat(p)
                     valid_uid = uid if uid is not None else stat.st_uid
                     valid_gid = gid if gid is not None else stat.st_gid
-                os.chown(p, valid_uid, valid_gid)
+                try:
+                    int_uid = int(valid_uid)
+                    int_gid = int(valid_gid)
+                except (TypeError, ValueError):
+                    log.exception(
+                        "invalid uid/gid to chown: {}/{}, skip chown", valid_uid, valid_gid
+                    )
+                    continue
+                try:
+                    os.chown(p, int_uid, int_gid)
+                except OSError as e:
+                    log.exception(
+                        "failed to chown {} to {}/{} (error: {})", p, int_uid, int_gid, repr(e)
+                    )
 
     async def prepare_scratch(self) -> None:
         loop = current_loop()


### PR DESCRIPTION
This is an auto-generated backport PR of #5713 to the 25.6 release.