### PR TITLE
chore: Improve NVM and Node.js installation logic

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -507,8 +507,11 @@ install_system_pkg() {
 }
 
 install_node() {
-  # Set NVM_DIR first
-  export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+  # Set NVM_DIR first, but respect any pre-existing value
+  if [ -z "${NVM_DIR-}" ]; then
+    NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+  fi
+  export NVM_DIR
 
   # Check if NVM is already installed by checking the directory and nvm.sh
   if [ ! -d "$NVM_DIR" ] || [ ! -s "$NVM_DIR/nvm.sh" ]; then


### PR DESCRIPTION
Refactored install_node to set NVM_DIR before checking for NVM, always source nvm.sh, and handle Node.js version activation more robustly. Now avoids exit code issues with .nvmrc and only installs Node.js if not already present.

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
