### PR TITLE
feat(BA-3446): Change default signup status to inactive

### DIFF
--- a/changes/7520.feature.md
+++ b/changes/7520.feature.md
@@ -1,0 +1,1 @@
+Change default signup status to inactive preventing newly registered accounts access system resources until an administrator explicitly activates them

--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -821,7 +821,7 @@ async def signup(request: web.Request, params: Any) -> web.Response:
             "need_password_change": False,
             "full_name": params["full_name"] if "full_name" in params else "",
             "description": params["description"] if "description" in params else "",
-            "status": UserStatus.ACTIVE,
+            "status": UserStatus.INACTIVE,
             "status_info": "user-signup",
             "role": UserRole.USER,
             "integration_id": None,


### PR DESCRIPTION
resolves #NNN (BA-MMM)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
