### PR TITLE
fix(BA-3188): Ensure primary agent uses old registry file name (#7009)

### DIFF
--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 import os
 import pickle
@@ -316,6 +317,11 @@ class CreateTaskInfo:
 
     kernel_id: KernelId
     session_id: SessionId
+
+
+class AgentClass(enum.Enum):
+    PRIMARY = enum.auto()
+    AUXILIARY = enum.auto()
 
 
 class AbstractKernelCreationContext(aobject, Generic[KernelObjectType]):
@@ -770,6 +776,7 @@ class AbstractAgent(
     aobject, Generic[KernelObjectType, KernelCreationContextType], metaclass=ABCMeta
 ):
     id: AgentId
+    agent_class: AgentClass
     loop: asyncio.AbstractEventLoop
     local_config: AgentUnifiedConfig
     etcd: AgentEtcdClientView
@@ -850,6 +857,7 @@ class AbstractAgent(
         kernel_registry: KernelRegistry,
         computers: Mapping[DeviceName, ComputerContext],
         slots: Mapping[SlotName, Decimal],
+        agent_class: AgentClass,
     ) -> None:
         self._skip_initial_scan = skip_initial_scan
         self.loop = current_loop()
@@ -857,6 +865,7 @@ class AbstractAgent(
         self.local_config = local_config
         self.id = AgentId(local_config.agent.defaulted_id)
         self.local_instance_id = generate_local_instance_id(__file__)
+        self.agent_class = agent_class
         self.agent_public_key = agent_public_key
         self.kernel_registry = kernel_registry.agent_mapping(self.id)
         self.computers = computers
@@ -2229,9 +2238,10 @@ class AbstractAgent(
         """
         ipc_base_path = self.local_config.agent.ipc_base_path
         var_base_path = self.local_config.agent.var_base_path
-        last_registry_file = f"last_registry.{self.id}.dat"
-        if os.path.isfile(ipc_base_path / last_registry_file):
-            shutil.move(ipc_base_path / last_registry_file, var_base_path / last_registry_file)
+        ipc_last_registry_file = self._resolve_conflicting_registry_file(ipc_base_path)
+        last_registry_file = self._resolve_conflicting_registry_file(var_base_path)
+        if (ipc_base_path / ipc_last_registry_file).is_file():
+            shutil.move(ipc_base_path / ipc_last_registry_file, var_base_path / last_registry_file)
         try:
             with open(var_base_path / last_registry_file, "rb") as f:
                 self.kernel_registry = pickle.load(f)
@@ -3698,7 +3708,7 @@ class AbstractAgent(
         if (not force) and (now <= self.last_registry_written_time + 60):
             return  # don't save too frequently
         var_base_path = self.local_config.agent.var_base_path
-        last_registry_file = f"last_registry.{self.id}.dat"
+        last_registry_file = self._last_registry_file
         try:
             with open(var_base_path / last_registry_file, "wb") as f:
                 pickle.dump(self.kernel_registry, f)
@@ -3710,6 +3720,36 @@ class AbstractAgent(
                 os.remove(var_base_path / last_registry_file)
             except FileNotFoundError:
                 pass
+
+    @property
+    def _last_registry_file(self) -> str:
+        match self.agent_class:
+            case AgentClass.PRIMARY:
+                return self._primary_last_registry_file
+            case AgentClass.AUXILIARY:
+                return self._auxiliary_last_registry_file
+
+    @property
+    def _primary_last_registry_file(self) -> str:
+        return f"last_registry.{self.local_instance_id}.dat"
+
+    @property
+    def _auxiliary_last_registry_file(self) -> str:
+        return f"last_registry.{self.id}.dat"
+
+    def _resolve_conflicting_registry_file(self, base_dir: Path) -> str:
+        primary_agent_file = base_dir / self._primary_last_registry_file
+        auxiliary_agent_file = base_dir / self._auxiliary_last_registry_file
+        if primary_agent_file.is_file() and auxiliary_agent_file.is_file():
+            primary_modification_time = primary_agent_file.stat().st_mtime
+            auxiliary_modification_time = auxiliary_agent_file.stat().st_mtime
+
+            if primary_modification_time > auxiliary_modification_time:
+                return self._primary_last_registry_file
+            else:
+                return self._auxiliary_last_registry_file
+        else:
+            return self._last_registry_file
 
 
 async def handle_volume_mount(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -104,6 +104,7 @@ from ..agent import (
     ACTIVE_STATUS_SET,
     AbstractAgent,
     AbstractKernelCreationContext,
+    AgentClass,
     ScanImagesResult,
 )
 from ..config.unified import AgentUnifiedConfig, ContainerSandboxType, ScratchType
@@ -1356,6 +1357,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         kernel_registry: KernelRegistry,
         computers: Mapping[DeviceName, ComputerContext],
         slots: Mapping[SlotName, Decimal],
+        agent_class: AgentClass,
     ) -> None:
         super().__init__(
             etcd,
@@ -1367,6 +1369,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             kernel_registry=kernel_registry,
             computers=computers,
             slots=slots,
+            agent_class=agent_class,
         )
         self.checked_invalid_images = set()
 

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -65,6 +65,7 @@ from ..agent import (
     ACTIVE_STATUS_SET,
     AbstractAgent,
     AbstractKernelCreationContext,
+    AgentClass,
     ScanImagesResult,
 )
 from ..config.unified import AgentUnifiedConfig, ScratchType
@@ -846,6 +847,7 @@ class KubernetesAgent(
         kernel_registry: KernelRegistry,
         computers: Mapping[DeviceName, ComputerContext],
         slots: Mapping[SlotName, Decimal],
+        agent_class: AgentClass,
     ) -> None:
         super().__init__(
             etcd,
@@ -857,6 +859,7 @@ class KubernetesAgent(
             kernel_registry=kernel_registry,
             computers=computers,
             slots=slots,
+            agent_class=agent_class,
         )
 
     async def __ainit__(self) -> None:

--- a/tests/agent/docker/test_agent.py
+++ b/tests/agent/docker/test_agent.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiodocker.exceptions import DockerError
 
+from ai.backend.agent.agent import AgentClass
 from ai.backend.agent.docker.agent import DockerAgent
 from ai.backend.agent.kernel import KernelRegistry
 from ai.backend.common.arch import DEFAULT_IMAGE_ARCH
@@ -40,6 +41,7 @@ async def agent(local_config, test_id, mocker, socket_relay_image):
         kernel_registry=kernel_registry,
         computers={},
         slots={},
+        agent_class=AgentClass.PRIMARY,
     )  # for faster test iteration
     agent.local_instance_id = test_case_id  # use per-test private registry file
     try:


### PR DESCRIPTION
This is an auto-generated backport PR of #7009 to the 25.17 release.