### PR TITLE
chore: Update SBOM workflow to use cyclonedx-bom via pipx

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,10 +10,13 @@ jobs:
       uses: actions/checkout@v6
       with:
         lfs: false
-    - name: Generate the SBOM report
-      uses: CycloneDX/gh-python-generate-sbom@v2
+    - name: Install SBOM tool
+      run: pipx install cyclonedx-bom
+    - name: Create SBOM step
+      # see for usage: https://pypi.org/project/cyclonedx-bom/
+      run: cyclonedx-py requirements -o bom.json
     - name: Upload the SBOM report
       uses: actions/upload-artifact@v5
       with:
         name: SBOM report
-        path: ./bom.xml
+        path: ./bom.json


### PR DESCRIPTION
Replaces the CycloneDX GitHub Action with direct installation of cyclonedx-bom using pipx and updates the SBOM generation step to output bom.json instead of bom.xml. Adjusts the artifact upload path accordingly.
