### PR TITLE
fix(BA-2549): Improve error handling in the traefik frontend of App Proxy

### DIFF
--- a/changes/6091.fix.md
+++ b/changes/6091.fix.md
@@ -1,0 +1,1 @@
+Improve error handling in the traefik frontend of App Proxy worker

--- a/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
@@ -119,7 +119,10 @@ class AbstractTraefikFrontend(Generic[TCircuitKey], BaseFrontend[TraefikBackend,
 
     async def mark_inactive(self, request: web.Request) -> web.StreamResponse:
         key = request.match_info["key"]
-        self.active_circuits.remove(uuid.UUID(key))
+        try:
+            self.active_circuits.remove(uuid.UUID(key))
+        except KeyError:
+            log.warning("mark_inactive(): key {!r} not found in active circuits", key)
 
         return web.StreamResponse(status=204)
 

--- a/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
@@ -104,7 +104,6 @@ class AbstractTraefikFrontend(Generic[TCircuitKey], BaseFrontend[TraefikBackend,
             log.debug("Wrote {} keys", len(keys))
         except Exception:
             log.exception("_last_used_time_marker_writer():")
-            raise
 
     async def mark_last_used_time(self, request: web.Request) -> web.StreamResponse:
         key = request.match_info["key"]

--- a/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/traefik.py
@@ -137,7 +137,6 @@ class AbstractTraefikFrontend(Generic[TCircuitKey], BaseFrontend[TraefikBackend,
                     self.redis_keys.update(keys)
         except Exception:
             log.exception("_active_circuit_writer():")
-            raise
 
     async def initialize_backend(self, circuit: Circuit, routes: list[RouteInfo]) -> TraefikBackend:
         return TraefikBackend(self.root_context, circuit, routes)


### PR DESCRIPTION
resolves #6089 (BA-2549)
- **fix: Prevent last-used marker sync timer from being shut down inadvertently**
- **fix: Make missing-key a warning instead of a loud error**

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
