### PR TITLE
fix: Set kernel status to terminated when the kernel is missing

### DIFF
--- a/changes/5903.fix.md
+++ b/changes/5903.fix.md
@@ -1,0 +1,1 @@
+Set kernel status to terminated when the kernel is missing

--- a/src/ai/backend/manager/sokovan/scheduler/scheduler.py
+++ b/src/ai/backend/manager/sokovan/scheduler/scheduler.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
 from typing import Any, Awaitable, Coroutine, Optional
+from uuid import UUID
 
 import aiotools
 import async_timeout
@@ -606,6 +607,10 @@ class Scheduler:
                     # If no agent/container, just mark as successful termination
                     # This is a fallback for kernels that might not have been scheduled properly
                     # or were already terminated
+                    await self._repository.update_kernel_status_terminated(
+                        UUID(kernel.kernel_id),
+                        session_result.reason,
+                    )
                     session_result.kernel_results.append(
                         KernelTerminationResult(
                             kernel_id=str(kernel.kernel_id),


### PR DESCRIPTION
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
