### PR TITLE
ci(BA-4626): add arch suffix to build-scies Pants cache key (#9185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
     - name: Bootstrap Pants
       uses: pantsbuild/actions/init-pants@v8
       with:
-        gha-cache-key: pants-cache-main-1-deploy-py${{ env.PROJECT_PYTHON_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+        gha-cache-key: v0-${{ runner.arch }}
         named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
         cache-lmdb-store: 'false'
     - name: Build both lazy and fat packages

--- a/changes/9185.fix.md
+++ b/changes/9185.fix.md
@@ -1,0 +1,1 @@
+Fix cross-architecture binary collision in build-scies CI job by including runner architecture in Pants cache key.


### PR DESCRIPTION
This is an auto-generated backport PR of #9185 to the 25.15 release.