### PR TITLE
fix(BA-4530): add migration to rename vfolderpermission PG enum type (#9067)

### DIFF
--- a/changes/9067.fix.md
+++ b/changes/9067.fix.md
@@ -1,0 +1,1 @@
+Fix UndefinedObjectError on vfolder queries after upgrade by adding alembic migration to rename the `vfolderpermission` PostgreSQL enum type to `vfoldermountpermission`.

--- a/src/ai/backend/manager/models/alembic/versions/03ff6767b2e4_rename_vfolderpermission_type.py
+++ b/src/ai/backend/manager/models/alembic/versions/03ff6767b2e4_rename_vfolderpermission_type.py
@@ -1,0 +1,45 @@
+"""Rename vfolderpermission PG enum type to vfoldermountpermission
+
+Revision ID: 03ff6767b2e4
+Revises: 12b02ba4d44b
+Create Date: 2026-02-18 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "03ff6767b2e4"
+down_revision = "12b02ba4d44b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename the PostgreSQL enum type from vfolderpermission to vfoldermountpermission
+    # to match the Python class name VFolderMountPermission (renamed from VFolderPermission in BA-2107).
+    # EnumValueType auto-derives the PG type name from enum_cls.__name__.lower(),
+    # so the DB type must match the Python class name.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'vfolderpermission') THEN
+                ALTER TYPE vfolderpermission RENAME TO vfoldermountpermission;
+            END IF;
+        END$$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'vfoldermountpermission') THEN
+                ALTER TYPE vfoldermountpermission RENAME TO vfolderpermission;
+            END IF;
+        END$$;
+        """
+    )


### PR DESCRIPTION
This is an auto-generated backport PR of #9067 to the 26.2 release.