### PR TITLE
doc(BA-2927): Translate remaining Korean text in component READMEs to English

### DIFF
--- a/changes/6594.doc.md
+++ b/changes/6594.doc.md
@@ -1,0 +1,1 @@
+Add Entry Point, Event, and Background Task architecture documentation

--- a/src/ai/backend/appproxy/coordinator/README.md
+++ b/src/ai/backend/appproxy/coordinator/README.md
@@ -1,1 +1,92 @@
-# appproxy-coordinator
+# Backend.AI App Proxy Coordinator
+
+## Purpose
+
+The App Proxy Coordinator manages routing information for App Proxy Workers, coordinates worker instances, and handles service port mappings for compute session services (Jupyter, SSH, TensorBoard, etc.).
+
+## Key Responsibilities
+
+### 1. Worker Management
+- Register and track App Proxy Worker instances
+- Monitor worker health and availability
+- Distribute routing information to workers
+- Handle worker failover
+
+### 2. Route Management
+- Manage service port mappings (session → service → port)
+- Update routing tables dynamically
+- Propagate route changes to workers
+- Handle route conflicts and resolution
+
+### 3. Service Discovery
+- Maintain service registry
+- Provide route lookup for workers
+- Update routes when sessions change
+- Clean up routes for terminated sessions
+
+## Entry Points
+
+App Proxy Coordinator has 1 entry point to receive and process requests.
+
+### 1. REST API
+
+**Framework**: aiohttp (async HTTP server)
+
+**Port**: 6030 (default)
+
+**Primary Purpose**:
+- Worker management (registration, monitoring)
+- Routing information management (session-to-service port mapping)
+
+**Key Features**:
+- HTTP/HTTPS-based communication
+- Centralized service routing information management
+- Real-time route updates
+- Persistent routing information storage in PostgreSQL
+
+**Processing Flow**:
+
+#### Worker Registration Flow
+```
+Worker → POST /workers/register → Coordinator
+                                      ↓
+                                  Register worker in DB
+                                      ↓
+                                  Return worker ID and routes
+```
+
+#### Route Creation Flow
+```
+Manager → POST /routes → Coordinator
+                             ↓
+                         Store route in DB
+                             ↓
+                         Notify all workers
+                             ↓
+                         Workers update local routing table
+```
+
+**Integrated Architecture**:
+
+```
+┌──────────────┐
+│   Manager    │
+│              │
+└──────┬───────┘
+       │ Route Management (REST)
+       ▼
+┌─────────────────────────────────────┐
+│  App Proxy Coordinator (Port 6030)  │
+│  - Worker registration              │
+│  - Route management                 │
+│  - Service port mapping             │
+│  - Route propagation                │
+└─────────┬───────────────────────────┘
+          │
+          ▼ Worker Registration & Route Updates
+    ┌─────┴─────┬─────────┬─────────┐
+    ▼           ▼         ▼         ▼
+┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
+│Worker 1│ │Worker 2│ │Worker 3│ │Worker N│
+└────────┘ └────────┘ └────────┘ └────────┘
+```

