### PR TITLE
fix(BA-3967): Extract mapping from resource policy row for backward compatibility

### DIFF
--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -790,11 +790,12 @@ class ModelServingRepository:
                     user_role=session_owner.role.value,
                 )
 
-                resource_policy = await self.get_keypair_resource_policy(
+                resource_policy_row = await self.get_keypair_resource_policy(
                     session_owner.resource_policy
                 )
-                if not resource_policy:
+                if not resource_policy_row:
                     raise InvalidAPIParameters("Resource policy not found")
+                resource_policy = resource_policy_row._mapping  # for backward compatibility
                 extra_mounts_input = spec.extra_mounts.optional_value()
                 if extra_mounts_input is not None:
                     extra_mounts = {


### PR DESCRIPTION
resolves #8163 (BA-3967)

This PR resolves a bug caused by upgrading SQLAlchemy 2.0 within the same sprint, so the changelog is skipped.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
