### PR TITLE
fix(BA-2372): Explicitly use UTC when resolving model service token expiration time (#5872)

### DIFF
--- a/changes/5872.fix.md
+++ b/changes/5872.fix.md
@@ -1,0 +1,1 @@
+Ensured model service token expiration times are handled consistently in UTC

--- a/src/ai/backend/manager/models/gql_models/endpoint.py
+++ b/src/ai/backend/manager/models/gql_models/endpoint.py
@@ -9,6 +9,7 @@ import graphene
 import jwt
 import sqlalchemy as sa
 from dateutil.parser import parse as dtparse
+from dateutil.tz import tzutc
 from graphene.types.datetime import DateTime as GQLDateTime
 from graphql import Undefined
 from sqlalchemy.orm import joinedload, selectinload
@@ -1311,7 +1312,7 @@ class EndpointToken(graphene.ObjectType):
             return None
         if "exp" not in decoded:
             return None
-        return datetime.datetime.fromtimestamp(decoded["exp"])
+        return datetime.datetime.fromtimestamp(decoded["exp"], tz=tzutc())
 
 
 class EndpointTokenList(graphene.ObjectType):


### PR DESCRIPTION
This is an auto-generated backport PR of #5872 to the 25.6 release.