### PR TITLE
fix(BA-4633): apply negated and case_insensitive flags in fair share StringFilter conditions (#9222)

### DIFF
--- a/changes/9222.fix.md
+++ b/changes/9222.fix.md
@@ -1,0 +1,1 @@
+Fix fair share StringFilter ignoring negation and case-insensitivity flags in Domain, Project, and User filter conditions

--- a/src/ai/backend/manager/api/gql/fair_share/types/domain.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/domain.py
@@ -237,16 +237,16 @@ class DomainFairShareFilter(GQLFilter):
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
                 contains_factory=lambda spec: DomainFairShareConditions.by_resource_group_contains(
-                    spec.value
+                    spec
                 ),
                 equals_factory=lambda spec: DomainFairShareConditions.by_resource_group_equals(
-                    spec.value
+                    spec
                 ),
                 starts_with_factory=lambda spec: DomainFairShareConditions.by_resource_group_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: DomainFairShareConditions.by_resource_group_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if sg_condition:
@@ -255,16 +255,14 @@ class DomainFairShareFilter(GQLFilter):
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
                 contains_factory=lambda spec: DomainFairShareConditions.by_domain_name_contains(
-                    spec.value
+                    spec
                 ),
-                equals_factory=lambda spec: DomainFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
+                equals_factory=lambda spec: DomainFairShareConditions.by_domain_name_equals(spec),
                 starts_with_factory=lambda spec: DomainFairShareConditions.by_domain_name_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: DomainFairShareConditions.by_domain_name_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if dn_condition:

--- a/src/ai/backend/manager/api/gql/fair_share/types/project.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/project.py
@@ -255,16 +255,14 @@ class ProjectFairShareProjectNestedFilter:
         if self.name:
             name_condition = self.name.build_query_condition(
                 contains_factory=lambda spec: ProjectFairShareConditions.by_project_name_contains(
-                    spec.value
+                    spec
                 ),
-                equals_factory=lambda spec: ProjectFairShareConditions.by_project_name_equals(
-                    spec.value
-                ),
+                equals_factory=lambda spec: ProjectFairShareConditions.by_project_name_equals(spec),
                 starts_with_factory=lambda spec: ProjectFairShareConditions.by_project_name_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: ProjectFairShareConditions.by_project_name_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if name_condition:
@@ -364,16 +362,16 @@ class ProjectFairShareFilter(GQLFilter):
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
                 contains_factory=lambda spec: ProjectFairShareConditions.by_resource_group_contains(
-                    spec.value
+                    spec
                 ),
                 equals_factory=lambda spec: ProjectFairShareConditions.by_resource_group_equals(
-                    spec.value
+                    spec
                 ),
                 starts_with_factory=lambda spec: ProjectFairShareConditions.by_resource_group_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: ProjectFairShareConditions.by_resource_group_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if sg_condition:
@@ -390,16 +388,14 @@ class ProjectFairShareFilter(GQLFilter):
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
                 contains_factory=lambda spec: ProjectFairShareConditions.by_domain_name_contains(
-                    spec.value
+                    spec
                 ),
-                equals_factory=lambda spec: ProjectFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
+                equals_factory=lambda spec: ProjectFairShareConditions.by_domain_name_equals(spec),
                 starts_with_factory=lambda spec: ProjectFairShareConditions.by_domain_name_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: ProjectFairShareConditions.by_domain_name_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if dn_condition:

--- a/src/ai/backend/manager/api/gql/fair_share/types/user.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/user.py
@@ -237,33 +237,27 @@ class UserFairShareUserNestedFilter:
         if self.username:
             username_condition = self.username.build_query_condition(
                 contains_factory=lambda spec: UserFairShareConditions.by_user_username_contains(
-                    spec.value
+                    spec
                 ),
-                equals_factory=lambda spec: UserFairShareConditions.by_user_username_equals(
-                    spec.value
-                ),
+                equals_factory=lambda spec: UserFairShareConditions.by_user_username_equals(spec),
                 starts_with_factory=lambda spec: UserFairShareConditions.by_user_username_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: UserFairShareConditions.by_user_username_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if username_condition:
                 conditions.append(username_condition)
         if self.email:
             email_condition = self.email.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_user_email_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: UserFairShareConditions.by_user_email_equals(
-                    spec.value
-                ),
+                contains_factory=lambda spec: UserFairShareConditions.by_user_email_contains(spec),
+                equals_factory=lambda spec: UserFairShareConditions.by_user_email_equals(spec),
                 starts_with_factory=lambda spec: UserFairShareConditions.by_user_email_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: UserFairShareConditions.by_user_email_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if email_condition:
@@ -342,16 +336,14 @@ class UserFairShareFilter(GQLFilter):
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
                 contains_factory=lambda spec: UserFairShareConditions.by_resource_group_contains(
-                    spec.value
+                    spec
                 ),
-                equals_factory=lambda spec: UserFairShareConditions.by_resource_group_equals(
-                    spec.value
-                ),
+                equals_factory=lambda spec: UserFairShareConditions.by_resource_group_equals(spec),
                 starts_with_factory=lambda spec: UserFairShareConditions.by_resource_group_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: UserFairShareConditions.by_resource_group_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if sg_condition:
@@ -375,17 +367,13 @@ class UserFairShareFilter(GQLFilter):
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: UserFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
+                contains_factory=lambda spec: UserFairShareConditions.by_domain_name_contains(spec),
+                equals_factory=lambda spec: UserFairShareConditions.by_domain_name_equals(spec),
                 starts_with_factory=lambda spec: UserFairShareConditions.by_domain_name_starts_with(
-                    spec.value
+                    spec
                 ),
                 ends_with_factory=lambda spec: UserFairShareConditions.by_domain_name_ends_with(
-                    spec.value
+                    spec
                 ),
             )
             if dn_condition:

--- a/src/ai/backend/manager/repositories/fair_share/options.py
+++ b/src/ai/backend/manager/repositories/fair_share/options.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
+from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain import DomainRow
@@ -38,58 +39,106 @@ class DomainFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainFairShareRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainFairShareRow.resource_group) == spec.value.lower()
+            else:
+                condition = DomainFairShareRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = DomainFairShareRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = DomainFairShareRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainFairShareRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainFairShareRow.domain_name) == spec.value.lower()
+            else:
+                condition = DomainFairShareRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = DomainFairShareRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainFairShareRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = DomainFairShareRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = DomainFairShareRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -193,58 +242,106 @@ class ProjectFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = ProjectFairShareRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = sa.func.lower(ProjectFairShareRow.resource_group) == spec.value.lower()
+            else:
+                condition = ProjectFairShareRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = ProjectFairShareRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = ProjectFairShareRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = ProjectFairShareRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(ProjectFairShareRow.domain_name) == spec.value.lower()
+            else:
+                condition = ProjectFairShareRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = ProjectFairShareRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = ProjectFairShareRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = ProjectFairShareRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -285,30 +382,54 @@ class ProjectFairShareConditions:
         return inner
 
     @staticmethod
