### PR TITLE
fix(BA-3628): Add missing startup_command field when creating session (#7807)

### DIFF
--- a/changes/7807.fix.md
+++ b/changes/7807.fix.md
@@ -1,0 +1,1 @@
+Add missing `startup_command` field when creating a session.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -665,6 +665,7 @@ class AgentRegistry:
                         route_id=route_id,
                         sudo_session_enabled=sudo_session_enabled,
                         network=network,
+                        startup_command=startup_command,
                     )
                 ),
             )
@@ -989,6 +990,7 @@ class AgentRegistry:
         route_id: Optional[uuid.UUID],
         sudo_session_enabled: bool,
         network: NetworkRow | None,
+        startup_command: str | None,
     ) -> SessionId:
         """Enqueue session using Sokovan scheduling controller."""
         kernel_enqueue_configs: List[KernelEnqueueingConfig] = session_enqueue_configs[
@@ -1020,6 +1022,7 @@ class AgentRegistry:
             designated_agent_list=list(agent_list) if agent_list else None,
             internal_data=internal_data,
             public_sgroup_only=public_sgroup_only,
+            startup_command=startup_command,
         )
 
         # Delegate to scheduling controller
@@ -1050,6 +1053,7 @@ class AgentRegistry:
         route_id: Optional[uuid.UUID] = None,
         sudo_session_enabled: bool = False,
         network: NetworkRow | None = None,
+        startup_command: str | None = None,
     ) -> SessionId:
         # Use sokovan scheduling controller if enabled
         if self._use_sokovan:
@@ -1076,6 +1080,7 @@ class AgentRegistry:
                 route_id=route_id,
                 sudo_session_enabled=sudo_session_enabled,
                 network=network,
+                startup_command=startup_command,
             )
 
         # Original implementation

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1019,6 +1019,7 @@ class ScheduleDBSource:
                 bootstrap_script=session_data.bootstrap_script,
                 use_host_network=session_data.use_host_network,
                 timeout=session_data.timeout,
+                startup_command=session_data.startup_command,
             )
 
             # Create kernel rows

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -104,6 +104,7 @@ class SessionCreationSpec:
     designated_agent_list: Optional[list[str]] = None
     internal_data: Optional[dict] = None
     public_sgroup_only: bool = True
+    startup_command: str | None = None
 
     @classmethod
     def from_deployment_info(
@@ -276,6 +277,7 @@ class SessionEnqueueData:
     bootstrap_script: Optional[str] = None
     use_host_network: bool = False
     timeout: Optional[int] = None
+    startup_command: str | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/preparer.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/preparer.py
@@ -157,6 +157,7 @@ class SessionPreparer:
             timeout=timeout,
             kernels=kernel_data_list,
             dependencies=spec.dependency_sessions or [],
+            startup_command=spec.startup_command,
         )
 
         return session_data


### PR DESCRIPTION
This is an auto-generated backport PR of #7807 to the 25.15 release.