### PR TITLE
fix(BA-4160): Add missing enum type drop in app_configs migration downgrade (#8454)

### DIFF
--- a/changes/8454.fix.md
+++ b/changes/8454.fix.md
@@ -1,0 +1,1 @@
+Add missing enum type drop in app_configs migration downgrade

--- a/src/ai/backend/manager/models/alembic/versions/d811b103dbfc_add_app_configs_table_for_frontend_.py
+++ b/src/ai/backend/manager/models/alembic/versions/d811b103dbfc_add_app_configs_table_for_frontend_.py
@@ -53,4 +53,5 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_app_configs_scope_type"), table_name="app_configs")
     op.drop_index(op.f("ix_app_configs_scope_id"), table_name="app_configs")
     op.drop_table("app_configs")
+    op.execute("DROP TYPE IF EXISTS app_config_scope_type")
     # ### end Alembic commands ###


### PR DESCRIPTION
This is an auto-generated backport PR of #8454 to the 26.1 release.