### PR TITLE
refactor: change DeploymentHandler status methods from classmethod to instance methods

### DIFF
--- a/src/ai/backend/manager/sokovan/deployment/handlers/base.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/base.py
@@ -40,9 +40,8 @@ class DeploymentHandler:
         """
         raise NotImplementedError("Subclasses must implement target_statuses()")
 
-    @classmethod
     @abstractmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after this handler's operation.
 
         Returns:
@@ -50,9 +49,8 @@ class DeploymentHandler:
         """
         raise NotImplementedError("Subclasses must implement next_status()")
 
-    @classmethod
     @abstractmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         """Get the failure deployment status if applicable.
 
         Returns:
@@ -60,9 +58,8 @@ class DeploymentHandler:
         """
         raise NotImplementedError("Subclasses must implement failure_status()")
 
-    @classmethod
     @abstractmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for different handler outcomes (BEP-1030).
 
         Returns:

--- a/src/ai/backend/manager/sokovan/deployment/handlers/destroying.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/destroying.py
@@ -50,18 +50,15 @@ class DestroyingDeploymentHandler(DeploymentHandler):
         """Get the target deployment statuses for this handler."""
         return [EndpointLifecycle.DESTROYING]
 
-    @classmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after destroying."""
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.DESTROYED)
 
-    @classmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         # No failure status for destroying deployments
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.DESTROYED)
 
-    @classmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for destroying deployment handler (BEP-1030).
 
         - success: Deployment → DESTROYED

--- a/src/ai/backend/manager/sokovan/deployment/handlers/pending.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/pending.py
@@ -49,17 +49,14 @@ class CheckPendingDeploymentHandler(DeploymentHandler):
         """Get the target deployment statuses for this handler."""
         return [EndpointLifecycle.PENDING, EndpointLifecycle.CREATED]
 
-    @classmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after this handler's operation."""
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.SCALING)
 
-    @classmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         return None
 
-    @classmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for check pending deployment handler (BEP-1030).
 
         - success: Deployment → SCALING

--- a/src/ai/backend/manager/sokovan/deployment/handlers/reconcile.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/reconcile.py
@@ -52,17 +52,14 @@ class ReconcileDeploymentHandler(DeploymentHandler):
         """Get the target deployment statuses for this handler."""
         return [EndpointLifecycle.READY]
 
-    @classmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after this handler's operation."""
         return None
 
-    @classmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.SCALING)
 
-    @classmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for reconcile deployment handler (BEP-1030).
 
         - success: None (stays READY)

--- a/src/ai/backend/manager/sokovan/deployment/handlers/replica.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/replica.py
@@ -49,17 +49,14 @@ class CheckReplicaDeploymentHandler(DeploymentHandler):
         """Get the target deployment statuses for this handler."""
         return [EndpointLifecycle.READY]
 
-    @classmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after this handler's operation."""
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.SCALING)
 
-    @classmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         return None
 
-    @classmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for check replica deployment handler (BEP-1030).
 
         - success: Deployment → SCALING

--- a/src/ai/backend/manager/sokovan/deployment/handlers/scaling.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/scaling.py
@@ -50,17 +50,14 @@ class ScalingDeploymentHandler(DeploymentHandler):
         """Get the target deployment statuses for this handler."""
         return [EndpointLifecycle.SCALING]
 
-    @classmethod
-    def next_status(cls) -> DeploymentLifecycleStatus | None:
+    def next_status(self) -> DeploymentLifecycleStatus | None:
         """Get the next deployment status after this handler's operation."""
         return DeploymentLifecycleStatus(lifecycle=EndpointLifecycle.READY)
 
-    @classmethod
-    def failure_status(cls) -> DeploymentLifecycleStatus | None:
+    def failure_status(self) -> DeploymentLifecycleStatus | None:
         return None
 
-    @classmethod
-    def status_transitions(cls) -> DeploymentStatusTransitions:
+    def status_transitions(self) -> DeploymentStatusTransitions:
         """Define state transitions for scaling deployment handler (BEP-1030).
 
         - success: Deployment → READY


### PR DESCRIPTION
## Summary
- Remove `@classmethod` from `next_status()`, `failure_status()`, and `status_transitions()` in `DeploymentHandler` base class and all five concrete handlers (pending, replica, scaling, reconcile, destroying)
- Change method signatures from `cls` to `self` to prepare for BEP-1049 strategy handlers that need per-instance return values based on runtime state
- Pure refactoring — no behavior change

## Context
Part of incremental changes for BEP-1049 (Deployment Strategy Handler). This is PR 1/6 that lays the foundation for strategy-based deployment handlers.

## Test plan
- [ ] Existing `test_coordinator_history.py` tests pass (they use `MagicMock(spec=DeploymentHandler)`, unaffected by this change)
- [ ] CI lint/check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)