### PR TITLE
chore: Revert Intel Mac runner and make SBOM optional for release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         # ubuntu-22.04: x86-64
         # ubuntu-22.04-arm64: aarch64
-        # self-hosted-macos-14-x64: intel
+        # macos-14-large: intel
         # self-hosted-macos-14: apple silicon
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, self-hosted-macos-14-x64, self-hosted-macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted-macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out the revision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,9 +367,9 @@ jobs:
       matrix:
         # ubuntu-22.04: x86-64
         # ubuntu-22.04-arm64: aarch64
-        # self-hosted-macos-14-x64: intel
+        # macos-14-large: intel
         # self-hosted-macos-14: apple silicon
-        os: [ubuntu-22.04, ubuntu-22.04-arm64, self-hosted-macos-14-x64, self-hosted-macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm64, macos-14-large, self-hosted-macos-14]
     runs-on: ${{ matrix.os }}
     env:
       SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
@@ -476,7 +476,7 @@ jobs:
     uses: ./.github/workflows/sbom.yml
 
   build-isla-sorna-image:
-    needs: [build-scies, build-wheels, build-sbom, optimize-ci]
+    needs: [build-scies, build-wheels, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     runs-on: ubuntu-latest
 
@@ -491,7 +491,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
 
   make-final-release:
-    needs: [build-scies, build-wheels, build-sbom, optimize-ci]
+    needs: [build-scies, build-wheels, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -532,6 +532,7 @@ jobs:
         cat dist/checksum-*.txt > dist/checksum.txt
         sort -u -k2 dist/checksum.txt -o dist/checksum.txt
     - name: Download SBOM report
+      continue-on-error: true
       uses: actions/download-artifact@v6
       with:
         name: SBOM report


### PR DESCRIPTION
- Revert Intel Mac build runner from self-hosted to macos-14-large
- Remove build-sbom from release job dependencies
- Add continue-on-error to SBOM artifact download

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
