### PR TITLE
fix(BA-3329): `check_presets` API returning inflated remaining resources (#7238)

### DIFF
--- a/changes/7238.fix.md
+++ b/changes/7238.fix.md
@@ -1,0 +1,1 @@
+Fix `check_presets` API returning inflated remaining resources by excluding non-ALIVE agents from calculation

--- a/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
@@ -20,6 +20,7 @@ from ai.backend.common.types import (
     SlotTypes,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
 from ai.backend.manager.errors.resource import (
@@ -353,6 +354,7 @@ class ResourcePresetDBSource:
                 AgentRow.scaling_group.in_(sgroup_names),
                 AgentRow.available_slots.isnot(None),
                 AgentRow.schedulable == sa.true(),
+                AgentRow.status == AgentStatus.ALIVE,
             )
         )
 


### PR DESCRIPTION
This is an auto-generated backport PR of #7238 to the 25.15 release.