### PR TITLE
fix(BA-3307): Remove fk relationship rows(session, route) when purge scaling group

### DIFF
--- a/changes/7582.fix.md
+++ b/changes/7582.fix.md
@@ -1,0 +1,1 @@
+Remove FK relationship rows(session, route, endpoint) when purging scaling group to prevent integrity errors when Integrity error deleting scaling group row

--- a/src/ai/backend/manager/models/gql_models/scaling_group.py
+++ b/src/ai/backend/manager/models/gql_models/scaling_group.py
@@ -18,20 +18,21 @@ import graphene_federation
 import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.engine.row import Row
-from sqlalchemy.exc import DBAPIError, IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only
 
 from ai.backend.common.types import AccessKey, ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
-from ai.backend.manager.errors.resource import ScalingGroupDeletionFailure, ScalingGroupNotFound
+from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentStatus
 from ai.backend.manager.models.user import UserRole
-from ai.backend.manager.models.utils import execute_with_txn_retry
 from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.scaling_group.creators import ScalingGroupCreatorSpec
 from ai.backend.manager.services.scaling_group.actions.create import (
     CreateScalingGroupAction,
+)
+from ai.backend.manager.services.scaling_group.actions.purge_scaling_group import (
+    PurgeScalingGroupAction,
 )
 
 from ..base import (
@@ -716,16 +717,11 @@ class DeleteScalingGroup(graphene.Mutation):
         name: str,
     ) -> DeleteScalingGroup:
         graph_ctx: GraphQueryContext = info.context
-        delete_query = sa.delete(scaling_groups).where(scaling_groups.c.name == name)
 
-        async def delete(db_session: AsyncSession) -> None:
-            await db_session.execute(delete_query)
+        await graph_ctx.processors.scaling_group.purge_scaling_group.wait_for_complete(
+            PurgeScalingGroupAction(purger=Purger(row_class=ScalingGroupRow, pk_value=name))
+        )
 
-        try:
-            async with graph_ctx.db.connect() as conn:
-                await execute_with_txn_retry(delete, graph_ctx.db.begin_session, conn)
-        except (DBAPIError, IntegrityError) as e:
-            raise ScalingGroupDeletionFailure from e
         return cls(ok=True, msg="success")
 
 

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -8,9 +8,14 @@ import sqlalchemy as sa
 
 from ai.backend.common.exception import ScalingGroupConflict
 from ai.backend.manager.data.scaling_group.types import ScalingGroupData, ScalingGroupListResult
+from ai.backend.manager.errors.resource import ScalingGroupNotFound
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.purger import Purger, execute_purger
 from ai.backend.manager.repositories.scaling_group.creators import ScalingGroupCreatorSpec
 
 if TYPE_CHECKING:
@@ -72,3 +77,54 @@ class ScalingGroupDBSource:
                 has_next_page=result.has_next_page,
                 has_previous_page=result.has_previous_page,
             )
+
+    async def purge_scaling_group(
+        self,
+        purger: Purger[ScalingGroupRow],
+    ) -> ScalingGroupData:
+        """Purges a scaling group and all related sessions and routes using a purger.
+
+        Cascade delete order:
+        1. RoutingRow (session FK with RESTRICT)
+        2. EndpointRow (resource_group FK with RESTRICT, has CASCADE to routing)
+        3. SessionRow (scaling_group FK)
+        4. ScalingGroupRow
+
+        Raises ScalingGroupNotFound if scaling group doesn't exist.
+        """
+        async with self._db.begin_session() as session:
+            scaling_group_name = purger.pk_value
+
+            # Step 1: Find all sessions belonging to this scaling group
+            session_ids_query = sa.select(SessionRow.id).where(
+                SessionRow.scaling_group_name == scaling_group_name
+            )
+            session_ids_result = await session.execute(session_ids_query)
+            session_ids = session_ids_result.scalars().all()
+
+            # Step 2: Delete all routings associated with these sessions
+            if session_ids:
+                delete_routings_stmt = sa.delete(RoutingRow).where(
+                    RoutingRow.session.in_(session_ids)
+                )
+                await session.execute(delete_routings_stmt)
+
+            # Step 3: Delete all endpoints belonging to this scaling group
+            delete_endpoints_stmt = sa.delete(EndpointRow).where(
+                EndpointRow.resource_group == scaling_group_name
+            )
+            await session.execute(delete_endpoints_stmt)
+
+            # Step 4: Delete all sessions belonging to this scaling group
+            delete_sessions_stmt = sa.delete(SessionRow).where(
+                SessionRow.scaling_group_name == scaling_group_name
+            )
+            await session.execute(delete_sessions_stmt)
+
+            # Step 5: Delete the scaling group itself using purger
+            result = await execute_purger(session, purger)
+
+            if result is None:
+                raise ScalingGroupNotFound(f"Scaling group not found (name:{purger.pk_value})")
+
+            return result.row.to_dataclass()

