### PR TITLE
fix(BA-4695): skip TERMINATING state on force-terminate (#9341)

### DIFF
--- a/changes/9341.fix.md
+++ b/changes/9341.fix.md
@@ -1,0 +1,1 @@
+Skip TERMINATING state and transition directly to TERMINATED on force-terminate to immediately free resources

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -745,10 +745,14 @@ class ScheduleDBSource:
         return dict(dependencies_by_session)
 
     async def mark_sessions_terminating(
-        self, session_ids: list[SessionId], reason: str = "USER_REQUESTED"
+        self,
+        session_ids: list[SessionId],
+        reason: str = "USER_REQUESTED",
+        *,
+        forced: bool = False,
     ) -> MarkTerminatingResult:
         """
-        Mark sessions and their kernels as TERMINATING.
+        Mark sessions and their kernels as TERMINATING (or directly TERMINATED when forced).
         Uses UPDATE ... WHERE ... RETURNING for atomic status transitions.
         Returns categorized session IDs based on their current status.
         """
@@ -759,18 +763,29 @@ class ScheduleDBSource:
                 db_sess, session_ids, reason, now
             )
 
-            # 2. Mark resource-occupying sessions as terminating
-            terminating_sessions = await self._mark_sessions_as_terminating(
-                db_sess, session_ids, reason, now
-            )
+            if forced:
+                # 2a. Force-terminate: set sessions directly to TERMINATED
+                force_terminated_sessions = await self._mark_sessions_as_force_terminated(
+                    db_sess, session_ids, reason, now
+                )
+                terminating_sessions: list[SessionId] = []
+            else:
+                # 2b. Normal: mark sessions as TERMINATING
+                force_terminated_sessions = []
+                terminating_sessions = await self._mark_sessions_as_terminating(
+                    db_sess, session_ids, reason, now
+                )
 
             # 3. Mark unprocessed sessions as skipped
-            processed_ids = set(cancelled_sessions) | set(terminating_sessions)
+            processed_ids = (
+                set(cancelled_sessions) | set(terminating_sessions) | set(force_terminated_sessions)
+            )
             skipped_sessions = [sid for sid in session_ids if sid not in processed_ids]
 
             return MarkTerminatingResult(
                 cancelled_sessions=cancelled_sessions,
                 terminating_sessions=terminating_sessions,
+                force_terminated_sessions=force_terminated_sessions,
                 skipped_sessions=skipped_sessions,
             )
 
@@ -868,6 +883,66 @@ class ScheduleDBSource:
             )
 
         return terminating_sessions
+
+    async def _mark_sessions_as_force_terminated(
+        self, db_sess: SASession, session_ids: list[SessionId], reason: str, now: datetime
+    ) -> list[SessionId]:
+        """Directly mark terminatable sessions and their kernels as TERMINATED (force-terminate)."""
+        now_iso = now.isoformat()
+        # Mark sessions as TERMINATED directly, recording both TERMINATING and TERMINATED timestamps
+        terminated_stmt = (
+            sa.update(SessionRow)
+            .values(
+                status=SessionStatus.TERMINATED,
+                status_info=reason,
+                terminated_at=now,
+                status_history=sql_json_merge(
+                    SessionRow.__table__.c.status_history,
+                    (),
+                    {
+                        SessionStatus.TERMINATING.name: now_iso,
+                        SessionStatus.TERMINATED.name: now_iso,
+                    },
+                ),
+            )
+            .where(
+                sa.and_(
+                    SessionRow.id.in_(session_ids),
+                    SessionRow.status.in_(SessionStatus.terminatable_statuses()),
+                )
+            )
+            .returning(SessionRow.id)
+        )
+        terminated_result = await db_sess.execute(terminated_stmt)
+        force_terminated_sessions = [cast(SessionId, row.id) for row in terminated_result]
+
+        # Mark kernels as TERMINATED directly
+        if force_terminated_sessions:
+            await db_sess.execute(
+                sa.update(KernelRow)
+                .values(
+                    status=KernelStatus.TERMINATED,
+                    status_info=reason,
+                    status_changed=now,
+                    terminated_at=now,
+                    status_history=sql_json_merge(
+                        KernelRow.__table__.c.status_history,
+                        (),
+                        {
+                            KernelStatus.TERMINATING.name: now_iso,
+                            KernelStatus.TERMINATED.name: now_iso,
+                        },
+                    ),
+                )
+                .where(
+                    sa.and_(
+                        KernelRow.session_id.in_(force_terminated_sessions),
+                        KernelRow.status.in_(KernelStatus.terminatable_statuses()),
+                    )
+                )
+            )
+
+        return force_terminated_sessions
 
     async def get_schedulable_scaling_groups(self) -> list[str]:
         """Get list of scaling groups that have schedulable agents."""

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -155,13 +155,17 @@ class SchedulerRepository:
 
     @scheduler_repository_resilience.apply()
     async def mark_sessions_terminating(
-        self, session_ids: list[SessionId], reason: str = "USER_REQUESTED"
+        self,
+        session_ids: list[SessionId],
+        reason: str = "USER_REQUESTED",
+        *,
+        forced: bool = False,
     ) -> MarkTerminatingResult:
         """
         Mark sessions for termination.
         """
         # Delegate to DB source
