### PR TITLE
feat(BA-3251): Update dry_run to use Sokovan scheduler event

### DIFF
--- a/changes/7119.feature.md
+++ b/changes/7119.feature.md
@@ -1,0 +1,1 @@
+Udate dry_run to use Sokovan scheduler event

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -249,12 +249,14 @@ class Services:
             agent_registry=args.agent_registry,
             background_task_manager=args.background_task_manager,
             event_dispatcher=args.event_dispatcher,
+            event_hub=args.event_hub,
             storage_manager=args.storage_manager,
             config_provider=args.config_provider,
             valkey_live=args.valkey_live,
             repository=repositories.model_serving.repository,
             admin_repository=repositories.model_serving.admin_repository,
             deployment_controller=args.deployment_controller,
+            scheduling_controller=args.scheduling_controller,
         )
 
         model_serving_auto_scaling = AutoScalingService(

--- a/tests/manager/services/model_serving/conftest.py
+++ b/tests/manager/services/model_serving/conftest.py
@@ -11,6 +11,7 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.endpoint.types import EndpointStatus
 from ai.backend.common.events.dispatcher import EventDispatcher
+from ai.backend.common.events.hub import EventHub
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.endpoint import (
@@ -35,6 +36,7 @@ from ai.backend.manager.services.model_serving.processors.model_serving import (
 from ai.backend.manager.services.model_serving.services.auto_scaling import AutoScalingService
 from ai.backend.manager.services.model_serving.services.model_serving import ModelServingService
 from ai.backend.manager.sokovan.deployment.deployment_controller import DeploymentController
+from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 
 
 @pytest.fixture
@@ -105,28 +107,48 @@ def mock_deployment_controller():
 
 
 @pytest.fixture
+def mock_event_hub():
+    mock_event_hub = MagicMock(spec=EventHub)
+    mock_event_hub.register_event_propagator = MagicMock()
+    mock_event_hub.unregister_event_propagator = MagicMock()
+    return mock_event_hub
+
+
+@pytest.fixture
+def mock_scheduling_controller():
+    mock_scheduling_controller = MagicMock(spec=SchedulingController)
+    mock_scheduling_controller.enqueue_session = AsyncMock()
+    mock_scheduling_controller.mark_sessions_for_termination = AsyncMock()
+    return mock_scheduling_controller
+
+
+@pytest.fixture
 def model_serving_service(
     database_fixture,
     database_engine,
     mock_storage_manager,
     mock_event_dispatcher,
+    mock_event_hub,
     mock_agent_registry,
     mock_background_task_manager,
     mock_config_provider,
     mock_valkey_live,
     mock_repositories,
     mock_deployment_controller,
+    mock_scheduling_controller,
 ) -> ModelServingService:
     return ModelServingService(
         agent_registry=mock_agent_registry,
         background_task_manager=mock_background_task_manager,
         event_dispatcher=mock_event_dispatcher,
+        event_hub=mock_event_hub,
         storage_manager=mock_storage_manager,
         config_provider=mock_config_provider,
         valkey_live=mock_valkey_live,
         repository=mock_repositories.repository,
         admin_repository=mock_repositories.admin_repository,
         deployment_controller=mock_deployment_controller,
+        scheduling_controller=mock_scheduling_controller,
     )
 
 

--- a/tests/manager/services/model_serving/fixtures.py
+++ b/tests/manager/services/model_serving/fixtures.py
@@ -11,6 +11,7 @@ from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.endpoint.types import EndpointStatus
 from ai.backend.common.events.dispatcher import EventDispatcher
+from ai.backend.common.events.hub import EventHub
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
@@ -27,6 +28,7 @@ from ai.backend.manager.services.model_serving.processors.model_serving import (
     ModelServingProcessors,
 )
 from ai.backend.manager.services.model_serving.services.model_serving import ModelServingService
+from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 
 
 @pytest.fixture
@@ -90,28 +92,48 @@ def mock_valkey_live():
 
 
 @pytest.fixture
+def mock_event_hub():
+    mock_event_hub = MagicMock(spec=EventHub)
+    mock_event_hub.register_event_propagator = MagicMock()
+    mock_event_hub.unregister_event_propagator = MagicMock()
+    return mock_event_hub
+
+
+@pytest.fixture
+def mock_scheduling_controller():
+    mock_scheduling_controller = MagicMock(spec=SchedulingController)
+    mock_scheduling_controller.enqueue_session = AsyncMock()
+    mock_scheduling_controller.mark_sessions_for_termination = AsyncMock()
+    return mock_scheduling_controller
+
+
+@pytest.fixture
 def mock_service(
     database_fixture,  # noqa: ARG001
     database_engine,  # noqa: ARG001
     mock_storage_manager,
     mock_event_dispatcher,
+    mock_event_hub,
     mock_agent_registry,
     mock_background_task_manager,
     mock_config_provider,
     mock_valkey_live,
     mock_repositories,
     mock_deployment_controller,
+    mock_scheduling_controller,
 ) -> ModelServingService:
     return ModelServingService(
         agent_registry=mock_agent_registry,
         background_task_manager=mock_background_task_manager,
         event_dispatcher=mock_event_dispatcher,
+        event_hub=mock_event_hub,
         storage_manager=mock_storage_manager,
         config_provider=mock_config_provider,
         valkey_live=mock_valkey_live,
         repository=mock_repositories.repository,
         admin_repository=mock_repositories.admin_repository,
         deployment_controller=mock_deployment_controller,
+        scheduling_controller=mock_scheduling_controller,
     )
 
 


### PR DESCRIPTION
- Replace AgentRegistry.create_session() with SchedulingController.enqueue_session()
- Replace multiple event subscriptions with AsyncBypassPropagator pattern
- Replace AgentRegistry.destroy_session() with mark_sessions_for_termination()
- Add PENDING and TERMINATING event broadcasts in SchedulingController
- Add status-to-legacy-event-name mapping for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves #7117 (BA-3251)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
