### PR TITLE
fix(BA-3313): Add missing lock IDs to handlers with short cycle (#7223)

### DIFF
--- a/changes/7223.fix.md
+++ b/changes/7223.fix.md
@@ -1,0 +1,1 @@
+Add missing lock IDs to handlers with short cycle preventing race conditions caused by concurrent execution between short and long cycles

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -105,9 +105,14 @@ class LockID(enum.IntEnum):
     # Retry timers (only long cycle - 30 seconds)
     LOCKID_SOKOVAN_RETRY_PREPARING_TIMER = 220
     LOCKID_SOKOVAN_RETRY_CREATING_TIMER = 221
-    # Deployment auto-scaler timer
-    LOCKID_DEPLOYMENT_AUTO_SCALER = 222
-
+    # Deployment locks
+    LOCKID_DEPLOYMENT_AUTO_SCALER = 222  # Lock for deployment auto-scaler
+    LOCKID_DEPLOYMENT_PROVISIONING_ROUTES = 223  # Lock for provisioning routes
+    LOCKID_DEPLOYMENT_HEALTH_CHECK_ROUTES = 224  # Lock for health check routes
+    LOCKID_DEPLOYMENT_RUNNING_ROUTES = 225  # Lock for running routes
+    LOCKID_DEPLOYMENT_CHECK_PENDING = 226  # For operations checking PENDING sessions
+    LOCKID_DEPLOYMENT_CHECK_REPLICA = 227  # For operations checking REPLICA sessions
+    LOCKID_DEPLOYMENT_DESTROYING = 228  # For operations destroying deployments
     # Sokovan target status locks (prevent concurrent operations on same status)
     LOCKID_SOKOVAN_TARGET_PENDING = 230  # For operations targeting PENDING sessions
     LOCKID_SOKOVAN_TARGET_PREPARING = 231  # For operations targeting PREPARING/PULLING sessions

--- a/src/ai/backend/manager/sokovan/deployment/handlers/destroying.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/destroying.py
@@ -39,8 +39,8 @@ class DestroyingDeploymentHandler(DeploymentHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for destroying deployments."""
-        return None
+        """Lock for destroying deployments."""
+        return LockID.LOCKID_DEPLOYMENT_DESTROYING
 
     @classmethod
     def target_statuses(cls) -> list[EndpointLifecycle]:

--- a/src/ai/backend/manager/sokovan/deployment/handlers/pending.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/pending.py
@@ -38,8 +38,8 @@ class CheckPendingDeploymentHandler(DeploymentHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for checking pending deployments."""
-        return None
+        """Lock for checking pending deployments."""
+        return LockID.LOCKID_DEPLOYMENT_CHECK_PENDING
 
     @classmethod
     def target_statuses(cls) -> list[EndpointLifecycle]:

--- a/src/ai/backend/manager/sokovan/deployment/handlers/replica.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/replica.py
@@ -38,8 +38,8 @@ class CheckReplicaDeploymentHandler(DeploymentHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for checking replicas."""
-        return None
+        """Lock for checking replicas."""
+        return LockID.LOCKID_DEPLOYMENT_CHECK_REPLICA
 
     @classmethod
     def target_statuses(cls) -> list[EndpointLifecycle]:

--- a/src/ai/backend/manager/sokovan/deployment/handlers/scaling.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/scaling.py
@@ -39,8 +39,8 @@ class ScalingDeploymentHandler(DeploymentHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for scaling deployments."""
-        return None
+        """Lock for scaling deployments."""
+        return LockID.LOCKID_DEPLOYMENT_AUTO_SCALER
 
     @classmethod
     def target_statuses(cls) -> list[EndpointLifecycle]:

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/health_check.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/health_check.py
@@ -35,8 +35,8 @@ class HealthCheckRouteHandler(RouteHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for health check."""
-        return None
+        """Lock for health check routes."""
+        return LockID.LOCKID_DEPLOYMENT_HEALTH_CHECK_ROUTES
 
     @classmethod
     def target_statuses(cls) -> list[RouteStatus]:

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/provisioning.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/provisioning.py
@@ -35,8 +35,8 @@ class ProvisioningRouteHandler(RouteHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for provisioning routes."""
-        return None
+        """Lock for provisioning routes."""
+        return LockID.LOCKID_DEPLOYMENT_PROVISIONING_ROUTES
 
     @classmethod
     def target_statuses(cls) -> list[RouteStatus]:

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/running.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/running.py
@@ -35,8 +35,8 @@ class RunningRouteHandler(RouteHandler):
 
     @property
     def lock_id(self) -> Optional[LockID]:
-        """No lock needed for checking running routes."""
-        return None
+        """Lock for checking running routes."""
+        return LockID.LOCKID_DEPLOYMENT_RUNNING_ROUTES
 
     @classmethod
     def target_statuses(cls) -> list[RouteStatus]:


### PR DESCRIPTION
This is an auto-generated backport PR of #7223 to the 25.15 release.