### PR TITLE
ci(BA-4629): fix release asset upload failure due to dist/export directory (#9194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,9 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: wheels
-        path: dist/*
+        path: |
+          dist/*
+          !dist/export/
     - name: Upload pants log
       uses: actions/upload-artifact@v5
       with:
@@ -569,7 +571,12 @@ jobs:
         path: dist
     - name: Create GitHub Release
       run: |
-        if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+        if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+          echo "Release already exists, updating..."
+          gh release edit "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file "CHANGELOG_RELEASE.md"
+        elif [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --notes-file "CHANGELOG_RELEASE.md" \
@@ -584,6 +591,10 @@ jobs:
     - name: Upload release assets
       run: |
         for file in dist/*; do
+          if [ -d "$file" ]; then
+            echo "Skipping directory $file"
+            continue
+          fi
           echo "Uploading $file..."
           for attempt in 1 2 3; do
             if gh release upload "${{ github.ref_name }}" "$file" --clobber; then
@@ -625,7 +636,7 @@ jobs:
       # We don't use `pants publish ::` because we manually rename the
       # wheels after building them to add arch-specific tags.
       run: |
-        twine upload dist/*.whl dist/*.tar.gz
+        twine upload --skip-existing dist/*.whl dist/*.tar.gz
     - name: Extract stable release version
       id: extract_stable_release_version
       run: |

--- a/changes/9194.fix.md
+++ b/changes/9194.fix.md
@@ -1,0 +1,1 @@
+Fix release CI failure where `dist/export/` directory caused asset upload loop to error with "is a directory".


### PR DESCRIPTION
This is an auto-generated backport PR of #9194 to the 26.2 release.