### PR TITLE
fix(BA-3595): Fix `unified_config` incorrectly assigned as tuple in `ServiceConfigNode.load`

### DIFF
--- a/changes/7635.fix.md
+++ b/changes/7635.fix.md
@@ -1,0 +1,1 @@
+Fix `unified_config` incorrectly assigned as tuple in `ServiceConfigNode.load`

--- a/src/ai/backend/manager/models/gql_models/service_config.py
+++ b/src/ai/backend/manager/models/gql_models/service_config.py
@@ -80,8 +80,8 @@ class ServiceConfigNode(graphene.ObjectType):
         def _fallback(x):
             return str(x)
 
-        unified_config = (
-            ctx.config_provider.config.model_dump(mode="json", by_alias=True, fallback=_fallback),
+        unified_config = ctx.config_provider.config.model_dump(
+            mode="json", by_alias=True, fallback=_fallback
         )
         unified_config_schema = ctx.config_provider.config.model_json_schema(mode="serialization")
 

--- a/tests/manager/models/gql_models/test_service_config.py
+++ b/tests/manager/models/gql_models/test_service_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.manager.models.gql_models.service_config import ServiceConfigNode
+
+
+@pytest.mark.asyncio
+async def test_service_config_node_load_returns_dict_not_tuple() -> None:
+    """Regression test for BA-3595: unified_config should be dict, not tuple."""
+    # Mock ResolveInfo and context
+    mock_info = MagicMock()
+    mock_config = MagicMock()
+    mock_config.model_dump.return_value = {"key": "value"}
+    mock_config.model_json_schema.return_value = {"type": "object"}
+    mock_info.context.config_provider.config = mock_config
+
+    # Call the method
+    result = await ServiceConfigNode.load(mock_info, "manager")
+
+    # Verify configuration is dict, not tuple (BA-3595 regression)
+    assert isinstance(result.configuration, dict), (
+        f"configuration should be dict, got {type(result.configuration)}"
+    )
+    assert result.configuration == {"key": "value"}
+    assert result.schema == {"type": "object"}
+    assert result.service == "manager"


### PR DESCRIPTION
Backported-from: main
Backported-to: 25.15
Backported-of: 7635