### PR TITLE
fix: Apply action pattern to update shared vfolder function (#5919)

### DIFF
--- a/changes/5919.fix.md
+++ b/changes/5919.fix.md
@@ -1,0 +1,1 @@
+Add missing RBAC function call in update-shared-vfolder action handler

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -948,6 +948,26 @@ class VfolderRepository:
             await session.execute(query)
 
     @repository_decorator()
+    async def update_invited_vfolder_mount_permission(
+        self, vfolder_id: uuid.UUID, user_id: uuid.UUID, permission: VFolderPermission
+    ) -> None:
+        """
+        Update the permission of an invited user for a specific vfolder.
+        """
+        async with self._db.begin_session() as session:
+            query = (
+                sa.update(VFolderPermissionRow)
+                .where(
+                    sa.and_(
+                        VFolderPermissionRow.vfolder == vfolder_id,
+                        VFolderPermissionRow.user == user_id,
+                    )
+                )
+                .values(permission=permission)
+            )
+            await session.execute(query)
+
+    @repository_decorator()
     async def get_pending_invitations_for_user(
         self, user_email: str
     ) -> list[tuple[VFolderInvitationData, VFolderData]]:

--- a/src/ai/backend/manager/services/vfolder/actions/invite.py
+++ b/src/ai/backend/manager/services/vfolder/actions/invite.py
@@ -170,3 +170,55 @@ class LeaveInvitedVFolderActionResult(BaseActionResult):
     @override
     def entity_id(self) -> Optional[str]:
         return str(self.vfolder_uuid)
+
+
+@dataclass
+class RevokeInvitedVFolderAction(VFolderInvitationAction):
+    vfolder_id: uuid.UUID
+    shared_user_id: uuid.UUID
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return str(self.vfolder_id)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "revoke"
+
+
+@dataclass
+class RevokeInvitedVFolderActionResult(BaseActionResult):
+    vfolder_id: uuid.UUID
+    shared_user_id: uuid.UUID
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return str(self.vfolder_id)
+
+
+@dataclass
+class UpdateInvitedVFolderMountPermissionAction(VFolderInvitationAction):
+    vfolder_id: uuid.UUID
+    user_id: uuid.UUID
+    permission: VFolderMountPermission
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return str(self.vfolder_id)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "update_permission"
+
+
+@dataclass
+class UpdateInvitedVFolderMountPermissionActionResult(BaseActionResult):
+    vfolder_id: uuid.UUID
+    user_id: uuid.UUID
+    permission: VFolderMountPermission
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return str(self.vfolder_id)

--- a/src/ai/backend/manager/services/vfolder/processors/invite.py
+++ b/src/ai/backend/manager/services/vfolder/processors/invite.py
@@ -15,8 +15,12 @@ from ..actions.invite import (
     ListInvitationActionResult,
     RejectInvitationAction,
     RejectInvitationActionResult,
+    RevokeInvitedVFolderAction,
+    RevokeInvitedVFolderActionResult,
     UpdateInvitationAction,
     UpdateInvitationActionResult,
+    UpdateInvitedVFolderMountPermissionAction,
+    UpdateInvitedVFolderMountPermissionActionResult,
 )
 from ..services.invite import VFolderInviteService
 
@@ -30,6 +34,12 @@ class VFolderInviteProcessors(AbstractProcessorPackage):
     leave_invited_vfolder: ActionProcessor[
         LeaveInvitedVFolderAction, LeaveInvitedVFolderActionResult
     ]
+    revoke_invited_vfolder: ActionProcessor[
+        RevokeInvitedVFolderAction, RevokeInvitedVFolderActionResult
+    ]
+    update_invited_vfolder_mount_permission: ActionProcessor[
+        UpdateInvitedVFolderMountPermissionAction, UpdateInvitedVFolderMountPermissionActionResult
+    ]
 
     def __init__(self, service: VFolderInviteService, action_monitors: list[ActionMonitor]):
         self.invite_vfolder = ActionProcessor(service.invite, action_monitors)
@@ -38,6 +48,12 @@ class VFolderInviteProcessors(AbstractProcessorPackage):
         self.update_invitation = ActionProcessor(service.update_invitation, action_monitors)
         self.list_invitation = ActionProcessor(service.list_invitation, action_monitors)
         self.leave_invited_vfolder = ActionProcessor(service.leave_invited_vfolder, action_monitors)
+        self.revoke_invited_vfolder = ActionProcessor(
+            service.revoke_invited_vfolder, action_monitors
+        )
+        self.update_invited_vfolder_mount_permission = ActionProcessor(
+            service.update_invited_vfolder_mount_permission, action_monitors
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -48,4 +64,6 @@ class VFolderInviteProcessors(AbstractProcessorPackage):
             UpdateInvitationAction.spec(),
             ListInvitationAction.spec(),
             LeaveInvitedVFolderAction.spec(),
+            RevokeInvitedVFolderAction.spec(),
+            UpdateInvitedVFolderMountPermissionAction.spec(),
         ]

--- a/src/ai/backend/manager/services/vfolder/services/invite.py
+++ b/src/ai/backend/manager/services/vfolder/services/invite.py
@@ -30,8 +30,12 @@ from ..actions.invite import (
     ListInvitationActionResult,
     RejectInvitationAction,
     RejectInvitationActionResult,
+    RevokeInvitedVFolderAction,
+    RevokeInvitedVFolderActionResult,
     UpdateInvitationAction,
     UpdateInvitationActionResult,
+    UpdateInvitedVFolderMountPermissionAction,
+    UpdateInvitedVFolderMountPermissionActionResult,
 )
 from ..types import VFolderInvitationInfo
 
@@ -271,3 +275,21 @@ class VFolderInviteService:
         await self._vfolder_repository.delete_vfolder_permission(action.vfolder_uuid, user_uuid)
 
         return LeaveInvitedVFolderActionResult(vfolder_data.id)
+
+    async def revoke_invited_vfolder(
+        self, action: RevokeInvitedVFolderAction
+    ) -> RevokeInvitedVFolderActionResult:
+        await self._vfolder_repository.delete_vfolder_permission(
+            action.vfolder_id, action.shared_user_id
+        )
+        return RevokeInvitedVFolderActionResult(action.vfolder_id, action.shared_user_id)
+
+    async def update_invited_vfolder_mount_permission(
+        self, action: UpdateInvitedVFolderMountPermissionAction
+    ) -> UpdateInvitedVFolderMountPermissionActionResult:
+        await self._vfolder_repository.update_invited_vfolder_mount_permission(
+            action.vfolder_id, action.user_id, action.permission
+        )
+        return UpdateInvitedVFolderMountPermissionActionResult(
+            action.vfolder_id, action.user_id, action.permission
+        )


### PR DESCRIPTION
This is an auto-generated backport PR of #5919 to the 25.14 release.