### PR TITLE
fix(BA-4652): Apply CANCEL delay policy to stat collection timers (backport to 25.15)

### DIFF
--- a/changes/9257.fix.md
+++ b/changes/9257.fix.md
@@ -1,0 +1,1 @@
+Apply CANCEL delay policy to stat collection timers to prevent task accumulation

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -968,13 +968,25 @@ class AbstractAgent(
 
         # Prepare stat collector tasks.
         self.timer_tasks.append(
-            aiotools.create_timer(self.collect_node_stat, UTILIZATION_METRIC_INTERVAL)
+            aiotools.create_timer(
+                self.collect_node_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            )
         )
         self.timer_tasks.append(
-            aiotools.create_timer(self.collect_container_stat, UTILIZATION_METRIC_INTERVAL)
+            aiotools.create_timer(
+                self.collect_container_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            )
         )
         self.timer_tasks.append(
-            aiotools.create_timer(self.collect_process_stat, UTILIZATION_METRIC_INTERVAL)
+            aiotools.create_timer(
+                self.collect_process_stat,
+                UTILIZATION_METRIC_INTERVAL,
+                delay_policy=aiotools.TimerDelayPolicy.CANCEL,
+            )
         )
 
         # Prepare heartbeats.


### PR DESCRIPTION
resolves BA-4652

Backport of #9257 to 25.15.

## Summary
- Apply `TimerDelayPolicy.CANCEL` to all stat collection timers (`collect_node_stat`, `collect_container_stat`, `collect_process_stat`) to prevent task accumulation when stat collection exceeds the timer interval.

## Conflict Resolution
- In 25.15, `collect_node_stat` is still in `agent.py` (not moved to `runtime.py`), so the CANCEL policy was applied directly there.
- `runtime.py` changes were dropped since the file doesn't exist in 25.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)