### PR TITLE
fix(BA-3185): Add initial_delay field to model_definition_iv trafaret validator (#7001)

### DIFF
--- a/changes/7001.fix.md
+++ b/changes/7001.fix.md
@@ -1,0 +1,1 @@
+Add initial_delay field to model_definition_iv trafaret validator

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -168,6 +168,7 @@ model_definition_iv = t.Dict({
                     t.Key("max_retries", default=10): t.Null | t.ToInt[1:],
                     t.Key("max_wait_time", default=15): t.Null | t.ToFloat[0:],
                     t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
+                    t.Key("initial_delay", default=60): t.Null | t.ToFloat[0:],
                 }),
             }),
             t.Key("metadata", default=None): t.Null


### PR DESCRIPTION
This is an auto-generated backport PR of #7001 to the 25.17 release.