### PR TITLE
fix(BA-4664): specify explicit PostgreSQL enum type name for SessionRow.result column (#9278)

### DIFF
--- a/changes/9278.fix.md
+++ b/changes/9278.fix.md
@@ -1,0 +1,1 @@
+Fix `DatatypeMismatchError` on session creation caused by mismatched PostgreSQL enum type name (`sessionresult` vs `sessionresults`) in `SessionRow.result` column ORM definition.

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -851,7 +851,7 @@ class SessionRow(Base):  # type: ignore[misc]
     startup_command: Mapped[str | None] = mapped_column("startup_command", sa.Text, nullable=True)
     result: Mapped[SessionResult] = mapped_column(
         "result",
-        EnumType(SessionResult),
+        EnumType(SessionResult, name="sessionresults"),
         default=SessionResult.UNDEFINED,
         server_default=SessionResult.UNDEFINED.name,
         nullable=False,


### PR DESCRIPTION
This is an auto-generated backport PR of #9278 to the 26.2 release.