### PR TITLE
feat(BA-4296): Add operation context variable and header middleware

### DIFF
--- a/changes/8642.feature.md
+++ b/changes/8642.feature.md
@@ -1,0 +1,1 @@
+Add operation context variable for tracking client operations via `X-BackendAI-Operation` header

--- a/src/ai/backend/common/contexts/operation.py
+++ b/src/ai/backend/common/contexts/operation.py
@@ -6,11 +6,20 @@ _client_operation_var: ContextVar[str] = ContextVar("client_operation", default=
 
 
 def get_client_operation() -> str:
+    """
+    Return the current client operation name from the context.
+    Returns an empty string if no operation context has been established,
+    unlike other context getters that return None for unset values.
+    """
     return _client_operation_var.get()
 
 
 @contextmanager
 def with_client_operation(operation: str) -> Iterator[None]:
+    """
+    Context manager to set the client operation name for the current scope.
+    Resets the context variable to its previous state on exit.
+    """
     token = _client_operation_var.set(operation)
     try:
         yield

--- a/src/ai/backend/common/contexts/operation.py
+++ b/src/ai/backend/common/contexts/operation.py
@@ -1,0 +1,18 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_client_operation_var: ContextVar[str] = ContextVar("client_operation", default="")
+
+
+def get_client_operation() -> str:
+    return _client_operation_var.get()
+
+
+@contextmanager
+def with_client_operation(operation: str) -> Iterator[None]:
+    token = _client_operation_var.set(operation)
+    try:
+        yield
+    finally:
+        _client_operation_var.reset(token)

--- a/src/ai/backend/common/middlewares/request_id.py
+++ b/src/ai/backend/common/middlewares/request_id.py
@@ -12,7 +12,7 @@ type Handler = Callable[
 ]
 
 REQUEST_ID_HEADER = "X-BackendAI-RequestID"
-OPERATION_HEADER = "X-BackendAI-Operation"
+OPERATION_HEADER = "X-BackendAI-Client-Operation"
 
 
 @web.middleware

--- a/src/ai/backend/common/middlewares/request_id.py
+++ b/src/ai/backend/common/middlewares/request_id.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable
 
 from aiohttp import web
 
+from ai.backend.common.contexts.operation import with_client_operation
 from ai.backend.common.contexts.request_id import with_request_id
 from ai.backend.logging.utils import with_log_context_fields
 
@@ -11,14 +12,17 @@ type Handler = Callable[
 ]
 
 REQUEST_ID_HEADER = "X-BackendAI-RequestID"
+OPERATION_HEADER = "X-BackendAI-Operation"
 
 
 @web.middleware
 async def request_id_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
     _handler = handler
     request_id: str | None = request.headers.get(REQUEST_ID_HEADER, None)
+    operation: str = request.headers.get(OPERATION_HEADER, "")
     with (
         with_request_id(request_id),
         with_log_context_fields({"request_id": request_id}),
+        with_client_operation(operation),
     ):
         return await _handler(request)

--- a/tests/unit/common/test_operation.py
+++ b/tests/unit/common/test_operation.py
@@ -1,0 +1,32 @@
+from ai.backend.common.contexts.operation import (
+    get_client_operation,
+    with_client_operation,
+)
+
+
+class TestGetClientOperation:
+    def test_returns_empty_string_when_not_set(self) -> None:
+        assert get_client_operation() == ""
+
+    def test_returns_correct_value_within_context(self) -> None:
+        with with_client_operation("createSession"):
+            assert get_client_operation() == "createSession"
+
+    def test_resets_after_context_exit(self) -> None:
+        with with_client_operation("createSession"):
+            pass
+        assert get_client_operation() == ""
+
+    def test_handles_empty_string_operation(self) -> None:
+        with with_client_operation(""):
+            assert get_client_operation() == ""
+
+
+class TestNestedClientOperationContexts:
+    def test_nested_contexts_restore_correctly(self) -> None:
+        with with_client_operation("outerOp"):
+            assert get_client_operation() == "outerOp"
+            with with_client_operation("innerOp"):
+                assert get_client_operation() == "innerOp"
+            assert get_client_operation() == "outerOp"
+        assert get_client_operation() == ""


### PR DESCRIPTION
resolves #8636 (BA-4296)

## Overview

Adds a new `ContextVar`-based context variable for tracking client operation names
through the request lifecycle. The `X-BackendAI-Operation` header is read in the
existing `request_id_middleware` and made available globally via `get_client_operation()`.

## Problem Statement

- Need to propagate client-provided operation names through request processing for observability
- Downstream components (metrics, logging) require access to the operation name without explicit parameter passing
- No context variable mechanism existed for operation tracking, unlike the existing `request_id` pattern

## Architecture

```mermaid
sequenceDiagram
    participant Client
    participant request_id_middleware
    participant Handler
    participant Downstream

    Client->>request_id_middleware: Request (X-BackendAI-Operation: "createSession")
    request_id_middleware->>request_id_middleware: Set ContextVar via with_client_operation()
    request_id_middleware->>Handler: Forward request
    Handler->>Downstream: get_client_operation() → "createSession"
    Downstream-->>Handler: Response
    Handler-->>request_id_middleware: Response
    request_id_middleware->>request_id_middleware: Reset ContextVar (finally)
    request_id_middleware-->>Client: Response
```

---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations