### PR TITLE
fix(BA-2596): Clean container utilization metric when destroy kernel (#6139)

### DIFF
--- a/changes/6139.fix.md
+++ b/changes/6139.fix.md
@@ -1,0 +1,1 @@
+Fix an issue where utilization metrics for destroyed kernels were not properly cleared from Prometheus, preventing users from seeing accumulated metrics from kernels that no longer exist

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1408,6 +1408,7 @@ class AbstractAgent(
             # let the destruction task finish first
             await destruction_task
             del destruction_task
+        await self.stat_ctx.remove_kernel_metric(ev.kernel_id)
         async with self.registry_lock:
             try:
                 kernel_obj = self.kernel_registry.get(ev.kernel_id)
@@ -1499,6 +1500,7 @@ class AbstractAgent(
             )
             raise
 
+        await self.stat_ctx.remove_kernel_metric(kernel_id)
         try:
             await self.clean_kernel(kernel_id, container_id, restarting=False)
         except Exception as e:

--- a/src/ai/backend/agent/metrics/types.py
+++ b/src/ai/backend/agent/metrics/types.py
@@ -13,6 +13,7 @@ MetricValueFieldPair = tuple[MetricValueFieldKey, str]
 CURRENT_METRIC_KEY = MetricValueFieldKey("current")
 CAPACITY_METRIC_KEY = MetricValueFieldKey("capacity")
 PCT_METRIC_KEY = MetricValueFieldKey("pct")
+ALL_METRIC_VALUE_TYPES = {CURRENT_METRIC_KEY, CAPACITY_METRIC_KEY, PCT_METRIC_KEY}
 
 
 @dataclass

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -405,6 +405,24 @@ class StatContext:
             )
         )
 
+    async def remove_kernel_metric(self, kernel_id: KernelId) -> None:
+        log.info("Removing metrics for kernel {}", kernel_id)
+        known_metrics = self.kernel_metrics.get(kernel_id)
+        log.debug("Known metrics for kernel {}: {}", kernel_id, known_metrics)
+        if known_metrics is None:
+            return
+        metric_keys = list(known_metrics.keys())
+        agent_id = self.agent.id
+        session_id, owner_user_id, project_id = self._get_ownership_info_from_kernel(kernel_id)
+        await self._utilization_metric_observer.lazy_remove_container_metric(
+            agent_id=agent_id,
+            kernel_id=kernel_id,
+            session_id=session_id,
+            owner_user_id=owner_user_id,
+            project_id=project_id,
+            keys=metric_keys,
+        )
+
     async def collect_node_stat(self) -> None:
         """
         Collect the per-node, per-device, and per-container statistics.

--- a/src/ai/backend/common/metrics/types.py
+++ b/src/ai/backend/common/metrics/types.py
@@ -3,6 +3,7 @@ from typing import Final
 UNDEFINED: Final[str] = "undefined"
 
 UTILIZATION_METRIC_INTERVAL: Final[float] = 5.0
+UTILIZATION_METRIC_DETENTION: Final[float] = 600.0  # 10 minutes
 
 CONTAINER_UTILIZATION_METRIC_LABEL_NAME: Final[str] = "container_metric_name"
 DEVICE_UTILIZATION_METRIC_LABEL_NAME: Final[str] = "device_metric_name"


### PR DESCRIPTION
This is an auto-generated backport PR of #6139 to the 25.14 release.