### PR TITLE
feat: Set expiry to Bgtask metadata id sets

### DIFF
--- a/changes/5736.feature.md
+++ b/changes/5736.feature.md
@@ -1,0 +1,1 @@
+Set expiry to set records of Bgtask metadata ids

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -460,7 +460,11 @@ class BackgroundTaskManager:
                 for task_id, bg_task in self._ongoing_tasks.items():
                     if not bg_task.done():
                         alive_task_ids.append(task_id)
-                await self._valkey_client.heartbeat(alive_task_ids)
+                await self._valkey_client.heartbeat(
+                    alive_task_ids,
+                    server_id=self._server_id,
+                    tags=self._tags,
+                )
             except Exception as e:
                 log.exception("Exception in heartbeat loop: {}", e)
             await asyncio.sleep(_HEARTBEAT_INTERVAL)

--- a/src/ai/backend/common/data/bgtask/defs.py
+++ b/src/ai/backend/common/data/bgtask/defs.py
@@ -1,2 +1,2 @@
-TASK_METADATA_TTL = 7200  # 2 hours
-TASK_TTL_THRESHOLD = 6900  # 1 hour 55 minutes
+TASK_METADATA_TTL = 60 * 60 * 24  # 24 hours
+TASK_TTL_THRESHOLD = TASK_METADATA_TTL - 60 * 5  # 5 minutes margin


### PR DESCRIPTION
resolves #5735 (BA-2256)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
