### PR TITLE
chore: Exclude web/static from DevSkim scanning

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -29,7 +29,7 @@ jobs:
         uses: microsoft/DevSkim-Action@v1
         with:
           ignore-globs: |
-            web/static/**
+            src/ai/backend/web/static/**
 
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Updated the DevSkim GitHub Action configuration to ignore files in the web/static directory during scans.
