### PR TITLE
fix(BA-3134): PureStorage client incorrectly using context variables (#6913)

### DIFF
--- a/changes/6913.fix.md
+++ b/changes/6913.fix.md
@@ -1,0 +1,1 @@
+fix Pure Storage client to properly handle authentication tokens. Previously, tokens were incorrectly stored in context variables, which could cause the client to lose access to authentication credentials

--- a/src/ai/backend/storage/volumes/purestorage/exceptions.py
+++ b/src/ai/backend/storage/volumes/purestorage/exceptions.py
@@ -1,0 +1,21 @@
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class UnauthorizedPurityClient(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/purity-unauthorized-client"
+    error_title = "Unauthorized Purity Client"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.STORAGE,
+            operation=ErrorOperation.ACCESS,
+            error_detail=ErrorDetail.UNAUTHORIZED,
+        )


### PR DESCRIPTION
This is an auto-generated backport PR of #6913 to the 25.17 release.