### PR TITLE
feat(BA-2653): Apply Resilience framework to agent client

### DIFF
--- a/changes/6211.feature.md
+++ b/changes/6211.feature.md
@@ -1,0 +1,1 @@
+Apply Resilience framework to agent client with exponential backoff retry policy for improved reliability in agent RPC communications

--- a/src/ai/backend/manager/sokovan/scheduler/scheduler.py
+++ b/src/ai/backend/manager/sokovan/scheduler/scheduler.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
-from typing import Any, Awaitable, Coroutine, Optional
+from typing import Any, Awaitable, Optional
 from uuid import UUID
 
 import aiotools
@@ -953,7 +953,7 @@ class Scheduler:
                         agent_image_configs[agent_id][canonical] = image_config
 
         # Trigger image checking and pulling on each agent
-        pull_tasks: list[Coroutine[Any, Any, Mapping[str, str]]] = []
+        pull_tasks: list[Awaitable[Mapping[str, str]]] = []
         for agent_id, agent_images in agent_image_configs.items():
             agent_client = self._agent_pool.get_agent_client(agent_id)
             pull_tasks.append(agent_client.check_and_pull(agent_images))


### PR DESCRIPTION
Replace client_decorator with Resilience framework for all agent RPC operations to provide consistent retry and metrics handling across the codebase.

Changes:
- Replace custom client_decorator with Resilience instance
- Add MetricPolicy for operation tracking (DomainType.CLIENT, LayerType.AGENT_CLIENT)
- Add RetryPolicy with exponential backoff (max_retries=3, BackendAIError non-retryable)
- Update all 40 public methods to use @agent_client_resilience.apply()

Benefits:
- Consistent with repository layer resilience pattern
- Improved backoff strategy (FIXED → EXPONENTIAL)
- Policy-based architecture allows future enhancements

Refs: BA-2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves #6198 (BA-2653)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
