### PR TITLE
fix: move filter specs to common and add build_query_condition to REST filters (#9247)

### DIFF
--- a/changes/9247.fix.md
+++ b/changes/9247.fix.md
@@ -1,0 +1,1 @@
+Move filter specs to common and add build_query_condition to REST filters

--- a/src/ai/backend/common/data/filter_specs.py
+++ b/src/ai/backend/common/data/filter_specs.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StringMatchSpec:
+    """Specification for string matching operations in query conditions."""
+
+    value: str
+    case_insensitive: bool
+    negated: bool
+
+
+@dataclass(frozen=True)
+class UUIDEqualMatchSpec:
+    """Specification for UUID equality operations (=, !=)."""
+
+    value: uuid.UUID
+    negated: bool
+
+
+@dataclass(frozen=True)
+class UUIDInMatchSpec:
+    """Specification for UUID IN operations (IN, NOT IN)."""
+
+    values: list[uuid.UUID]
+    negated: bool

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import uuid
+from collections.abc import Callable
 from datetime import date, datetime
+from typing import TypeVar
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
+
+_QC = TypeVar("_QC")
 
 
 class DateTimeRangeFilter(BaseRequestModel):
@@ -99,6 +106,98 @@ class StringFilter(BaseRequestModel):
         default=None, description="Not ends with (case-insensitive)"
     )
 
+    def build_query_condition(
+        self,
+        contains_factory: Callable[[StringMatchSpec], _QC],
+        equals_factory: Callable[[StringMatchSpec], _QC],
+        starts_with_factory: Callable[[StringMatchSpec], _QC],
+        ends_with_factory: Callable[[StringMatchSpec], _QC],
+    ) -> _QC | None:
+        """Build a query condition from this filter using the provided factory callables.
+
+        Args:
+            contains_factory: Factory for LIKE '%value%' operations
+            equals_factory: Factory for exact match (=) operations
+            starts_with_factory: Factory for LIKE 'value%' operations
+            ends_with_factory: Factory for LIKE '%value' operations
+
+        Returns:
+            _QC if any filter field is set, None otherwise
+        """
+        # equals operations
+        if self.equals is not None:
+            return equals_factory(
+                StringMatchSpec(self.equals, case_insensitive=False, negated=False)
+            )
+        if self.i_equals is not None:
+            return equals_factory(
+                StringMatchSpec(self.i_equals, case_insensitive=True, negated=False)
+            )
+        if self.not_equals is not None:
+            return equals_factory(
+                StringMatchSpec(self.not_equals, case_insensitive=False, negated=True)
+            )
+        if self.i_not_equals is not None:
+            return equals_factory(
+                StringMatchSpec(self.i_not_equals, case_insensitive=True, negated=True)
+            )
+
+        # contains operations
+        if self.contains is not None:
+            return contains_factory(
+                StringMatchSpec(self.contains, case_insensitive=False, negated=False)
+            )
+        if self.i_contains is not None:
+            return contains_factory(
+                StringMatchSpec(self.i_contains, case_insensitive=True, negated=False)
+            )
+        if self.not_contains is not None:
+            return contains_factory(
+                StringMatchSpec(self.not_contains, case_insensitive=False, negated=True)
+            )
+        if self.i_not_contains is not None:
+            return contains_factory(
+                StringMatchSpec(self.i_not_contains, case_insensitive=True, negated=True)
+            )
+
+        # starts_with operations
+        if self.starts_with is not None:
+            return starts_with_factory(
+                StringMatchSpec(self.starts_with, case_insensitive=False, negated=False)
+            )
+        if self.i_starts_with is not None:
+            return starts_with_factory(
+                StringMatchSpec(self.i_starts_with, case_insensitive=True, negated=False)
+            )
+        if self.not_starts_with is not None:
+            return starts_with_factory(
+                StringMatchSpec(self.not_starts_with, case_insensitive=False, negated=True)
+            )
+        if self.i_not_starts_with is not None:
+            return starts_with_factory(
+                StringMatchSpec(self.i_not_starts_with, case_insensitive=True, negated=True)
+            )
+
+        # ends_with operations
+        if self.ends_with is not None:
+            return ends_with_factory(
+                StringMatchSpec(self.ends_with, case_insensitive=False, negated=False)
+            )
+        if self.i_ends_with is not None:
+            return ends_with_factory(
+                StringMatchSpec(self.i_ends_with, case_insensitive=True, negated=False)
+            )
+        if self.not_ends_with is not None:
+            return ends_with_factory(
+                StringMatchSpec(self.not_ends_with, case_insensitive=False, negated=True)
+            )
+        if self.i_not_ends_with is not None:
+            return ends_with_factory(
+                StringMatchSpec(self.i_not_ends_with, case_insensitive=True, negated=True)
+            )
+
+        return None
+
 
 class UUIDFilter(BaseRequestModel):
     """Filter for UUID fields supporting equality and set operations.
@@ -113,6 +212,30 @@ class UUIDFilter(BaseRequestModel):
     # NOT operations
     not_equals: uuid.UUID | None = Field(default=None, description="Not equals UUID")
     not_in: list[uuid.UUID] | None = Field(default=None, description="UUID is not in list")
+
+    def build_query_condition(
+        self,
+        equals_factory: Callable[[UUIDEqualMatchSpec], _QC],
+        in_factory: Callable[[UUIDInMatchSpec], _QC],
+    ) -> _QC | None:
+        """Build a query condition from this filter using the provided factory callables.
+
+        Args:
+            equals_factory: Factory function for equality operations (=, !=)
+            in_factory: Factory function for IN operations (IN, NOT IN)
+
+        Returns:
+            _QC if any filter field is set, None otherwise
+        """
+        if self.equals is not None:
+            return equals_factory(UUIDEqualMatchSpec(value=self.equals, negated=False))
+        if self.not_equals is not None:
+            return equals_factory(UUIDEqualMatchSpec(value=self.not_equals, negated=True))
+        if self.in_ is not None:
+            return in_factory(UUIDInMatchSpec(values=self.in_, negated=False))
+        if self.not_in is not None:
+            return in_factory(UUIDInMatchSpec(values=self.not_in, negated=True))
+        return None
 
 
 class ListGroupQuery(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapter.py
+++ b/src/ai/backend/manager/api/adapter.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import final
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
-from ai.backend.manager.api.gql.base import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.repositories.base import QueryCondition
 
 

--- a/src/ai/backend/manager/api/export/adapter.py
+++ b/src/ai/backend/manager/api/export/adapter.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.dto.manager.export import (
     AuditLogExportFilter,
     AuditLogExportOrder,
@@ -25,7 +26,6 @@ from ai.backend.common.dto.manager.export import (
 )
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.manager.api.adapter import BaseFilterAdapter
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.errors.export import InvalidExportFieldKeys
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
 from ai.backend.manager.repositories.base.export import (

--- a/src/ai/backend/manager/api/fair_share/adapter.py
+++ b/src/ai/backend/manager/api/fair_share/adapter.py
@@ -123,13 +123,25 @@ class FairShareAdapter:
         """Convert domain fair share filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                DomainFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=DomainFairShareConditions.by_resource_group_contains,
