### PR TITLE
fix(BA-2844): Refresh VAST cluster info cache (#6428)

### DIFF
--- a/changes/6428.fix.md
+++ b/changes/6428.fix.md
@@ -1,0 +1,1 @@
+Refresh VAST cluster info cache rather than keep the cache alive forever

--- a/src/ai/backend/storage/volumes/vast/__init__.py
+++ b/src/ai/backend/storage/volumes/vast/__init__.py
@@ -229,10 +229,11 @@ class VASTVolume(BaseVolume):
             api_version=self.config["vast_api_version"],
             ssl=ssl_verify,
             force_login=self.config["vast_force_login"],
+            cluster_info_cache_ttl=self.config["vast_cluster_info_cache_ttl"],
         )
 
     async def shutdown(self) -> None:
-        self.api_client.cache.cluster_info = None
+        pass
 
     async def create_quota_model(self) -> VASTQuotaModel:
         return VASTQuotaModel(self.mount_path, self.api_client)

--- a/src/ai/backend/storage/volumes/vast/config.py
+++ b/src/ai/backend/storage/volumes/vast/config.py
@@ -6,6 +6,7 @@ import trafaret as t
 from ai.backend.common import validators as tx
 
 DEFAULT_CLUSTER_ID: Final = 1
+DEFAULT_CLUSTER_INFO_CACHE_TTL: Final = 120.0  # seconds
 
 
 class APIVersion(StrEnum):
@@ -23,4 +24,5 @@ config_iv = t.Dict({
     t.Key("vast_api_version", default=APIVersion.V2): tx.Enum(APIVersion),
     t.Key("vast_cluster_id", default=DEFAULT_CLUSTER_ID): t.Int,
     t.Key("vast_storage_base_dir", default="/"): t.String(),
+    t.Key("vast_cluster_info_cache_ttl", default=DEFAULT_CLUSTER_INFO_CACHE_TTL): t.Float,
 }).allow_extra("*")


### PR DESCRIPTION
This is an auto-generated backport PR of #6428 to the 25.15 release.