### PR TITLE
fix: Add ResourceSlot serialization for FairShareScalingGroupSpec

### DIFF
--- a/src/ai/backend/manager/models/scaling_group/types.py
+++ b/src/ai/backend/manager/models/scaling_group/types.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 from ai.backend.common.types import ResourceSlot
 
@@ -35,3 +36,8 @@ class FairShareScalingGroupSpec(BaseModel):
     If a resource type is not specified, default weight (1.0) is used.
     Example: ResourceSlot({"cpu": 1.0, "mem": 0.001, "cuda.device": 10.0})
     """
+
+    @field_serializer("resource_weights")
+    def serialize_resource_weights(self, value: ResourceSlot) -> dict[str, Any]:
+        """Serialize ResourceSlot to dict for JSON compatibility."""
+        return dict(value)


### PR DESCRIPTION
- Add @field_serializer for resource_weights field
- Convert ResourceSlot to dict for Pydantic JSON serialization
- Resolves PydanticSerializationError when updating fair_share_spec

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
