### PR TITLE
fix(BA-2762): add filtering and ordering field to group table

### DIFF
--- a/changes/6328.feature.md
+++ b/changes/6328.feature.md
@@ -1,0 +1,1 @@
+Add the `row_id` field to the Group GraphQL model's `queryfilter_fieldspec` and `queryorder_colmap`, allowing it to be used in queries and sorting operations.

--- a/src/ai/backend/manager/models/gql_models/group.py
+++ b/src/ai/backend/manager/models/gql_models/group.py
@@ -113,6 +113,7 @@ class GroupNode(graphene.ObjectType):
 
     queryfilter_fieldspec: Mapping[str, FieldSpecItem] = {
         "id": ("id", None),
+        "row_id": ("id", None),
         "name": ("name", None),
         "is_active": ("is_active", None),
         "created_at": ("created_at", dtparse),
@@ -123,6 +124,7 @@ class GroupNode(graphene.ObjectType):
 
     queryorder_colmap: Mapping[str, OrderSpecItem] = {
         "id": ("id", None),
+        "row_id": ("id", None),
         "name": ("name", None),
         "is_active": ("is_active", None),
         "created_at": ("created_at", None),


### PR DESCRIPTION
Resolves #6327 ([BA-2762](https://lablup.atlassian.net/browse/BA-2762))

# Add `row_id` field to Group GraphQL model

This PR adds the `row_id` field to the Group GraphQL model's queryfilter_fieldspec and queryorder_colmap, allowing it to be used in queries and sorting operations. It also improves code formatting for better readability in the `from_dto` and `to_action` methods.

**Checklist:**

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations

[BA-2762]: https://lablup.atlassian.net/browse/BA-2762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