### PR TITLE
fix: Change object permission bulk insert to use ORM functions (#5893)

### DIFF
--- a/changes/5893.fix.md
+++ b/changes/5893.fix.md
@@ -1,0 +1,1 @@
+Change object permission bulk insert to use ORM functions

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -168,11 +168,12 @@ class RoleManager:
             for operation in operations
         ]
 
-        rows = await db_session.execute(
-            sa.insert(ObjectPermissionRow).returning(ObjectPermissionRow),
-            [input.fields_to_store() for input in creators],
-        )
-        result = [ObjectPermissionRow.from_sa_row(row).to_data() for row in rows]
+        rows = [ObjectPermissionRow.from_input(creator) for creator in creators]
+        db_session.add_all(rows)
+        await db_session.flush()
+        for row in rows:
+            await db_session.refresh(row)
+        result = [row.to_data() for row in rows]
         return result
 
     async def delete_object_permission_of_user(


### PR DESCRIPTION
This is an auto-generated backport PR of #5893 to the 25.14 release.