### PR TITLE
chore(BA-2328): Add Dockerfile and entrypoint for Backend.AI Manager

### DIFF
--- a/backend.ai-manager.Dockerfile
+++ b/backend.ai-manager.Dockerfile
@@ -1,0 +1,27 @@
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION} AS builder
+ARG PKGVER
+COPY dist /dist
+RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-manager==${PKGVER} --find-links=/dist
+
+FROM python:${PYTHON_VERSION}
+COPY --from=builder /wheels /wheels
+RUN mkdir -p /root/.ssh
+RUN apt-get update && apt-get install -y vim && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir /wheels/*.whl
+
+# Create necessary directories
+RUN mkdir -p /tmp/backend.ai/ipc /var/log/backend.ai /etc/backend.ai /app/fixtures
+
+# Set working directory
+WORKDIR /app
+
+# Copy entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Expose the manager service port
+EXPOSE 8091
+
+# Set the default command to run the entrypoint script
+CMD ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+echo "=== Backend.AI Manager Container starting ==="
+
+# fixtures directory creation (default path structure)
+mkdir -p /app/fixtures/manager
+
+# RPC keypair not found. Generating...
+if [ ! -f "/app/fixtures/manager/manager.key" ] || [ ! -f "/app/fixtures/manager/manager.key_secret" ]; then
+    echo "RPC keypair not found. Generating..."
+    python -m ai.backend.manager.cli generate-rpc-keypair /app/fixtures/manager 'manager'
+    echo "RPC keypair generated successfully."
+    echo "   - Public Key: /app/fixtures/manager/manager.key"
+    echo "   - Secret Key: /app/fixtures/manager/manager.key_secret"
+else
+    echo "RPC keypair already exists."
+fi
+
+# Log directory creation
+mkdir -p /var/log/backend.ai
+
+# IPC directory creation
+mkdir -p /tmp/backend.ai/ipc
+
+echo "=== Manager server starting ==="
+exec python -m ai.backend.manager.server --config /etc/backend.ai/manager.toml


### PR DESCRIPTION
Introduces backend.ai-manager.Dockerfile to build and run the Backend.AI Manager service, including wheel installation, directory setup, and port exposure. Adds entrypoint.sh to handle keypair generation, directory creation, and service startup.

resolve #5823 (BA-2328)

```
docker run -d \
  --name backend-ai-manager \
  --add-host host.docker.internal:host-gateway \
  -p 8091:8091 \
  -v $(pwd)/fixtures:/app/fixtures:ro \
  -v $(pwd)/manager.toml:/etc/backend.ai/manager.toml:ro \
  -v $(pwd)/logs:/var/log/backend.ai \
  -v /tmp/backend.ai/ipc:/tmp/backend.ai/ipc \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e PYTHONUNBUFFERED=1 \
  --restart unless-stopped \
  backend.ai/manager:25.14.3
```

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
