### PR TITLE
feat(BA-3446): Change default signup status to inactive (#7520)

### DIFF
--- a/changes/7520.feature.md
+++ b/changes/7520.feature.md
@@ -1,0 +1,1 @@
+Change default signup status to inactive preventing newly registered accounts access system resources until an administrator explicitly activates them

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -228,7 +228,7 @@ class AuthService:
             "need_password_change": False,
             "full_name": action.full_name if action.full_name is not None else "",
             "description": action.description if action.description is not None else "",
-            "status": UserStatus.ACTIVE,
+            "status": UserStatus.INACTIVE,
             "status_info": "user-signup",
             "role": UserRole.USER,
             "integration_id": None,


### PR DESCRIPTION
This is an auto-generated backport PR of #7520 to the 25.15 release.