### PR TITLE
refactor(BA-2385): Introduce `ModelDefinitionGenerator` pattern to support multiple runtime variant in model service

### DIFF
--- a/changes/5924.enhance.md
+++ b/changes/5924.enhance.md
@@ -1,0 +1,1 @@
+Introduce ModelDefinitionGenerator pattern to support multiple runtime variant in model service

--- a/changes/5924.fix.md
+++ b/changes/5924.fix.md
@@ -1,1 +1,0 @@
-Validate model definition file during model service creation only for custom runtime variants

--- a/changes/5924.fix.md
+++ b/changes/5924.fix.md
@@ -1,0 +1,1 @@
+Validate model definition file during model service creation only for custom runtime variants

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -159,6 +159,7 @@ class ErrorDomain(enum.StrEnum):
     VFOLDER = "vfolder"
     VFOLDER_INVITATION = "vfolder-invitation"
     MODEL_SERVICE = "model-service"
+    MODEL_DEPLOYMENT = "model-deployment"
     RESOURCE_PRESET = "resource-preset"
     STORAGE = "storage"
     AGENT = "agent"
@@ -565,4 +566,36 @@ class ArtifactDefaultRevisionResolveError(BackendAIError, web.HTTPBadRequest):
             domain=ErrorDomain.ARTIFACT,
             operation=ErrorOperation.REQUEST,
             error_detail=ErrorDetail.BAD_REQUEST,
+        )
+
+
+class RuntimeVariantNotSupportedError(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/runtime-variant-not-supported"
+    error_title = "Runtime Variant Not Supported"
+
+    def __init__(self, runtime_variant: str) -> None:
+        super().__init__(extra_msg=f"Runtime variant '{runtime_variant}' is not supported.")
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_DEPLOYMENT,
+            operation=ErrorOperation.REQUEST,
+            error_detail=ErrorDetail.BAD_REQUEST,
+        )
+
+
+class ServiceDefinitionNotLoadedError(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/service-definition-not-loaded"
+    error_title = "Service Definition Not Loaded"
+
+    def __init__(self) -> None:
+        super().__init__(extra_msg="Service definition is not loaded yet.")
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_DEPLOYMENT,
+            operation=ErrorOperation.GENERIC,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
         )

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -583,19 +583,3 @@ class RuntimeVariantNotSupportedError(BackendAIError, web.HTTPBadRequest):
             operation=ErrorOperation.REQUEST,
             error_detail=ErrorDetail.BAD_REQUEST,
         )
-
-
-class ServiceDefinitionNotLoadedError(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/service-definition-not-loaded"
-    error_title = "Service Definition Not Loaded"
-
-    def __init__(self) -> None:
-        super().__init__(extra_msg="Service definition is not loaded yet.")
-
-    @classmethod
-    def error_code(cls) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )

--- a/src/ai/backend/manager/services/model_serving/types.py
+++ b/src/ai/backend/manager/services/model_serving/types.py
@@ -296,7 +296,7 @@ class ModelServiceDefinition(BaseModel):
         ],
     )
 
-    def ovrride_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
+    def override_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
         """Override model revision configuration with model service definition values."""
         if self.resource_slots:
             model_revision.resource_spec.resource_slots = self.resource_slots

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+from ai.backend.common.config import ModelDefinition
+from ai.backend.manager.data.deployment.types import (
+    ModelRevisionSpec,
+)
+
+TDefinition = TypeVar("TDefinition")
+
+
+class ModelDefinitionGenerator(ABC):
+    """Abstract base class for generating model definitions."""
+
+    @abstractmethod
+    async def generate_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
+        """Generate a model definition based on the provided revision (RuntimeVariant)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def validate_configuration(self, config: dict) -> None:
+        """Validate the provided model configuration."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def override_service_definition(
+        self, model_revision: ModelRevisionSpec
+    ) -> ModelRevisionSpec:
+        """Apply overrides to the model revision based on the service definition."""
+        raise NotImplementedError

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
@@ -10,7 +10,7 @@ class ModelDefinitionGenerator(ABC):
     """Abstract base class for generating model definitions."""
 
     @abstractmethod
