### PR TITLE
fix(BA-2723): Avoid groups full scan when query VFolder (#6300)

### DIFF
--- a/changes/6300.fix.md
+++ b/changes/6300.fix.md
@@ -1,0 +1,1 @@
+Improve the performance of VFolder queries by optimizing group lookups, resulting in faster VFolder detail panel popups and quicker session creation page loading


### PR DESCRIPTION
This is an auto-generated backport PR of #6300 to the 25.15 release.