### PR TITLE
fix(BA-4684): use uid-based prometheus multiprocess dir to avoid permission errors (#9319)

### DIFF
--- a/changes/9319.fix.md
+++ b/changes/9319.fix.md
@@ -1,0 +1,1 @@
+Fix prometheus multiprocess dir permission error by using a uid-based path (`/tmp/backendai.{uid}/prometheus/`) and logging clear errors on `mkdir()` failures.

--- a/src/ai/backend/common/metrics/multiprocess.py
+++ b/src/ai/backend/common/metrics/multiprocess.py
@@ -29,7 +29,8 @@ log = logging.getLogger(__spec__.name)
 
 _multiprocess_dir: Path | None = None
 
-_DEFAULT_BASE_DIR = Path(tempfile.gettempdir()) / "backendai" / "prometheus"
+_uid = os.getuid() if hasattr(os, "getuid") else "common"
+_DEFAULT_BASE_DIR = Path(tempfile.gettempdir()) / f"backendai.{_uid}" / "prometheus"
 
 
 def setup_prometheus_multiprocess_dir(
@@ -55,7 +56,16 @@ def setup_prometheus_multiprocess_dir(
         return _multiprocess_dir
 
     multiprocess_dir = _DEFAULT_BASE_DIR / component
-    multiprocess_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        multiprocess_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.error(
+            "Cannot create prometheus multiprocess dir %s — permission denied. "
+            "Ensure the directory is writable by the current user (uid=%s).",
+            multiprocess_dir,
+            _uid,
+        )
+        raise
 
     # Clean stale .db files from previous runs
     for db_file in multiprocess_dir.glob("*.db"):

--- a/tests/unit/common/test_prometheus_multiprocess.py
+++ b/tests/unit/common/test_prometheus_multiprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -122,3 +123,23 @@ class TestCleanupPrometheusMultiprocDir:
 
         # Should not raise
         cleanup_prometheus_multiprocess_dir()
+
+
+class TestDefaultBaseDirUid:
+    def test_default_base_dir_contains_uid(self) -> None:
+        uid = os.getuid() if hasattr(os, "getuid") else "common"
+        assert f"backendai.{uid}" in str(mp_mod._DEFAULT_BASE_DIR)
+        assert str(mp_mod._DEFAULT_BASE_DIR).endswith("/prometheus")
+
+    def test_setup_raises_on_permission_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path),
+            patch.object(Path, "mkdir", side_effect=PermissionError("mock denied")),
+            caplog.at_level(logging.ERROR),
+        ):
+            with pytest.raises(PermissionError):
+                setup_prometheus_multiprocess_dir("manager")
+
+        assert "permission denied" in caplog.text.lower()


### PR DESCRIPTION
This is an auto-generated backport PR of #9319 to the 26.2 release.