### PR TITLE
chore(ci): Add workflow to sync JIRA ticket with GitHub issue

### DIFF
--- a/.github/workflows/ticket-issue-number-sync.yml
+++ b/.github/workflows/ticket-issue-number-sync.yml
@@ -49,12 +49,22 @@ jobs:
         echo "JIRA API Response: $JIRA_RESPONSE"
 
         # Extract issue number from GitHub Issue URL field
-        # Find field that exactly matches "GitHub Issue URL" in JIRA
-        GITHUB_ISSUE_URL=$(echo "$JIRA_RESPONSE" | jq -r '.fields | to_entries[] | select(.key == "GitHub Issue URL") | .value' 2>/dev/null | head -1)
+        # Search for fields containing GitHub issue URLs (customfield_* or regular fields)
+        GITHUB_ISSUE_URL=$(echo "$JIRA_RESPONSE" | jq -r '
+          .fields
+          | to_entries[]
+          | select(.value != null and .value != "")
+          | select(
+              (.value | type == "string" and test("github.com/.*/issues/[0-9]+"))
+            )
+          | .value
+        ' 2>/dev/null | head -1)
 
         # Fail immediately if GitHub Issue URL is not found
         if [ -z "$GITHUB_ISSUE_URL" ] || [ "$GITHUB_ISSUE_URL" = "null" ]; then
-          echo "No GitHub Issue URL found in JIRA ticket"
+          echo "❌ No GitHub Issue URL found in JIRA ticket $TICKET_NUMBER"
+          echo "Available fields (first 20):"
+          echo "$JIRA_RESPONSE" | jq -r '.fields | keys[]' 2>/dev/null | head -20
           exit 1
         fi
 
@@ -63,12 +73,12 @@ jobs:
         GITHUB_ISSUE_NUMBER=$(echo "$GITHUB_ISSUE_URL" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
 
         if [ -n "$GITHUB_ISSUE_NUMBER" ]; then
-          echo "Extracted GitHub Issue Number: $GITHUB_ISSUE_NUMBER"
+          echo "✅ Extracted GitHub Issue Number: $GITHUB_ISSUE_NUMBER"
           echo "github_issue_number=$GITHUB_ISSUE_NUMBER" >> $GITHUB_OUTPUT
           echo "has_github_issue=true" >> $GITHUB_OUTPUT
         else
           echo "❌ Could not extract issue number from GitHub Issue URL: $GITHUB_ISSUE_URL"
-          echo "Please verify the GitHub Issue URL format is correct."
+          echo "Please verify the GitHub Issue URL format is correct (expected: https://github.com/owner/repo/issues/NUMBER)"
           exit 1
         fi
 
@@ -83,7 +93,7 @@ jobs:
         # Get current PR body
         PR_BODY=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}" | \
+          "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | \
           jq -r '.body // ""')
 
         echo "Current PR body: $PR_BODY"
@@ -93,13 +103,13 @@ jobs:
         echo "Generated resolves clause: $RESOLVES_CLAUSE"
 
         # Replace existing resolves clause or add new one
-        if echo "$PR_BODY" | grep -qi "resolves #.*("; then
-          # Replace existing resolves clause
-          NEW_BODY=$(echo "$PR_BODY" | sed -E "s/resolves #[0-9]+ \([^)]+\)/$RESOLVES_CLAUSE/gi")
+        if echo "$PR_BODY" | grep -qiE "resolves #[0-9]+ ?\("; then
+          # Replace existing resolves clause (case-insensitive)
+          NEW_BODY=$(echo "$PR_BODY" | sed -E "s/[Rr]esolves #[0-9]+ ?\([^)]+\)/$RESOLVES_CLAUSE/g")
           echo "Replaced existing resolves clause"
         else
-          # Add new resolves clause
-          NEW_BODY=$(printf "%s\n\n%s" "$PR_BODY" "$RESOLVES_CLAUSE")
+          # Add new resolves clause at the beginning
+          NEW_BODY=$(printf "%s\n\n%s" "$RESOLVES_CLAUSE" "$PR_BODY")
           echo "Added new resolves clause"
         fi
 
@@ -108,7 +118,7 @@ jobs:
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-Type: application/json" \
-          "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}" \
+          "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
           -d "{\"body\": $(echo "$NEW_BODY" | jq -R -s .)}"
 
         echo "✅ Added resolves clause: $RESOLVES_CLAUSE"