-        return await self._db_source.mark_sessions_terminating(session_ids, reason)
+        return await self._db_source.mark_sessions_terminating(session_ids, reason, forced=forced)
 
     @scheduler_repository_resilience.apply()
     async def get_schedulable_scaling_groups(self) -> list[str]:

--- a/src/ai/backend/manager/repositories/scheduler/types/session.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session.py
@@ -168,14 +168,21 @@ class MarkTerminatingResult:
 
     cancelled_sessions: list[SessionId]  # Sessions that were cancelled (PENDING)
     terminating_sessions: list[SessionId]  # Sessions marked as TERMINATING
+    force_terminated_sessions: list[SessionId]  # Sessions directly set to TERMINATED (forced)
     skipped_sessions: list[
         SessionId
     ]  # Sessions not processed (already terminated, not found, etc.)
 
     def has_processed(self) -> bool:
         """Check if any sessions were actually processed (state changed)."""
-        return bool(self.cancelled_sessions or self.terminating_sessions)
+        return bool(
+            self.cancelled_sessions or self.terminating_sessions or self.force_terminated_sessions
+        )
 
     def processed_count(self) -> int:
         """Get count of sessions that were actually processed."""
-        return len(self.cancelled_sessions) + len(self.terminating_sessions)
+        return (
+            len(self.cancelled_sessions)
+            + len(self.terminating_sessions)
+            + len(self.force_terminated_sessions)
+        )

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -752,12 +752,13 @@ class SessionService:
         mark_result = await self._scheduling_controller.mark_sessions_for_termination(
             session_ids,
             reason=reason.value,
+            forced=forced,
         )
 
-        # Build stats for response - prioritize cancelled over terminating
+        # Build stats for response - prioritize cancelled over terminating/force-terminated
         if mark_result.cancelled_sessions:
             last_stat = {"status": "cancelled"}
-        elif mark_result.terminating_sessions:
+        elif mark_result.terminating_sessions or mark_result.force_terminated_sessions:
             last_stat = {"status": "terminated"}
         else:
             last_stat = {}

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -319,32 +319,38 @@ class SchedulingController:
         self,
         session_ids: list[SessionId],
         reason: str = "USER_REQUESTED",
+        *,
+        forced: bool = False,
     ) -> MarkTerminatingResult:
         """
         Mark multiple sessions and their kernels for termination by updating their status to TERMINATING.
 
-        This method handles the lifecycle management of sessions by marking them
-        for termination, which will be processed by the scheduler's terminate_sessions method.
-        It also automatically requests TERMINATE scheduling if sessions were processed.
+        When forced=True, sessions skip TERMINATING and go directly to TERMINATED so the manager
+        immediately considers the session done and frees resources.
 
         Args:
             session_ids: List of session IDs to terminate
             reason: Reason for termination
+            forced: If True, skip TERMINATING and set directly to TERMINATED
 
         Returns:
             MarkTerminatingResult with categorized session statuses
         """
