### PR TITLE
fix(BA-2326): Add Accept header and error handling when querying wsproxy status (#5829)

### DIFF
--- a/changes/5829.fix.md
+++ b/changes/5829.fix.md
@@ -1,0 +1,1 @@
+Fixed JSON parsing error when querying wsproxy status endpoint occurred when wsproxy returned HTML error responses

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterable, Tuple
@@ -10,7 +11,11 @@ from aiohttp import web
 
 from ai.backend.common import validators as tx
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.api.exceptions import ObjectNotFound, ServerMisconfiguredError
+from ai.backend.manager.errors.common import (
+    InternalServerError,
+    ObjectNotFound,
+    ServerMisconfiguredError,
+)
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 from ..models import query_allowed_sgroups
@@ -35,8 +40,16 @@ async def query_wsproxy_status(
     wsproxy_addr: str,
 ) -> dict[str, Any]:
     async with aiohttp.ClientSession() as session:
-        async with session.get(wsproxy_addr + "/status") as resp:
-            return await resp.json()
+        async with session.get(
+            wsproxy_addr + "/status",
+            headers={"Accept": "application/json"},
+        ) as resp:
+            try:
+                result = await resp.json()
+            except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+                log.error("Failed to parse wsproxy status response from {}: {}", wsproxy_addr, e)
+                raise InternalServerError("Got invalid response from wsproxy when querying status")
+            return result
 
 
 @auth_required


### PR DESCRIPTION
This is an auto-generated backport PR of #5829 to the 24.09 release.