### PR TITLE
fix(BA-3522): Prevent race condition in kernel metrics cleanup (#8250)

### DIFF
--- a/changes/8250.fix.md
+++ b/changes/8250.fix.md
@@ -1,0 +1,1 @@
+Fix race condition in kernel metrics cleanup by removing automatic cleanup from `collect_container_stat()`

--- a/src/ai/backend/agent/metrics/metric.py
+++ b/src/ai/backend/agent/metrics/metric.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import enum
 import functools
 import uuid
-from collections.abc import Iterable
-from typing import Optional, Self
+from collections.abc import Iterable, MutableMapping
+from typing import TYPE_CHECKING, Optional, Self
 
 from prometheus_client import Counter, Gauge, Histogram
 
@@ -20,6 +22,9 @@ from .types import (
     FlattenedDeviceMetric,
     FlattenedKernelMetric,
 )
+
+if TYPE_CHECKING:
+    from ai.backend.agent.stats import Metric
 
 
 class StatScope(enum.StrEnum):
@@ -129,6 +134,7 @@ class UtilizationMetricObserver:
 
     async def lazy_remove_container_metric(
         self,
+        kernel_metrics: MutableMapping[KernelId, dict[MetricKey, Metric]],
         *,
         agent_id: AgentId,
         kernel_id: KernelId,
@@ -156,6 +162,7 @@ class UtilizationMetricObserver:
 
         def callback(task: asyncio.Task) -> None:
             self._removal_tasks.pop(kernel_id, None)
+            kernel_metrics.pop(kernel_id, None)
 
         task = asyncio.create_task(remove_later())
         self._removal_tasks[kernel_id] = task

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -417,11 +417,14 @@ class StatContext:
         known_metrics = self.kernel_metrics.get(kernel_id)
         log.debug("Known metrics for kernel {}: {}", kernel_id, known_metrics)
         if known_metrics is None:
+            log.warning("No known metrics for kernel {}", kernel_id)
             return
         metric_keys = list(known_metrics.keys())
         agent_id = self.agent.id
         session_id, owner_user_id, project_id = self._get_ownership_info_from_kernel(kernel_id)
+        # TODO: Remove passing kernel_metrics dict to UtilizationMetricObserver
         await self._utilization_metric_observer.lazy_remove_container_metric(
+            self.kernel_metrics,
             agent_id=agent_id,
             kernel_id=kernel_id,
             session_id=session_id,
@@ -651,10 +654,6 @@ class StatContext:
                 else:
                     kernel_id_map[ContainerId(cid)] = kid
                     kernel_obj_map[kid] = info
-            unused_kernel_ids = set(self.kernel_metrics.keys()) - set(kernel_id_map.values())
-            for unused_kernel_id in unused_kernel_ids:
-                log.debug("removing kernel_metric for {}", unused_kernel_id)
-                self.kernel_metrics.pop(unused_kernel_id, None)
 
             # Here we use asyncio.gather() instead of aiotools.TaskGroup
             # to keep methods of other plugins running when a plugin raises an error


### PR DESCRIPTION
This is an auto-generated backport PR of #8250 to the 26.1 release.