### PR TITLE
fix(BA-3200): Add tarfile.data_filter to prevent path traversal attacks (#7035)

### DIFF
--- a/changes/7035.fix.md
+++ b/changes/7035.fix.md
@@ -1,0 +1,1 @@
+Add tarfile.data_filter to prevent path traversal attacks

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -1114,7 +1114,7 @@ class ComputeSession(BaseFunction):
                         pbar.update(len(chunk))
                     fp.close()
                     with tarfile.open(fp.name) as tarf:
-                        tarf.extractall(path=dest)
+                        tarf.extractall(path=dest, filter=tarfile.data_filter)
                         file_names.extend(tarf.getnames())
                     os.unlink(fp.name)
         return {"file_names": file_names}


### PR DESCRIPTION
This is an auto-generated backport PR of #7035 to the 25.15 release.