### PR TITLE
fix(BA-4680): skip `produce_error_event()` when EMFILE error occured in `_observe_stat_task`

### DIFF
--- a/changes/9305.fix.md
+++ b/changes/9305.fix.md
@@ -1,1 +1,1 @@
-Skip traceback payload in `produce_error_event()` for EMFILE errors in `_observe_stat_task` to avoid high-volume stack trace payloads during FD exhaustion.
+Skip `produce_error_event()` entirely for EMFILE errors in `_observe_stat_task` to avoid high-volume error event payloads during FD exhaustion.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -804,10 +804,12 @@ def _observe_stat_task(
             except OSError as e:
                 if e.errno == errno.EMFILE:
                     log.warning("skipping {} due to FD exhaustion", func.__name__)
-                    await self.produce_error_event(exc_info=(type(e), e, None))
-                else:
-                    log.exception("unhandled exception in {}", func.__name__)
-                    await self.produce_error_event()
+                    stat_task_observer.observe_stat_task_failure(
+                        agent_id=self.id, stat_scope=stat_scope, exception=e
+                    )
+                    return
+                log.exception("unhandled exception in {}", func.__name__)
+                await self.produce_error_event()
                 stat_task_observer.observe_stat_task_failure(
                     agent_id=self.id, stat_scope=stat_scope, exception=e
                 )

--- a/tests/unit/agent/test_observe_stat_task.py
+++ b/tests/unit/agent/test_observe_stat_task.py
@@ -64,7 +64,7 @@ class TestObserveStatTaskDecorator:
 
         mock_log.warning.assert_called_once()
         mock_log.exception.assert_not_called()
-        mock_agent.produce_error_event.assert_awaited_once()
+        mock_agent.produce_error_event.assert_not_called()
         mock_stat_task_observer.observe_stat_task_failure.assert_called_once()
         mock_stat_task_observer.observe_stat_task_success.assert_not_called()
 
@@ -93,25 +93,6 @@ class TestObserveStatTaskDecorator:
         mock_agent.produce_error_event.assert_awaited_once()
         mock_stat_task_observer.observe_stat_task_failure.assert_called_once()
         mock_stat_task_observer.observe_stat_task_success.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_emfile_produces_error_event_without_traceback(
-        self,
-        mock_agent: AsyncMock,
-        mock_stat_task_observer: Mock,
-    ) -> None:
-        @_observe_stat_task(stat_scope=StatScope.CONTAINER)
-        async def emfile_task(self: object) -> None:
-            raise OSError(errno.EMFILE, "Too many open files")
-
-        await emfile_task(mock_agent)
-
-        mock_agent.produce_error_event.assert_awaited_once()
-        call_args = mock_agent.produce_error_event.call_args
-        exc_info = call_args.kwargs["exc_info"]
-        exc_type, _exc_val, exc_tb = exc_info
-        assert exc_tb is None
-        assert exc_type is OSError
 
     @pytest.mark.asyncio
     async def test_cancelled_error_is_silently_swallowed(


### PR DESCRIPTION
Resolves #9303 (BA-4680)
## Summary
- In the `_observe_stat_task` decorator (merged via PR #9291), the EMFILE branch correctly avoids `log.exception()` but still calls `self.produce_error_event()` unconditionally. `produce_error_event()` internally calls traceback.format_tb(tb) which generates the same high-volume traceback payloads that the EMFILE handling is designed to avoid.

## Solution
In the EMFILE branch, skip `produce_error_event()` entirely so the AgentErrorEvent carries only the exception message without a stack trace.