### PR TITLE
fix(BA-4682): allow fair share and usage bucket queries without resource group membership (#9321)

### DIFF
--- a/changes/9321.fix.md
+++ b/changes/9321.fix.md
@@ -1,0 +1,1 @@
+Allow fair share and usage bucket queries for entities not registered in a resource group, returning default values instead of raising errors.

--- a/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
@@ -46,11 +46,7 @@ from ai.backend.manager.models.resource_usage_history import (
     UsageBucketEntryRow,
     UserUsageBucketRow,
 )
-from ai.backend.manager.models.scaling_group import (
-    ScalingGroupForDomainRow,
-    ScalingGroupForProjectRow,
-    ScalingGroupRow,
-)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.scaling_group.types import FairShareScalingGroupSpec
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base import (
@@ -135,25 +131,20 @@ class FairShareDBSource:
         """Get domain fair share data.
 
         Steps:
-        1. Check if (scaling_group, domain) combination exists in scaling_group_for_domain
+        1. Check if domain exists
         2. Query fair share record with (resource_group, domain_name)
         3. If record exists, convert and return
         4. If no record, create default from scaling group spec
 
         Raises:
-            DomainNotFound: If domain is not associated with the scaling group
+            DomainNotFound: If domain does not exist
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
-            # Step 1: Check scaling_group_for_domain association
-            assoc_query = sa.select(ScalingGroupForDomainRow).where(
-                ScalingGroupForDomainRow.scaling_group == resource_group,
-                ScalingGroupForDomainRow.domain == domain_name,
-            )
-            assoc_result = await db_sess.execute(assoc_query)
-            if assoc_result.one_or_none() is None:
-                raise DomainNotFound(
-                    f"Domain {domain_name} not associated with scaling group {resource_group}"
-                )
+            # Step 1: Check domain existence (no RG membership required)
+            domain_query = sa.select(DomainRow.name).where(DomainRow.name == domain_name)
+            domain_result = await db_sess.execute(domain_query)
+            if domain_result.one_or_none() is None:
+                raise DomainNotFound(domain_name)
 
             # Step 2: Query fair share record
             fs_query = sa.select(DomainFairShareRow).where(
@@ -220,8 +211,9 @@ class FairShareDBSource:
     ) -> DomainFairShareEntitySearchResult:
         """Search domain fair shares within a resource group.
 
-        This method returns all domains associated with a resource group,
-        with complete fair share data (either from records or defaults).
+        This method returns all domains with complete fair share data
+        (either from records or defaults). Domains do not need to be
+        registered in the resource group to appear in results.
 
         Args:
             scope: Required scope with resource_group.
@@ -231,20 +223,18 @@ class FairShareDBSource:
             DomainFairShareEntitySearchResult with domain entities and their complete fair share details.
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
-            # Build LEFT JOIN query: domains associated with resource_group LEFT JOIN fair_share
+            # Build LEFT JOIN query: all domains LEFT JOIN fair_share (filtered by resource_group)
             query = (
                 sa.select(
-                    ScalingGroupForDomainRow.scaling_group,
-                    ScalingGroupForDomainRow.domain,
+                    DomainRow.name.label("domain_name"),
                     DomainFairShareRow,
                 )
-                .select_from(ScalingGroupForDomainRow)
-                .join(DomainRow, ScalingGroupForDomainRow.domain == DomainRow.name)
+                .select_from(DomainRow)
                 .outerjoin(
                     DomainFairShareRow,
                     sa.and_(
-                        ScalingGroupForDomainRow.scaling_group == DomainFairShareRow.resource_group,
-                        ScalingGroupForDomainRow.domain == DomainFairShareRow.domain_name,
+                        DomainRow.name == DomainFairShareRow.domain_name,
+                        DomainFairShareRow.resource_group == scope.resource_group,
                     ),
                 )
             )
@@ -258,8 +248,8 @@ class FairShareDBSource:
 
             items = [
                 self._build_domain_data(
-                    resource_group=row.scaling_group,
-                    domain_name=row.domain,
+                    resource_group=scope.resource_group,
+                    domain_name=row.domain_name,
                     fair_share_row=row.DomainFairShareRow,
                     spec=spec,
                     available_slots=available_slots,
@@ -344,32 +334,22 @@ class FairShareDBSource:
         """Get project fair share data.
 
         Steps:
-        1. Check if (scaling_group, project) combination exists in scaling_group_for_project
+        1. Check if project exists and get domain_name
         2. Query fair share record with (resource_group, project_id)
         3. If record exists, convert and return
         4. If no record, create default from scaling group spec
 
         Raises:
-            ProjectNotFound: If project is not associated with the scaling group
+            ProjectNotFound: If project does not exist
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
-            # Step 1: Check scaling_group_for_project association and get domain_name
-            assoc_query = (
-                sa.select(GroupRow.domain_name)
-                .select_from(ScalingGroupForProjectRow)
-                .join(GroupRow, ScalingGroupForProjectRow.group == GroupRow.id)
-                .where(
-                    ScalingGroupForProjectRow.scaling_group == resource_group,
-                    ScalingGroupForProjectRow.group == project_id,
-                )
-            )
-            assoc_result = await db_sess.execute(assoc_query)
-            assoc_row = assoc_result.one_or_none()
-            if assoc_row is None:
-                raise ProjectNotFound(
-                    f"Project {project_id} not associated with scaling group {resource_group}"
-                )
-            domain_name = assoc_row[0]
+            # Step 1: Check project existence and get domain_name (no RG membership required)
+            project_query = sa.select(GroupRow.domain_name).where(GroupRow.id == project_id)
+            project_result = await db_sess.execute(project_query)
+            project_row = project_result.one_or_none()
+            if project_row is None:
+                raise ProjectNotFound(str(project_id))
+            domain_name = project_row[0]
 
             # Step 2: Query fair share record
             fs_query = sa.select(ProjectFairShareRow).where(
@@ -436,8 +416,9 @@ class FairShareDBSource:
     ) -> ProjectFairShareEntitySearchResult:
         """Search project fair shares within a resource group.
 
-        This method returns all projects associated with a resource group,
-        with complete fair share data (either from records or defaults).
+        This method returns all projects with complete fair share data
+        (either from records or defaults). Projects do not need to be
+        registered in the resource group to appear in results.
 
         Args:
             scope: Required scope with resource_group.
@@ -447,23 +428,20 @@ class FairShareDBSource:
             ProjectFairShareEntitySearchResult with project entities and their complete fair share details.
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
-            # Build LEFT JOIN query: projects associated with resource_group LEFT JOIN fair_share
+            # Build LEFT JOIN query: all projects LEFT JOIN fair_share (filtered by resource_group)
             query = (
                 sa.select(
-                    ScalingGroupForProjectRow.scaling_group,
-                    ScalingGroupForProjectRow.group.label("project_id"),
-                    DomainRow.name.label("domain_name"),
+                    GroupRow.id.label("project_id"),
+                    GroupRow.domain_name.label("domain_name"),
                     ProjectFairShareRow,
                 )
-                .select_from(ScalingGroupForProjectRow)
-                .join(GroupRow, ScalingGroupForProjectRow.group == GroupRow.id)
+                .select_from(GroupRow)
                 .join(DomainRow, GroupRow.domain_name == DomainRow.name)
                 .outerjoin(
                     ProjectFairShareRow,
                     sa.and_(
-                        ScalingGroupForProjectRow.scaling_group
-                        == ProjectFairShareRow.resource_group,
-                        ScalingGroupForProjectRow.group == ProjectFairShareRow.project_id,
+                        GroupRow.id == ProjectFairShareRow.project_id,
+                        ProjectFairShareRow.resource_group == scope.resource_group,
                     ),
                 )
             )
@@ -477,7 +455,7 @@ class FairShareDBSource:
 
             items = [
                 self._build_project_data(
-                    resource_group=row.scaling_group,
+                    resource_group=scope.resource_group,
                     project_id=row.project_id,
                     domain_name=row.domain_name,
                     fair_share_row=row.ProjectFairShareRow,
@@ -790,8 +768,9 @@ class FairShareDBSource:
     ) -> UserFairShareEntitySearchResult:
         """Search user fair shares within a resource group.
 
-        This method returns all users associated with a resource group (via project membership),
-        with complete fair share data (either from records or defaults).
+        This method returns all users (via project membership) with complete
+        fair share data (either from records or defaults). Users do not need
+        to be in a project registered in the resource group to appear in results.
 
         Args:
             scope: Required scope with resource_group.
@@ -802,29 +781,25 @@ class FairShareDBSource:
         """
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             # Build LEFT JOIN query:
-            # Users in projects associated with resource_group LEFT JOIN fair_share
-            # Path: ScalingGroupForProjectRow -> AssocGroupUserRow -> UserFairShareRow
+            # Users via project membership LEFT JOIN fair_share (filtered by resource_group)
+            # Path: AssocGroupUserRow -> GroupRow -> DomainRow -> UserRow -> LEFT JOIN UserFairShareRow
             query = (
                 sa.select(
-                    ScalingGroupForProjectRow.scaling_group,
                     AssocGroupUserRow.user_id.label("user_uuid"),
                     AssocGroupUserRow.group_id.label("project_id"),
                     DomainRow.name.label("domain_name"),
                     UserFairShareRow,
                 )
-                .select_from(ScalingGroupForProjectRow)
-                .join(
-                    AssocGroupUserRow, ScalingGroupForProjectRow.group == AssocGroupUserRow.group_id
-                )
-                .join(GroupRow, ScalingGroupForProjectRow.group == GroupRow.id)
+                .select_from(AssocGroupUserRow)
+                .join(GroupRow, AssocGroupUserRow.group_id == GroupRow.id)
                 .join(DomainRow, GroupRow.domain_name == DomainRow.name)
                 .join(UserRow, AssocGroupUserRow.user_id == UserRow.uuid)
                 .outerjoin(
                     UserFairShareRow,
                     sa.and_(
-                        ScalingGroupForProjectRow.scaling_group == UserFairShareRow.resource_group,
                         AssocGroupUserRow.user_id == UserFairShareRow.user_uuid,
                         AssocGroupUserRow.group_id == UserFairShareRow.project_id,
+                        UserFairShareRow.resource_group == scope.resource_group,
                     ),
                 )
             )
@@ -838,7 +813,7 @@ class FairShareDBSource:
 
             items = [
                 self._build_user_data(
-                    resource_group=row.scaling_group,
+                    resource_group=scope.resource_group,
                     user_uuid=row.user_uuid,
                     project_id=row.project_id,
                     domain_name=row.domain_name,

--- a/src/ai/backend/manager/repositories/fair_share/options.py
+++ b/src/ai/backend/manager/repositories/fair_share/options.py
@@ -17,10 +17,6 @@ from ai.backend.manager.models.fair_share import (
     UserFairShareRow,
 )
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
-from ai.backend.manager.models.scaling_group import (
-    ScalingGroupForDomainRow,
-    ScalingGroupForProjectRow,
-)
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base.types import QueryCondition, QueryOrder
 
@@ -834,14 +830,14 @@ class UserFairShareOrders:
 class RGDomainFairShareConditions:
     """Query conditions for rg-scoped domain fair share queries.
 
-    References ScalingGroupForDomainRow (INNER JOIN'd base table)
-    instead of DomainFairShareRow (LEFT JOIN'd).
+    References DomainRow (base table) for domain_name conditions and
+    DomainFairShareRow (LEFT JOIN'd) for resource_group conditions.
     """
 
     @staticmethod
     def by_domain_name(domain_name: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.domain == domain_name
+            return DomainRow.name == domain_name
 
         return inner
 
@@ -849,9 +845,9 @@ class RGDomainFairShareConditions:
     def by_domain_name_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.domain.ilike(f"%{spec.value}%")
+                condition = DomainRow.name.ilike(f"%{spec.value}%")
             else:
-                condition = ScalingGroupForDomainRow.domain.like(f"%{spec.value}%")
+                condition = DomainRow.name.like(f"%{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -862,9 +858,9 @@ class RGDomainFairShareConditions:
     def by_domain_name_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = sa.func.lower(ScalingGroupForDomainRow.domain) == spec.value.lower()
+                condition = sa.func.lower(DomainRow.name) == spec.value.lower()
             else:
-                condition = ScalingGroupForDomainRow.domain == spec.value
+                condition = DomainRow.name == spec.value
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -875,9 +871,9 @@ class RGDomainFairShareConditions:
     def by_domain_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.domain.ilike(f"{spec.value}%")
+                condition = DomainRow.name.ilike(f"{spec.value}%")
             else:
-                condition = ScalingGroupForDomainRow.domain.like(f"{spec.value}%")
+                condition = DomainRow.name.like(f"{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -888,9 +884,9 @@ class RGDomainFairShareConditions:
     def by_domain_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.domain.ilike(f"%{spec.value}")
+                condition = DomainRow.name.ilike(f"%{spec.value}")
             else:
-                condition = ScalingGroupForDomainRow.domain.like(f"%{spec.value}")
+                condition = DomainRow.name.like(f"%{spec.value}")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -900,7 +896,7 @@ class RGDomainFairShareConditions:
     @staticmethod
     def by_resource_group(resource_group: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group == resource_group
+            return DomainFairShareRow.resource_group == resource_group
 
         return inner
 
@@ -908,9 +904,9 @@ class RGDomainFairShareConditions:
     def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"%{spec.value}%")
+                condition = DomainFairShareRow.resource_group.ilike(f"%{spec.value}%")
             else:
-                condition = ScalingGroupForDomainRow.scaling_group.like(f"%{spec.value}%")
+                condition = DomainFairShareRow.resource_group.like(f"%{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -921,11 +917,9 @@ class RGDomainFairShareConditions:
     def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = (
-                    sa.func.lower(ScalingGroupForDomainRow.scaling_group) == spec.value.lower()
-                )
+                condition = sa.func.lower(DomainFairShareRow.resource_group) == spec.value.lower()
             else:
-                condition = ScalingGroupForDomainRow.scaling_group == spec.value
+                condition = DomainFairShareRow.resource_group == spec.value
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -936,9 +930,9 @@ class RGDomainFairShareConditions:
     def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"{spec.value}%")
+                condition = DomainFairShareRow.resource_group.ilike(f"{spec.value}%")
             else:
-                condition = ScalingGroupForDomainRow.scaling_group.like(f"{spec.value}%")
+                condition = DomainFairShareRow.resource_group.like(f"{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -949,9 +943,9 @@ class RGDomainFairShareConditions:
     def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForDomainRow.scaling_group.ilike(f"%{spec.value}")
+                condition = DomainFairShareRow.resource_group.ilike(f"%{spec.value}")
             else:
-                condition = ScalingGroupForDomainRow.scaling_group.like(f"%{spec.value}")
+                condition = DomainFairShareRow.resource_group.like(f"%{spec.value}")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -962,26 +956,26 @@ class RGDomainFairShareConditions:
 class RGDomainFairShareOrders:
     """Query orders for rg-scoped domain fair share queries.
 
-    Uses INNER JOIN'd columns where available to avoid NULL sorting issues.
+    Uses DomainRow (base table) columns for reliable sorting.
     """
 
     @staticmethod
     def by_domain_name(ascending: bool = True) -> QueryOrder:
-        col = ScalingGroupForDomainRow.domain
+        col = DomainRow.name
         return col.asc() if ascending else col.desc()
 
 
 class RGProjectFairShareConditions:
     """Query conditions for rg-scoped project fair share queries.
 
-    References ScalingGroupForProjectRow/GroupRow/DomainRow (INNER JOIN'd)
-    instead of ProjectFairShareRow (LEFT JOIN'd).
+    References GroupRow (base table) for project conditions, DomainRow (INNER JOIN'd)
+    for domain conditions, and ProjectFairShareRow (LEFT JOIN'd) for resource_group conditions.
     """
 
     @staticmethod
     def by_project_id(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            condition = ScalingGroupForProjectRow.group == spec.value
+            condition = GroupRow.id == spec.value
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -991,7 +985,7 @@ class RGProjectFairShareConditions:
     @staticmethod
     def by_project_ids(spec: UUIDInMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            condition = ScalingGroupForProjectRow.group.in_(spec.values)
+            condition = GroupRow.id.in_(spec.values)
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1060,7 +1054,7 @@ class RGProjectFairShareConditions:
     @staticmethod
     def by_resource_group(resource_group: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group == resource_group
+            return ProjectFairShareRow.resource_group == resource_group
 
         return inner
 
@@ -1068,9 +1062,9 @@ class RGProjectFairShareConditions:
     def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}%")
+                condition = ProjectFairShareRow.resource_group.ilike(f"%{spec.value}%")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}%")
+                condition = ProjectFairShareRow.resource_group.like(f"%{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1081,11 +1075,9 @@ class RGProjectFairShareConditions:
     def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = (
-                    sa.func.lower(ScalingGroupForProjectRow.scaling_group) == spec.value.lower()
-                )
+                condition = sa.func.lower(ProjectFairShareRow.resource_group) == spec.value.lower()
             else:
-                condition = ScalingGroupForProjectRow.scaling_group == spec.value
+                condition = ProjectFairShareRow.resource_group == spec.value
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1096,9 +1088,9 @@ class RGProjectFairShareConditions:
     def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"{spec.value}%")
+                condition = ProjectFairShareRow.resource_group.ilike(f"{spec.value}%")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"{spec.value}%")
+                condition = ProjectFairShareRow.resource_group.like(f"{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1109,9 +1101,9 @@ class RGProjectFairShareConditions:
     def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}")
+                condition = ProjectFairShareRow.resource_group.ilike(f"%{spec.value}")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}")
+                condition = ProjectFairShareRow.resource_group.like(f"%{spec.value}")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1122,8 +1114,8 @@ class RGProjectFairShareConditions:
 class RGUserFairShareConditions:
     """Query conditions for rg-scoped user fair share queries.
 
-    References AssocGroupUserRow/DomainRow/ScalingGroupForProjectRow (INNER JOIN'd)
-    instead of UserFairShareRow (LEFT JOIN'd).
+    References AssocGroupUserRow (base table), GroupRow/DomainRow/UserRow (INNER JOIN'd),
+    and UserFairShareRow (LEFT JOIN'd) for resource_group conditions.
     """
 
     @staticmethod
@@ -1228,7 +1220,7 @@ class RGUserFairShareConditions:
     @staticmethod
     def by_resource_group(resource_group: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForProjectRow.scaling_group == resource_group
+            return UserFairShareRow.resource_group == resource_group
 
         return inner
 
@@ -1236,9 +1228,9 @@ class RGUserFairShareConditions:
     def by_resource_group_contains(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}%")
+                condition = UserFairShareRow.resource_group.ilike(f"%{spec.value}%")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}%")
+                condition = UserFairShareRow.resource_group.like(f"%{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1249,11 +1241,9 @@ class RGUserFairShareConditions:
     def by_resource_group_equals(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = (
-                    sa.func.lower(ScalingGroupForProjectRow.scaling_group) == spec.value.lower()
-                )
+                condition = sa.func.lower(UserFairShareRow.resource_group) == spec.value.lower()
             else:
-                condition = ScalingGroupForProjectRow.scaling_group == spec.value
+                condition = UserFairShareRow.resource_group == spec.value
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1264,9 +1254,9 @@ class RGUserFairShareConditions:
     def by_resource_group_starts_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"{spec.value}%")
+                condition = UserFairShareRow.resource_group.ilike(f"{spec.value}%")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"{spec.value}%")
+                condition = UserFairShareRow.resource_group.like(f"{spec.value}%")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition
@@ -1277,9 +1267,9 @@ class RGUserFairShareConditions:
     def by_resource_group_ends_with(spec: StringMatchSpec) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             if spec.case_insensitive:
-                condition = ScalingGroupForProjectRow.scaling_group.ilike(f"%{spec.value}")
+                condition = UserFairShareRow.resource_group.ilike(f"%{spec.value}")
             else:
-                condition = ScalingGroupForProjectRow.scaling_group.like(f"%{spec.value}")
+                condition = UserFairShareRow.resource_group.like(f"%{spec.value}")
             if spec.negated:
                 condition = sa.not_(condition)
             return condition

--- a/src/ai/backend/manager/repositories/fair_share/types.py
+++ b/src/ai/backend/manager/repositories/fair_share/types.py
@@ -23,11 +23,7 @@ from ai.backend.manager.errors.resource import (
 )
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.scaling_group import (
-    ScalingGroupForDomainRow,
-    ScalingGroupForProjectRow,
-    ScalingGroupRow,
-)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 __all__ = (
@@ -56,11 +52,14 @@ class DomainFairShareSearchScope(SearchScope):
     """Required. The scaling group to search within."""
 
     def to_condition(self) -> QueryCondition:
-        """Convert scope to a query condition for ScalingGroupForDomainRow."""
-        resource_group = self.resource_group
+        """Convert scope to a query condition for DomainRow.
+
+        Returns a trivial condition since all domains are included;
+        the resource_group filter is applied in the LEFT JOIN condition.
+        """
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return ScalingGroupForDomainRow.scaling_group == resource_group
+            return sa.literal(True)
 
         return inner
 
@@ -90,15 +89,15 @@ class ProjectFairShareSearchScope(SearchScope):
     """Required. The domain to search within."""
 
     def to_condition(self) -> QueryCondition:
-        """Convert scope to a query condition for ScalingGroupForProjectRow joined with DomainRow."""
-        resource_group = self.resource_group
+        """Convert scope to a query condition for GroupRow filtered by domain.
+
+        The resource_group filter is applied in the LEFT JOIN condition,
+        so only the domain filter is needed here.
+        """
         domain_name = self.domain_name
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return sa.and_(
-                ScalingGroupForProjectRow.scaling_group == resource_group,
-                DomainRow.name == domain_name,
-            )
+            return GroupRow.domain_name == domain_name
 
         return inner
 
@@ -136,15 +135,17 @@ class UserFairShareSearchScope(SearchScope):
     """Required. The project to search within."""
 
     def to_condition(self) -> QueryCondition:
-        """Convert scope to a query condition for ScalingGroupForProjectRow joined with DomainRow and GroupRow."""
-        resource_group = self.resource_group
+        """Convert scope to a query condition for GroupRow filtered by domain and project.
+
+        The resource_group filter is applied in the LEFT JOIN condition,
+        so only domain and project filters are needed here.
+        """
         domain_name = self.domain_name
         project_id = self.project_id
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
-                ScalingGroupForProjectRow.scaling_group == resource_group,
-                DomainRow.name == domain_name,
+                GroupRow.domain_name == domain_name,
                 GroupRow.id == project_id,
             )
 

--- a/src/ai/backend/manager/repositories/resource_usage_history/types.py
+++ b/src/ai/backend/manager/repositories/resource_usage_history/types.py
@@ -216,8 +216,8 @@ class DomainUsageBucketSearchScope(SearchScope):
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
-                DomainUsageBucketRow.resource_group == resource_group,
                 DomainUsageBucketRow.domain_name == domain_name,
+                DomainUsageBucketRow.resource_group == resource_group,
             )
 
         return inner
@@ -253,9 +253,9 @@ class ProjectUsageBucketSearchScope(SearchScope):
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
-                ProjectUsageBucketRow.resource_group == resource_group,
                 ProjectUsageBucketRow.domain_name == domain_name,
                 ProjectUsageBucketRow.project_id == project_id,
+                ProjectUsageBucketRow.resource_group == resource_group,
             )
 
         return inner
@@ -298,10 +298,10 @@ class UserUsageBucketSearchScope(SearchScope):
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
-                UserUsageBucketRow.resource_group == resource_group,
                 UserUsageBucketRow.domain_name == domain_name,
                 UserUsageBucketRow.project_id == project_id,
                 UserUsageBucketRow.user_uuid == user_uuid,
+                UserUsageBucketRow.resource_group == resource_group,
             )
 
         return inner

--- a/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
+++ b/tests/unit/manager/repositories/fair_share/test_entity_based_search.py
@@ -438,12 +438,15 @@ class TestSearchDomainFairSharesEntityBased:
         assert result_domains[domain_without_record].data.metadata is None
 
     @pytest.mark.asyncio
-    async def test_filters_by_resource_group_in_scope(
+    async def test_returns_all_domains_regardless_of_rg_membership(
         self,
         fair_share_repository: FairShareRepository,
         two_scaling_groups_with_domains: TwoScalingGroupsFixture,
     ) -> None:
-        """Search should only return domains associated with resource_group in scope."""
+        """BA-4682: Search should return ALL domains, not just RG-registered ones.
+
+        Both domains appear in results; fair share data is from the queried RG.
+        """
         fixture = two_scaling_groups_with_domains
         scope = DomainFairShareSearchScope(resource_group=fixture.rg1)
         querier = BatchQuerier(
@@ -454,9 +457,14 @@ class TestSearchDomainFairSharesEntityBased:
 
         result = await fair_share_repository.search_rg_domain_fair_shares(scope, querier)
 
-        assert result.total_count == 1
-        assert len(result.items) == 1
-        assert result.items[0].domain_name == fixture.domain_in_rg1
+        assert result.total_count == 2
+        assert len(result.items) == 2
+        result_domains = {d.domain_name: d for d in result.items}
+        assert fixture.domain_in_rg1 in result_domains
+        assert fixture.domain_in_rg2 in result_domains
+        # Both get default data since no fair share records exist
+        assert result_domains[fixture.domain_in_rg1].data.use_default is True
+        assert result_domains[fixture.domain_in_rg2].data.use_default is True
 
     @pytest.mark.asyncio
     async def test_pagination_includes_all_entities(
@@ -554,6 +562,56 @@ class TestSearchDomainFairSharesEntityBased:
         assert result_with.total_count == 1
         assert result_with.items[0].domain_name == domain_with_record
         assert result_with.items[0].data.use_default is False
+
+    # ==================== BA-4682: Non-RG-member entity search regression ====================
+
+    @pytest.fixture
+    async def domain_not_in_rg(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> str:
+        """Create a domain NOT associated with any scaling group."""
+        domain_name = f"no-rg-domain-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                DomainRow(
+                    name=domain_name,
+                    description="Domain not in any RG",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            await db_sess.commit()
+        return domain_name
+
+    @pytest.mark.asyncio
+    async def test_search_includes_domain_not_in_rg(
+        self,
+        fair_share_repository: FairShareRepository,
+        scaling_group: str,
+        domain_with_record: str,
+        domain_not_in_rg: str,
+    ) -> None:
+        """BA-4682: Domain not in any RG should appear in search results with defaults."""
+        scope = DomainFairShareSearchScope(resource_group=scaling_group)
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=100, offset=0),
+            conditions=[],
+            orders=[],
+        )
+
+        result = await fair_share_repository.search_rg_domain_fair_shares(scope, querier)
+
+        assert result.total_count == 2
+        result_domains = {d.domain_name: d for d in result.items}
+        assert domain_with_record in result_domains
+        assert domain_not_in_rg in result_domains
+        # Domain in RG with record: use_default=False
+        assert result_domains[domain_with_record].data.use_default is False
+        # Domain not in any RG: use_default=True (defaults from queried RG)
+        assert result_domains[domain_not_in_rg].data.use_default is True
 
 
 class TestSearchProjectFairSharesEntityBased:
@@ -875,6 +933,71 @@ class TestSearchProjectFairSharesEntityBased:
         assert len(result.items) == 1
         assert result.items[0].project_id == project_without_record
         assert result.items[0].data.use_default is True
+
+    # ==================== BA-4682: Non-RG-member entity search regression ====================
+
+    @pytest.fixture
+    async def project_not_in_rg(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+    ) -> uuid.UUID:
+        """Create a project NOT associated with any scaling group."""
+        project_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy_name = f"test-policy-{uuid.uuid4().hex[:8]}"
+            db_sess.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_network_count=10,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(
+                GroupRow(
+                    id=project_id,
+                    name=f"no-rg-project-{project_id.hex[:8]}",
+                    domain_name=domain_name,
+                    description="Project not in any RG",
+                    resource_policy=policy_name,
+                )
+            )
+            await db_sess.commit()
+        return project_id
+
+    @pytest.mark.asyncio
+    async def test_search_includes_project_not_in_rg(
+        self,
+        fair_share_repository: FairShareRepository,
+        scaling_group: str,
+        domain_name: str,
+        project_with_record: uuid.UUID,
+        project_not_in_rg: uuid.UUID,
+    ) -> None:
+        """BA-4682: Project not in any RG should appear in search results with defaults."""
+        scope = ProjectFairShareSearchScope(
+            resource_group=scaling_group,
+            domain_name=domain_name,
+        )
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=100, offset=0),
+            conditions=[],
+            orders=[],
+        )
+
+        result = await fair_share_repository.search_rg_project_fair_shares(scope, querier)
+
+        assert result.total_count == 2
+        result_projects = {p.project_id: p for p in result.items}
+        assert project_with_record in result_projects
+        assert project_not_in_rg in result_projects
+        # Project in RG with record: use_default=False
+        assert result_projects[project_with_record].data.use_default is False
+        # Project not in any RG: use_default=True
+        assert result_projects[project_not_in_rg].data.use_default is True
 
 
 class TestSearchUserFairSharesEntityBased:

--- a/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
+++ b/tests/unit/manager/repositories/fair_share/test_fair_share_repository.py
@@ -723,3 +723,93 @@ class TestFairShareRepository:
         assert result.user_uuid == test_user_uuid
         assert result.project_id == test_project_id
         assert result.data.spec.weight == Decimal("1.8")
+
+    # ==================== Regression: Non-RG-member lookup tests (BA-4682) ====================
+
+    @pytest.fixture
+    async def domain_not_in_rg(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> str:
+        """Create a domain NOT associated with any scaling group."""
+        domain_name = f"no-rg-domain-{uuid.uuid4().hex[:8]}"
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            domain = DomainRow(
+                name=domain_name,
+                description="Domain not in any RG",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+                allowed_docker_registries=[],
+            )
+            db_sess.add(domain)
+            await db_sess.commit()
+
+        return domain_name
+
+    @pytest.fixture
+    async def project_not_in_rg(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_not_in_rg: str,
+    ) -> uuid.UUID:
+        """Create a project NOT associated with any scaling group."""
+        project_id = uuid.uuid4()
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy_name = f"test-project-policy-{uuid.uuid4().hex[:8]}"
+            policy = ProjectResourcePolicyRow(
+                name=policy_name,
+                max_vfolder_count=10,
+                max_quota_scope_size=-1,
+                max_network_count=10,
+            )
+            db_sess.add(policy)
+            await db_sess.flush()
+
+            group = GroupRow(
+                id=project_id,
+                name=f"no-rg-project-{project_id.hex[:8]}",
+                domain_name=domain_not_in_rg,
+                description="Project not in any RG",
+                resource_policy=policy_name,
+            )
+            db_sess.add(group)
+            await db_sess.commit()
+
+        return project_id
+
+    @pytest.mark.asyncio
+    async def test_get_domain_fair_share_without_rg_membership(
+        self,
+        fair_share_repository: FairShareRepository,
+        test_scaling_group: str,
+        domain_not_in_rg: str,
+    ) -> None:
+        """BA-4682: Domain not in any RG should return default fair share, not raise."""
+        result = await fair_share_repository.get_domain_fair_share(
+            resource_group=test_scaling_group,
+            domain_name=domain_not_in_rg,
+        )
+
+        assert result.domain_name == domain_not_in_rg
+        assert result.resource_group == test_scaling_group
+        assert result.data.use_default is True
+
+    @pytest.mark.asyncio
+    async def test_get_project_fair_share_without_rg_membership(
+        self,
+        fair_share_repository: FairShareRepository,
+        test_scaling_group: str,
+        project_not_in_rg: uuid.UUID,
+    ) -> None:
+        """BA-4682: Project not in any RG should return default fair share, not raise."""
+        result = await fair_share_repository.get_project_fair_share(
+            resource_group=test_scaling_group,
+            project_id=project_not_in_rg,
+        )
+
+        assert result.project_id == project_not_in_rg
+        assert result.resource_group == test_scaling_group
+        assert result.data.use_default is True


### PR DESCRIPTION
This is an auto-generated backport PR of #9321 to the 26.2 release.