### PR TITLE
fix(BA-3088): Ensure no default ID set until instance ID fetched

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -45,7 +45,7 @@ from typing import (
     TypeVar,
     cast,
 )
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import aiotools
 import attrs
@@ -852,7 +852,7 @@ class AbstractAgent(
         self.loop = current_loop()
         self.etcd = etcd
         self.local_config = local_config
-        self.id = AgentId(local_config.agent.id or f"agent-{uuid4()}")
+        self.id = AgentId(local_config.agent.defaulted_id)
         self.local_instance_id = generate_local_instance_id(__file__)
         self.agent_public_key = agent_public_key
         self.kernel_registry = kernel_registry.agent_mapping(self.id)

--- a/src/ai/backend/agent/etcd.py
+++ b/src/ai/backend/agent/etcd.py
@@ -36,7 +36,7 @@ class AgentEtcdClientView(AbstractKVStore):
         """
         return {
             ConfigScopes.SGROUP: f"sgroup/{self._config.agent.scaling_group}",
-            ConfigScopes.NODE: f"nodes/agents/{self._config.agent.id}",
+            ConfigScopes.NODE: f"nodes/agents/{self._config.agent.defaulted_id}",
         }
 
     def _augment_scope_prefix_map(

--- a/src/ai/backend/agent/runtime.py
+++ b/src/ai/backend/agent/runtime.py
@@ -58,7 +58,7 @@ class AgentRuntime:
         create_agent_tasks: list[asyncio.Task] = []
         async with asyncio.TaskGroup() as tg:
             for agent_config in agent_configs:
-                agent_id = AgentId(agent_config.agent.id)
+                agent_id = AgentId(agent_config.agent.defaulted_id)
 
                 etcd_view = AgentEtcdClientView(etcd, agent_config)
                 etcd_views[agent_id] = etcd_view

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -344,8 +344,8 @@ class AgentRPCServer(aobject):
 
         # Start serving requests.
         async with asyncio.TaskGroup() as tg:
-            for agent_id in self.local_config.agent_ids:
-                tg.create_task(self.update_status("starting", agent_id))
+            for agent in self.runtime.get_agents():
+                tg.create_task(self.update_status("starting", agent.id))
 
         rpc_addr = self.local_config.agent_common.rpc_listen_addr
         self.rpc_server = Peer(
@@ -1352,7 +1352,7 @@ async def etcd_ctx(local_config: AgentUnifiedConfig) -> AsyncGenerator[AsyncEtcd
     scope_prefix_map = {
         ConfigScopes.GLOBAL: "",
         ConfigScopes.SGROUP: f"sgroup/{local_config.agent.scaling_group}",
-        ConfigScopes.NODE: f"nodes/agents/{local_config.agent.id}",
+        ConfigScopes.NODE: f"nodes/agents/{local_config.agent.defaulted_id}",
     }
     etcd_config_data = local_config.etcd.to_dataclass()
     etcd = AsyncEtcd(
@@ -1490,7 +1490,7 @@ async def service_discovery_ctx(
         sd_type,
         service_discovery,
         ServiceMetadata(
-            display_name=f"agent-{local_config.agent_default.id}",  # defaults to instance id
+            display_name=f"agent-{local_config.agent_default.defaulted_id}",  # defaults to instance id
             service_group="agent",
             version=VERSION,
             endpoint=ServiceEndpoint(


### PR DESCRIPTION
resolves #NNN (BA-3088)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

There was a bug in the Agent config parsing, where the default agent ID value was being set before it could be overridden with the instance ID of the nodes. This change fixes this issue by making sure that the agent ID on the config side remains optional, and we set defaults only after the server had the chance of setting the agent ID to the ID of the node instance.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
