### PR TITLE
feat(BA-3714): Add field_data() methods Base Action classes

### DIFF
--- a/changes/7788.feature.md
+++ b/changes/7788.feature.md
@@ -1,1 +1,1 @@
-Add `field_type()` and `field_id()` methods to Base Action classes. This supports RBAC permission inheritance when an entity exists as a field of another entity.
+Add `field_data()` method to Base Action classes. This supports RBAC permission inheritance when an entity exists as a field of another entity.

--- a/src/ai/backend/manager/actions/action/batch.py
+++ b/src/ai/backend/manager/actions/action/batch.py
@@ -1,10 +1,10 @@
 from abc import abstractmethod
-from collections.abc import Mapping
 from typing import TypeVar, override
 
-from ai.backend.manager.data.permission.types import EntityType, OperationType
+from ai.backend.manager.data.permission.types import OperationType
 
 from .base import BaseAction, BaseActionResult
+from .types import BatchFieldData
 
 
 class BaseBatchAction(BaseAction):
@@ -16,20 +16,12 @@ class BaseBatchAction(BaseAction):
     def entity_ids(self) -> list[str]:
         raise NotImplementedError
 
-    @classmethod
     @abstractmethod
-    def field_type(cls) -> EntityType | None:
+    def field_data(self) -> BatchFieldData | None:
         """
-        Returns the entity type of this action's targets when they exist as fields
-        of another entity. Returns None if these entities are not fields.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def field_ids(self) -> Mapping[str, str | None]:
-        """
-        Returns a mapping of target entity IDs to their field entity IDs.
-        The value is None if the corresponding entity is not a field.
+        Returns batch field data containing the field type and IDs when the
+        action's targets exist as fields of another entity.
+        Returns None if these entities are not fields.
         """
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/action/single_entity.py
+++ b/src/ai/backend/manager/actions/action/single_entity.py
@@ -1,9 +1,10 @@
 from abc import abstractmethod
 from typing import TypeVar, override
 
-from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.common.data.permission.types import OperationType
 
 from .base import BaseAction, BaseActionResult
+from .types import FieldData
 
 
 class BaseSingleEntityAction(BaseAction):
@@ -15,20 +16,12 @@ class BaseSingleEntityAction(BaseAction):
     def target_entity_id(self) -> str:
         raise NotImplementedError
 
-    @classmethod
     @abstractmethod
-    def field_type(cls) -> EntityType | None:
+    def field_data(self) -> FieldData | None:
         """
-        Returns the entity type of this action's target when it exists as a field
-        of another entity. Returns None if this entity is not a field.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def field_id(self) -> str | None:
-        """
-        Returns the entity ID of this action's target when it exists as a field
-        of another entity. Returns None if this entity is not a field.
+        Returns field data containing the field type and ID when the action's
+        target exists as a field of another entity.
+        Returns None if this entity is not a field.
         """
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/action/types.py
+++ b/src/ai/backend/manager/actions/action/types.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from ai.backend.common.data.permission.types import EntityType
+
+
+@dataclass
+class FieldData:
+    field_type: EntityType
+    field_id: str
+
+
+@dataclass
+class BatchFieldData:
+    field_type: EntityType
+    field_ids: list[str]

--- a/src/ai/backend/manager/services/vfolder/actions/base.py
+++ b/src/ai/backend/manager/services/vfolder/actions/base.py
@@ -15,7 +15,8 @@ from ai.backend.manager.actions.action.single_entity import (
     BaseSingleEntityAction,
     BaseSingleEntityActionResult,
 )
-from ai.backend.manager.data.permission.types import EntityType, OperationType
+from ai.backend.manager.actions.action.types import FieldData
+from ai.backend.manager.data.permission.types import OperationType
 from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.models.vfolder import (
@@ -57,12 +58,7 @@ class VFolderSingleEntityAction(BaseSingleEntityAction):
         return "vfolder"
 
     @override
-    @classmethod
-    def field_type(cls) -> EntityType | None:
-        return None
-
-    @override
-    def field_id(self) -> str | None:
+    def field_data(self) -> FieldData | None:
         return None
 
 


### PR DESCRIPTION
resolves #7744 (BA-3714)

- Add field_data() method to BaseSingleEntityAction
- Add field_data() method to BaseBatchAction (returns BatchFieldData | None)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
