### PR TITLE
fix(BA-3322): remove unnecessary shmem pre-deduction from Memory cgroup (#7222)

### DIFF
--- a/changes/7222.fix.md
+++ b/changes/7222.fix.md
@@ -1,0 +1,1 @@
+remove unnecessary shmem pre-deduction from Memory cgroup

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1094,9 +1094,11 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
 
         if resource_opts and resource_opts.get("shmem"):
             shmem = int(resource_opts.get("shmem", "0"))
+            # Only set ShmSize limit for tmpfs (/dev/shm).
+            # Do NOT subtract shmem from Memory/MemorySwap because:
+            # - shm (tmpfs) and app memory share the Memory cgroup space
+            # - Pre-deducting would unnecessarily reduce available memory
             self.computer_docker_args["HostConfig"]["ShmSize"] = shmem
-            self.computer_docker_args["HostConfig"]["MemorySwap"] -= shmem
-            self.computer_docker_args["HostConfig"]["Memory"] -= shmem
 
         service_ports_label: list[str] = []
         service_ports_label += image_labels.get(LabelName.SERVICE_PORTS, "").split(",")


### PR DESCRIPTION
This is an auto-generated backport PR of #7222 to the 25.15 release.