### PR TITLE
feat(BA-2547): Prevent accidental container termination by `pkill -f python` command (#6085)

### DIFF
--- a/changes/6085.feature.md
+++ b/changes/6085.feature.md
@@ -1,0 +1,1 @@
+Prevent the kernel runner (and the user container) being accidentally terminated by user's `pkill -f python` command

--- a/src/ai/backend/kernel/__init__.py
+++ b/src/ai/backend/kernel/__init__.py
@@ -1,5 +1,53 @@
-from .base import BaseRunner
-from .terminal import Terminal
+from __future__ import annotations
+
+import os
+import site
+import sys
+from pathlib import Path
+
+
+def _reexec_with_argv0(display_name: str) -> None:
+    if os.environ.get("BACKEND_REEXECED") != "1":
+        env = os.environ.copy()
+        env["BACKEND_REEXECED"] = "1"
+        mod_name = None
+        try:
+            spec = globals().get("__spec__")
+            if spec and getattr(spec, "name", None):
+                mod_name = spec.name
+        except Exception:
+            pass
+        # Pass original argv via file to hide strings including "python" in runtime-type and runtime-path.
+        args_path = Path(f"/tmp/{os.getpid()}.krunner-args")
+        args_path.write_text("\0".join(sys.argv[1:]))
+        # "-s" option is to disable user site configurations.
+        if mod_name:
+            argv = [display_name, "-s", "-m", mod_name]
+        else:
+            argv = [display_name, "-s", sys.argv[0]]
+        venv = os.environ.get("VIRTUAL_ENV", None)
+        if venv is None:
+            env["PYTHONHOME"] = sys.prefix
+        # The process is re-executed in place, overriding argv and cmdline.
+        os.execvpe(sys.executable, argv, env)
+    else:
+        venv = os.environ.get("VIRTUAL_ENV", None)
+        os.environ.pop("PYTHONHOME", None)
+        if venv is not None:
+            venv_sitepkg_path = site.getsitepackages([venv])[0]
+            sys.prefix = venv
+            sys.path.insert(0, venv_sitepkg_path)
+
+
+# Prevent being terminated by "pkill -f python" by overriding the cmdline executable name.
+# Though, this trick should NOT be used within pytest sessions.
+if os.environ.get("PYTEST_VERSION") is None:
+    _reexec_with_argv0("bai-krunner")
+
+
+# The above reexec function must run before ANY import!
+from .base import BaseRunner  # noqa: E402
+from .terminal import Terminal  # noqa: E402
 
 __all__ = (
     "BaseRunner",

--- a/src/ai/backend/kernel/__main__.py
+++ b/src/ai/backend/kernel/__main__.py
@@ -2,6 +2,8 @@
 The kernel main program.
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib
 import os
@@ -13,7 +15,7 @@ from . import lang_map
 from .compat import asyncio_run_forever
 
 
-def setproctitle(title):
+def setproctitle(title: str) -> None:
     # setproctitle package doesn't work for unknown reasons
     # We don't need a portable implementation, so here is a Linux-only version
     import ctypes
@@ -22,19 +24,25 @@ def setproctitle(title):
     libc_path = ctypes.util.find_library("c")
     libc = ctypes.CDLL(libc_path)
     PR_SET_NAME = 15
-    title = ctypes.c_char_p(bytes(title, "utf-8"))
-    libc.prctl(PR_SET_NAME, title)
+    raw_title = ctypes.c_char_p(title.encode())
+    libc.prctl(PR_SET_NAME, raw_title)
 
 
-def parse_args(args=None):
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action="store_true", default=False)
     parser.add_argument("lang", type=str, choices=lang_map.keys())
     parser.add_argument("runtime_path", type=Path, nargs="?", default=None)
+    if os.environ.get("BACKEND_REEXECED") == "1":
+        args_path = Path(f"/tmp/{os.getpid()}.krunner-args")
+        args = args_path.read_text().split("\0")
+        args_path.unlink()
+    else:
+        args = None  # read from sys.argv
     return parser.parse_args(args)
 
 
-def main(args) -> None:
+def main(args: argparse.Namespace) -> None:
     cls_name = lang_map[args.lang]
     imp_path, cls_name = cls_name.rsplit(".", 1)
     mod = importlib.import_module(imp_path)


### PR DESCRIPTION
This is an auto-generated backport PR of #6085 to the 25.6 release.