### PR TITLE
fix: Ensure monitoring containers start by copying configs (#6745)

### DIFF
--- a/src/ai/backend/install/configs/loki-config.yaml
+++ b/src/ai/backend/install/configs/loki-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/loki/loki-config.yaml

--- a/src/ai/backend/install/configs/otel-collector-config.yaml
+++ b/src/ai/backend/install/configs/otel-collector-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/otel/otel-collector-config.yaml

--- a/src/ai/backend/install/configs/tempo-config.yaml
+++ b/src/ai/backend/install/configs/tempo-config.yaml
@@ -1,0 +1,1 @@
+../../../../../configs/tempo/tempo-config.yaml

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -263,6 +263,9 @@ class Context(metaclass=ABCMeta):
         self.copy_config("prometheus.yaml")
         self.copy_config("grafana-dashboards")
         self.copy_config("grafana-provisioning")
+        self.copy_config("otel-collector-config.yaml")
+        self.copy_config("loki-config.yaml")
+        self.copy_config("tempo-config.yaml")
 
         volume_path = self.install_info.base_path / "volumes"
         (volume_path / "postgres-data").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This is an auto-generated backport PR of #6745 to the 25.15 release.