### PR TITLE
fix(BA-2430): Handle Undefined group ids when modifying user

### DIFF
--- a/changes/5955.fix.md
+++ b/changes/5955.fix.md
@@ -1,0 +1,1 @@
+Handle Undefined group ids when modifying user

--- a/changes/5955.fix.md
+++ b/changes/5955.fix.md
@@ -1,1 +1,1 @@
-Handle Undefined group ids when modifying user
+Handle Undefined group IDs when modifying user

--- a/src/ai/backend/manager/models/gql_models/user.py
+++ b/src/ai/backend/manager/models/gql_models/user.py
@@ -889,8 +889,10 @@ class ModifyUserInput(graphene.InputObjectType):
                 container_gids=TriState[list[int]].from_graphql(
                     self.container_gids,
                 ),
+                group_ids=OptionalState[list[str]].from_graphql(
+                    self.group_ids,
+                ),
             ),
-            group_ids=self.group_ids,
         )
 
 

--- a/src/ai/backend/manager/repositories/user/repository.py
+++ b/src/ai/backend/manager/repositories/user/repository.py
@@ -155,7 +155,6 @@ class UserRepository:
         self,
         email: str,
         modifier: UserModifier,
-        group_ids: Optional[list[str]],
         requester_uuid: Optional[UUID],
     ) -> UserData:
         """
@@ -192,6 +191,7 @@ class UserRepository:
                 await self._sync_keypair_roles(conn, updated_user.uuid, role)
 
             # Handle group updates
+            group_ids = modifier.group_ids_value
             if prev_role != updated_user.role and group_ids is None:
                 await self._clear_user_groups(conn, updated_user.uuid)
 

--- a/src/ai/backend/manager/services/user/actions/modify_user.py
+++ b/src/ai/backend/manager/services/user/actions/modify_user.py
@@ -28,6 +28,7 @@ class UserModifier(PartialModifier):
     container_uid: TriState[int] = field(default_factory=TriState.nop)
     container_main_gid: TriState[int] = field(default_factory=TriState.nop)
     container_gids: TriState[list[int]] = field(default_factory=TriState.nop)
+    group_ids: OptionalState[list[str]] = field(default_factory=OptionalState.nop)
 
     def fields_to_update(self) -> dict[str, Any]:
         to_update: dict[str, Any] = {}
@@ -59,12 +60,15 @@ class UserModifier(PartialModifier):
             to_update["status"] = status
         return to_update
 
+    @property
+    def group_ids_value(self) -> Optional[list[str]]:
+        return self.group_ids.optional_value()
+
 
 @dataclass
 class ModifyUserAction(UserAction):
     email: str
     modifier: UserModifier
-    group_ids: Optional[list[str]] = None
 
     @override
     def entity_id(self) -> Optional[str]:

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -79,14 +79,13 @@ class UserService:
     async def modify_user(self, action: ModifyUserAction) -> ModifyUserActionResult:
         email = action.email
         data = action.modifier.fields_to_update()
-        group_ids = action.group_ids
-        if not data and group_ids is None:
+
+        if not data and action.modifier.group_ids_value is None:
             raise NoUserUpdateError("No fields to update for user {email}.")
 
         user_data_result = await self._user_repository.update_user_validated(
             email=email,
             modifier=action.modifier,
-            group_ids=group_ids,
             requester_uuid=None,  # No user context available in ModifyUserAction
         )
         return ModifyUserActionResult(

--- a/tests/manager/integration/services/user/test_user_integration.py
+++ b/tests/manager/integration/services/user/test_user_integration.py
@@ -396,8 +396,8 @@ class TestModifyUserIntegration:
             email=user_email,
             modifier=UserModifier(
                 domain_name=OptionalState.update("test-domain"),
+                group_ids=OptionalState.update([str(new_team_id), str(research_team_id)]),
             ),
-            group_ids=[str(new_team_id), str(research_team_id)],
         )
 
         result = await processors.modify_user.wait_for_complete(action)

--- a/tests/manager/repositories/user/test_user_repository.py
+++ b/tests/manager/repositories/user/test_user_repository.py
@@ -373,7 +373,6 @@ class TestUserRepository:
                     result = await user_repository.update_user_validated(
                         email="test@example.com",
                         modifier=modifier,
-                        group_ids=["new_group"],
                         requester_uuid=None,
                     )
 
@@ -404,7 +403,6 @@ class TestUserRepository:
                 await user_repository.update_user_validated(
                     email="nonexistent@example.com",
                     modifier=modifier,
-                    group_ids=None,
                     requester_uuid=None,
                 )
 


### PR DESCRIPTION
resolves #5953 (BA-2430)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
