### PR TITLE
fix(BA-4166): Make `group` parameter required in `check_presets` API instead of using default value "default" (#8462)

### DIFF
--- a/changes/8462.fix.md
+++ b/changes/8462.fix.md
@@ -1,0 +1,1 @@
+Make `group` parameter required in `check_presets` API. Previously, the default value "default" caused `ProjectNotFound` errors when the default group did not exist in the system.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -7902,8 +7902,7 @@
                     "type": "string"
                   },
                   "group": {
-                    "type": "string",
-                    "default": "default"
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -82,7 +82,7 @@ async def list_presets(request: web.Request) -> web.Response:
 @check_api_params(
     t.Dict({
         t.Key("scaling_group", default=None): t.Null | t.String,
-        t.Key("group", default="default"): t.String,
+        t.Key("group"): t.String,
     })
 )
 async def check_presets(request: web.Request, params: Any) -> web.Response:


### PR DESCRIPTION
This is an auto-generated backport PR of #8462 to the 26.1 release.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--8464.org.readthedocs.build/en/8464/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--8464.org.readthedocs.build/ko/8464/

<!-- readthedocs-preview sorna-ko end -->