### PR TITLE
chore: Update krunner-extractor base image to Alpine 3.21 (#7285)

### DIFF
--- a/changes/7285.deps.md
+++ b/changes/7285.deps.md
@@ -1,0 +1,1 @@
+Upgrade krunner-extractor container image from Alpine 3.8 to Alpine 3.21

--- a/src/ai/backend/runner/krunner-extractor.dockerfile
+++ b/src/ai/backend/runner/krunner-extractor.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.21
 
 RUN apk add --no-cache xz
 

--- a/src/ai/backend/runner/krunner-extractor.img.aarch64.tar.xz
+++ b/src/ai/backend/runner/krunner-extractor.img.aarch64.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b56c8abdfd6d07ceb57d0a6bdf4c404a60edf15bee1658e44ce8cb467261c869
-size 1674528
+oid sha256:570b9cb5b730e087a54a1d590205151e041c50f8a89f4b4ee368eb7d15ff031d
+size 3211380

--- a/src/ai/backend/runner/krunner-extractor.img.x86_64.tar.xz
+++ b/src/ai/backend/runner/krunner-extractor.img.x86_64.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd989ba19320da4ed97c7f3a938ed526af4b4ef1173dfd3ff853c0a8ad724ea9
-size 1853504
+oid sha256:655a82f0bf8085e6c8303ecad6a18a0b41dd324c07886d75d0120f58ad69afea
+size 2993156


### PR DESCRIPTION
This is an auto-generated backport PR of #7285 to the 25.18 release.