### PR TITLE
feat: add DEPLOYING lifecycle infrastructure, repository ops, and service branching

### DIFF
--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -353,6 +353,7 @@ class DeploymentInfo:
     network: DeploymentNetworkSpec
     model_revisions: list[ModelRevisionSpec]
     current_revision_id: UUID | None = None
+    deploying_revision_id: UUID | None = None
 
     def target_revision(self) -> ModelRevisionSpec | None:
         if self.model_revisions:

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -110,6 +110,7 @@ class LockID(enum.IntEnum):
     LOCKID_DEPLOYMENT_CHECK_PENDING = 226  # For operations checking PENDING sessions
     LOCKID_DEPLOYMENT_CHECK_REPLICA = 227  # For operations checking REPLICA sessions
     LOCKID_DEPLOYMENT_DESTROYING = 228  # For operations destroying deployments
+    LOCKID_DEPLOYMENT_DEPLOYING = 229  # For deploying strategy handler (BEP-1049)
     # Sokovan target status locks (prevent concurrent operations on same status)
     LOCKID_SOKOVAN_TARGET_PENDING = 230  # For operations targeting PENDING sessions
     LOCKID_SOKOVAN_TARGET_PREPARING = 231  # For operations targeting PREPARING/PULLING sessions

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -145,3 +145,15 @@ class RouteUnhealthy(BackendAIError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
+
+
+class DeploymentAlreadyInProgress(BackendAIError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/deployment-already-in-progress"
+    error_title = "A deployment is already in progress."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MODEL_SERVICE,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -837,6 +837,7 @@ class EndpointRow(Base):  # type: ignore[misc]
                 ),
             ],
             current_revision_id=self.current_revision,
+            deploying_revision_id=self.deploying_revision,
         )
 
     def _to_deployment_info_legacy(self) -> DeploymentInfo:
@@ -898,6 +899,7 @@ class EndpointRow(Base):  # type: ignore[misc]
                 ),
             ],
             current_revision_id=self.current_revision,
+            deploying_revision_id=self.deploying_revision,
         )
 
 

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -631,7 +631,7 @@ class DeploymentDBSource:
         Returns:
             Total number of rows updated
         """
-        if not batch_updaters:
+        if not batch_updaters and not bulk_creator.specs:
             return 0
 
         async with self._begin_session_read_committed() as db_sess:
@@ -2118,6 +2118,64 @@ class DeploymentDBSource:
             await db_sess.execute(update_query)
 
             return previous_revision_id
+
+    async def begin_deployment(
+        self,
+        endpoint_id: uuid.UUID,
+        deploying_revision_id: uuid.UUID,
+    ) -> None:
+        """Atomically set deploying_revision and transition lifecycle to DEPLOYING."""
+        async with self._begin_session_read_committed() as db_sess:
+            update_query = (
+                sa.update(EndpointRow)
+                .where(EndpointRow.id == endpoint_id)
+                .values(
+                    deploying_revision=deploying_revision_id,
+                    lifecycle_stage=EndpointLifecycle.DEPLOYING,
+                )
+            )
+            await db_sess.execute(update_query)
+
+    async def complete_deployment_revision_swap(
+        self,
+        endpoint_ids: Sequence[uuid.UUID],
+    ) -> None:
+        """Atomically swap deploying_revision -> current_revision for completed deployments.
+
+        Sets current_revision = deploying_revision and deploying_revision = NULL
+        for all specified endpoints in a single query.
+        """
+        if not endpoint_ids:
+            return
+        async with self._begin_session_read_committed() as db_sess:
+            update_query = (
+                sa.update(EndpointRow)
+                .where(EndpointRow.id.in_(endpoint_ids))
+                .values(
+                    current_revision=EndpointRow.deploying_revision,
+                    deploying_revision=None,
+                )
+            )
+            await db_sess.execute(update_query)
+
+    async def clear_deploying_revision(
+        self,
+        endpoint_ids: Sequence[uuid.UUID],
+    ) -> None:
+        """Clear deploying_revision for rolled-back deployments.
+
+        Sets deploying_revision = NULL without changing current_revision.
+        Used when a deployment strategy is rolled back.
+        """
+        if not endpoint_ids:
+            return
+        async with self._begin_session_read_committed() as db_sess:
+            update_query = (
+                sa.update(EndpointRow)
+                .where(EndpointRow.id.in_(endpoint_ids))
+                .values(deploying_revision=None)
+            )
+            await db_sess.execute(update_query)
 
     # -------------------------------------------------------------------------
     # Auto-Scaling Policy Methods (DeploymentAutoScalingPolicyRow)

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -1126,6 +1126,31 @@ class DeploymentRepository:
         """
         return await self._db_source.update_current_revision(endpoint_id, revision_id)
 
