### PR TITLE
fix(BA-4664): specify explicit PostgreSQL enum type name for SessionRow.result column (#9278)

### DIFF
--- a/changes/9278.fix.md
+++ b/changes/9278.fix.md
@@ -1,0 +1,1 @@
+Fix `DatatypeMismatchError` on session creation caused by mismatched PostgreSQL enum type name (`sessionresult` vs `sessionresults`) in `SessionRow.result` column ORM definition.

--- a/src/ai/backend/manager/models/session.py
+++ b/src/ai/backend/manager/models/session.py
@@ -817,7 +817,7 @@ class SessionRow(Base):
     startup_command = sa.Column("startup_command", sa.Text, nullable=True)
     result = sa.Column(
         "result",
-        EnumType(SessionResult),
+        EnumType(SessionResult, name="sessionresults"),
         default=SessionResult.UNDEFINED,
         server_default=SessionResult.UNDEFINED.name,
         nullable=False,


### PR DESCRIPTION
This is an auto-generated backport PR of #9278 to the 25.15 release.