### PR TITLE
fix(BA-4154): Add missing partial index definitions to `KernelRow` model   (#8436)

### DIFF
--- a/changes/8436.fix.md
+++ b/changes/8436.fix.md
@@ -1,0 +1,1 @@
+Add missing partial index definitions to `KernelRow` model

--- a/src/ai/backend/manager/models/kernel/row.py
+++ b/src/ai/backend/manager/models/kernel/row.py
@@ -625,6 +625,19 @@ class KernelRow(Base):
             sa.func.greatest("created_at", "terminated_at", "status_changed"),
             unique=False,
         ),
+        # Partial index for running kernels (fair share observation)
+        sa.Index(
+            "ix_kernels_fair_share_running",
+            "scaling_group",
+            postgresql_where=sa.text("terminated_at IS NULL AND starts_at IS NOT NULL"),
+        ),
+        # Partial index for terminated kernels (fair share observation)
+        sa.Index(
+            "ix_kernels_fair_share_terminated",
+            "scaling_group",
+            "terminated_at",
+            postgresql_where=sa.text("terminated_at IS NOT NULL AND starts_at IS NOT NULL"),
+        ),
     )
 
     session: Mapped[SessionRow] = relationship("SessionRow", back_populates="kernels")


### PR DESCRIPTION
This is an auto-generated backport PR of #8436 to the 26.1 release.