### PR TITLE
fix(BA-2921): Disallow dot('.') usage in model service name (#6800)

### DIFF
--- a/changes/6800.fix.md
+++ b/changes/6800.fix.md
@@ -1,0 +1,1 @@
+Disallow dot('.') usage in model service name

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -940,6 +940,9 @@
         "properties": {
           "name": {
             "description": "Name of the service",
+            "maxLength": 24,
+            "minLength": 4,
+            "pattern": "^\\w[\\w-]*\\w$",
             "title": "Name",
             "type": "string"
           },

--- a/src/ai/backend/common/typed_validators.py
+++ b/src/ai/backend/common/typed_validators.py
@@ -2,7 +2,6 @@ import datetime
 import ipaddress
 import os
 import pwd
-import re
 from collections.abc import Mapping, Sequence
 from datetime import tzinfo
 from pathlib import Path
@@ -169,20 +168,6 @@ NaiveTimeDuration = Annotated[TVariousDelta, _NaiveTimeDurationPydanticAnnotatio
 """Time duration validator which also accepts negative value"""
 
 SESSION_NAME_MAX_LENGTH: Final[int] = 24
-SESSION_NAME_MATCHER = re.compile(
-    r"^(?=.{4,%d}$)\w[\w.-]*\w$" % (SESSION_NAME_MAX_LENGTH,), re.ASCII
-)
-
-
-def session_name_validator(s: str) -> str:
-    if SESSION_NAME_MATCHER.search(s):
-        return s
-    else:
-        raise AssertionError(f"String did not match {SESSION_NAME_MATCHER}")
-
-
-SessionName = Annotated[str, AfterValidator(session_name_validator)]
-"""Validator with extended re.ASCII option to match session name string literal"""
 
 
 def _vfolder_name_validator(name: str) -> str:

--- a/src/ai/backend/manager/api/service.py
+++ b/src/ai/backend/manager/api/service.py
@@ -410,9 +410,12 @@ class ValidationResult:
 
 
 class NewServiceRequestModel(LegacyBaseRequestModel):
-    service_name: tv.SessionName = Field(
+    service_name: str = Field(
         description="Name of the service",
         validation_alias=AliasChoices("name", "clientSessionToken"),
+        pattern=r"^\w[\w-]*\w$",
+        min_length=4,
+        max_length=tv.SESSION_NAME_MAX_LENGTH,
     )
     replicas: int = Field(
         description="Number of sessions to serve traffic. Replacement of `desired_session_count` (or `desiredSessionCount`).",


### PR DESCRIPTION
This is an auto-generated backport PR of #6800 to the 25.15 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--6805.org.readthedocs.build/en/6805/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--6805.org.readthedocs.build/ko/6805/

<!-- readthedocs-preview sorna-ko end -->