-        result = await self._repository.mark_sessions_terminating(session_ids, reason)
+        result = await self._repository.mark_sessions_terminating(
+            session_ids, reason, forced=forced
+        )
 
         if result.has_processed():
             log.info(
-                "Marked {} sessions for termination (cancelled: {}, terminating: {})",
+                "Marked {} sessions for termination"
+                " (cancelled: {}, terminating: {}, force_terminated: {})",
                 result.processed_count(),
                 len(result.cancelled_sessions),
                 len(result.terminating_sessions),
+                len(result.force_terminated_sessions),
             )
 
-            # Broadcast status events for cancelled and terminating sessions
+            # Broadcast status events for cancelled, terminating, and force-terminated sessions
             broadcast_events: list[AbstractBroadcastEvent] = [
                 SchedulingBroadcastEvent(
                     session_id=session_id,
@@ -363,6 +369,15 @@ class SchedulingController:
                 )
                 for session_id in result.terminating_sessions
             ])
+            broadcast_events.extend([
+                SchedulingBroadcastEvent(
+                    session_id=session_id,
+                    creation_id="",
+                    status_transition=str(SessionStatus.TERMINATED),
+                    reason=reason,
+                )
+                for session_id in result.force_terminated_sessions
+            ])
             if broadcast_events:
                 await self._event_producer.broadcast_events_batch(broadcast_events)
             # Record metric for termination attempts
@@ -371,6 +386,7 @@ class SchedulingController:
                 count=result.processed_count(),
             )
             # Request termination scheduling for the next cycle
+            # For force-terminated sessions, agents still need cleanup RPCs
             await self.mark_scheduling_needed([ScheduleType.TERMINATE])
 
         return result

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -488,6 +488,7 @@ class TestDestroySession:
             return_value=MarkTerminatingResult(
                 cancelled_sessions=[sample_session_id],
                 terminating_sessions=[],
+                force_terminated_sessions=[],
                 skipped_sessions=[],
             )
         )
@@ -515,12 +516,48 @@ class TestDestroySession:
         sample_session_id: SessionId,
         sample_access_key: AccessKey,
     ) -> None:
-        """Test successfully destroying session (terminated status)"""
+        """Test successfully destroying session (terminated status via normal termination)"""
         mock_session_repository.get_target_session_ids = AsyncMock(return_value=[sample_session_id])
         mock_scheduling_controller.mark_sessions_for_termination = AsyncMock(
             return_value=MarkTerminatingResult(
                 cancelled_sessions=[],
                 terminating_sessions=[sample_session_id],
+                force_terminated_sessions=[],
+                skipped_sessions=[],
+            )
+        )
+
+        action = DestroySessionAction(
+            user_role=UserRole.USER,
+            session_name="test-session",
+            forced=False,
+            recursive=False,
+            owner_access_key=sample_access_key,
+        )
+        result = await session_service.destroy_session(action)
+
+        assert result.result == {"stats": {"status": "terminated"}}
+        mock_scheduling_controller.mark_sessions_for_termination.assert_called_once_with(
+            [sample_session_id],
+            reason="user-requested",
+            forced=False,
+        )
+
+    async def test_force_terminate_directly_terminated(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        mock_scheduling_controller: MagicMock,
+        sample_session_id: SessionId,
+        sample_access_key: AccessKey,
+    ) -> None:
+        """Test force-terminate skips TERMINATING and goes directly to TERMINATED"""
+        mock_session_repository.get_target_session_ids = AsyncMock(return_value=[sample_session_id])
+        mock_scheduling_controller.mark_sessions_for_termination = AsyncMock(
+            return_value=MarkTerminatingResult(
+                cancelled_sessions=[],
+                terminating_sessions=[],
+                force_terminated_sessions=[sample_session_id],
                 skipped_sessions=[],
             )
         )
@@ -535,6 +572,11 @@ class TestDestroySession:
         result = await session_service.destroy_session(action)
 
         assert result.result == {"stats": {"status": "terminated"}}
