### PR TITLE
feat(BA-3138): Replace GlobalTimer with LeaderCron in App Proxy (#6927)

### DIFF
--- a/changes/6927.feature.md
+++ b/changes/6927.feature.md
@@ -1,0 +1,1 @@
+Replace GlobalTimer with LeaderCron in App Proxy

--- a/src/ai/backend/appproxy/coordinator/types.py
+++ b/src/ai/backend/appproxy/coordinator/types.py
@@ -35,6 +35,7 @@ from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiv
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.health_checker.probe import HealthProbe
+from ai.backend.common.leader import ValkeyLeaderElection
 from ai.backend.common.lock import AbstractDistributedLock
 from ai.backend.common.metrics.metric import (
     APIMetricObserver,
@@ -291,6 +292,7 @@ class RootContext:
 
     metrics: CoordinatorMetricRegistry
     health_probe: HealthProbe
+    leader_election: ValkeyLeaderElection
 
 
 CleanupContext: TypeAlias = Callable[["RootContext"], AsyncContextManager[None]]


### PR DESCRIPTION
This is an auto-generated backport PR of #6927 to the 25.17 release.