### PR TITLE
fix(BA-4156): Add missing `permission_group_id` index from `ObjectPermissionRow` (#8443)

### DIFF
--- a/changes/8443.fix.md
+++ b/changes/8443.fix.md
@@ -1,0 +1,1 @@
+Add missing `permission_group_id` index from `ObjectPermissionRow`

--- a/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
@@ -74,6 +74,7 @@ class ObjectPermissionRow(Base):
         GUID,
         sa.ForeignKey("permission_groups.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
     entity_type: Mapped[EntityType] = mapped_column(
         "entity_type", StrEnumType(EntityType, length=32), nullable=False


### PR DESCRIPTION
This is an auto-generated backport PR of #8443 to the 26.1 release.