### PR TITLE
fix(BA-3146): Remove model definition YAML requirement for non-CUSTOM runtimes (#6936)

### DIFF
--- a/changes/6936.fix.md
+++ b/changes/6936.fix.md
@@ -1,0 +1,1 @@
+Remove model definition YAML requirement for non-CUSTOM runtimes

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/custom.py
@@ -18,8 +18,8 @@ class CustomModelDefinitionGenerator(ModelDefinitionGenerator):
 
     @override
     async def generate_model_definition(self, model_revision: ModelRevisionSpec) -> ModelDefinition:
-        definition_files = await self._deployment_repository.fetch_definition_files(
+        model_definition_content = await self._deployment_repository.fetch_model_definition(
             vfolder_id=model_revision.mounts.model_vfolder_id,
             model_definition_path=model_revision.mounts.model_definition_path,
         )
-        return ModelDefinition.model_validate(definition_files.model_definition)
+        return ModelDefinition.model_validate(model_definition_content)

--- a/src/ai/backend/manager/sokovan/deployment/revision_generator/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_generator/base.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from ai.backend.common.types import RuntimeVariant
 from ai.backend.manager.data.deployment.types import (
-    DefinitionFiles,
     ModelRevisionSpec,
     ModelRevisionSpecDraft,
     ModelServiceDefinition,
@@ -93,14 +92,9 @@ class BaseRevisionGenerator(RevisionGenerator):
         - resource_slots.mem: "16gb" (from root)
         - environ: {MY_VAR: "default", VLLM_SPECIFIC: "true"} (merged)
         """
-        definition_files: DefinitionFiles = (
-            await self._deployment_repository.fetch_definition_files(
-                vfolder_id=vfolder_id,
-                model_definition_path=model_definition_path,
-            )
+        service_definition_dict = await self._deployment_repository.fetch_service_definition(
+            vfolder_id
         )
-
-        service_definition_dict = definition_files.service_definition
         if service_definition_dict is None:
             return None
 

--- a/src/ai/backend/manager/sokovan/deployment/revision_generator/custom.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_generator/custom.py
@@ -5,7 +5,6 @@ from typing import override
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.manager.data.deployment.types import (
-    DefinitionFiles,
     ModelRevisionSpec,
 )
 from ai.backend.manager.sokovan.deployment.revision_generator.base import BaseRevisionGenerator
@@ -24,14 +23,12 @@ class CustomRevisionGenerator(BaseRevisionGenerator):
         """
         Validate CUSTOM variant revision by checking model definition.
         """
-        definition_files: DefinitionFiles = (
-            await self._deployment_repository.fetch_definition_files(
-                vfolder_id=revision.mounts.model_vfolder_id,
-                model_definition_path=revision.mounts.model_definition_path,
-            )
+        model_definition_content = await self._deployment_repository.fetch_model_definition(
+            vfolder_id=revision.mounts.model_vfolder_id,
+            model_definition_path=revision.mounts.model_definition_path,
         )
 
         try:
-            ModelDefinition.model_validate(definition_files.model_definition)
+            ModelDefinition.model_validate(model_definition_content)
         except Exception as e:
             raise InvalidAPIParameters(f"Invalid model definition for CUSTOM variant: {e}") from e


### PR DESCRIPTION
This is an auto-generated backport PR of #6936 to the 25.17 release.