### PR TITLE
fix(BA-4136): Prevent kernel status regression from TERMINATED to TERMINATING (#8406)

### DIFF
--- a/changes/8406.fix.md
+++ b/changes/8406.fix.md
@@ -1,0 +1,1 @@
+Prevent kernel status regression from TERMINATED to TERMINATING in `destroy_session()` which caused a livelock in model serving sessions

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2687,6 +2687,13 @@ class AgentRegistry:
                             await self.event_producer.anycast_event(
                                 KernelTerminatedAnycastEvent(kernel.id, target_session.id, reason),
                             )
+                        case KernelStatus.TERMINATED | KernelStatus.CANCELLED:
+                            log.debug(
+                                "skip destroying kernel already in terminal state (k:{}, status:{})",
+                                kernel.id,
+                                kernel.status,
+                            )
+                            continue
                         case _:
 
                             async def _update() -> None:


### PR DESCRIPTION
This is an auto-generated backport PR of #8406 to the 26.1 release.