### PR TITLE
feat(BA-4244): add Project V2 repository and service layer

### DIFF
--- a/changes/8558.feature.md
+++ b/changes/8558.feature.md
@@ -1,0 +1,1 @@
+Add Project V2 repository and service layer with search capabilities following User V2 pattern

--- a/src/ai/backend/manager/repositories/group/options.py
+++ b/src/ai/backend/manager/repositories/group/options.py
@@ -1,0 +1,227 @@
+"""Query conditions and orders for group repository operations."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+
+__all__ = (
+    "GroupConditions",
+    "GroupOrders",
+)
+
+
+class GroupConditions:
+    """Query conditions for filtering groups/projects."""
+
+    # ==================== Name Filters ====================
+
+    @staticmethod
+    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = GroupRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(GroupRow.name) == spec.value.lower()
+            else:
+                condition = GroupRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = GroupRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = GroupRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    # ==================== Domain Name Filters ====================
+
+    @staticmethod
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = GroupRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(GroupRow.domain_name) == spec.value.lower()
+            else:
+                condition = GroupRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = GroupRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = GroupRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = GroupRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    # ==================== Type Filters ====================
+
+    @staticmethod
+    def by_type_equals(project_type: ProjectType) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return GroupRow.type == project_type
+
+        return inner
+
+    @staticmethod
+    def by_type_in(types: Collection[ProjectType]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return GroupRow.type.in_(types)
+
+        return inner
+
+    # ==================== Active Status Filters ====================
+
+    @staticmethod
+    def by_is_active(is_active: bool) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return GroupRow.is_active == is_active
+
+        return inner
+
+    # ==================== Cursor Pagination ====================
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: UUID) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(GroupRow.created_at).where(GroupRow.id == cursor_id).scalar_subquery()
+            )
+            return GroupRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: UUID) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Uses subquery to get created_at of the cursor row and compare.
+        """
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(GroupRow.created_at).where(GroupRow.id == cursor_id).scalar_subquery()
+            )
+            return GroupRow.created_at > subquery
+
+        return inner
+
+
+class GroupOrders:
+    """Query orders for sorting groups/projects."""
+
+    @staticmethod
+    def id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.id.asc()
+        return GroupRow.id.desc()
+
+    @staticmethod
+    def name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.name.asc()
+        return GroupRow.name.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.created_at.asc()
+        return GroupRow.created_at.desc()
+
+    @staticmethod
+    def modified_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.modified_at.asc()
+        return GroupRow.modified_at.desc()
+
+    @staticmethod
+    def domain_name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.domain_name.asc()
+        return GroupRow.domain_name.desc()
+
+    @staticmethod
+    def type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return GroupRow.type.asc()
+        return GroupRow.type.desc()

--- a/src/ai/backend/manager/repositories/group/types.py
+++ b/src/ai/backend/manager/repositories/group/types.py
@@ -1,0 +1,94 @@
+"""Types for group repository operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.group.types import GroupData
+from ai.backend.manager.errors.resource import DomainNotFound
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group.row import AssocGroupUserRow, GroupRow
+from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
+
+__all__ = (
+    "GroupSearchResult",
+    "DomainProjectSearchScope",
+    "UserProjectSearchScope",
+)
+
+
+@dataclass
+class GroupSearchResult:
+    """Result from searching groups/projects."""
+
+    items: list[GroupData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+
+@dataclass(frozen=True)
+class DomainProjectSearchScope(SearchScope):
+    """Required scope for searching projects within a domain.
+
+    Used for domain-scoped project search (domain admin+).
+    """
+
+    domain_name: str
+    """Required. The domain to search within."""
+
+    def to_condition(self) -> QueryCondition:
+        """Convert scope to a query condition for GroupRow."""
+        domain_name = self.domain_name
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return GroupRow.domain_name == domain_name
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[str]]:
+        """Return existence checks for scope validation."""
+        return [
+            ExistenceCheck(
+                column=DomainRow.name,
+                value=self.domain_name,
+                error=DomainNotFound(self.domain_name),
+            ),
+        ]
+
+
+@dataclass(frozen=True)
+class UserProjectSearchScope(SearchScope):
+    """Required scope for searching projects a user is member of.
+
+    Used for user-scoped project search (any authenticated user).
+    Requires checking association_groups_users table.
+    """
+
+    user_uuid: UUID
+    """Required. The user UUID to search projects for."""
+
+    def to_condition(self) -> QueryCondition:
+        """Convert scope to a query condition for AssocGroupUserRow.
+
+        This will be used in a JOIN query with GroupRow.
+        """
+        user_uuid = self.user_uuid
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return AssocGroupUserRow.user_id == user_uuid
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[UUID]]:
+        """Return existence checks for scope validation.
+
+        Note: User existence is typically already validated by auth layer.
+        """
+        return []

--- a/src/ai/backend/manager/services/group/actions/search_projects.py
+++ b/src/ai/backend/manager/services/group/actions/search_projects.py
@@ -1,0 +1,110 @@
+"""Actions for searching projects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.data.group.types import GroupData
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.group.types import (
+    DomainProjectSearchScope,
+    UserProjectSearchScope,
+)
+from ai.backend.manager.services.group.actions.base import GroupAction
+
+
+@dataclass
+class SearchProjectsAction(GroupAction):
+    """Search all projects (admin scope - no scope filter)."""
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "search"
+
+
+@dataclass
+class SearchProjectsByDomainAction(GroupAction):
+    """Search projects within a domain."""
+
+    scope: DomainProjectSearchScope
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "search"
+
+
+@dataclass
+class SearchProjectsByUserAction(GroupAction):
+    """Search projects a user is member of."""
+
+    scope: UserProjectSearchScope
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "search"
+
+
+@dataclass
+class GetProjectAction(GroupAction):
+    """Get a single project by UUID."""
+
+    project_id: UUID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.project_id)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> str:
+        return "get"
+
+
+# Result types
+
+
+@dataclass
+class SearchProjectsActionResult(BaseActionResult):
+    """Result from searching projects."""
+
+    items: list[GroupData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+
+@dataclass
+class GetProjectActionResult(BaseActionResult):
+    """Result from getting a single project."""
+
+    data: GroupData
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.data.id)


### PR DESCRIPTION
Add Project V2 repository and service layer following User V2 pattern. Implements search capabilities with SearchScope pattern for domain/user-scoped queries.

Key features:
- Search projects with domain/user scope filtering
- GroupConditions and GroupOrders for flexible querying
- DomainProjectSearchScope and UserProjectSearchScope
- Separated methods instead of isinstance() checks

Changes:
- Add GroupSearchResult, SearchScope types
- Add GroupConditions and GroupOrders for query building
- Implement search_projects(), search_projects_by_domain(), search_projects_by_user()
- Implement get_project() for single project retrieval
- Add corresponding service layer methods and actions
- Remove get_project_users() (redundant with User repository)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
