### PR TITLE
chore: Upgrade mypy and add type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ preview = true
 [tool.mypy]
 plugins = ["pydantic.mypy", "strawberry.ext.mypy_plugin"]
 ignore_missing_imports = true
+follow_untyped_imports = false
 mypy_path = "stubs:src:tools/pants-plugins"
 namespace_packages = true
 explicit_package_bases = true

--- a/python.lock
+++ b/python.lock
@@ -115,12 +115,17 @@
 //     "types-PyYAML",
 //     "types-aiofiles",
 //     "types-cachetools",
+//     "types-colorama",
+//     "types-networkx",
+//     "types-pexpect",
+//     "types-psutil",
 //     "types-python-dateutil",
 //     "types-redis",
 //     "types-setuptools",
 //     "types-six",
 //     "types-tabulate",
 //     "types-toml",
+//     "types-tqdm",
 //     "typing_extensions~=4.11",
 //     "uvloop~=0.21; sys_platform != \"Windows\"",
 //     "valkey-glide~=2.0.1",
@@ -1223,13 +1228,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f831e847396f5a2eac6c106f4dfadedf46c4f804733574b15fe86d2ed45a9588",
-              "url": "https://files.pythonhosted.org/packages/ea/8e/0a37e44878fd76fac9eff5355a1bf760701f53cb5c38cdcd59a8fd9ab2a2/blessed-1.21.0-py2.py3-none-any.whl"
+              "hash": "a1fed52d708a1aa26dfb8d3eaecf6f4714bff590e728baeefcb44f2c16c8de82",
+              "url": "https://files.pythonhosted.org/packages/11/b7/a19b55c4cd0b5ca5009ca11d3634994758a1a446976b8e7afa25e719613c/blessed-1.22.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ece8bbc4758ab9176452f4e3a719d70088eb5739798cd5582c9e05f2a28337ec",
-              "url": "https://files.pythonhosted.org/packages/0c/5e/3cada2f7514ee2a76bb8168c71f9b65d056840ebb711962e1ec08eeaa7b0/blessed-1.21.0.tar.gz"
+              "hash": "1818efb7c10015478286f21a412fcdd31a3d8b94a18f6d926e733827da7a844b",
+              "url": "https://files.pythonhosted.org/packages/7c/51/a72df7730aa34a94bc43cebecb7b63ffa42f019868637dbeb45e0620d26e/blessed-1.22.0.tar.gz"
             }
           ],
           "project_name": "blessed",
@@ -1240,7 +1245,7 @@
             "wcwidth>=0.1.4"
           ],
           "requires_python": ">=2.7",
-          "version": "1.21.0"
+          "version": "1.22.0"
         },
         {
           "artifacts": [
@@ -1404,61 +1409,61 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9",
-              "url": "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl"
+              "hash": "6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b",
+              "url": "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3",
-              "url": "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca",
+              "url": "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd",
-              "url": "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb",
+              "url": "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5",
-              "url": "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c",
+              "url": "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed",
-              "url": "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl"
+              "hash": "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+              "url": "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683",
-              "url": "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+              "url": "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2",
-              "url": "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl"
+              "hash": "07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b",
+              "url": "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e",
-              "url": "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl"
+              "hash": "dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3",
+              "url": "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4",
-              "url": "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+              "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
-              "url": "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+              "hash": "f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2",
+              "url": "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl"
             }
           ],
           "project_name": "cffi",
           "requires_dists": [
-            "pycparser"
+            "pycparser; implementation_name != \"PyPy\""
           ],
-          "requires_python": ">=3.8",
-          "version": "1.17.1"
+          "requires_python": ">=3.9",
+          "version": "2.0.0"
         },
         {
           "artifacts": [
@@ -2619,38 +2624,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86754c2d6d5afb11b0a435e6e18911a4199262fe77553f8c50d75e21242193ea",
-              "url": "https://files.pythonhosted.org/packages/84/17/7caf27a1d101bfcb05be85850d4aa0a265b2e1acc2d4d52a48026ef1d299/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "f900481cf6e362a6c549c61ff77468bd59d6dd082f3170a36acfef2eb6a6793f",
+              "url": "https://files.pythonhosted.org/packages/2c/3d/ab7109e607ed321afaa690f557a9ada6d6d164ec852fd6bf9979665dc3d6/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c99073ce404462e909f1d5839b2d14a3827b8fe75ed8aed551ba6609c026c803",
-              "url": "https://files.pythonhosted.org/packages/23/0f/5b60fc28ee7f8cc17a5114a584fd6b86e11c3e0a6e142a7f97a161e9640a/hf_xet-1.1.9.tar.gz"
+              "hash": "eae7c1fc8a664e54753ffc235e11427ca61f4b0477d757cc4eb9ae374b69f09c",
+              "url": "https://files.pythonhosted.org/packages/01/a7/0b2e242b918cc30e1f91980f3c4b026ff2eedaf1e2ad96933bca164b2869/hf_xet-1.1.10-cp37-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b486de7a64a66f9a172f4b3e0dfe79c9f0a93257c501296a2521a13495a698a",
-              "url": "https://files.pythonhosted.org/packages/3a/e6/2d0d16890c5f21b862f5df3146519c182e7f0ae49b4b4bf2bd8a40d0b05e/hf_xet-1.1.9-cp37-abi3-macosx_11_0_arm64.whl"
+              "hash": "6b6bceb6361c80c1cc42b5a7b4e3efd90e64630bcf11224dcac50ef30a47e435",
+              "url": "https://files.pythonhosted.org/packages/15/07/86397573efefff941e100367bbda0b21496ffcdb34db7ab51912994c32a2/hf_xet-1.1.10-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ad1022e9a998e784c97b2173965d07fe33ee26e4594770b7785a8cc8f922cd95",
-              "url": "https://files.pythonhosted.org/packages/6c/3c/28cc4db153a7601a996985bcb564f7b8f5b9e1a706c7537aad4b4809f358/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "71081925383b66b24eedff3013f8e6bbd41215c3338be4b94ba75fd75b21513b",
+              "url": "https://files.pythonhosted.org/packages/31/f9/6215f948ac8f17566ee27af6430ea72045e0418ce757260248b483f4183b/hf_xet-1.1.10-cp37-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a4c5a840c2c4e6ec875ed13703a60e3523bc7f48031dfd750923b2a4d1a5fc3c",
-              "url": "https://files.pythonhosted.org/packages/81/42/7e6955cf0621e87491a1fb8cad755d5c2517803cea174229b0ec00ff0166/hf_xet-1.1.9-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0a0005fd08f002180f7a12d4e13b22be277725bc23ed0529f8add5c7a6309c06",
+              "url": "https://files.pythonhosted.org/packages/4a/25/3e32ab61cc7145b11eee9d745988e2f0f4fafda81b25980eebf97d8cff15/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a3b6215f88638dd7a6ff82cb4e738dcbf3d863bf667997c093a3c990337d1160",
-              "url": "https://files.pythonhosted.org/packages/de/12/56e1abb9a44cdef59a411fe8a8673313195711b5ecce27880eb9c8fa90bd/hf_xet-1.1.9-cp37-abi3-macosx_10_12_x86_64.whl"
+              "hash": "408aef343800a2102374a883f283ff29068055c111f003ff840733d3b715bb97",
+              "url": "https://files.pythonhosted.org/packages/74/31/feeddfce1748c4a233ec1aa5b7396161c07ae1aa9b7bdbc9a72c3c7dd768/hf_xet-1.1.10.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "96a6139c9e44dad1c52c52520db0fffe948f6bce487cfb9d69c125f254bb3790",
-              "url": "https://files.pythonhosted.org/packages/df/8b/759233bce05457f5f7ec062d63bbfd2d0c740b816279eaaa54be92aa452a/hf_xet-1.1.9-cp37-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "686083aca1a6669bc85c21c0563551cbcdaa5cf7876a91f3d074a030b577231d",
+              "url": "https://files.pythonhosted.org/packages/f7/a2/343e6d05de96908366bdc0081f2d8607d61200be2ac802769c4284cc65bd/hf_xet-1.1.10-cp37-abi3-macosx_10_12_x86_64.whl"
             }
           ],
           "project_name": "hf-xet",
@@ -2658,7 +2663,7 @@
             "pytest; extra == \"tests\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.1.9"
