### PR TITLE
fix(BA-3053): Add missing advertise_address info in app proxy status response (#6772)

### DIFF
--- a/changes/6772.fix.md
+++ b/changes/6772.fix.md
@@ -1,0 +1,1 @@
+Add missing advertise_address info in app proxy status response

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -720,8 +720,17 @@ async def on_prepare(request: web.Request, response: web.StreamResponse) -> None
 
 
 async def status(request: web.Request) -> web.Response:
+    root_ctx: RootContext = request.app["_root.context"]
     request["do_not_print_access_log"] = True
-    return web.json_response({"api_version": "v2"})
+    advertised_addr = root_ctx.local_config.proxy_coordinator.advertised_addr
+    if advertised_addr is None:
+        return web.json_response({
+            "api_version": "v2",
+        })
+    return web.json_response({
+        "api_version": "v2",
+        "advertise_address": str(root_ctx.local_config.proxy_coordinator.advertised_addr),
+    })
 
 
 def handle_loop_error(


### PR DESCRIPTION
This is an auto-generated backport PR of #6772 to the 25.15 release.