### PR TITLE
fix(BA-4158): Restore missing index and constraint in redesign_rbac_tables migration downgrade (#8446)

### DIFF
--- a/changes/8446.fix.md
+++ b/changes/8446.fix.md
@@ -1,0 +1,1 @@
+Handle missing constraint and index in permission tables migration downgrade

--- a/src/ai/backend/manager/models/alembic/versions/28fecac94e67_redesign_rbac_tables.py
+++ b/src/ai/backend/manager/models/alembic/versions/28fecac94e67_redesign_rbac_tables.py
@@ -39,3 +39,15 @@ def downgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_object_permissions")),
     )
+    # Restore index and constraint from 643deb439458 state
+    op.create_index(
+        "ix_role_id_entity_id",
+        "object_permissions",
+        ["status", "role_id", "entity_id"],
+        unique=False,
+    )
+    op.create_unique_constraint(
+        "uq_object_permissions_entity_id_operation",
+        "object_permissions",
+        ["entity_id", "operation"],
+    )


### PR DESCRIPTION
This is an auto-generated backport PR of #8446 to the 26.1 release.