### PR TITLE
fix(BA-4299): Fix async resolver timing in GQL middleware

### DIFF
--- a/changes/8643.fix.md
+++ b/changes/8643.fix.md
@@ -1,0 +1,1 @@
+Fix async resolver timing measurement in GraphQL metric middleware to record actual execution time instead of near-zero coroutine creation time


### PR DESCRIPTION
resolves #8639 (BA-4299)

## Overview

Fixes async resolver timing in `GQLMetricMiddleware` to measure actual execution time instead of near-zero coroutine creation time. Async resolvers are wrapped in an `_observe_coroutine()` helper that records duration after the coroutine is awaited, while preserving DataLoader batching.

## Problem Statement

- `GQLMetricMiddleware.resolve()` measured `time.perf_counter()` around `next(root, info, **args)`, which returns a coroutine instantly for async resolvers (~0ms)
- graphql-core awaits the coroutine later, outside the timing window
- All async resolver metrics reported near-zero duration (e.g., `0.000123s` for a 500ms+ query)
- Sync resolvers were unaffected

---

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
