### PR TITLE
fix(BA-3054): Wrong parse of inference metrics (#6801)

### DIFF
--- a/changes/6801.fix.md
+++ b/changes/6801.fix.md
@@ -1,0 +1,1 @@
+Fix auto-scaling functionality for inference services when using framework-based scaling rules. Metrics collection and rule comparison logic have been corrected to ensure proper scaling behavior

--- a/src/ai/backend/appproxy/worker/metrics.py
+++ b/src/ai/backend/appproxy/worker/metrics.py
@@ -100,13 +100,17 @@ async def gather_prometheus_inference_measures(
                             histogram_metrics_labels[metric_name] = tuple(labels)
                             histogram_bucket_metrics[metric_name][route.route_id] = tuple(values)
                         case "gauge":
-                            gauge_metrics[metric_name][route.route_id] = Decimal(
-                                metric_family.samples[0].value
-                            )
+                            try:
+                                value = metric_family.samples[0].value
+                            except IndexError:
+                                continue
+                            gauge_metrics[metric_name][route.route_id] = Decimal(value)
                         case "counter":
-                            counter_metrics[metric_name][route.route_id] = Decimal(
-                                metric_family.samples[0].value
-                            )
+                            try:
+                                value = metric_family.samples[0].value
+                            except IndexError:
+                                continue
+                            counter_metrics[metric_name][route.route_id] = Decimal(value)
 
     measures: list[InferenceMeasurement] = []
     for metric_name, per_route_histogram_metrics in histogram_bucket_metrics.items():

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, DecimalException
 from typing import Any, Optional, cast
 
 import tomli
@@ -639,7 +639,23 @@ class DeploymentRepository:
 
                 metric_value = cast(dict[str, Any], endpoint_stat[rule.condition.metric_name])
                 route_count = len(routes) if routes else 1
-                current_value = Decimal(str(metric_value.get("current", 0))) / Decimal(route_count)
+                metric_type = metric_value.get("__type")
+                match metric_type:
+                    case "HISTOGRAM":
+                        log.exception("Unable to set auto-scaling rule on histogram metrics. Skip")
+                        continue
+                    case "GAUGE" | "COUNTER" | _:
+                        current_metric_value = metric_value.get("current", 0)
+                        try:
+                            current_value = Decimal(str(current_metric_value)) / Decimal(
+                                route_count
+                            )
+                        except DecimalException:
+                            log.exception(
+                                "Unable parse metric value '{}' to decimal. Skip",
+                                current_metric_value,
+                            )
+                            continue
 
             else:
                 log.warning(


### PR DESCRIPTION
This is an auto-generated backport PR of #6801 to the 25.15 release.