### PR TITLE
fix: Ensure monitoring containers start by copying configs

### DIFF
--- a/src/ai/backend/install/configs/loki-config.yaml
+++ b/src/ai/backend/install/configs/loki-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/loki/loki-config.yaml

--- a/src/ai/backend/install/configs/otel-collector-config.yaml
+++ b/src/ai/backend/install/configs/otel-collector-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/otel/otel-collector-config.yaml

--- a/src/ai/backend/install/configs/tempo-config.yaml
+++ b/src/ai/backend/install/configs/tempo-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/tempo/tempo-config.yaml

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -268,6 +268,9 @@ class Context(metaclass=ABCMeta):
         self.copy_config("prometheus.yaml")
         self.copy_config("grafana-dashboards")
         self.copy_config("grafana-provisioning")
+        self.copy_config("otel-collector-config.yaml")
+        self.copy_config("loki-config.yaml")
+        self.copy_config("tempo-config.yaml")
 
         volume_path = self.install_info.base_path / "volumes"
         (volume_path / "postgres-data").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
resolves #6744  (BA-3035)
This pull request updates the installation process for observability tools by adding support for OpenTelemetry Collector, Loki, and Tempo. The main changes involve including new configuration files and ensuring they are copied during the installation routine.

**Observability stack configuration:**

* Added `otel-collector-config.yaml`, `loki-config.yaml`, and `tempo-config.yaml` symlinks to the `src/ai/backend/install/configs` directory, referencing their respective locations in the central configs folder.
* Updated the `install_halfstack` method in `context.py` to copy these new configuration files during installation.
**Checklist:** (if applicable)

- [x] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
