### PR TITLE
chore(deps): Update wheel to 0.46.2 in setuptools requirements

### DIFF
--- a/tools/setuptools-requirements.txt
+++ b/tools/setuptools-requirements.txt
@@ -1,2 +1,2 @@
 setuptools~=80.0.0
-wheel~=0.44.0
+wheel~=0.46.2

--- a/tools/setuptools.lock
+++ b/tools/setuptools.lock
@@ -4,18 +4,20 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 3,
+//   "version": 4,
 //   "valid_for_interpreter_constraints": [
 //     "CPython==3.13.7"
 //   ],
 //   "generated_with_requirements": [
 //     "setuptools~=80.0.0",
-//     "wheel~=0.44.0"
+//     "wheel~=0.46.2"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
 //   "only_binary": [],
-//   "no_binary": []
+//   "no_binary": [],
+//   "excludes": [],
+//   "overrides": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -30,6 +32,24 @@
   "locked_resolves": [
     {
       "locked_requirements": [
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529",
+              "url": "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
+              "url": "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz"
+            }
+          ],
+          "project_name": "packaging",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "26.0"
+        },
         {
           "artifacts": [
             {
@@ -104,24 +124,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f",
-              "url": "https://files.pythonhosted.org/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl"
+              "hash": "4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d",
+              "url": "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49",
-              "url": "https://files.pythonhosted.org/packages/b7/a0/95e9e962c5fd9da11c1e28aa4c0d8210ab277b1ada951d2aee336b505813/wheel-0.44.0.tar.gz"
+              "hash": "e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803",
+              "url": "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz"
             }
           ],
           "project_name": "wheel",
           "requires_dists": [
+            "packaging>=24.0",
             "pytest>=6.0.0; extra == \"test\"",
-            "setuptools>=65; extra == \"test\""
+            "setuptools>=77; extra == \"test\""
           ],
-          "requires_python": ">=3.8",
-          "version": "0.44.0"
+          "requires_python": ">=3.9",
+          "version": "0.46.3"
         }
       ],
+      "marker": null,
       "platform_tag": null
     }
   ],
@@ -129,15 +151,15 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.50.4",
-  "pip_version": "25.2",
+  "pex_version": "2.77.0",
+  "pip_version": "25.3",
   "prefer_older_binary": false,
   "requirements": [
     "setuptools~=80.0.0",
-    "wheel~=0.44.0"
+    "wheel~=0.46.2"
   ],
   "requires_python": [
-    "==3.13.7"
+    "CPython==3.13.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",


### PR DESCRIPTION
Bump the wheel dependency from 0.44.0 to 0.46.2 in tools/setuptools-requirements.txt. The lockfile is updated accordingly, reflecting new transitive dependencies and metadata.