-    def by_project_name_contains(name: str) -> QueryCondition:
+    def by_project_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return GroupRow.name.like(f"%{name}%")
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = GroupRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_name_equals(name: str) -> QueryCondition:
+    def by_project_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return GroupRow.name == name
+            if spec.case_insensitive:
+                condition = sa.func.lower(GroupRow.name) == spec.value.lower()
+            else:
+                condition = GroupRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_name_starts_with(name: str) -> QueryCondition:
+    def by_project_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return GroupRow.name.like(f"{name}%")
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = GroupRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_name_ends_with(name: str) -> QueryCondition:
+    def by_project_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return GroupRow.name.like(f"%{name}")
+            if spec.case_insensitive:
+                condition = GroupRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = GroupRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -404,58 +525,106 @@ class UserFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = UserFairShareRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserFairShareRow.resource_group) == spec.value.lower()
+            else:
+                condition = UserFairShareRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = UserFairShareRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = UserFairShareRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = UserFairShareRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserFairShareRow.domain_name) == spec.value.lower()
+            else:
+                condition = UserFairShareRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = UserFairShareRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = UserFairShareRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = UserFairShareRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -496,58 +665,106 @@ class UserFairShareConditions:
         return inner
 
     @staticmethod
-    def by_user_username_contains(username: str) -> QueryCondition:
+    def by_user_username_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.username.like(f"%{username}%")
+            if spec.case_insensitive:
+                condition = UserRow.username.ilike(f"%{spec.value}%")
+            else:
+                condition = UserRow.username.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_username_equals(username: str) -> QueryCondition:
+    def by_user_username_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.username == username
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserRow.username) == spec.value.lower()
+            else:
+                condition = UserRow.username == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_username_starts_with(username: str) -> QueryCondition:
+    def by_user_username_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.username.like(f"{username}%")
+            if spec.case_insensitive:
+                condition = UserRow.username.ilike(f"{spec.value}%")
+            else:
+                condition = UserRow.username.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_username_ends_with(username: str) -> QueryCondition:
+    def by_user_username_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.username.like(f"%{username}")
+            if spec.case_insensitive:
+                condition = UserRow.username.ilike(f"%{spec.value}")
+            else:
+                condition = UserRow.username.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_email_contains(email: str) -> QueryCondition:
+    def by_user_email_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.email.like(f"%{email}%")
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"%{spec.value}%")
+            else:
+                condition = UserRow.email.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_email_equals(email: str) -> QueryCondition:
+    def by_user_email_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.email == email
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserRow.email) == spec.value.lower()
+            else:
+                condition = UserRow.email == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_email_starts_with(email: str) -> QueryCondition:
+    def by_user_email_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.email.like(f"{email}%")
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"{spec.value}%")
+            else:
+                condition = UserRow.email.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_email_ends_with(email: str) -> QueryCondition:
+    def by_user_email_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.email.like(f"%{email}")
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"%{spec.value}")
+            else:
+                condition = UserRow.email.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/tests/unit/manager/api/gql/fair_share/test_nested_filters_and_orders.py
+++ b/tests/unit/manager/api/gql/fair_share/test_nested_filters_and_orders.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.fair_share.types.domain import (
     DomainFairShareDomainNestedFilter,
@@ -219,3 +224,100 @@ class TestUserFairShareEntityOrderField:
         )
         query_order = order_by.to_query_order()
         assert query_order is not None
