### PR TITLE
fix(BA-3600): IndexError when vfolder rm called without filenames

### DIFF
--- a/changes/7806.fix.md
+++ b/changes/7806.fix.md
@@ -1,0 +1,1 @@
+Add defensive error checker and command validity flag for vfolder rm op.

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -541,7 +541,7 @@ def mv(name, src, dst):
 
 @vfolder.command(aliases=["delete-file"])
 @click.argument("name", type=str)
-@click.argument("filenames", nargs=-1)
+@click.argument("filenames", nargs=-1, required=True)
 @click.option("-r", "--recursive", is_flag=True, help="Enable recursive deletion of directories.")
 def rm(name, filenames, recursive):
     """
@@ -553,7 +553,7 @@ def rm(name, filenames, recursive):
 
     \b
     NAME: Name of a virtual folder.
-    FILENAMES: Paths of the files to delete.
+    FILENAMES: Paths of the files to delete (at least one required).
     """
     with Session() as session:
         try:

--- a/src/ai/backend/storage/utils.py
+++ b/src/ai/backend/storage/utils.py
@@ -102,12 +102,14 @@ async def log_manager_api_entry(
                 params["dst_vfid"],
             )
         elif "relpaths" in params:
+            relpaths = params["relpaths"]
+            paths_summary = str(relpaths[0]) + "..." if relpaths else "(empty)"
             log.info(
                 "ManagerAPI::{}(v:{}, f:{}, p*:{})",
                 name.upper(),
                 params["volume"],
                 params["vfid"],
-                str(params["relpaths"][0]) + "...",
+                paths_summary,
             )
         elif "relpath" in params:
             log.info(


### PR DESCRIPTION
resolves #7645 (BA-3600)

When user enters `backend.ai vfolder {vfolder_name}`, It crushed the storage module without any error handling.

#### solution
Add required=True to filenames argument in CLI
Add explicit validation for empty filenames list



**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
