### PR TITLE
chore: Remove no longer used symbolic link

### DIFF
--- a/src/ai/backend/install/configs/wsproxy.toml
+++ b/src/ai/backend/install/configs/wsproxy.toml
@@ -1,1 +1,0 @@
-../../../../../configs/wsproxy/halfstack.toml


### PR DESCRIPTION
To avoid bogus error messages when using ripgrep
