### PR TITLE
refactor(BA-2451): Remove duplicated exception handling in `ResourcePresetCacheSource`

### DIFF
--- a/changes/5976.enhance.md
+++ b/changes/5976.enhance.md
@@ -1,0 +1,1 @@
+Remove duplicated exception handling in ResourcePresetCacheSource

--- a/src/ai/backend/manager/repositories/resource_preset/cache_source/cache_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/cache_source/cache_source.py
@@ -34,12 +34,9 @@ class ResourcePresetCacheSource:
         Try to get a preset from cache by ID.
         Returns None if not in cache.
         """
-        try:
-            data = await self._valkey_stat.get_resource_preset_by_id(str(preset_id))
-            if data:
-                return ResourcePresetData.from_cache(load_json(data))
-        except Exception as e:
-            log.debug("Failed to get preset from cache by id {}: {}", preset_id, e)
+        data = await self._valkey_stat.get_resource_preset_by_id(str(preset_id))
+        if data:
+            return ResourcePresetData.from_cache(load_json(data))
         return None
 
     async def get_preset_by_name(self, name: str) -> Optional[ResourcePresetData]:
@@ -47,28 +44,22 @@ class ResourcePresetCacheSource:
         Try to get a preset from cache by name.
         Returns None if not in cache.
         """
-        try:
-            data = await self._valkey_stat.get_resource_preset_by_name(name)
-            if data:
-                return ResourcePresetData.from_cache(load_json(data))
-        except Exception as e:
-            log.debug("Failed to get preset from cache by name {}: {}", name, e)
+        data = await self._valkey_stat.get_resource_preset_by_name(name)
+        if data:
+            return ResourcePresetData.from_cache(load_json(data))
         return None
 
     async def set_preset(self, preset: ResourcePresetData) -> None:
         """
         Cache a preset by both ID and name.
         """
-        try:
-            serialized = dump_json(preset.to_cache())
-            await self._valkey_stat.set_resource_preset_by_id_and_name(
-                str(preset.id),
-                preset.name,
-                serialized,
-                expire_sec=CACHE_TTL,
-            )
-        except Exception as e:
-            log.debug("Failed to cache preset {}: {}", preset.name, e)
+        serialized = dump_json(preset.to_cache())
+        await self._valkey_stat.set_resource_preset_by_id_and_name(
+            str(preset.id),
+            preset.name,
+            serialized,
+            expire_sec=CACHE_TTL,
+        )
 
     async def get_preset_list(
         self, scaling_group: Optional[str] = None
@@ -76,13 +67,10 @@ class ResourcePresetCacheSource:
         """
         Get cached preset list for a scaling group.
         """
-        try:
-            data = await self._valkey_stat.get_resource_preset_list(scaling_group)
-            if data:
-                items = load_json(data)
-                return [ResourcePresetData.from_cache(item) for item in items]
-        except Exception as e:
-            log.debug("Failed to get preset list from cache: {}", e)
+        data = await self._valkey_stat.get_resource_preset_list(scaling_group)
+        if data:
+            items = load_json(data)
+            return [ResourcePresetData.from_cache(item) for item in items]
         return None
 
     async def set_preset_list(
@@ -91,13 +79,10 @@ class ResourcePresetCacheSource:
         """
         Cache a list of presets for a scaling group.
         """
-        try:
-            serialized = dump_json([p.to_cache() for p in presets])
-            await self._valkey_stat.set_resource_preset_list(
-                scaling_group, serialized, expire_sec=CACHE_TTL
-            )
-        except Exception as e:
-            log.debug("Failed to cache preset list: {}", e)
+        serialized = dump_json([p.to_cache() for p in presets])
+        await self._valkey_stat.set_resource_preset_list(
+            scaling_group, serialized, expire_sec=CACHE_TTL
+        )
 
     async def get_check_presets_data(
         self,
@@ -110,14 +95,10 @@ class ResourcePresetCacheSource:
         Get cached check presets data as JSON string.
         Returns the raw JSON string to avoid complex deserialization.
         """
-        try:
-            data = await self._valkey_stat.get_resource_preset_check_data(
-                str(access_key), group, domain, scaling_group
-            )
-            return data
-        except Exception as e:
-            log.debug("Failed to get check presets data from cache: {}", e)
-        return None
+        data = await self._valkey_stat.get_resource_preset_check_data(
+            str(access_key), group, domain, scaling_group
+        )
+        return data
 
     async def set_check_presets_data(
         self,
@@ -131,12 +112,9 @@ class ResourcePresetCacheSource:
         Cache check presets data as JSON string.
         Takes pre-serialized JSON string to avoid double serialization.
         """
-        try:
-            await self._valkey_stat.set_resource_preset_check_data(
-                str(access_key), group, domain, scaling_group, data, expire_sec=CACHE_TTL
-            )
-        except Exception as e:
-            log.debug("Failed to cache check presets data: {}", e)
+        await self._valkey_stat.set_resource_preset_check_data(
+            str(access_key), group, domain, scaling_group, data, expire_sec=CACHE_TTL
+        )
 
     async def invalidate_preset(
         self, preset_id: Optional[UUID] = None, name: Optional[str] = None
@@ -146,12 +124,7 @@ class ResourcePresetCacheSource:
         Note: Since we can't scan for patterns, we only delete the specific keys we know.
         Check presets and lists will expire naturally with TTL.
         """
-        try:
-            await self._valkey_stat.delete_resource_preset(
-                str(preset_id) if preset_id else None, name
-            )
-        except Exception as e:
-            log.debug("Failed to invalidate preset cache: {}", e)
+        await self._valkey_stat.delete_resource_preset(str(preset_id) if preset_id else None, name)
 
     async def invalidate_all_presets(self) -> None:
         """

--- a/src/ai/backend/manager/repositories/resource_preset/cache_source/cache_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/cache_source/cache_source.py
@@ -31,7 +31,7 @@ class ResourcePresetCacheSource:
 
     async def get_preset_by_id(self, preset_id: UUID) -> Optional[ResourcePresetData]:
         """
-        Try to get a preset from cache by ID.
+        Get a preset from cache by ID.
         Returns None if not in cache.
         """
         data = await self._valkey_stat.get_resource_preset_by_id(str(preset_id))
@@ -41,7 +41,7 @@ class ResourcePresetCacheSource:
 
     async def get_preset_by_name(self, name: str) -> Optional[ResourcePresetData]:
         """
-        Try to get a preset from cache by name.
+        Get a preset from cache by name.
         Returns None if not in cache.
         """
         data = await self._valkey_stat.get_resource_preset_by_name(name)


### PR DESCRIPTION
resolves #5975 (BA-2451)

Though currently using a context manager that suppresses exceptions, duplicate try-except blocks are being employed within the cache source to control exception occurrence. We intend to remove these redundant try-except structures.

```python
@repository_decorator()
    async def check_presets(
        self,
        ...
    ) -> CheckPresetsResult:
        ...
        with suppress_with_log([Exception], message="Failed to get check presets data from cache"):
            cached_data = await self._cache_source.get_check_presets_data(
                access_key, group_name, domain_name, scaling_group
            )
            if cached_data:
                log.info(
                    "Cache hit for check_presets: {}, {}, {}", access_key, group_name, domain_name
                )
                return CheckPresetsResult.from_cache(cached_data)


    async def get_check_presets_data(
        self,
        ...
    ) -> Optional[bytes]:
        ...
        try:
            data = await self._valkey_stat.get_resource_preset_check_data(
                str(access_key), group, domain, scaling_group
            )
            return data
        except Exception as e:
            log.debug("Failed to get check presets data from cache: {}", e)
        return None
```


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
