### PR TITLE
fix(BA-3200): Add tarfile.data_filter to prevent path traversal attacks (#7035)

### DIFF
--- a/changes/7035.fix.md
+++ b/changes/7035.fix.md
@@ -1,0 +1,1 @@
+Add tarfile.data_filter to prevent path traversal attacks

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1114,7 +1114,7 @@ class ComputeSession(BaseFunction):
                         pbar.update(len(chunk))
                     fp.close()
                     with tarfile.open(fp.name) as tarf:
-                        tarf.extractall(path=dest)
+                        tarf.extractall(path=dest, filter=tarfile.data_filter)
                         file_names.extend(tarf.getnames())
                     os.unlink(fp.name)
         return {"file_names": file_names}

--- a/src/ai/backend/storage/services/artifacts/reservoir.py
+++ b/src/ai/backend/storage/services/artifacts/reservoir.py
@@ -1130,7 +1130,7 @@ class TarExtractor:
                     log.warning(f"Failed to remove temp file {temp_file}: {e}")
 
     def _extract_tar(self, tar_path: Path, target_dir: Path) -> None:
-        """Extract tar archive to target directory."""
+        """Extract tar archive to target directory safely."""
         with tarfile.open(tar_path, "r") as tar:
-            tar.extractall(path=target_dir)
+            tar.extractall(path=target_dir, filter=tarfile.data_filter)
         log.debug(f"Tar extraction completed: {tar_path} -> {target_dir}")


### PR DESCRIPTION
This is an auto-generated backport PR of #7035 to the 25.17 release.