### PR TITLE
feat(BA-3260): Apply default order for offset pagination when order_by is not provided

### DIFF
--- a/changes/7137.feature.md
+++ b/changes/7137.feature.md
@@ -1,0 +1,1 @@
+Apply default order for offset pagination when order_by is not provided

--- a/src/ai/backend/manager/api/gql/notification/resolver.py
+++ b/src/ai/backend/manager/api/gql/notification/resolver.py
@@ -11,7 +11,7 @@ from strawberry import ID, UNSET, Info
 from strawberry.relay import Connection, Edge
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.manager.api.gql.adapter import CursorPaginationFactories, PaginationOptions
+from ai.backend.manager.api.gql.adapter import PaginationOptions, PaginationSpec
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.errors.auth import InvalidAuthParameters
 from ai.backend.manager.repositories.notification.options import (
@@ -62,26 +62,26 @@ from .types import (
     ValidateNotificationRulePayload,
 )
 
-# Cursor pagination factories
+# Pagination specs
 
 
 @lru_cache(maxsize=1)
-def _get_channel_cursor_factories() -> CursorPaginationFactories:
-    return CursorPaginationFactories(
-        forward_cursor_order=NotificationChannelOrders.created_at(ascending=False),
-        backward_cursor_order=NotificationChannelOrders.created_at(ascending=True),
-        forward_cursor_condition_factory=NotificationChannelConditions.by_cursor_forward,
-        backward_cursor_condition_factory=NotificationChannelConditions.by_cursor_backward,
+def _get_channel_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=NotificationChannelOrders.created_at(ascending=False),
+        backward_order=NotificationChannelOrders.created_at(ascending=True),
+        forward_condition_factory=NotificationChannelConditions.by_cursor_forward,
+        backward_condition_factory=NotificationChannelConditions.by_cursor_backward,
     )
 
 
 @lru_cache(maxsize=1)
-def _get_rule_cursor_factories() -> CursorPaginationFactories:
-    return CursorPaginationFactories(
-        forward_cursor_order=NotificationRuleOrders.created_at(ascending=False),
-        backward_cursor_order=NotificationRuleOrders.created_at(ascending=True),
-        forward_cursor_condition_factory=NotificationRuleConditions.by_cursor_forward,
-        backward_cursor_condition_factory=NotificationRuleConditions.by_cursor_backward,
+def _get_rule_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=NotificationRuleOrders.created_at(ascending=False),
+        backward_order=NotificationRuleOrders.created_at(ascending=True),
+        forward_condition_factory=NotificationRuleConditions.by_cursor_forward,
+        backward_condition_factory=NotificationRuleConditions.by_cursor_backward,
     )
 
 
@@ -149,7 +149,7 @@ async def notification_channels(
             limit=limit,
             offset=offset,
         ),
-        _get_channel_cursor_factories(),
+        _get_channel_pagination_spec(),
         filter=filter,
         order_by=order_by,
     )
@@ -209,7 +209,7 @@ async def notification_rules(
             limit=limit,
             offset=offset,
         ),
-        _get_rule_cursor_factories(),
+        _get_rule_pagination_spec(),
         filter=filter,
         order_by=order_by,
     )

--- a/src/ai/backend/manager/api/gql/scaling_group/resolver.py
+++ b/src/ai/backend/manager/api/gql/scaling_group/resolver.py
@@ -9,7 +9,7 @@ import strawberry
 from strawberry import ID, Info
 from strawberry.relay import Connection, Edge
 