+          "version": "1.1.10"
         },
         {
           "artifacts": [
@@ -2742,13 +2747,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9b365d781739c93ff90c359844221beef048403f1bc1f1c123c191257c3c890a",
-              "url": "https://files.pythonhosted.org/packages/39/7b/bb06b061991107cd8783f300adff3e7b7f284e330fd82f507f2a1417b11d/huggingface_hub-0.34.4-py3-none-any.whl"
+              "hash": "fea377adc6e9b6c239c1450e41a1409cbf2c6364d289c04c31d7dbaa222842e3",
+              "url": "https://files.pythonhosted.org/packages/79/3d/55ef77a0539b0124efd47d8b3759bf49e880f57729f7123c0311b41a9bb8/huggingface_hub-0.34.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a4228daa6fb001be3f4f4bdaf9a0db00e1739235702848df00885c9b5742c85c",
-              "url": "https://files.pythonhosted.org/packages/45/c9/bdbe19339f76d12985bc03572f330a01a93c04dffecaaea3061bdd7fb892/huggingface_hub-0.34.4.tar.gz"
+              "hash": "f676c6db41bc3fbd4020f520c842a0548f4c9a3f698dbfa6514bd8e41c3ab52a",
+              "url": "https://files.pythonhosted.org/packages/1f/08/306b0d3db3679b3c07cab9ce117a920de77f3ea4dba6ba27646660518619/huggingface_hub-0.34.5.tar.gz"
             }
           ],
           "project_name": "huggingface-hub",
@@ -2880,7 +2885,7 @@
             "urllib3<2.0; extra == \"testing\""
           ],
           "requires_python": ">=3.8.0",
-          "version": "0.34.4"
+          "version": "0.34.5"
         },
         {
           "artifacts": [
@@ -4003,6 +4008,99 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "ed635ff692483b8e3f0fcaa8e7eb8a75ee71aa6d975388224f70821421800cea",
+              "url": "https://files.pythonhosted.org/packages/b6/27/b3922660c45513f9377b3fb42240bec63f203c71416093476ec9aa0719dc/numpy-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "40051003e03db4041aa325da2a0971ba41cf65714e65d296397cc0e32de6018b",
+              "url": "https://files.pythonhosted.org/packages/05/24/43da09aa764c68694b76e84b3d3f0c44cb7c18cdc1ba80e48b0ac1d2cd39/numpy-2.3.3-cp313-cp313t-macosx_14_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eda59e44957d272846bb407aad19f89dc6f58fecf3504bd144f4c5cf81a7eacc",
+              "url": "https://files.pythonhosted.org/packages/11/d0/0d1ddec56b162042ddfafeeb293bac672de9b0cfd688383590090963720a/numpy-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "952cfd0748514ea7c3afc729a0fc639e61655ce4c55ab9acfab14bda4f402b4c",
+              "url": "https://files.pythonhosted.org/packages/23/83/377f84aaeb800b64c0ef4de58b08769e782edcefa4fea712910b6f0afd3c/numpy-2.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9dc13c6a5829610cc07422bc74d3ac083bd8323f14e2827d992f9e52e22cd6a6",
+              "url": "https://files.pythonhosted.org/packages/35/c7/477a83887f9de61f1203bad89cf208b7c19cc9fef0cebef65d5a1a0619f2/numpy-2.3.3-cp313-cp313-macosx_14_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "823d04112bc85ef5c4fda73ba24e6096c8f869931405a80aa8b0e604510a26bc",
+              "url": "https://files.pythonhosted.org/packages/36/9e/1996ca6b6d00415b6acbdd3c42f7f03ea256e2c3f158f80bd7436a8a19f3/numpy-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d79715d95f1894771eb4e60fb23f065663b2298f7d22945d66877aadf33d00c7",
+              "url": "https://files.pythonhosted.org/packages/52/47/93b953bd5866a6f6986344d045a207d3f1cfbad99db29f534ea9cee5108c/numpy-2.3.3-cp313-cp313-macosx_14_0_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94fcaa68757c3e2e668ddadeaa86ab05499a70725811e582b6a9858dd472fb30",
+              "url": "https://files.pythonhosted.org/packages/55/52/af46ac0795e09657d45a7f4db961917314377edecf66db0e39fa7ab5c3d3/numpy-2.3.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f5415fb78995644253370985342cd03572ef8620b934da27d77377a2285955bf",
+              "url": "https://files.pythonhosted.org/packages/7d/b9/984c2b1ee61a8b803bf63582b4ac4242cf76e2dbd663efeafcb620cc0ccb/numpy-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5b83648633d46f77039c29078751f80da65aa64d5622a3cd62aaef9d835b6c93",
+              "url": "https://files.pythonhosted.org/packages/9a/a5/bf3db6e66c4b160d6ea10b534c381a1955dfab34cb1017ea93aa33c70ed3/numpy-2.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2990adf06d1ecee3b3dcbb4977dfab6e9f09807598d647f04d385d29e7a3c3d3",
+              "url": "https://files.pythonhosted.org/packages/9d/9d/9d8d358f2eb5eced14dba99f110d83b5cd9a4460895230f3b396ad19a323/numpy-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b001bae8cea1c7dfdb2ae2b017ed0a6f2102d7a70059df1e338e307a4c78a8ae",
+              "url": "https://files.pythonhosted.org/packages/a2/59/1287924242eb4fa3f9b3a2c30400f2e17eb2707020d1c5e3086fe7330717/numpy-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d00de139a3324e26ed5b95870ce63be7ec7352171bc69a4cf1f157a48e3eb6b7",
+              "url": "https://files.pythonhosted.org/packages/a6/e4/07970e3bed0b1384d22af1e9912527ecbeb47d3b26e9b6a3bced068b3bea/numpy-2.3.3-cp313-cp313-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "da1a74b90e7483d6ce5244053399a614b1d6b7bc30a60d2f570e5071f8959d3e",
+              "url": "https://files.pythonhosted.org/packages/a7/b1/dc226b4c90eb9f07a3fff95c2f0db3268e2e54e5cce97c4ac91518aee71b/numpy-2.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6ee9086235dd6ab7ae75aba5662f582a81ced49f0f1c6de4260a78d8f2d91a19",
+              "url": "https://files.pythonhosted.org/packages/bc/14/50ffb0f22f7218ef8af28dd089f79f68289a7a05a208db9a2c5dcbe123c1/numpy-2.3.3-cp313-cp313t-macosx_14_0_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029",
+              "url": "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8e9aced64054739037d42fb84c54dd38b81ee238816c948c8f3ed134665dcd86",
+              "url": "https://files.pythonhosted.org/packages/e6/93/b3d47ed882027c35e94ac2320c37e452a549f582a5e801f2d34b56973c97/numpy-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl"
+            }
+          ],
+          "project_name": "numpy",
+          "requires_dists": [],
+          "requires_python": ">=3.11",
+          "version": "2.3.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1",
               "url": "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl"
             },
