### PR TITLE
fix(BA-3199): Remove faulty multi agent device separation logic (#7024)

### DIFF
--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -236,17 +236,6 @@ class AbstractAllocMap(metaclass=ABCMeta):
                     hint_for_next_allocation.append(dev)
         affinity_hint.devices = hint_for_next_allocation
 
-    @final
-    def update_device_slot_amounts(self, slot_amounts: Mapping[SlotName, Decimal]) -> None:
-        self.device_slots = {
-            device_id: DeviceSlotInfo(
-                slot_type=slot_info.slot_type,
-                slot_name=slot_info.slot_name,
-                amount=slot_amounts[slot_info.slot_name],
-            )
-            for device_id, slot_info in self.device_slots.items()
-        }
-
     @abstractmethod
     def allocate(
         self,

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -614,7 +614,6 @@ class ResourceAllocator(aobject):
             devices_allocated_slots.append(device_allocated_slots)
 
             agent_alloc_map = await ctx.instance.create_alloc_map()
-            agent_alloc_map.update_device_slot_amounts(device_allocated_slots)
             agent_computers[device_name] = ComputerContext(
                 ctx.instance, ctx.devices, agent_alloc_map
             )

--- a/tests/agent/test_resource_allocation.py
+++ b/tests/agent/test_resource_allocation.py
@@ -25,6 +25,7 @@ from ai.backend.agent.config.unified import (
     ResourceAllocationMode,
 )
 from ai.backend.agent.resources import (
+    AbstractComputeDevice,
     AbstractComputePlugin,
     ResourceAllocator,
 )
@@ -151,6 +152,13 @@ def create_mock_computers(
         mock_plugin: AbstractComputePlugin = Mock(spec=AbstractComputePlugin)  # type: ignore[assignment]
         mock_plugin.get_metadata.return_value = {"slot_name": str(device_name)}  # type: ignore[attr-defined]
 
+        # Create mock devices for each device_id in the alloc_map
+        mock_devices: list[AbstractComputeDevice] = []
+        for dev_id in alloc_map.device_slots.keys():
+            mock_device: AbstractComputeDevice = Mock(spec=AbstractComputeDevice)  # type: ignore[assignment]
+            mock_device.device_id = dev_id  # type: ignore[attr-defined]
+            mock_devices.append(mock_device)
+
         # Create a fresh alloc_map for each call
         async def _create_alloc_map(original_map: AbstractAllocMap = alloc_map) -> AbstractAllocMap:  # type: ignore[misc]
             if isinstance(original_map, FractionAllocMap):
@@ -166,7 +174,7 @@ def create_mock_computers(
             raise NotImplementedError(f"Unsupported alloc_map type: {type(original_map)}")
 
         mock_plugin.create_alloc_map = _create_alloc_map  # type: ignore[attr-defined,assignment]
-        mock_plugin.list_devices = AsyncMock(return_value=[])  # type: ignore[attr-defined,method-assign]
+        mock_plugin.list_devices = AsyncMock(return_value=mock_devices)  # type: ignore[attr-defined,method-assign]
         mock_plugin.cleanup = AsyncMock(return_value=None)  # type: ignore[attr-defined,method-assign]
 
         result[device_name] = mock_plugin
@@ -235,8 +243,7 @@ class TestSharedMode:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
@@ -276,9 +283,10 @@ class TestSharedMode:
             reserved_mem="4G",
         )
 
+        # Create 8 CPU devices (1 core each). Single mem device with 16G.
         computers = create_mock_computers({
             DeviceName("cpu"): create_fraction_alloc_map({
-                DeviceId("cpu"): (SlotName("cpu"), Decimal("8")),
+                DeviceId(f"cpu{i}"): (SlotName("cpu"), Decimal("1")) for i in range(8)
             }),
             DeviceName("root"): create_fraction_alloc_map({
                 DeviceId("root"): (SlotName("mem"), Decimal(BinarySize.finite_from_str("16G"))),
@@ -287,25 +295,25 @@ class TestSharedMode:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
 
-        expected_cpu = Decimal("8") - Decimal("2")
-        expected_mem = Decimal(BinarySize.finite_from_str("16G")) - Decimal(
-            BinarySize.finite_from_str("4G")
-        )
+        # alloc_map shows original hardware amounts (unchanged)
+        for i in range(8):
+            assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
+                DeviceId(f"cpu{i}")
+            ].amount == Decimal("1")
+        assert agent1_computers[DeviceName("root")].alloc_map.device_slots[
+            DeviceId("root")
+        ].amount == Decimal(BinarySize.finite_from_str("16G"))
 
-        # In SHARED mode with single agent, resources are reduced by reservation
-        assert (
-            agent1_computers[DeviceName("cpu")].alloc_map.device_slots[DeviceId("cpu")].amount
-            == expected_cpu
-        )
-        assert (
-            agent1_computers[DeviceName("root")].alloc_map.device_slots[DeviceId("root")].amount
-            == expected_mem
-        )
+        # SHARED mode: reserved_slots = system reserved only (not from other agents)
+        # For CPU: total=8, available=6, reserved_slots = 8 - 6 = 2
+        # For mem: total=16G, available=12G, reserved_slots = 16G - 12G = 4G
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        assert reserved1[SlotName("cpu")] == Decimal("2")
+        assert reserved1[SlotName("mem")] == Decimal(BinarySize.finite_from_str("4G"))
 
         await allocator.__aexit__(None, None, None)
 
@@ -321,6 +329,7 @@ class TestAutoSplitMode:
             num_agents=2,
         )
 
+        # Single CUDA device with 1.0 shares
         computers = create_mock_computers({
             DeviceName("cuda"): create_fraction_alloc_map({
                 DeviceId("cuda"): (SlotName("cuda.shares"), Decimal("1.0")),
@@ -329,20 +338,21 @@ class TestAutoSplitMode:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # Each agent gets half
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("0.5")
+        ].amount == Decimal("1.0")
         assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("0.5")
+        ].amount == Decimal("1.0")
 
+        # AUTO_SPLIT: Each agent gets half (1.0 / 2 = 0.5)
+        # reserved_slots = total - allocated = 1.0 - 0.5 = 0.5
         reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
         reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
         assert reserved1[SlotName("cuda.shares")] == Decimal("0.5")
@@ -360,6 +370,7 @@ class TestAutoSplitMode:
             num_agents=2,
         )
 
+        # Single CUDA device with 8 slots
         computers = create_mock_computers({
             DeviceName("cuda"): create_discrete_alloc_map({
                 DeviceId("cuda"): (SlotName("cuda"), Decimal("8")),
@@ -368,19 +379,25 @@ class TestAutoSplitMode:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # Each agent gets 4
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("4")
+        ].amount == Decimal("8")
         assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("4")
+        ].amount == Decimal("8")
+
+        # AUTO_SPLIT: Each agent gets 4 (8 / 2 agents)
+        # reserved_slots = total - allocated = 8 - 4 = 4
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cuda")] == Decimal("4")
+        assert reserved2[SlotName("cuda")] == Decimal("4")
 
         await allocator.__aexit__(None, None, None)
 
@@ -394,6 +411,7 @@ class TestAutoSplitMode:
             num_agents=3,
         )
 
+        # Single CUDA device with 5 slots
         computers = create_mock_computers({
             DeviceName("cuda"): create_discrete_alloc_map({
                 DeviceId("cuda"): (SlotName("cuda"), Decimal("5")),
@@ -402,24 +420,32 @@ class TestAutoSplitMode:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
-        # 5 divided by 3 = 1 with remainder 2
-        # First two agents get 2, last agent gets 1
+        # alloc_map shows original hardware amounts (unchanged)
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
         agent3_computers = allocator.get_computers(AgentId("agent3"))
 
         assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("2")
+        ].amount == Decimal("5")
         assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("2")
+        ].amount == Decimal("5")
         assert agent3_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda")
-        ].amount == Decimal("1")
+        ].amount == Decimal("5")
+
+        # 5 divided by 3 = 1 with remainder 2
+        # First two agents get 2, last agent gets 1
+        # reserved_slots = total - allocated
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        reserved3 = allocator.agent_reserved_slots[AgentId("agent3")]
+        assert reserved1[SlotName("cuda")] == Decimal("3")  # 5 - 2 = 3
+        assert reserved2[SlotName("cuda")] == Decimal("3")  # 5 - 2 = 3
+        assert reserved3[SlotName("cuda")] == Decimal("4")  # 5 - 1 = 4
 
         await allocator.__aexit__(None, None, None)
 
@@ -434,31 +460,34 @@ class TestAutoSplitMode:
             num_agents=2,
         )
 
+        # 8 CPU devices with 2 cores each (total 16 cores)
         computers = create_mock_computers({
             DeviceName("cpu"): create_fraction_alloc_map({
-                DeviceId("cpu"): (SlotName("cpu"), Decimal("16")),
+                DeviceId(f"cpu{i}"): (SlotName("cpu"), Decimal("2")) for i in range(8)
             }),
         })
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # (16 - 4) / 2 = 6 per agent
-        assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
-            DeviceId("cpu")
-        ].amount == Decimal("6")
-        assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
-            DeviceId("cpu")
-        ].amount == Decimal("6")
+        # alloc_map shows original hardware amounts (unchanged)
+        for i in range(8):
+            assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
+                DeviceId(f"cpu{i}")
+            ].amount == Decimal("2")
+            assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
+                DeviceId(f"cpu{i}")
+            ].amount == Decimal("2")
 
+        # Total = 16, reserved_cpu = 4, available = 12
+        # Split between 2 agents: 12 / 2 = 6 per agent
+        # reserved_slots = total - allocated = 16 - 6 = 10
         reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
         reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
-        # Each agent has 10 reserved away (6 for other agent + 4 for system)
         assert reserved1[SlotName("cpu")] == Decimal("10")
         assert reserved2[SlotName("cpu")] == Decimal("10")
 
@@ -478,34 +507,47 @@ class TestManualMode:
             num_agents=2,
         )
 
+        # Separate CPU and mem devices in different device groups
+        # CPU device group with 1 device (16 cores)
+        # Root device group with 1 device (32G mem)
         computers = create_mock_computers({
             DeviceName("cpu"): create_fraction_alloc_map({
                 DeviceId("cpu"): (SlotName("cpu"), Decimal("16")),
+            }),
+            DeviceName("root"): create_fraction_alloc_map({
                 DeviceId("mem"): (SlotName("mem"), Decimal(BinarySize.finite_from_str("32G"))),
             }),
         })
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # Each agent gets exactly what was allocated
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("4")
-        assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
+        ].amount == Decimal("16")
+        assert agent1_computers[DeviceName("root")].alloc_map.device_slots[
             DeviceId("mem")
-        ].amount == Decimal(BinarySize.finite_from_str("8G"))
+        ].amount == Decimal(BinarySize.finite_from_str("32G"))
         assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("4")