--- a/src/ai/backend/manager/repositories/scaling_group/repository.py
+++ b/src/ai/backend/manager/repositories/scaling_group/repository.py
@@ -15,6 +15,7 @@ from ai.backend.manager.data.scaling_group.types import ScalingGroupData, Scalin
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
 
 from .db_source import ScalingGroupDBSource
 
@@ -66,3 +67,14 @@ class ScalingGroupRepository:
     ) -> ScalingGroupListResult:
         """Searches scaling groups with total count."""
         return await self._db_source.search_scaling_groups(querier=querier)
+
+    @scaling_group_repository_resilience.apply()
+    async def purge_scaling_group(
+        self,
+        purger: Purger[ScalingGroupRow],
+    ) -> ScalingGroupData:
+        """Purges a scaling group and all related sessions and routes using a purger.
+
+        Raises ScalingGroupNotFound if scaling group doesn't exist.
+        """
+        return await self._db_source.purge_scaling_group(purger)

--- a/src/ai/backend/manager/services/scaling_group/actions/purge_scaling_group.py
+++ b/src/ai/backend/manager/services/scaling_group/actions/purge_scaling_group.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.data.scaling_group.types import ScalingGroupData
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.services.scaling_group.actions.base import ScalingGroupAction
+
+
+@dataclass
+class PurgeScalingGroupAction(ScalingGroupAction):
+    """Action to purge a scaling group by name, including all related sessions and routes."""
+
+    purger: Purger[ScalingGroupRow]
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "purge"
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return str(self.purger.pk_value)
+
+
+@dataclass
+class PurgeScalingGroupActionResult(BaseActionResult):
+    """Result of purging a scaling group."""
+
+    data: ScalingGroupData
+
+    @override
+    def entity_id(self) -> Optional[str]:
+        return self.data.name

--- a/src/ai/backend/manager/services/scaling_group/processors.py
+++ b/src/ai/backend/manager/services/scaling_group/processors.py
@@ -11,22 +11,29 @@ from ai.backend.manager.services.scaling_group.actions.list_scaling_groups impor
     SearchScalingGroupsAction,
     SearchScalingGroupsActionResult,
 )
+from ai.backend.manager.services.scaling_group.actions.purge_scaling_group import (
+    PurgeScalingGroupAction,
+    PurgeScalingGroupActionResult,
+)
 from ai.backend.manager.services.scaling_group.service import ScalingGroupService
 
 
 class ScalingGroupProcessors(AbstractProcessorPackage):
     create_scaling_group: ActionProcessor[CreateScalingGroupAction, CreateScalingGroupActionResult]
+    purge_scaling_group: ActionProcessor[PurgeScalingGroupAction, PurgeScalingGroupActionResult]
     search_scaling_groups: ActionProcessor[
         SearchScalingGroupsAction, SearchScalingGroupsActionResult
     ]
 
     def __init__(self, service: ScalingGroupService, action_monitors: list[ActionMonitor]) -> None:
         self.create_scaling_group = ActionProcessor(service.create_scaling_group, action_monitors)
+        self.purge_scaling_group = ActionProcessor(service.purge_scaling_group, action_monitors)
         self.search_scaling_groups = ActionProcessor(service.search_scaling_groups, action_monitors)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
         return [
             CreateScalingGroupAction.spec(),
+            PurgeScalingGroupAction.spec(),
             SearchScalingGroupsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/scaling_group/service.py
+++ b/src/ai/backend/manager/services/scaling_group/service.py
@@ -10,6 +10,10 @@ from ai.backend.manager.services.scaling_group.actions.list_scaling_groups impor
     SearchScalingGroupsAction,
     SearchScalingGroupsActionResult,
 )
+from ai.backend.manager.services.scaling_group.actions.purge_scaling_group import (
+    PurgeScalingGroupAction,
+    PurgeScalingGroupActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -41,3 +45,10 @@ class ScalingGroupService:
         """Creates a scaling group."""
         scaling_group_data = await self._repository.create_scaling_group(action.creator)
         return CreateScalingGroupActionResult(scaling_group=scaling_group_data)
+
+    async def purge_scaling_group(
+        self, action: PurgeScalingGroupAction
+    ) -> PurgeScalingGroupActionResult:
+        """Purges a scaling group and all related sessions and routes."""
+        data = await self._repository.purge_scaling_group(action.purger)
+        return PurgeScalingGroupActionResult(data=data)


### PR DESCRIPTION
resolves #7202 (BA-3307)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
