### PR TITLE
feat(BA-3017): Add missing and new fields to service field specifications (#6714)

### DIFF
--- a/changes/6714.feature.md
+++ b/changes/6714.feature.md
@@ -1,0 +1,1 @@
+Add missing and newly introduced fields to service field specifications

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -306,6 +306,7 @@ service_fields = FieldSet([
     FieldSpec("resource_slots", formatter=nested_dict_formatter),
     FieldSpec("url"),
     FieldSpec("model"),
+    FieldSpec("model_definition_path"),
     FieldSpec("model_mount_destination"),
     FieldSpec("created_user"),
     FieldSpec("session_owner"),
@@ -320,10 +321,16 @@ service_fields = FieldSet([
     FieldSpec("cluster_mode"),
     FieldSpec("cluster_size"),
     FieldSpec("open_to_public"),
+    FieldSpec("runtime_variant"),
+    FieldSpec("created_at"),
+    FieldSpec("destroyed_at"),
     FieldSpec(
         "routings { routing_id session status traffic_ratio }",
         formatter=InlineRoutingFormatter(),
     ),
+    FieldSpec("retries"),
+    FieldSpec("status"),
+    FieldSpec("lifecycle_stage"),
 ])
 
 


### PR DESCRIPTION
This is an auto-generated backport PR of #6714 to the 25.6 release.