### PR TITLE
feat(BA-4146): Device-based MANUAL mode config

### DIFF
--- a/changes/8463.feature.md
+++ b/changes/8463.feature.md
@@ -1,0 +1,1 @@
+Change MANUAL mode configuration from slot-based to device-based format for explicit device assignments in multi-agent configurations


### PR DESCRIPTION
resolves #8428 (BA-4146)

## Overview

Changes MANUAL mode resource allocation from slot-based format (`{"cuda.mem": 0.5}`) to device-based format (`cuda = ["cuda0", "cuda1"]`), enabling explicit device-to-agent mapping in multi-agent configurations.

## Problem Statement

- MANUAL mode used slot-based decimal allocation which didn't align with device-centric resource model
- No explicit control over which physical devices are assigned to which agents
- BEP-1041 migration to device-centric resource allocation was incomplete without MANUAL mode support

## Architecture

```mermaid
flowchart TB
    subgraph "Configuration (unified.py)"
        RC[ResourceAllocationConfig]
        RC -->|"devices: Mapping[DeviceName, Sequence[DeviceId]]"| DV[Device Validator]
        DV -->|"Detect old format"| ERR[Validation Error]
        DV -->|"Parse new format"| OK[Valid Config]
    end

    subgraph "Resource Allocation (resources.py)"
        RA[ResourceAllocator.__ainit__]
        RA -->|MANUAL mode| GMA[_generate_manual_assignments]
        RA -->|AUTO_SPLIT| GAS[_generate_auto_split_assignments]
        RA -->|SHARED| GSA[_generate_shared_assignments]
        GMA --> ADA[_apply_device_assignments]
        GAS --> ADA
        GSA --> ADA
    end

    OK --> GMA
```

## Configuration Format Change

**Old slot-based format (rejected):**
```toml
[resource.allocations]
devices = {"cuda.mem" = 0.5, "cuda.shares" = 2}
```

**New device-based format:**
```toml
[resource.allocations]
devices = {cuda = ["cuda0", "cuda1"], rocm = ["rocm0"]}
```

---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations