### PR TITLE
chore: optimize CI workflows to reduce concurrent runners per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,24 @@ jobs:
         run: echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
       - name: Alembic
         id: alembic
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'comp:manager')
-          || github.event_name == 'merge_group'
-        run: echo "ALEMBIC=true" >> $GITHUB_OUTPUT
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
+            echo "ALEMBIC=true" >> $GITHUB_OUTPUT
+          else
+            changed=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+              --paginate --jq '.[].filename')
+            if echo "$changed" | grep -qE '^src/ai/backend/manager/models/'; then
+              echo "ALEMBIC=true" >> $GITHUB_OUTPUT
+            fi
+          fi
 
 
 
 
-  lint:
+  lint-and-typecheck:
     if: |
       needs.optimize-ci.outputs.skip != 'true'
     needs: [optimize-ci]
@@ -129,47 +138,58 @@ jobs:
         gha-cache-key: v0
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'true'
-    - name: Check BUILD files
+    - name: Calculate base ref
       run: |
-        IS_RELEASE="${{ needs.optimize-ci.outputs.release }}"
-        if [ "$IS_RELEASE" == "true" ]; then
-          # For releases, check all BUILD files
-          pants tailor --check update-build-files --check '::'
-        elif [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
           [ -n "$GITHUB_BASE_REF" ] && BASE_REF_SHORT="${GITHUB_BASE_REF}" || BASE_REF_SHORT="main"
-          BASE_REF="origin/${BASE_REF_SHORT}"
-          # Ensure the base branch exists locally to avoid 'bad revision' errors
+          echo "BASE_REF=origin/${BASE_REF_SHORT}" >> $GITHUB_ENV
           git remote set-branches origin "$BASE_REF_SHORT"
           BASE_COMMIT=$(git rev-list --first-parent --max-parents=0 --max-count=1 HEAD)
           BASE_TIMESTAMP=$(git log --format=%ct "${BASE_COMMIT}")
           git fetch --no-tags --shallow-since "${BASE_TIMESTAMP}" origin "${BASE_REF_SHORT}"
-          pants tailor --check update-build-files --check --changed-since=$BASE_REF
         else
-          BASE_REF="HEAD~1"
+          echo "BASE_REF=HEAD~1" >> $GITHUB_ENV
+        fi
+    - name: Check BUILD files
+      run: |
+        IS_RELEASE="${{ needs.optimize-ci.outputs.release }}"
+        if [ "$IS_RELEASE" == "true" ]; then
+          pants tailor --check update-build-files --check '::'
+        else
           pants tailor --check update-build-files --check --changed-since=$BASE_REF
         fi
     - name: Lint
+      id: lint
+      continue-on-error: true
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
           echo "(skipping matchers for pull request from local branches)"
         else
           echo "::add-matcher::.github/workflows/flake8-matcher.json"
         fi
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-          [ -n "$GITHUB_BASE_REF" ] && BASE_REF_SHORT="${GITHUB_BASE_REF}" || BASE_REF_SHORT="main"
-          BASE_REF="origin/${BASE_REF_SHORT}"
-          git remote set-branches origin "$BASE_REF_SHORT"
-          BASE_COMMIT=$(git rev-list --first-parent --max-parents=0 --max-count=1 HEAD)
-          BASE_TIMESTAMP=$(git log --format=%ct "${BASE_COMMIT}")
-          git fetch --no-tags --shallow-since "${BASE_TIMESTAMP}" origin "${BASE_REF_SHORT}"
-        else
-          BASE_REF="HEAD~1"
-        fi
         pants lint --changed-since=$BASE_REF --changed-dependents=transitive
+    - name: Typecheck
+      id: typecheck
+      continue-on-error: true
+      run: |
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
+          echo "(skipping matchers for pull request from local branches)"
+        else
+          echo "::add-matcher::.github/workflows/mypy-matcher.json"
+        fi
+        pants check --changed-since=$BASE_REF --changed-dependents=transitive
+    - name: Check results
+      if: always()
+      run: |
+        if [ "${{ steps.lint.outcome }}" != "success" ] || [ "${{ steps.typecheck.outcome }}" != "success" ]; then
+          echo "Lint outcome: ${{ steps.lint.outcome }}"
+          echo "Typecheck outcome: ${{ steps.typecheck.outcome }}"
+          exit 1
+        fi
     - name: Upload pants log
       uses: actions/upload-artifact@v5
       with:
-        name: pants.lint.log
+        name: pants.lint-and-typecheck.log
         path: .pants.d/workdir/pants.log
       if: always()  # We want the log even on failures.
 
@@ -230,74 +250,6 @@ jobs:
         echo "REVISION_FILE=$revision_file" >> $GITHUB_OUTPUT
     - name: Verify that revision is empty
       run: python scripts/check-alembic-revision.py ${{ steps.create-revision.outputs.REVISION_FILE }}
-
-
-  typecheck:
-    if: |
-      needs.optimize-ci.outputs.skip != 'true'
-    needs: [optimize-ci]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Calculate the fetch depth
-      run: |
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-          echo "GIT_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-        else
-          echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
-        fi
-    - name: Check out the revision with minimal required history
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
-        lfs: false
-    - name: Extract Python version from pants.toml
-      run: |
-        PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
-        echo "PANTS_CONFIG_FILES=pants.ci.toml" >> $GITHUB_ENV
-        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
-    - name: Set up Python as Runtime
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
-    - name: Set up remote cache backend (if applicable)
-      run: |
-        echo "PANTS_REMOTE_STORE_ADDRESS=${REMOTE_CACHE_BACKEND_ENDPOINT}" >> $GITHUB_ENV
-        echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
-        echo "PANTS_REMOTE_CACHE_WRITE=true" >> $GITHUB_ENV
-        echo "PANTS_REMOTE_INSTANCE_NAME=main" >> $GITHUB_ENV
-      env:
-        REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT_ARC }}
-      if: ${{ env.REMOTE_CACHE_BACKEND_ENDPOINT != '' }}
-    - name: Bootstrap Pants
-      uses: pantsbuild/actions/init-pants@v10
-      with:
-        gha-cache-key: v0
-        named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
-        cache-lmdb-store: 'true'
-    - name: Typecheck
-      run: |
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
-          echo "(skipping matchers for pull request from local branches)"
-        else
-          echo "::add-matcher::.github/workflows/mypy-matcher.json"
-        fi
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-          [ -n "$GITHUB_BASE_REF" ] && BASE_REF_SHORT="${GITHUB_BASE_REF}" || BASE_REF_SHORT="main"
-          BASE_REF="origin/${BASE_REF_SHORT}"
-          git remote set-branches origin "$BASE_REF_SHORT"
-          BASE_COMMIT=$(git rev-list --first-parent --max-parents=0 --max-count=1 HEAD)
-          BASE_TIMESTAMP=$(git log --format=%ct "${BASE_COMMIT}")
-          git fetch --no-tags --shallow-since "${BASE_TIMESTAMP}" origin "${BASE_REF_SHORT}"
-        else
-          BASE_REF="HEAD~1"
-        fi
-        pants check --changed-since=$BASE_REF --changed-dependents=transitive
-    - name: Upload pants log
-      uses: actions/upload-artifact@v5
-      with:
-        name: pants.check.log
-        path: .pants.d/workdir/pants.log
-      if: always()  # We want the log even on failures.
 
 
   test:
