### PR TITLE
fix(BA-2786): Prevent re-terminating sessions already in terminal states (#6353)

### DIFF
--- a/changes/6353.fix.md
+++ b/changes/6353.fix.md
@@ -1,0 +1,1 @@
+Prevent re-terminating sessions already in terminal states

--- a/src/ai/backend/manager/data/kernel/types.py
+++ b/src/ai/backend/manager/data/kernel/types.py
@@ -77,6 +77,23 @@ class KernelStatus(CIStrEnum):
 
     @classmethod
     @lru_cache(maxsize=1)
+    def terminatable_statuses(cls) -> frozenset["KernelStatus"]:
+        """Return statuses that can transition to TERMINATING."""
+        return frozenset(
+            status
+            for status in cls
+            if status
+            not in (
+                cls.PENDING,
+                cls.TERMINATING,
+                cls.TERMINATED,
+                cls.CANCELLED,
+                cls.ERROR,
+            )
+        )
+
+    @classmethod
+    @lru_cache(maxsize=1)
     def terminal_statuses(cls) -> frozenset["KernelStatus"]:
         """
         Returns a set of kernel statuses that are considered terminal.

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -65,6 +65,23 @@ class SessionStatus(CIStrEnum):
 
     @classmethod
     @lru_cache(maxsize=1)
+    def terminatable_statuses(cls) -> frozenset["SessionStatus"]:
+        """Return statuses that can transition to TERMINATING."""
+        return frozenset(
+            status
+            for status in cls
+            if status
+            not in (
+                cls.PENDING,
+                cls.TERMINATING,
+                cls.TERMINATED,
+                cls.CANCELLED,
+                cls.ERROR,
+            )
+        )
+
+    @classmethod
+    @lru_cache(maxsize=1)
     def terminal_statuses(cls) -> frozenset["SessionStatus"]:
         return frozenset((
             cls.ERROR,

--- a/src/ai/backend/manager/repositories/schedule/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/schedule/db_source/db_source.py
@@ -655,7 +655,7 @@ class ScheduleDBSource:
     async def _mark_sessions_as_terminating(
         self, db_sess: SASession, session_ids: list[SessionId], reason: str, now: datetime
     ) -> list[SessionId]:
-        """Mark resource-occupying sessions and their kernels as terminating."""
+        """Mark terminatable sessions and their kernels as terminating."""
         # Mark sessions as terminating
         terminating_stmt = (
             sa.update(SessionRow)
@@ -671,7 +671,7 @@ class ScheduleDBSource:
             .where(
                 sa.and_(
                     SessionRow.id.in_(session_ids),
-                    SessionRow.status.in_(SessionStatus.resource_occupied_statuses()),
+                    SessionRow.status.in_(SessionStatus.terminatable_statuses()),
                 )
             )
             .returning(SessionRow.id)
@@ -692,7 +692,12 @@ class ScheduleDBSource:
                         {KernelStatus.TERMINATING.name: now.isoformat()},
                     ),
                 )
-                .where(KernelRow.session_id.in_(terminating_sessions))
+                .where(
+                    sa.and_(
+                        KernelRow.session_id.in_(terminating_sessions),
+                        KernelRow.status.in_(KernelStatus.terminatable_statuses()),
+                    )
+                )
             )
 
         return terminating_sessions


### PR DESCRIPTION
This is an auto-generated backport PR of #6353 to the 25.15 release.