### PR TITLE
fix(BA-2358): Handle empty `supported_accelerators` list in `Image`, `ImageNode`

### DIFF
--- a/changes/5869.fix.md
+++ b/changes/5869.fix.md
@@ -1,0 +1,1 @@
+Handle empty `supported_accelerators` list in `Image`, `ImageNode`

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -223,7 +223,7 @@ class Image(graphene.ObjectType):
                 )
                 for k, v in row.resources.items()
             ],
-            supported_accelerators=(row.accelerators or "").split(","),
+            supported_accelerators=row.accelerators.split(",") if row.accelerators else [],
             installed=len(installed_agents) > 0,
             installed_agents=installed_agents if not hide_agents else None,
             # legacy
@@ -560,7 +560,7 @@ class ImageNode(graphene.ObjectType):
                 )
                 for k, v in row.resources.items()
             ],
-            supported_accelerators=(row.accelerators or "").split(","),
+            supported_accelerators=row.accelerators.split(",") if row.accelerators else [],
             aliases=[alias_row.alias for alias_row in row.aliases],
             permissions=[] if permissions is None else permissions,
             status=row.status,


### PR DESCRIPTION
Backported-from: main
Backported-to: 25.6
Backported-of: 5869
