### PR TITLE
feat(BA-3077): modify the `scripts/delete-dev.sh` script to include a confirmation step

### DIFF
--- a/changes/6815.feature.md
+++ b/changes/6815.feature.md
@@ -1,0 +1,1 @@
+delete-dev.sh now supports interactive confirmation and non-interactive -y/--yes flag.

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -95,12 +95,16 @@ REMOVE_VENVS=1
 REMOVE_CONTAINERS=1
 REMOVE_DB=1
 
+FORCE_YES=0
+FORCE_NO=0
+
 while [ $# -gt 0 ]; do
   case $1 in
     -h | --help)           usage; exit 1 ;;
     --skip-venvs)          REMOVE_VENVS=0 ;;
     --skip-containers)     REMOVE_CONTAINERS=0 ;;
     --skip-db)             REMOVE_DB=0 ;;
+    -y | --yes)            FORCE_YES=1 ;;
     *)
       echo "Unknown option: $1"
       echo "Run '$0 --help' for usage."
@@ -108,6 +112,20 @@ while [ $# -gt 0 ]; do
   esac
   shift 1
 done
+
+# Confirm before deleting all resources
+if [ $FORCE_YES -eq 1 ]; then
+  show_info "Proceeding without confirmation (--yes flag)."
+else
+  echo ""
+  echo -n "Are you sure you want to delete all development resources? [y/N]: "
+  read -r confirm
+  confirm=$(echo "$confirm" | tr '[:upper:]' '[:lower:]')
+  if [ "$confirm" != "y" ] && [ "$confirm" != "yes" ]; then
+    show_warning "Deletion cancelled."
+    exit 0
+  fi
+fi
 
 if [ $REMOVE_VENVS -eq 1 ]; then
   show_info "Removing the unified and temporary venvs..."


### PR DESCRIPTION
resolves BA-3077

# Add confirmation prompt to [delete-dev.sh](http://delete-dev.sh) script

This PR adds a confirmation prompt to the `delete-dev.sh` script to prevent accidental deletion of development resources. The script now asks the user to confirm with "y" before proceeding with the deletion process, providing an additional safety measure.

**Checklist:**

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
    - Fixtures for db schema changes
    - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
    - Demonstrate the difference of before/after
    - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
    - Contents in the `docs` directory
    - docstrings in public interfaces and type annotations