### PR TITLE
fix(BA-2720): Only create XFS lockfile when XFS storage backend is configured (#6285)

### DIFF
--- a/changes/6285.fix.md
+++ b/changes/6285.fix.md
@@ -1,0 +1,1 @@
+Fix an issue where the Storage Proxy would unnecessarily attempt to create an XFS backend lockfile at `/tmp/backendai-xfs-file-lock` even when XFS storage was not configured. This could cause permission errors if the Storage Proxy lacked access to the `/tmp` directory, preventing the service from starting properly.

--- a/src/ai/backend/storage/volumes/xfs/__init__.py
+++ b/src/ai/backend/storage/volumes/xfs/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import (
@@ -14,6 +15,9 @@ from typing import (
 import aiofiles
 import aiofiles.os
 
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
+from ai.backend.common.exception import InvalidConfigError
 from ai.backend.common.lock import FileLock
 from ai.backend.common.types import QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
@@ -25,13 +29,13 @@ from ...types import (
     QuotaUsage,
 )
 from ...volumes.abc import CAP_QUOTA, CAP_VFOLDER
+from ...watcher import WatcherClient
 from ..abc import AbstractQuotaModel
 from ..vfs import BaseQuotaModel, BaseVolume
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
-LOCK_FILE = Path("/tmp/backendai-xfs-file-lock")
-Path(LOCK_FILE).touch()
+DEFAULT_LOCK_FILE = Path("/tmp/backendai-xfs-file-lock")
 
 
 class XfsProjectRegistry:
@@ -149,11 +153,13 @@ class XFSProjectQuotaModel(BaseQuotaModel):
         self,
         mount_path: Path,
         project_registry: XfsProjectRegistry,
+        lock_path: Path,
     ) -> None:
         super().__init__(mount_path)
         self.project_registry = project_registry
         stat_vfs = os.statvfs(mount_path)
         self.block_size = stat_vfs.f_bsize
+        self._lock_path = lock_path
 
     async def create_quota_scope(
         self,
@@ -167,7 +173,7 @@ class XFSProjectQuotaModel(BaseQuotaModel):
                 # Set the limit as the filesystem size
                 vfs_stat = os.statvfs(self.mount_path)
                 options = QuotaConfig(vfs_stat.f_blocks * self.block_size)
-            async with FileLock(LOCK_FILE):
+            async with FileLock(self._lock_path):
                 log.info(
                     "creating project quota (qs:{}, q:{})",
                     quota_scope_id,
@@ -260,7 +266,7 @@ class XFSProjectQuotaModel(BaseQuotaModel):
             raise QuotaDirectoryNotEmptyError(
                 f"Cannot delete quota scope '{quota_scope_id}': directory not empty"
             )
-        async with FileLock(LOCK_FILE):
+        async with FileLock(self._lock_path):
             await self.project_registry.read_project_info()
             await self.project_registry.remove_project_entry(quota_scope_id)
             await self.project_registry.read_project_info()
@@ -281,6 +287,39 @@ class XfsVolume(BaseVolume):
 
     project_registry: XfsProjectRegistry
 
+    def __init__(
+        self,
+        local_config: Mapping[str, Any],
+        mount_path: Path,
+        *,
+        etcd: AsyncEtcd,
+        event_dispatcher: EventDispatcher,
+        event_producer: EventProducer,
+        watcher: Optional[WatcherClient] = None,
+        options: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            local_config,
+            mount_path,
+            etcd=etcd,
+            event_dispatcher=event_dispatcher,
+            event_producer=event_producer,
+            watcher=watcher,
+            options=options,
+        )
+        self._lock_path = Path(self.config.get("lock_file_path", DEFAULT_LOCK_FILE))
+        try:
+            self._lock_path.touch()
+        except OSError as e:
+            log.exception(
+                "Failed to create XFS backend lock file at {}: (Error: {})",
+                self._lock_path,
+                e,
+            )
+            raise InvalidConfigError(
+                f"Cannot create XFS backend lock file at {self._lock_path}"
+            ) from e
+
     async def init(self) -> None:
         self.project_registry = XfsProjectRegistry()
         await self.project_registry.init(self)
@@ -290,6 +329,7 @@ class XfsVolume(BaseVolume):
         return XFSProjectQuotaModel(
             self.mount_path,
             self.project_registry,
+            self._lock_path,
         )
 
     async def get_capabilities(self) -> FrozenSet[str]:


### PR DESCRIPTION
This is an auto-generated backport PR of #6285 to the 25.15 release.