### PR TITLE
doc(BA-4663): Add per-package CLAUDE.md guardrail files

### DIFF
--- a/src/ai/backend/agent/CLAUDE.md
+++ b/src/ai/backend/agent/CLAUDE.md
@@ -1,0 +1,39 @@
+# Agent — Guardrails
+
+> For full component overview, see `src/ai/backend/agent/README.md`.
+
+## Exceptions
+
+- Every exception raised in business logic MUST inherit from `BackendAIError`.
+- NEVER raise `RuntimeError`, `ValueError`, or other built-ins directly in business logic.
+- Define new exceptions in `agent/errors/` — NOT in `agent/exception.py` (that file is legacy).
+
+## Async Rules
+
+- All I/O MUST use `async`/`await`.
+- `time.sleep()` is forbidden — use `asyncio.sleep()`.
+- Blocking calls inside async functions are forbidden — use `asyncio.to_thread()` if unavoidable.
+
+## Container Lifecycle
+
+- Container state transitions MUST go through the defined state machine in `agent/stage/`.
+- Direct Docker/K8s API calls that change container state outside the lifecycle handler are forbidden.
+- Health check and heartbeat logic belongs in `agent/health/` — do not inline it into the main loop.
+
+## Infrastructure Implementations (Docker / Kubernetes / Dummy)
+
+- Always check the abstract base class in `agent/` before implementing.
+- The Dummy implementation must be updated alongside Docker/Kubernetes changes.
+- New infrastructure-specific code goes in the corresponding subdirectory
+  (`agent/docker/`, `agent/kubernetes/`, `agent/dummy/`).
+
+## Manager Communication
+
+- Agent → Manager communication uses the event system only.
+- Direct Manager RPC calls are allowed only from the designated RPC Server entry point.
+- Do NOT add new direct HTTP calls to the Manager from inside Agent business logic.
+
+## Resource Tracking
+
+- Resource allocation / deallocation MUST go through `alloc_map.py`.
+- Do NOT manipulate resource counters directly outside `alloc_map.py`.

--- a/src/ai/backend/common/CLAUDE.md
+++ b/src/ai/backend/common/CLAUDE.md
@@ -1,0 +1,35 @@
+# Common Package — Guardrails
+
+> Every component (manager, agent, storage, client SDK) depends on this package.
+> A change here affects the entire system — verify all callers before modifying anything.
+
+## What Belongs Here
+
+- Abstractions and utilities shared by two or more components.
+- Base exception classes, event types, DTO base classes, shared type definitions.
+- Infrastructure clients (Redis, etcd, message queue) used across components.
+
+## What Does NOT Belong Here
+
+- Component-specific logic (manager session management, agent kernel handling, etc.).
+- Any import from `manager/`, `agent/`, or `storage/` — dependency must flow inward only.
+
+## Adding to This Package
+
+- Before adding a new module, confirm it is genuinely needed by multiple components.
+- Single-component utilities belong in that component's own package, not here.
+
+## Sub-package Highlights
+
+| Sub-package | Purpose |
+|-------------|---------|
+| `common/events/` | Event type definitions and dispatcher — see existing AbstractEvent subclasses |
+| `common/bgtask/` | Background task framework — extend `BaseBackgroundTaskHandler` |
+| `common/dto/` | Cross-component DTOs — see `common/dto/CLAUDE.md` |
+| `common/exception.py` | Root `BackendAIError` and `ErrorCode` — all component exceptions inherit from here |
+| `common/types.py` | Shared primitive types used across layers |
+
+## Exceptions
+
+- `common/exception.py` defines the root hierarchy — do NOT add component-specific exceptions here.
+- New shared exception base classes are acceptable; concrete domain exceptions are not.

