### PR TITLE
fix(BA-2490): Correct mount permission check when creating session

### DIFF
--- a/changes/6021.fix.md
+++ b/changes/6021.fix.md
@@ -1,0 +1,1 @@
+Skip mounting vfolders from inaccessible hosts

--- a/changes/6021.fix.md
+++ b/changes/6021.fix.md
@@ -1,1 +1,1 @@
-Skip mounting vfolders from inaccessible hosts
+Fix mount permission check during session creation

--- a/src/ai/backend/manager/errors/storage.py
+++ b/src/ai/backend/manager/errors/storage.py
@@ -205,6 +205,19 @@ class VFolderDeletionNotAllowed(BackendAIError, web.HTTPBadRequest):
         )
 
 
+class InsufficientStoragePermission(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/storage-permission-not-allowed"
+    error_title = "The specified storage permission is not allowed."
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE,
+            operation=ErrorOperation.ACCESS,
+            error_detail=ErrorDetail.FORBIDDEN,
+        )
+
+
 class VFolderInvalidParameter(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/vfolder-invalid-parameter"
     error_title = "Invalid parameter for virtual folder operation."

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -68,6 +68,7 @@ from ..defs import (
 from ..errors.api import InvalidAPIParameters
 from ..errors.common import ObjectNotFound
 from ..errors.storage import (
+    InsufficientStoragePermission,
     VFolderGone,
     VFolderNotFound,
     VFolderOperationFailed,
@@ -974,9 +975,17 @@ async def prepare_vfolder_mounts(
                 group_id=user_scope.group_id,
                 permission=VFolderHostPermission.MOUNT_IN_SESSION,
             )
-        except InvalidAPIParameters:
-            log.exception("Cannot mount vfolder of host {}, skipping", vfolder["host"])
-            continue
+        except InsufficientStoragePermission as e:
+            if vfolder["name"].startswith("."):
+                log.warning(
+                    "Skipping auto-mount VFolder '{}' due to insufficient permission",
+                    vfolder["name"],
+                )
+                continue
+            raise InsufficientStoragePermission(
+                f"Permission denied to mount VFolder '{vfolder_name}' on host '{vfolder['host']}'. {e.extra_msg}",
+                e.extra_data,
+            ) from e
         if unmanaged_path := cast(Optional[str], vfolder["unmanaged_path"]):
             vfid = VFolderID(vfolder["quota_scope_id"], vfolder["id"])
             vfsubpath = PurePosixPath(".")
@@ -1178,7 +1187,9 @@ async def ensure_host_permission_allowed(
         group_id=group_id,
     )
     if folder_host not in allowed_hosts or permission not in allowed_hosts[folder_host]:
-        raise InvalidAPIParameters(f"`{permission}` Not allowed in vfolder host(`{folder_host}`)")
+        raise InsufficientStoragePermission(
+            f"`{permission}` Not allowed in vfolder host(`{folder_host}`)"
+        )
 
 
 async def filter_host_allowed_permission(
@@ -1193,7 +1204,7 @@ async def filter_host_allowed_permission(
     allowed_hosts = VFolderHostPermissionMap()
     if "user" in allowed_vfolder_types:
         allowed_hosts_by_user = await get_allowed_vfolder_hosts_by_user(
-            db_conn, resource_policy, domain_name, user_uuid
+            db_conn, resource_policy, domain_name, user_uuid, group_id
         )
         allowed_hosts = allowed_hosts | allowed_hosts_by_user
     if "group" in allowed_vfolder_types and group_id is not None:


### PR DESCRIPTION
resolves #6013 (BA-2490)

**Checklist:** (if applicable)

- [x] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
