### PR TITLE
fix(BA-2372): Explicitly use UTC when resolving model service token expiration time

### DIFF
--- a/src/ai/backend/manager/models/gql_models/endpoint.py
+++ b/src/ai/backend/manager/models/gql_models/endpoint.py
@@ -11,6 +11,7 @@ import graphene_federation
 import jwt
 import sqlalchemy as sa
 from dateutil.parser import parse as dtparse
+from dateutil.tz import tzutc
 from graphene.types.datetime import DateTime as GQLDateTime
 from graphql import Undefined, UndefinedType
 from sqlalchemy.orm import joinedload, selectinload
@@ -1310,7 +1311,7 @@ class EndpointToken(graphene.ObjectType):
             return None
         if "exp" not in decoded:
             return None
-        return datetime.datetime.fromtimestamp(decoded["exp"])
+        return datetime.datetime.fromtimestamp(decoded["exp"], tz=tzutc())
 
 
 class EndpointTokenList(graphene.ObjectType):


### PR DESCRIPTION
resolves #5871 (BA-2372)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
