### PR TITLE
fix(BA-4280): Prevent `scoped_query` from overriding `project` param with `group_id` (#8628)

### DIFF
--- a/changes/8628.fix.md
+++ b/changes/8628.fix.md
@@ -1,0 +1,1 @@
+Prevent `scoped_query` from overriding `project` param with `group_id`

--- a/src/ai/backend/manager/api/gql_legacy/base.py
+++ b/src/ai/backend/manager/api/gql_legacy/base.py
@@ -613,8 +613,6 @@ def scoped_query(
             kwargs["domain_name"] = domain_name
             if group_id is not None:
                 kwargs["group_id"] = group_id
-            if kwargs.get("project") is not None:
-                kwargs["project"] = group_id
             kwargs[user_key] = user_id
             return await resolve_func(root, info, *args, **kwargs)
 

--- a/tests/unit/manager/api/test_gql_legacy_scoped_query.py
+++ b/tests/unit/manager/api/test_gql_legacy_scoped_query.py
@@ -1,0 +1,54 @@
+"""
+Regression test for scoped_query: the `project` parameter must not be
+silently overridden by `group_id`. (BA-4280)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import graphene
+import pytest
+
+from ai.backend.manager.api.gql_legacy.base import scoped_query
+from ai.backend.manager.models.user import UserRole
+
+
+class TestScopedQuery:
+    """Test fixes for scoped_query bugs BA-4280."""
+
+    @pytest.fixture
+    def mock_graphene_info(self) -> MagicMock:
+        """Mock GraphQL ResolveInfo with SUPERADMIN context."""
+        ctx = MagicMock()
+        ctx.user = {"role": UserRole.SUPERADMIN, "domain_name": "default", "uuid": uuid.uuid4()}
+        ctx.access_key = "test-key"
+        info = MagicMock(spec=graphene.ResolveInfo)
+        info.context = ctx
+        return info
+
+    @pytest.mark.asyncio
+    async def test_project_param_preserved(self, mock_graphene_info: MagicMock) -> None:
+        """Regression: project was silently overridden by group_id in scoped_query."""
+        project_id = uuid.uuid4()
+        group_id = uuid.uuid4()
+        received: dict[str, Any] = {}
+
+        @scoped_query(autofill_user=False, user_key="user_uuid")
+        async def _mock_resolver(
+            _root: Any,
+            _info: graphene.ResolveInfo,
+            *,
+            project: uuid.UUID | None = None,
+            group_id: uuid.UUID | None = None,
+            domain_name: str | None = None,
+            user_uuid: uuid.UUID | None = None,
+        ) -> None:
+            received.update(project=project, group_id=group_id)
+
+        await _mock_resolver(None, mock_graphene_info, project=project_id, group_id=group_id)
+
+        assert received["project"] == project_id
+        assert received["group_id"] == group_id


### PR DESCRIPTION
This is an auto-generated backport PR of #8628 to the 26.1 release.