### PR TITLE
fix: Build missing agent watcher wheel (#6115)

### DIFF
--- a/changes/6115.deps.md
+++ b/changes/6115.deps.md
@@ -1,0 +1,1 @@
+Build missing agent watcher wheel

--- a/src/ai/backend/agent/BUILD
+++ b/src/ai/backend/agent/BUILD
@@ -42,6 +42,7 @@ python_distribution(
     name="dist",
     dependencies=[
         ":src",
+        ":src-watcher",
         "src/ai/backend/kernel:src",  # included only in binary dists
         "!!stubs/trafaret:stubs",
     ],


### PR DESCRIPTION
This is an auto-generated backport PR of #6115 to the 25.14 release.