### PR TITLE
fix(BA-2769): Omit unset mount `type` fields in client SDK to pass new service creation input validation (#6347)

### DIFF
--- a/changes/6347.fix.md
+++ b/changes/6347.fix.md
@@ -1,0 +1,1 @@
+Fix model service extra mounts in client SDK to omit unset mount `type` fields, ensuring compatibility with the manager API

--- a/src/ai/backend/client/func/service.py
+++ b/src/ai/backend/client/func/service.py
@@ -179,8 +179,9 @@ class Service(BaseFunction):
                     vfolder_id = vfolder_name_to_id[mount]
                 extra_mount_body[str(vfolder_id)] = {
                     "mount_destination": extra_mount_map.get(mount),
-                    "type": extra_mount_options.get(mount, {}).get("type"),
                 }
+                if mount_type := extra_mount_options.get(mount, {}).get("type"):
+                    extra_mount_body[str(vfolder_id)]["type"] = mount_type
         model_config = {
             "model": model_id_or_name,
             "model_mount_destination": model_mount_destination,


### PR DESCRIPTION
This is an auto-generated backport PR of #6347 to the 25.6 release.