### PR TITLE
chore: Update MinIO healthcheck settings in compose files

### DIFF
--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -385,9 +385,9 @@ services:
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
 networks:
   half:

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -200,9 +200,9 @@ services:
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
 networks:
   half:


### PR DESCRIPTION
Reduced healthcheck interval and timeout, and increased retries for the MinIO service in both docker-compose.halfstack-ha.yml and docker-compose.halfstack-main.yml. This should improve responsiveness and reliability of health monitoring.
