### PR TITLE
fix(BA-4652): Apply CANCEL delay policy to stat collection timers (#9257)

### DIFF
--- a/changes/9257.fix.md
+++ b/changes/9257.fix.md
@@ -1,0 +1,1 @@
+Apply CANCEL delay policy to stat collection timers to prevent task accumulation

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1029,10 +1029,18 @@ class AbstractAgent[
 
         # Prepare stat collector tasks.
         self.timer_tasks.append(
-            aiotools.create_timer(self.collect_container_stat, UTILIZATION_METRIC_INTERVAL)
+            aiotools.create_timer(
+                self.collect_container_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            )
         )
         self.timer_tasks.append(
-            aiotools.create_timer(self.collect_process_stat, UTILIZATION_METRIC_INTERVAL)
+            aiotools.create_timer(
+                self.collect_process_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            )
         )
 
         # Prepare heartbeats.

--- a/src/ai/backend/agent/runtime.py
+++ b/src/ai/backend/agent/runtime.py
@@ -163,7 +163,11 @@ class AgentRuntime:
         self._stop_signal = signal.SIGTERM
         self._timer_tasks = [
             aiotools.create_timer(self._update_slots, 30.0),
-            aiotools.create_timer(self._collect_node_stat, UTILIZATION_METRIC_INTERVAL),
+            aiotools.create_timer(
+                self._collect_node_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            ),
         ]
 
     async def __aexit__(self, *exc_info: Any) -> None:


### PR DESCRIPTION
This is an auto-generated backport PR of #9257 to the 26.2 release.