+                equals_factory=DomainFairShareConditions.by_resource_group_equals,
+                starts_with_factory=DomainFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=DomainFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(DomainFairShareConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=DomainFairShareConditions.by_domain_name_contains,
+                equals_factory=DomainFairShareConditions.by_domain_name_equals,
+                starts_with_factory=DomainFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=DomainFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -173,13 +185,25 @@ class FairShareAdapter:
         """Convert domain fair share filter using RG-context conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                RGDomainFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=RGDomainFairShareConditions.by_resource_group_contains,
+                equals_factory=RGDomainFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGDomainFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGDomainFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(RGDomainFairShareConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=RGDomainFairShareConditions.by_domain_name_contains,
+                equals_factory=RGDomainFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGDomainFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGDomainFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -248,21 +272,33 @@ class FairShareAdapter:
         """Convert project fair share filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                ProjectFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=ProjectFairShareConditions.by_resource_group_contains,
+                equals_factory=ProjectFairShareConditions.by_resource_group_equals,
+                starts_with_factory=ProjectFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=ProjectFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.project_id is not None:
-            if filter.project_id.equals is not None:
-                conditions.append(
-                    ProjectFairShareConditions.by_project_id(filter.project_id.equals)
-                )
-            elif filter.project_id.in_ is not None:
-                conditions.append(ProjectFairShareConditions.by_project_ids(filter.project_id.in_))
+            cond = filter.project_id.build_query_condition(
+                equals_factory=ProjectFairShareConditions.by_project_id,
+                in_factory=ProjectFairShareConditions.by_project_ids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(ProjectFairShareConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=ProjectFairShareConditions.by_domain_name_contains,
+                equals_factory=ProjectFairShareConditions.by_domain_name_equals,
+                starts_with_factory=ProjectFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=ProjectFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -303,25 +339,33 @@ class FairShareAdapter:
         """Convert project fair share filter using RG-context conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                RGProjectFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=RGProjectFairShareConditions.by_resource_group_contains,
+                equals_factory=RGProjectFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGProjectFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGProjectFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.project_id is not None:
-            if filter.project_id.equals is not None:
-                conditions.append(
-                    RGProjectFairShareConditions.by_project_id(filter.project_id.equals)
-                )
-            elif filter.project_id.in_ is not None:
-                conditions.append(
-                    RGProjectFairShareConditions.by_project_ids(filter.project_id.in_)
-                )
-
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(
-                RGProjectFairShareConditions.by_domain_name(filter.domain_name.equals)
+            cond = filter.project_id.build_query_condition(
+                equals_factory=RGProjectFairShareConditions.by_project_id,
+                in_factory=RGProjectFairShareConditions.by_project_ids,
             )
+            if cond is not None:
+                conditions.append(cond)
+
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=RGProjectFairShareConditions.by_domain_name_contains,
+                equals_factory=RGProjectFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGProjectFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGProjectFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -369,25 +413,41 @@ class FairShareAdapter:
         """Convert user fair share filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                UserFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=UserFairShareConditions.by_resource_group_contains,
+                equals_factory=UserFairShareConditions.by_resource_group_equals,
+                starts_with_factory=UserFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=UserFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.user_uuid is not None:
-            if filter.user_uuid.equals is not None:
-                conditions.append(UserFairShareConditions.by_user_uuid(filter.user_uuid.equals))
-            elif filter.user_uuid.in_ is not None:
-                conditions.append(UserFairShareConditions.by_user_uuids(filter.user_uuid.in_))
+            cond = filter.user_uuid.build_query_condition(
+                equals_factory=UserFairShareConditions.by_user_uuid,
+                in_factory=UserFairShareConditions.by_user_uuids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.project_id is not None:
-            if filter.project_id.equals is not None:
-                conditions.append(UserFairShareConditions.by_project_id(filter.project_id.equals))
-            elif filter.project_id.in_ is not None:
-                conditions.append(UserFairShareConditions.by_project_ids(filter.project_id.in_))
+            cond = filter.project_id.build_query_condition(
+                equals_factory=UserFairShareConditions.by_project_id,
+                in_factory=UserFairShareConditions.by_project_ids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(UserFairShareConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=UserFairShareConditions.by_domain_name_contains,
+                equals_factory=UserFairShareConditions.by_domain_name_equals,
+                starts_with_factory=UserFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=UserFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -426,25 +486,41 @@ class FairShareAdapter:
         """Convert user fair share filter using RG-context conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                RGUserFairShareConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=RGUserFairShareConditions.by_resource_group_contains,
+                equals_factory=RGUserFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGUserFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGUserFairShareConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.user_uuid is not None:
-            if filter.user_uuid.equals is not None:
-                conditions.append(RGUserFairShareConditions.by_user_uuid(filter.user_uuid.equals))
-            elif filter.user_uuid.in_ is not None:
-                conditions.append(RGUserFairShareConditions.by_user_uuids(filter.user_uuid.in_))
+            cond = filter.user_uuid.build_query_condition(
+                equals_factory=RGUserFairShareConditions.by_user_uuid,
+                in_factory=RGUserFairShareConditions.by_user_uuids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         if filter.project_id is not None:
-            if filter.project_id.equals is not None:
-                conditions.append(RGUserFairShareConditions.by_project_id(filter.project_id.equals))
-            elif filter.project_id.in_ is not None:
-                conditions.append(RGUserFairShareConditions.by_project_ids(filter.project_id.in_))
+            cond = filter.project_id.build_query_condition(
+                equals_factory=RGUserFairShareConditions.by_project_id,
+                in_factory=RGUserFairShareConditions.by_project_ids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(RGUserFairShareConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=RGUserFairShareConditions.by_domain_name_contains,
+                equals_factory=RGUserFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGUserFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGUserFairShareConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -501,13 +577,25 @@ class FairShareAdapter:
         """Convert domain usage bucket filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                DomainUsageBucketConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=DomainUsageBucketConditions.by_resource_group_contains,
+                equals_factory=DomainUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=DomainUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=DomainUsageBucketConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.domain_name is not None and filter.domain_name.equals is not None:
-            conditions.append(DomainUsageBucketConditions.by_domain_name(filter.domain_name.equals))
+        if filter.domain_name is not None:
+            cond = filter.domain_name.build_query_condition(
+                contains_factory=DomainUsageBucketConditions.by_domain_name_contains,
+                equals_factory=DomainUsageBucketConditions.by_domain_name_equals,
+                starts_with_factory=DomainUsageBucketConditions.by_domain_name_starts_with,
+                ends_with_factory=DomainUsageBucketConditions.by_domain_name_ends_with,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -571,13 +659,23 @@ class FairShareAdapter:
         """Convert project usage bucket filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                ProjectUsageBucketConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=ProjectUsageBucketConditions.by_resource_group_contains,
+                equals_factory=ProjectUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=ProjectUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=ProjectUsageBucketConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.project_id is not None and filter.project_id.equals is not None:
-            conditions.append(ProjectUsageBucketConditions.by_project_id(filter.project_id.equals))
+        if filter.project_id is not None:
+            cond = filter.project_id.build_query_condition(
+                equals_factory=ProjectUsageBucketConditions.by_project_id,
+                in_factory=ProjectUsageBucketConditions.by_project_ids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 
@@ -642,16 +740,31 @@ class FairShareAdapter:
         """Convert user usage bucket filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        if filter.resource_group is not None and filter.resource_group.equals is not None:
-            conditions.append(
-                UserUsageBucketConditions.by_resource_group(filter.resource_group.equals)
+        if filter.resource_group is not None:
+            cond = filter.resource_group.build_query_condition(
+                contains_factory=UserUsageBucketConditions.by_resource_group_contains,
+                equals_factory=UserUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=UserUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=UserUsageBucketConditions.by_resource_group_ends_with,
             )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.user_uuid is not None and filter.user_uuid.equals is not None:
-            conditions.append(UserUsageBucketConditions.by_user_uuid(filter.user_uuid.equals))
+        if filter.user_uuid is not None:
+            cond = filter.user_uuid.build_query_condition(
+                equals_factory=UserUsageBucketConditions.by_user_uuid,
+                in_factory=UserUsageBucketConditions.by_user_uuids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
-        if filter.project_id is not None and filter.project_id.equals is not None:
-            conditions.append(UserUsageBucketConditions.by_project_id(filter.project_id.equals))
+        if filter.project_id is not None:
+            cond = filter.project_id.build_query_condition(
+                equals_factory=UserUsageBucketConditions.by_project_id,
+                in_factory=UserUsageBucketConditions.by_project_ids,
+            )
+            if cond is not None:
+                conditions.append(cond)
 
         return conditions
 

--- a/src/ai/backend/manager/api/fair_share/handler.py
+++ b/src/ai/backend/manager/api/fair_share/handler.py
@@ -13,6 +13,7 @@ from aiohttp import web
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam, api_handler
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.dto.manager.fair_share import (
     BulkUpsertDomainFairShareWeightRequest,
     BulkUpsertDomainFairShareWeightResponse,
@@ -70,7 +71,6 @@ from ai.backend.common.dto.manager.fair_share import (
 )
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.manager.api.auth import auth_required_for_method
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.api.types import CORSOptions, WebMiddleware
 from ai.backend.manager.dto.context import ProcessorsCtx
 from ai.backend.manager.repositories.base import (

--- a/src/ai/backend/manager/api/gql/base.py
+++ b/src/ai/backend/manager/api/gql/base.py
@@ -15,6 +15,7 @@ from graphql_relay.utils import base64, unbase64
 from strawberry.relay import Edge, Node
 from strawberry.types import get_object_definition, has_object_definition
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.common.types import IntFilterData, SearchResult, StringFilterData
 
 if TYPE_CHECKING:
@@ -22,31 +23,6 @@ if TYPE_CHECKING:
     from ai.backend.manager.types import (
         PaginationOptions,
     )
-
-
-@dataclass(frozen=True)
-class StringMatchSpec:
-    """Specification for string matching operations in query conditions."""
-
-    value: str
-    case_insensitive: bool
-    negated: bool
-
-
-@dataclass(frozen=True)
-class UUIDEqualMatchSpec:
-    """Specification for UUID equality operations (=, !=)."""
-
-    value: uuid.UUID
-    negated: bool
-
-
-@dataclass(frozen=True)
-class UUIDInMatchSpec:
-    """Specification for UUID IN operations (IN, NOT IN)."""
-
-    values: list[uuid.UUID]
-    negated: bool
 
 
 @strawberry.scalar

--- a/src/ai/backend/manager/api/gql/data_loader/project/loader.py
+++ b/src/ai/backend/manager/api/gql/data_loader/project/loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Sequence
 
-from ai.backend.manager.api.gql.base import UUIDInMatchSpec
+from ai.backend.common.data.filter_specs import UUIDInMatchSpec
 from ai.backend.manager.data.group.types import GroupData
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.group.options import GroupConditions

--- a/src/ai/backend/manager/api/gql/data_loader/user/loader.py
+++ b/src/ai/backend/manager/api/gql/data_loader/user/loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Sequence
 
-from ai.backend.manager.api.gql.base import UUIDInMatchSpec
+from ai.backend.common.data.filter_specs import UUIDInMatchSpec
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.repositories.base import BatchQuerier, NoPagination
 from ai.backend.manager.repositories.user.options import UserConditions

--- a/src/ai/backend/manager/api/gql/fair_share/types/domain.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/domain.py
@@ -237,34 +237,20 @@ class DomainFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: DomainFairShareConditions.by_resource_group_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: DomainFairShareConditions.by_resource_group_equals(
-                    spec
-                ),
-                starts_with_factory=lambda spec: DomainFairShareConditions.by_resource_group_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: DomainFairShareConditions.by_resource_group_ends_with(
-                    spec
-                ),
+                contains_factory=DomainFairShareConditions.by_resource_group_contains,
+                equals_factory=DomainFairShareConditions.by_resource_group_equals,
+                starts_with_factory=DomainFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=DomainFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: DomainFairShareConditions.by_domain_name_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: DomainFairShareConditions.by_domain_name_equals(spec),
-                starts_with_factory=lambda spec: DomainFairShareConditions.by_domain_name_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: DomainFairShareConditions.by_domain_name_ends_with(
-                    spec
-                ),
+                contains_factory=DomainFairShareConditions.by_domain_name_contains,
+                equals_factory=DomainFairShareConditions.by_domain_name_equals,
+                starts_with_factory=DomainFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=DomainFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)
@@ -329,36 +315,20 @@ class RGDomainFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: RGDomainFairShareConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGDomainFairShareConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGDomainFairShareConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGDomainFairShareConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGDomainFairShareConditions.by_resource_group_contains,
+                equals_factory=RGDomainFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGDomainFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGDomainFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: RGDomainFairShareConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGDomainFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGDomainFairShareConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGDomainFairShareConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGDomainFairShareConditions.by_domain_name_contains,
+                equals_factory=RGDomainFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGDomainFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGDomainFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/api/gql/fair_share/types/project.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/project.py
@@ -255,16 +255,10 @@ class ProjectFairShareProjectNestedFilter:
         conditions: list[QueryCondition] = []
         if self.name:
             name_condition = self.name.build_query_condition(
-                contains_factory=lambda spec: ProjectFairShareConditions.by_project_name_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: ProjectFairShareConditions.by_project_name_equals(spec),
-                starts_with_factory=lambda spec: ProjectFairShareConditions.by_project_name_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: ProjectFairShareConditions.by_project_name_ends_with(
-                    spec
-                ),
+                contains_factory=ProjectFairShareConditions.by_project_name_contains,
+                equals_factory=ProjectFairShareConditions.by_project_name_equals,
+                starts_with_factory=ProjectFairShareConditions.by_project_name_starts_with,
+                ends_with_factory=ProjectFairShareConditions.by_project_name_ends_with,
             )
             if name_condition:
                 conditions.append(name_condition)
@@ -362,42 +356,28 @@ class ProjectFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: ProjectFairShareConditions.by_resource_group_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: ProjectFairShareConditions.by_resource_group_equals(
-                    spec
-                ),
-                starts_with_factory=lambda spec: ProjectFairShareConditions.by_resource_group_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: ProjectFairShareConditions.by_resource_group_ends_with(
-                    spec
-                ),
+                contains_factory=ProjectFairShareConditions.by_resource_group_contains,
+                equals_factory=ProjectFairShareConditions.by_resource_group_equals,
+                starts_with_factory=ProjectFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=ProjectFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: ProjectFairShareConditions.by_project_id(spec.value),
-                in_factory=lambda spec: ProjectFairShareConditions.by_project_ids(spec.values),
+                equals_factory=ProjectFairShareConditions.by_project_id,
+                in_factory=ProjectFairShareConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: ProjectFairShareConditions.by_domain_name_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: ProjectFairShareConditions.by_domain_name_equals(spec),
-                starts_with_factory=lambda spec: ProjectFairShareConditions.by_domain_name_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: ProjectFairShareConditions.by_domain_name_ends_with(
-                    spec
-                ),
+                contains_factory=ProjectFairShareConditions.by_domain_name_contains,
+                equals_factory=ProjectFairShareConditions.by_domain_name_equals,
+                starts_with_factory=ProjectFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=ProjectFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)
@@ -465,44 +445,28 @@ class RGProjectFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: RGProjectFairShareConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGProjectFairShareConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGProjectFairShareConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGProjectFairShareConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGProjectFairShareConditions.by_resource_group_contains,
+                equals_factory=RGProjectFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGProjectFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGProjectFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: RGProjectFairShareConditions.by_project_id(spec.value),
-                in_factory=lambda spec: RGProjectFairShareConditions.by_project_ids(spec.values),
+                equals_factory=RGProjectFairShareConditions.by_project_id,
+                in_factory=RGProjectFairShareConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: RGProjectFairShareConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGProjectFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGProjectFairShareConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGProjectFairShareConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGProjectFairShareConditions.by_domain_name_contains,
+                equals_factory=RGProjectFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGProjectFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGProjectFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/api/gql/fair_share/types/user.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/user.py
@@ -237,29 +237,19 @@ class UserFairShareUserNestedFilter:
         conditions: list[QueryCondition] = []
         if self.username:
             username_condition = self.username.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_user_username_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: UserFairShareConditions.by_user_username_equals(spec),
-                starts_with_factory=lambda spec: UserFairShareConditions.by_user_username_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: UserFairShareConditions.by_user_username_ends_with(
-                    spec
-                ),
+                contains_factory=UserFairShareConditions.by_user_username_contains,
+                equals_factory=UserFairShareConditions.by_user_username_equals,
+                starts_with_factory=UserFairShareConditions.by_user_username_starts_with,
+                ends_with_factory=UserFairShareConditions.by_user_username_ends_with,
             )
             if username_condition:
                 conditions.append(username_condition)
         if self.email:
             email_condition = self.email.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_user_email_contains(spec),
-                equals_factory=lambda spec: UserFairShareConditions.by_user_email_equals(spec),
-                starts_with_factory=lambda spec: UserFairShareConditions.by_user_email_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: UserFairShareConditions.by_user_email_ends_with(
-                    spec
-                ),
+                contains_factory=UserFairShareConditions.by_user_email_contains,
+                equals_factory=UserFairShareConditions.by_user_email_equals,
+                starts_with_factory=UserFairShareConditions.by_user_email_starts_with,
+                ends_with_factory=UserFairShareConditions.by_user_email_ends_with,
             )
             if email_condition:
                 conditions.append(email_condition)
@@ -336,46 +326,36 @@ class UserFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_resource_group_contains(
-                    spec
-                ),
-                equals_factory=lambda spec: UserFairShareConditions.by_resource_group_equals(spec),
-                starts_with_factory=lambda spec: UserFairShareConditions.by_resource_group_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: UserFairShareConditions.by_resource_group_ends_with(
-                    spec
-                ),
+                contains_factory=UserFairShareConditions.by_resource_group_contains,
+                equals_factory=UserFairShareConditions.by_resource_group_equals,
+                starts_with_factory=UserFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=UserFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.user_uuid:
             uuid_condition = self.user_uuid.build_query_condition(
-                equals_factory=lambda spec: UserFairShareConditions.by_user_uuid(spec.value),
-                in_factory=lambda spec: UserFairShareConditions.by_user_uuids(spec.values),
+                equals_factory=UserFairShareConditions.by_user_uuid,
+                in_factory=UserFairShareConditions.by_user_uuids,
             )
             if uuid_condition:
                 conditions.append(uuid_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: UserFairShareConditions.by_project_id(spec.value),
-                in_factory=lambda spec: UserFairShareConditions.by_project_ids(spec.values),
+                equals_factory=UserFairShareConditions.by_project_id,
+                in_factory=UserFairShareConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: UserFairShareConditions.by_domain_name_contains(spec),
-                equals_factory=lambda spec: UserFairShareConditions.by_domain_name_equals(spec),
-                starts_with_factory=lambda spec: UserFairShareConditions.by_domain_name_starts_with(
-                    spec
-                ),
-                ends_with_factory=lambda spec: UserFairShareConditions.by_domain_name_ends_with(
-                    spec
-                ),
+                contains_factory=UserFairShareConditions.by_domain_name_contains,
+                equals_factory=UserFairShareConditions.by_domain_name_equals,
+                starts_with_factory=UserFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=UserFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)
@@ -446,52 +426,36 @@ class RGUserFairShareFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: RGUserFairShareConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGUserFairShareConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGUserFairShareConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGUserFairShareConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGUserFairShareConditions.by_resource_group_contains,
+                equals_factory=RGUserFairShareConditions.by_resource_group_equals,
+                starts_with_factory=RGUserFairShareConditions.by_resource_group_starts_with,
+                ends_with_factory=RGUserFairShareConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.user_uuid:
             uuid_condition = self.user_uuid.build_query_condition(
-                equals_factory=lambda spec: RGUserFairShareConditions.by_user_uuid(spec.value),
-                in_factory=lambda spec: RGUserFairShareConditions.by_user_uuids(spec.values),
+                equals_factory=RGUserFairShareConditions.by_user_uuid,
+                in_factory=RGUserFairShareConditions.by_user_uuids,
             )
             if uuid_condition:
                 conditions.append(uuid_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: RGUserFairShareConditions.by_project_id(spec.value),
-                in_factory=lambda spec: RGUserFairShareConditions.by_project_ids(spec.values),
+                equals_factory=RGUserFairShareConditions.by_project_id,
+                in_factory=RGUserFairShareConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: RGUserFairShareConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: RGUserFairShareConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: RGUserFairShareConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: RGUserFairShareConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=RGUserFairShareConditions.by_domain_name_contains,
+                equals_factory=RGUserFairShareConditions.by_domain_name_equals,
+                starts_with_factory=RGUserFairShareConditions.by_domain_name_starts_with,
+                ends_with_factory=RGUserFairShareConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/api/gql/resource_usage/types/domain_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/domain_usage.py
@@ -236,36 +236,20 @@ class DomainUsageBucketFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: DomainUsageBucketConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: DomainUsageBucketConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: DomainUsageBucketConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: DomainUsageBucketConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=DomainUsageBucketConditions.by_resource_group_contains,
+                equals_factory=DomainUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=DomainUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=DomainUsageBucketConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: DomainUsageBucketConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: DomainUsageBucketConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: DomainUsageBucketConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: DomainUsageBucketConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=DomainUsageBucketConditions.by_domain_name_contains,
+                equals_factory=DomainUsageBucketConditions.by_domain_name_equals,
+                starts_with_factory=DomainUsageBucketConditions.by_domain_name_starts_with,
+                ends_with_factory=DomainUsageBucketConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
@@ -9,6 +9,7 @@ import strawberry
 from strawberry import ID, Info
 from strawberry.relay import Connection, Edge, Node, NodeID
 
+from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.manager.api.gql.base import (
     DateFilter,
     OrderDirection,
@@ -162,7 +163,9 @@ class ProjectUsageBucketGQL(Node):
             limit=limit,
             offset=offset,
             base_conditions=[
-                UserUsageBucketConditions.by_project_id(self.project_id),
+                UserUsageBucketConditions.by_project_id(
+                    UUIDEqualMatchSpec(value=self.project_id, negated=False)
+                ),
                 UserUsageBucketConditions.by_resource_group(self.resource_group_name),
                 UserUsageBucketConditions.by_period_start(self.metadata.period_start),
             ],
@@ -247,44 +250,28 @@ class ProjectUsageBucketFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: ProjectUsageBucketConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: ProjectUsageBucketConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: ProjectUsageBucketConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: ProjectUsageBucketConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=ProjectUsageBucketConditions.by_resource_group_contains,
+                equals_factory=ProjectUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=ProjectUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=ProjectUsageBucketConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: ProjectUsageBucketConditions.by_project_id(spec.value),
-                in_factory=lambda spec: ProjectUsageBucketConditions.by_project_id(spec.values[0]),
+                equals_factory=ProjectUsageBucketConditions.by_project_id,
+                in_factory=ProjectUsageBucketConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: ProjectUsageBucketConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: ProjectUsageBucketConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: ProjectUsageBucketConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: ProjectUsageBucketConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=ProjectUsageBucketConditions.by_domain_name_contains,
+                equals_factory=ProjectUsageBucketConditions.by_domain_name_equals,
+                starts_with_factory=ProjectUsageBucketConditions.by_domain_name_starts_with,
+                ends_with_factory=ProjectUsageBucketConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
@@ -208,52 +208,36 @@ class UserUsageBucketFilter(GQLFilter):
 
         if self.resource_group:
             sg_condition = self.resource_group.build_query_condition(
-                contains_factory=lambda spec: UserUsageBucketConditions.by_resource_group_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: UserUsageBucketConditions.by_resource_group_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: UserUsageBucketConditions.by_resource_group_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: UserUsageBucketConditions.by_resource_group_ends_with(
-                    spec.value
-                ),
+                contains_factory=UserUsageBucketConditions.by_resource_group_contains,
+                equals_factory=UserUsageBucketConditions.by_resource_group_equals,
+                starts_with_factory=UserUsageBucketConditions.by_resource_group_starts_with,
+                ends_with_factory=UserUsageBucketConditions.by_resource_group_ends_with,
             )
             if sg_condition:
                 conditions.append(sg_condition)
 
         if self.user_uuid:
             uuid_condition = self.user_uuid.build_query_condition(
-                equals_factory=lambda spec: UserUsageBucketConditions.by_user_uuid(spec.value),
-                in_factory=lambda spec: UserUsageBucketConditions.by_user_uuid(spec.values[0]),
+                equals_factory=UserUsageBucketConditions.by_user_uuid,
+                in_factory=UserUsageBucketConditions.by_user_uuids,
             )
             if uuid_condition:
                 conditions.append(uuid_condition)
 
         if self.project_id:
             pid_condition = self.project_id.build_query_condition(
-                equals_factory=lambda spec: UserUsageBucketConditions.by_project_id(spec.value),
-                in_factory=lambda spec: UserUsageBucketConditions.by_project_id(spec.values[0]),
+                equals_factory=UserUsageBucketConditions.by_project_id,
+                in_factory=UserUsageBucketConditions.by_project_ids,
             )
             if pid_condition:
                 conditions.append(pid_condition)
 
         if self.domain_name:
             dn_condition = self.domain_name.build_query_condition(
-                contains_factory=lambda spec: UserUsageBucketConditions.by_domain_name_contains(
-                    spec.value
-                ),
-                equals_factory=lambda spec: UserUsageBucketConditions.by_domain_name_equals(
-                    spec.value
-                ),
-                starts_with_factory=lambda spec: UserUsageBucketConditions.by_domain_name_starts_with(
-                    spec.value
-                ),
-                ends_with_factory=lambda spec: UserUsageBucketConditions.by_domain_name_ends_with(
-                    spec.value
-                ),
+                contains_factory=UserUsageBucketConditions.by_domain_name_contains,
+                equals_factory=UserUsageBucketConditions.by_domain_name_equals,
+                starts_with_factory=UserUsageBucketConditions.by_domain_name_starts_with,
+                ends_with_factory=UserUsageBucketConditions.by_domain_name_ends_with,
             )
             if dn_condition:
                 conditions.append(dn_condition)

--- a/src/ai/backend/manager/repositories/agent/options.py
+++ b/src/ai/backend/manager/repositories/agent/options.py
@@ -2,7 +2,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder

--- a/src/ai/backend/manager/repositories/agent/query.py
+++ b/src/ai/backend/manager/repositories/agent/query.py
@@ -2,6 +2,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.types import AgentId
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.models.agent import AgentRow

--- a/src/ai/backend/manager/repositories/artifact/options.py
+++ b/src/ai/backend/manager/repositories/artifact/options.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.artifact.types import (
     ArtifactAvailability,
     ArtifactRemoteStatus,

--- a/src/ai/backend/manager/repositories/deployment/options/deployment.py
+++ b/src/ai/backend/manager/repositories/deployment/options/deployment.py
@@ -9,8 +9,8 @@ from typing import Any, cast
 import sqlalchemy as sa
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.model_deployment.types import ModelDeploymentStatus
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
 

--- a/src/ai/backend/manager/repositories/deployment/options/revision.py
+++ b/src/ai/backend/manager/repositories/deployment/options/revision.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
 

--- a/src/ai/backend/manager/repositories/domain/options.py
+++ b/src/ai/backend/manager/repositories/domain/options.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.group.row import GroupRow

--- a/src/ai/backend/manager/repositories/fair_share/options.py
+++ b/src/ai/backend/manager/repositories/fair_share/options.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain import DomainRow
@@ -225,16 +225,22 @@ class ProjectFairShareConditions:
         return inner
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.project_id == project_id
+            condition = ProjectFairShareRow.project_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_ids(project_ids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectFairShareRow.project_id.in_(project_ids)
+            condition = ProjectFairShareRow.project_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -494,30 +500,42 @@ class UserFairShareConditions:
         return inner
 
     @staticmethod
-    def by_user_uuid(user_uuid: uuid.UUID) -> QueryCondition:
+    def by_user_uuid(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.user_uuid == user_uuid
+            condition = UserFairShareRow.user_uuid == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.project_id == project_id
+            condition = UserFairShareRow.project_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_uuids(user_uuids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_user_uuids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.user_uuid.in_(user_uuids)
+            condition = UserFairShareRow.user_uuid.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_ids(project_ids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserFairShareRow.project_id.in_(project_ids)
+            condition = UserFairShareRow.project_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -828,30 +846,54 @@ class RGDomainFairShareConditions:
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.domain.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.domain.ilike(f"%{spec.value}%")
+            else:
+                condition = ScalingGroupForDomainRow.domain.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.domain == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(ScalingGroupForDomainRow.domain) == spec.value.lower()
+            else:
+                condition = ScalingGroupForDomainRow.domain == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.domain.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.domain.ilike(f"{spec.value}%")
+            else:
+                condition = ScalingGroupForDomainRow.domain.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.domain.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.domain.ilike(f"%{spec.value}")
+            else:
+                condition = ScalingGroupForDomainRow.domain.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -863,30 +905,56 @@ class RGDomainFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"%{spec.value}%")
+            else:
+                condition = ScalingGroupForDomainRow.scaling_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group == resource_group
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(ScalingGroupForDomainRow.scaling_group) == spec.value.lower()
+                )
+            else:
+                condition = ScalingGroupForDomainRow.scaling_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"{spec.value}%")
+            else:
+                condition = ScalingGroupForDomainRow.scaling_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"%{spec.value}")
+            else:
+                condition = ScalingGroupForDomainRow.scaling_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -911,16 +979,22 @@ class RGProjectFairShareConditions:
     """
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.group == project_id
+            condition = ScalingGroupForProjectRow.group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_ids(project_ids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.group.in_(project_ids)
+            condition = ScalingGroupForProjectRow.group.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -932,30 +1006,54 @@ class RGProjectFairShareConditions:
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainRow.name) == spec.value.lower()
+            else:
+                condition = DomainRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = DomainRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = DomainRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -967,30 +1065,56 @@ class RGProjectFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}%")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group == resource_group
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(ScalingGroupForProjectRow.scaling_group) == spec.value.lower()
+                )
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"{spec.value}%")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -1003,30 +1127,42 @@ class RGUserFairShareConditions:
     """
 
     @staticmethod
-    def by_user_uuid(user_uuid: uuid.UUID) -> QueryCondition:
+    def by_user_uuid(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AssocGroupUserRow.user_id == user_uuid
+            condition = AssocGroupUserRow.user_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_uuids(user_uuids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_user_uuids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AssocGroupUserRow.user_id.in_(user_uuids)
+            condition = AssocGroupUserRow.user_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AssocGroupUserRow.group_id == project_id
+            condition = AssocGroupUserRow.group_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_ids(project_ids: Collection[uuid.UUID]) -> QueryCondition:
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AssocGroupUserRow.group_id.in_(project_ids)
+            condition = AssocGroupUserRow.group_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -1038,30 +1174,54 @@ class RGUserFairShareConditions:
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainRow.name) == spec.value.lower()
+            else:
+                condition = DomainRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = DomainRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainRow.name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = DomainRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = DomainRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -1073,29 +1233,55 @@ class RGUserFairShareConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}%")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group == resource_group
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(ScalingGroupForProjectRow.scaling_group) == spec.value.lower()
+                )
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"{spec.value}%")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}")
+            else:
+                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner

--- a/src/ai/backend/manager/repositories/group/options.py
+++ b/src/ai/backend/manager/repositories/group/options.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain import DomainRow

--- a/src/ai/backend/manager/repositories/image/options.py
+++ b/src/ai/backend/manager/repositories/image/options.py
@@ -7,8 +7,8 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.types import ImageID
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.image.types import ImageStatus
 from ai.backend.manager.models.image import ImageAliasRow, ImageRow
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder

--- a/src/ai/backend/manager/repositories/notification/options.py
+++ b/src/ai/backend/manager/repositories/notification/options.py
@@ -5,8 +5,8 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.notification import NotificationChannelType, NotificationRuleType
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.models.notification import NotificationChannelRow, NotificationRuleRow
 from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
 

--- a/src/ai/backend/manager/repositories/permission_controller/options.py
+++ b/src/ai/backend/manager/repositories/permission_controller/options.py
@@ -5,7 +5,8 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.manager.data.permission.id import ObjectId
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import EntityType, RoleSource, ScopeType
 from ai.backend.manager.models.domain.row import DomainRow

--- a/src/ai/backend/manager/repositories/resource_usage_history/options.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/options.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.models.resource_usage_history import (
     DomainUsageBucketRow,
     KernelUsageRecordRow,
@@ -92,58 +93,106 @@ class DomainUsageBucketConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainUsageBucketRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainUsageBucketRow.resource_group) == spec.value.lower()
+            else:
+                condition = DomainUsageBucketRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = DomainUsageBucketRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = DomainUsageBucketRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = DomainUsageBucketRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(DomainUsageBucketRow.domain_name) == spec.value.lower()
+            else:
+                condition = DomainUsageBucketRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = DomainUsageBucketRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return DomainUsageBucketRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = DomainUsageBucketRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = DomainUsageBucketRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -285,65 +334,128 @@ class ProjectUsageBucketConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = ProjectUsageBucketRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = (
+                    sa.func.lower(ProjectUsageBucketRow.resource_group) == spec.value.lower()
+                )
+            else:
+                condition = ProjectUsageBucketRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = ProjectUsageBucketRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = ProjectUsageBucketRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = ProjectUsageBucketRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(ProjectUsageBucketRow.domain_name) == spec.value.lower()
+            else:
+                condition = ProjectUsageBucketRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = ProjectUsageBucketRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = ProjectUsageBucketRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = ProjectUsageBucketRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ProjectUsageBucketRow.project_id == project_id
+            condition = ProjectUsageBucketRow.project_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ProjectUsageBucketRow.project_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -485,72 +597,146 @@ class UserUsageBucketConditions:
         return inner
 
     @staticmethod
-    def by_resource_group_contains(resource_group: str) -> QueryCondition:
+    def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.resource_group.like(f"%{resource_group}%")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.resource_group.ilike(f"%{spec.value}%")
+            else:
+                condition = UserUsageBucketRow.resource_group.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_equals(resource_group: str) -> QueryCondition:
+    def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.resource_group == resource_group
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserUsageBucketRow.resource_group) == spec.value.lower()
+            else:
+                condition = UserUsageBucketRow.resource_group == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_starts_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.resource_group.like(f"{resource_group}%")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.resource_group.ilike(f"{spec.value}%")
+            else:
+                condition = UserUsageBucketRow.resource_group.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_resource_group_ends_with(resource_group: str) -> QueryCondition:
+    def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.resource_group.like(f"%{resource_group}")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.resource_group.ilike(f"%{spec.value}")
+            else:
+                condition = UserUsageBucketRow.resource_group.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_contains(domain_name: str) -> QueryCondition:
+    def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.domain_name.like(f"%{domain_name}%")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.domain_name.ilike(f"%{spec.value}%")
+            else:
+                condition = UserUsageBucketRow.domain_name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_equals(domain_name: str) -> QueryCondition:
+    def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.domain_name == domain_name
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserUsageBucketRow.domain_name) == spec.value.lower()
+            else:
+                condition = UserUsageBucketRow.domain_name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_starts_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.domain_name.like(f"{domain_name}%")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.domain_name.ilike(f"{spec.value}%")
+            else:
+                condition = UserUsageBucketRow.domain_name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_domain_name_ends_with(domain_name: str) -> QueryCondition:
+    def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.domain_name.like(f"%{domain_name}")
+            if spec.case_insensitive:
+                condition = UserUsageBucketRow.domain_name.ilike(f"%{spec.value}")
+            else:
+                condition = UserUsageBucketRow.domain_name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_user_uuid(user_uuid: uuid.UUID) -> QueryCondition:
+    def by_user_uuid(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.user_uuid == user_uuid
+            condition = UserUsageBucketRow.user_uuid == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
     @staticmethod
-    def by_project_id(project_id: uuid.UUID) -> QueryCondition:
+    def by_user_uuids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserUsageBucketRow.project_id == project_id
+            condition = UserUsageBucketRow.user_uuid.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = UserUsageBucketRow.project_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = UserUsageBucketRow.project_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/src/ai/backend/manager/repositories/scaling_group/options.py
+++ b/src/ai/backend/manager/repositories/scaling_group/options.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.models.scaling_group import (
     ScalingGroupForProjectRow,
     ScalingGroupRow,

--- a/src/ai/backend/manager/repositories/scheduler/options.py
+++ b/src/ai/backend/manager/repositories/scheduler/options.py
@@ -11,7 +11,11 @@ import sqlalchemy as sa
 from ai.backend.manager.models.scaling_group.row import ScalingGroupRow
 
 if TYPE_CHECKING:
-    from ai.backend.manager.api.gql.base import UUIDEqualMatchSpec, UUIDInMatchSpec
+    from ai.backend.common.data.filter_specs import (
+        StringMatchSpec,
+        UUIDEqualMatchSpec,
+        UUIDInMatchSpec,
+    )
     from ai.backend.manager.api.gql.kernel.types import KernelStatusInMatchSpec
 
 from ai.backend.common.types import KernelId, SessionId

--- a/src/ai/backend/manager/repositories/scheduling_history/options.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/options.py
@@ -7,8 +7,8 @@ from typing import cast
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.types import KernelId, SessionId
-from ai.backend.manager.api.gql.base import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.deployment.types import RouteStatus
 from ai.backend.manager.data.kernel.types import KernelSchedulingPhase
 from ai.backend.manager.data.session.types import SchedulingResult, SessionStatus

--- a/src/ai/backend/manager/repositories/scheduling_history/types.py
+++ b/src/ai/backend/manager/repositories/scheduling_history/types.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
-from ai.backend.manager.api.gql.base import UUIDEqualMatchSpec
+from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.manager.errors.deployment import EndpointNotFound
 from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.errors.service import RouteNotFound

--- a/src/ai/backend/manager/repositories/user/options.py
+++ b/src/ai/backend/manager/repositories/user/options.py
@@ -8,8 +8,8 @@ from typing import Any
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.common.data.user.types import UserRole
-from ai.backend.manager.api.gql.base import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow

--- a/tests/unit/manager/api/gql/test_base.py
+++ b/tests/unit/manager/api/gql/test_base.py
@@ -9,10 +9,10 @@ import pytest
 import sqlalchemy as sa
 from graphql_relay.utils import base64
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.api.gql.base import (
     CURSOR_VERSION,
     StringFilter,
-    StringMatchSpec,
     decode_cursor,
     encode_cursor,
 )

--- a/tests/unit/manager/api/test_adapter.py
+++ b/tests/unit/manager/api/test_adapter.py
@@ -11,9 +11,9 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.manager.api.adapter import BaseFilterAdapter
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.repositories.base import QueryCondition
 
 if TYPE_CHECKING:

--- a/tests/unit/manager/repositories/domain/test_options.py
+++ b/tests/unit/manager/repositories/domain/test_options.py
@@ -8,9 +8,9 @@ from collections.abc import AsyncGenerator
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus

--- a/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
+++ b/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
@@ -19,6 +19,7 @@ from decimal import Decimal
 
 import pytest
 
+from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentRow
@@ -497,7 +498,9 @@ class TestSearchDomainFairSharesEntityBased:
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
-                RGDomainFairShareConditions.by_domain_name_equals(domain_without_record),
+                RGDomainFairShareConditions.by_domain_name_equals(
+                    StringMatchSpec(domain_without_record, case_insensitive=False, negated=False)
+                ),
             ],
             orders=[],
         )
@@ -524,7 +527,9 @@ class TestSearchDomainFairSharesEntityBased:
         querier_without = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
-                RGDomainFairShareConditions.by_domain_name_equals(domain_without_record),
+                RGDomainFairShareConditions.by_domain_name_equals(
+                    StringMatchSpec(domain_without_record, case_insensitive=False, negated=False)
+                ),
             ],
             orders=[],
         )
@@ -539,7 +544,9 @@ class TestSearchDomainFairSharesEntityBased:
         querier_with = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
-                RGDomainFairShareConditions.by_domain_name_equals(domain_with_record),
+                RGDomainFairShareConditions.by_domain_name_equals(
+                    StringMatchSpec(domain_with_record, case_insensitive=False, negated=False)
+                ),
             ],
             orders=[],
         )
@@ -855,7 +862,9 @@ class TestSearchProjectFairSharesEntityBased:
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
-                RGProjectFairShareConditions.by_project_id(project_without_record),
+                RGProjectFairShareConditions.by_project_id(
+                    UUIDEqualMatchSpec(value=project_without_record, negated=False)
+                ),
             ],
             orders=[],
         )
