### PR TITLE
chore(BA-4613): Separate ClientConnectionError handling from generic exception in web proxy (#9158)

### DIFF
--- a/changes/9158.misc.md
+++ b/changes/9158.misc.md
@@ -1,0 +1,1 @@
+Separate ClientConnectionError handling from generic exception in web proxy to prevent unnecessary 500 error responses and noisy error logs on normal client disconnections.

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from typing import Any, Final, cast
 
 import aiohttp
-from aiohttp import web
+from aiohttp import ClientConnectionError, web
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 from multidict import CIMultiDict
@@ -294,6 +294,13 @@ async def web_handler(
             }),
             content_type="application/problem+json",
         )
+    except ClientConnectionError:
+        log.warning(
+            "web_handler: ClientConnectionError - Client disconnected during proxying: method: {}, path: {}",
+            frontend_rqst.method,
+            path,
+        )
+        raise
     except Exception:
         log.exception("web_handler: unexpected error")
         return web.HTTPInternalServerError(
@@ -460,6 +467,13 @@ async def web_handler_with_jwt(
             }),
             content_type="application/problem+json",
         )
+    except ClientConnectionError:
+        log.warning(
+            "web_handler_with_jwt: ClientConnectionError - Client disconnected during proxying: method: {}, path: {}",
+            frontend_rqst.method,
+            path,
+        )
+        raise
     except Exception:
         log.exception("web_handler_with_jwt: unexpected error")
         return web.HTTPInternalServerError(


### PR DESCRIPTION
This is an auto-generated backport PR of #9158 to the 26.2 release.