### PR TITLE
fix(BA-3600): IndexError when vfolder rm called without filenames (#7806)

### DIFF
--- a/changes/7806.fix.md
+++ b/changes/7806.fix.md
@@ -1,0 +1,1 @@
+Add defensive error checker and command validity flag for vfolder rm op.

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -542,7 +542,7 @@ def mv(name, src, dst):
 
 @vfolder.command(aliases=["delete-file"])
 @click.argument("name", type=str)
-@click.argument("filenames", nargs=-1)
+@click.argument("filenames", nargs=-1, required=True)
 @click.option("-r", "--recursive", is_flag=True, help="Enable recursive deletion of directories.")
 def rm(name, filenames, recursive):
     """
@@ -554,7 +554,7 @@ def rm(name, filenames, recursive):
 
     \b
     NAME: Name of a virtual folder.
-    FILENAMES: Paths of the files to delete.
+    FILENAMES: Paths of the files to delete (at least one required).
     """
     with Session() as session:
         try:

--- a/src/ai/backend/storage/utils.py
+++ b/src/ai/backend/storage/utils.py
@@ -97,12 +97,14 @@ async def log_manager_api_entry(
                 params["dst_vfid"],
             )
         elif "relpaths" in params:
+            relpaths = params["relpaths"]
+            paths_summary = str(relpaths[0]) + "..." if relpaths else "(empty)"
             log.info(
                 "ManagerAPI::{}(v:{}, f:{}, p*:{})",
                 name.upper(),
                 params["volume"],
                 params["vfid"],
-                str(params["relpaths"][0]) + "...",
+                paths_summary,
             )
         elif "relpath" in params:
             log.info(


### PR DESCRIPTION
This is an auto-generated backport PR of #7806 to the 25.15 release.