### PR TITLE
fix(BA-4159): Add IF NOT EXISTS to enum values and missing column drop in endpoint/routing migration (#8450)

### DIFF
--- a/changes/8450.fix.md
+++ b/changes/8450.fix.md
@@ -1,0 +1,1 @@
+Add IF NOT EXISTS to enum values and missing column drop in endpoint/routing migration

--- a/src/ai/backend/manager/models/alembic/versions/fb01c44db0d6_update_endpoint_and_routing_for_sokovan.py
+++ b/src/ai/backend/manager/models/alembic/versions/fb01c44db0d6_update_endpoint_and_routing_for_sokovan.py
@@ -30,10 +30,10 @@ def upgrade() -> None:
         sa.Column("desired_replicas", sa.Integer(), server_default=sa.text("NULL"), nullable=True),
     )
     op.add_column("routings", sa.Column("weight", sa.Integer(), nullable=True))
-    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE '{PENDING}'")
-    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE '{SCALING}'")
-    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE '{READY}'")
-    op.execute(f"ALTER TYPE {route_status_enum_name} ADD VALUE '{TERMINATED}'")
+    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE IF NOT EXISTS '{PENDING}'")
+    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE IF NOT EXISTS '{SCALING}'")
+    op.execute(f"ALTER TYPE {endpoint_lifecycle_enum_name} ADD VALUE IF NOT EXISTS '{READY}'")
+    op.execute(f"ALTER TYPE {route_status_enum_name} ADD VALUE IF NOT EXISTS '{TERMINATED}'")
     op.create_index(
         "ix_endpoints_unique_name_when_not_destroyed",
         "endpoints",
@@ -62,4 +62,5 @@ def downgrade() -> None:
         table_name="endpoints",
         postgresql_where=sa.text("lifecycle_stage != 'destroyed'"),
     )
+    op.drop_column("routings", "weight")
     op.drop_column("endpoints", "desired_replicas")


### PR DESCRIPTION
This is an auto-generated backport PR of #8450 to the 26.1 release.