+
+
+# postgresql.dialect (PGDialect) has untyped __init__; assign via Any to avoid [no-untyped-call].
+_pg_dialect_cls: Any = postgresql.dialect
+_PG_DIALECT: sa.engine.Dialect = _pg_dialect_cls()
+
+
+def _compile_sql(expr: sa.sql.expression.ColumnElement[bool]) -> str:
+    """Compile a SQLAlchemy expression to a string for assertion."""
+    return str(expr.compile(dialect=_PG_DIALECT, compile_kwargs={"literal_binds": True}))
+
+
+class TestDomainFairShareFilterNegatedCaseInsensitive:
+    """Regression tests: negated/case-insensitive filters go through GQL → SQL correctly (BA-4633)."""
+
+    def test_not_contains_filter(self) -> None:
+        f = DomainFairShareFilter(resource_group=StringFilter(not_contains="a"))
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+        assert "LIKE" in sql
+
+    def test_i_contains_filter(self) -> None:
+        f = DomainFairShareFilter(domain_name=StringFilter(i_contains="a"))
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "ILIKE" in sql
+
+    def test_i_not_contains_filter(self) -> None:
+        f = DomainFairShareFilter(resource_group=StringFilter(i_not_contains="a"))
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+        assert "ILIKE" in sql
+
+
+class TestProjectFairShareFilterNegatedCaseInsensitive:
+    """Regression tests: negated/case-insensitive project filters (BA-4633)."""
+
+    def test_project_name_not_contains(self) -> None:
+        nested = ProjectFairShareProjectNestedFilter(
+            name=StringFilter(not_contains="test"),
+        )
+        conditions = nested.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+
+    def test_project_name_i_contains(self) -> None:
+        nested = ProjectFairShareProjectNestedFilter(
+            name=StringFilter(i_contains="test"),
+        )
+        conditions = nested.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "ILIKE" in sql
+
+    def test_resource_group_i_not_contains(self) -> None:
+        f = ProjectFairShareFilter(resource_group=StringFilter(i_not_contains="rg"))
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+        assert "ILIKE" in sql
+
+
+class TestUserFairShareFilterNegatedCaseInsensitive:
+    """Regression tests: negated/case-insensitive user filters (BA-4633)."""
+
+    def test_username_not_contains(self) -> None:
+        nested = UserFairShareUserNestedFilter(
+            username=StringFilter(not_contains="admin"),
+        )
+        conditions = nested.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+
+    def test_email_i_contains(self) -> None:
+        nested = UserFairShareUserNestedFilter(
+            email=StringFilter(i_contains="@EXAMPLE"),
+        )
+        conditions = nested.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "ILIKE" in sql
+
+    def test_domain_name_i_not_contains(self) -> None:
+        f = UserFairShareFilter(domain_name=StringFilter(i_not_contains="dom"))
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile_sql(conditions[0]())
+        assert "NOT" in sql
+        assert "ILIKE" in sql

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_entity_options.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_entity_options.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 
+from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
@@ -50,22 +51,26 @@ class TestProjectFairShareEntityConditions:
     """Tests for project entity conditions on ProjectFairShareConditions."""
 
     def test_by_project_name_contains(self) -> None:
