### PR TITLE
doc(BA-3601): Add missing login command in quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Start each component in separate terminals:
 Set up client environment:
 ```bash
 source env-local-user-session.sh
+# This script prints your default User ID and Password;
+./backend.ai login
+# When prompted, enter the User ID and Password shown above.
 ```
 
 Run a simple Python session:

--- a/changes/7800.doc.md
+++ b/changes/7800.doc.md
@@ -1,0 +1,1 @@
+Add additional instruction for quick-start section.


### PR DESCRIPTION
resolves #7646 (BA-3601)

## Summary
- Add missing `./backend.ai login` command in quickstart instructions
- Users need to authenticate before running sessions
- Unlike logging in with web ui, authenication for running session is not intuitive.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
