### PR TITLE
fix(BA-4109): Pin pycares version in BUILD file explicilty

### DIFF
--- a/changes/8357.fix.md
+++ b/changes/8357.fix.md
@@ -1,0 +1,1 @@
+Add explicit `pycares` dependency to `backend.ai-common` to prevent version mismatch when installing from wheel

--- a/src/ai/backend/common/BUILD
+++ b/src/ai/backend/common/BUILD
@@ -4,6 +4,7 @@ python_sources(
     dependencies=[
         ":resources",
         "stubs/trafaret:stubs",
+        "//:reqs#pycares",  # aiodns runtime dependency - pin version explicitly
     ],
 )
 


### PR DESCRIPTION
This is a backport PR of https://github.com/lablup/backend.ai/pull/8357 to the 26.1 release.