### PR TITLE
fix(BA-3247): Read HTTP responses before connection closes in Agent Watcher API (#7165)

### DIFF
--- a/changes/7165.fix.md
+++ b/changes/7165.fix.md
@@ -1,0 +1,1 @@
+Read HTTP responses before connection closes in Agent Watcher APIs

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -880,70 +880,6 @@ class KeypairResourcePolicyNotFound(BackendAIError, web.HTTPNotFound):
         )
 
 
-class BaseNFSMountCheckFailed(BackendAIError):
-    pass
-
-
-class ShowmountFailed(BaseNFSMountCheckFailed, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/showmount-failed"
-    error_title = "showmount command failed"
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.EXTERNAL_SYSTEM,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class ShowmountNotFound(BaseNFSMountCheckFailed, web.HTTPNotFound):
-    error_type = "https://api.backend.ai/probs/showmount-not-found"
-    error_title = "showmount command not found"
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.EXTERNAL_SYSTEM,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class ExportPathNotFound(BaseNFSMountCheckFailed, web.HTTPNotFound):
-    error_type = "https://api.backend.ai/probs/nfs-export-path-not-found"
-    error_title = "NFS export path not found on the server"
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.EXTERNAL_SYSTEM,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class NFSTimeoutError(BaseNFSMountCheckFailed, web.HTTPRequestTimeout):
-    error_type = "https://api.backend.ai/probs/nfs-timeout"
-    error_title = "NFS server is not reachable (timeout)"
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.EXTERNAL_SYSTEM,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.TIMEOUT,
-        )
-
-
-class NFSUnexpectedError(BaseNFSMountCheckFailed, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/nfs-unexpected-error"
-    error_title = "Unexpected NFS error"
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.EXTERNAL_SYSTEM,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
 class AgentWatcherResponseError(BackendAIError, web.HTTPServiceUnavailable):
     """
     Wraps and forwards errors from agent watcher requests with original status code and message.
@@ -969,15 +905,3 @@ class AgentWatcherResponseError(BackendAIError, web.HTTPServiceUnavailable):
 
     def error_code(self) -> ErrorCode:
         return self._error_code
-
-
-class ContainerRegistryGroupsAlreadyAssociated(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/container-registry/groups-already-associated"
-    error_title = "Container registry groups already associated."
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.CONTAINER_REGISTRY,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.ALREADY_EXISTS,
-        )


### PR DESCRIPTION
This is an auto-generated backport PR of #7165 to the 25.19 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--8300.org.readthedocs.build/en/8300/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--8300.org.readthedocs.build/ko/8300/

<!-- readthedocs-preview sorna-ko end -->