### PR TITLE
fix(BA-4384): Align duplicate endpoint name check with DB unique index to exclude only destroyed endpoints

### DIFF
--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -349,6 +349,7 @@ class DeploymentDBSource:
                     EndpointRow.domain == domain_name,
                     EndpointRow.project == project_id,
                     EndpointRow.name == name,
+                    EndpointRow.lifecycle_stage != EndpointLifecycle.DESTROYED,
                 )
             )
             .limit(1)


### PR DESCRIPTION
resolves #8792 (BA-4384)

follow up of https://github.com/lablup/backend.ai/pull/8647, add missing endpoint status condition check

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