@@ -4784,85 +4882,86 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "56c843e69aad724dc5a795f32ebd6fec1d1592f58cabf89d2d148697c22c41be",
-              "url": "https://files.pythonhosted.org/packages/86/30/cc865c630d5c9f72f488a89463aabfd33895984955c489f66b5a524f9573/pycares-4.10.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+              "hash": "a98fac4a3d4f780817016b6f00a8a2c2f41df5d25dfa8e5b1aa0d783645a6566",
+              "url": "https://files.pythonhosted.org/packages/55/2a/eafb235c371979e11f8998d686cbaa91df6a84a34ffe4d997dfe57c45445/pycares-4.11.0-cp313-cp313-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef107d30a9d667c295db58897390c2d32c206eb1802b14d98ac643990be4e04f",
-              "url": "https://files.pythonhosted.org/packages/01/56/47fda9dbc23c3acfe42fa6d57bb850db6ede65a2a9476641a54621166464/pycares-4.10.0-cp313-cp313-musllinux_1_2_s390x.whl"
+              "hash": "bac55842047567ddae177fb8189b89a60633ac956d5d37260f7f71b517fd8b87",
+              "url": "https://files.pythonhosted.org/packages/63/11/731b565ae1e81c43dac247a248ee204628186f6df97c9927bd06c62237f8/pycares-4.11.0-cp313-cp313-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f9eecd9e28e43254c6fb1c69518bd6b753bf18230579c23e7f272ac52036d41f",
-              "url": "https://files.pythonhosted.org/packages/07/9f/be45f60277a0825d03feed2378a283ce514b4feea64785e917b926b8441e/pycares-4.10.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+              "hash": "c863d9003ca0ce7df26429007859afd2a621d3276ed9fef154a9123db9252557",
+              "url": "https://files.pythonhosted.org/packages/8d/ad/9d1e96486d2eb5a2672c4d9a2dd372d015b8d7a332c6ac2722c4c8e6bbbf/pycares-4.11.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1dcfdda868ad2cee8d171288a4cd725a9ad67498a2f679428874a917396d464e",
-              "url": "https://files.pythonhosted.org/packages/12/1d/306d071837073eccff6efb93560fdb4e53d53ca0c1002260bb34e074f706/pycares-4.10.0-cp313-cp313-manylinux_2_28_ppc64le.whl"
+              "hash": "3ef1ab7abbd238bb2dbbe871c3ea39f5a7fc63547c015820c1e24d0d494a1689",
+              "url": "https://files.pythonhosted.org/packages/91/c2/16dbc3dc33781a3c79cbdd76dd1cda808d98ba078d9a63a725d6a1fad181/pycares-4.11.0-cp313-cp313-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4904ebd5e4d0c78e9fd56e6c974da005eaa721365961764922929e8e8f7dd0a",
-              "url": "https://files.pythonhosted.org/packages/21/bd/7a1448f5f0852628520dc9cdff21b4d6f01f4ab5faaf208d030fba28e0e2/pycares-4.10.0-cp313-cp313-macosx_10_13_x86_64.whl"
+              "hash": "ea785d1f232b42b325578f0c8a2fa348192e182cc84a1e862896076a4a2ba2a7",
+              "url": "https://files.pythonhosted.org/packages/a9/b7/b3a5f99d4ab776662e71d5a56e8f6ea10741230ff988d1f502a8d429236b/pycares-4.11.0-cp313-cp313-manylinux_2_28_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f9a259bf46cc51c51c7402a2bf32d1416f029b9a4af3de8b8973345520278092",
-              "url": "https://files.pythonhosted.org/packages/22/7a/ec4734c1274205d0ac1419310464bfa5e1a96924a77312e760790c02769c/pycares-4.10.0-cp313-cp313-manylinux_2_28_aarch64.whl"
+              "hash": "7830709c23bbc43fbaefbb3dde57bdd295dc86732504b9d2e65044df8fd5e9fb",
+              "url": "https://files.pythonhosted.org/packages/c6/fb/9266979ba59d37deee1fd74452b2ae32a7395acafe1bee510ac023c6c9a5/pycares-4.11.0-cp313-cp313-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "95f4d976bf2feb3f406aef6b1314845dc1384d2e4ea0c439c7d50631f2b6d166",
-              "url": "https://files.pythonhosted.org/packages/2b/bd/de9ed896e752fb22141d6310f6680bcb62ea1d6aa07dc129d914377bd4b4/pycares-4.10.0-cp313-cp313-manylinux_2_28_x86_64.whl"
+              "hash": "2c296ab94d1974f8d2f76c499755a9ce31ffd4986e8898ef19b90e32525f7d84",
+              "url": "https://files.pythonhosted.org/packages/dc/a9/62fea7ad72ac1fed2ac9dd8e9a7379b7eb0288bf2b3ea5731642c3a6f7de/pycares-4.11.0-cp313-cp313-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7144676e54b0686605333ec62ffdb7bb2b6cb4a6c53eed3e35ae3249dc64676b",
-              "url": "https://files.pythonhosted.org/packages/4d/6d/0e436ddb540a06fa898b8b6cd135babe44893d31d439935eee42bcd4f07b/pycares-4.10.0-cp313-cp313-macosx_11_0_arm64.whl"
+              "hash": "aa160dc9e785212c49c12bb891e242c949758b99542946cc8e2098ef391f93b0",
+              "url": "https://files.pythonhosted.org/packages/ea/77/a00d962b90432993afbf3bd05da8fe42117e0d9037cd7fd428dc41094d7b/pycares-4.11.0-cp313-cp313-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f2d57bb27c884d130ac62d8c0ac57a158d27f8d75011f8700c7d44601f093652",
-              "url": "https://files.pythonhosted.org/packages/5e/e9/2b517302d42a9ff101201b58e9e2cbd2458c0a1ed68cca7d4dc1397ed246/pycares-4.10.0-cp313-cp313-manylinux_2_28_s390x.whl"
+              "hash": "e0fcd3a8bac57a0987d9b09953ba0f8703eb9dca7c77f7051d8c2ed001185be8",
+              "url": "https://files.pythonhosted.org/packages/f4/ac/0317d6d0d3bd7599c53b8f1db09ad04260647d2f6842018e322584791fd5/pycares-4.11.0-cp313-cp313-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4f8ec43ce0db38152cded6939a3fa4d8aba888e323803cda99f67fa3053fa15",
-              "url": "https://files.pythonhosted.org/packages/91/21/ca7bd328d07c560a1fe0ba29008c24a48e88184d3ade658946aeaef25992/pycares-4.10.0-cp313-cp313-musllinux_1_2_ppc64le.whl"
+              "hash": "4da2e805ed8c789b9444ef4053f6ef8040cd13b0c1ca6d3c4fe6f9369c458cb4",
+              "url": "https://files.pythonhosted.org/packages/f5/30/a2631fe2ffaa85475cdbff7df1d9376bc0b2a6ae77ca55d53233c937a5da/pycares-4.11.0-cp313-cp313-manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9df70dce6e05afa5d477f48959170e569485e20dad1a089c4cf3b2d7ffbd8bf9",
-              "url": "https://files.pythonhosted.org/packages/e0/2f/5b46bb8e65070eb1f7f549d2f2e71db6b9899ef24ac9f82128014aeb1e25/pycares-4.10.0.tar.gz"
+              "hash": "a4060d8556c908660512d42df1f4a874e4e91b81f79e3a9090afedc7690ea5ba",
+              "url": "https://files.pythonhosted.org/packages/ff/75/f003905e55298a6dd5e0673a2dc11e31518a5141393b925dc05fcaba9fb4/pycares-4.11.0-cp313-cp313-musllinux_1_2_s390x.whl"
             }
           ],
           "project_name": "pycares",
           "requires_dists": [
-            "cffi>=1.5.0",
+            "cffi>=1.5.0; python_version < \"3.14\"",
+            "cffi>=2.0.0b1; python_version >= \"3.14\"",
             "idna>=2.1; extra == \"idna\""
           ],
           "requires_python": ">=3.9",
-          "version": "4.10.0"
+          "version": "4.11.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
-              "url": "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              "hash": "e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934",
+              "url": "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
-              "url": "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              "hash": "78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2",
+              "url": "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz"
             }
           ],
           "project_name": "pycparser",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "2.22"
+          "version": "2.23"
         },
         {
           "artifacts": [
@@ -4961,13 +5060,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b",
-              "url": "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl"
+              "hash": "c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2",
+              "url": "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db",
-              "url": "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz"
+              "hash": "6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2",
+              "url": "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz"
             }
           ],
           "project_name": "pydantic",
@@ -4980,7 +5079,7 @@
             "tzdata; (python_version >= \"3.9\" and platform_system == \"Windows\") and extra == \"timezone\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.11.7"
+          "version": "2.11.9"
         },
         {
           "artifacts": [
@@ -5223,13 +5322,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf",
-              "url": "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl"
+              "hash": "8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99",
+              "url": "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea",
-              "url": "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz"
+              "hash": "c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57",
+              "url": "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz"
             }
           ],
           "project_name": "pytest-asyncio",
@@ -5240,10 +5339,10 @@
             "pytest<9,>=8.2",
             "sphinx-rtd-theme>=1; extra == \"docs\"",
             "sphinx>=5.3; extra == \"docs\"",
-            "typing-extensions>=4.12; python_version < \"3.10\""
+            "typing-extensions>=4.12; python_version < \"3.13\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.1.0"
+          "version": "1.2.0"
         },
         {
           "artifacts": [
@@ -6519,13 +6618,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "183dd76c1871a48936d7b931488e41f0f25a7463abe10b5816be275fc11506d5",
-              "url": "https://files.pythonhosted.org/packages/21/f7/68029931e7539e3246b33386a19c475f234c71d2a878411847b20bb31960/types_cffi-1.17.0.20250822-py3-none-any.whl"
+              "hash": "cef4af1116c83359c11bb4269283c50f0688e9fc1d7f0eeb390f3661546da52c",
+              "url": "https://files.pythonhosted.org/packages/aa/ec/092f2b74b49ec4855cdb53050deb9699f7105b8fda6fe034c0781b8687f3/types_cffi-1.17.0.20250915-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf6f5a381ea49da7ff895fae69711271e6192c434470ce6139bf2b2e0d0fa08d",
-              "url": "https://files.pythonhosted.org/packages/da/0c/76a48cb6e742cac4d61a4ec632dd30635b6d302f5acdc2c0a27572ac7ae3/types_cffi-1.17.0.20250822.tar.gz"
+              "hash": "4362e20368f78dabd5c56bca8004752cc890e07a71605d9e0d9e069dbaac8c06",
+              "url": "https://files.pythonhosted.org/packages/2a/98/ea454cea03e5f351323af6a482c65924f3c26c515efd9090dede58f2b4b6/types_cffi-1.17.0.20250915.tar.gz"
             }
           ],
           "project_name": "types-cffi",
@@ -6533,7 +6632,25 @@
             "types-setuptools"
           ],
           "requires_python": ">=3.9",
