### PR TITLE
fix(BA-2656): Raise correct exception in `SessionTransitionData.main_kernel` (#6202)

### DIFF
--- a/changes/6202.fix.md
+++ b/changes/6202.fix.md
@@ -1,0 +1,1 @@
+Raise correct exception in `SessionTransitionData.main_kernel`

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -963,7 +963,7 @@ async def agent_registry_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
             network_plugin_ctx=root_ctx.network_plugin_ctx,
         )
     )
-    # Create deployment controller if Sokovan is enabled
+    # Create deployment controller
     root_ctx.deployment_controller = DeploymentController(
         DeploymentControllerArgs(
             scheduling_controller=root_ctx.scheduling_controller,

--- a/src/ai/backend/manager/sokovan/scheduler/types.py
+++ b/src/ai/backend/manager/sokovan/scheduler/types.py
@@ -22,6 +22,7 @@ from ai.backend.common.types import (
     SlotTypes,
 )
 from ai.backend.manager.defs import DEFAULT_ROLE
+from ai.backend.manager.errors.kernel import MainKernelNotFound, TooManyKernelsFound
 from ai.backend.manager.exceptions import ErrorStatusInfo
 from ai.backend.manager.models.kernel import KernelStatus
 from ai.backend.manager.models.network import NetworkType
@@ -807,9 +808,9 @@ class SessionTransitionData:
         """Get the main kernel (kernel with DEFAULT_ROLE as cluster_role)."""
         main_kernels = [k for k in self.kernels if k.cluster_role == DEFAULT_ROLE]
         if len(main_kernels) > 1:
-            raise ValueError(f"Session {self.session_id} has more than 1 main kernel")
+            raise TooManyKernelsFound(f"Session {self.session_id} has more than 1 main kernel")
         if len(main_kernels) == 0:
-            raise ValueError(f"Session {self.session_id} has no main kernel")
+            raise MainKernelNotFound(f"Session {self.session_id} has no main kernel")
         return main_kernels[0]
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #6202 to the 25.15 release.