-        assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
+        ].amount == Decimal("16")
+        assert agent2_computers[DeviceName("root")].alloc_map.device_slots[
             DeviceId("mem")
-        ].amount == Decimal(BinarySize.finite_from_str("8G"))
+        ].amount == Decimal(BinarySize.finite_from_str("32G"))
+
+        # MANUAL mode: Each agent gets 4 CPU and 8G mem
+        # reserved_slots = total - allocated
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cpu")] == Decimal("12")  # 16 - 4 = 12
+        assert reserved1[SlotName("mem")] == Decimal(BinarySize.finite_from_str("24G"))  # 32G - 8G
+        assert reserved2[SlotName("cpu")] == Decimal("12")
+        assert reserved2[SlotName("mem")] == Decimal(BinarySize.finite_from_str("24G"))
 
         await allocator.__aexit__(None, None, None)
 
@@ -519,35 +561,41 @@ class TestManualMode:
             allocated_cpu=8,
             allocated_mem="16G",
             allocated_devices={
-                SlotName("cuda.shares"): Decimal("0.3"),
-                SlotName("cuda.mem"): Decimal("8000000000"),
+                SlotName("cuda.shares"): Decimal("0.5"),
             },
         )
 
+        # Each device in its own group
+        # CPU device group with 1 device
+        # Root device group with 1 device (mem)
+        # CUDA device group with 1 device (cuda.shares only)
         computers = create_mock_computers({
             DeviceName("cpu"): create_fraction_alloc_map({
                 DeviceId("cpu"): (SlotName("cpu"), Decimal("16")),
+            }),
+            DeviceName("root"): create_fraction_alloc_map({
                 DeviceId("mem"): (SlotName("mem"), Decimal(BinarySize.finite_from_str("32G"))),
             }),
             DeviceName("cuda"): create_fraction_alloc_map({
-                DeviceId("cuda.shares"): (SlotName("cuda.shares"), Decimal("1.0")),
-                DeviceId("cuda.mem"): (SlotName("cuda.mem"), Decimal("16000000000")),
+                DeviceId("cuda0"): (SlotName("cuda.shares"), Decimal("1.0")),
             }),
         })
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
 
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
-            DeviceId("cuda.shares")
-        ].amount == Decimal("0.3")
-        assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
-            DeviceId("cuda.mem")
-        ].amount == Decimal("8000000000")
+            DeviceId("cuda0")
+        ].amount == Decimal("1.0")
+
+        # MANUAL mode: agent gets 0.5 cuda.shares
+        # reserved_slots = total - allocated = 1.0 - 0.5 = 0.5
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        assert reserved1[SlotName("cuda.shares")] == Decimal("0.5")
 
         await allocator.__aexit__(None, None, None)
 
