### PR TITLE
fix(BA-4597): add resource_slot_types seed data fixture for oneshot DB init (#9129)

### DIFF
--- a/changes/9129.fix.md
+++ b/changes/9129.fix.md
@@ -1,0 +1,1 @@
+Fix FK violation on agent heartbeat by seeding `resource_slot_types` table during oneshot DB initialization.

--- a/fixtures/manager/example-resource-slot-types.json
+++ b/fixtures/manager/example-resource-slot-types.json
@@ -1,0 +1,144 @@
+{
+  "resource_slot_types": [
+    {
+      "slot_name": "cpu",
+      "slot_type": "count",
+      "display_name": "CPU",
+      "description": "CPU",
+      "display_unit": "Core",
+      "display_icon": "cpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 100
+    },
+    {
+      "slot_name": "mem",
+      "slot_type": "bytes",
+      "display_name": "RAM",
+      "description": "Memory",
+      "display_unit": "GiB",
+      "display_icon": "ram",
+      "number_format": {"binary": true, "round_length": 0},
+      "rank": 200
+    },
+    {
+      "slot_name": "cuda.device",
+      "slot_type": "count",
+      "display_name": "GPU",
+      "description": "CUDA-capable GPU",
+      "display_unit": "GPU",
+      "display_icon": "nvidia",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 300
+    },
+    {
+      "slot_name": "cuda.shares",
+      "slot_type": "count",
+      "display_name": "fGPU",
+      "description": "CUDA-capable GPU (fractional)",
+      "display_unit": "fGPU",
+      "display_icon": "nvidia",
+      "number_format": {"binary": false, "round_length": 2},
+      "rank": 400
+    },
+    {
+      "slot_name": "rocm.device",
+      "slot_type": "count",
+      "display_name": "GPU",
+      "description": "ROCm-capable GPU",
+      "display_unit": "GPU",
+      "display_icon": "rocm",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 500
+    },
+    {
+      "slot_name": "tpu.device",
+      "slot_type": "count",
+      "display_name": "TPU",
+      "description": "TPU device",
+      "display_unit": "GPU",
+      "display_icon": "tpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 600
+    },
+    {
+      "slot_name": "ipu.device",
+      "slot_type": "count",
+      "display_name": "IPU",
+      "description": "IPU device",
+      "display_unit": "IPU",
+      "display_icon": "ipu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 700
+    },
+    {
+      "slot_name": "atom.device",
+      "slot_type": "count",
+      "display_name": "ATOM Device",
+      "description": "ATOM",
+      "display_unit": "ATOM",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 800
+    },
+    {
+      "slot_name": "atom-plus.device",
+      "slot_type": "count",
+      "display_name": "ATOM+ Device",
+      "description": "ATOM+",
+      "display_unit": "ATOM+",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 900
+    },
+    {
+      "slot_name": "atom-max.device",
+      "slot_type": "count",
+      "display_name": "ATOM Max Device",
+      "description": "ATOM Max",
+      "display_unit": "ATOM Max",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1000
+    },
+    {
+      "slot_name": "gaudi2.device",
+      "slot_type": "count",
+      "display_name": "Gaudi 2 Device",
+      "description": "Gaudi 2",
+      "display_unit": "Gaudi 2",
+      "display_icon": "gaudi",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1100
+    },
+    {
+      "slot_name": "warboy.device",
+      "slot_type": "count",
+      "display_name": "Warboy Device",
+      "description": "Furiosa Warboy",
+      "display_unit": "Warboy",
+      "display_icon": "furiosa",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1200
+    },
+    {
+      "slot_name": "rngd.device",
+      "slot_type": "count",
+      "display_name": "RNGD Device",
+      "description": "Furiosa RNGD",
+      "display_unit": "RNGD",
+      "display_icon": "furiosa",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1300
+    },
+    {
+      "slot_name": "hyperaccel-lpu.device",
+      "slot_type": "count",
+      "display_name": "Hyperaccel LPU Device",
+      "description": "Hyperaccel LPU",
+      "display_unit": "LPU",
+      "display_icon": "lpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1400
+    }
+  ]
+}

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1167,6 +1167,7 @@ configure_backendai() {
   ./backend.ai mgr fixture populate fixtures/manager/example-users.json
   ./backend.ai mgr fixture populate fixtures/manager/example-keypairs.json
   ./backend.ai mgr fixture populate fixtures/manager/example-set-user-main-access-keys.json
+  ./backend.ai mgr fixture populate fixtures/manager/example-resource-slot-types.json
   ./backend.ai mgr fixture populate fixtures/manager/example-resource-presets.json
   ./backend.ai mgr fixture populate fixtures/manager/example-roles.json
 

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -418,6 +418,10 @@ class Context(metaclass=ABCMeta):
         ) as path:
             await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
         with self.resource_path(
+            "ai.backend.install.fixtures", "example-resource-slot-types.json"
+        ) as path:
+            await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])
+        with self.resource_path(
             "ai.backend.install.fixtures", "example-resource-presets.json"
         ) as path:
             await self.run_manager_cli(["mgr", "fixture", "populate", str(path)])

