### PR TITLE
feat: Add build-isla-sorna-image workflow (#5466)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,20 @@ jobs:
     if: needs.optimize-ci.outputs.release == 'true'
     uses: ./.github/workflows/sbom.yml
 
+  build-isla-sorna-image:
+    needs: [build-scies, build-wheels, build-sbom, optimize-ci]
+    if: needs.optimize-ci.outputs.release == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Isla Sorna repo image build
+        run: |
+          gh api repos/lablup/isla-sorna/dispatches \
+            -f event_type='build-images' \
+            -f client_payload.version="${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+  
 
   make-final-release:
     needs: [build-scies, build-wheels, build-sbom, optimize-ci]


### PR DESCRIPTION
This is an auto-generated backport PR of #5466 to the 25.6 release.