### PR TITLE
chore: Restores the tags of the krunner-extractor image (#7980)

### DIFF
--- a/src/ai/backend/runner/krunner-extractor.img.aarch64.tar.xz
+++ b/src/ai/backend/runner/krunner-extractor.img.aarch64.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:570b9cb5b730e087a54a1d590205151e041c50f8a89f4b4ee368eb7d15ff031d
-size 3211380
+oid sha256:19bd2d54906d38b3be8893124b7dbdb498425e99c1c39031123be2a8aa74e86a
+size 3211352

--- a/src/ai/backend/runner/krunner-extractor.img.x86_64.tar.xz
+++ b/src/ai/backend/runner/krunner-extractor.img.x86_64.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:655a82f0bf8085e6c8303ecad6a18a0b41dd324c07886d75d0120f58ad69afea
-size 2993156
+oid sha256:7ee72fad2a8d986afaf639b06011f21f3ea866364ae217a59a226fb306bc1c4b
+size 2991564


### PR DESCRIPTION
This is an auto-generated backport PR of #7980 to the 25.19 release.