### PR TITLE
chore(BA-3796): Disable extra Python package index to speed up generate-lockfiles

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -64,9 +64,10 @@ search_path = ["<PYENV>"]
 [python-infer]
 use_rust_parser = true
 
-[python-repos]
-indexes = ["https://dist.backend.ai/pypi/simple/", "https://pypi.org/simple/"]
-find_links = ["file://%(buildroot)s/wheelhouse"]
+# This slows down `generate-lockfiles` severely. Enable only when strictly needed.
+# [python-repos]
+# indexes = ["https://dist.backend.ai/pypi/simple/", "https://pypi.org/simple/"]
+# find_links = ["file://%(buildroot)s/wheelhouse"]
 
 [python.resolves]
 python-default = "python.lock"


### PR DESCRIPTION
resolves #7855 (BA-3796)

## Summary

- Disable extra Python package indexes in `pants.toml` to improve `pants generate-lockfiles` performance
- Add a note explaining the configuration should only be enabled when strictly needed

## Test plan

- [x] Verify pants commands still work with default pypi.org index

[BA-3796]: https://lablup.atlassian.net/browse/BA-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