### PR TITLE
feat(BA-2522): add enable-reservoir webserver option to enable management of reservoir-related features in the webui

### DIFF
--- a/changes/6055.feature.md
+++ b/changes/6055.feature.md
@@ -1,0 +1,1 @@
+Add the `enable_reservoir` webserver option to enable management of reservoir-related functions in the webui.

--- a/changes/6055.feature.md
+++ b/changes/6055.feature.md
@@ -1,1 +1,1 @@
-Add the `enable_reservoir` webserver option to enable management of reservoir-related functions in the webui.
+Add the `enable_reservoir` webserver option to enable reservoir-related features in the webui

--- a/configs/webserver/halfstack.conf
+++ b/configs/webserver/halfstack.conf
@@ -16,6 +16,7 @@ enable_2FA = false
 force_2FA = false
 directory_based_usage = false
 #static_path = "/absolute/path/to/static/resources/"
+enable_reservoir = false
 
 [resources]
 open_port_to_public = false

--- a/configs/webserver/sample.conf
+++ b/configs/webserver/sample.conf
@@ -75,6 +75,8 @@ is_directory_size_visible = true
 enable_interactive_login_account_switch = true
 # Default file browser image. If not specified, an arbitrary installed file browser image will be used.
 # default_file_browser_image = ""
+# Enable/disable reservoir feature.
+enable_reservoir = false
 
 [resources]
 # Display "Open port to public" checkbox in the app launcher.

--- a/src/ai/backend/web/config/unified.py
+++ b/src/ai/backend/web/config/unified.py
@@ -369,6 +369,15 @@ class ServiceConfig(BaseModel):
         validation_alias=AliasChoices("default_file_browser_image", "default-file-browser-image"),
         serialization_alias="default-file-browser-image",
     )
+    enable_reservoir: bool = Field(
+        default=False,
+        description="""
+        Whether to enable reservoir feature.
+        """,
+        examples=[True, False],
+        validation_alias=AliasChoices("enable_reservoir", "enable-reservoir"),
+        serialization_alias="enable-reservoir",
+    )
 
     @field_validator("static_path")
     @classmethod

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -32,6 +32,7 @@ connectionMode = "SESSION"
 {% toml_field "enableExtendLoginSession" config["service"]["enable-extend-login-session"] %}
 {% toml_field "enableInteractiveLoginAccountSwitch" config["service"]["enable-interactive-login-account-switch"] %}
 {% toml_field "defaultFileBrowserImage" config["service"]["default-file-browser-image"] %}
+{% toml_field "enableReservoir" config["service"]["enable-reservoir"] %}
 
 [resources]
 {% toml_field "openPortToPublic" config["resources"]["open-port-to-public"] %}


### PR DESCRIPTION
resolves #6055 (BA-2522)

This PR adds enable-reservoir option to enable management of reservoir-related functions in the webui

**changes**
* add `enable-reservoir` to `configs/webserver/halfstack.conf` and `configs/webserver/sample.conf`
* add type for `enable-reservoir` to `src/ai/backend/web/config/unified.py`
* add `enable-reservoir` to `src/ai/backend/web/templates/config.toml.j2` 

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