@@ -580,8 +628,7 @@ class TestMultiDeviceScenarios:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         # Verify total slots by summing from computers
         total_cpu = sum(
@@ -595,13 +642,20 @@ class TestMultiDeviceScenarios:
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # Each agent gets 4 cores (8 / 2 agents)
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("4")
+        ].amount == Decimal("8")
         assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("4")
+        ].amount == Decimal("8")
+
+        # AUTO_SPLIT: Each agent gets 4 cores (8 / 2 agents)
+        # reserved_slots = total - allocated = 8 - 4 = 4
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cpu")] == Decimal("4")
+        assert reserved2[SlotName("cpu")] == Decimal("4")
 
         await allocator.__aexit__(None, None, None)
 
@@ -617,30 +671,37 @@ class TestMultiDeviceScenarios:
             allocated_mem="8G",
         )
 
-        # Create 1 CPU device with 8 cores and 1 memory device
+        # Separate CPU and memory into different device groups
+        # CPU device group with 1 device (8 cores)
+        # Root device group with 1 device (16G mem)
         computers = create_mock_computers({
             DeviceName("cpu"): create_discrete_alloc_map({
                 DeviceId("cpu"): (SlotName("cpu"), Decimal("8")),
+            }),
+            DeviceName("root"): create_discrete_alloc_map({
                 DeviceId("mem"): (SlotName("mem"), Decimal(BinarySize.finite_from_str("16G"))),
             }),
         })
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
 
