### PR TITLE
chore: Make pre-commit, pre-push hooks interruptible

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -2,6 +2,14 @@
 # implementation: backend.ai monorepo standard pre-commit hook
 set -e  # Exit on error
 
+# Make it interruptible.
+cleanup() {
+  local sig="${1:-TERM}"
+  jobs -p | xargs -r kill -s "$sig"
+  wait; exit 1
+}
+trap cleanup SIGINT SIGTERM
+
 BASE_PATH=$(cd "$(dirname "$0")"/.. && pwd)
 cd "$BASE_PATH"
 

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,4 +1,13 @@
 #! /bin/bash
+
+# Make it interruptible.
+cleanup() {
+  local sig="${1:-TERM}"
+  jobs -p | xargs -r kill -s "$sig"
+  wait; exit 1
+}
+trap cleanup SIGINT SIGTERM
+
 # implementation: backend.ai monorepo standard pre-push hook
 BASE_PATH=$(cd "$(dirname "$0")"/.. && pwd)
 if [ -f .pants.rc ]; then


### PR DESCRIPTION
A small developer-experience improvement.

It is also important for when using agentic coding tools because users may want to cleanly and promptly interrupt what AI is doing.

It is also important to interrupt `git commit` or `git push` when using multiple worktress and pants getting stuck to wait for another pants instance complete.