### PR TITLE
fix(BA-2514): Add missing `kernel_host` field in `KernelCreationInfo`

### DIFF
--- a/changes/6050.fix.md
+++ b/changes/6050.fix.md
@@ -1,0 +1,1 @@
+Add missing `kernel_host` field in `KernelCreationInfo`

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1907,6 +1907,7 @@ class ScheduleDBSource:
                     stdin_port=creation_info.stdin_port,
                     stdout_port=creation_info.stdout_port,
                     service_ports=creation_info.service_ports,
+                    kernel_host=creation_info.kernel_host,
                     status_history=sql_json_merge(
                         KernelRow.status_history,
                         (),

--- a/src/ai/backend/manager/sokovan/scheduler/types.py
+++ b/src/ai/backend/manager/sokovan/scheduler/types.py
@@ -672,6 +672,7 @@ class KernelCreationInfo:
     stdin_port: Optional[int] = None
     stdout_port: Optional[int] = None
     service_ports: list[int] = field(default_factory=list)
+    kernel_host: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "KernelCreationInfo":
@@ -685,6 +686,7 @@ class KernelCreationInfo:
             stdin_port=data.get("stdin_port"),
             stdout_port=data.get("stdout_port"),
             service_ports=data.get("service_ports", []),
+            kernel_host=data.get("kernel_host"),
         )
 
     def get_resource_allocations(self) -> ResourceSlot:


### PR DESCRIPTION
resolves #6041 (BA-2514)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
