### PR TITLE
chore: Exclude backend.ai Dockerfiles from SBOM matrix

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -37,7 +37,7 @@ jobs:
       id: set-matrix
       run: |
         # Find all Dockerfiles in docker/ directory
-        DOCKERFILES=$(find docker -type f -name "*.dockerfile")
+        DOCKERFILES=$(find docker -type f -name "*.dockerfile" ! -name "backend.ai-*.dockerfile")
 
         # Build JSON array for matrix
         MATRIX_JSON='{"include":['


### PR DESCRIPTION
Updated the workflow to exclude Dockerfiles matching 'backend.ai-*.dockerfile' from the SBOM matrix generation. This prevents these specific Dockerfiles from being processed in the workflow.

