### PR TITLE
fix(BA-3789): duplicated field cause zip error

### DIFF
--- a/changes/7826.fix.md
+++ b/changes/7826.fix.md
@@ -1,0 +1,1 @@
+Fix duplicated status field in vfolder CLI list causing zip strict mode error

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -43,7 +43,6 @@ _default_list_fields = (
     vfolder_fields["group_id"],
     vfolder_fields["permission"],
     vfolder_fields["ownership_type"],
-    vfolder_fields["status"],
 )
 
 T = TypeVar("T")


### PR DESCRIPTION
resolves #7825  (BA-3789)

Duplicated field declared in `src/ai/backend/cli/func/vfolder.py`, caused cli error when  `./backend.ai vfolder list` typed when vfolders are existing. 

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [v] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
