### PR TITLE
fix(BA-2599): Insert model-store vfolder data in `VFolderPermissionRow` only when vfolder ownership type is user

### DIFF
--- a/changes/2599.fix.md
+++ b/changes/2599.fix.md
@@ -1,0 +1,1 @@
+Insert model-store vfolder data in `VFolderPermissionRow` only when vfolder ownership type is user

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -372,7 +372,10 @@ class VFolderService:
                 result = await conn.execute(query)
 
                 # Here we grant creator the permission to alter VFolder contents
-                if group_type == ProjectType.MODEL_STORE:
+                if (
+                    group_type == ProjectType.MODEL_STORE
+                    and ownership_type == VFolderOwnershipType.USER
+                ):
                     query = sa.insert(VFolderPermissionRow).values({
                         "user": user_uuid,
                         "vfolder": vfid.folder_id.hex,


### PR DESCRIPTION
resolves #NNN (BA-2599)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
