### PR TITLE
fix: Endpoint mutation by loading image of service endpoint (#5905)

### DIFF
--- a/changes/5905.fix.md
+++ b/changes/5905.fix.md
@@ -1,0 +1,1 @@
+Fix Endpoint mutation by querying endpoint records with image objects

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -763,6 +763,7 @@ class ModelServingRepository:
                         load_session_owner=True,
                         load_model=True,
                         load_routes=True,
+                        load_image=True,
                     )
                     match action.requester_ctx.user_role:
                         case UserRole.SUPERADMIN:


### PR DESCRIPTION
This is an auto-generated backport PR of #5905 to the 25.14 release.