### PR TITLE
fix(BA-3565): Add detailed log why command execution failed in kernel (#7591)

### DIFF
--- a/changes/7591.fix.md
+++ b/changes/7591.fix.md
@@ -1,0 +1,1 @@
+Add detailed log why command execution failed in kernel

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -476,8 +476,8 @@ class BaseRunner(metaclass=ABCMeta):
                 ret = await self.execute_heuristic()
             else:
                 ret = await self.run_subproc(exec_cmd, batch=True)
-        except Exception:
-            log.exception("unexpected error")
+        except Exception as e:
+            log.exception("unexpected error: {}", e)
             ret = -1
         finally:
             await asyncio.sleep(0.01)  # extra delay to flush logs


### PR DESCRIPTION
This is an auto-generated backport PR of #7591 to the 25.15 release.