### PR TITLE
feat(BA-2316): Remove obsolete max slot limit validation during session creation (#5807)

### DIFF
--- a/changes/5807.feature.md
+++ b/changes/5807.feature.md
@@ -1,0 +1,1 @@
+Remove obsolete max slot limit validation during session creation

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -331,7 +331,7 @@ scalar BigInt
 type ResourceLimit {
   key: String
   min: String
-  max: String
+  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
 }
 
 type AgentList implements PaginatedList {
@@ -1871,7 +1871,7 @@ input KVPairInput {
 input ResourceLimitInput {
   key: String
   min: String
-  max: String
+  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
 }
 
 """Added in 24.03.0."""

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -778,7 +778,9 @@ class DataLoaderManager:
 class ResourceLimit(graphene.ObjectType):
     key = graphene.String()
     min = graphene.String()
-    max = graphene.String()
+    max = graphene.String(
+        deprecation_reason="Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 
 
 class KVPair(graphene.ObjectType):
@@ -789,7 +791,9 @@ class KVPair(graphene.ObjectType):
 class ResourceLimitInput(graphene.InputObjectType):
     key = graphene.String()
     min = graphene.String()
-    max = graphene.String()
+    max = graphene.String(
+        deprecation_reason="Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 
 
 class KVPairInput(graphene.InputObjectType):

--- a/src/ai/backend/manager/models/gql_models/base.py
+++ b/src/ai/backend/manager/models/gql_models/base.py
@@ -12,7 +12,9 @@ SAFE_MAX_INT = 9007199254740991
 class ResourceLimit(graphene.ObjectType):
     key = graphene.String()
     min = graphene.String()
-    max = graphene.String()
+    max = graphene.String(
+        deprecation_reason="Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 
 
 class KVPair(graphene.ObjectType):
@@ -23,7 +25,9 @@ class KVPair(graphene.ObjectType):
 class ResourceLimitInput(graphene.InputObjectType):
     key = graphene.String()
     min = graphene.String()
-    max = graphene.String()
+    max = graphene.String(
+        deprecation_reason="Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 
 
 class KVPairInput(graphene.InputObjectType):

--- a/src/ai/backend/manager/models/gql_models/image.py
+++ b/src/ai/backend/manager/models/gql_models/image.py
@@ -117,11 +117,7 @@ class Image(graphene.ObjectType):
             aliases=[alias_row.alias for alias_row in row.aliases],
             size_bytes=row.size_bytes,
             resource_limits=[
-                ResourceLimit(
-                    key=k,
-                    min=v.get("min", Decimal(0)),
-                    max=v.get("max", Decimal("Infinity")),
-                )
+                ResourceLimit(key=k, min=v.get("min", Decimal(0)), max=Decimal("Infinity"))
                 for k, v in row.resources.items()
             ],
             supported_accelerators=row.accelerators.split(",") if row.accelerators else ["*"],
@@ -386,11 +382,7 @@ class ImageNode(graphene.ObjectType):
             labels=[KVPair(key=k, value=v) for k, v in row.labels.items()],
             size_bytes=row.size_bytes,
             resource_limits=[
-                ResourceLimit(
-                    key=k,
-                    min=v.get("min", Decimal(0)),
-                    max=v.get("max", Decimal("Infinity")),
-                )
+                ResourceLimit(key=k, min=v.get("min", Decimal(0)), max=Decimal("Infinity"))
                 for k, v in row.resources.items()
             ],
             supported_accelerators=row.accelerators.split(",") if row.accelerators else ["*"],

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -509,13 +509,12 @@ class ImageRow(Base):
     def __repr__(self) -> str:
         return self.__str__()
 
-    async def get_slot_ranges(
+    async def get_min_slot(
         self,
         shared_config: SharedConfig,
-    ) -> Tuple[ResourceSlot, ResourceSlot]:
+    ) -> ResourceSlot:
         slot_units = await shared_config.get_resource_slots()
         min_slot = ResourceSlot()
-        max_slot = ResourceSlot()
         # When the original image does not have any metadata label, self.resources is already filled
         # with the intrinsic resource slots with their defualt minimums (defs.INTRINSIC_SLOTS_MIN)
         # during rescanning the registry.
@@ -529,30 +528,20 @@ class ImageRow(Base):
             min_value = resource.get("min")
             if min_value is None:
                 min_value = Decimal(0)
-            max_value = resource.get("max")
-            if max_value is None:
-                max_value = Decimal("Infinity")
             if slot_unit == "bytes":
                 if not isinstance(min_value, Decimal):
                     min_value = BinarySize.from_str(min_value)
-                if not isinstance(max_value, Decimal):
-                    max_value = BinarySize.from_str(max_value)
             else:
                 if not isinstance(min_value, Decimal):
                     min_value = Decimal(min_value)
-                if not isinstance(max_value, Decimal):
-                    max_value = Decimal(max_value)
             min_slot[slot_key] = min_value
-            max_slot[slot_key] = max_value
 
         # fill missing
         for slot_key in slot_units.keys():
             if slot_key not in min_slot:
                 min_slot[slot_key] = Decimal(0)
-            if slot_key not in max_slot:
-                max_slot[slot_key] = Decimal("Infinity")
 
-        return min_slot, max_slot
+        return min_slot
 
     def _parse_row(self):
         res_limits = []

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1092,7 +1092,7 @@ class AgentRegistry:
                     "enqueue_session(): image ref => {} ({})", image_ref, image_ref.architecture
                 )
                 image_row = await ImageRow.resolve(session, [image_ref])
-            image_min_slots, image_max_slots = await image_row.get_slot_ranges(self.shared_config)
+            image_min_slots = await image_row.get_min_slot(self.shared_config)
             known_slot_types = await self.shared_config.get_resource_slots()
 
             labels = cast(dict, image_row.labels)
@@ -1203,7 +1203,6 @@ class AgentRegistry:
             log.debug(log_fmt + " -> requested_slots: {}", *log_args, requested_slots)
             log.debug(log_fmt + " -> resource_opts: {}", *log_args, resource_opts)
             log.debug(log_fmt + " -> image_min_slots: {}", *log_args, image_min_slots)
-            log.debug(log_fmt + " -> image_max_slots: {}", *log_args, image_max_slots)
 
             # Check if: requested >= image-minimum
             if image_min_slots > requested_slots:
@@ -1213,18 +1212,6 @@ class AgentRegistry:
                         " ".join(
                             f"{k}={v}"
                             for k, v in image_min_slots.to_humanized(known_slot_types).items()
-                        )
-                    )
-                )
-
-            # Check if: requested <= image-maximum
-            if not (requested_slots <= image_max_slots):
-                raise InvalidAPIParameters(
-                    "Your resource request is larger than "
-                    "the maximum allowed by the image. ({})".format(
-                        " ".join(
-                            f"{k}={v}"
-                            for k, v in image_max_slots.to_humanized(known_slot_types).items()
                         )
                     )
                 )


### PR DESCRIPTION
This is a backport PR of https://github.com/lablup/backend.ai/pull/5807 to the 24.09 release.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
