### PR TITLE
chore: Add 'proposals' directory to pants-ignore list

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -23,6 +23,7 @@ pants_ignore = [
     "/scripts/",
     "/plugins/",
     "/docs/",  # TODO: docs build config
+    "/proposals/",
     "*.log",
     "/tools/pants-plugins",
     "/wheelhouse/*/",


### PR DESCRIPTION
When there are code samples, it should not trigger `pants tailor` to create BUILD configurations for them.
