### PR TITLE
fix(BA-2588): Resolve kernel `resource_opts` field in `ComputeSessionNode` using dataloader

### DIFF
--- a/changes/6156.fix.md
+++ b/changes/6156.fix.md
@@ -1,0 +1,1 @@
+Explicitly load kernel `resource_opts` data in `ComputeSessionNode` using dataloader instead of accessing `self.resource_opts` directly

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -503,10 +503,7 @@ class ComputeSessionNode(graphene.ObjectType):
         ctx: GraphQueryContext = info.context
         loader = ctx.dataloader_manager.get_loader(ctx, "KernelNode.by_session_id")
         kernels = await loader.load(self.row_id)
-        kernel_nodes = ConnectionResolverResult[KernelConnection](
-            kernels, None, None, None, total_count=len(kernels)
-        )
-        return {kernel.cluster_hostname: kernel.resource_opts for kernel in kernel_nodes.node_list}
+        return {kernel.cluster_hostname: kernel.resource_opts for kernel in kernels}
 
     async def resolve_dependees(
         self,

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -501,6 +501,13 @@ class ComputeSessionNode(graphene.ObjectType):
 
     async def resolve_resource_opts(self, info: graphene.ResolveInfo) -> dict[str, Any]:
         kernel_nodes = self.kernel_nodes
+        if kernel_nodes is None:
+            ctx: GraphQueryContext = info.context
+            loader = ctx.dataloader_manager.get_loader(ctx, "KernelNode.by_session_id")
+            kernels: list[list[KernelNode]] = await loader.load(self.row_id)
+            kernel_nodes = ConnectionResolverResult(
+                kernels, None, None, None, total_count=len(kernels)
+            )
         return {kernel.cluster_hostname: kernel.resource_opts for kernel in kernel_nodes.node_list}
 
     async def resolve_dependees(

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -500,14 +500,10 @@ class ComputeSessionNode(graphene.ObjectType):
         )
 
     async def resolve_resource_opts(self, info: graphene.ResolveInfo) -> dict[str, Any]:
-        kernel_nodes = self.kernel_nodes
-        if kernel_nodes is None:
-            ctx: GraphQueryContext = info.context
-            loader = ctx.dataloader_manager.get_loader(ctx, "KernelNode.by_session_id")
-            kernels: list[list[KernelNode]] = await loader.load(self.row_id)
-            kernel_nodes = ConnectionResolverResult(
-                kernels, None, None, None, total_count=len(kernels)
-            )
+        ctx: GraphQueryContext = info.context
+        loader = ctx.dataloader_manager.get_loader(ctx, "KernelNode.by_session_id")
+        kernels: list[list[KernelNode]] = await loader.load(self.row_id)
+        kernel_nodes = ConnectionResolverResult(kernels, None, None, None, total_count=len(kernels))
         return {kernel.cluster_hostname: kernel.resource_opts for kernel in kernel_nodes.node_list}
 
     async def resolve_dependees(

--- a/src/ai/backend/manager/models/gql_models/session.py
+++ b/src/ai/backend/manager/models/gql_models/session.py
@@ -502,8 +502,10 @@ class ComputeSessionNode(graphene.ObjectType):
     async def resolve_resource_opts(self, info: graphene.ResolveInfo) -> dict[str, Any]:
         ctx: GraphQueryContext = info.context
         loader = ctx.dataloader_manager.get_loader(ctx, "KernelNode.by_session_id")
-        kernels: list[list[KernelNode]] = await loader.load(self.row_id)
-        kernel_nodes = ConnectionResolverResult(kernels, None, None, None, total_count=len(kernels))
+        kernels = await loader.load(self.row_id)
+        kernel_nodes = ConnectionResolverResult[KernelConnection](
+            kernels, None, None, None, total_count=len(kernels)
+        )
         return {kernel.cluster_hostname: kernel.resource_opts for kernel in kernel_nodes.node_list}
 
     async def resolve_dependees(


### PR DESCRIPTION
resolves #6136 (BA-2588)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