--- a/src/ai/backend/install/fixtures/example-resource-slot-types.json
+++ b/src/ai/backend/install/fixtures/example-resource-slot-types.json
@@ -1,0 +1,144 @@
+{
+  "resource_slot_types": [
+    {
+      "slot_name": "cpu",
+      "slot_type": "count",
+      "display_name": "CPU",
+      "description": "CPU",
+      "display_unit": "Core",
+      "display_icon": "cpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 100
+    },
+    {
+      "slot_name": "mem",
+      "slot_type": "bytes",
+      "display_name": "RAM",
+      "description": "Memory",
+      "display_unit": "GiB",
+      "display_icon": "ram",
+      "number_format": {"binary": true, "round_length": 0},
+      "rank": 200
+    },
+    {
+      "slot_name": "cuda.device",
+      "slot_type": "count",
+      "display_name": "GPU",
+      "description": "CUDA-capable GPU",
+      "display_unit": "GPU",
+      "display_icon": "nvidia",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 300
+    },
+    {
+      "slot_name": "cuda.shares",
+      "slot_type": "count",
+      "display_name": "fGPU",
+      "description": "CUDA-capable GPU (fractional)",
+      "display_unit": "fGPU",
+      "display_icon": "nvidia",
+      "number_format": {"binary": false, "round_length": 2},
+      "rank": 400
+    },
+    {
+      "slot_name": "rocm.device",
+      "slot_type": "count",
+      "display_name": "GPU",
+      "description": "ROCm-capable GPU",
+      "display_unit": "GPU",
+      "display_icon": "rocm",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 500
+    },
+    {
+      "slot_name": "tpu.device",
+      "slot_type": "count",
+      "display_name": "TPU",
+      "description": "TPU device",
+      "display_unit": "GPU",
+      "display_icon": "tpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 600
+    },
+    {
+      "slot_name": "ipu.device",
+      "slot_type": "count",
+      "display_name": "IPU",
+      "description": "IPU device",
+      "display_unit": "IPU",
+      "display_icon": "ipu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 700
+    },
+    {
+      "slot_name": "atom.device",
+      "slot_type": "count",
+      "display_name": "ATOM Device",
+      "description": "ATOM",
+      "display_unit": "ATOM",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 800
+    },
+    {
+      "slot_name": "atom-plus.device",
+      "slot_type": "count",
+      "display_name": "ATOM+ Device",
+      "description": "ATOM+",
+      "display_unit": "ATOM+",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 900
+    },
+    {
+      "slot_name": "atom-max.device",
+      "slot_type": "count",
+      "display_name": "ATOM Max Device",
+      "description": "ATOM Max",
+      "display_unit": "ATOM Max",
+      "display_icon": "rebel",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1000
+    },
+    {
+      "slot_name": "gaudi2.device",
+      "slot_type": "count",
+      "display_name": "Gaudi 2 Device",
+      "description": "Gaudi 2",
+      "display_unit": "Gaudi 2",
+      "display_icon": "gaudi",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1100
+    },
+    {
+      "slot_name": "warboy.device",
+      "slot_type": "count",
+      "display_name": "Warboy Device",
+      "description": "Furiosa Warboy",
+      "display_unit": "Warboy",
+      "display_icon": "furiosa",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1200
+    },
+    {
+      "slot_name": "rngd.device",
+      "slot_type": "count",
+      "display_name": "RNGD Device",
+      "description": "Furiosa RNGD",
+      "display_unit": "RNGD",
+      "display_icon": "furiosa",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1300
+    },
+    {
+      "slot_name": "hyperaccel-lpu.device",
+      "slot_type": "count",
+      "display_name": "Hyperaccel LPU Device",
+      "description": "Hyperaccel LPU",
+      "display_unit": "LPU",
+      "display_icon": "lpu",
+      "number_format": {"binary": false, "round_length": 0},
+      "rank": 1400
+    }
+  ]
+}

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -847,6 +847,11 @@ async def populate_fixture(
                         if col.name in row and row[col.name] is not None:
                             if not isinstance(row[col.name], VFolderHostPermissionMap):
                                 row[col.name] = VFolderHostPermissionMap(row[col.name])
+                elif isinstance(col.type, PydanticColumn):
+                    for row in rows:
+                        if col.name in row and row[col.name] is not None:
+                            if not isinstance(row[col.name], col.type._schema):
+                                row[col.name] = col.type._schema.model_validate(row[col.name])
 
             match op_mode:
                 case FixtureOpModes.INSERT:

--- a/tests/unit/manager/models/resource_slot/test_resource_slot_fixture.py
+++ b/tests/unit/manager/models/resource_slot/test_resource_slot_fixture.py
@@ -1,0 +1,109 @@
+"""Regression tests for BA-4597: resource_slot_types fixture loading.
+
+Verifies that:
+1. populate_fixture correctly handles PydanticColumn (number_format) when
+   loading resource_slot_types from JSON fixture data.
+2. AgentResourceRow insertion succeeds after loading the fixture (FK satisfied).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from ai.backend.manager.models.base import populate_fixture
+from ai.backend.manager.models.resource_slot import (
+    AgentResourceRow,
+    NumberFormat,
+    ResourceSlotTypeRow,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+class TestPopulateFixtureWithPydanticColumn:
+    """Regression tests for populate_fixture handling PydanticColumn (BA-4597)."""
+
+    async def test_populate_resource_slot_types_with_dict_number_format(
+        self,
+        database_with_resource_slot_tables: ExtendedAsyncSAEngine,
+    ) -> None:
+        """populate_fixture must accept dict for PydanticColumn columns (number_format).
+
+        Before the fix, passing a raw dict for a PydanticColumn caused
+        AttributeError: 'dict' object has no attribute 'model_dump' because
+        process_bind_param called .model_dump() on the dict.
+        """
+        fixture_data: dict[str, list[dict[str, object]]] = {
+            "resource_slot_types": [
+                {
+                    "slot_name": "cpu",
+                    "slot_type": "count",
+                    "display_name": "CPU",
+                    "description": "CPU",
+                    "display_unit": "Core",
+                    "display_icon": "cpu",
+                    "number_format": {"binary": False, "round_length": 0},
+                    "rank": 100,
+                },
+                {
+                    "slot_name": "mem",
+                    "slot_type": "bytes",
+                    "display_name": "RAM",
+                    "description": "Memory",
+                    "display_unit": "GiB",
+                    "display_icon": "ram",
+                    "number_format": {"binary": True, "round_length": 0},
+                    "rank": 200,
+                },
+            ]
+        }
+
+        # Should not raise AttributeError for dict number_format
+        await populate_fixture(database_with_resource_slot_tables, fixture_data)
+
+        async with database_with_resource_slot_tables.begin_session() as db_sess:
+            cpu = await db_sess.get(ResourceSlotTypeRow, "cpu")
+            mem = await db_sess.get(ResourceSlotTypeRow, "mem")
+
+        assert cpu is not None
+        assert cpu.number_format == NumberFormat(binary=False, round_length=0)
+        assert cpu.rank == 100
+
+        assert mem is not None
+        assert mem.number_format == NumberFormat(binary=True, round_length=0)
+
+    async def test_agent_resource_insert_succeeds_after_fixture_load(
+        self,
+        database_with_resource_slot_tables: ExtendedAsyncSAEngine,
+        agent_id: str,
+    ) -> None:
+        """FK on agent_resources(slot_name) is satisfied after loading resource_slot_types fixture.
+
+        Regression: before the fix, oneshot DB creation left resource_slot_types
+        empty, causing ForeignKeyViolationError on agent heartbeat.
+        """
+        fixture_data: dict[str, list[dict[str, object]]] = {
+            "resource_slot_types": [
+                {
+                    "slot_name": "cpu",
+                    "slot_type": "count",
+                    "number_format": {"binary": False, "round_length": 0},
+                },
+            ]
+        }
+        await populate_fixture(database_with_resource_slot_tables, fixture_data)
+
+        # Inserting an agent_resource with slot_name='cpu' must succeed (FK satisfied)
+        async with database_with_resource_slot_tables.begin_session() as db_sess:
+            db_sess.add(
+                AgentResourceRow(
+                    agent_id=agent_id,
+                    slot_name="cpu",
+                    capacity=Decimal("4"),
+                )
+            )
+            await db_sess.flush()
+
+        async with database_with_resource_slot_tables.begin_session() as db_sess:
+            row = await db_sess.get(AgentResourceRow, (agent_id, "cpu"))
+        assert row is not None
+        assert row.capacity == Decimal("4.000000")


### PR DESCRIPTION
This is an auto-generated backport PR of #9129 to the 26.2 release.