### PR TITLE
fix(BA-2915): Add missing hook call in sokovan (#6584)

### DIFF
--- a/changes/6584.fix.md
+++ b/changes/6584.fix.md
@@ -1,0 +1,1 @@
+Add missing `PRE_ENQUEUE_HOOK` and `POST_ENQUEUE_HOOK` call in Sokovan scheduler

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -961,6 +961,7 @@ async def agent_registry_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
             event_producer=root_ctx.event_producer,
             valkey_schedule=root_ctx.valkey_schedule,
             network_plugin_ctx=root_ctx.network_plugin_ctx,
+            hook_plugin_ctx=root_ctx.hook_plugin_ctx,
         )
     )
     # Create deployment controller

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -10,10 +10,12 @@ from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.common.events.event_types.session.broadcast import SchedulingBroadcastEvent
 from ai.backend.common.events.types import AbstractBroadcastEvent
 from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.plugin.hook import ALL_COMPLETED, PASSED, HookPluginContext
 from ai.backend.common.types import ResourceSlot, SessionId
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.errors.common import RejectedByHook
 from ai.backend.manager.metrics.scheduler import (
     SchedulerOperationMetricObserver,
     SchedulerPhaseMetricObserver,
@@ -62,6 +64,7 @@ class SchedulingControllerArgs:
     event_producer: EventProducer
     valkey_schedule: ValkeyScheduleClient
     network_plugin_ctx: NetworkPluginContext
+    hook_plugin_ctx: HookPluginContext
 
 
 class SchedulingController:
@@ -81,6 +84,7 @@ class SchedulingController:
     _resource_calculator: ResourceCalculator
     _metric_observer: SchedulerPhaseMetricObserver
     _operation_metrics: SchedulerOperationMetricObserver
+    _hook_plugin_ctx: HookPluginContext
 
     def __init__(self, args: SchedulingControllerArgs) -> None:
         """Initialize the scheduling controller with required services."""
@@ -90,6 +94,7 @@ class SchedulingController:
         self._event_producer = args.event_producer
         self._valkey_schedule = args.valkey_schedule
         self._network_plugin_ctx = args.network_plugin_ctx
+        self._hook_plugin_ctx = args.hook_plugin_ctx
 
         # Initialize metric observers (singletons)
         self._metric_observer = SchedulerPhaseMetricObserver.instance()
@@ -224,6 +229,14 @@ class SchedulingController:
                 calculated_resources,
             )
 
+        hook_result = await self._hook_plugin_ctx.dispatch(
+            "PRE_ENQUEUE_SESSION",
+            (session_data.id, session_data.name, session_data.access_key),
+            return_when=ALL_COMPLETED,
+        )
+        if hook_result.status != PASSED:
+            raise RejectedByHook.from_hook_result(hook_result)
+
         # Phase 5: Enqueue in repository
         with self._metric_observer.measure_phase(
             "scheduling_controller", validated_scaling_group.name, "enqueue"
@@ -243,6 +256,10 @@ class SchedulingController:
                 session_id,
                 e,
             )
+        await self._hook_plugin_ctx.notify(
+            "POST_ENQUEUE_SESSION",
+            (session_id, session_data.name, session_data.access_key),
+        )
         return session_id
 
     async def mark_scheduling_needed(self, schedule_type: ScheduleType) -> None:

--- a/tests/manager/sokovan/scheduling_controller/test_integration.py
+++ b/tests/manager/sokovan/scheduling_controller/test_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from dateutil.tz import tzutc
 
+from ai.backend.common.plugin.hook import HookResult, HookResults
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -75,6 +76,10 @@ async def scheduling_controller(
     mock_config_provider,
 ):
     """Create a SchedulingController instance with mocks."""
+    hook_result = HookResult(status=HookResults.PASSED)
+    hook_plugin_ctx = AsyncMock()
+    hook_plugin_ctx.notify = AsyncMock(return_value=hook_result)
+    hook_plugin_ctx.dispatch = AsyncMock(return_value=hook_result)
     args = SchedulingControllerArgs(
         repository=mock_repository,
         config_provider=mock_config_provider,
@@ -82,6 +87,7 @@ async def scheduling_controller(
         event_producer=AsyncMock(),
         valkey_schedule=AsyncMock(),
         network_plugin_ctx=AsyncMock(),
+        hook_plugin_ctx=hook_plugin_ctx,
     )
     return SchedulingController(args)
 


### PR DESCRIPTION
This is an auto-generated backport PR of #6584 to the 25.15 release.