--- a/src/ai/backend/common/dto/CLAUDE.md
+++ b/src/ai/backend/common/dto/CLAUDE.md
@@ -1,0 +1,21 @@
+# Common DTO — Guardrails
+
+> This package is shared across all components. Any change here affects manager, agent, storage,
+> and the client SDK simultaneously — verify all callers before modifying a field.
+
+## Purpose
+
+DTOs shared across multiple backend.ai components (manager, agent, storage, client SDK).
+If a DTO is only used within a single component, put it in that component's own `dto/` directory.
+
+## Directory Structure
+
+Organize by target component: `common/dto/{manager|agent|storage|clients|internal}/`.
+
+## Rules
+
+- All DTOs MUST inherit from `BaseRequestModel` (Pydantic v2).
+- Only import from Python stdlib and `common/types` — never from component-specific packages
+  (`manager/`, `agent/`, `storage/`).
+- No business logic — validation and serialization only.
+- Before modifying any field, verify all callers across components.

--- a/src/ai/backend/manager/CLAUDE.md
+++ b/src/ai/backend/manager/CLAUDE.md
@@ -1,0 +1,35 @@
+# Manager Component — Guardrails
+
+> For component overview and architecture, see `src/ai/backend/manager/README.md`.
+> For implementation patterns, use the skills referenced in the root `CLAUDE.md`.
+
+## Layer Order (top → bottom)
+
+```
+api/ → services/ → repositories/ → models/
+         ↑ data/ and dto/ serve all layers
+```
+
+Each layer has its own `CLAUDE.md`. Read it before modifying code in that directory.
+
+## Cross-Layer Rules
+
+- Imports MUST follow the layer order — lower layers must never import from upper layers.
+  (`models/` must not import from `services/`; `repositories/` must not import from `api/`.)
+- `data/` types flow upward freely; ORM `Row` types must not cross above `repositories/`.
+
+## Entry Points
+
+- `server.py` — HTTP server bootstrap. Changes here affect startup and DI wiring.
+- `dependencies/` — Dependency composer. Add new dependencies here, not in `server.py`.
+- `event_dispatcher/` — Manager-side event handlers. New event subscriptions go here.
+
+## Errors
+
+- `manager/exceptions.py` and `manager/errors/` both exist; `errors/` is the current standard.
+- New domain exceptions go in `manager/errors/{domain}.py` — not in `manager/exceptions.py`.
+
+## Scheduler
+
+- Scheduling logic belongs in `manager/scheduler/` — do not add scheduling decisions inside
+  API handlers or service methods.

--- a/src/ai/backend/manager/api/CLAUDE.md
+++ b/src/ai/backend/manager/api/CLAUDE.md
@@ -1,0 +1,41 @@
+# Manager API Layer — Guardrails
+
+> For full implementation patterns, see the `/api-guide` skill.
+
+## Handler Style
+
+- All handlers MUST be methods on an `APIHandler` class — no module-level async functions.
+- Parse requests via `BodyParam[T]` and `PathParam[T]` — never read `request.json()` or
+  `request.rel_url.query` directly inside a handler.
+- Return `APIResponse.build(status_code=..., response_model=...)` — never `web.json_response()`.
+
+## Calling Services
+
+- Handlers MUST invoke services through a Processor, not directly:
+  ```python
+  # CORRECT
+  await processors_ctx.processors.foo.wait_for_complete(FooAction(...))
+  # WRONG
+  await self._foo_service.do_something(...)
+  ```
+
+## Naming
+
+- Scoped endpoints: `{scope}_create_`, `{scope}_search_`, `{scope}_update_`, ... prefix.
+- Superadmin-only endpoints (no scope): `admin_` prefix + call `_check_superadmin(request)` first.
+
+## Routing
+
+- Route registration belongs exclusively in `create_app()`.
+- `app["prefix"]` must be set to the URL segment for this sub-app.
+
+## What Belongs Here
+
+- HTTP request/response translation only.
+- Auth decorators (`@auth_required_for_method`).
+
+## What Does NOT Belong Here
+
+- Business logic or domain rules.
+- Direct database access or ORM imports from `manager/models/`.
+- Imports of Repository or Service classes (use Processors via context).

