### PR TITLE
fix(BA-3926): Invalid moving statistics utilization caused by counter reset (#8124)

### DIFF
--- a/changes/8124.fix.md
+++ b/changes/8124.fix.md
@@ -1,0 +1,1 @@
+Fix invalid moving statistics utilization values caused by counter reset

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -238,15 +238,19 @@ class MovingStatistics:
     @property
     def diff(self) -> Decimal:
         if len(self._last) == 2:
-            return self._last[-1][0] - self._last[-2][0]
+            delta = self._last[-1][0] - self._last[-2][0]
+            if delta < 0:  # Counter reset (e.g., container restart)
+                return Decimal(0)
+            return delta
         return Decimal(0)
 
     @property
     def rate(self) -> Decimal:
         if len(self._last) == 2:
-            return (self._last[-1][0] - self._last[-2][0]) / Decimal(
-                self._last[-1][1] - self._last[-2][1]
-            )
+            delta = self._last[-1][0] - self._last[-2][0]
+            if delta < 0:  # Counter reset (e.g., container restart)
+                return Decimal(0)
+            return delta / Decimal(self._last[-1][1] - self._last[-2][1])
         return Decimal(0)
 
     def to_serializable_dict(self) -> MovingStatValue:

--- a/tests/agent/test_stats.py
+++ b/tests/agent/test_stats.py
@@ -1,6 +1,86 @@
-# currently empty
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from ai.backend.agent.stats import MovingStatistics
 
 
-def test_dummy():
-    # prevent pants error due to pytest exit code 5: "no tests collected"
-    pass
+class TestMovingStatistics:
+    """Tests for MovingStatistics class, focusing on counter reset detection."""
+
+    @pytest.fixture
+    def stats(self) -> MovingStatistics:
+        return MovingStatistics()
+
+    @dataclass(frozen=True)
+    class DiffTestCase:
+        id: str
+        first_value: Decimal
+        second_value: Decimal
+        expected_diff: Decimal
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            DiffTestCase(
+                id="positive_delta_for_increasing_values",
+                first_value=Decimal(100),
+                second_value=Decimal(150),
+                expected_diff=Decimal(50),
+            ),
+            DiffTestCase(
+                id="zero_on_counter_reset",
+                first_value=Decimal(1000),
+                second_value=Decimal(100),
+                expected_diff=Decimal(0),
+            ),
+        ],
+        ids=lambda case: case.id,
+    )
+    def test_diff(self, stats: MovingStatistics, case: DiffTestCase) -> None:
+        """Test that diff correctly handles both increasing values and counter resets."""
+        with patch("time.perf_counter", side_effect=[1.0, 2.0]):
+            stats.update(case.first_value)
+            stats.update(case.second_value)
+
+        assert stats.diff == case.expected_diff
+
+    @dataclass(frozen=True)
+    class RateTestCase:
+        id: str
+        first_value: Decimal
+        second_value: Decimal
+        time_values: tuple[float, float]
+        expected_rate: Decimal
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            RateTestCase(
+                id="positive_rate_for_increasing_values",
+                first_value=Decimal(100),
+                second_value=Decimal(200),
+                time_values=(1.0, 3.0),
+                expected_rate=Decimal(50),
+            ),
+            RateTestCase(
+                id="zero_on_counter_reset",
+                first_value=Decimal(500),
+                second_value=Decimal(50),
+                time_values=(1.0, 2.0),
+                expected_rate=Decimal(0),
+            ),
+        ],
+        ids=lambda case: case.id,
+    )
+    def test_rate(self, stats: MovingStatistics, case: RateTestCase) -> None:
+        """Test that rate correctly handles both increasing values and counter resets."""
+        with patch("time.perf_counter", side_effect=list(case.time_values)):
+            stats.update(case.first_value)
+            stats.update(case.second_value)
+
+        assert stats.rate == case.expected_rate


### PR DESCRIPTION
This is an auto-generated backport PR of #8124 to the 25.6 release.