### PR TITLE
chore: Fix pre-commit and pre-push hooks

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,24 +1,18 @@
 #! /bin/bash
-set -Eeuo pipefail
 
 # Make it interruptible.
 PGID="$(ps -o pgid= $$ | tr -d ' ')"
 cleanup() {
   local sig="$1"
   trap - SIGINT SIGTERM
-  echo -e "\nPre-commit hook is interrupted ($sig)."
-  kill "-${sig}" -- "-${PGID}"
-  wait
-  case "${sig}" in
-    INT)  exit 130 ;;
-    TERM) exit 143 ;;
-    *)    exit 1   ;;
-  esac
+  echo -e "Pre-commit hook is interrupted ($sig)." >&2
+  kill -s "${sig}" -- "-${PGID}"
 }
 trap 'cleanup INT' SIGINT
 trap 'cleanup TERM' SIGTERM
 
 # --- Hook Body ---
+set -Eeuo pipefail
 
 BASE_PATH=$(cd "$(dirname "$0")"/.. && pwd)
 cd "$BASE_PATH"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,24 +1,18 @@
 #! /bin/bash
-set -Eeuo pipefail
 
 # Make it interruptible.
 PGID="$(ps -o pgid= $$ | tr -d ' ')"
 cleanup() {
   local sig="$1"
   trap - SIGINT SIGTERM
-  echo -e "\nPre-push hook is interrupted ($sig)."
-  kill "-${sig}" -- "-${PGID}"
-  wait
-  case "${sig}" in
-    INT)  exit 130 ;;
-    TERM) exit 143 ;;
-    *)    exit 1   ;;
-  esac
+  echo -e "\nPre-push hook is interrupted ($sig)." >&2
+  kill -s "${sig}" -- "-${PGID}"
 }
 trap 'cleanup INT' SIGINT
 trap 'cleanup TERM' SIGTERM
 
 # --- Hook Body ---
+set -Eeuo pipefail
 
 BASE_PATH=$(cd "$(dirname "$0")"/.. && pwd)
 if [ -f .pants.rc ]; then


### PR DESCRIPTION
Follow-up fix to #7873

`jobs -p` used in the prior PR did not properly shutdown foreground processes.

Also, ensure the hook body can be interrupted using `set -Eeuo pipefail` while ensuring expected command failure does not terminate the script: `$(... || true)`.

> [!TIP]
> `pants` client command detects overlapped pants command execution within the current session. If we use `setsid` to split the process tree, it no longer works.
