### PR TITLE
fix: fix downgrade SQL in dropping permission group migration

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/f41bbe0c0f12_remove_permission_groups_table_and_fk.py
+++ b/src/ai/backend/manager/models/alembic/versions/f41bbe0c0f12_remove_permission_groups_table_and_fk.py
@@ -103,13 +103,19 @@ def downgrade() -> None:
         sa.text("""
         UPDATE object_permissions op
         SET permission_group_id = pg.id
-        FROM permission_groups pg
-        JOIN association_scopes_entities ase
-            ON pg.scope_type = ase.scope_type
-            AND pg.scope_id = ase.scope_id
-            AND ase.entity_type = op.entity_type
-            AND ase.entity_id = op.entity_id
-        WHERE pg.role_id = op.role_id
+        FROM permission_groups pg, association_scopes_entities ase
+        WHERE pg.scope_type = ase.scope_type
+          AND pg.scope_id = ase.scope_id
+          AND ase.entity_type = op.entity_type
+          AND ase.entity_id = op.entity_id
+          AND pg.role_id = op.role_id
+    """)
+    )
+
+    # Delete orphan object_permissions that couldn't be mapped to a permission_group
+    conn.execute(
+        sa.text("""
+        DELETE FROM object_permissions WHERE permission_group_id IS NULL
     """)
     )
 


### PR DESCRIPTION
- Fix invalid table alias reference in UPDATE...FROM JOIN (PostgreSQL doesn't allow referencing the target table in JOIN ON clauses)
- Delete orphan object_permissions before setting NOT NULL constraint

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
