### PR TITLE
fix(BA-4551): Fix alembic migration naming convention for BA-4308 (#9070)

### DIFF
--- a/changes/9070.fix.md
+++ b/changes/9070.fix.md
@@ -1,0 +1,1 @@
+Fix alembic migration naming convention for BA-4308 by renaming file and revision ID to use standard 12-char hex format.

--- a/src/ai/backend/manager/models/alembic/versions/12b02ba4d44b_add_usage_bucket_entries_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/12b02ba4d44b_add_usage_bucket_entries_table.py
@@ -1,6 +1,6 @@
 """add_usage_bucket_entries_table
 
-Revision ID: ba4308_usage_entries
+Revision ID: 12b02ba4d44b
 Revises: ccf8ae5c90fe
 Create Date: 2026-02-14 00:00:00.000000
 
@@ -12,7 +12,7 @@ from alembic import op
 from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
-revision = "ba4308_usage_entries"
+revision = "12b02ba4d44b"
 down_revision = "ccf8ae5c90fe"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
This is an auto-generated backport PR of #9070 to the 26.2 release.