-    async def generate_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
+    async def generate_model_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
         """Generate a model definition based on the provided revision (RuntimeVariant)."""
         raise NotImplementedError
 
@@ -20,8 +20,5 @@ class ModelDefinitionGenerator(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def override_service_definition(
-        self, model_revision: ModelRevisionSpec
-    ) -> ModelRevisionSpec:
-        """Apply overrides to the model revision based on the service definition."""
+    async def generate_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
         raise NotImplementedError

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
@@ -1,12 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.manager.data.deployment.types import (
     ModelRevisionSpec,
 )
-
-TDefinition = TypeVar("TDefinition")
 
 
 class ModelDefinitionGenerator(ABC):

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/base.py
@@ -15,10 +15,5 @@ class ModelDefinitionGenerator(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def validate_configuration(self, config: dict) -> None:
-        """Validate the provided model configuration."""
-        raise NotImplementedError
-
-    @abstractmethod
     async def generate_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
         raise NotImplementedError

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
@@ -1,0 +1,51 @@
+from typing import Optional, override
+
+from ai.backend.common.config import ModelDefinition
+from ai.backend.common.exception import ServiceDefinitionNotLoadedError
+from ai.backend.manager.data.deployment.types import (
+    DefinitionFiles,
+    ModelRevisionSpec,
+)
+from ai.backend.manager.repositories.deployment import DeploymentRepository
+from ai.backend.manager.services.model_serving.types import ModelServiceDefinition
+from ai.backend.manager.sokovan.deployment.definition_generator.base import ModelDefinitionGenerator
+
+
+class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
+    """Model definition generator implementation for custom runtime variant."""
+
+    _deployment_repository: DeploymentRepository
+    _service_definition: Optional[ModelServiceDefinition]
+
+    def __init__(self, deployment_repository: DeploymentRepository) -> None:
+        self._deployment_repository = deployment_repository
+        self._service_definition: Optional[ModelServiceDefinition] = None
+
+    @override
+    async def generate_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
+        definition_files: DefinitionFiles = (
+            await self._deployment_repository.fetch_definition_files(
+                vfolder_id=model_revision.mounts.model_vfolder_id,
+                model_definition_path=model_revision.mounts.model_definition_path,
+            )
+        )
+        if definition_files.service_definition:
+            self._service_definition = ModelServiceDefinition.model_validate(
+                definition_files.service_definition
+            )
+        return ModelDefinition.model_validate(definition_files.model_definition)
+
+    @override
+    async def validate_configuration(self, config: dict) -> None:
+        # Already validated during generation
+        pass
+
+    @override
+    async def override_service_definition(
+        self, model_revision: ModelRevisionSpec
+    ) -> ModelRevisionSpec:
+        if not self._service_definition:
+            raise ServiceDefinitionNotLoadedError()
+        model_revision = self._service_definition.override_model_revision(model_revision)
+        self._service_definition = None
+        return model_revision

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
@@ -1,7 +1,6 @@
-from typing import Optional, override
+from typing import Any, override
 
 from ai.backend.common.config import ModelDefinition
-from ai.backend.common.exception import ServiceDefinitionNotLoadedError
 from ai.backend.manager.data.deployment.types import (
     DefinitionFiles,
     ModelRevisionSpec,
@@ -15,24 +14,18 @@ class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
     """Model definition generator implementation for custom runtime variant."""
 
     _deployment_repository: DeploymentRepository
-    _service_definition: Optional[ModelServiceDefinition]
 
     def __init__(self, deployment_repository: DeploymentRepository) -> None:
         self._deployment_repository = deployment_repository
-        self._service_definition: Optional[ModelServiceDefinition] = None
 
     @override
-    async def generate_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
+    async def generate_model_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
         definition_files: DefinitionFiles = (
             await self._deployment_repository.fetch_definition_files(
                 vfolder_id=model_revision.mounts.model_vfolder_id,
                 model_definition_path=model_revision.mounts.model_definition_path,
             )
         )
-        if definition_files.service_definition:
-            self._service_definition = ModelServiceDefinition.model_validate(
-                definition_files.service_definition
-            )
         return ModelDefinition.model_validate(definition_files.model_definition)
 
     @override
@@ -40,12 +33,21 @@ class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
         # Already validated during generation
         pass
 
+    async def _validate_model_definition_dict(self, model_definition: dict[str, Any]) -> None:
+        ModelDefinition.model_validate(model_definition)
+
     @override
-    async def override_service_definition(
-        self, model_revision: ModelRevisionSpec
-    ) -> ModelRevisionSpec:
-        if not self._service_definition:
-            raise ServiceDefinitionNotLoadedError()
-        model_revision = self._service_definition.override_model_revision(model_revision)
-        self._service_definition = None
-        return model_revision
+    async def generate_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
+        definition_files: DefinitionFiles = (
+            await self._deployment_repository.fetch_definition_files(
+                vfolder_id=model_revision.mounts.model_vfolder_id,
+                model_definition_path=model_revision.mounts.model_definition_path,
+            )
+        )
+        await self._validate_model_definition_dict(definition_files.model_definition)
+        if definition_files.service_definition is None:
+            return model_revision
+        service_definition = ModelServiceDefinition.model_validate(
+            definition_files.service_definition
+        )
+        return service_definition.override_model_revision(model_revision)

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
@@ -1,4 +1,4 @@
-from typing import Any, override
+from typing import override
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.manager.data.deployment.types import (
@@ -20,21 +20,11 @@ class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
 
     @override
     async def generate_model_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
-        definition_files: DefinitionFiles = (
-            await self._deployment_repository.fetch_definition_files(
-                vfolder_id=model_revision.mounts.model_vfolder_id,
-                model_definition_path=model_revision.mounts.model_definition_path,
-            )
+        definition_files = await self._deployment_repository.fetch_definition_files(
+            vfolder_id=model_revision.mounts.model_vfolder_id,
+            model_definition_path=model_revision.mounts.model_definition_path,
         )
         return ModelDefinition.model_validate(definition_files.model_definition)
-
-    @override
-    async def validate_configuration(self, config: dict) -> None:
-        # Already validated during generation
-        pass
-
-    async def _validate_model_definition_dict(self, model_definition: dict[str, Any]) -> None:
-        ModelDefinition.model_validate(model_definition)
 
     @override
     async def generate_model_revision(self, model_revision: ModelRevisionSpec) -> ModelRevisionSpec:
@@ -44,7 +34,7 @@ class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
                 model_definition_path=model_revision.mounts.model_definition_path,
             )
         )
-        await self._validate_model_definition_dict(definition_files.model_definition)
+        ModelDefinition.model_validate(definition_files.model_definition)
         if definition_files.service_definition is None:
             return model_revision
         service_definition = ModelServiceDefinition.model_validate(

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/registry.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/registry.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from ai.backend.common.exception import RuntimeVariantNotSupportedError
+from ai.backend.common.types import RuntimeVariant
+from ai.backend.manager.repositories.deployment import DeploymentRepository
+from ai.backend.manager.sokovan.deployment.definition_generator.base import ModelDefinitionGenerator
+from ai.backend.manager.sokovan.deployment.definition_generator.custom import (
+    CustomModelDefinitionGenerator,
+)
+
+
+@dataclass
+class RegistryArgs:
+    deployment_repository: DeploymentRepository
+
+
+class ModelDefinitionGeneratorRegistry:
+    _generators: dict[RuntimeVariant, ModelDefinitionGenerator]
+
+    def __init__(self, args: RegistryArgs) -> None:
+        self._generators: dict[RuntimeVariant, ModelDefinitionGenerator] = {}
+        self._generators[RuntimeVariant.CUSTOM] = CustomModelDefinitionGenerator(
+            args.deployment_repository
+        )
+
+    def get(self, runtime_variant: RuntimeVariant) -> ModelDefinitionGenerator:
+        generator = self._generators.get(runtime_variant)
+        if generator is None:
+            raise RuntimeVariantNotSupportedError(runtime_variant)
+        return generator

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -84,7 +84,6 @@ class DeploymentController:
 
     async def _validate_model_revision(self, model_revision: ModelRevisionSpec) -> None:
         """Validate the model revision specification."""
-
         generator = self._model_definition_generator_registry.get(
             model_revision.execution.runtime_variant
         )

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -88,10 +88,9 @@ class DeploymentController:
         generator = self._model_definition_generator_registry.get(
             model_revision.execution.runtime_variant
         )
-        _ = await generator.generate_definition(model_revision)
-        overrided_revision = await generator.override_service_definition(model_revision)
+        model_revision = await generator.generate_model_revision(model_revision)
         await self._scheduling_controller.validate_session_spec(
-            SessionValidationSpec.from_revision(model_revision=overrided_revision)
+            SessionValidationSpec.from_revision(model_revision=model_revision)
         )
 
     async def update_deployment(

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -85,7 +85,7 @@ class DeploymentController:
                 variant_def = ModelServiceDefinition.model_validate(
                     definition_files.service_definition
                 )
-                model_revision = variant_def.ovrride_model_revision(model_revision)
+                model_revision = variant_def.override_model_revision(model_revision)
             ModelDefinition.model_validate(definition_files.model_definition)
         await self._scheduling_controller.validate_session_spec(
             SessionValidationSpec.from_revision(model_revision=model_revision)

--- a/src/ai/backend/manager/sokovan/deployment/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/executor.py
@@ -11,7 +11,7 @@ from ai.backend.common.clients.http_client.client_pool import (
     ClientPool,
 )
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
-from ai.backend.common.config import ModelDefinition, ModelHealthCheck
+from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.types import (
     RuntimeVariant,
 )
@@ -32,6 +32,10 @@ from ai.backend.manager.data.deployment.types import (
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
 from ai.backend.manager.errors.service import ModelDefinitionNotFound
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    ModelDefinitionGeneratorRegistry,
+    RegistryArgs,
+)
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 
 from .types import (
@@ -67,6 +71,9 @@ class DeploymentExecutor:
         self._config_provider = config_provider
         self._client_pool = client_pool
         self._valkey_stat = valkey_stat
+        self._model_definition_generator_registry = ModelDefinitionGeneratorRegistry(
+            RegistryArgs(deployment_repository=self._deployment_repo)
+        )
 
     async def check_pending_deployments(
         self, deployments: Sequence[DeploymentInfo]
@@ -317,11 +324,10 @@ class DeploymentExecutor:
         target_revision = deployment.target_revision()
         if not target_revision:
             raise ModelDefinitionNotFound(f"No target revision for deployment {deployment.id}")
-        model_definition_content = await self._deployment_repo.fetch_model_definition(
-            vfolder_id=target_revision.mounts.model_vfolder_id,
-            model_definition_path=target_revision.mounts.model_definition_path,
+        generator = self._model_definition_generator_registry.get(
+            target_revision.execution.runtime_variant
         )
-        model_definition = ModelDefinition.model_validate(model_definition_content)
+        model_definition = await generator.generate_definition(target_revision)
         health_check_config = model_definition.health_check_config()
         if not health_check_config:
             log.debug(

--- a/src/ai/backend/manager/sokovan/deployment/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/executor.py
@@ -327,7 +327,7 @@ class DeploymentExecutor:
         generator = self._model_definition_generator_registry.get(
             target_revision.execution.runtime_variant
         )
-        model_definition = await generator.generate_definition(target_revision)
+        model_definition = await generator.generate_model_definition(target_revision)
         health_check_config = model_definition.health_check_config()
         if not health_check_config:
             log.debug(


### PR DESCRIPTION
resolves #5889 #5933 #5934 (BA-2385, BA-2411, BA-2412)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
