### PR TITLE
feat(BA-3895): Add FK constraint from object_permissions to permission_groups

### DIFF
--- a/changes/8032.feature.md
+++ b/changes/8032.feature.md
@@ -1,0 +1,1 @@
+Add foreign key constraint from `object_permissions` to `permission_groups` with CASCADE DELETE. This prevents dangling object permission records when permission groups are deleted due to race conditions.

--- a/src/ai/backend/manager/data/permission/object_permission.py
+++ b/src/ai/backend/manager/data/permission/object_permission.py
@@ -53,5 +53,6 @@ class ObjectPermissionDeleteInput:
 class ObjectPermissionData:
     id: uuid.UUID
     role_id: uuid.UUID
+    permission_group_id: uuid.UUID
     object_id: ObjectId
     operation: OperationType

--- a/src/ai/backend/manager/models/alembic/versions/f8a9b3c2d1e0_add_fk_constraints_to_rbac_permission_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/f8a9b3c2d1e0_add_fk_constraints_to_rbac_permission_tables.py
@@ -1,0 +1,146 @@
+"""add foreign key constraints to rbac permission tables
+
+Revision ID: f8a9b3c2d1e0
+Revises: 71343531dd5a
+Create Date: 2026-01-14 20:30:00.000000
+
+"""
+
+import textwrap
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "f8a9b3c2d1e0"
+down_revision = "71343531dd5a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Step 1: Clean up orphan records in permission_groups
+    # Delete permission_groups where role_id does not exist in roles table
+    # Using NOT EXISTS for better performance with large roles table
+    conn.execute(
+        sa.text(
+            textwrap.dedent("""\
+                DELETE FROM permission_groups pg
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM roles r WHERE r.id = pg.role_id
+                )
+            """)
+        )
+    )
+
+    # Step 2: Clean up orphan records in permissions
+    # Delete permissions where permission_group_id does not exist in permission_groups table
+    # Using NOT EXISTS for better performance with large permission_groups table
+    conn.execute(
+        sa.text(
+            textwrap.dedent("""\
+                DELETE FROM permissions p
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM permission_groups pg WHERE pg.id = p.permission_group_id
+                )
+            """)
+        )
+    )
+
+    # Step 3: Add permission_group_id column to object_permissions (nullable first)
+    op.add_column(
+        "object_permissions",
+        sa.Column("permission_group_id", GUID(), nullable=True),
+    )
+
+    # Step 4: Migrate data - set permission_group_id based on role_id and scope mapping
+    # Find permission_group with same role_id where object_permission's entity is mapped to the scope
+    # Using CTE with DISTINCT ON for better performance (single pass instead of correlated subquery)
+    conn.execute(
+        sa.text(
+            textwrap.dedent("""\
+                WITH matched AS (
+                    SELECT DISTINCT ON (op.id) op.id AS op_id, pg.id AS pg_id
+                    FROM object_permissions op
+                    JOIN permission_groups pg ON pg.role_id = op.role_id
+                    JOIN association_scopes_entities ase
+                        ON pg.scope_type = ase.scope_type
+                        AND pg.scope_id = ase.scope_id
+                        AND ase.entity_type = op.entity_type
+                        AND ase.entity_id = op.entity_id
+                )
+                UPDATE object_permissions op
+                SET permission_group_id = matched.pg_id
+                FROM matched
+                WHERE op.id = matched.op_id
+            """)
+        )
+    )
+
+    # Step 5: Delete object_permissions that couldn't be mapped (orphans)
+    conn.execute(
+        sa.text(
+            textwrap.dedent("""\
+                DELETE FROM object_permissions
+                WHERE permission_group_id IS NULL
+            """)
+        )
+    )
+
+    # Step 6: Make permission_group_id NOT NULL
+    op.alter_column(
+        "object_permissions",
+        "permission_group_id",
+        nullable=False,
+    )
+
+    # Step 7: Add FK constraint to object_permissions.permission_group_id -> permission_groups.id
+    op.create_foreign_key(
+        op.f("fk_object_permissions_permission_group_id_permission_groups"),
+        "object_permissions",
+        "permission_groups",
+        ["permission_group_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Step 8: Add FK constraint to permissions.permission_group_id -> permission_groups.id
+    op.create_foreign_key(
+        op.f("fk_permissions_permission_group_id_permission_groups"),
+        "permissions",
+        "permission_groups",
+        ["permission_group_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Step 9: Add index for the new column
+    op.create_index(
+        "ix_object_permissions_permission_group_id",
+        "object_permissions",
+        ["permission_group_id"],
+    )
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index("ix_object_permissions_permission_group_id", table_name="object_permissions")
+
+    # Drop FK constraints
+    op.drop_constraint(
+        op.f("fk_permissions_permission_group_id_permission_groups"),
+        "permissions",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_object_permissions_permission_group_id_permission_groups"),
+        "object_permissions",
+        type_="foreignkey",
+    )
+
+    # Drop column
+    op.drop_column("object_permissions", "permission_group_id")

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -37,7 +37,10 @@ class PermissionRow(Base):
         "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     permission_group_id: Mapped[uuid.UUID] = mapped_column(
-        "permission_group_id", GUID, nullable=False
+        "permission_group_id",
+        GUID,
+        sa.ForeignKey("permission_groups.id", ondelete="CASCADE"),
+        nullable=False,
     )
     entity_type: Mapped[EntityType] = mapped_column(
         "entity_type", StrEnumType(EntityType, length=32), nullable=False

--- a/src/ai/backend/manager/models/rbac_models/permission/permission_group.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission_group.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.models.rbac_models.role import RoleRow
 
+    from .object_permission import ObjectPermissionRow
     from .permission import PermissionRow
 
 
@@ -48,6 +49,14 @@ def _get_permission_join_condition():
     from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 
     return PermissionGroupRow.id == foreign(PermissionRow.permission_group_id)
+
+
+def _get_object_permission_join_condition():
+    from ai.backend.manager.models.rbac_models.permission.object_permission import (
+        ObjectPermissionRow,
+    )
+
+    return PermissionGroupRow.id == foreign(ObjectPermissionRow.permission_group_id)
 
 
 class PermissionGroupRow(Base):
@@ -77,6 +86,7 @@ class PermissionGroupRow(Base):
         "RoleRow",
         back_populates="permission_group_rows",
         primaryjoin=_get_role_join_condition,
+        viewonly=True,
     )
     mapped_entities: Mapped[list[AssociationScopesEntitiesRow]] = relationship(
         "AssociationScopesEntitiesRow",
@@ -87,6 +97,13 @@ class PermissionGroupRow(Base):
         "PermissionRow",
         back_populates="permission_group_row",
         primaryjoin=_get_permission_join_condition,
+        passive_deletes=True,
+    )
+    object_permission_rows: Mapped[list[ObjectPermissionRow]] = relationship(
+        "ObjectPermissionRow",
+        back_populates="permission_group_row",
+        primaryjoin=_get_object_permission_join_condition,
+        passive_deletes=True,
     )
 
     def parsed_scope_id(self) -> ScopeId:

--- a/src/ai/backend/manager/models/rbac_models/role.py
+++ b/src/ai/backend/manager/models/rbac_models/role.py
@@ -94,11 +94,13 @@ class RoleRow(Base):
         "ObjectPermissionRow",
         back_populates="role_row",
         primaryjoin=_get_object_permission_rows_join_condition,
+        viewonly=True,
     )
     permission_group_rows: Mapped[list[PermissionGroupRow]] = relationship(
         "PermissionGroupRow",
         back_populates="role_row",
         primaryjoin=_get_permission_group_rows_join_condition,
+        viewonly=True,
     )
 
     def to_data(self) -> RoleData:

--- a/tests/unit/manager/repositories/permission_controller/test_fk_constraints.py
+++ b/tests/unit/manager/repositories/permission_controller/test_fk_constraints.py
@@ -1,0 +1,275 @@
+"""Tests for RBAC foreign key constraints and CASCADE DELETE behavior.
+
+These tests verify that:
+1. Deleting a PermissionGroup cascades to ObjectPermission
+2. Deleting a PermissionGroup cascades to Permission
+3. Role deletion does NOT cascade to PermissionGroup (no FK)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    ScopeType,
+)
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission_group import PermissionGroupRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+
+class TestRBACFKConstraints:
+    """Test cases for RBAC FK constraints and CASCADE DELETE behavior."""
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        """Database connection with RBAC tables. TRUNCATE CASCADE handles cleanup."""
+        async with with_tables(
+            database_connection,
+            [
+                # FK dependency order: parents before children
+                RoleRow,
+                UserRoleRow,
+                PermissionGroupRow,
+                PermissionRow,
+                ObjectPermissionRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.mark.asyncio
+    async def test_cascade_delete_permission_group_removes_object_permissions(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """When a permission_group is deleted, its object_permissions should be CASCADE deleted."""
+        db = db_with_cleanup
+
+        role_id = uuid4()
+        async with db.begin_session() as db_session:
+            role = RoleRow(
+                id=role_id,
+                name="test-role",
+                description="Test role for object permission FK constraint test",
+            )
+            db_session.add(role)
+            await db_session.flush()
+
+            pg = PermissionGroupRow(
+                role_id=role_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id="test-project-id",
+            )
+            db_session.add(pg)
+            await db_session.flush()
+            pg_id = pg.id
+
+            op = ObjectPermissionRow(
+                role_id=role_id,
+                permission_group_id=pg_id,
+                entity_type=EntityType.VFOLDER,
+                entity_id="test-vfolder-id",
+                operation=OperationType.READ,
+            )
+            db_session.add(op)
+            await db_session.flush()
+            op_id = op.id
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(ObjectPermissionRow).where(ObjectPermissionRow.id == op_id)
+            )
+            assert result.scalar_one_or_none() is not None
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionGroupRow).where(PermissionGroupRow.id == pg_id)
+            )
+            pg_to_delete = result.scalar_one()
+            await db_session.delete(pg_to_delete)
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(ObjectPermissionRow).where(ObjectPermissionRow.id == op_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+    @pytest.mark.asyncio
+    async def test_cascade_delete_permission_group_removes_permissions(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """When a permission_group is deleted, its permissions should be CASCADE deleted."""
+        db = db_with_cleanup
+
+        role_id = uuid4()
+        async with db.begin_session() as db_session:
+            role = RoleRow(
+                id=role_id,
+                name="test-role-2",
+                description="Test role for permission FK constraint test",
+            )
+            db_session.add(role)
+            await db_session.flush()
+
+            pg = PermissionGroupRow(
+                role_id=role_id,
+                scope_type=ScopeType.DOMAIN,
+                scope_id="test-domain-id",
+            )
+            db_session.add(pg)
+            await db_session.flush()
+            pg_id = pg.id
+
+            perm = PermissionRow(
+                permission_group_id=pg_id,
+                entity_type=EntityType.SESSION,
+                operation=OperationType.CREATE,
+            )
+            db_session.add(perm)
+            await db_session.flush()
+            perm_id = perm.id
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionRow).where(PermissionRow.id == perm_id)
+            )
+            assert result.scalar_one_or_none() is not None
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionGroupRow).where(PermissionGroupRow.id == pg_id)
+            )
+            pg_to_delete = result.scalar_one()
+            await db_session.delete(pg_to_delete)
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionRow).where(PermissionRow.id == perm_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+    @pytest.mark.asyncio
+    async def test_cascade_delete_permission_group_removes_both(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """When a permission_group is deleted, both permissions and object_permissions should be CASCADE deleted."""
+        db = db_with_cleanup
+
+        role_id = uuid4()
+        async with db.begin_session() as db_session:
+            role = RoleRow(
+                id=role_id,
+                name="test-role-3",
+                description="Test role for combined cascade delete test",
+            )
+            db_session.add(role)
+            await db_session.flush()
+
+            pg = PermissionGroupRow(
+                role_id=role_id,
+                scope_type=ScopeType.USER,
+                scope_id="test-user-id",
+            )
+            db_session.add(pg)
+            await db_session.flush()
+            pg_id = pg.id
+
+            perm = PermissionRow(
+                permission_group_id=pg_id,
+                entity_type=EntityType.IMAGE,
+                operation=OperationType.UPDATE,
+            )
+            db_session.add(perm)
+            await db_session.flush()
+            perm_id = perm.id
+
+            op = ObjectPermissionRow(
+                role_id=role_id,
+                permission_group_id=pg_id,
+                entity_type=EntityType.SESSION,
+                entity_id="test-session-id",
+                operation=OperationType.READ,
+            )
+            db_session.add(op)
+            await db_session.flush()
+            op_id = op.id
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionRow).where(PermissionRow.id == perm_id)
+            )
+            assert result.scalar_one_or_none() is not None
+            result = await db_session.execute(
+                sa.select(ObjectPermissionRow).where(ObjectPermissionRow.id == op_id)
+            )
+            assert result.scalar_one_or_none() is not None
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionGroupRow).where(PermissionGroupRow.id == pg_id)
+            )
+            pg_to_delete = result.scalar_one()
+            await db_session.delete(pg_to_delete)
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionRow).where(PermissionRow.id == perm_id)
+            )
+            assert result.scalar_one_or_none() is None
+            result = await db_session.execute(
+                sa.select(ObjectPermissionRow).where(ObjectPermissionRow.id == op_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+    @pytest.mark.asyncio
+    async def test_role_deletion_does_not_cascade_to_permission_group(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> None:
+        """Role deletion should NOT cascade to permission_group (no FK constraint)."""
+        db = db_with_cleanup
+
+        role_id = uuid4()
+        async with db.begin_session() as db_session:
+            role = RoleRow(
+                id=role_id,
+                name="test-role-4",
+                description="Test role for no-cascade test",
+            )
+            db_session.add(role)
+            await db_session.flush()
+
+            pg = PermissionGroupRow(
+                role_id=role_id,
+                scope_type=ScopeType.GLOBAL,
+                scope_id="global",
+            )
+            db_session.add(pg)
+            await db_session.flush()
+            pg_id = pg.id
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(sa.select(RoleRow).where(RoleRow.id == role_id))
+            role_to_delete = result.scalar_one()
+            await db_session.delete(role_to_delete)
+
+        async with db.begin_session() as db_session:
+            result = await db_session.execute(
+                sa.select(PermissionGroupRow).where(PermissionGroupRow.id == pg_id)
+            )
+            assert result.scalar_one_or_none() is not None


### PR DESCRIPTION
resolves #8029 (BA-3895)

This change redesigns the FK structure to prevent dangling object permissions caused by race conditions during permission group operations.

Changes:
- Add permission_group_id column to object_permissions with CASCADE DELETE FK
- Remove FK constraints from role_id columns (columns retained for queries)
- Add Alembic migration with data migration strategy
- Add unit tests for CASCADE DELETE behavior


**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
