### PR TITLE
fix(BA-3807): Restore id parameter name from `agent_id` to `id` in `ModifyAgent` mutation

### DIFF
--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -873,7 +873,7 @@ class ModifyAgent(graphene.Mutation):
     @classmethod
     @privileged_mutation(
         UserRole.SUPERADMIN,
-        lambda id, **kwargs: (None, id),
+        lambda id, **kwargs: (None, id),  # noqa: A006
     )
     async def mutate(
         cls,


### PR DESCRIPTION
resolves #7890 (BA-3807)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
