### PR TITLE
fix(BA-2997): Handle redirect parameter in app proxy auth endpoint

### DIFF
--- a/changes/6686.fix.md
+++ b/changes/6686.fix.md
@@ -1,0 +1,1 @@
+Fix app proxy to properly handle redirect parameter in HTTP protocol auth flow by appending the redirect path to the generated proxy URL


### PR DESCRIPTION
## Summary

Fixed an issue where the `redirect` query parameter in `/v2/proxy/auth` requests was being ignored for HTTP protocol apps. The app proxy now correctly handles the redirect path by incorporating it into the URL generation logic.

## Problem

When accessing apps through `/v2/proxy/auth` with a redirect parameter (e.g., `?redirect=/notebooks/08_dimensionality_reduction.ipynb`), the parameter was:
- ✅ Received in coordinator as query parameter
- ✅ Encoded into JWT token body  
- ✅ Decoded in worker setup handler
- ❌ **NOT APPENDED** to the final proxy URL

## Solution

Refactored the URL generation to handle redirect paths within the `generate_proxy_url` function:
- Added `redirect_path` optional parameter to `generate_proxy_url()`
- Function now generates complete URLs including redirect paths
- Ensures redirect paths start with `/` for proper URL construction
- Simplified HTTP protocol handler to use the enhanced function

## Changes

- Modified `generate_proxy_url()` to accept and process redirect paths
- Updated HTTP protocol case to pass redirect parameter to URL generator
- Added explicit `redirect_path=None` for TCP protocol for clarity
- Created changelog entry in `changes/2997.fix.md`

## Test plan

- [x] Create a session with Jupyter notebook app
- [x] Access `/v2/proxy/auth?app=jupyter&protocol=http&token={token}&session_id={session_id}&redirect=/notebooks/08_dimensionality_reduction.ipynb`
- [x] Verify it redirects to `http://127.0.0.1:10200/notebooks/08_dimensionality_reduction.ipynb` (complete path)
- [x] Verify that without redirect parameter, it redirects to base URL only
- [x] Test with various redirect paths (with/without leading slash)

## Example

**Before:** `?redirect=/notebooks/test.ipynb` → Redirects to `http://127.0.0.1:10200/` (base URL only)  
**After:** `?redirect=/notebooks/test.ipynb` → Redirects to `http://127.0.0.1:10200/notebooks/test.ipynb` (full path)