### PR TITLE
chore: Sort milestones using version sort in workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -103,7 +103,7 @@ jobs:
           done
           echo "Milestones with the corresponding release branch: ${milestones[@]}"
 
-          sort_milestones=($(printf "%s\n" "${milestones[@]}" | sort -r))
+          sort_milestones=($(printf "%s\n" "${milestones[@]}" | sort -V -r))
           for i in "${!sort_milestones[@]}"; do
             if [[ "${sort_milestones[$i]}" == "$target_milestone" ]]; then
               target_milestones=("${sort_milestones[@]:0:$((i+1))}")


### PR DESCRIPTION
Updated the backport workflow to use version sort (-V) when sorting milestones, ensuring correct ordering for versioned milestone names.
