### PR TITLE
fix(BA-4635): filter zero-valued resource slots from allocation limit response (#9221)

### DIFF
--- a/changes/9221.fix.md
+++ b/changes/9221.fix.md
@@ -1,0 +1,1 @@
+Filter out zero-valued resource slots from the `resource_allocation_limit_for_sessions` scaling group response.

--- a/src/ai/backend/manager/api/gql_legacy/scaling_group.py
+++ b/src/ai/backend/manager/api/gql_legacy/scaling_group.py
@@ -393,7 +393,9 @@ class ScalingGroup(graphene.ObjectType):  # type: ignore[misc]
         result: ResourceSlot | None = None
         for agent_row in agent_list:
             result = _compare_each_resource_and_get_max(agent_row.available_slots, result)
-        return dict(result.to_json()) if result is not None else {}
+        if result is None:
+            return {}
+        return {k: v for k, v in result.to_json().items() if v != "0"}
 
     # TODO: Replace this field with a generic resource slot query API
     async def resolve_own_session_occupied_resource_slots(


### PR DESCRIPTION
This is an auto-generated backport PR of #9221 to the 26.2 release.