-from ai.backend.manager.api.gql.adapter import CursorPaginationFactories, PaginationOptions
+from ai.backend.manager.api.gql.adapter import PaginationOptions, PaginationSpec
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.repositories.scaling_group.options import (
     ScalingGroupConditions,
@@ -26,16 +26,16 @@ from .types import (
     ScalingGroupV2GQL,
 )
 
-# Cursor pagination factories
+# Pagination specs
 
 
 @lru_cache(maxsize=1)
-def _get_scaling_group_cursor_factories() -> CursorPaginationFactories:
-    return CursorPaginationFactories(
-        forward_cursor_order=ScalingGroupOrders.created_at(ascending=False),
-        backward_cursor_order=ScalingGroupOrders.created_at(ascending=True),
-        forward_cursor_condition_factory=ScalingGroupConditions.by_cursor_forward,
-        backward_cursor_condition_factory=ScalingGroupConditions.by_cursor_backward,
+def _get_scaling_group_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=ScalingGroupOrders.created_at(ascending=False),
+        backward_order=ScalingGroupOrders.created_at(ascending=True),
+        forward_condition_factory=ScalingGroupConditions.by_cursor_forward,
+        backward_condition_factory=ScalingGroupConditions.by_cursor_backward,
     )
 
 
@@ -81,7 +81,7 @@ async def scaling_groups_v2(
             limit=limit,
             offset=offset,
         ),
-        _get_scaling_group_cursor_factories(),
+        _get_scaling_group_pagination_spec(),
         filter=filter,
         order_by=order_by,
     )
@@ -134,7 +134,7 @@ async def all_scaling_groups_v2(
             limit=limit,
             offset=offset,
         ),
-        _get_scaling_group_cursor_factories(),
+        _get_scaling_group_pagination_spec(),
         filter=filter,
         order_by=order_by,
     )

--- a/tests/manager/api/gql/test_adapter.py
+++ b/tests/manager/api/gql/test_adapter.py
@@ -10,8 +10,8 @@ import pytest
 from ai.backend.manager.api.gql.adapter import (
     DEFAULT_PAGINATION_LIMIT,
     BaseGQLAdapter,
-    CursorPaginationFactories,
     PaginationOptions,
+    PaginationSpec,
 )
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.errors.api import InvalidGraphQLParameters
@@ -48,15 +48,15 @@ class TestBaseGQLAdapterBuildPagination:
         return MagicMock()
 
     @pytest.fixture
-    def cursor_factories(
+    def pagination_spec(
         self, mock_cursor_factory: MagicMock, mock_forward_order: Any, mock_backward_order: Any
-    ) -> CursorPaginationFactories:
-        """Create CursorPaginationFactories with mocks."""
-        return CursorPaginationFactories(
-            forward_cursor_order=mock_forward_order,
-            backward_cursor_order=mock_backward_order,
-            forward_cursor_condition_factory=mock_cursor_factory,
-            backward_cursor_condition_factory=mock_cursor_factory,
+    ) -> PaginationSpec:
+        """Create PaginationSpec with mocks."""
+        return PaginationSpec(
+            forward_order=mock_forward_order,
+            backward_order=mock_backward_order,
+            forward_condition_factory=mock_cursor_factory,
+            backward_condition_factory=mock_cursor_factory,
         )
 
     def test_build_pagination_forward_cursor(
@@ -64,13 +64,13 @@ class TestBaseGQLAdapterBuildPagination:
         adapter: BaseGQLAdapter,
         mock_cursor_factory: MagicMock,
         mock_forward_order: Any,
-        cursor_factories: CursorPaginationFactories,
+        pagination_spec: PaginationSpec,
     ) -> None:
         """Test that first + after returns CursorForwardPagination."""
         cursor = encode_cursor("test-cursor-value")
         querier = adapter.build_querier(
             PaginationOptions(first=10, after=cursor),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, CursorForwardPagination)
@@ -84,22 +84,21 @@ class TestBaseGQLAdapterBuildPagination:
         mock_cursor_factory: MagicMock,
         mock_forward_order: Any,
         mock_backward_order: Any,
-        cursor_factories: CursorPaginationFactories,
     ) -> None:
         """Test that last + before returns CursorBackwardPagination."""
         cursor = encode_cursor("test-cursor-value")
         # Need a fresh factory for backward since we check call count
         backward_factory = MagicMock()
         backward_factory.return_value = MagicMock()