+        mock_scheduling_controller.mark_sessions_for_termination.assert_called_once_with(
+            [sample_session_id],
+            reason="force-terminated",
+            forced=True,
+        )
 
     async def test_recursive_destroy(
         self,
@@ -550,6 +592,7 @@ class TestDestroySession:
             return_value=MarkTerminatingResult(
                 cancelled_sessions=session_ids,
                 terminating_sessions=[],
+                force_terminated_sessions=[],
                 skipped_sessions=[],
             )
         )
@@ -581,6 +624,7 @@ class TestDestroySession:
             return_value=MarkTerminatingResult(
                 cancelled_sessions=[],
                 terminating_sessions=[],
+                force_terminated_sessions=[],
                 skipped_sessions=[],
             )
         )

--- a/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
@@ -23,8 +23,10 @@ from ai.backend.common.types import (
     VFolderMount,
     VFolderUsageMode,
 )
+from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts
+from ai.backend.manager.repositories.scheduler import MarkTerminatingResult
 from ai.backend.manager.repositories.scheduler.types.session_creation import (
     AllowedScalingGroup,
     ContainerUserInfo,
@@ -1022,3 +1024,67 @@ class TestMultiClusterScenarios:
         # All should have same image
         for kernel in session_data.kernels:
             assert kernel.image == "llm:server"
+
+
+@pytest.mark.asyncio
+class TestMarkSessionsForTermination:
+    """Test cases for SchedulingController.mark_sessions_for_termination"""
+
+    async def test_force_terminate_broadcasts_terminated_event(
+        self, scheduling_controller: Any, mock_repository: AsyncMock
+    ) -> None:
+        """Test that forced=True results in TERMINATED broadcast events."""
+        session_id = SessionId(uuid.uuid4())
+        mock_repository.mark_sessions_terminating = AsyncMock(
+            return_value=MarkTerminatingResult(
+                cancelled_sessions=[],
+                terminating_sessions=[],
+                force_terminated_sessions=[session_id],
+                skipped_sessions=[],
+            )
+        )
+
+        result = await scheduling_controller.mark_sessions_for_termination(
+            [session_id], reason="FORCE_TERMINATED", forced=True
+        )
+
+        assert result.force_terminated_sessions == [session_id]
+        assert result.terminating_sessions == []
+        mock_repository.mark_sessions_terminating.assert_called_once_with(
+            [session_id], "FORCE_TERMINATED", forced=True
+        )
+
+        # Verify TERMINATED event was broadcast
+        event_producer = scheduling_controller._event_producer
+        event_producer.broadcast_events_batch.assert_called_once()
+        broadcast_events = event_producer.broadcast_events_batch.call_args[0][0]
+        assert len(broadcast_events) == 1
+        assert broadcast_events[0].status_transition == str(SessionStatus.TERMINATED)
+
+    async def test_normal_terminate_broadcasts_terminating_event(
+        self, scheduling_controller: Any, mock_repository: AsyncMock
+    ) -> None:
+        """Test that forced=False results in TERMINATING broadcast events."""
+        session_id = SessionId(uuid.uuid4())
+        mock_repository.mark_sessions_terminating = AsyncMock(
+            return_value=MarkTerminatingResult(
+                cancelled_sessions=[],
+                terminating_sessions=[session_id],
+                force_terminated_sessions=[],
+                skipped_sessions=[],
+            )
+        )
+
+        result = await scheduling_controller.mark_sessions_for_termination(
+            [session_id], reason="USER_REQUESTED", forced=False
+        )
+
+        assert result.terminating_sessions == [session_id]
+        assert result.force_terminated_sessions == []
+
+        # Verify TERMINATING event was broadcast
+        event_producer = scheduling_controller._event_producer
+        event_producer.broadcast_events_batch.assert_called_once()
+        broadcast_events = event_producer.broadcast_events_batch.call_args[0][0]
+        assert len(broadcast_events) == 1
+        assert broadcast_events[0].status_transition == str(SessionStatus.TERMINATING)


### PR DESCRIPTION
This is an auto-generated backport PR of #9341 to the 26.2 release.