### PR TITLE
fix(BA-4251): Check keypair vfolder permissions when clone vfolder (#8569)

### DIFF
--- a/changes/8569.fix.md
+++ b/changes/8569.fix.md
@@ -1,0 +1,1 @@
+Check vfolder permissions of requester's keypair rather when clone vfolder. This allows users with sufficient permission can clone vfolders from model store.

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -616,7 +616,7 @@ class VFolderService:
             )
 
         allowed_vfolder_hosts = await self._vfolder_repository.get_allowed_vfolder_hosts(
-            action.requester_user_uuid, source_vfolder_data.group
+            action.requester_user_uuid, None
         )
 
         # Check host permissions using the user's actual resource policy


### PR DESCRIPTION
This is an auto-generated backport PR of #8569 to the 26.1 release.