### PR TITLE
fix(BA-4155): Update index name in `KernelUsageRecordRow` to match migration (#8438)

### DIFF
--- a/changes/8438.fix.md
+++ b/changes/8438.fix.md
@@ -1,0 +1,1 @@
+Update index name in `KernelUsageRecordRow` to match migration

--- a/src/ai/backend/manager/models/resource_usage_history/row.py
+++ b/src/ai/backend/manager/models/resource_usage_history/row.py
@@ -152,7 +152,7 @@ class KernelUsageRecordRow(Base):
     )
 
     __table_args__ = (
-        sa.Index("ix_kernel_usage_sg_period", "resource_group", "period_start"),
+        sa.Index("ix_kernel_usage_rg_period", "resource_group", "period_start"),
         sa.Index("ix_kernel_usage_user_period", "user_uuid", "period_start"),
     )
 


### PR DESCRIPTION
This is an auto-generated backport PR of #8438 to the 26.1 release.