-          "version": "1.17.0.20250822"
+          "version": "1.17.0.20250915"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b6e89bd3b250fdad13a8b6a465c933f4a5afe485ea2e2f104d739be50b13eea9",
+              "url": "https://files.pythonhosted.org/packages/95/3a/44ccbbfef6235aeea84c74041dc6dfee6c17ff3ddba782a0250e41687ec7/types_colorama-0.4.15.20250801-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "02565d13d68963d12237d3f330f5ecd622a3179f7b5b14ee7f16146270c357f5",
+              "url": "https://files.pythonhosted.org/packages/99/37/af713e7d73ca44738c68814cbacf7a655aa40ddd2e8513d431ba78ace7b3/types_colorama-0.4.15.20250801.tar.gz"
+            }
+          ],
+          "project_name": "types-colorama",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "0.4.15.20250801"
         },
         {
           "artifacts": [
@@ -6572,6 +6689,62 @@
           "requires_dists": [],
           "requires_python": null,
           "version": "1.1.10"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "35706c368f80eb115b8c8ed2a777ca1d714b2e57b792e908cd4e69422a9d484a",
+              "url": "https://files.pythonhosted.org/packages/82/55/9be4b551a758636380dab60f685d56372d64f27aba05abe3253af178ad60/types_networkx-3.5.0.20250914-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba3e97132ab02e873494e393402b0947434146f23b57c80543aae1e76fa739b8",
+              "url": "https://files.pythonhosted.org/packages/cc/8e/8f6ec9f4b63d61bfdc9775aa2580b7aa9d78a8fa6f5f9cac14de6ed5d59e/types_networkx-3.5.0.20250914.tar.gz"
+            }
+          ],
+          "project_name": "types-networkx",
+          "requires_dists": [
+            "numpy>=1.20"
+          ],
+          "requires_python": ">=3.10",
+          "version": "3.5.0.20250914"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7fa43cb96042ac58bc74f7c28e5d85782be0ee01344149886849e9d90936fe8a",
+              "url": "https://files.pythonhosted.org/packages/aa/6d/7740e235a9fb2570968da7d386d7feb511ce68cd23472402ff8cdf7fc78f/types_pexpect-4.9.0.20250916-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "69e5fed6199687a730a572de780a5749248a4c5df2ff1521e194563475c9928d",
+              "url": "https://files.pythonhosted.org/packages/0c/e6/cc43e306dc7de14ec7861c24ac4957f688741ae39ae685049695d796b587/types_pexpect-4.9.0.20250916.tar.gz"
+            }
+          ],
+          "project_name": "types-pexpect",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "4.9.0.20250916"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "81c82f01aba5a4510b9d8b28154f577b780be75a08954aed074aa064666edc09",
+              "url": "https://files.pythonhosted.org/packages/7d/46/45006309e20859e12c024d91bb913e6b89a706cd6f9377031c9f7e274ece/types_psutil-7.0.0.20250822-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "226cbc0c0ea9cc0a50b8abcc1d91a26c876dcb40be238131f697883690419698",
+              "url": "https://files.pythonhosted.org/packages/6d/aa/09699c829d7cc4624138d3ae67eecd4de9574e55729b1c63ca3e5a657f86/types_psutil-7.0.0.20250822.tar.gz"
+            }
+          ],
+          "project_name": "types-psutil",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "7.0.0.20250822"
         },
         {
           "artifacts": [
@@ -6616,19 +6789,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1fe1a5e146aa315483592d292b72a172b65b946a6d98aa6ddd8e4aa838ab7098",
-              "url": "https://files.pythonhosted.org/packages/32/8e/8f0aca667c97c0d76024b37cffa39e76e2ce39ca54a38f285a64e6ae33ba/types_pyyaml-6.0.12.20250822-py3-none-any.whl"
+              "hash": "e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6",
+              "url": "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "259f1d93079d335730a9db7cff2bcaf65d7e04b4a56b5927d49a612199b59413",
-              "url": "https://files.pythonhosted.org/packages/49/85/90a442e538359ab5c9e30de415006fb22567aa4301c908c09f19e42975c2/types_pyyaml-6.0.12.20250822.tar.gz"
+              "hash": "0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3",
+              "url": "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "6.0.12.20250822"
+          "version": "6.0.12.20250915"
         },
         {
           "artifacts": [
@@ -6650,6 +6823,26 @@
           ],
           "requires_python": ">=3.8",
           "version": "4.6.0.20241004"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1",
+              "url": "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d",
+              "url": "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz"
+            }
+          ],
+          "project_name": "types-requests",
+          "requires_dists": [
+            "urllib3>=2"
+          ],
+          "requires_python": ">=3.9",
+          "version": "2.32.4.20250913"
         },
         {
           "artifacts": [
@@ -6722,6 +6915,26 @@
           "requires_dists": [],
           "requires_python": ">=3.8",
           "version": "0.10.8.20240310"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1a73053b31fcabf3c1f3e2a9d5ecdba0f301bde47a418cd0e0bdf774827c5c57",
+              "url": "https://files.pythonhosted.org/packages/3f/13/3ff0781445d7c12730befce0fddbbc7a76e56eb0e7029446f2853238360a/types_tqdm-4.67.0.20250809-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "02bf7ab91256080b9c4c63f9f11b519c27baaf52718e5fdab9e9606da168d500",
+              "url": "https://files.pythonhosted.org/packages/fb/d0/cf498fc630d9fdaf2428b93e60b0e67b08008fec22b78716b8323cf644dc/types_tqdm-4.67.0.20250809.tar.gz"
+            }
+          ],
+          "project_name": "types-tqdm",
+          "requires_dists": [
+            "types-requests"
+          ],
+          "requires_python": ">=3.9",
+          "version": "4.67.0.20250809"
         },
         {
           "artifacts": [
@@ -7307,12 +7520,17 @@
     "types-PyYAML",
     "types-aiofiles",
     "types-cachetools",
+    "types-colorama",
+    "types-networkx",
+    "types-pexpect",
+    "types-psutil",
     "types-python-dateutil",
     "types-redis",
     "types-setuptools",
     "types-six",
     "types-tabulate",
     "types-toml",
+    "types-tqdm",
     "typing_extensions~=4.11",
     "uvloop~=0.21; sys_platform != \"Windows\"",
     "valkey-glide~=2.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,11 +111,16 @@ types-setuptools
 types-python-dateutil
 types-aiofiles
 types-cachetools
+types-colorama
 types-Jinja2
+types-networkx
+types-pexpect
+types-psutil
 types-PyYAML
 types-redis
 types-tabulate
 types-toml
+types-tqdm
 backend.ai-krunner-alpine==5.4.0
 backend.ai-krunner-static-gnu==4.4.0
 

--- a/src/ai/backend/client/cli/admin/image.py
+++ b/src/ai/backend/client/cli/admin/image.py
@@ -12,7 +12,7 @@ from ai.backend.common.bgtask.types import BgtaskStatus
 from ...compat import asyncio_run
 from ...session import AsyncSession
 from ..extensions import pass_ctx_obj
-from ..pretty import PorgressBarWithSpinner, print_done, print_error, print_fail, print_warn
+from ..pretty import ProgressBarWithSpinner, print_done, print_error, print_fail, print_warn
 from ..types import CLIContext
 from . import admin
 
@@ -77,7 +77,7 @@ def rescan(registry: str, project: Optional[str] = None) -> None:
             try:
                 async with (
                     bgtask.listen_events() as response,
-                    PorgressBarWithSpinner("Scanning the registry...", unit="images") as pbar,
+                    ProgressBarWithSpinner("Scanning the registry...", unit="images") as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)

--- a/src/ai/backend/client/cli/admin/image.py
+++ b/src/ai/backend/client/cli/admin/image.py
@@ -12,7 +12,7 @@ from ai.backend.common.bgtask.types import BgtaskStatus
 from ...compat import asyncio_run
 from ...session import AsyncSession
 from ..extensions import pass_ctx_obj
-from ..pretty import ProgressViewer, print_done, print_error, print_fail, print_warn
+from ..pretty import PorgressBarWithSpinner, print_done, print_error, print_fail, print_warn
 from ..types import CLIContext
 from . import admin
 
@@ -73,22 +73,19 @@ def rescan(registry: str, project: Optional[str] = None) -> None:
             print_done("Started updating the image metadata from the configured registries.")
             bgtask_id = result["task_id"]
             bgtask = session.BackgroundTask(bgtask_id)
+            completion_msg_func = lambda: print_done("Finished registry scanning.")
             try:
-                completion_msg_func = lambda: print_done("Finished registry scanning.")
                 async with (
                     bgtask.listen_events() as response,
-                    ProgressViewer("Scanning the registry...") as viewer,
+                    PorgressBarWithSpinner("Scanning the registry...", unit="images") as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)
                         match ev.event:
                             case BgtaskStatus.UPDATED:
-                                if viewer.tqdm is None:
-                                    pbar = await viewer.to_tqdm(unit="images")
-                                else:
-                                    pbar.total = data["total_progress"]
-                                    pbar.write(data["message"])
-                                    pbar.update(data["current_progress"] - pbar.n)
+                                pbar.total = data["total_progress"]
+                                pbar.write(data["message"])
+                                pbar.update(data["current_progress"] - pbar.n)
                             case BgtaskStatus.FAILED:
                                 error_msg = data["message"]
                                 completion_msg_func = lambda: print_fail(

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -205,7 +205,7 @@ def show_warning(message, category, filename, lineno, file=None, line=None):
     )
 
 
-class PorgressBarWithSpinner(tqdm):
+class ProgressBarWithSpinner(tqdm):
     """
     A simple extension to tqdm adding a spinner.
 

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -248,11 +248,11 @@ class ProgressBarWithSpinner(tqdm):
     ) -> None:
         self.spinner_msg = spinner_msg
         self.spinner_delay = spinner_delay
-        self.prefix = style("", fg="bright_yellow", reset=False)
+        prefix = style("", fg="bright_yellow", reset=False)
         if spinner_msg:
-            initial_desc = f"{self.prefix}  {spinner_msg} "
+            initial_desc = f"{prefix}  {spinner_msg} "
         else:
-            initial_desc = f"{self.prefix}  "
+            initial_desc = f"{prefix}  "
         self._orig_format_meter = self.format_meter
         super().__init__(
             total=float("inf"),
@@ -264,13 +264,14 @@ class ProgressBarWithSpinner(tqdm):
         self.set_postfix_str(style("", reset=True))
 
     async def spin(self) -> None:
+        prefix = style("", fg="bright_yellow", reset=False)
         try:
             while True:
                 for char in "|/-\\":
                     if self.spinner_msg:
-                        self.set_description_str(f"{self.prefix}{char} {self.spinner_msg} ")
+                        self.set_description_str(f"{prefix}{char} {self.spinner_msg} ")
                     else:
-                        self.set_description_str(f"{self.prefix}{char} ")
+                        self.set_description_str(f"{prefix}{char} ")
                     await asyncio.sleep(self.spinner_delay)
         except asyncio.CancelledError:
             pass
@@ -298,9 +299,10 @@ class ProgressBarWithSpinner(tqdm):
         if self.spinner_task is not None and not self.spinner_task.done():
             self.spinner_task.cancel()
             await self.spinner_task
+        prefix = style("", fg="bright_green", reset=False)
         if self.spinner_msg:
-            self.set_description_str(f"{self.prefix}✓ {self.spinner_msg}")
+            self.set_description_str(f"{prefix}✓ {self.spinner_msg}")
         else:
-            self.set_description_str(f"{self.prefix}✓ ")
+            self.set_description_str(f"{prefix}✓ ")
         self.close()
         return None

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -22,7 +22,7 @@ from ..exceptions import BackendError
 from ..output.fields import routing_fields, service_fields
 from ..output.types import FieldSpec
 from .extensions import pass_ctx_obj
-from .pretty import PorgressBarWithSpinner, print_done, print_fail, print_warn
+from .pretty import ProgressBarWithSpinner, print_done, print_fail, print_warn
 from .types import CLIContext
 
 _default_detail_fields: Sequence[FieldSpec] = (
@@ -555,7 +555,7 @@ def try_start(
                 bgtask = session.BackgroundTask(bgtask_id)
                 async with (
                     bgtask.listen_events() as response,
-                    PorgressBarWithSpinner("Starting the session...") as pbar,
+                    ProgressBarWithSpinner("Starting the session...") as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -22,7 +22,7 @@ from ..exceptions import BackendError
 from ..output.fields import routing_fields, service_fields
 from ..output.types import FieldSpec
 from .extensions import pass_ctx_obj
-from .pretty import ProgressViewer, print_done, print_fail, print_warn
+from .pretty import PorgressBarWithSpinner, print_done, print_fail, print_warn
 from .types import CLIContext
 
 _default_detail_fields: Sequence[FieldSpec] = (
@@ -550,23 +550,20 @@ def try_start(
 
     async def try_start_tracker(bgtask_id):
         async with AsyncSession() as session:
+            completion_msg_func = lambda: print_done("Model service validation started.")
             try:
                 bgtask = session.BackgroundTask(bgtask_id)
-                completion_msg_func = lambda: print_done("Model service validation started.")
                 async with (
                     bgtask.listen_events() as response,
-                    ProgressViewer("Starting the session...") as viewer,
+                    PorgressBarWithSpinner("Starting the session...") as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)
                         match ev.event:
                             case BgtaskStatus.UPDATED:
                                 print(data["message"])
-                                if viewer.tqdm is None:
-                                    pbar = await viewer.to_tqdm()
-                                else:
-                                    pbar.total = data["total_progress"]
-                                    pbar.update(data["current_progress"] - pbar.n)
+                                pbar.total = data["total_progress"]
+                                pbar.update(data["current_progress"] - pbar.n)
                             case BgtaskStatus.FAILED:
                                 error_msg = data["message"]
                                 completion_msg_func = lambda: print_fail(

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -36,7 +36,7 @@ from ...output.types import FieldSpec
 from ...session import AsyncSession, Session
 from ..events import SubscribableEvents
 from ..pretty import (
-    PorgressBarWithSpinner,
+    ProgressBarWithSpinner,
     print_done,
     print_error,
     print_fail,
@@ -1038,7 +1038,7 @@ def convert_to_image(session_id: str, image_name: str) -> None:
                 bgtask = session.BackgroundTask(bgtask_id)
                 async with (
                     bgtask.listen_events() as response,
-                    PorgressBarWithSpinner("Starting the session...") as pbar,
+                    ProgressBarWithSpinner("Starting the session...") as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -25,7 +25,7 @@ from ..compat import asyncio_run
 from ..session import AsyncSession
 from .extensions import pass_ctx_obj
 from .pretty import (
-    PorgressBarWithSpinner,
+    ProgressBarWithSpinner,
     print_done,
     print_error,
     print_fail,
@@ -837,7 +837,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 completion_msg_func = lambda: print_done("Cloning the vfolder is complete.")
                 async with (
                     bgtask.listen_events() as response,
-                    PorgressBarWithSpinner(
+                    ProgressBarWithSpinner(
                         "Cloning the vfolder... "
                         "(This may take a while depending on its size and number of files!)",
                     ) as viewer,

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -840,18 +840,15 @@ def clone(name, target_name, target_host, usage_mode, permission):
                     ProgressBarWithSpinner(
                         "Cloning the vfolder... "
                         "(This may take a while depending on its size and number of files!)",
-                    ) as viewer,
+                    ) as pbar,
                 ):
                     async for ev in response:
                         data = json.loads(ev.data)
                         match ev.event:
                             case BgtaskStatus.UPDATED:
-                                if viewer.tqdm is None:
-                                    pbar = await viewer.to_tqdm()
-                                else:
-                                    pbar.total = data["total_progress"]
-                                    pbar.write(data["message"])
-                                    pbar.update(data["current_progress"] - pbar.n)
+                                pbar.total = data["total_progress"]
+                                pbar.write(data["message"])
+                                pbar.update(data["current_progress"] - pbar.n)
                             case BgtaskStatus.FAILED:
                                 error_msg = data["message"]
                                 completion_msg_func = lambda: print_fail(

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -25,7 +25,7 @@ from ..compat import asyncio_run
 from ..session import AsyncSession
 from .extensions import pass_ctx_obj
 from .pretty import (
-    ProgressViewer,
+    PorgressBarWithSpinner,
     print_done,
     print_error,
     print_fail,
@@ -837,7 +837,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 completion_msg_func = lambda: print_done("Cloning the vfolder is complete.")
                 async with (
                     bgtask.listen_events() as response,
-                    ProgressViewer(
+                    PorgressBarWithSpinner(
                         "Cloning the vfolder... "
                         "(This may take a while depending on its size and number of files!)",
                     ) as viewer,

--- a/src/ai/backend/test/cli_integration/admin/test_domain.py
+++ b/src/ai/backend/test/cli_integration/admin/test_domain.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import closing
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_add_domain(run_admin: ClientRunnerFunc):
@@ -36,13 +36,13 @@ def test_add_domain(run_admin: ClientRunnerFunc):
     ]
     with closing(run_admin(add_arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Domain creation not successful"
 
     # Check if domain is added
     with closing(run_admin(["--output=json", "admin", "domain", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         domain_list = loaded.get("items")
         assert isinstance(domain_list, list), "Domain list not printed properly"
@@ -108,13 +108,13 @@ def test_update_domain(run_admin: ClientRunnerFunc):
     ]
     with closing(run_admin(add_arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Domain update not successful"
 
     # Check if domain is updated
     with closing(run_admin(["--output=json", "admin", "domain", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         domain_list = loaded.get("items")
         assert isinstance(domain_list, list), "Domain list not printed properly"
@@ -151,7 +151,7 @@ def test_delete_domain(run_admin: ClientRunnerFunc):
     with closing(run_admin(["--output=json", "admin", "domain", "purge", "test123"])) as p:
         p.sendline("y")
         p.expect(EOF)
-        before = p.before.decode()
+        before = decode(p.before)
         response = json.loads(before[before.index("{") :])
         assert response.get("ok") is True, "Domain deletion failed"
 
@@ -159,7 +159,7 @@ def test_delete_domain(run_admin: ClientRunnerFunc):
 def test_list_domain(run_admin: ClientRunnerFunc):
     with closing(run_admin(["--output=json", "admin", "domain", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         domain_list = loaded.get("items")
         assert isinstance(domain_list, list), "Domain list not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_group.py
+++ b/src/ai/backend/test/cli_integration/admin/test_group.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import closing
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_add_group(run_admin: ClientRunnerFunc):
@@ -20,7 +20,7 @@ def test_list_group(run_admin: ClientRunnerFunc):
     print("[ List group ]")
     with closing(run_admin(["--output=json", "admin", "group", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         group_list = loaded.get("items")
         assert isinstance(group_list, list), "Group list not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_image.py
+++ b/src/ai/backend/test/cli_integration/admin/test_image.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import closing
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_alias_image(run_admin: ClientRunnerFunc):
@@ -16,7 +16,7 @@ def test_list_image(run_admin: ClientRunnerFunc):
     print("[ List image ]")
     with closing(run_admin(["--output=json", "admin", "image", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         image_list = loaded.get("items")
         assert isinstance(image_list, list), "Image list not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_keypair.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair.py
@@ -2,7 +2,7 @@ import json
 from contextlib import closing
 from typing import Tuple
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 from ..conftest import KeypairOption, User
 
 
@@ -35,7 +35,7 @@ def test_add_keypair(
         ]
         with closing(run_admin(arguments)) as p:
             p.expect(EOF)
-            response = json.loads(p.before.decode())
+            response = json.loads(decode(p.before))
             assert response.get("ok") is True, f"Account#{i + 1} add error"
             user_ids.append(response["user"]["uuid"])
 
@@ -48,7 +48,7 @@ def test_add_keypair(
     ]
     with closing(run_admin(arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         group_id = response.get("items")[0]["id"]
 
     # FIXME: Delete the following code
@@ -65,7 +65,7 @@ def test_add_keypair(
     ]
     with closing(run_admin(arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "cannot add users to group"
 
     # Create keypair
@@ -86,12 +86,12 @@ def test_add_keypair(
             keypair_add_arguments.extend(["--rate-limit", rate_limit])
         with closing(run_admin(keypair_add_arguments)) as p:
             p.expect(EOF)
-            response = json.loads(p.before.decode())
+            response = json.loads(decode(p.before))
             assert response.get("ok") is True, f"Keypair#{i + 1} add error"
     # Check if keypair is added
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         keypair_list = loaded.get("items")
         assert isinstance(keypair_list, list), "List not printed properly!"
@@ -124,7 +124,7 @@ def test_update_keypair(
     # Get access key
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         keypair_list = loaded.get("items")
         assert isinstance(keypair_list, list), "List not printed properly!"
@@ -149,13 +149,13 @@ def test_update_keypair(
         # Update keypair
         with closing(run_admin(keypair_update_arguments)) as p:
             p.expect(EOF)
-            response = json.loads(p.before.decode())
+            response = json.loads(decode(p.before))
             assert response.get("ok") is True, f"Keypair#{i + 1} update error"
 
     # Check if keypair is updated
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         updated_keypair_list = loaded.get("items")
         assert isinstance(updated_keypair_list, list), "List not printed properly!"
@@ -187,7 +187,7 @@ def test_delete_keypair(run_admin: ClientRunnerFunc, users: Tuple[User]):
     # Get access key
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         keypair_list = loaded.get("items")
         assert isinstance(keypair_list, list), "List not printed properly!"
@@ -204,7 +204,7 @@ def test_delete_keypair(run_admin: ClientRunnerFunc, users: Tuple[User]):
         with closing(run_admin(["--output=json", "admin", "user", "purge", user.email])) as p:
             p.sendline("y")
             p.expect(EOF)
-            before = p.before.decode()
+            before = decode(p.before)
             response = json.loads(before[before.index("{") :])
             assert response.get("ok") is True, f"Account deletion failed: {user.username}"
 
@@ -215,7 +215,7 @@ def test_list_keypair(run_admin: ClientRunnerFunc):
     """
     with closing(run_admin(["--output=json", "admin", "keypair", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         keypair_list = loaded.get("items")
         assert isinstance(keypair_list, list), "List not printed properly!"
@@ -232,7 +232,7 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
     ]
     with closing(run_admin(admin_find_command)) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         item = loaded.get("items")
         assert len(item) == 1, "admin user not found"
@@ -252,7 +252,7 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
     ]
     with closing(run_admin(keypair_add_arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         access_key = response.get("access_key")
         assert access_key
         assert response.get("ok") is True, "Admin keypair add error"
@@ -260,7 +260,7 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
     # find image
     with closing(run_admin(["--output=json", "admin", "image", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         image_list = loaded.get("items")
         assert isinstance(image_list, list), "Image list not printed properly"
@@ -293,12 +293,12 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
 
     with closing(run_admin(create_session_command)) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         assert "is enqueued for scheduling." in decoded, "Session creation failed"
 
     with closing(run_admin(["--output=json", "admin", "session", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         session_list = loaded.get("items")
         assert isinstance(session_list, list), "Session list not printed properly"
@@ -309,7 +309,7 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
     # delete keypair
     with closing(run_admin(["--output=json", "admin", "keypair", "delete", access_key])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         print("delete keypair response", loaded)
         assert loaded.get("ok") is False, "Keypair should not be deleted"
@@ -319,13 +319,13 @@ def test_delete_keypair_on_running_session(run_admin: ClientRunnerFunc):
         run_admin(["--output=json", "session", "rm", session_name, "-o", access_key])
     ) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         assert "Done" in decoded, "Session deletion failed"
 
     # delete keypair
     with closing(run_admin(["--output=json", "admin", "keypair", "delete", access_key])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         assert loaded.get("ok") is True, "Keypair deletion failed"
 

--- a/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import closing
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_add_keypair_resource_policy(run_admin: ClientRunnerFunc, keypair_resource_policy: str):
@@ -40,13 +40,13 @@ def test_add_keypair_resource_policy(run_admin: ClientRunnerFunc, keypair_resour
     ]
     with closing(run_admin(add_arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Keypair resource policy creation not successful"
 
     # Check if keypair resource policy is created
     with closing(run_admin(["--output=json", "admin", "keypair-resource-policy", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         krp_list = loaded.get("items")
         assert isinstance(krp_list, list), "Keypair resource policy list not printed properly"
@@ -117,13 +117,13 @@ def test_update_keypair_resource_policy(run_admin: ClientRunnerFunc, keypair_res
     ]
     with closing(run_admin(add_arguments)) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Keypair resource policy update not successful"
 
     # Check if keypair resource policy is updated
     with closing(run_admin(["--output=json", "admin", "keypair-resource-policy", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         krp_list = loaded.get("items")
         assert isinstance(krp_list, list), "Keypair resource policy list not printed properly"
@@ -172,7 +172,7 @@ def test_delete_keypair_resource_policy(run_admin: ClientRunnerFunc, keypair_res
     ) as p:
         p.sendline("y")
         p.expect(EOF)
-        before = p.before.decode()
+        before = decode(p.before)
         response = json.loads(before[before.index("{") :])
         assert response.get("ok") is True, "Keypair resource policy deletion failed"
 
@@ -181,7 +181,7 @@ def test_list_keypair_resource_policy(run_admin: ClientRunnerFunc):
     print("[ List keypair resource policy ]")
     with closing(run_admin(["--output=json", "admin", "keypair-resource-policy", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         krp_list = loaded.get("items")
         assert isinstance(krp_list, list), "Keypair resource policy list not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_scaling_group.py
+++ b/src/ai/backend/test/cli_integration/admin/test_scaling_group.py
@@ -3,7 +3,7 @@ from contextlib import closing
 
 from ai.backend.common.types import AgentSelectionStrategy
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_add_scaling_group(run_admin: ClientRunnerFunc):
@@ -27,13 +27,13 @@ def test_add_scaling_group(run_admin: ClientRunnerFunc):
         ])
     ) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Test scaling group not created successfully"
 
     # Check if scaling group is created
     with closing(run_admin(["--output=json", "admin", "scaling-group", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         scaling_group_list = loaded.get("items")
         assert isinstance(scaling_group_list, list), "Scaling group list not printed properly"
@@ -46,7 +46,7 @@ def test_add_scaling_group(run_admin: ClientRunnerFunc):
         run_admin(["--output=json", "admin", "scaling-group", "info", "test_group1"])
     ) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         scaling_group_list = loaded.get("items")
         assert isinstance(scaling_group_list, list), "Scaling group info not printed properly"
@@ -88,7 +88,7 @@ def test_update_scaling_group(run_admin: ClientRunnerFunc):
         ])
     ) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Test scaling group not updated successfully"
 
     # Check if scaling group is updated
@@ -96,7 +96,7 @@ def test_update_scaling_group(run_admin: ClientRunnerFunc):
         run_admin(["--output=json", "admin", "scaling-group", "info", "test_group1"])
     ) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         scaling_group_list = loaded.get("items")
         assert isinstance(scaling_group_list, list), "Scaling group list not printed properly"
@@ -125,14 +125,14 @@ def test_delete_scaling_group(run_admin: ClientRunnerFunc):
         run_admin(["--output=json", "admin", "scaling-group", "delete", "test_group1"])
     ) as p:
         p.expect(EOF)
-        response = json.loads(p.before.decode())
+        response = json.loads(decode(p.before))
         assert response.get("ok") is True, "Test scaling group deletion unsuccessful"
 
 
 def test_list_scaling_group(run_admin: ClientRunnerFunc):
     with closing(run_admin(["--output=json", "admin", "scaling-group", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         scaling_group_list = loaded.get("items")
         assert isinstance(scaling_group_list, list), "Scaling group list not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_storage.py
+++ b/src/ai/backend/test/cli_integration/admin/test_storage.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import closing
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 def test_list_storage(run_admin: ClientRunnerFunc):
@@ -11,7 +11,7 @@ def test_list_storage(run_admin: ClientRunnerFunc):
     print("[ List storage ]")
     with closing(run_admin(["--output=json", "admin", "storage", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         storage_list = loaded.get("items")
         assert isinstance(storage_list, list), "Storage list not printed properly"
@@ -24,7 +24,7 @@ def test_info_storage(run_admin: ClientRunnerFunc):
     print("[ Print storage info ]")
     with closing(run_admin(["--output=json", "admin", "storage", "info", "local:volume1"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         storage_list = loaded.get("items")
         assert isinstance(storage_list, list), "Storage info not printed properly"

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -2,7 +2,7 @@ import json
 from contextlib import closing
 from typing import Callable, Tuple
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 from ..conftest import User
 
 
@@ -35,13 +35,13 @@ def test_add_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
             add_arguments.append("--need-password-change")
         with closing(run_admin(add_arguments)) as p:
             p.expect(EOF)
-            response = json.loads(p.before.decode())
+            response = json.loads(decode(p.before))
             assert response.get("ok") is True, f"Account creation failed: Account#{i + 1}"
 
     # Check if user is added
     with closing(run_admin(["--output=json", "admin", "user", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         user_list = loaded.get("items")
 
@@ -114,7 +114,7 @@ def test_update_user(
     # Check if user is updated correctly
     with closing(run_admin(["--output=json", "admin", "user", "list"])) as p:
         p.expect(EOF)
-        after_update_decoded = p.before.decode()
+        after_update_decoded = decode(p.before)
         after_update_loaded = json.loads(after_update_decoded)
         updated_user_list = after_update_loaded.get("items")
         assert isinstance(updated_user_list, list), "Expected user list"
@@ -148,7 +148,7 @@ def test_delete_user(run_admin: ClientRunnerFunc, users: Tuple[User, ...]):
         with closing(run_admin(["--output=json", "admin", "user", "purge", fake_user.email])) as p:
             p.sendline("y")
             p.expect(EOF)
-            before = p.before.decode()
+            before = decode(p.before)
             response = json.loads(before[before.index("{") :])
             assert response.get("ok") is True, f"Account deletion failed: Account#{i + 1}"
 
@@ -159,7 +159,7 @@ def test_list_user(run_admin: ClientRunnerFunc):
     """
     with closing(run_admin(["--output=json", "admin", "user", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         user_list = loaded.get("items")
         assert isinstance(user_list, list)

--- a/src/ai/backend/test/cli_integration/user/test_vfolder.py
+++ b/src/ai/backend/test/cli_integration/user/test_vfolder.py
@@ -5,7 +5,7 @@ from io import TextIOWrapper
 
 import pytest
 
-from ...utils.cli import EOF, ClientRunnerFunc
+from ...utils.cli import EOF, ClientRunnerFunc, decode
 
 
 @pytest.mark.dependency()
@@ -18,26 +18,26 @@ def test_create_vfolder(run_user: ClientRunnerFunc):
     # Create group first
     # with closing(run(['admin', 'group', 'add', 'default', 'testgroup'])) as p:
     #     p.expect(EOF)
-    #     assert 'Group name testgroup is created in domain default' in p.before.decode(), \
+    #     assert 'Group name testgroup is created in domain default' in decode(p.before), \
     #         'Test group not created successfully.'
     print("[ Create vfolder ]")
     # Create vfolder
     with closing(run_user(["vfolder", "create", "-p", "rw", "test_folder1", "local:volume1"])) as p:
         p.expect(EOF)
-        assert 'Virtual folder "test_folder1" is created' in p.before.decode(), (
+        assert 'Virtual folder "test_folder1" is created' in decode(p.before), (
             "Test folder1 not created successfully."
         )
 
     with closing(run_user(["vfolder", "create", "-p", "ro", "test_folder2", "local:volume1"])) as p:
         p.expect(EOF)
-        assert 'Virtual folder "test_folder2" is created' in p.before.decode(), (
+        assert 'Virtual folder "test_folder2" is created' in decode(p.before), (
             "Test folder2 not created successfully."
         )
 
     # Check if vfolder is created
     with closing(run_user(["--output=json", "vfolder", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         folder_list = loaded.get("items")
         assert isinstance(folder_list, list), "Error in listing test folders!"
@@ -63,12 +63,12 @@ def test_rename_vfolder(run_user: ClientRunnerFunc):
     # Rename vfolder
     with closing(run_user(["vfolder", "rename", "test_folder1", "test_folder3"])) as p:
         p.expect(EOF)
-        assert "Renamed" in p.before.decode(), "Test folder1 not renamed successfully."
+        assert "Renamed" in decode(p.before), "Test folder1 not renamed successfully."
 
     # Check if vfolder is updated
     with closing(run_user(["--output=json", "vfolder", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         folder_list = loaded.get("items")
         assert isinstance(folder_list, list), "Error in listing test folders!"
@@ -91,12 +91,12 @@ def test_upload_file(run_user: ClientRunnerFunc, txt_file: TextIOWrapper):
     # Upload the file to vfolder
     with closing(run_user(["vfolder", "upload", vfolder_name, file_name])) as p:
         p.expect(EOF)
-        assert "Done." in p.before.decode(), "File upload failed."
+        assert "Done." in decode(p.before), "File upload failed."
 
     # Check if the file has been successfully uploaded
     with closing(run_user(["vfolder", "ls", vfolder_name])) as p:
         p.expect(EOF)
-        assert file_name in p.before.decode(), "File was not uploaded successfully."
+        assert file_name in decode(p.before), "File was not uploaded successfully."
 
 
 @pytest.mark.dependency(depends=["test_create_vfolder", "test_upload_file"])
@@ -115,11 +115,11 @@ def test_rename_file(run_user: ClientRunnerFunc):
         run_user(["vfolder", "rename-file", vfolder_name, old_file_name, new_file_name])
     ) as p:
         p.expect(EOF)
-        assert "Renamed." in p.before.decode(), "File rename failed."
+        assert "Renamed." in decode(p.before), "File rename failed."
 
     with closing(run_user(["vfolder", "ls", vfolder_name])) as p:
         p.expect(EOF)
-        assert new_file_name in p.before.decode(), "File was not renamed successfully."
+        assert new_file_name in decode(p.before), "File was not renamed successfully."
 
 
 @pytest.mark.dependency(depends=["test_create_vfolder", "test_upload_file", "test_rename_file"])
@@ -136,7 +136,7 @@ def test_download_file(run_user: ClientRunnerFunc):
     # Download the file from vfolder
     with closing(run_user(["vfolder", "download", vfolder_name, file_name])) as p:
         p.expect(EOF)
-        assert "Done." in p.before.decode(), "File download failed."
+        assert "Done." in decode(p.before), "File download failed."
 
     # Check if the file has been successfully downloaded
     assert os.path.isfile(file_name), "File was not downloaded successfully."
@@ -159,19 +159,17 @@ def test_mkdir_vfolder(run_user: ClientRunnerFunc):
     # Create directory in the vfolder
     with closing(run_user(["vfolder", "mkdir", vfolder_name, dir_paths[0]])) as p:
         p.expect(EOF)
-        assert "Successfully created" in p.before.decode(), "Directory creation failed."
+        assert "Successfully created" in decode(p.before), "Directory creation failed."
 
     # Create already existing directory with exist-ok option
     with closing(run_user(["vfolder", "mkdir", "-e", vfolder_name, dir_paths[0]])) as p:
         p.expect(EOF)
-        assert "Successfully created" in p.before.decode(), (
-            "Exist-ok option does not work properly."
-        )
+        assert "Successfully created" in decode(p.before), "Exist-ok option does not work properly."
 
     # Test whether the parent directory is created automatically
     with closing(run_user(["vfolder", "mkdir", "-p", vfolder_name, dir_paths[1]])) as p:
         p.expect(EOF)
-        assert "Successfully created" in p.before.decode(), (
+        assert "Successfully created" in decode(p.before), (
             "The parent directory is not created automatically."
         )
 
@@ -194,15 +192,15 @@ def test_mv_file(run_user: ClientRunnerFunc):
         run_user(["vfolder", "mv", vfolder_name, file_name, f"{dir_path}/{file_name}"])
     ) as p:
         p.expect(EOF)
-        assert "Moved." in p.before.decode(), "File move failed."
+        assert "Moved." in decode(p.before), "File move failed."
 
     with closing(run_user(["vfolder", "ls", vfolder_name])) as p:
         p.expect(EOF)
-        assert file_name not in p.before.decode(), "File was not moved successfully."
+        assert file_name not in decode(p.before), "File was not moved successfully."
 
     with closing(run_user(["vfolder", "ls", vfolder_name, dir_path])) as p:
         p.expect(EOF)
-        assert file_name in p.before.decode(), "File was not moved successfully."
+        assert file_name in decode(p.before), "File was not moved successfully."
 
 
 @pytest.mark.dependency(depends=["test_create_vfolder", "test_rename_file"])
@@ -215,11 +213,11 @@ def test_delete_vfolder(run_user: ClientRunnerFunc):
     print("[ Delete vfolder ]")
     with closing(run_user(["vfolder", "delete", "test_folder2"])) as p:
         p.expect(EOF)
-        assert "Deleted" in p.before.decode(), "Test folder 2 not deleted successfully."
+        assert "Deleted" in decode(p.before), "Test folder 2 not deleted successfully."
 
     with closing(run_user(["vfolder", "delete", "test_folder3"])) as p:
         p.expect(EOF)
-        assert "Deleted" in p.before.decode(), "Test folder 3 not deleted successfully."
+        assert "Deleted" in decode(p.before), "Test folder 3 not deleted successfully."
 
 
 def test_delete_vfolder_the_same_vfolder_name(
@@ -239,13 +237,13 @@ def test_delete_vfolder_the_same_vfolder_name(
 
     with closing(run_user(["vfolder", "delete", vfolder_name])) as p:
         p.expect(EOF)
-        assert "Deleted" in p.before.decode(), (
+        assert "Deleted" in decode(p.before), (
             "Test folder created by user not deleted successfully."
         )
 
     with closing(run_user2(["vfolder", "delete", vfolder_name])) as p:
         p.expect(EOF)
-        assert "Deleted" in p.before.decode(), (
+        assert "Deleted" in decode(p.before), (
             "Test folder created by user2 not deleted successfully."
         )
 
@@ -256,7 +254,7 @@ def test_list_vfolder(run_user: ClientRunnerFunc):
     """
     with closing(run_user(["--output=json", "vfolder", "list"])) as p:
         p.expect(EOF)
-        decoded = p.before.decode()
+        decoded = decode(p.before)
         loaded = json.loads(decoded)
         folder_list = loaded.get("items")
         assert isinstance(folder_list, list)

--- a/src/ai/backend/test/utils/cli.py
+++ b/src/ai/backend/test/utils/cli.py
@@ -32,3 +32,9 @@ def run(
         **kwargs,
     )
     return p
+
+
+def decode(pexpect_capture: bytes | None) -> str:
+    if pexpect_capture is None:
+        return ""
+    return pexpect_capture.decode()

--- a/tools/mypy-requirements.txt
+++ b/tools/mypy-requirements.txt
@@ -1,3 +1,3 @@
-mypy==1.17.1
+mypy==1.18.1
 pydantic~=2.11.3
 strawberry-graphql~=0.278.0

--- a/tools/mypy.lock
+++ b/tools/mypy.lock
@@ -9,7 +9,7 @@
 //     "CPython==3.13.7"
 //   ],
 //   "generated_with_requirements": [
-//     "mypy==1.17.1",
+//     "mypy==1.18.1",
 //     "pydantic~=2.11.3",
 //     "strawberry-graphql~=0.278.0"
 //   ],
@@ -95,38 +95,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9",
-              "url": "https://files.pythonhosted.org/packages/1d/f3/8fcd2af0f5b806f6cf463efaffd3c9548a28f84220493ecd38d127b6b66d/mypy-1.17.1-py3-none-any.whl"
+              "hash": "b76a4de66a0ac01da1be14ecc8ae88ddea33b8380284a9e3eae39d57ebcbe26e",
+              "url": "https://files.pythonhosted.org/packages/e0/1d/4b97d3089b48ef3d904c9ca69fab044475bd03245d878f5f0b3ea1daf7ce/mypy-1.18.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81",
-              "url": "https://files.pythonhosted.org/packages/07/ac/ee93fbde9d2242657128af8c86f5d917cd2887584cf948a8e3663d0cd737/mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl"
+              "hash": "9e988c64ad3ac5987f43f5154f884747faf62141b7f842e87465b45299eea5a9",
+              "url": "https://files.pythonhosted.org/packages/14/a3/931e09fc02d7ba96da65266884da4e4a8806adcdb8a57faaacc6edf1d538/mypy-1.18.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6",
-              "url": "https://files.pythonhosted.org/packages/5a/68/946a1e0be93f17f7caa56c45844ec691ca153ee8b62f21eddda336a2d203/mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "c378d946e8a60be6b6ede48c878d145546fb42aad61df998c056ec151bf6c746",
+              "url": "https://files.pythonhosted.org/packages/89/4e/899dba0bfe36bbd5b7c52e597de4cf47b5053d337b6d201a30e3798e77a6/mypy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7",
-              "url": "https://files.pythonhosted.org/packages/5b/82/aec2fc9b9b149f372850291827537a508d6c4d3664b1750a324b91f71355/mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl"
+              "hash": "1a0e70b87eb27b33209fa4792b051c6947976f6ab829daa83819df5f58330c71",
+              "url": "https://files.pythonhosted.org/packages/98/43/b7e429fc4be10e390a167b0cd1810d41cb4e4add4ae50bab96faff695a3b/mypy-1.18.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01",
-              "url": "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz"
+              "hash": "b8367e33506300f07a43012fc546402f283c3f8bcff1dc338636affb710154ce",
+              "url": "https://files.pythonhosted.org/packages/a1/82/0ea6c3953f16223f0b8eda40c1aeac6bd266d15f4902556ae6e91f6fca4c/mypy-1.18.1-cp313-cp313-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849",
-              "url": "https://files.pythonhosted.org/packages/9f/0f/478b4dce1cb4f43cf0f0d00fba3030b21ca04a01b74d1cd272a528cf446f/mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "913f668ec50c3337b89df22f973c1c8f0b29ee9e290a8b7fe01cc1ef7446d42e",
+              "url": "https://files.pythonhosted.org/packages/ae/ef/5e2057e692c2690fc27b3ed0a4dbde4388330c32e2576a23f0302bc8358d/mypy-1.18.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14",
-              "url": "https://files.pythonhosted.org/packages/ca/70/afa5850176379d1b303f992a828de95fc14487429a7139a4e0bdd17a8279/mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+              "hash": "d70d2b5baf9b9a20bc9c730015615ae3243ef47fb4a58ad7b31c3e0a59b5ef1f",
+              "url": "https://files.pythonhosted.org/packages/e4/ec/ef4a7260e1460a3071628a9277a7579e7da1b071bc134ebe909323f2fbc7/mypy-1.18.1-cp313-cp313-macosx_10_13_x86_64.whl"
             }
           ],
           "project_name": "mypy",
@@ -142,7 +142,7 @@
             "typing_extensions>=4.6.0"
           ],
           "requires_python": ">=3.9",
-          "version": "1.17.1"
+          "version": "1.18.1"
         },
         {
           "artifacts": [
@@ -202,13 +202,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b",
-              "url": "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl"
+              "hash": "c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2",
+              "url": "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db",
-              "url": "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz"
+              "hash": "6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2",
+              "url": "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz"
             }
           ],
           "project_name": "pydantic",
@@ -221,7 +221,7 @@
             "tzdata; (python_version >= \"3.9\" and platform_system == \"Windows\") and extra == \"timezone\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.11.7"
+          "version": "2.11.9"
         },
         {
           "artifacts": [
@@ -401,19 +401,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
-              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
+              "hash": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
+              "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
-              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
+              "hash": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+              "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.1"
+          "version": "4.15.0"
         },
         {
           "artifacts": [
@@ -447,7 +447,7 @@
   "pip_version": "25.2",
   "prefer_older_binary": false,
   "requirements": [
-    "mypy==1.17.1",
+    "mypy==1.18.1",
     "pydantic~=2.11.3",
     "strawberry-graphql~=0.278.0"
   ],


### PR DESCRIPTION
* Upgrade mypy (1.17.1 -> 1.18.1)
  - https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-18
* Add missing type stub packages:
  - types-colorama
  - types-networkx
  - types-pexpect
  - types-psutil
  - types-requests
  - types-tqdm
* Fix newly found type errors
* Along with types-tqdm, rewrite `client.cli.pretty.ProgressViewer` (→ `ProgressBarWithSpinner`) in #1049 to make type checkers happy.
  - Use tqdm's own `set_description_str()` method to print the spinner character to prevent garbling the terminal output.
  - Now it fully utilizes the tqdm inheritance and temporarily overrides the `format_meter()` method so that the progress bar is hidden at first but first assignment to `total` attribute reactivates the progress bar display. If `total` is not set, it just works as a spinner.
    - Previously the user had to call `to_tqdm()` manually and this encouraged a dark pattern accessing undefined variable and making typecheckers angry.
  - Improved coloring so that the progress bar follows the "WAITING" color (bright yellow) and the completed (closed) progress bar follows the "DONE" color (bright green).
