### PR TITLE
chore(BA-3312): Upgrade pants to 2.29

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.27.0"
+pants_version = "2.29.0"
 pythonpath = ["%(buildroot)s/tools/pants-plugins"]
 backend_packages = [
     "pants.backend.python",


### PR DESCRIPTION
resolves #7206 (BA-3312)

There is no additioanl work required for our plugins and configurations.

> [!NOTE]
> `pants` command will auto-install the latest version and you don't have to do anything special.
> If this does not work, run `SCIE_BOOT=update pants` and try again.

Confirmed:

- `pants lint check ::` works as expected.
- `pants package ::` works as expected, creating fat/lazy scie executables and Python wheel packages with appropriate contents.