-        # CPU device should show the manually allocated amount (3 cores out of 8 available)
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("3")
-
-        # Memory device should be set to allocated amount (8G out of 16G available)
-        assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
+        ].amount == Decimal("8")
+        assert agent1_computers[DeviceName("root")].alloc_map.device_slots[
             DeviceId("mem")
-        ].amount == Decimal(BinarySize.finite_from_str("8G"))
+        ].amount == Decimal(BinarySize.finite_from_str("16G"))
+
+        # MANUAL mode: agent gets 3 CPU cores and 8G mem
+        # reserved_slots = total - allocated
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        assert reserved1[SlotName("cpu")] == Decimal("5")  # 8 - 3 = 5
+        assert reserved1[SlotName("mem")] == Decimal(BinarySize.finite_from_str("8G"))  # 16G - 8G
 
         await allocator.__aexit__(None, None, None)
 
@@ -664,8 +725,7 @@ class TestMultiDeviceScenarios:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         # 4 GPUs × 8GB each = 32GB total VRAM
         total_cuda_mem = sum(
@@ -698,24 +758,24 @@ class TestMultiDeviceScenarios:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
         agent3_computers = allocator.get_computers(AgentId("agent3"))
 
-        # In SHARED mode, all agents see all devices with full capacity
+        # In SHARED mode, all agents see all devices
+        # Total = 4, with 4 devices, amount per device = 4 / 4 = 1
         for i in range(4):
             assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
                 DeviceId(f"cuda{i}")
-            ].amount == Decimal("4")
+            ].amount == Decimal("1")
             assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
                 DeviceId(f"cuda{i}")
-            ].amount == Decimal("4")
+            ].amount == Decimal("1")
             assert agent3_computers[DeviceName("cuda")].alloc_map.device_slots[
                 DeviceId(f"cuda{i}")
-            ].amount == Decimal("4")
+            ].amount == Decimal("1")
 
         await allocator.__aexit__(None, None, None)
 
@@ -746,8 +806,7 @@ class TestMultiDeviceScenarios:
 
         setup_mock_resources(monkeypatch, computers)
 