+    @deployment_repository_resilience.apply()
+    async def begin_deployment(
+        self,
+        endpoint_id: uuid.UUID,
+        deploying_revision_id: uuid.UUID,
+    ) -> None:
+        """Atomically set deploying_revision and transition lifecycle to DEPLOYING."""
+        await self._db_source.begin_deployment(endpoint_id, deploying_revision_id)
+
+    @deployment_repository_resilience.apply()
+    async def complete_deployment_revision_swap(
+        self,
+        endpoint_ids: Sequence[uuid.UUID],
+    ) -> None:
+        """Atomically swap deploying_revision -> current_revision for completed deployments."""
+        await self._db_source.complete_deployment_revision_swap(endpoint_ids)
+
+    @deployment_repository_resilience.apply()
+    async def clear_deploying_revision(
+        self,
+        endpoint_ids: Sequence[uuid.UUID],
+    ) -> None:
+        """Clear deploying_revision for rolled-back deployments."""
+        await self._db_source.clear_deploying_revision(endpoint_ids)
+
     # ========== Deployment Auto-Scaling Policy Operations ==========
 
     @deployment_repository_resilience.apply()

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -32,7 +32,8 @@ from ai.backend.manager.data.deployment.types import (
     RouteInfo,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.errors.service import RoutingNotFound
+from ai.backend.manager.errors.deployment import DeploymentAlreadyInProgress
+from ai.backend.manager.errors.service import DeploymentPolicyNotFound, RoutingNotFound
 from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
 from ai.backend.manager.repositories.base import Creator
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
@@ -518,31 +519,68 @@ class DeploymentService:
     ) -> ActivateRevisionActionResult:
         """Activate a specific revision to be the current revision.
 
+        If a deployment policy with a strategy (e.g. ROLLING) is configured,
+        the endpoint transitions to DEPLOYING so the strategy handler can
+        drive the rollout.  Otherwise the current_revision is swapped
+        instantly (legacy / instant path).
+
         Args:
             action: Action containing deployment and revision IDs
 
         Returns:
             ActivateRevisionActionResult: Result containing the updated deployment
+
+        Raises:
+            DeploymentAlreadyInProgress: If the endpoint is already DEPLOYING.
         """
         # 1. Validate revision exists (raises exception if not found)
         _revision = await self._deployment_repository.get_revision(action.revision_id)
 
-        # 2. Update endpoint.current_revision and get previous revision
-        previous_revision_id = await self._deployment_repository.update_current_revision(
-            action.deployment_id, action.revision_id
-        )
+        # 2. Guard: reject if already deploying
+        deployment_info = await self._deployment_repository.get_endpoint_info(action.deployment_id)
+        if deployment_info.state.lifecycle == EndpointLifecycle.DEPLOYING:
+            raise DeploymentAlreadyInProgress(
+                f"Deployment {action.deployment_id} is already in DEPLOYING state"
+            )
 
