### PR TITLE
test(artifact): Update tests to use Querier pattern (Part 4/4)

### DIFF
--- a/tests/manager/services/artifact/actions/test_list_artifacts.py
+++ b/tests/manager/services/artifact/actions/test_list_artifacts.py
@@ -1,13 +1,11 @@
 import pytest
 
-from ai.backend.manager.repositories.artifact.repository import ArtifactOrderingOptions
-from ai.backend.manager.repositories.types import PaginationOptions
+from ai.backend.manager.repositories.base import OffsetPagination, Querier
 from ai.backend.manager.services.artifact.actions.list import (
     ListArtifactsAction,
     ListArtifactsActionResult,
 )
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
-from ai.backend.manager.types import OffsetBasedPaginationOptions
 
 from ...fixtures import (
     ARTIFACT_FIXTURE_DATA,
@@ -22,11 +20,10 @@ from ...utils import ScenarioBase
         ScenarioBase.success(
             "Success Case - List all artifacts",
             ListArtifactsAction(
-                pagination=PaginationOptions(
-                    offset=OffsetBasedPaginationOptions(
-                        limit=10,
-                        offset=0,
-                    )
+                querier=Querier(
+                    conditions=[],
+                    orders=[],
+                    pagination=OffsetPagination(limit=10, offset=0),
                 ),
             ),
             ListArtifactsActionResult(
@@ -37,13 +34,11 @@ from ...utils import ScenarioBase
         ScenarioBase.success(
             "Success Case - List with ordering",
             ListArtifactsAction(
-                pagination=PaginationOptions(
-                    offset=OffsetBasedPaginationOptions(
-                        limit=10,
-                        offset=0,
-                    )
+                querier=Querier(
+                    conditions=[],
+                    orders=[],
+                    pagination=OffsetPagination(limit=10, offset=0),
                 ),
-                ordering=ArtifactOrderingOptions(),
             ),
             ListArtifactsActionResult(
                 data=[ARTIFACT_FIXTURE_DATA],

--- a/tests/manager/services/artifact_revision/actions/test_list_artifact_revisions.py
+++ b/tests/manager/services/artifact_revision/actions/test_list_artifact_revisions.py
@@ -1,15 +1,11 @@
 import pytest
 
-from ai.backend.manager.repositories.artifact.types import (
-    ArtifactRevisionOrderingOptions,
-)
-from ai.backend.manager.repositories.types import PaginationOptions
+from ai.backend.manager.repositories.base import OffsetPagination, Querier
 from ai.backend.manager.services.artifact_revision.actions.list import (
     ListArtifactRevisionsAction,
     ListArtifactRevisionsActionResult,
 )
 from ai.backend.manager.services.artifact_revision.processors import ArtifactRevisionProcessors
-from ai.backend.manager.types import OffsetBasedPaginationOptions
 
 from ...fixtures import (
     ARTIFACT_FIXTURE_DICT,
@@ -25,11 +21,10 @@ from ...utils import ScenarioBase
         ScenarioBase.success(
             "Success Case - List all artifact revisions",
             ListArtifactRevisionsAction(
-                pagination=PaginationOptions(
-                    offset=OffsetBasedPaginationOptions(
-                        limit=10,
-                        offset=0,
-                    )
+                querier=Querier(
+                    conditions=[],
+                    orders=[],
+                    pagination=OffsetPagination(limit=10, offset=0),
                 ),
             ),
             ListArtifactRevisionsActionResult(
@@ -40,13 +35,11 @@ from ...utils import ScenarioBase
         ScenarioBase.success(
             "Success Case - List with ordering",
             ListArtifactRevisionsAction(
-                pagination=PaginationOptions(
-                    offset=OffsetBasedPaginationOptions(
-                        limit=10,
-                        offset=0,
-                    )
+                querier=Querier(
+                    conditions=[],
+                    orders=[],
+                    pagination=OffsetPagination(limit=10, offset=0),
                 ),
-                ordering=ArtifactRevisionOrderingOptions(),
             ),
             ListArtifactRevisionsActionResult(
                 data=[ARTIFACT_REVISION_FIXTURE_DATA],


### PR DESCRIPTION
## Summary
Part 4 of 4-part refactoring (split from PR #7083).

Updates tests to use new Querier-based repository methods instead of old pagination methods.

## Changes (-12 lines net)
- Update artifact service tests to use Querier pattern
- Update artifact revision service tests to use Querier pattern

## Related Issue
BA-3233

## Dependencies
Depends on PR #7091 (Part 3/4)

Generated with [Claude Code](https://claude.com/claude-code)