--- a/src/ai/backend/manager/api/gql/CLAUDE.md
+++ b/src/ai/backend/manager/api/gql/CLAUDE.md
@@ -1,0 +1,36 @@
+# Manager GraphQL Layer — Guardrails
+
+> For full implementation patterns, see the `/api-guide` skill (GraphQL Patterns section).
+
+## Type Naming
+
+- Every Strawberry type MUST carry a `GQL` suffix: `DomainGQL`, `DomainFilterGQL`, `DomainScopeGQL`.
+- Applies to all `@strawberry.type`, `@strawberry.input`, and `@strawberry.enum` classes.
+
+## Imports
+
+- NEVER import Strawberry types inside `TYPE_CHECKING` blocks — Strawberry evaluates types at
+  runtime and will fail silently or raise errors.
+- Always import Strawberry types at module level.
+
+## Cross-Entity References
+
+- Use `strawberry.lazy()` for cross-entity node references to avoid circular imports —
+  see `/api-guide` skill for the correct `Annotated[T, lazy(...)] | None` syntax.
+
+## N+1 Prevention
+
+- Never call individual fetch functions inside resolvers for related entities.
+- Always use `info.context.data_loaders.*` for cross-entity data loading.
+
+## Admin Check
+
+- Superadmin-only resolvers: call `check_admin_only(info)` as the first statement.
+
+## Calling Services
+
+- Resolvers MUST invoke services through a Processor — never call service methods directly.
+
+## Legacy Code
+
+- Do NOT copy patterns from `gql_legacy/` (Graphene) — it is being migrated to Strawberry.

--- a/src/ai/backend/manager/data/CLAUDE.md
+++ b/src/ai/backend/manager/data/CLAUDE.md
@@ -1,0 +1,25 @@
+# Manager Data Layer — Guardrails
+
+> Pure domain types only — no framework dependencies allowed here.
+
+## Purpose
+
+Immutable value objects that sit between ORM Row objects and the Service/API layers.
+No SQLAlchemy, Pydantic, or aiohttp imports are permitted in this package.
+
+## Directory Structure (per domain)
+
+Each domain follows: `data/{domain}/__init__.py` (re-exports) + `types.py` (frozen dataclasses).
+
+## Type Rules
+
+- All data classes MUST be `@dataclass(frozen=True)`.
+- Allowed imports: Python stdlib and `ai.backend.common.types` — nothing else.
+- Do NOT import from `manager/models/`, `manager/repositories/`, `manager/services/`,
+  or any external framework (`pydantic`, `sqlalchemy`, `aiohttp`).
+
+## What Does NOT Belong Here
+
+- Business logic methods (pure data containers only).
+- Pydantic models — use `manager/dto/` or `common/dto/` for request/response types.
+- Mutable state or default-factory fields that hide complexity.

--- a/src/ai/backend/manager/dto/CLAUDE.md
+++ b/src/ai/backend/manager/dto/CLAUDE.md
@@ -1,0 +1,26 @@
+# Manager DTO — Guardrails
+
+> For API integration patterns that use these DTOs, see the `/api-guide` skill.
+
+## Where to Put a New DTO
+
+| Used by                                          | Location                       |
+|--------------------------------------------------|--------------------------------|
+| Manager API handlers only                        | `manager/dto/`                 |
+| Multiple components (agent, storage, client SDK) | `common/dto/manager/{domain}/` |
+
+When in doubt: if anything outside `manager/` imports it, put it in `common/dto/`.
+
+## DTO Rules
+
+- All DTOs MUST inherit from `BaseRequestModel` (Pydantic v2).
+- DTOs handle serialization and validation only — no business logic methods.
+- Do NOT import ORM `Row` types from `manager/models/` inside a DTO.
+- Do NOT import `data/` domain types into DTOs used by external callers
+  (keep the dependency direction: dto → common types only).
+
+## Naming Convention
+
+- Request: `{Operation}{Entity}Req` — e.g., `CreateUserReq`, `SearchSessionsReq`.
+- Response: `{Operation}{Entity}Response` — e.g., `CreateUserResponse`.
+- Path params: `{Entity}PathParam` — e.g., `ArtifactPathParam`.

