### PR TITLE
chore: Update pyproject.toml and IDE guides for basedpyright

### DIFF
--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -320,7 +320,7 @@ Then put the followings in ``.vimrc`` (or ``.nvimrc`` for NeoVim) in the build r
    let g:ale_fix_on_save = 1
 
 When using CoC, run ``:CocInstall coc-basedpyright @yaegassy/coc-ruff`` and ``:CocLocalConfig`` after opening a file
-in the local working copy to initialize Pyright functionalities.
+in the local working copy to initialize basedpyright functionalities.
 In the local configuration file (``.vim/coc-settings.json``), you may put the linter/formatter configurations
 just like VSCode (see `the official reference <https://www.npmjs.com/package/coc-pyright>`_,
 as basedpyright shares most configurations with pyright).

--- a/docs/dev/daily-workflows.rst
+++ b/docs/dev/daily-workflows.rst
@@ -319,17 +319,19 @@ Then put the followings in ``.vimrc`` (or ``.nvimrc`` for NeoVim) in the build r
    let g:ale_fixers = {'python': ['ruff']}
    let g:ale_fix_on_save = 1
 
-When using CoC, run ``:CocInstall coc-pyright @yaegassy/coc-ruff`` and ``:CocLocalConfig`` after opening a file
+When using CoC, run ``:CocInstall coc-basedpyright @yaegassy/coc-ruff`` and ``:CocLocalConfig`` after opening a file
 in the local working copy to initialize Pyright functionalities.
 In the local configuration file (``.vim/coc-settings.json``), you may put the linter/formatter configurations
-just like VSCode (see `the official reference <https://www.npmjs.com/package/coc-pyright>`_).
+just like VSCode (see `the official reference <https://www.npmjs.com/package/coc-pyright>`_,
+as basedpyright shares most configurations with pyright).
 
 .. code-block:: json5
 
    {
-     "coc.preferences.formatOnType": false,
-     "coc.preferences.willSaveHandlerTimeout": 5000,
+     "coc.preferences.formatOnType": true,
+     "coc.preferences.formatOnSaveFiletypes": ["python"],
      "python.pythonPath": "dist/export/python/virtualenvs/python-default/3.13.7/bin/python",
+     "python.analysis.extraPaths": ["dist/export/python/virtualenvs/pytest/3.13.7/lib/python3.13/site-packages"],
      "python.linting.mypyEnabled": true,
      "python.linting.mypyPath": "dist/export/python/virtualenvs/mypy/3.13.7/bin/mypy",
      "python.linting.ruffEnabled": true,
@@ -341,15 +343,19 @@ just like VSCode (see `the official reference <https://www.npmjs.com/package/coc
 .. code-block:: json5
 
    {
-     "coc.preferences.formatOnType": false,
-     "coc.preferences.willSaveHandlerTimeout": 5000,
+     "coc.preferences.formatOnType": true,
+     "coc.preferences.formatOnSaveFiletypes": ["python"],
      "python.pythonPath": "dist/export/python/virtualenvs/python-default/3.13.7/bin/python",
+     "python.analysis.extraPaths": ["dist/export/python/virtualenvs/pytest/3.13.7/lib/python3.13/site-packages"],
      "python.linting.mypyEnabled": true,
      "python.linting.mypyPath": "dist/export/python/virtualenvs/mypy/3.13.7/bin/mypy",
-     "python.linting.ruffEnabled": false,
-     // when using @yaegassy/coc-ruff extension
+     "python.linting.ruffEnabled": false,  // delegate to coc-ruff
+     "python.formatting.provider": "none",  // delegate to coc-ruff
+     "pyright.organizeimports.provider": "none",  // delegate to coc-ruff
+     // configuration for @yaegassy/coc-ruff extension
      "ruff.enabled": true,
      "ruff.autoFixOnSave": true,
+     "ruff.useDetectRuffCommand": false,
      "ruff.path": "/abs/path/to/dist/export/bin/ruff",  // absolute path
      "ruff.nativeServer": true,
    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ exclude = [
 ]
 venvPath = "dist/export/python/virtualenvs/python-default"
 venv = "3.13.7"
+typeCheckingMode = "standard"
 
 [tool.pydantic-mypy]
 init_forbid_extra = true
@@ -142,4 +143,4 @@ init_typed = true
 warn_required_dynamic_aliases = false
 
 [tool.setuptools.dynamic]
-version = {file = "VERSION"}
+version = { file = "VERSION" }


### PR DESCRIPTION
[basedpyright](https://docs.basedpyright.com/latest/) is an open source alternative of pylance, which is a VSCode-specific proprietary extension to pyright.
It provides faster performance and more LSP features and now became [the default in the Zed editor as of v204.](https://zed.dev/releases/stable/0.204.1)

As it shares the configuration with pyright (e.g., `[tool.pyright]` section in `pyproject.toml`),
this PR explicitly sets `typeCheckingMode = "standard"` to ensure consistency because the defaults in pyright and basedpyright are different.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--6052.org.readthedocs.build/en/6052/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--6052.org.readthedocs.build/ko/6052/

<!-- readthedocs-preview sorna-ko end -->