--- a/src/ai/backend/appproxy/worker/README.md
+++ b/src/ai/backend/appproxy/worker/README.md
@@ -1,1 +1,107 @@
-# appproxy-worker
+# Backend.AI App Proxy Worker
+
+## Purpose
+
+The App Proxy Worker is a high-performance reverse proxy that routes user traffic to compute session services (Jupyter, SSH, TensorBoard, etc.) running on agents. It receives routing information from the Coordinator and handles SSL/TLS termination, load balancing, and traffic forwarding.
+
+## Key Responsibilities
+
+### 1. Traffic Proxying
+- Proxy HTTP/HTTPS requests to session services
+- Proxy WebSocket connections for interactive services
+- Handle SSL/TLS termination
+- Stream responses efficiently
+
+### 2. Route Resolution
+- Receive routing tables from Coordinator
+- Resolve session services from URLs
+- Cache routing information locally
+- Update routes dynamically
+
+### 3. Health Checking
+- Monitor backend service health
+- Detect failed services
+- Report health status to Coordinator
+- Handle service failover
+
+## Architecture
+
+### 1. Traffic Proxy (Main)
+
+**Framework**: aiohttp + custom reverse proxy
+
+**Port**: 5050 (default, HTTPS)
+
+**Protocol**: HTTP/HTTPS, WebSocket
+
+**Key Features**:
+
+#### HTTP/HTTPS Proxy
+- Route user requests to session services
+- URL Pattern: `https://<worker-domain>/<session-id>/<service-name>/...`
+
+#### WebSocket Proxy
+- Interactive service communication (Jupyter Kernel, SSH, etc.)
+- Real-time log streaming
+
+**Key Characteristics**:
+- SSL/TLS termination (Let's Encrypt auto-certificate)
+- High-performance async proxy
+- Connection pooling and reuse
+- Streaming support (large file downloads)
+- Sticky session support
+- Auto-retry and failover
+
+**Processing Flow**:
+
+#### HTTP Proxy Flow
+```
+User → HTTPS Request → Worker (SSL termination)
+                           ↓
+                       Parse URL (extract session_id, service_name)
+                           ↓
+                       Lookup route from local cache
+                           ↓
+                       Resolve backend address (agent:port)
+                           ↓
+                       Proxy request to agent
+                           ↓
+                       Stream response back to user
+```
+
+#### WebSocket Proxy Flow
+```
+User → WS Upgrade Request → Worker
+                               ↓
+                           Establish WS connection to agent
+                               ↓
+                           Bidirectional message forwarding
+```
+
+### 2. REST API (Management)
+
+**Framework**: aiohttp (async HTTP server)
+
+**Port**: 6040 (default, separate management port)
+
+**Key Features**:
+- Communication with Coordinator
+- Health check endpoints
+- Metrics exposure (Prometheus)
+- Internal management (no external access)
+
+### Component Interaction
+
+**Traffic Proxy Flow**:
+```
+User (Browser) → Worker (Port 5050) → Kernel (on Agent)
+                    │
+                    ├─ SSL/TLS termination
+                    ├─ Route resolution
+                    └─ Traffic proxying
+```
+
+**Management Flow**:
+```
+Coordinator → Worker REST API (Port 6040) → Route updates
+```

--- a/src/ai/backend/common/README.md
+++ b/src/ai/backend/common/README.md
@@ -1,12 +1,133 @@
-Backend.AI Commons
-==================
+Backend.AI Common Package
+=========================
+
+← [Back to Backend.AI Architecture](../README.md)
 
 [![PyPI release version](https://badge.fury.io/py/backend.ai-common.svg)](https://pypi.org/project/backend.ai-common/)
 ![Supported Python versions](https://img.shields.io/pypi/pyversions/backend.ai-common.svg)
 [![Gitter](https://badges.gitter.im/lablup/backend.ai-common.svg)](https://gitter.im/lablup/backend.ai-common)
 
-Common utilities library for Backend.AI
+## Overview
 
+The Backend.AI Common package provides utilities, infrastructure, and shared components used across all Backend.AI components (Manager, Agent, Storage Proxy, Webserver, App Proxy, etc.).
+
+## Package Structure
+
+### Entry Point System
+
+Core event-based communication and asynchronous task processing framework for Backend.AI.
+
+- **[events/](./events/README.md)** - Event Dispatcher System
+  - Asynchronous event-based communication between components
+  - Broadcast and Anycast event type support
+  - Message queue-based event delivery
+  - Event handler registration and routing
+
+- **[bgtask/](./bgtask/README.md)** - Background Task Handler System
+  - Process long-running tasks asynchronously
+  - Issue Task IDs and track tasks
+  - Progress monitoring and Heartbeat
+  - Notify via event publishing upon completion
+
+### Infrastructure Components
+
+Client and abstraction layer for integration with external services and systems.
+
+- **clients/** - External service client wrappers
+  - Agent client (ZeroMQ RPC)
+  - Storage Proxy client (HTTP/gRPC)
+  - Valkey/Redis client
+  - etcd client
+
+- **message_queue/** - Message queue interface and implementation
+  - Provide message publish/subscribe interface
+  - Currently implemented based on Redis Streams
+  - Consumer Group management
+  - Future support for other message queue systems planned
+
+- **service_discovery/** - Service registration and integration
+  - etcd-based service registration and discovery
+  - Provide service information for Prometheus metrics collection
+  - Automatic health check and update
+  - Future expansion of additional service discovery features planned
+
+- **resilience/** - Inter-layer communication resilience patterns
+  - Generalize request processing between layers
+  - Retry, Timeout, Circuit Breaker
+  - Automatic metric collection
+  - Fallback support
+
+### Data and Types
+
+Common structures for data exchange and type definitions between components.
+
+- **dto/** - Data Transfer Objects (for inter-component communication)
+  - Data structures used for inter-component communication
+  - Request/Response models
+  - Event payloads
+  - Recommended to use Pydantic-based
+
+- **types.py** - Common type definitions (for internal logic)
+  - Domain types used within components (SessionId, AgentId, AccessKey, etc.)
+  - Shared Enum types
+  - Common constants
+  - Mainly used in internal business logic
+
+### Utilities
+
+Utility modules for development convenience and common functionality.
+
+- **metrics/** - Metrics collection and Prometheus integration
+  - Metric observer pattern
+  - Prometheus metric types (Counter, Gauge, Histogram)
+  - HTTP metrics middleware
+
+- **auth/** - Authentication utilities
+  - Authentication between Webserver (Gateway) and Manager
+  - JWT token generation/verification
+  - Signature generation/verification
+  - API Key management
+
+- **web/** - Web utilities
+  - HTTP helper functions
+  - CORS configuration
+  - Request/response processing
+
+- **middlewares/** - Common middlewares
+  - Commonly used across all components
+  - Authentication middleware
+  - Logging middleware
+  - Error handling middleware
+
+- **configs/** - Configuration management utilities
+  - Configuration processing commonly used internally
+  - Configuration file parsing (TOML, YAML)
+  - Environment variable processing
+  - Configuration validation
+
+### Other Components
+
+- **contexts/** - Context management utilities
+  - ContextVar-based request and user tracking
+  - Current request ID tracking
+  - Current user information management
+  - Context propagation
+
+- **data/** - Common data utilities
+  - Data-based value processing used in internal logic
+  - Data transformation and validation
+  - Common data type handling
+
+- **exception.py** - Common exception classes
+  - Base exceptions for all Backend.AI services
+  - Exception definitions must inherit from BackendAIError
+  - Domain-specific exception classes
+  - Communicate error situations externally
+
+- **utils.py** - Other utility functions
+  - String processing
+  - Time conversion
+  - Other helper functions
 
 ## Installation
 
@@ -36,3 +157,11 @@ The tests for `common.redis` module requires availability of local TCP ports 163
 In macOS, they require a local `redis-server` executable to be installed, preferably via `brew`,
 because `docker compose` in macOS does not support host-mode networking and Redis *cannot* be
 configured to use different self IP addresses to announce to the cluster nodes and clients.
+
+## Related Documentation
+
+- [Event Dispatcher System](./events/README.md)
+- [Background Task Handler System](./bgtask/README.md)
+- [Manager Component](../manager/README.md)
+- [Agent Component](../agent/README.md)
+- [Storage Proxy Component](../storage/README.md)

--- a/src/ai/backend/common/bgtask/README.md
+++ b/src/ai/backend/common/bgtask/README.md
@@ -1,0 +1,175 @@
+# Background Task Handler System
+
+← [Back to Common Package](../README.md)
+
+## Overview
+
+The Background Task Handler system is a framework for asynchronously processing long-running tasks in Backend.AI. It issues Task IDs to track tasks and notifies upon completion via events.
+
+## Architecture
+
+```
+┌──────────────────────────────────────┐
+│    BackgroundTaskManager             │
+│                                      │
+│  - Task execution and management     │
+│  - Task metadata storage (Redis)     │
+│  - Event publishing                  │
+│  - Heartbeat and retry logic         │
+└───────────┬──────────────────────────┘
+            │
+            ├─→ Task Registry  (task registration)
+            ├─→ Task Hooks     (middleware processing)
+            └─→ ProgressReporter (progress reporting)
+                     │
+                     ↓
+            ┌────────────────────┐
+            │   Redis Storage    │ Metadata storage (recoverable)
+            └────────────────────┘
+                     │
+                     ↓
+            ┌────────────────────┐
+            │  Event Producer    │ Publish success/failure events
+            └────────────────────┘
+```
+
+## Key Components
+
+### 1. BackgroundTaskManager
+
+Central manager that manages all background tasks.
+
+**Key Features:**
+- Task startup and execution management
+- Store task metadata in Redis for recovery after server restart/failure
+- Publish task success/failure events to support monitoring by other components and users
+- Task status tracking via heartbeat
+- Retry failed tasks
+- Task cancellation and cleanup
+
+### 2. Task Types
+
+#### LocalBgtask
+Planned for deprecation.
+
+#### SingleBgtask
+Single task that can be retried on failure.
+
+**Characteristics:**
+- Store metadata in Redis
+- Retriable (`retriable() = True`)
+- Progress tracking available
+
+**Usage Examples:**
+- Image pulling tasks (requires progress tracking)
+- Large-scale data cleanup tasks
+- Long-running tasks
+
+#### ParallelBgtask
+Executes multiple tasks in parallel.
+
+**Characteristics:**
+- Only failed tasks can be retried when some tasks fail
+- Individual progress tracking of some tasks via event subscription
+- Execute multiple subtasks in parallel
+- Independent progress tracking for each subtask
+
+**Usage Examples:**
+- Simultaneously check status of multiple agents
+- Split and execute large-scale session cleanup tasks in batches
+
+### 3. Task Hooks
+
+Hooks executed before and after task execution handle additional features such as:
+
+- Task execution metric collection (start/completion time, success/failure count, etc.)
+- Publish task state change events
+- Clean up Redis metadata on task completion
+
+### 4. Task Registry
+
+Registry that registers and manages task handlers.
+
+## Task Lifecycle
+
+Tasks are created in `ONGOING` state immediately upon registration. There is no PENDING state.
+
+```
+┌──────────┐
+│ ONGOING  │ Task registration and execution start
+└────┬─────┘
+     │
+     ├─→ Success ─→ ┌──────────┐
+     │              │ SUCCESS  │
+     │              └──────────┘
+     │
+     ├─→ Failure ─→ ┌──────────┐
+     │              │ FAILURE  │ No more retries
+     │              └──────────┘
+     │
+     └─→ Cancel ─→ ┌───────────┐
+                   │ CANCELLED │
+                   └───────────┘
+```
+
+**Retry Mechanism**:
+- `FAILURE` state is the final failure state with no retries
+- Retries only apply to tasks that remain in `ONGOING` state but are no longer managed due to server restarts, etc.
+
+## State Management
+
+### Task States
+
+- `ONGOING`: Task executing
+- `SUCCESS`: Task completed successfully
+- `FAILURE`: Task failed
+- `CANCELLED`: Task cancelled
+
+### Heartbeat
+
+BackgroundTaskManager periodically sends heartbeats for running tasks. If a heartbeat is not updated for a certain period, the task can be retried by another server capable of performing it.
+
+## Redis Metadata Storage
+
+Task metadata is stored in Redis and used for recovery and monitoring upon server restart.
+
+## Event Publishing
+
+Events are published via Event Dispatcher when task state changes.
+
+### Published Events
+
+#### BgtaskUpdatedEvent
+Published when task progress is updated.
+
+#### BgtaskDoneEvent
+Published when task completes successfully.
+
+#### BgtaskFailedEvent
+Published when task fails.
+
+#### BgtaskCancelledEvent
+Published when task is cancelled.
+
+## Performance Considerations
+
+### Batch Processing
+
+When processing large volumes of items, divide into batches for processing.
+
+## Related Documentation
+
+- [Event Dispatcher System](../events/README.md) - Event publishing and subscription
+- [Manager Services](../../manager/services/README.md) - Using Background Tasks in Services
+- [Storage Background Tasks](../../storage/bgtask/) - Storage Proxy background tasks
+
+## Reference Materials
+
+### Task Type Selection Guide
+
+| Requirement | Recommended Task Type | Reason |
+|------------|----------------------|--------|
+| Retry needed | SingleBgtask | Can retry on failure |
+| Parallel processing needed | ParallelBgtask | Execute multiple tasks simultaneously |
+| Progress tracking needed | SingleBgtask/ParallelBgtask | Progress tracking available |
+| Long-running tasks | SingleBgtask/ParallelBgtask | Status tracking via heartbeat |

--- a/src/ai/backend/common/events/README.md
+++ b/src/ai/backend/common/events/README.md
@@ -1,0 +1,161 @@
+# Event Dispatcher System
+
+← [Back to Common Package](../README.md)
+
+## Overview
+
+The Event Dispatcher system provides asynchronous event-based communication between Backend.AI components. This system is a unified framework for event publishing, subscription, and processing, enabling efficient communication while maintaining loose coupling between components.
+
+**Important Notes:**
+- Message production and delivery are not guaranteed. Messages may be lost, so caution is required.
+- **Broadcast**: Attempts delivery to all subscribers, but message loss is possible. Use only for fast feedback, and it's recommended to use other mechanisms like polling for critical notifications.
+- **Anycast**: Delivered to only one consumer in the consumer group. Use when the task can be performed on any single server among multiple servers (task distribution, load balancing).
+
+## Architecture
+
+```
+┌──────────────────┐
+│  EventProducer   │  Event publishing
+│                  │
+│  - produce()     │
+└────────┬─────────┘
+         │
+         ↓ (Message Queue)
+         │
+┌────────┴─────────┐
+│ EventDispatcher  │  Event consumption and routing
+│                  │
+│  - consume()     │  Anycast events (1:1)
+│  - subscribe()   │  Broadcast events (1:N)
+└────────┬─────────┘
+         │
+         ↓
+┌────────┴─────────┐
+│  EventHandler    │  Event processing
+│                  │
+│  - callback()    │  Actual event processing logic
+│  - context       │  Handler context
+└──────────────────┘
+```
+
+## Key Components
+
+### 1. EventProducer
+
+Component that publishes events to the message queue.
+
+**Key Features:**
+- Publish event objects to message queue
+- Support Broadcast and Anycast event types
+- Event serialization and metadata management
+
+### 2. EventDispatcher
+
+Component that consumes events from the message queue and routes them to registered handlers.
+
+**Key Features:**
+- Anycast event consumption (Consumer): Only one subscriber processes
+- Broadcast event subscription (Subscriber): All subscribed servers can process messages
+- Event handler registration and management
+
+**Anycast vs Broadcast:**
+
+| Type | Anycast (Consumer) | Broadcast (Subscriber) |
+|------|-------------------|----------------------|
+| Processing | One of all subscribers processes | All subscribed servers can process |
+| Use Cases | Task distribution, load balancing | Notifications, state synchronization |
+| Message Queue | Uses Consumer Group | Independent stream per subscriber |
+
+### 3. EventHandler
+
+Component representing registered event handlers. Handlers process specific event types and operate in Anycast (CONSUMER) or Broadcast (SUBSCRIBER) mode.
+
+## Event Types
+
+### Event Type Directory Structure
+
+```
+event_types/
+├── kernel/          # Kernel lifecycle events
+├── session/         # Session state change events
+├── bgtask/          # Background task events
+├── agent/           # Agent state events
+├── vfolder/         # Virtual folder events
+├── volume/          # Volume management events
+├── image/           # Image registry events
+├── schedule/        # Scheduling events
+├── artifact/        # Artifact events
+├── artifact_registry/ # Artifact registry events
+├── model_serving/   # Model serving events
+├── log/             # Log events
+└── idle/            # Idle state events
+```
+
+### Major Event Types
+
+#### Kernel Events
+- `KernelTerminatedBroadcastEvent`: Kernel termination notification
+- `KernelStartedEvent`: Kernel start notification
+- `KernelPullingImageEvent`: Image download progress
+
+#### Session Events
+- `SessionStartedEvent`: Session start
+- `SessionTerminatedEvent`: Session termination
+- `SessionStatusChangedEvent`: Session status change
+
+#### Background Task Events
+- `BgtaskUpdatedEvent`: Task progress update
+- `BgtaskDoneEvent`: Task completion
+- `BgtaskFailedEvent`: Task failure
+- `BgtaskCancelledEvent`: Task cancellation
+
+#### Agent Events
+- `AgentHeartbeatEvent`: Agent heartbeat
+- `AgentStatusChangedEvent`: Agent status change
+
+## Component Usage Examples
+
+**Manager**: Publishes kernel/session state change events, subscribes to agent heartbeats
+
+**Agent**: Publishes kernel state events, subscribes to session execution requests
+
+**Storage Proxy**: Subscribes to folder deletion events and performs cleanup tasks
+
+## Message Queue Integration
+
+Event Dispatcher is currently implemented based on Redis Streams.
+
+- **Anycast**: Uses Consumer Group so only one consumer processes
+- **Broadcast**: Each subscriber consumes from independent stream
+
+## Monitoring
+
+System status can be monitored by automatically collecting event processing success/failure metrics and processing times.
+
+## Error Handling
+
+### When Handler Raises Exception
+
+- **Broadcast Events**: Continue processing without affecting other handlers
+- **Anycast Events**: Message moves to reprocessing queue (retry possible)
+
+### Retry Strategy
+
+Automatic retry is configured at message queue level:
+- Dead Letter Queue (DLQ) support
+- Maximum retry count setting
+- Backoff strategy
+
+## Performance Considerations
+
+### Handler Performance
+
+- **Async Processing**: All handlers written as async functions
+- **Avoid Blocking Operations**: CPU-intensive tasks separated into separate threads/processes
+- **Lightweight Handlers**: Keep handlers lightweight and delegate heavy tasks to Background Tasks
+
+## Related Documentation
+
+- [Background Task System](../bgtask/README.md) - Long-running task processing
+- [Message Queue](../message_queue/) - Message queue interface and implementation
+- [Manager Events API](../../manager/api/events.py) - SSE-based event streaming

--- a/src/ai/backend/manager/api/README.md
+++ b/src/ai/backend/manager/api/README.md
@@ -1,0 +1,102 @@
+# Manager REST API Entry Points
+
+← [Back to Manager](../README.md)
+
+## Overview
+
+Manager REST API provides Backend.AI's main HTTP-based API endpoints. Built on the Starlette web framework, it offers various features including session creation, virtual folder management, and user management.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────┐
+│         Client (SDK/CLI/Web UI)          │
+└────────────────┬─────────────────────────┘
+                 │
+                 ↓ HTTP Request
+┌────────────────────────────────────────────┐
+│            REST API Handler                │
+│         (Starlette Routes)                 │
+│                                            │
+│  - session.py (session creation/mgmt)      │
+│  - vfolder.py (virtual folders)            │
+│  - admin.py (admin tasks)                  │
+│  - auth.py (authentication)                │
+│  - scaling_group.py (scaling groups)       │
+│  - ... (other endpoints)                   │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│           Middleware Stack                 │
+│                                            │
+│  1. Authentication Middleware              │
+│  2. Rate Limiting Middleware               │
+│  3. Request Validation                     │
+│  4. Error Handling Middleware              │
+│  5. Metric Collection                      │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│         Action Processor Layer             │
+│                                            │
+│  - Authorization (RBAC)                    │
+│  - Action Validation                       │
+│  - Audit Logging                           │
+│  - Monitoring                              │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│           Services Layer                   │
+│                                            │
+│  - Business Logic                          │
+│  - External Service Orchestration          │
+│  - Quota/Limit Enforcement                 │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│         Repositories Layer                 │
+│                                            │
+│  - Data Access                             │
+│  - Transaction Management                  │
+└────────────────────────────────────────────┘
+```
+
+## Middleware Stack
+
+### 1. Authentication Middleware
+
+Handles authentication for API handlers with `@auth_required` decorator.
+
+**Supported Authentication Methods:**
+- **HMAC-SHA256 signature** (`Authorization` header)
+- **JWT token** (`X-Backendai-Token` header)
+
+### 2. Error Handling Middleware
+
+Converts exceptions to appropriate HTTP responses.
+
+## Actions Layer Integration
+
+REST API handlers and GraphQL handlers invoke Action Processor to execute business logic.
+
+**Handler Responsibilities:**
+- Only handles HTTP request/response data conversion
+- Creates Action objects and invokes Processor
+- Does not implement business logic directly
+
+See [Actions Layer Documentation](../actions/README.md) for details.
+
+## Error Handling
+
+Exceptions from each layer are converted to appropriate HTTP responses via Error Handling Middleware.
+
+## Related Documentation
+
+- [GraphQL API](./gql/README.md) - GraphQL endpoints
+- [Actions Layer](../actions/README.md) - Action Processor details
+- [Services Layer](../services/README.md) - Business logic
+- [Event Stream API](./events.py) - Server-Sent Events

--- a/src/ai/backend/manager/api/gql/README.md
+++ b/src/ai/backend/manager/api/gql/README.md
@@ -1,0 +1,76 @@
+# Manager GraphQL API (Strawberry)
+
+← [Back to Manager API](../README.md)
+
+## Overview
+
+Manager GraphQL API is a GraphQL interface built using the Strawberry framework.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────┐
+│      Client (Web UI/SDK)                 │
+└────────────────┬─────────────────────────┘
+                 │
+                 ↓ GraphQL Request
+┌────────────────────────────────────────────┐
+│        GraphQL Schema (Strawberry)         │
+│                                            │
+│  ┌─────────┐  ┌──────────┐  ┌──────────┐   │
+│  │  Query  │  │ Mutation │  │Subscript.│   │
+│  └─────────┘  └──────────┘  └──────────┘   │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│           Resolver Layer                   │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│         Data Loader Layer                  │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│       Action Processor Layer               │
+└────────────────┬───────────────────────────┘
+                 │
+                 ↓
+┌────────────────────────────────────────────┐
+│         Services Layer                     │
+└────────────────────────────────────────────┘
+```
+
+## Key Principles
+
+### Python Type Hints-Based
+Schemas are defined based on Python type hints using the Strawberry framework.
+
+### Using DataLoader
+DataLoader is used to solve N+1 query problems.
+
+### Service Layer Invocation
+All business logic is processed through the Services Layer.
+
+### Common Error Handling
+Raise `BackendAIError` to connect to common error handling middleware.
+
+### Real-time Subscription
+Provides real-time updates via WebSocket.
+
+## Schema Reference
+
+For detailed GraphQL schema information, refer to the [GraphQL Reference](../../../../docs/manager/graphql-reference) documentation.
+
+## Related Documentation
+
+- [Manager API Overview](../README.md)
+- [Legacy GraphQL (Graphene)](../../models/gql_models/README.md) - DEPRECATED
+- [Services Layer](../../services/README.md)
+- [Repositories Layer](../../repositories/README.md)
+
+## Migration from Graphene
+
+Currently migrating from Graphene to Strawberry. New features are implemented in Strawberry, and existing Graphene code is gradually migrated.

--- a/src/ai/backend/manager/models/gql_models/README.md
+++ b/src/ai/backend/manager/models/gql_models/README.md
@@ -1,0 +1,36 @@
+# Legacy GraphQL (Graphene) - DEPRECATED
+
+← [Back to Manager](../../README.md)
+
+## ⚠️ DEPRECATED
+
+**This GraphQL implementation is no longer in use.**
+
+New GraphQL endpoint development should use the **Strawberry**-based [New GraphQL API](../../api/gql/README.md).
+
+This directory provides only some Graphene-based endpoints for backward compatibility and is gradually being migrated to Strawberry.
+
+## Developer Guide
+
+### Developing New Endpoints
+
+**❌ Don't:**
+- Add new types or queries with Graphene
+- Create new files in `models/gql_models/`
+
+**✅ Do:**
+- Define new types with Strawberry
+- Create new files in `api/gql/`
+- Refer to [Strawberry Documentation](../../api/gql/README.md)
+
+### Modifying Existing Endpoints
+
+If you need to modify existing Graphene endpoints:
+
+1. **Urgent bug fixes**: Direct modification of Graphene code is acceptable
+2. **Feature additions/changes**: Migrate to Strawberry first, then work on it
+
+## Related Documentation
+
+- **[Strawberry GraphQL API](../../api/gql/README.md)** - New GraphQL API implementation
+- **[Manager Overview](../../README.md)** - Manager component architecture

--- a/src/ai/backend/manager/services/README.md
+++ b/src/ai/backend/manager/services/README.md
@@ -39,6 +39,7 @@ Database Models (models/)
 
 **Note**: Authorization is handled by the Action Processor layer, and transaction management is the responsibility of the Repository layer.
 
+
 ## Directory Structure
 
 ```

--- a/src/ai/backend/storage/README.md
+++ b/src/ai/backend/storage/README.md
@@ -36,6 +36,60 @@ The Storage Proxy provides a unified abstraction layer for various storage backe
 - Support parallel uploads/downloads
 - Optimize large file operations
 
+## Entry Points
+
+Storage Proxy has 4 entry points to receive and process external requests.
+
+### 1. REST API (Client)
+
+**Framework**: aiohttp (async HTTP server)
+
+**Port**: 6021 (default)
+
+**Location**: `src/ai/backend/storage/api/client.py`
+
+**Purpose**: External API used by Client SDK/CLI/Web UI
+
+**Key Features**:
+- File upload/download and VFolder management
+- API Key-based authentication
+- HTTP/HTTPS communication
+
+### 2. REST API (Manager)
+
+**Framework**: aiohttp (async HTTP server)
+
+**Port**: 6022 (default, separate from Client API)
+
+**Location**: `src/ai/backend/storage/api/manager.py`
+
+**Purpose**: Internal API used by Manager and Agent
+
+**Key Features**:
+- Manager-only API (internal network access only)
+- Provides VFolder mount information (used by Agent)
+- Volume and Quota management
+
+### 3. Event Dispatcher
+
+**Framework**: Backend.AI Event Dispatcher (Redis Streams-based)
+
+**Location**: `src/ai/backend/common/events/`
+
+**Key Features**:
+- VFolder lifecycle event publishing and consumption
+- Broadcast and Anycast event type support
+
+**Related Documentation**: [Event Dispatcher System](../common/events/README.md)
+
+### 4. Background Task Handler
+
+**Framework**: Backend.AI Background Task Handler (Valkey-based)
+
+**Location**: `src/ai/backend/common/bgtask/`
+
+**Related Documentation**: [Background Task Handler System](../common/bgtask/README.md)
+
 ## Architecture
 
 ```
@@ -47,13 +101,11 @@ The Storage Proxy provides a unified abstraction layer for various storage backe
 │       VFS Layer (vfs/)                  │  ← Virtual filesystem
 ├─────────────────────────────────────────┤
 │  Storage Backends (storages/)           │  ← Backend implementations
-│  ├── CephFS                             │
-│  ├── NetApp                             │
-│  ├── PureStorage                        │
-│  ├── Dell EMC                           │
 │  └── ...                                │
 └─────────────────────────────────────────┘
 ```
+
+**Supported Storage Backends**: See `volumes/` directory for available backend implementations.
 
 ## Directory Structure
 
@@ -69,12 +121,7 @@ storage/
 │   ├── base.py         # VFS base classes
 │   └── local.py        # Local filesystem implementation
 ├── storages/           # Backend-specific implementations
-│   ├── cephfs/         # CephFS support
-│   ├── netapp/         # NetApp support
-│   ├── purestorage/    # Pure Storage support
-│   ├── dellemc/        # Dell EMC support
-│   ├── weka/           # WekaFS support
-│   └── ...
+│   └── ...             # See volumes/ directory
 ├── volumes/            # Volume management
 │   └── quota.py        # Quota tracking
 ├── bgtask/             # Background tasks
@@ -108,16 +155,7 @@ Each backend implements a common interface:
 - `get_quota()`: Query vfolder usage and quota
 - `set_quota()`: Update vfolder quota
 
-Supported backends:
-- **CephFS**: Ceph filesystem
-- **NetApp**: NetApp ONTAP storage
-- **Pure Storage**: Pure Storage FlashBlade
-- **Dell EMC**: Dell EMC Isilon/PowerScale
-- **WekaFS**: Weka filesystem
-- **VAST**: VAST Data storage
-- **DDN**: DataDirect Networks storage
-- **XFS**: Local XFS filesystem
-- **NFS**: Generic NFS mount
+**Supported backends**: See `volumes/` directory for available backend implementations.
 
 ### VFolder Types
 


### PR DESCRIPTION
Complete English translation of component documentation including common package, manager, and repositories sections. This ensures consistent English-only documentation across all Backend.AI components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves #6593 (BA-2927)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
