### PR TITLE
fix(BA-2358): Handle empty `supported_accelerators` list correctly in `Image`, `ImageNode` (#5878)

### DIFF
--- a/changes/5878.fix.md
+++ b/changes/5878.fix.md
@@ -1,0 +1,1 @@
+Handle empty `supported_accelerators` list correctly in Image, ImageNode

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Backend.AI Manager API",
     "description": "Backend.AI Manager REST API specification",
-    "version": "24.09.13",
+    "version": "25.14.0",
     "contact": {
       "name": "Lablup Inc.",
       "url": "https://docs.backend.ai",

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -124,7 +124,7 @@ class Image(graphene.ObjectType):
                 )
                 for k, v in row.resources.items()
             ],
-            supported_accelerators=(row.accelerators or "").split(","),
+            supported_accelerators=row.accelerators.split(",") if row.accelerators else ["*"],
             installed=len(installed_agents) > 0,
             installed_agents=installed_agents if not hide_agents else None,
             # legacy
@@ -393,7 +393,7 @@ class ImageNode(graphene.ObjectType):
                 )
                 for k, v in row.resources.items()
             ],
-            supported_accelerators=(row.accelerators or "").split(","),
+            supported_accelerators=row.accelerators.split(",") if row.accelerators else ["*"],
             aliases=[alias_row.alias for alias_row in row.aliases],
         )
 


### PR DESCRIPTION
This is an auto-generated backport PR of #5878 to the 24.09 release.