### PR TITLE
fix(BA-4142): Add missing ordering when querying pending sessions (#8419)

### DIFF
--- a/changes/8419.fix.md
+++ b/changes/8419.fix.md
@@ -1,0 +1,1 @@
+Add missing ordering when querying pending sessions

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -262,7 +262,10 @@ class ScheduleDBSource:
     async def _fetch_pending_sessions(
         self, db_sess: SASession, scaling_group: str
     ) -> PendingSessions:
-        """Fetch pending sessions with kernels using single JOIN query."""
+        """
+        Fetch pending sessions with kernels using single JOIN query.
+        The result is sorted by session creation time (oldest first).
+        """
         query = (
             sa.select(
                 SessionRow.id,
@@ -285,6 +288,7 @@ class ScheduleDBSource:
             )
             .select_from(SessionRow)
             .outerjoin(KernelRow, SessionRow.id == KernelRow.session_id)
+            .order_by(SessionRow.created_at.asc())
             .where(
                 sa.and_(
                     SessionRow.scaling_group_name == scaling_group,


### PR DESCRIPTION
This is an auto-generated backport PR of #8419 to the 26.1 release.