### PR TITLE
fix(BA-3520): Query all user keypairs instead of just look up main access key (#7533)

### DIFF
--- a/changes/7533.fix.md
+++ b/changes/7533.fix.md
@@ -1,0 +1,1 @@
+Fix credential lookup to use keypairs table join instead of user table's  `main_access_key` col, resolving authentication failures for non-main keypairs

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -466,11 +466,14 @@ async def auth_middleware(request: web.Request, handler) -> web.StreamResponse:
             j = users.join(
                 user_resource_policies,
                 users.c.resource_policy == user_resource_policies.c.name,
+            ).join(
+                keypairs,
+                users.c.uuid == keypairs.c.user,
             )
             query = (
                 sa.select([users, user_resource_policies], use_labels=True)
                 .select_from(j)
-                .where((users.c.main_access_key == access_key))
+                .where((keypairs.c.access_key == access_key))
             )
             result = await conn.execute(query)
             user_row = result.first()


### PR DESCRIPTION
This is an auto-generated backport PR of #7533 to the 25.15 release.