### PR TITLE
fix(BA-4394): Use `select_from` when join table to avoid Cartesian product in model serving query (#8813)

### DIFF
--- a/changes/8813.fix.md
+++ b/changes/8813.fix.md
@@ -1,0 +1,1 @@
+Fix Cartesian product warning in model serving repository by using `select_from()` pattern for JOIN queries, resolving SQLAlchemy warnings about missing join conditions between `users` and `keypairs` tables.

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -500,9 +500,11 @@ class ModelServingRepository:
         """
         Get user with their main access key.
         """
-        async with self._db.begin_readonly_session() as session:
-            query = sa.select(sa.join(UserRow, KeyPairRow, KeyPairRow.user == UserRow.uuid)).where(
-                UserRow.uuid == user_id
+        async with self._db.begin_readonly_session_read_committed() as session:
+            query = (
+                sa.select(UserRow, KeyPairRow)
+                .select_from(sa.join(UserRow, KeyPairRow, KeyPairRow.user == UserRow.uuid))
+                .where(UserRow.uuid == user_id)
             )
             result = await session.execute(query)
             return result.fetchone()


### PR DESCRIPTION
This is an auto-generated backport PR of #8813 to the 26.1 release.