### PR TITLE
chore: Use current endpoint for graphql url in graphiql

### DIFF
--- a/src/ai/backend/manager/api/spec.py
+++ b/src/ai/backend/manager/api/spec.py
@@ -90,8 +90,8 @@ GRAPHIQL_V2_HTML = """
 
     <script>
       const fetcher = GraphiQL.createFetcher({
-        url: 'http://0.0.0.0:8090/func/admin/gql',
-        subscriptionUrl: 'ws://0.0.0.0:8090/func/admin/gql'
+        url: '/func/admin/gql',
+        subscriptionUrl: '/func/admin/gql'
       });
 
       ReactDOM.render(


### PR DESCRIPTION
resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