-        condition = ProjectFairShareConditions.by_project_name_contains("test")
+        spec = StringMatchSpec(value="test", case_insensitive=False, negated=False)
+        condition = ProjectFairShareConditions.by_project_name_contains(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_project_name_equals(self) -> None:
-        condition = ProjectFairShareConditions.by_project_name_equals("test-project")
+        spec = StringMatchSpec(value="test-project", case_insensitive=False, negated=False)
+        condition = ProjectFairShareConditions.by_project_name_equals(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_project_name_starts_with(self) -> None:
-        condition = ProjectFairShareConditions.by_project_name_starts_with("test")
+        spec = StringMatchSpec(value="test", case_insensitive=False, negated=False)
+        condition = ProjectFairShareConditions.by_project_name_starts_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_project_name_ends_with(self) -> None:
-        condition = ProjectFairShareConditions.by_project_name_ends_with("project")
+        spec = StringMatchSpec(value="project", case_insensitive=False, negated=False)
+        condition = ProjectFairShareConditions.by_project_name_ends_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
@@ -121,42 +126,50 @@ class TestUserFairShareEntityConditions:
     """Tests for user entity conditions on UserFairShareConditions."""
 
     def test_by_user_username_contains(self) -> None:
-        condition = UserFairShareConditions.by_user_username_contains("admin")
+        spec = StringMatchSpec(value="admin", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_username_contains(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_username_equals(self) -> None:
-        condition = UserFairShareConditions.by_user_username_equals("admin")
+        spec = StringMatchSpec(value="admin", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_username_equals(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_username_starts_with(self) -> None:
-        condition = UserFairShareConditions.by_user_username_starts_with("adm")
+        spec = StringMatchSpec(value="adm", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_username_starts_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_username_ends_with(self) -> None:
-        condition = UserFairShareConditions.by_user_username_ends_with("min")
+        spec = StringMatchSpec(value="min", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_username_ends_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_email_contains(self) -> None:
-        condition = UserFairShareConditions.by_user_email_contains("@example")
+        spec = StringMatchSpec(value="@example", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_email_contains(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_email_equals(self) -> None:
-        condition = UserFairShareConditions.by_user_email_equals("user@example.com")
+        spec = StringMatchSpec(value="user@example.com", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_email_equals(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_email_starts_with(self) -> None:
-        condition = UserFairShareConditions.by_user_email_starts_with("user")
+        spec = StringMatchSpec(value="user", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_email_starts_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 
     def test_by_user_email_ends_with(self) -> None:
-        condition = UserFairShareConditions.by_user_email_ends_with(".com")
+        spec = StringMatchSpec(value=".com", case_insensitive=False, negated=False)
+        condition = UserFairShareConditions.by_user_email_ends_with(spec)
         expr = condition()
         assert isinstance(expr, sa.sql.expression.ColumnElement)
 

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_options.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_options.py
@@ -1,0 +1,148 @@
+"""Regression tests for StringMatchSpec support in fair share condition methods.
+
+Verifies that negated and case_insensitive flags are correctly applied
+to generated SQL conditions (BA-4633).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.manager.repositories.fair_share.options import (
+    DomainFairShareConditions,
+    ProjectFairShareConditions,
+    UserFairShareConditions,
+)
+
+# postgresql.dialect (PGDialect) has untyped __init__; assign via Any to avoid [no-untyped-call].
+_pg_dialect_cls: Any = postgresql.dialect
+_PG_DIALECT: sa.engine.Dialect = _pg_dialect_cls()
+
+
+def _compile_sql(expr: sa.sql.expression.ColumnElement[bool]) -> str:
+    """Compile a SQLAlchemy expression to a string for assertion."""
+    return str(expr.compile(dialect=_PG_DIALECT, compile_kwargs={"literal_binds": True}))
+
+
+class TestDomainFairShareConditionsStringMatchSpec:
+    """Regression tests for DomainFairShareConditions with StringMatchSpec."""
+
+    def test_contains_default(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=False, negated=False)
+        sql = _compile_sql(DomainFairShareConditions.by_resource_group_contains(spec)())
+        assert "LIKE" in sql
+        assert "ILIKE" not in sql
+        assert "NOT" not in sql
+
+    def test_contains_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=True, negated=False)
+        sql = _compile_sql(DomainFairShareConditions.by_resource_group_contains(spec)())
+        assert "ILIKE" in sql
+        assert "NOT" not in sql
+
+    def test_contains_negated(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=False, negated=True)
+        sql = _compile_sql(DomainFairShareConditions.by_resource_group_contains(spec)())
+        assert "NOT" in sql
+        assert "LIKE" in sql
+
+    def test_contains_case_insensitive_negated(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=True, negated=True)
+        sql = _compile_sql(DomainFairShareConditions.by_resource_group_contains(spec)())
+        assert "NOT" in sql
+        assert "ILIKE" in sql
+
+    def test_equals_default(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=False, negated=False)
+        sql = _compile_sql(DomainFairShareConditions.by_domain_name_equals(spec)())
+        assert "lower" not in sql
+        assert "NOT" not in sql
+
+    def test_equals_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="X", case_insensitive=True, negated=False)
+        sql = _compile_sql(DomainFairShareConditions.by_domain_name_equals(spec)())
+        assert "lower" in sql
+
+    def test_equals_negated(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=False, negated=True)
+        sql = _compile_sql(DomainFairShareConditions.by_domain_name_equals(spec)())
+        assert "!=" in sql
+
+    def test_starts_with_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=True, negated=False)
+        sql = _compile_sql(DomainFairShareConditions.by_resource_group_starts_with(spec)())
+        assert "ILIKE" in sql
+
+    def test_ends_with_negated(self) -> None:
+        spec = StringMatchSpec(value="x", case_insensitive=False, negated=True)
+        sql = _compile_sql(DomainFairShareConditions.by_domain_name_ends_with(spec)())
+        assert "NOT" in sql
+
+
+class TestProjectFairShareConditionsStringMatchSpec:
+    """Regression tests for ProjectFairShareConditions with StringMatchSpec."""
+
+    def test_resource_group_contains_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="rg", case_insensitive=True, negated=False)
+        sql = _compile_sql(ProjectFairShareConditions.by_resource_group_contains(spec)())
+        assert "ILIKE" in sql
+
+    def test_resource_group_contains_negated(self) -> None:
+        spec = StringMatchSpec(value="rg", case_insensitive=False, negated=True)
+        sql = _compile_sql(ProjectFairShareConditions.by_resource_group_contains(spec)())
+        assert "NOT" in sql
+
+    def test_domain_name_equals_case_insensitive_negated(self) -> None:
+        spec = StringMatchSpec(value="Dom", case_insensitive=True, negated=True)
+        sql = _compile_sql(ProjectFairShareConditions.by_domain_name_equals(spec)())
+        assert "!=" in sql
+        assert "lower" in sql
+
+    def test_project_name_contains_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="proj", case_insensitive=True, negated=False)
+        sql = _compile_sql(ProjectFairShareConditions.by_project_name_contains(spec)())
+        assert "ILIKE" in sql
+
+    def test_project_name_starts_with_negated(self) -> None:
+        spec = StringMatchSpec(value="proj", case_insensitive=False, negated=True)
+        sql = _compile_sql(ProjectFairShareConditions.by_project_name_starts_with(spec)())
+        assert "NOT" in sql
+
+
+class TestUserFairShareConditionsStringMatchSpec:
+    """Regression tests for UserFairShareConditions with StringMatchSpec."""
+
+    def test_resource_group_ends_with_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="rg", case_insensitive=True, negated=False)
+        sql = _compile_sql(UserFairShareConditions.by_resource_group_ends_with(spec)())
+        assert "ILIKE" in sql
+
+    def test_domain_name_starts_with_negated(self) -> None:
+        spec = StringMatchSpec(value="dom", case_insensitive=False, negated=True)
+        sql = _compile_sql(UserFairShareConditions.by_domain_name_starts_with(spec)())
+        assert "NOT" in sql
+
+    def test_username_contains_case_insensitive_negated(self) -> None:
+        spec = StringMatchSpec(value="admin", case_insensitive=True, negated=True)
+        sql = _compile_sql(UserFairShareConditions.by_user_username_contains(spec)())
+        assert "NOT" in sql
+        assert "ILIKE" in sql
+
+    def test_username_equals_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value="Admin", case_insensitive=True, negated=False)
+        sql = _compile_sql(UserFairShareConditions.by_user_username_equals(spec)())
+        assert "lower" in sql
+
+    def test_email_contains_negated(self) -> None:
+        spec = StringMatchSpec(value="@example", case_insensitive=False, negated=True)
+        sql = _compile_sql(UserFairShareConditions.by_user_email_contains(spec)())
+        assert "NOT" in sql
+
+    def test_email_ends_with_case_insensitive(self) -> None:
+        spec = StringMatchSpec(value=".COM", case_insensitive=True, negated=False)
+        sql = _compile_sql(UserFairShareConditions.by_user_email_ends_with(spec)())
+        assert "ILIKE" in sql


### PR DESCRIPTION
This is an auto-generated backport PR of #9222 to the 26.2 release.