### PR TITLE
fix: appproxy worker shutdown clears all circuits (#6095)

### DIFF
--- a/changes/6095.fix.md
+++ b/changes/6095.fix.md
@@ -1,0 +1,1 @@
+Fix worker and all related entities removed from database when leaving the AppProxy cluster

--- a/src/ai/backend/appproxy/coordinator/api/worker_v2.py
+++ b/src/ai/backend/appproxy/coordinator/api/worker_v2.py
@@ -275,7 +275,7 @@ async def delete_worker(request: web.Request) -> PydanticResponse[StubResponseMo
         worker = await Worker.get(sess, worker_id)
         worker.nodes -= 1
         if worker.nodes == 0:
-            await sess.delete(worker)
+            worker.status = WorkerStatus.LOST
 
     async with root_ctx.db.connect() as db_conn:
         await execute_with_txn_retry(_update, root_ctx.db.begin_session, db_conn)


### PR DESCRIPTION
This is an auto-generated backport PR of #6095 to the 25.14 release.