### PR TITLE
fix(BA-4031): Restrict IDE config gitignore patterns to root directory (#8238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,21 +79,21 @@ venv/
 ENV/
 
 # IDE/vim
-.idea
+/.idea
 .swp
 .swo
 .*.swp
 .*.swo
-.vscode
-.vim
-.vimrc
-.nvimrc
-.exrc
-.ripgreprc
-.neoconf.json
-.zed
-.ropeproject
-pyrightconfig.json
+/.vscode
+/.vim
+/.vimrc
+/.nvimrc
+/.exrc
+/.ripgreprc
+/.neoconf.json
+/.zed
+/.ropeproject
+/pyrightconfig.json
 
 # Pants
 /.pants.d/

--- a/changes/8238.fix.md
+++ b/changes/8238.fix.md
@@ -1,0 +1,1 @@
+Fix missing `.vimrc` in runner package by restricting gitignore patterns to project root


### PR DESCRIPTION
This is an auto-generated backport PR of #8238 to the 25.15 release.