### PR TITLE
feat(BA-3899): Add Method based validators for *_required_for_method

### DIFF
--- a/changes/8046.feature.md
+++ b/changes/8046.feature.md
@@ -1,0 +1,1 @@
+Add method based authorization decorator for pydantic migration

--- a/src/ai/backend/manager/api/etcd.py
+++ b/src/ai/backend/manager/api/etcd.py
@@ -284,7 +284,7 @@ async def app_ctx(app: web.Application) -> AsyncGenerator[None, None]:
 
 
 @superadmin_required
-async def get_docker_registries(request: web.Request) -> web.Response:
+async def get_docker_registries(request: web.Request) -> web.StreamResponse:
     """
     Returns the list of all registered docker registries.
     """

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -340,7 +340,7 @@ class TestGetRole:
 
         mock_root_ctx.processors.auth.get_role.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
-        response_body = json.loads(cast(bytes, response.body))
+        response_body = json.loads(cast(bytes, cast(web.Response, response).body))
         assert response_body["global_role"] == global_role
         assert response_body["domain_role"] == domain_role
         assert response_body["group_role"] is None
@@ -555,7 +555,7 @@ class TestGetSSHKeypair:
 
         mock_root_ctx.processors.auth.get_ssh_keypair.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
-        response_body = json.loads(cast(bytes, response.body))
+        response_body = json.loads(cast(bytes, cast(web.Response, response).body))
         assert response_body["ssh_public_key"] == public_key
 
     @pytest.mark.asyncio
@@ -596,7 +596,7 @@ class TestGenerateSSHKeypair:
 
         mock_root_ctx.processors.auth.generate_ssh_keypair.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
-        response_body = json.loads(cast(bytes, response.body))
+        response_body = json.loads(cast(bytes, cast(web.Response, response).body))
         assert response_body["ssh_public_key"] == ssh_public_key
         assert response_body["ssh_private_key"] == ssh_private_key
 
@@ -642,7 +642,7 @@ class TestUploadSSHKeypair:
 
         mock_root_ctx.processors.auth.upload_ssh_keypair.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
-        response_body = json.loads(cast(bytes, response.body))
+        response_body = json.loads(cast(bytes, cast(web.Response, response).body))
         assert "ssh_public_key" in response_body
         assert "ssh_private_key" in response_body
 

--- a/tests/unit/manager/api/rbac/test_scope_handlers.py
+++ b/tests/unit/manager/api/rbac/test_scope_handlers.py
@@ -146,8 +146,9 @@ class TestGetScopeTypesHandler:
             response = await handler.get_scope_types(superadmin_request)
 
         assert response.status == HTTPStatus.OK
-        assert response.body is not None
-        response_data = json.loads(cast(bytes, response.body))
+        response_body = cast(web.Response, response).body
+        assert response_body is not None
+        response_data = json.loads(cast(bytes, response_body))
         assert "items" in response_data
         assert len(response_data["items"]) == self.EXPECTED_SCOPE_TYPES_COUNT
 
@@ -364,8 +365,9 @@ class TestSearchScopesHandler:
             response = await handler.search_scopes(superadmin_request)
 
         assert response.status == HTTPStatus.OK
-        assert response.body is not None
-        response_data = json.loads(cast(bytes, response.body))
+        response_body = cast(web.Response, response).body
+        assert response_body is not None
+        response_data = json.loads(cast(bytes, response_body))
         assert "items" in response_data
         assert "pagination" in response_data
         assert len(response_data["items"]) == len(single_scope_result.items)
@@ -406,7 +408,8 @@ class TestSearchScopesHandler:
         ):
             response = await handler.search_scopes(superadmin_request)
 
-        response_data = json.loads(cast(bytes, response.body))
+        response_body = cast(web.Response, response).body
+        response_data = json.loads(cast(bytes, response_body))
         assert response_data is not None
         assert response_data["pagination"]["total"] == self.PAGINATION_TOTAL
         assert response_data["pagination"]["offset"] == self.DEFAULT_OFFSET

--- a/tests/unit/manager/api/test_resource.py
+++ b/tests/unit/manager/api/test_resource.py
@@ -184,8 +184,9 @@ class TestGetContainerRegistries:
         mock_root_ctx.processors.container_registry.get_container_registries.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
         # Verify response body contains expected registries
-        assert response.body is not None
-        response_body = json.loads(cast(bytes, response.body))
+        json_response = cast(web.Response, response)
+        assert json_response.body is not None
+        response_body = json.loads(cast(bytes, json_response.body))
         assert response_body == expected_registries
 
     @pytest.mark.asyncio
@@ -222,8 +223,9 @@ class TestListPresets:
         mock_root_ctx.processors.resource_preset.list_presets.wait_for_complete.assert_called_once()
         assert response.status == HTTPStatus.OK
         # Verify response body contains presets wrapped in dict
-        assert response.body is not None
-        response_body = json.loads(cast(bytes, response.body))
+        json_response = cast(web.Response, response)
+        assert json_response.body is not None
+        response_body = json.loads(cast(bytes, json_response.body))
         assert response_body == {"presets": expected_presets}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
resolves #8042 (BA-3899)

Add method_based decorators which is needed while migrating api layer into class based handlers.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
