### PR TITLE
fix: Read creation configs using correct key

### DIFF
--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -2826,6 +2826,7 @@ class ScheduleDBSource:
                 SessionRow.access_key,
                 SessionRow.session_type,
                 SessionRow.name,
+                SessionRow.environ,
                 SessionRow.cluster_mode,
                 SessionRow.user_uuid,
                 KernelRow.id.label("kernel_id"),
@@ -2879,6 +2880,7 @@ class ScheduleDBSource:
                     "access_key": row.access_key,
                     "session_type": row.session_type,
                     "name": row.name,
+                    "environ": row.environ,
                     "cluster_mode": row.cluster_mode,
                     "user_uuid": row.user_uuid,
                 }
@@ -2961,6 +2963,7 @@ class ScheduleDBSource:
                 )
                 for k in data["kernels"]
             ]
+            log.info(f"kernel preopen ports: {[k.preopen_ports for k in kernel_bindings]}")
 
             sessions_for_start.append(
                 SessionDataForStart(
@@ -2971,6 +2974,7 @@ class ScheduleDBSource:
                     name=session_info["name"],
                     cluster_mode=session_info["cluster_mode"],
                     kernels=kernel_bindings,
+                    environ=session_info.get("environ", {}),
                     user_uuid=session_info["user_uuid"],
                     user_email=user_info.email,
                     user_name=user_info.username,

--- a/src/ai/backend/manager/sokovan/scheduler/scheduler.py
+++ b/src/ai/backend/manager/sokovan/scheduler/scheduler.py
@@ -1068,8 +1068,8 @@ class Scheduler:
                     key=keyfunc,
                 )
             }
-
             environ: dict[str, str] = {
+                **session.environ,
                 "BACKENDAI_USER_UUID": str(session.user_uuid),
                 "BACKENDAI_USER_EMAIL": session.user_email,
                 "BACKENDAI_USER_NAME": session.user_name,

--- a/src/ai/backend/manager/sokovan/scheduler/types.py
+++ b/src/ai/backend/manager/sokovan/scheduler/types.py
@@ -546,6 +546,7 @@ class SessionDataForStart:
     user_uuid: UUID
     user_email: str
     user_name: str
+    environ: dict[str, str]
     network_type: Optional[NetworkType] = None
     network_id: Optional[str] = None
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/rules.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/rules.py
@@ -91,7 +91,10 @@ class ServicePortRule(SessionValidatorRule):
         # Validate for each kernel spec
         for kernel_spec in spec.kernel_specs:
             # Get preopen ports from kernel spec or fall back to creation config
-            preopen_ports = kernel_spec.get("preopen_ports") or creation_preopen_ports
+            preopen_ports = (
+                kernel_spec.get("creation_config", {}).get("preopen_ports")
+                or creation_preopen_ports
+            )
             if not preopen_ports:
                 continue
             if not isinstance(preopen_ports, list):


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