-        allocator = ResourceAllocator(config, mock_etcd)
-        await allocator.__ainit__()
+        allocator = await ResourceAllocator.new(config, mock_etcd)
 
         # Verify total slots by summing from computers
         total_cpu = sum(
@@ -768,20 +827,109 @@ class TestMultiDeviceScenarios:
         agent1_computers = allocator.get_computers(AgentId("agent1"))
         agent2_computers = allocator.get_computers(AgentId("agent2"))
 
-        # CPU split: each agent gets 2 cores (4 / 2 agents)
+        # alloc_map shows original hardware amounts (unchanged)
         assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("2")
+        ].amount == Decimal("4")
         assert agent2_computers[DeviceName("cpu")].alloc_map.device_slots[
             DeviceId("cpu")
-        ].amount == Decimal("2")
-
-        # GPU shares split fractionally: each agent gets 0.5 shares
+        ].amount == Decimal("4")
         assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda0")
-        ].amount == Decimal("0.5")
+        ].amount == Decimal("1.0")
         assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
             DeviceId("cuda0")
-        ].amount == Decimal("0.5")
+        ].amount == Decimal("1.0")
+
+        # AUTO_SPLIT:
+        # CPU: each agent gets 2 cores, reserved = 4 - 2 = 2
+        # GPU shares: each agent gets 0.5 shares, reserved = 1.0 - 0.5 = 0.5
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cpu")] == Decimal("2")
+        assert reserved2[SlotName("cpu")] == Decimal("2")
+        assert reserved1[SlotName("cuda.shares")] == Decimal("0.5")
+        assert reserved2[SlotName("cuda.shares")] == Decimal("0.5")
+
+        await allocator.__aexit__(None, None, None)
+
+    async def test_multi_gpu_auto_split(
+        self,
+        mock_etcd: AsyncEtcd,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test AUTO_SPLIT with multiple GPU devices sharing the same slot type."""
+        config = create_test_config(
+            allocation_mode=ResourceAllocationMode.AUTO_SPLIT,
+            num_agents=2,
+        )
+
+        # 4 GPU devices with 1.0 shares each (total 4.0 shares)
+        computers = create_mock_computers({
+            DeviceName("cuda"): create_fraction_alloc_map({
+                DeviceId(f"cuda{i}"): (SlotName("cuda.shares"), Decimal("1.0")) for i in range(4)
+            }),
+        })
+
+        setup_mock_resources(monkeypatch, computers)
+
+        allocator = await ResourceAllocator.new(config, mock_etcd)
+
+        agent1_computers = allocator.get_computers(AgentId("agent1"))
+        agent2_computers = allocator.get_computers(AgentId("agent2"))
+
+        # alloc_map shows original hardware amounts (unchanged)
+        for i in range(4):
+            assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
+                DeviceId(f"cuda{i}")
+            ].amount == Decimal("1.0")
+            assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
+                DeviceId(f"cuda{i}")
+            ].amount == Decimal("1.0")
+
+        # AUTO_SPLIT: Total = 4.0 shares, each agent gets 2.0 shares
+        # reserved_slots = total - allocated = 4.0 - 2.0 = 2.0
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cuda.shares")] == Decimal("2")
+        assert reserved2[SlotName("cuda.shares")] == Decimal("2")
+
+        await allocator.__aexit__(None, None, None)
+
+    async def test_multi_gpu_shared_mode_with_reservation(
+        self,
+        mock_etcd: AsyncEtcd,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test SHARED mode with multiple GPU devices and system reservation."""
+        config = create_test_config(
+            allocation_mode=ResourceAllocationMode.SHARED,
+            num_agents=2,
+        )
+
+        # 4 GPU devices with 8GB memory each (total 32GB)
+        computers = create_mock_computers({
+            DeviceName("cuda"): create_discrete_alloc_map({
+                DeviceId(f"cuda{i}"): (SlotName("cuda.mem"), Decimal("8000000000"))
+                for i in range(4)
+            }),
+        })
+
+        setup_mock_resources(monkeypatch, computers)
+
+        allocator = await ResourceAllocator.new(config, mock_etcd)
+
+        agent1_computers = allocator.get_computers(AgentId("agent1"))
+        agent2_computers = allocator.get_computers(AgentId("agent2"))
+
+        # SHARED mode: both agents get full resources
+        # Total = 32GB, with 4 devices, per-device = 32GB / 4 = 8GB
+        for i in range(4):
+            assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
+                DeviceId(f"cuda{i}")
+            ].amount == Decimal("8000000000")
+            assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
+                DeviceId(f"cuda{i}")
+            ].amount == Decimal("8000000000")
 
         await allocator.__aexit__(None, None, None)


### PR DESCRIPTION
This is an auto-generated backport PR of #7024 to the 25.17 release.