### PR TITLE
feat(BA-3032): Add Hive router setup in install_halfstack()

### DIFF
--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -265,7 +265,6 @@ class Context(metaclass=ABCMeta):
     async def install_halfstack(self) -> None:
         self.log_header("Installing halfstack...")
 
-        # TODO: 설치할 때 routing url이 달라질수 있으니 인스톨러에서 flag로 세팅하여 routing_url 수정하도록 변경필요
         self.log_header("Generating supergraph.graphql via rover CLI...")
 
         compose_cmd = [


### PR DESCRIPTION
resolves #6739  (BA-3032)

This PR updates the setup process for the Hive Router container.
It uses the Rover CLI to make gateway.config.ts and supergraph.graphql, ensuring the container starts correctly with the required configuration files

**Checklist:** (if applicable)
- [x] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options