### PR TITLE
refactor(BA-4143): Remove slot-based device partitioning methods

### DIFF
--- a/tests/unit/agent/test_resource_allocation.py
+++ b/tests/unit/agent/test_resource_allocation.py
@@ -319,8 +319,10 @@ class TestSharedMode:
 
 
 @pytest.mark.skip(
-    reason="BA-4143: AUTO_SPLIT partitioning temporarily disabled. "
-    "All modes now behave like SHARED until BEP-1041 device-centric design is implemented."
+    reason=(
+        "BA-4143: AUTO_SPLIT partitioning temporarily disabled. All modes now behave "
+        "like SHARED until BEP-1041 device-centric design is implemented."
+    )
 )
 class TestAutoSplitMode:
     async def test_fraction_alloc_map(
@@ -499,8 +501,10 @@ class TestAutoSplitMode:
 
 
 @pytest.mark.skip(
-    reason="BA-4143: MANUAL allocation temporarily disabled. "
-    "All modes now behave like SHARED until BEP-1041 device-centric design is implemented."
+    reason=(
+        "BA-4143: MANUAL allocation temporarily disabled. All modes now behave "
+        "like SHARED until BEP-1041 device-centric design is implemented."
+    )
 )
 class TestManualMode:
     async def test_cpu_mem(

--- a/tests/unit/agent/test_resource_allocation.py
+++ b/tests/unit/agent/test_resource_allocation.py
@@ -318,6 +318,10 @@ class TestSharedMode:
         await allocator.__aexit__(None, None, None)
 
 
+@pytest.mark.skip(
+    reason="BA-4143: AUTO_SPLIT partitioning temporarily disabled. "
+    "All modes now behave like SHARED until BEP-1041 device-centric design is implemented."
+)
 class TestAutoSplitMode:
     async def test_fraction_alloc_map(
         self,
@@ -494,6 +498,10 @@ class TestAutoSplitMode:
         await allocator.__aexit__(None, None, None)
 
 
+@pytest.mark.skip(
+    reason="BA-4143: MANUAL allocation temporarily disabled. "
+    "All modes now behave like SHARED until BEP-1041 device-centric design is implemented."
+)
 class TestManualMode:
     async def test_cpu_mem(
         self,
@@ -608,6 +616,7 @@ class TestMultiDeviceScenarios:
     - Multiple physical devices (multi-GPU systems, NUMA nodes)
     """
 
+    @pytest.mark.skip(reason="BA-4143: AUTO_SPLIT partitioning temporarily disabled.")
     async def test_multiple_cpu_cores_auto_split(
         self,
         mock_etcd: AsyncEtcd,
@@ -659,6 +668,7 @@ class TestMultiDeviceScenarios:
 
         await allocator.__aexit__(None, None, None)
 
+    @pytest.mark.skip(reason="BA-4143: MANUAL allocation temporarily disabled.")
     async def test_multiple_cpu_cores_manual_mode(
         self,
         mock_etcd: AsyncEtcd,
@@ -779,6 +789,7 @@ class TestMultiDeviceScenarios:
 
         await allocator.__aexit__(None, None, None)
 
+    @pytest.mark.skip(reason="BA-4143: AUTO_SPLIT partitioning temporarily disabled.")
     async def test_mixed_devices_with_different_slot_types(
         self,
         mock_etcd: AsyncEtcd,
@@ -853,6 +864,7 @@ class TestMultiDeviceScenarios:
 
         await allocator.__aexit__(None, None, None)
 
+    @pytest.mark.skip(reason="BA-4143: AUTO_SPLIT partitioning temporarily disabled.")
     async def test_multi_gpu_auto_split(
         self,
         mock_etcd: AsyncEtcd,
@@ -933,3 +945,129 @@ class TestMultiDeviceScenarios:
             ].amount == Decimal("8000000000")
 
         await allocator.__aexit__(None, None, None)
+
+
+class TestAllocationModesFallbackToShared:
+    """
+    Tests verifying that AUTO_SPLIT and MANUAL modes now behave like SHARED.
+
+    BA-4143: As a baseline before implementing BEP-1041's device-centric design,
+    all allocation modes see all devices (no partitioning).
+    """
+
+    async def test_auto_split_behaves_like_shared(
+        self,
+        mock_etcd: AsyncEtcd,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify AUTO_SPLIT mode now gives all agents full access to all resources."""
+        config = create_test_config(
+            allocation_mode=ResourceAllocationMode.AUTO_SPLIT,
+            num_agents=2,
+        )
+
+        computers = create_mock_computers({
+            DeviceName("cuda"): create_fraction_alloc_map({
+                DeviceId("cuda"): (SlotName("cuda.shares"), Decimal("1.0")),
+            }),
+        })
+
+        setup_mock_resources(monkeypatch, computers)
+
+        allocator = await ResourceAllocator.new(config, mock_etcd)
+
+        # Both agents should see full device slot amounts (no partitioning)
+        agent1_computers = allocator.get_computers(AgentId("agent1"))
+        agent2_computers = allocator.get_computers(AgentId("agent2"))
+        assert agent1_computers[DeviceName("cuda")].alloc_map.device_slots[
+            DeviceId("cuda")
+        ].amount == Decimal("1.0")
+        assert agent2_computers[DeviceName("cuda")].alloc_map.device_slots[
+            DeviceId("cuda")
+        ].amount == Decimal("1.0")
+
+        # No resources reserved between agents (all see full resources)
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        reserved2 = allocator.agent_reserved_slots[AgentId("agent2")]
+        assert reserved1[SlotName("cuda.shares")] == Decimal("0")
+        assert reserved2[SlotName("cuda.shares")] == Decimal("0")
+
+        await allocator.__aexit__(None, None, None)
+
+    async def test_manual_behaves_like_shared(
+        self,
+        mock_etcd: AsyncEtcd,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify MANUAL mode now gives all agents full access to all resources."""
+        config = create_test_config(
+            allocation_mode=ResourceAllocationMode.MANUAL,
+            allocated_cpu=4,
+            allocated_mem="8G",
+            num_agents=1,
+        )
+
+        computers = create_mock_computers({
+            DeviceName("cpu"): create_fraction_alloc_map({
+                DeviceId("cpu"): (SlotName("cpu"), Decimal("16")),
+            }),
+            DeviceName("root"): create_fraction_alloc_map({
+                DeviceId("mem"): (SlotName("mem"), Decimal(BinarySize.finite_from_str("32G"))),
+            }),
+        })
+
+        setup_mock_resources(monkeypatch, computers)
+
+        allocator = await ResourceAllocator.new(config, mock_etcd)
+
+        # Agent should see full device slot amounts (manual allocations ignored)
+        agent1_computers = allocator.get_computers(AgentId("agent1"))
+        assert agent1_computers[DeviceName("cpu")].alloc_map.device_slots[
+            DeviceId("cpu")
+        ].amount == Decimal("16")
+        assert agent1_computers[DeviceName("root")].alloc_map.device_slots[
+            DeviceId("mem")
+        ].amount == Decimal(BinarySize.finite_from_str("32G"))
+
+        # No resources reserved (all see full resources)
+        reserved1 = allocator.agent_reserved_slots[AgentId("agent1")]
+        assert reserved1[SlotName("cpu")] == Decimal("0")
+        assert reserved1[SlotName("mem")] == Decimal("0")
+
+        await allocator.__aexit__(None, None, None)
+
+    async def test_scaling_factor_always_one(
+        self,
+        mock_etcd: AsyncEtcd,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify scaling factor is always 1.0 regardless of allocation mode."""
+        for mode in [
+            ResourceAllocationMode.SHARED,
+            ResourceAllocationMode.AUTO_SPLIT,
+            ResourceAllocationMode.MANUAL,
+        ]:
+            config = create_test_config(
+                allocation_mode=mode,
+                allocated_cpu=4 if mode == ResourceAllocationMode.MANUAL else None,
+                allocated_mem="8G" if mode == ResourceAllocationMode.MANUAL else None,
+                num_agents=2,
+            )
+
+            computers = create_mock_computers({
+                DeviceName("cpu"): create_fraction_alloc_map({
+                    DeviceId("cpu"): (SlotName("cpu"), Decimal("8")),
+                }),
+            })
+
+            setup_mock_resources(monkeypatch, computers)
+
+            allocator = await ResourceAllocator.new(config, mock_etcd)
+
+            # Scaling factor should always be 1.0
+            factor1 = allocator.get_resource_scaling_factor(AgentId("agent1"))
+            factor2 = allocator.get_resource_scaling_factor(AgentId("agent2"))
+            assert factor1[SlotName("cpu")] == Decimal("1.0")
+            assert factor2[SlotName("cpu")] == Decimal("1.0")
+
+            await allocator.__aexit__(None, None, None)


### PR DESCRIPTION
resolves #8425 (BA-4143)

## Overview

Simplify `ResourceAllocator` by removing mode-specific partitioning logic. All allocation modes (SHARED, AUTO_SPLIT, MANUAL) now behave like SHARED, where agents see all devices with no reserved slots between them. This establishes a clean baseline before implementing BEP-1041's device-centric partitioning design.

## Problem Statement

- The current multi-agent resource allocation uses slot-based configuration with complex `_calculate_device_slot_*` methods that tightly couple slot calculation with allocation modes
- Before implementing the new device-based approach from BEP-1041, we need to establish a clean baseline by removing this complexity
- This allows us to incrementally rebuild the partitioning logic with the new device-centric design

## Implementation

**Removed methods from ResourceAllocator:**
- `_calculate_device_slot()` - the mode dispatch method
- `_calculate_device_slot_shared()` - SHARED mode calculation
- `_calculate_device_slot_auto_split()` - AUTO_SPLIT mode calculation  
- `_calculate_device_slot_manual()` - MANUAL mode calculation
- `_ensure_slots_are_not_overallocated()` - MANUAL mode validation

**Simplified methods:**
- `_calculate_device_slots()` - now always returns full available slots (SHARED behavior)
- `_calculate_resource_scaling_factor()` - now always returns 1.0
- `_calculate_agent_partition()` - removed unused parameters

**Test changes:**
- Skipped `TestAutoSplitMode` and `TestManualMode` classes with BA-4143/BEP-1041 explanations
- Skipped partitioning tests in `TestMultiDeviceScenarios`
- Added `TestAllocationModesFallbackToShared` class with 3 tests verifying all modes behave identically

---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations