### PR TITLE
fix(BA-3968): Remove non-existent `config` field deletion logic when generating endpoint token

### DIFF
--- a/src/ai/backend/appproxy/coordinator/models/circuit.py
+++ b/src/ai/backend/appproxy/coordinator/models/circuit.py
@@ -433,7 +433,6 @@ class Circuit(Base, BaseMixin):
         payload["user"] = str(created_user)
         payload["exp"] = exp
         # mask unrelated & sensitive information
-        del payload["config"]
         del payload["route_info"]
 
         return jwt.encode(payload, jwt_secret, algorithm="HS256")


### PR DESCRIPTION
resolves #8165 (BA-3968)

This is a bug fix for [the same sprint PR](https://github.com/lablup/backend.ai/pull/7705), so the changelog is skipped.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