--- a/src/ai/backend/manager/models/CLAUDE.md
+++ b/src/ai/backend/manager/models/CLAUDE.md
@@ -1,0 +1,30 @@
+# Manager Models Layer — Guardrails
+
+> This layer defines ORM schema only. For query patterns see `/repository-guide`;
+> for data type conventions see `manager/data/CLAUDE.md`.
+
+## Directory Structure (per domain)
+
+Every domain MUST follow: `models/{domain}/__init__.py` (re-exports only) + `row.py` (ORM class).
+Single-file shortcuts (`models/simple.py`) are legacy — do not add new ones.
+
+## Row Class Rules
+
+- Inherit from `Base` (defined in `manager/models/base.py`).
+- `__tablename__` is required on every Row class.
+- Cross-entity relationships: put related Row imports inside `TYPE_CHECKING` blocks only.
+
+## No Logic in Row Classes
+
+- Do NOT add query builder methods to Row classes — that is `repositories/db_source/`'s job.
+- Do NOT add business logic methods — that is `services/`'s job.
+- `session/row.py` contains legacy query methods; do NOT follow that pattern.
+
+## Custom Column Types
+
+- Reuse existing `TypeDecorator` wrappers from `models/base.py` whenever possible.
+- New `TypeDecorator` additions go in `models/base.py` only — not in individual row files.
+
+## `__init__.py` Rule
+
+- Only re-export the `Row` classes declared in `row.py` — nothing else.

--- a/src/ai/backend/manager/repositories/CLAUDE.md
+++ b/src/ai/backend/manager/repositories/CLAUDE.md
@@ -1,0 +1,36 @@
+# Manager Repositories Layer — Guardrails
+
+> For full implementation patterns, see the `/repository-guide` skill.
+
+## Directory Structure (per domain)
+
+Core files per domain: `repository.py` (single-entity CRUD interface), `repositories.py`
+(multi-entity container / `RepositoryArgs`), `types.py` (SearchScope + SearchResult),
+`options.py` (QueryCondition/QueryOrder enums), `db_source/db_source.py` (all queries).
+Optional per-operation helpers: `creators.py`, `updaters.py`, `purgers.py`, `upserters.py`.
+
+## Method Naming
+
+- Getter method uses the entity name, not `get_`: e.g., `user(id)`, `session(id)`.
+- Standard six operations: `create` / `{entity}` / `search` / `update` / `delete` / `purge`.
+
+## Transaction Rules
+
+- `begin_session()` for writes, `begin_readonly_session()` for reads.
+- Each public method owns its own transaction boundary.
+- NEVER accept a DB session from the caller (Service layer does not manage sessions).
+
+## SearchScope Rules
+
+- Must be `@dataclass(frozen=True)`.
+- Must implement `to_condition() -> QueryCondition` (singular, defined in `types.py`).
+
+## DB Source Rules
+
+- All SQLAlchemy query code belongs in `db_source/db_source.py`.
+- `repository.py` only delegates — no query logic allowed there.
+
+## What Does NOT Belong Here
+
+- Business logic or domain validation (belongs in `services/`).
+- Exposing `Row` objects directly to callers — convert to `data/` types before returning.

