### PR TITLE
fix(BA-3789): duplicated field cause zip error (#7826)

### DIFF
--- a/changes/7826.fix.md
+++ b/changes/7826.fix.md
@@ -1,0 +1,1 @@
+Fix duplicated status field in vfolder CLI list causing zip strict mode error

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -42,7 +42,6 @@ _default_list_fields = (
     vfolder_fields["group_id"],
     vfolder_fields["permission"],
     vfolder_fields["ownership_type"],
-    vfolder_fields["status"],
 )
 
 T = TypeVar("T")


### PR DESCRIPTION
This is an auto-generated backport PR of #7826 to the 25.15 release.