-        # 3. Trigger lifecycle check to update routes with new revision
-        await self._deployment_controller.mark_lifecycle_needed(
-            DeploymentLifecycleType.CHECK_REPLICA
-        )
+        # 3. Determine deployment path based on policy
+        use_strategy = False
+        try:
+            policy = await self._deployment_repository.get_deployment_policy(action.deployment_id)
+            if policy.strategy in (DeploymentStrategy.ROLLING, DeploymentStrategy.BLUE_GREEN):
+                use_strategy = True
+        except DeploymentPolicyNotFound:
+            pass
 
-        log.info(
-            "Activated revision {} for deployment {} (previous: {})",
-            action.revision_id,
-            action.deployment_id,
-            previous_revision_id,
-        )
+        if use_strategy:
+            # Strategy-based path: set deploying_revision and transition to DEPLOYING
+            await self._deployment_repository.begin_deployment(
+                action.deployment_id, action.revision_id
+            )
+            await self._deployment_controller.mark_lifecycle_needed(
+                DeploymentLifecycleType.DEPLOYING
+            )
+            previous_revision_id = deployment_info.current_revision_id
+            log.info(
+                "Started strategy-based deployment for revision {} on deployment {} (current: {})",
+                action.revision_id,
+                action.deployment_id,
+                previous_revision_id,
+            )
+        else:
+            # Instant path: swap current_revision immediately
+            previous_revision_id = await self._deployment_repository.update_current_revision(
+                action.deployment_id, action.revision_id
+            )
+            await self._deployment_controller.mark_lifecycle_needed(
+                DeploymentLifecycleType.CHECK_REPLICA
+            )
+            log.info(
+                "Activated revision {} for deployment {} (previous: {})",
+                action.revision_id,
+                action.deployment_id,
+                previous_revision_id,
+            )
 
         # 4. Get updated deployment info
         deployment_info = await self._deployment_repository.get_endpoint_info(action.deployment_id)

--- a/src/ai/backend/manager/sokovan/deployment/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/types.py
@@ -5,7 +5,11 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ai.backend.manager.data.deployment.types import DeploymentInfo, RouteStatus
+from ai.backend.manager.data.deployment.types import (
+    DeploymentInfo,
+    DeploymentSubStatus,
+    RouteStatus,
+)
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.deployment.types import DeploymentInfoWithRoutes, RouteInfo
@@ -15,8 +19,21 @@ class DeploymentLifecycleType(StrEnum):
     CHECK_PENDING = "check_pending"
     CHECK_REPLICA = "check_replica"
     SCALING = "scaling"
+    DEPLOYING = "deploying"
     RECONCILE = "reconcile"
     DESTROYING = "destroying"
+
+
+class DeploymentSubStep(DeploymentSubStatus):
+    """Sub-step variants for deployment strategies (BEP-1049).
+
+    Both Blue-Green and Rolling Update strategies use these
+    sub-steps to represent their internal FSM states.
+    """
+
+    PROVISIONING = "provisioning"
+    PROGRESSING = "progressing"
+    ROLLED_BACK = "rolled_back"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `DeploymentLifecycleType.DEPLOYING` enum, `DeploymentSubStep` enum, `LockID`, `DeploymentAlreadyInProgress` error, `deploying_revision_id` field
- Add repository methods: `begin_deployment()`, `complete_deployment_revision_swap()`, `clear_deploying_revision()`
- Update `activate_revision()` to branch between strategy-based (DEPLOYING) and instant (legacy) paths based on deployment policy
- Fix early-return condition in `update_endpoint_lifecycle_bulk_with_history` to allow history-only writes

## Context
Part 1/2 of BEP-1049 (Deployment Strategy Handler). This PR adds the lower-layer infrastructure (types, repository, service). Part 2 will add the coordinator evaluator pattern and deploying handlers.

## Test plan
- [ ] CI lint/check pass
- [ ] Existing deployment tests pass (instant path unchanged)
- [ ] Strategy path tested in Part 2 with deploying handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)