### PR TITLE
fix(BA-2898): Artifact revision not found error caused by `get_artifact_revision_readme` (#6485)

### DIFF
--- a/changes/6485.fix.md
+++ b/changes/6485.fix.md
@@ -1,0 +1,1 @@
+Artifact revision not found error caused by `get_artifact_revision_readme`

--- a/src/ai/backend/manager/repositories/artifact/repository.py
+++ b/src/ai/backend/manager/repositories/artifact/repository.py
@@ -788,10 +788,6 @@ class ArtifactRepository:
                 )
             )
             readme = result.scalar_one_or_none()
-            if readme is None:
-                raise ArtifactRevisionNotFoundError(
-                    f"Artifact revision with ID {artifact_revision_id} not found"
-                )
             return readme
 
     @repository_decorator()


### PR DESCRIPTION
This is an auto-generated backport PR of #6485 to the 25.15 release.