### PR TITLE
fix(BA-4628): Pass SCIENCE_AUTH GitHub token to Pants subprocess env (#9186)

### DIFF
--- a/changes/9186.fix.md
+++ b/changes/9186.fix.md
@@ -1,0 +1,1 @@
+Pass SCIENCE_AUTH_API_GITHUB_COM_BEARER to Pants subprocess environment to prevent GitHub API rate limit errors during scie build in CI.

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -8,5 +8,8 @@ search_path = ["<PATH>"]
 [stats]
 log = true
 
+[subprocess-environment]
+env_vars.add = ["SCIENCE_AUTH_API_GITHUB_COM_BEARER"]
+
 [pytest]
 args = ["-vv", "--no-header", "--suppress-no-test-exit-code"]


### PR DESCRIPTION
This is an auto-generated backport PR of #9186 to the 25.15 release.