### PR TITLE
fix(BA-4164): Missing Alembic migration scripts in packaged Backend.AI Manager (#8459)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -27,11 +27,7 @@ pants_ignore = [
     "*.log",
     "/tools/pants-plugins",
     "/wheelhouse/*/",
-    "/wheelhouse/*.whl",
-    # Alembic migration files - legacy SQLAlchemy 1.x style, excluded from type checking
-    "/src/ai/backend/manager/models/alembic/versions/",
-    "/src/ai/backend/account_manager/models/alembic/versions/",
-    "/src/ai/backend/appproxy/coordinator/models/alembic/versions/",
+    "/wheelhouse/*.whl"
 ]
 build_file_prelude_globs = ["tools/build-macros.py"]
 


### PR DESCRIPTION
This is an auto-generated backport PR of #8459 to the 26.1 release.