### PR TITLE
fix(BA-2715): Make agent batch loading resolvers work without `batch_result` method (#6280)

### DIFF
--- a/changes/6280.fix.md
+++ b/changes/6280.fix.md
@@ -1,0 +1,1 @@
+Decoupled agent batch loading resolvers that previously depended on the `from_row` function.

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -132,7 +132,7 @@ class AgentRepository:
 
         async with self._db_source._db.begin_readonly_session() as db_session:
             result = await db_session.scalars(stmt)
-            agent_rows = cast(list[AgentRow], result.all())
+            agent_rows = cast(list[AgentRow], result.unique().all())
             return [agent_row.to_data() for agent_row in agent_rows]
 
     @repository_decorator()


### PR DESCRIPTION
This is an auto-generated backport PR of #6280 to the 25.15 release.