### PR TITLE
fix(BA-4689): restore AppProxyConnectionError HTTP status to 500 (#9330)

### DIFF
--- a/changes/9330.fix.md
+++ b/changes/9330.fix.md
@@ -1,0 +1,1 @@
+Restore AppProxyConnectionError HTTP status code from 503 to 500 to match client-side error handling

--- a/src/ai/backend/manager/errors/appproxy.py
+++ b/src/ai/backend/manager/errors/appproxy.py
@@ -11,7 +11,7 @@ from ai.backend.common.exception import (
 )
 
 
-class AppProxyConnectionError(BackendAIError, web.HTTPServiceUnavailable):
+class AppProxyConnectionError(BackendAIError, web.HTTPInternalServerError):
     """Raised when connection to AppProxy fails."""
 
     error_type = "https://api.backend.ai/probs/appproxy-connection-error"


### PR DESCRIPTION
This is an auto-generated backport PR of #9330 to the 26.2 release.