### PR TITLE
feat(BA-2958): Support bind, advertised address configuration for app proxy (#6631)

### DIFF
--- a/changes/6631.feature.md
+++ b/changes/6631.feature.md
@@ -1,0 +1,1 @@
+Support bind, advertised address configuration options for app-proxy coordinator and worker components

--- a/configs/app-proxy-coordinator/halfstack.toml
+++ b/configs/app-proxy-coordinator/halfstack.toml
@@ -18,6 +18,11 @@ aiomonitor_webui_port = 49510
 allow_unauthorized_configure_request = true
 
 [proxy_coordinator.bind_addr]
+host = "0.0.0.0"
+port = 10200
+
+[proxy_coordinator.advertised_addr]
+# Change `host` and `port` to the actual host and port for user access
 host = "127.0.0.1"
 port = 10200
 

--- a/configs/app-proxy-worker/halfstack.toml
+++ b/configs/app-proxy-worker/halfstack.toml
@@ -11,10 +11,14 @@ aiomonitor_webui_port = 49610
 frontend_mode = "port"
 protocol = "http"
 accepted_traffics = ["inference", "interactive"]
-api_bind_addr = { host = "127.0.0.1", port = 10201 }
+api_bind_addr = { host = "0.0.0.0", port = 10201 }
+# Change `host` to the public/external address for user access. Change `port` only if port mapping is in use.
+api_advertised_addr = { host = "127.0.0.1", port = 10201 }
 
 [proxy_worker.port_proxy]
-bind_host = "127.0.0.1"
+bind_host = "0.0.0.0"
+# Change to the actual host for user access
+advertised_host = "127.0.0.1"
 bind_port_range = [10205, 10300]
 
 [secrets]


### PR DESCRIPTION
This is an auto-generated backport PR of #6631 to the 25.15 release.