-        factories = CursorPaginationFactories(
-            forward_cursor_order=mock_forward_order,
-            backward_cursor_order=mock_backward_order,
-            forward_cursor_condition_factory=mock_cursor_factory,
-            backward_cursor_condition_factory=backward_factory,
+        spec = PaginationSpec(
+            forward_order=mock_forward_order,
+            backward_order=mock_backward_order,
+            forward_condition_factory=mock_cursor_factory,
+            backward_condition_factory=backward_factory,
         )
         querier = adapter.build_querier(
             PaginationOptions(last=5, before=cursor),
-            factories,
+            spec,
         )
 
         assert isinstance(querier.pagination, CursorBackwardPagination)
@@ -108,12 +107,12 @@ class TestBaseGQLAdapterBuildPagination:
         assert querier.pagination.cursor_order is mock_backward_order
 
     def test_build_pagination_offset(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that limit + offset returns OffsetPagination."""
         querier = adapter.build_querier(
             PaginationOptions(limit=20, offset=10),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, OffsetPagination)
@@ -121,12 +120,12 @@ class TestBaseGQLAdapterBuildPagination:
         assert querier.pagination.offset == 10
 
     def test_build_pagination_offset_without_offset(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that limit without offset defaults offset to 0."""
         querier = adapter.build_querier(
             PaginationOptions(limit=20),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, OffsetPagination)
@@ -134,12 +133,12 @@ class TestBaseGQLAdapterBuildPagination:
         assert querier.pagination.offset == 0
 
     def test_build_pagination_default(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that no parameters returns default OffsetPagination."""
         querier = adapter.build_querier(
             PaginationOptions(),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, OffsetPagination)
@@ -147,35 +146,35 @@ class TestBaseGQLAdapterBuildPagination:
         assert querier.pagination.offset == 0
 
     def test_build_pagination_mixed_modes_first_and_limit_error(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that first + limit raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(first=10, limit=20),
-                cursor_factories,
+                pagination_spec,
             )
         assert "Only one pagination mode allowed" in str(exc_info.value)
 
     def test_build_pagination_mixed_modes_last_and_limit_error(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that last + limit raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(last=10, limit=20),
-                cursor_factories,
+                pagination_spec,
             )
         assert "Only one pagination mode allowed" in str(exc_info.value)
 
     def test_build_pagination_mixed_modes_first_and_last_error(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that first + last raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(first=10, last=10),
-                cursor_factories,
+                pagination_spec,
             )
         assert "Only one pagination mode allowed" in str(exc_info.value)
 
@@ -183,12 +182,12 @@ class TestBaseGQLAdapterBuildPagination:
         self,
         adapter: BaseGQLAdapter,
         mock_forward_order: Any,
-        cursor_factories: CursorPaginationFactories,
+        pagination_spec: PaginationSpec,
     ) -> None:
         """Test that first without after returns CursorForwardPagination with no cursor condition."""
         querier = adapter.build_querier(
             PaginationOptions(first=10),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, CursorForwardPagination)
@@ -200,12 +199,12 @@ class TestBaseGQLAdapterBuildPagination:
         self,
         adapter: BaseGQLAdapter,
         mock_backward_order: Any,
-        cursor_factories: CursorPaginationFactories,
+        pagination_spec: PaginationSpec,
     ) -> None:
         """Test that last without before returns CursorBackwardPagination with no cursor condition."""
         querier = adapter.build_querier(
             PaginationOptions(last=10),
-            cursor_factories,
+            pagination_spec,
         )
 
         assert isinstance(querier.pagination, CursorBackwardPagination)
@@ -216,47 +215,117 @@ class TestBaseGQLAdapterBuildPagination:
     def test_build_pagination_first_must_be_positive(
         self,
         adapter: BaseGQLAdapter,
-        cursor_factories: CursorPaginationFactories,
+        pagination_spec: PaginationSpec,
     ) -> None:
         """Test that first <= 0 raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(first=0),
-                cursor_factories,
+                pagination_spec,
             )
         assert "first must be positive" in str(exc_info.value)
 
     def test_build_pagination_last_must_be_positive(
         self,
         adapter: BaseGQLAdapter,
-        cursor_factories: CursorPaginationFactories,
+        pagination_spec: PaginationSpec,
     ) -> None:
         """Test that last <= 0 raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(last=-1),
-                cursor_factories,
+                pagination_spec,
             )
         assert "last must be positive" in str(exc_info.value)
 
     def test_build_pagination_limit_must_be_positive(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that limit <= 0 raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(limit=0),
-                cursor_factories,
+                pagination_spec,
             )
         assert "limit must be positive" in str(exc_info.value)
 
     def test_build_pagination_offset_must_be_non_negative(
-        self, adapter: BaseGQLAdapter, cursor_factories: CursorPaginationFactories
+        self, adapter: BaseGQLAdapter, pagination_spec: PaginationSpec
     ) -> None:
         """Test that negative offset raises InvalidGraphQLParameters."""
         with pytest.raises(InvalidGraphQLParameters) as exc_info:
             adapter.build_querier(
                 PaginationOptions(limit=10, offset=-1),
-                cursor_factories,
+                pagination_spec,
             )
         assert "offset must be non-negative" in str(exc_info.value)
+
+    def test_offset_pagination_applies_default_order_when_order_by_is_none(
+        self,
+        adapter: BaseGQLAdapter,
+        mock_forward_order: Any,
+        pagination_spec: PaginationSpec,
+    ) -> None:
+        """Test that offset pagination uses forward_order as default when order_by is not provided."""
+        querier = adapter.build_querier(
+            PaginationOptions(limit=10),
+            pagination_spec,
+        )
+
+        assert isinstance(querier.pagination, OffsetPagination)
+        assert len(querier.orders) == 1
+        assert querier.orders[0] is mock_forward_order
+
+    def test_default_pagination_applies_default_order_when_order_by_is_none(
+        self,
+        adapter: BaseGQLAdapter,
+        mock_forward_order: Any,
+        pagination_spec: PaginationSpec,
+    ) -> None:
+        """Test that default pagination (no params) uses forward_order as default."""
+        querier = adapter.build_querier(
+            PaginationOptions(),
+            pagination_spec,
+        )
+
+        assert isinstance(querier.pagination, OffsetPagination)
+        assert len(querier.orders) == 1
+        assert querier.orders[0] is mock_forward_order
+
+    def test_offset_pagination_does_not_apply_default_order_when_order_by_is_provided(
+        self,
+        adapter: BaseGQLAdapter,
+        mock_forward_order: Any,
+        pagination_spec: PaginationSpec,
+    ) -> None:
+        """Test that offset pagination does not add default order when order_by is provided."""
+        mock_order_by = MagicMock()
+        mock_query_order = MagicMock()
+        mock_order_by.to_query_order.return_value = mock_query_order
+
+        querier = adapter.build_querier(
+            PaginationOptions(limit=10),
+            pagination_spec,
+            order_by=[mock_order_by],
+        )
+
+        assert isinstance(querier.pagination, OffsetPagination)
+        assert len(querier.orders) == 1
+        assert querier.orders[0] is mock_query_order
+        assert querier.orders[0] is not mock_forward_order
+
+    def test_cursor_pagination_does_not_add_default_order_to_querier_orders(
+        self,
+        adapter: BaseGQLAdapter,
+        pagination_spec: PaginationSpec,
+    ) -> None:
+        """Test that cursor pagination does not add forward_order to querier.orders."""
+        querier = adapter.build_querier(
+            PaginationOptions(first=10),
+            pagination_spec,
+        )
+
+        assert isinstance(querier.pagination, CursorForwardPagination)
+        # Cursor pagination should NOT add default order to querier.orders
+        # (it uses cursor_order internally in pagination object)
+        assert len(querier.orders) == 0

--- a/tests/manager/api/scaling_group/test_adapter.py
+++ b/tests/manager/api/scaling_group/test_adapter.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 from ai.backend.manager.api.gql.adapter import (
     BaseGQLAdapter,
-    CursorPaginationFactories,
     PaginationOptions,
+    PaginationSpec,
 )
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.scaling_group.types import (
@@ -23,18 +23,18 @@ from ai.backend.manager.repositories.scaling_group.options import (
 )
 
 
-def _get_cursor_factories() -> CursorPaginationFactories:
-    """Create cursor pagination factories for scaling groups.
+def _get_pagination_spec() -> PaginationSpec:
+    """Create pagination spec for scaling groups.
 
     For typical "newest first" lists:
     - Forward (first/after): DESC order, shows newer items first, next page shows older items
     - Backward (last/before): ASC order, fetches older items first (reversed for display)
     """
-    return CursorPaginationFactories(
-        forward_cursor_order=ScalingGroupOrders.created_at(ascending=False),
-        backward_cursor_order=ScalingGroupOrders.created_at(ascending=True),
-        forward_cursor_condition_factory=ScalingGroupConditions.by_cursor_forward,
-        backward_cursor_condition_factory=ScalingGroupConditions.by_cursor_backward,
+    return PaginationSpec(
+        forward_order=ScalingGroupOrders.created_at(ascending=False),
+        backward_order=ScalingGroupOrders.created_at(ascending=True),
+        forward_condition_factory=ScalingGroupConditions.by_cursor_forward,
+        backward_condition_factory=ScalingGroupConditions.by_cursor_backward,
     )
 
 
@@ -46,11 +46,12 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
         )
 
         assert len(querier.conditions) == 0
-        assert len(querier.orders) == 0
+        # Default order is applied for offset pagination when order_by is not provided
+        assert len(querier.orders) == 1
         # Default pagination is applied
         assert querier.pagination is not None
         assert isinstance(querier.pagination, OffsetPagination)
@@ -63,7 +64,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -80,7 +81,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -96,7 +97,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -112,7 +113,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -128,7 +129,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -144,7 +145,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -160,7 +161,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -176,7 +177,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -190,7 +191,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -204,7 +205,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -218,7 +219,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -232,7 +233,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -246,7 +247,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -260,7 +261,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -274,7 +275,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -288,7 +289,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -307,7 +308,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -328,7 +329,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -348,7 +349,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -367,7 +368,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -394,7 +395,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
         )
 
@@ -414,7 +415,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -432,7 +433,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -450,7 +451,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -468,7 +469,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -486,7 +487,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -504,7 +505,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -522,7 +523,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -540,7 +541,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -562,7 +563,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             order_by=order_by,
         )
 
@@ -575,7 +576,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=10, offset=5),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
         )
 
         assert querier.pagination is not None
@@ -598,7 +599,7 @@ class TestBaseGQLAdapter:
         adapter = BaseGQLAdapter()
         querier = adapter.build_querier(
             PaginationOptions(limit=20, offset=10),
-            _get_cursor_factories(),
+            _get_pagination_spec(),
             filter=filter_obj,
             order_by=order_by,
         )


### PR DESCRIPTION
- Rename `CursorPaginationFactories` to `PaginationSpec` for clearer naming
- Remove "cursor" prefix from field names:
  - forward_cursor_order → forward_order
  - backward_cursor_order → backward_order
  - forward_cursor_condition_factory → forward_condition_factory
  - backward_cursor_condition_factory → backward_condition_factory
- Add default order for offset pagination when order_by is not provided (reuses forward_order as the default)
- Update all usages in notification and scaling_group resolvers
- Update related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves #7136 (BA-3260)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
