### PR TITLE
fix(BA-4137): Fix batch sessions immediately timing out when `batch_timeout` is not set (#8408)

### DIFF
--- a/changes/8408.fix.md
+++ b/changes/8408.fix.md
@@ -1,0 +1,1 @@
+Fix batch sessions immediately failing with 'task-timeout' when `batch_timeout` is not explicitly configured

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2431,6 +2431,7 @@ class AbstractAgent(
             "exec": startup_command,
         }
         try:
+            # NOTE: asyncio.timeout(0) immediately times out
             async with asyncio.timeout(timeout):
                 while True:
                     try:

--- a/src/ai/backend/manager/clients/agent/client.py
+++ b/src/ai/backend/manager/clients/agent/client.py
@@ -230,7 +230,7 @@ class AgentClient(BackendAIClient):
         session_id: SessionId,
         kernel_id: KernelId,
         startup_command: str,
-        batch_timeout: float,
+        batch_timeout: float | None,
     ) -> None:
         """Trigger batch execution on the agent."""
         await self._peer.call.trigger_batch_execution(

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -3006,7 +3006,7 @@ class AgentRegistry:
                     session.id,
                     session.main_kernel.id,
                     session.main_kernel.startup_command or "",
-                    float(session.batch_timeout) if session.batch_timeout else 0.0,
+                    float(session.batch_timeout) if session.batch_timeout is not None else None,
                 )
 
     async def interrupt_session(

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -124,11 +124,12 @@ class RunningTransitionHook(StatusTransitionHook):
                 success_detail=f"Triggered batch execution on agent {agent_id}",
             ):
                 async with self._deps.agent_client_pool.acquire(agent_id) as client:
+                    session_batch_timeout = session.session_info.lifecycle.batch_timeout
                     await client.trigger_batch_execution(
                         session_id,
                         main_kernel.id,
                         main_kernel.runtime.startup_command or "",
-                        float(session.session_info.lifecycle.batch_timeout or 0),
+                        float(session_batch_timeout) if session_batch_timeout is not None else None,
                     )
         log.info(
             "Successfully triggered batch execution for session {} on agent {}",

--- a/src/ai/backend/test/testcases/session/creation_failure_command_timeout.py
+++ b/src/ai/backend/test/testcases/session/creation_failure_command_timeout.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.types import ClusterMode
 from ai.backend.test.contexts.client_session import ClientSessionContext
 from ai.backend.test.contexts.image import ImageContext
@@ -28,7 +29,7 @@ class BatchSessionCreationFailureTimeout(TestCode):
                     session_name,
                     "session_failure",
                     {"session_success", "session_cancelled"},
-                    expected_failure_reason="task-timeout",
+                    expected_failure_reason=KernelLifecycleEventReason.TASK_TIMEOUT,
                 ),
                 _TASK_TIMEOUT,
             )


### PR DESCRIPTION
This is an auto-generated backport PR of #8408 to the 26.1 release.