### PR TITLE
fix(BA-2882): Change keypair query to include keypairs of users with no group membership (#6455)

### DIFF
--- a/changes/6455.fix.md
+++ b/changes/6455.fix.md
@@ -1,0 +1,1 @@
+Change keypair query to include keypairs of users with no group membership

--- a/src/ai/backend/manager/models/gql_models/keypair.py
+++ b/src/ai/backend/manager/models/gql_models/keypair.py
@@ -297,8 +297,8 @@ class KeyPair(graphene.ObjectType):
 
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
-            .join(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
-            .join(groups, association_groups_users.c.group_id == groups.c.id)
+            .outerjoin(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
+            .outerjoin(groups, association_groups_users.c.group_id == groups.c.id)
         )
         query = sa.select([sa.func.count()]).group_by(keypairs.c.access_key).select_from(j)
         if domain_name is not None:
@@ -332,8 +332,8 @@ class KeyPair(graphene.ObjectType):
 
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
-            .join(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
-            .join(groups, association_groups_users.c.group_id == groups.c.id)
+            .outerjoin(association_groups_users, users.c.uuid == association_groups_users.c.user_id)
+            .outerjoin(groups, association_groups_users.c.group_id == groups.c.id)
         )
         query = (
             sa.select([


### PR DESCRIPTION
This is an auto-generated backport PR of #6455 to the 25.15 release.