### PR TITLE
chore(ci): Update create-pull-request action to v7

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -167,7 +167,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Create Backport PR
         id: pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.OCTODOG }}
           author: "${{ needs.get-backport-target-branch.outputs.author }} <${{ needs.get-backport-target-branch.outputs.author_email }}>"


### PR DESCRIPTION
Bump the peter-evans/create-pull-request GitHub Action from v6 to v7 in the backport workflow for improved features and maintenance.

The create-pull-request tool has compatibility issues with checkout@v6, so we are upgrading to the latest version.


