### PR TITLE
fix(BA-3247): Read HTTP responses before connection closes in Agent Watcher API (#7165)

### DIFF
--- a/changes/7165.fix.md
+++ b/changes/7165.fix.md
@@ -1,0 +1,1 @@
+Read HTTP responses before connection closes in Agent Watcher APIs

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -164,6 +164,7 @@ class ErrorDomain(enum.StrEnum):
     MODEL_DEPLOYMENT = "model-deployment"
     RESOURCE_PRESET = "resource-preset"
     STORAGE = "storage"
+    WATCHER = "watcher"
     AGENT = "agent"
     PERMISSION = "permission"
     METRIC = "metric"
@@ -671,4 +672,22 @@ class AgentNotFound(BackendAIError, web.HTTPNotFound):
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
+class AgentWatcherResponseError(BackendAIError, web.HTTPServiceUnavailable):
+    """
+    Wraps and forwards errors from agent watcher requests with original status code and message.
+    This allows transparent error propagation from requests to API clients.
+    """
+
+    error_type = "https://api.backend.ai/probs/agent-watcher-response-error"
+    error_title = "Agent Watcher Response Error"
+
+    @classmethod
+    def error_code(cls) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.REQUEST,
+            error_detail=ErrorDetail.UNAVAILABLE,
         )

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -301,12 +301,7 @@ async def get_watcher_status(request: web.Request, params: Any) -> web.Response:
         GetWatcherStatusAction(agent_id=params["agent_id"])
     )
 
-    if result.resp.status == HTTPStatus.OK:
-        data = await result.resp.json()
-        return web.json_response(data, status=result.resp.status)
-    else:
-        data = await result.resp.text()
-        return web.Response(text=data, status=result.resp.status)
+    return web.json_response(result.data, status=HTTPStatus.OK)
 
 
 @server_status_required(READ_ALLOWED)
@@ -324,12 +319,7 @@ async def watcher_agent_start(request: web.Request, params: Any) -> web.Response
         WatcherAgentStartAction(agent_id=params["agent_id"])
     )
 
-    if result.resp.status == HTTPStatus.OK:
-        data = await result.resp.json()
-        return web.json_response(data, status=result.resp.status)
-    else:
-        data = await result.resp.text()
-        return web.Response(text=data, status=result.resp.status)
+    return web.json_response(result.data, status=HTTPStatus.OK)
 
 
 @server_status_required(READ_ALLOWED)
@@ -347,12 +337,7 @@ async def watcher_agent_stop(request: web.Request, params: Any) -> web.Response:
         WatcherAgentStopAction(agent_id=params["agent_id"])
     )
 
-    if result.resp.status == HTTPStatus.OK:
-        data = await result.resp.json()
-        return web.json_response(data, status=result.resp.status)
-    else:
-        data = await result.resp.text()
-        return web.Response(text=data, status=result.resp.status)
+    return web.json_response(result.data, status=HTTPStatus.OK)
 
 
 @server_status_required(READ_ALLOWED)
@@ -372,12 +357,7 @@ async def watcher_agent_restart(request: web.Request, params: Any) -> web.Respon
         )
     )
 
-    if result.resp.status == HTTPStatus.OK:
-        data = await result.resp.json()
-        return web.json_response(data, status=result.resp.status)
-    else:
-        data = await result.resp.text()
-        return web.Response(text=data, status=result.resp.status)
+    return web.json_response(result.data, status=HTTPStatus.OK)
 
 
 @superadmin_required

--- a/src/ai/backend/manager/services/agent/actions/get_watcher_status.py
+++ b/src/ai/backend/manager/services/agent/actions/get_watcher_status.py
@@ -22,8 +22,7 @@ class GetWatcherStatusAction(AgentAction):
 
 @dataclass
 class GetWatcherStatusActionResult(BaseActionResult):
-    # TODO: Add proper type
-    resp: Any
+    data: dict[str, Any]
     agent_id: AgentId
 
     @override

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_restart.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_restart.py
@@ -22,8 +22,7 @@ class WatcherAgentRestartAction(AgentAction):
 
 @dataclass
 class WatcherAgentRestartActionResult(BaseActionResult):
-    # TODO: Add proper type
-    resp: Any
+    data: dict[str, Any]
     agent_id: AgentId
 
     @override

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_start.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_start.py
@@ -22,8 +22,7 @@ class WatcherAgentStartAction(AgentAction):
 
 @dataclass
 class WatcherAgentStartActionResult(BaseActionResult):
-    # TODO: Add proper type
-    resp: Any
+    data: dict[str, Any]
     agent_id: AgentId
 
     @override

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_stop.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_stop.py
@@ -22,8 +22,7 @@ class WatcherAgentStopAction(AgentAction):
 
 @dataclass
 class WatcherAgentStopActionResult(BaseActionResult):
-    # TODO: Add proper type
-    resp: Any
+    data: dict[str, Any]
     agent_id: AgentId
 
     @override


### PR DESCRIPTION
This is an auto-generated backport PR of #7165 to the 25.15 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--8301.org.readthedocs.build/en/8301/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--8301.org.readthedocs.build/ko/8301/

<!-- readthedocs-preview sorna-ko end -->