@@ -1246,7 +1255,9 @@ class TestSearchUserFairSharesEntityBased:
         querier = BatchQuerier(
             pagination=OffsetPagination(limit=100, offset=0),
             conditions=[
-                RGUserFairShareConditions.by_user_uuid(user_without_record),
+                RGUserFairShareConditions.by_user_uuid(
+                    UUIDEqualMatchSpec(value=user_without_record, negated=False)
+                ),
             ],
             orders=[],
         )

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_entity_options.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_entity_options.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_options.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_options.py
@@ -11,7 +11,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.repositories.fair_share.options import (
     DomainFairShareConditions,
     ProjectFairShareConditions,

--- a/tests/unit/manager/repositories/group/test_options.py
+++ b/tests/unit/manager/repositories/group/test_options.py
@@ -9,9 +9,9 @@ from typing import Any
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.user.types import UserStatus

--- a/tests/unit/manager/repositories/notification/test_notification_options.py
+++ b/tests/unit/manager/repositories/notification/test_notification_options.py
@@ -12,13 +12,13 @@ from datetime import UTC, datetime, timedelta
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.notification import (
     NotificationChannelType,
     NotificationRuleType,
     WebhookSpec,
 )
 from ai.backend.common.types import BinarySize, ResourceSlot
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ai.backend.manager.api.gql.base import StringMatchSpec
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.models.rbac_models import UserRoleRow
 from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow

--- a/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
@@ -10,9 +10,9 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.permission.types import GLOBAL_SCOPE_ID, ScopeType
 from ai.backend.common.types import ResourceSlot
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow

--- a/tests/unit/manager/repositories/user/test_options.py
+++ b/tests/unit/manager/repositories/user/test_options.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
-from ai.backend.manager.api.gql.base import StringMatchSpec
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.models.agent import AgentRow


### PR DESCRIPTION
This is an auto-generated backport PR of #9247 to the 26.2 release.