### PR TITLE
feat(BA-3840): Implement ErrorLog Strawberry GraphQL DataLoaders

### DIFF
--- a/changes/7957.feature.md
+++ b/changes/7957.feature.md
@@ -1,0 +1,1 @@
+Implement `ErrorLog` Strawberry GraphQL DataLoaders

--- a/src/ai/backend/manager/api/gql/data_loader/error_log/__init__.py
+++ b/src/ai/backend/manager/api/gql/data_loader/error_log/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .loader import load_error_logs_by_ids
+
+__all__ = ("load_error_logs_by_ids",)

--- a/src/ai/backend/manager/api/gql/data_loader/error_log/loader.py
+++ b/src/ai/backend/manager/api/gql/data_loader/error_log/loader.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Optional
+
+from ai.backend.manager.data.error_log.types import ErrorLogData
+from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.error_log import ErrorLogConditions
+from ai.backend.manager.services.error_log.actions.search import SearchErrorLogsAction
+from ai.backend.manager.services.error_log.processors import ErrorLogProcessors
+
+
+async def load_error_logs_by_ids(
+    processor: ErrorLogProcessors,
+    error_log_ids: Sequence[uuid.UUID],
+) -> list[Optional[ErrorLogData]]:
+    """Batch load error logs by their IDs.
+
+    Args:
+        processor: The error log processor.
+        error_log_ids: Sequence of error log UUIDs to load.
+
+    Returns:
+        List of ErrorLogData (or None if not found) in the same order as error_log_ids.
+    """
+    if not error_log_ids:
+        return []
+
+    querier = BatchQuerier(
+        pagination=OffsetPagination(limit=len(error_log_ids)),
+        conditions=[ErrorLogConditions.by_ids(error_log_ids)],
+    )
+
+    action_result = await processor.search.wait_for_complete(SearchErrorLogsAction(querier=querier))
+
+    error_log_map = {error_log.id: error_log for error_log in action_result.data}
+    return [error_log_map.get(error_log_id) for error_log_id in error_log_ids]

--- a/src/ai/backend/manager/repositories/error_log/__init__.py
+++ b/src/ai/backend/manager/repositories/error_log/__init__.py
@@ -1,8 +1,10 @@
 from .creators import ErrorLogCreatorSpec
+from .options import ErrorLogConditions
 from .repositories import ErrorLogRepositories
 from .repository import ErrorLogRepository
 
 __all__ = (
+    "ErrorLogConditions",
     "ErrorLogCreatorSpec",
     "ErrorLogRepositories",
     "ErrorLogRepository",

--- a/src/ai/backend/manager/repositories/error_log/options.py
+++ b/src/ai/backend/manager/repositories/error_log/options.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Collection
+
+import sqlalchemy as sa
+
+from ai.backend.manager.models.error_logs import ErrorLogRow
+from ai.backend.manager.repositories.base import QueryCondition
+
+
+class ErrorLogConditions:
+    """Query conditions for error logs."""
+
+    @staticmethod
+    def by_ids(error_log_ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ErrorLogRow.id.in_(error_log_ids)
+
+        return inner

--- a/src/ai/backend/manager/services/error_log/processors.py
+++ b/src/ai/backend/manager/services/error_log/processors.py
@@ -7,6 +7,7 @@ from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 
 from .actions import CreateErrorLogAction, CreateErrorLogActionResult
+from .actions.search import SearchErrorLogsAction, SearchErrorLogsActionResult
 from .service import ErrorLogService
 
 __all__ = ("ErrorLogProcessors",)
@@ -16,12 +17,15 @@ class ErrorLogProcessors(AbstractProcessorPackage):
     """Processor package for error log operations."""
 
     create: ActionProcessor[CreateErrorLogAction, CreateErrorLogActionResult]
+    search: ActionProcessor[SearchErrorLogsAction, SearchErrorLogsActionResult]
 
     def __init__(self, service: ErrorLogService, action_monitors: list[ActionMonitor]) -> None:
         self.create = ActionProcessor(service.create, action_monitors)
+        self.search = ActionProcessor(service.search, action_monitors)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
         return [
             CreateErrorLogAction.spec(),
+            SearchErrorLogsAction.spec(),
         ]

--- a/tests/unit/manager/api/error_log/BUILD
+++ b/tests/unit/manager/api/error_log/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/error_log/test_dataloader.py
+++ b/tests/unit/manager/api/error_log/test_dataloader.py
@@ -1,0 +1,67 @@
+"""Tests for error_log GraphQL DataLoader utilities."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from ai.backend.manager.api.gql.data_loader.error_log.loader import (
+    load_error_logs_by_ids,
+)
+from ai.backend.manager.data.error_log.types import ErrorLogData
+
+
+class TestLoadErrorLogsByIds:
+    """Tests for load_error_logs_by_ids function."""
+
+    @staticmethod
+    def create_mock_error_log(error_log_id: uuid.UUID) -> MagicMock:
+        return MagicMock(spec=ErrorLogData, id=error_log_id)
+
+    @staticmethod
+    def create_mock_processor(error_logs: list[MagicMock]) -> MagicMock:
+        mock_processor = MagicMock()
+        mock_action_result = MagicMock()
+        mock_action_result.data = error_logs
+        mock_processor.search.wait_for_complete = AsyncMock(return_value=mock_action_result)
+        return mock_processor
+
+    async def test_empty_ids_returns_empty_list(self) -> None:
+        # Given
+        mock_processor = MagicMock()
+
+        # When
+        result = await load_error_logs_by_ids(mock_processor, [])
+
+        # Then
+        assert result == []
+        mock_processor.search.wait_for_complete.assert_not_called()
+
+    async def test_returns_error_logs_in_request_order(self) -> None:
+        # Given
+        id1, id2, id3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        error_log1 = self.create_mock_error_log(id1)
+        error_log2 = self.create_mock_error_log(id2)
+        error_log3 = self.create_mock_error_log(id3)
+        mock_processor = self.create_mock_processor(
+            [error_log3, error_log1, error_log2]  # DB returns in different order
+        )
+
+        # When
+        result = await load_error_logs_by_ids(mock_processor, [id1, id2, id3])
+
+        # Then
+        assert result == [error_log1, error_log2, error_log3]
+
+    async def test_returns_none_for_missing_ids(self) -> None:
+        # Given
+        existing_id = uuid.uuid4()
+        missing_id = uuid.uuid4()
+        existing_error_log = self.create_mock_error_log(existing_id)
+        mock_processor = self.create_mock_processor([existing_error_log])
+
+        # When
+        result = await load_error_logs_by_ids(mock_processor, [existing_id, missing_id])
+
+        # Then
+        assert result == [existing_error_log, None]


### PR DESCRIPTION
Resolves BA-3840.

## Summary
- Add `ErrorLogConditions` with `by_ids` method for batch loading error logs
- Update `ErrorLogProcessors` to include the `search` processor
- Implement `load_error_logs_by_ids` DataLoader function following the AuditLog pattern from #7846
- Add unit tests for the new DataLoader

## Test plan
- [x] Unit tests for `load_error_logs_by_ids` function
- [ ] Verify DataLoader can be used in GraphQL resolvers

🤖 Generated with [Claude Code](https://claude.ai/code)