### PR TITLE
docs: Reserve BEP-1043 for Scope types description

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -130,7 +130,7 @@ BEP numbers start from 1000.
 | [1040](BEP-1040-multiple-path-zip-download-implementation.md) | Multiple Files Download in ZIP | TaekYoung Kwon | Draft |
 | [1041](BEP-1041-scope-based-graphql-api-naming.md) | Scope-Based GraphQL API Naming Convention | HyeokJin Kim | Draft |
 | [1042](BEP-1042-mypy-strict-mode-migration.md) | MyPy Strict Mode Migration | HyeokJin Kim | Draft |
-| [1043](BEP-1043-scope-types.md) | Scope types description | Sanghun Lee | Draft |
+| [1043](BEP-1043-scope-types.md) | Scope Types Description | Sanghun Lee | Draft |
 | _next_ | _(reserve your number here)_ | | |
 
 ## File Structure


### PR DESCRIPTION
resolves #NNN (BA-MMM)

Add BEP-1043 for Scope types description

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