@@ -381,7 +333,7 @@ jobs:
 
 
   build-scies:
-    needs: [lint, typecheck, test, check-alembic-migrations, optimize-ci]
+    needs: [lint-and-typecheck, test, check-alembic-migrations, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     strategy:
       fail-fast: false
@@ -448,7 +400,7 @@ jobs:
 
 
   build-wheels:
-    needs: [lint, typecheck, test, check-alembic-migrations, optimize-ci]
+    needs: [lint-and-typecheck, test, check-alembic-migrations, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     runs-on: ubuntu-22.04
     steps:
@@ -494,12 +446,12 @@ jobs:
 
 
   build-sbom:
-    needs: [lint, typecheck, test, check-alembic-migrations, optimize-ci]
+    needs: [lint-and-typecheck, test, check-alembic-migrations, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     uses: ./.github/workflows/sbom.yml
 
   build-supergraph:
-    needs: [lint, typecheck, test, check-alembic-migrations, optimize-ci]
+    needs: [lint-and-typecheck, test, check-alembic-migrations, optimize-ci]
     if: needs.optimize-ci.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -8,8 +8,6 @@ name: DevSkim
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '18 4 * * 4'
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -12,10 +12,6 @@
 name: OSV-Scanner
 
 on:
-  pull_request:
-    branches: [ "main" ]
-  merge_group:
-    branches: [ "main" ]
   schedule:
     - cron: '43 20 * * 3'
   push:
@@ -30,16 +26,7 @@ permissions:
 
 jobs:
   scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6fc714450122bda9d00e4ad5d639ad6a39eedb1f" # v2.0.1
-    with:
-      # Example of specifying custom arguments
-      scan-args: |-
-        -r
-        ./
-  scan-pr:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6fc714450122bda9d00e4ad5d639ad6a39eedb1f" # v2.0.1
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -56,20 +43,12 @@ jobs:
       uses: actions/checkout@v6
       with:
         lfs: false
-        fetch-depth: 0  # Need full history for git diff
 
     - name: Find Dockerfiles to scan
       id: set-matrix
       run: |
-        # For PR: only scan changed Dockerfiles
-        # For schedule/push: scan all Dockerfiles
-        if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
-          echo "Scanning only changed Dockerfiles in PR"
-          DOCKERFILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD | grep '^docker/.*\.dockerfile$' || true)
-        else
-          echo "Scanning all Dockerfiles"
-          DOCKERFILES=$(find docker -type f -name "*.dockerfile")
-        fi
+        echo "Scanning all Dockerfiles"
+        DOCKERFILES=$(find docker -type f -name "*.dockerfile")
 
         # Build JSON matrix
         MATRIX_JSON=$(echo "$DOCKERFILES" | jq -R -s -c '

--- a/.github/workflows/pr-prefix.yml
+++ b/.github/workflows/pr-prefix.yml
@@ -2,7 +2,7 @@ name: check-pr-title-prefix
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened]
 
 jobs:
   check-pr-prefix:


### PR DESCRIPTION
- Merge lint and typecheck into single lint-and-typecheck job (-1 runner)
- Switch alembic migration check from label-based to paths-based detection (-1 runner, conditional)
- Remove PR triggers from osv-scanner workflow (-2 runners)
- Remove PR trigger from DevSkim workflow (-1 runner)
- Remove unnecessary synchronize trigger from pr-prefix workflow (-1 runner)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

resolves #NNN (BA-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