--- a/src/ai/backend/manager/services/CLAUDE.md
+++ b/src/ai/backend/manager/services/CLAUDE.md
@@ -1,0 +1,37 @@
+# Manager Services Layer — Guardrails
+
+> For full implementation patterns, see the `/service-guide` skill.
+
+## Directory Structure (per domain)
+
+Each domain follows: `services/{domain}/types.py`, `service.py`, `processors.py`,
+and `actions/{base,{operation}}.py` — one file per operation under `actions/`.
+
+## Action Rules
+
+- Actions and ActionResults MUST be `@dataclass(frozen=True)`.
+- Every action file contains exactly ONE `Action` + ONE `ActionResult` pair.
+- `entity_id()` and `operation_type()` must be overridden in every concrete Action.
+
+## Service Method Rules
+
+- One service method = one repository call (preferred). If multiple repository calls are
+  required, add a comment explaining why.
+- Service methods MUST NOT create DB sessions or transactions — delegate to the Repository.
+- Each method accepts an Action and returns an ActionResult — no other return types.
+
+## Processor Rules
+
+- Wrap every service method in an `ActionProcessor`; never expose raw service methods to handlers.
+- `AbstractProcessorPackage` must be subclassed; `supported_actions()` must be overridden.
+
+## What Belongs Here
+
+- Domain validation and business rules.
+- Orchestration across multiple repositories (exceptional, must be justified).
+
+## What Does NOT Belong Here
+
+- SQL queries or ORM operations.
+- HTTP request/response handling.
+- Direct DB session creation (`begin_session()` / `begin_readonly_session()`).

--- a/src/ai/backend/storage/CLAUDE.md
+++ b/src/ai/backend/storage/CLAUDE.md
@@ -1,0 +1,37 @@
+# Storage Proxy — Guardrails
+
+> For component overview, see `src/ai/backend/storage/README.md`.
+
+## API Handlers
+
+- All handlers MUST be methods on a typed handler class — no module-level async functions.
+- Use `@api_handler` or `@stream_api_handler` decorators.
+- Parse requests via `PathParam[T]` and `BodyParam[T]` — never access the raw request object.
+
+## Exceptions
+
+- All exceptions MUST inherit from `StorageProxyError` (which inherits `BackendAIError`).
+- `storage/exception.py` is legacy — do NOT add new exceptions there.
+- All new exceptions go in `storage/errors/` only, organized by feature:
+  `object.py`, `quota.py`, `vfolder.py`, `volume.py`, `process.py`.
+- Never raise built-in exceptions (`RuntimeError`, `OSError`, etc.) directly in business logic.
+
+## Storage Volume Plugins
+
+- New storage backends MUST be added as plugins under `storage/volumes/`.
+- Every plugin MUST implement the abstract volume interface — no duck typing shortcuts.
+
+## Authentication
+
+- Use Storage's own `token_auth_middleware` — do NOT copy `@auth_required` from `manager/api/`.
+- The Storage proxy has its own auth model independent of the Manager.
+
+## Database Independence
+
+- Storage has its own database — NEVER share a DB connection or session with the Manager.
+- Do NOT import Manager ORM models (`manager/models/`) from Storage code.
+
+## What Belongs Here
+
+- File/volume operations, quota management, vfolder lifecycle.
+- Background tasks related to storage (scan, cleanup, migration).

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -3,6 +3,18 @@
 This document provides testing patterns and best practices for Backend.AI.
 For TDD workflow, see `/tdd-guide` skill.
 
+## Which Directory to Use
+
+| Test target | Directory |
+|-------------|-----------|
+| Service / handler logic (mocking) | `tests/unit/{component}/` |
+| Repository / Model (real DB, `with_tables`) | `tests/unit/{component}/repositories/` |
+| HTTP API layer (real aiohttp server + DB) | `tests/component/{component}/` |
+| E2E user scenarios (Client SDK v2) | `tests/integration/` |
+| Legacy DB tests — do NOT add new ones | `tests/manager/` |
+
+Each directory has its own `CLAUDE.md` with setup patterns.
+
 ## Test Strategy
 
 **Use the appropriate testing approach based on the component:**

