### PR TITLE
refactor(BA-3958):OpenAPI automation builder for pydantic handlers

### DIFF
--- a/changes/8245.enhance.md
+++ b/changes/8245.enhance.md
@@ -1,0 +1,1 @@
+Add auto detection logic for api handlers which is currently migrating in `manager/`.


### PR DESCRIPTION
resolves #8150 (BA-3958)

current OpenAPI's logic doesn't support auto detection for pydantic handlers. 
As pydantic migration is on progress, putting right detection logic important.

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
