### PR TITLE
fix: roll back traefik configuration update logic

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Temporarily revert traefik configuration update delta calculation logic

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -171,32 +171,6 @@ class CircuitManager:
         worker_authority = circuit.worker_row.authority
         etcd_prefix = f"worker_{worker_authority}/{circuit.protocol.value.lower()}"
 
-        old = set(
-            RouteInfo(**{
-                **r.model_dump(),
-                "health_status": None,
-                "last_health_check": None,
-                "consecutive_failures": 0,
-            })
-            for r in old_routes
-        )
-        new = set(
-            RouteInfo(**{
-                **r.model_dump(),
-                "health_status": None,
-                "last_health_check": None,
-                "consecutive_failures": 0,
-            })
-            for r in circuit.healthy_routes
-        )
-        intersect = old & new
-        routes_to_delete = old - intersect
-        routes_to_create = new - intersect
-
-        if len(routes_to_delete) == 0 and len(routes_to_create) == 0:
-            # Nothing to update
-            return
-
         # Use health-aware services configuration
         new_route_keys = {
             f"bai_session_{r.session_id}_{circuit.id}" for r in circuit.healthy_routes
@@ -208,7 +182,7 @@ class CircuitManager:
         }
 
         # clear old routes
-        for route in routes_to_delete:
+        for route in old_routes:
             log.debug(
                 "traefik_etcd.delete_prefix {}",
                 f"{etcd_prefix}/services/bai_session_{route.session_id}_{circuit.id}",


### PR DESCRIPTION
This PR rolls back traefik configuration partial update as we found critical bug where the delta is calculated incorrectly.