--- a/tests/component/CLAUDE.md
+++ b/tests/component/CLAUDE.md
@@ -1,0 +1,37 @@
+# Component Tests — Guardrails
+
+> Tests the HTTP API layer with a real aiohttp server and real DB.
+> Business logic is verified in `tests/unit/` — do not duplicate it here.
+
+## What to Test Here
+
+- HTTP routing, auth decorators, request/response serialization.
+- Behavior differences between roles (superadmin vs. user keypair).
+- Error responses for invalid inputs at the API boundary.
+
+## Core Fixtures
+
+**`create_app_and_client` (`AppBuilder`)** — spins up a real aiohttp server with selective
+`cleanup_contexts`. Returns `(app, client)` via the `AppBuilder` protocol:
+```python
+async def test_something(create_app_and_client: AppBuilder) -> None:
+    app, client = await create_app_and_client(...)
+```
+
+**`get_headers(keypair, method, path, ...)`** — generates signed HMAC auth headers.
+- NEVER construct auth headers manually — always use this fixture.
+
+## No `@pytest.mark.integration` Marker
+
+Component tests run whenever a DB is available — do not add `@pytest.mark.integration`.
+That marker is for `tests/integration/` only.
+
+## BUILD Files
+
+- Every new subdirectory needs a `BUILD` file with `python_tests()`.
+
+## What Does NOT Belong Here
+
+- Business logic assertions (service behavior) → `tests/unit/`.
+- Full E2E user workflows (create → list → delete) → `tests/integration/`.
+- Raw `aiohttp.ClientSession` usage — always go through the provided fixtures.

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -1,0 +1,42 @@
+# Integration Tests — Guardrails
+
+> Full-stack E2E tests using Client SDK v2. Validates user-facing workflows end to end.
+
+## What to Test Here
+
+- Complete user-perspective scenarios: create → read → update → delete flows.
+- Permission boundaries between roles (superadmin vs. regular user).
+- Behaviors that span multiple API calls or components.
+
+## `@pytest.mark.integration` Marker
+
+Apply at the **class level** — required for all test classes here:
+```python
+@pytest.mark.integration
+class TestUserLifecycle:
+    async def test_full_user_lifecycle(self, admin_registry, ...) -> None:
+```
+
+## Core Fixtures
+
+**`admin_registry`** — `BackendAIClientRegistry` with superadmin keypair.
+**`user_registry`** — `BackendAIClientRegistry` with normal-user keypair.
+
+- NEVER use raw `aiohttp.ClientSession` or hand-crafted auth headers.
+- Always call the API through `BackendAIClientRegistry` methods.
+
+## Server Setup
+
+Integration tests use a full-stack server (`cleanup_contexts=None`, all contexts included).
+Do not change `cleanup_contexts` from `None` in `server_factory` — integration tests
+require all contexts running.
+
+## Directory Structure
+
+Keep domain-based subdirectory structure: `integration/user/`, `integration/session/`, etc.
+Each subdirectory needs its own `BUILD` with `python_tests()`.
+
+## What Does NOT Belong Here
+
+- Unit-level assertions on service internals → `tests/unit/`.
+- HTTP-layer-only checks (routing, auth decorators) → `tests/component/`.

--- a/tests/manager/CLAUDE.md
+++ b/tests/manager/CLAUDE.md
@@ -1,0 +1,22 @@
+# tests/manager/ — Legacy Directory
+
+> This directory is legacy. Do NOT add new test files or subdirectories here.
+
+## Current Contents
+
+- `tests/manager/models/` — legacy ORM model tests
+- `tests/manager/repositories/` — legacy repository DB tests
+
+## Where to Add New Tests Instead
+
+| What you want to test | Where to add it |
+|-----------------------|----------------|
+| New repository / model (real DB) | `tests/unit/manager/repositories/` |
+| New service / handler (mocking) | `tests/unit/manager/services/` |
+| New API endpoint (real server) | `tests/component/manager/api/` |
+
+## Existing Tests
+
+- Modifying existing tests in this directory is allowed.
+- Existing pattern: `database_engine` fixture + `with_tables` (same as `tests/unit/`).
+- Do NOT create new `.py` files or subdirectories here.

