### PR TITLE
docs(BA-4071): Add Traefik integration guide links to appproxy README

### DIFF
--- a/src/ai/backend/appproxy/README.md
+++ b/src/ai/backend/appproxy/README.md
@@ -158,7 +158,7 @@ Backends handle actual proxy implementation:
 - Advanced routing rules
 - Middleware chains
 - Enterprise features
-- See [Traefik Integration Guide](../../../docs/app-proxy/traefik-integration.md) for detailed configuration
+- See [Traefik Integration Guide](../../../../docs/app-proxy/traefik-integration.md) for detailed configuration
 
 ### Load Balancing Strategies
 
@@ -425,7 +425,7 @@ See [README.md](./README.md) for development setup instructions.
 
 - [Coordinator README](./coordinator/README.md) - Coordinator details
 - [Worker README](./worker/README.md) - Worker details
-- [Traefik Integration Guide](../../../docs/app-proxy/traefik-integration.md) - Traefik mode configuration and setup
+- [Traefik Integration Guide](../../../../docs/app-proxy/traefik-integration.md) - Traefik mode configuration and setup
 - [Manager Component](../manager/README.md) - API gateway
 - [Agent Component](../agent/README.md) - Container management
 - [Overall Architecture](../README.md) - System-wide architecture


### PR DESCRIPTION
resolves #8284 (BA-4071)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [x] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
