### PR TITLE
docs: Add CVE-2025-49651 to CHANGELOG clarifying false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Implemented Scaling Group creation action with the Creator pattern.
 ### Security Fixes
 Security vulnerability fixes and hardening were applied.
 
+* **CVE-2025-49651**: Clarified that direct access to compute nodes via port scanning is not a software vulnerability but requires proper network isolation as part of deployment architecture. Backend.AI is designed to operate with compute nodes in network-isolated environments where inbound access is restricted to App Proxy components only. Added comprehensive documentation on required network security configuration ([#7587](https://github.com/lablup/backend.ai/issues/7587))
 * **CVE-2025-49652**: Change default signup status to inactive, preventing newly registered accounts from accessing system resources until an administrator explicitly activates them ([#7520](https://github.com/lablup/backend.ai/issues/7520))
 
 ### Improvements


### PR DESCRIPTION
Clarify that CVE-2025-49651 (direct compute node access via port
scanning) is not a software vulnerability but an operational security
requirement. Backend.AI assumes compute nodes are deployed in
network-isolated environments with inbound access restricted to
App Proxy components only.

This entry references the comprehensive network security documentation
added in #7587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