--- a/tests/unit/CLAUDE.md
+++ b/tests/unit/CLAUDE.md
@@ -1,0 +1,31 @@
+# Unit Tests — Guardrails
+
+> For TDD workflow, see `/tdd-guide` skill. For `with_tables` patterns, see `tests/CLAUDE.md`.
+
+## Directory Layout
+
+Mirror `src/ai/backend/{component}/` exactly:
+`tests/unit/{component}/services/`, `tests/unit/{component}/repositories/`, etc.
+
+## Service / Handler Tests (mocking)
+
+- Mock all repository calls with `unittest.mock.AsyncMock`.
+- Do NOT spin up a real DB or real aiohttp server — that belongs in `tests/component/`.
+- One test class per target class; one test function per meaningful behavior.
+
+## Repository / Model Tests (real DB)
+
+- Place under `tests/unit/{component}/repositories/`.
+- Use `with_tables` from `ai.backend.testutils.db` with a real `database_engine` fixture.
+- List all `Row` dependencies in FK order (parent before child).
+- Do NOT mock DB calls — the point is to test actual queries and constraints.
+
+## BUILD Files
+
+- Every new test directory needs a `BUILD` file with `python_tests()`.
+- Shared fixtures go in `conftest.py` — never import from sibling test files.
+
+## What Does NOT Belong Here
+
+- Real aiohttp server setup (`create_app_and_client`) → use `tests/component/`.
+- E2E user scenarios using `BackendAIClientRegistry` → use `tests/integration/`.


### PR DESCRIPTION
## Summary

- Add 17 `CLAUDE.md` files across source packages and test directories to guide AI coding agents with layer-specific constraints and DO NOT rules
- Each file is ≤60 lines, focused on boundaries and common mistake prevention, and references the corresponding skill or README for full patterns

**Source packages (12 files):**
- `manager/` root: layer order, cross-layer import rules, entry points
- `manager/api/`: class-based handlers, `BodyParam`/`PathParam`, Processor-only calls
- `manager/api/gql/`: `GQL` suffix, `strawberry.lazy()` reference, DataLoader, no `gql_legacy`
- `manager/services/`: Action/ActionResult pairs, Processor wrapping, single repo call
- `manager/repositories/`: `db_source/` separation, `to_condition()` (singular), SearchScope, helper files
- `manager/models/`: `row.py`-only structure, no logic in Row classes
- `manager/data/`: frozen dataclasses, no framework imports
- `manager/dto/`: placement guide (`manager/dto/` vs `common/dto/`)
- `common/` root: cross-component impact warning, dependency direction
- `common/dto/`: cross-component DTO rules
- `agent/`: `BackendAIError` enforcement, container lifecycle, `errors/` vs legacy `exception.py`
- `storage/`: class-based handlers, `StorageProxyError` hierarchy, legacy `exception.py` warning

**Test directories (5 files):**
- `tests/CLAUDE.md`: add directory decision table (unit / component / integration / manager)
- `tests/unit/`: mocking rules, `with_tables` placement, mirror `src/` structure
- `tests/component/`: `AppBuilder`/`get_headers` fixtures, no `integration` marker
- `tests/integration/`: `@pytest.mark.integration` required, `BackendAIClientRegistry` only, `cleanup_contexts=None`
- `tests/manager/`: legacy warning, redirect to correct directories

## Test plan

- [ ] No source code changes — documentation only
- [ ] Verify file count: 17 new `CLAUDE.md` files, 1 modified (`tests/CLAUDE.md`)
- [ ] Spot-check that rules in each file match actual code patterns in the corresponding package

🤖 Generated with [Claude Code](https://claude.com/claude-code)