### PR TITLE
feat: add DEPLOYING lifecycle types and infrastructure for BEP-1049

### DIFF
--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -353,6 +353,7 @@ class DeploymentInfo:
     network: DeploymentNetworkSpec
     model_revisions: list[ModelRevisionSpec]
     current_revision_id: UUID | None = None
+    deploying_revision_id: UUID | None = None
 
     def target_revision(self) -> ModelRevisionSpec | None:
         if self.model_revisions:

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -110,6 +110,7 @@ class LockID(enum.IntEnum):
     LOCKID_DEPLOYMENT_CHECK_PENDING = 226  # For operations checking PENDING sessions
     LOCKID_DEPLOYMENT_CHECK_REPLICA = 227  # For operations checking REPLICA sessions
     LOCKID_DEPLOYMENT_DESTROYING = 228  # For operations destroying deployments
+    LOCKID_DEPLOYMENT_DEPLOYING = 229  # For deploying strategy handler (BEP-1049)
     # Sokovan target status locks (prevent concurrent operations on same status)
     LOCKID_SOKOVAN_TARGET_PENDING = 230  # For operations targeting PENDING sessions
     LOCKID_SOKOVAN_TARGET_PREPARING = 231  # For operations targeting PREPARING/PULLING sessions

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -145,3 +145,15 @@ class RouteUnhealthy(BackendAIError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
+
+
+class DeploymentAlreadyInProgress(BackendAIError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/deployment-already-in-progress"
+    error_title = "A deployment is already in progress."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_SERVICE,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -837,6 +837,7 @@ class EndpointRow(Base):  # type: ignore[misc]
                 ),
             ],
             current_revision_id=self.current_revision,
+            deploying_revision_id=self.deploying_revision,
         )
 
     def _to_deployment_info_legacy(self) -> DeploymentInfo:
@@ -898,6 +899,7 @@ class EndpointRow(Base):  # type: ignore[misc]
                 ),
             ],
             current_revision_id=self.current_revision,
+            deploying_revision_id=self.deploying_revision,
         )
 
 

--- a/src/ai/backend/manager/sokovan/deployment/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/types.py
@@ -5,7 +5,11 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ai.backend.manager.data.deployment.types import DeploymentInfo, RouteStatus
+from ai.backend.manager.data.deployment.types import (
+    DeploymentInfo,
+    DeploymentSubStatus,
+    RouteStatus,
+)
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.deployment.types import DeploymentInfoWithRoutes, RouteInfo
@@ -15,8 +19,21 @@ class DeploymentLifecycleType(StrEnum):
     CHECK_PENDING = "check_pending"
     CHECK_REPLICA = "check_replica"
     SCALING = "scaling"
+    DEPLOYING = "deploying"
     RECONCILE = "reconcile"
     DESTROYING = "destroying"
+
+
+class DeploymentSubStep(DeploymentSubStatus):
+    """Sub-step variants for deployment strategies (BEP-1049).
+
+    Both Blue-Green and Rolling Update strategies use these
+    sub-steps to represent their internal FSM states.
+    """
+
+    PROVISIONING = "provisioning"
+    PROGRESSING = "progressing"
+    ROLLED_BACK = "rolled_back"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `DeploymentLifecycleType.DEPLOYING` enum value for strategy-based deployments
- Add `DeploymentSubStep` enum (`PROVISIONING`, `PROGRESSING`, `ROLLED_BACK`) for deployment strategy FSM states
- Add `LockID.LOCKID_DEPLOYMENT_DEPLOYING` for coordinator lock
- Add `DeploymentAlreadyInProgress` error class
- Add `deploying_revision_id` field to `DeploymentInfo` and map from `EndpointRow`

## Context
Part of incremental changes for BEP-1049 (Deployment Strategy Handler). This PR adds only types, enums, errors, and constants — no logic changes. All new symbols are unused until subsequent PRs wire them in.

## Test plan
- [ ] CI lint/check pass (no behavior change, types only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)