### PR TITLE
fix(BA-3471): Include service labels in Prometheus service discovery response (#7466)

### DIFF
--- a/changes/7466.fix.md
+++ b/changes/7466.fix.md
@@ -1,0 +1,1 @@
+Include service labels in Prometheus service discovery response

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -1593,6 +1593,7 @@ def build_prometheus_service_discovery_handler(
             resp.append({
                 "targets": [f"{service.endpoint.prometheus_address}"],
                 "labels": {
+                    **service.labels,
                     "service_id": service.id,
                     "service_group": service.service_group,
                     "display_name": service.display_name,


### PR DESCRIPTION
This is an auto-generated backport PR of #7466 to the 25.18 release.