### PR TITLE
fix(BA-2721): Change owner of glide socket file (#6284)

### DIFF
--- a/changes/6284.fix.md
+++ b/changes/6284.fix.md
@@ -1,0 +1,1 @@
+Fix a permission issue where Storage Proxy would fail to access its glide socket after changing process uid/gid. Users running Storage Proxy with non-root credentials will no longer encounter "Permission Denied" errors during startup.

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -297,6 +297,11 @@ async def server_main(
                 uid = local_config.storage_proxy.user
                 gid = local_config.storage_proxy.group
                 if uid is not None and gid is not None:
+                    # TODO: Remove this tmp_path handling
+                    # after implementing Storage Proxy worker
+                    tmp_path = Path("/tmp")
+                    for glide_socket in tmp_path.glob("glide-socket-*"):
+                        os.chown(glide_socket, uid, gid)
                     os.setgroups(
                         [g.gr_gid for g in grp.getgrall() if pwd.getpwuid(uid).pw_name in g.gr_mem],
                     )


### PR DESCRIPTION
This is an auto-generated backport PR of #6284 to the 25.15 release.