### PR TITLE
chore: Add permissions for SBOM container generation

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -66,6 +66,9 @@ jobs:
   sbom-containers:
     name: Generate Container SBOMs
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     needs: prepare-matrix
     if: needs.prepare-matrix.outputs.matrix != '{"include":[]}'
     strategy:


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow for generating container SBOMs. The change grants additional permissions needed for writing ID tokens and attestations, which may be required for secure artifact attestation or integration with supply chain security tools.

* GitHub Actions workflow update:
  * Added `id-token: write` and `attestations: write` permissions to the `sbom-containers` job in `.github/workflows/sbom.yml`.