### PR TITLE
chore(BA-4706): enable local pants check/test and fix pre-push.sh fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,18 +37,17 @@ Skills are in `.claude/skills/{name}/SKILL.md`. See `.claude/skills/README.md` f
 
 ## Before Committing
 
-Always run these commands and fix all errors:
+Before committing, run these commands and fix all errors:
 
 ```bash
-pants fmt ::
-pants fix ::
+pants fmt --changed-since=HEAD~1
+pants fix --changed-since=HEAD~1
 pants lint --changed-since=HEAD~1
+pants check --changed-since=HEAD~1
+pants test --changed-since=HEAD~1
 ```
 
-The pre-commit hook runs `pants fmt` and `pants lint` automatically.
-Type checking (`pants check`) and tests (`pants test`) are enforced by CI only — do **not** run them locally.
-
-**Fix all lint errors - never suppress or skip.**
+**Fix all lint, type, and test errors — never suppress or skip.**
 
 ## Development Guidelines
 

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -23,9 +23,9 @@ CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if ! command -v gh &> /dev/null; then
-  echo "GitHub CLI (gh) is not installed. Since we cannot determine the base branch, running the full check before push."
-  pants tailor --check update-build-files --check ::
-  pants lint check ::
+  echo "GitHub CLI (gh) is not installed. Running lint on HEAD~1."
+  pants tailor --check update-build-files --check --changed-since=HEAD~1
+  pants lint --changed-since=HEAD~1
 else
   # Get the base branch name from GitHub if we are on a pull request.
   BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName' 2>/dev/null || true)
@@ -55,5 +55,5 @@ else
   fi
   echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
   pants tailor --check update-build-files --check --changed-since="${ORIGIN}/${BASE_BRANCH}"
-  pants lint check --changed-since="${ORIGIN}/${BASE_BRANCH}"
+  pants lint --changed-since="${ORIGIN}/${BASE_BRANCH}"
 fi


### PR DESCRIPTION
## Summary
- `CLAUDE.md`: allow `pants fmt/fix/lint/check/test --changed-since=HEAD~1` locally before committing; remove outdated CI-only restriction and incorrect pre-commit hook description
- `scripts/pre-push.sh`: fix `gh` CLI fallback from full-codebase scan (`::`) to `--changed-since=HEAD~1`; keep lint-only scope in pre-push (remove `check`)

## Test plan
- [ ] Verify `pants check --changed-since=HEAD~1` runs successfully in a worktree
- [ ] Verify `pants test --changed-since=HEAD~1` runs successfully in a worktree
- [ ] Verify `pre-push.sh` runs without errors when `gh` is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)