--- a/.github/workflows/ticket-issue-number-sync.yml
+++ b/.github/workflows/ticket-issue-number-sync.yml
@@ -1,0 +1,116 @@
+name: ticket-issue-number-sync
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ticket-issue-number-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Extract JIRA ticket number from PR title
+      id: extract_ticket
+      run: |
+        # Extract JIRA ticket number from PR title (e.g., "fix(BA-1234): aaaa" -> "BA-1234")
+        TITLE="${{ github.event.pull_request.title }}"
+        echo "PR Title: $TITLE"
+
+        # Extract ticket number using regex pattern BA-XXXX format
+        TICKET_NUMBER=$(echo "$TITLE" | grep -oE 'BA-[0-9]+' | head -1)
+
+        if [ -n "$TICKET_NUMBER" ]; then
+          echo "Extracted ticket: $TICKET_NUMBER"
+          echo "ticket_number=$TICKET_NUMBER" >> $GITHUB_OUTPUT
+          echo "has_ticket=true" >> $GITHUB_OUTPUT
+        else
+          echo "No JIRA ticket number found in PR title"
+          echo "has_ticket=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Get GitHub Issue URL from JIRA
+      if: steps.extract_ticket.outputs.has_ticket == 'true'
+      id: get_jira_issue
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      run: |
+        TICKET_NUMBER="${{ steps.extract_ticket.outputs.ticket_number }}"
+        echo "Fetching GitHub Issue URL for JIRA ticket: $TICKET_NUMBER"
+
+        # Get ticket information through JIRA API
+        JIRA_RESPONSE=$(curl -s -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
+          -H "Accept: application/json" \
+          "$JIRA_BASE_URL/rest/api/3/issue/$TICKET_NUMBER")
+
+        echo "JIRA API Response: $JIRA_RESPONSE"
+
+        # Extract issue number from GitHub Issue URL field
+        # Find field that exactly matches "GitHub Issue URL" in JIRA
+        GITHUB_ISSUE_URL=$(echo "$JIRA_RESPONSE" | jq -r '.fields | to_entries[] | select(.key == "GitHub Issue URL") | .value' 2>/dev/null | head -1)
+
+        # Fail immediately if GitHub Issue URL is not found
+        if [ -z "$GITHUB_ISSUE_URL" ] || [ "$GITHUB_ISSUE_URL" = "null" ]; then
+          echo "No GitHub Issue URL found in JIRA ticket"
+          exit 1
+        fi
+
+        echo "Found GitHub Issue URL: $GITHUB_ISSUE_URL"
+        # Extract GitHub issue number (e.g., https://github.com/owner/repo/issues/123 -> 123)
+        GITHUB_ISSUE_NUMBER=$(echo "$GITHUB_ISSUE_URL" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
+
+        if [ -n "$GITHUB_ISSUE_NUMBER" ]; then
+          echo "Extracted GitHub Issue Number: $GITHUB_ISSUE_NUMBER"
+          echo "github_issue_number=$GITHUB_ISSUE_NUMBER" >> $GITHUB_OUTPUT
+          echo "has_github_issue=true" >> $GITHUB_OUTPUT
+        else
+          echo "❌ Could not extract issue number from GitHub Issue URL: $GITHUB_ISSUE_URL"
+          echo "Please verify the GitHub Issue URL format is correct."
+          exit 1
+        fi
+
+    - name: Update PR body with resolves clause
+      if: steps.extract_ticket.outputs.has_ticket == 'true' && steps.get_jira_issue.outputs.has_github_issue == 'true'
+      env:
+        TICKET_NUMBER: ${{ steps.extract_ticket.outputs.ticket_number }}
+        GITHUB_ISSUE_NUMBER: ${{ steps.get_jira_issue.outputs.github_issue_number }}
+      run: |
+        echo "Using GitHub issue number: $GITHUB_ISSUE_NUMBER from JIRA"
+
+        # Get current PR body
+        PR_BODY=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}" | \
+          jq -r '.body // ""')
+
+        echo "Current PR body: $PR_BODY"
+
+        # Check if PR body already contains resolves clause
+        if echo "$PR_BODY" | grep -qi "resolves #"; then
+          echo "PR body already contains resolves clause, skipping update"
+          exit 0
+        fi
+
+        # Generate resolves clause
+        RESOLVES_CLAUSE="resolves #$GITHUB_ISSUE_NUMBER ($TICKET_NUMBER)"
+        echo "Generated resolves clause: $RESOLVES_CLAUSE"
+
+        # Create new PR body
+        if [ -n "$PR_BODY" ]; then
+          NEW_BODY=$(printf "%s\n\n%s" "$PR_BODY" "$RESOLVES_CLAUSE")
+        else
+          NEW_BODY="$RESOLVES_CLAUSE"
+        fi
+
+        # Update PR body
+        curl -s -X PATCH \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Content-Type: application/json" \
+          "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${{ github.event.pull_request.number }}" \
+          -d "{\"body\": $(echo "$NEW_BODY" | jq -R -s .)}"
+
+        echo "✅ Added resolves clause: $RESOLVES_CLAUSE"

--- a/.github/workflows/ticket-issue-number-sync.yml
+++ b/.github/workflows/ticket-issue-number-sync.yml
@@ -88,21 +88,19 @@ jobs:
 
         echo "Current PR body: $PR_BODY"
 
-        # Check if PR body already contains resolves clause
-        if echo "$PR_BODY" | grep -qi "resolves #"; then
-          echo "PR body already contains resolves clause, skipping update"
-          exit 0
-        fi
-
         # Generate resolves clause
         RESOLVES_CLAUSE="resolves #$GITHUB_ISSUE_NUMBER ($TICKET_NUMBER)"
         echo "Generated resolves clause: $RESOLVES_CLAUSE"
 
-        # Create new PR body
-        if [ -n "$PR_BODY" ]; then
-          NEW_BODY=$(printf "%s\n\n%s" "$PR_BODY" "$RESOLVES_CLAUSE")
+        # Replace existing resolves clause or add new one
+        if echo "$PR_BODY" | grep -qi "resolves #.*("; then
+          # Replace existing resolves clause
+          NEW_BODY=$(echo "$PR_BODY" | sed -E "s/resolves #[0-9]+ \([^)]+\)/$RESOLVES_CLAUSE/gi")
+          echo "Replaced existing resolves clause"
         else
-          NEW_BODY="$RESOLVES_CLAUSE"
+          # Add new resolves clause
+          NEW_BODY=$(printf "%s\n\n%s" "$PR_BODY" "$RESOLVES_CLAUSE")
+          echo "Added new resolves clause"
         fi
 
         # Update PR body


### PR DESCRIPTION
Introduces a GitHub Actions workflow that extracts a JIRA ticket number from the PR title, fetches the corresponding GitHub issue number from JIRA, and updates the PR body with a resolves clause to link the PR to the GitHub issue. This automates cross-referencing between JIRA tickets and GitHub issues for improved traceability.

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
