### PR TITLE
feat: Add EntityScope query options and registered_at field

### DIFF
--- a/src/ai/backend/manager/data/permission/association_scopes_entities.py
+++ b/src/ai/backend/manager/data/permission/association_scopes_entities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 
 from ai.backend.common.data.permission.types import RelationType
 
@@ -14,3 +15,4 @@ class AssociationScopesEntitiesData:
     scope_id: ScopeId
     object_id: ObjectId
     relation_type: RelationType
+    registered_at: datetime

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -79,4 +79,5 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
             ),
             object_id=self.object_id(),
             relation_type=self.relation_type,
+            registered_at=self.registered_at,
         )

--- a/src/ai/backend/manager/repositories/permission_controller/options.py
+++ b/src/ai/backend/manager/repositories/permission_controller/options.py
@@ -620,6 +620,76 @@ class EntityScopeConditions:
 
         return inner
 
+    @staticmethod
+    def by_entity_id_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.entity_id.ilike(f"%{spec.value}%")
+            else:
+                condition = AssociationScopesEntitiesRow.entity_id.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(AssociationScopesEntitiesRow.entity_id) == spec.value.lower()
+                )
+            else:
+                condition = AssociationScopesEntitiesRow.entity_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.entity_id.ilike(f"{spec.value}%")
+            else:
+                condition = AssociationScopesEntitiesRow.entity_id.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AssociationScopesEntitiesRow.entity_id.ilike(f"%{spec.value}")
+            else:
+                condition = AssociationScopesEntitiesRow.entity_id.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+
+class EntityScopeOrders:
+    """Query orders for entity scope search."""
+
+    @staticmethod
+    def entity_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AssociationScopesEntitiesRow.entity_type.asc()
+        return AssociationScopesEntitiesRow.entity_type.desc()
+
+    @staticmethod
+    def registered_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AssociationScopesEntitiesRow.registered_at.asc()
+        return AssociationScopesEntitiesRow.registered_at.desc()
+
 
 class ScopedPermissionConditions:
     """Query conditions for scoped permissions."""


### PR DESCRIPTION
resolves #NNN (BA-MMM)
- Add registered_at field to AssociationScopesEntitiesData
- Add entity_id UUID filter conditions to EntityScopeConditions
- Add EntityScopeOrders class for entity_type and registered_at ordering

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
