### PR TITLE
fix: Wrong required `reservoir_config` error (#6361)

### DIFF
--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -1063,24 +1063,13 @@ async def leader_election_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     task_specs = root_ctx.sokovan_orchestrator.create_task_specs()
 
     # Rescan reservoir registry periodically
-    reservoir_config = root_ctx.config_provider.config.reservoir
 
-    if reservoir_config and reservoir_config.use_delegation:
-        task_specs.append(
-            EventTaskSpec(
-                name="reservoir_registry_scan",
-                event_factory=lambda: DoScanReservoirRegistryEvent(),
-                interval=600,  # 10 minutes
-                initial_delay=0,
-            )
-        )
-        task_specs.append(
-            EventTaskSpec(
-                name="reservoir_registry_pull",
-                event_factory=lambda: DoPullReservoirRegistryEvent(),
-                interval=600,  # 10 minutes
-                initial_delay=0,
-            )
+    task_specs.append(
+        EventTaskSpec(
+            name="reservoir_registry_scan",
+            event_factory=lambda: DoScanReservoirRegistryEvent(),
+            interval=600,  # 10 minutes
+            initial_delay=0,
         )
     )
 


### PR DESCRIPTION
This is an auto-generated backport PR of #6361 to the 25.15 release.