### PR TITLE
refactor: unify RBACEntityUnbinder into RBACScopeWideEntityUnbinder

### DIFF
--- a/src/ai/backend/manager/api/gql_legacy/scaling_group.py
+++ b/src/ai/backend/manager/api/gql_legacy/scaling_group.py
@@ -42,14 +42,14 @@ from ai.backend.manager.repositories.scaling_group.creators import (
     ScalingGroupForProjectCreatorSpec,
 )
 from ai.backend.manager.repositories.scaling_group.purgers import (
-    AllScalingGroupsForDomainPurgerSpec,
-    AllScalingGroupsForProjectPurgerSpec,
-    ScalingGroupForDomainPurgerSpec,
     ScalingGroupForKeypairsPurgerSpec,
-    ScalingGroupForProjectPurgerSpec,
-    ScalingGroupsForDomainPurgerSpec,
     ScalingGroupsForKeypairsPurgerSpec,
-    ScalingGroupsForProjectPurgerSpec,
+)
+from ai.backend.manager.repositories.scaling_group.scope_binders import (
+    AllSGsFromDomainUnbinder,
+    AllSGsFromProjectUnbinder,
+    SGDomainEntityUnbinder,
+    SGProjectEntityUnbinder,
 )
 from ai.backend.manager.repositories.scaling_group.updaters import (
     ScalingGroupDriverConfigUpdaterSpec,
@@ -893,12 +893,10 @@ class DisassociateScalingGroupWithDomain(graphene.Mutation):  # type: ignore[mis
     ) -> DisassociateScalingGroupWithDomain:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithDomainsAction(
-            purger=BatchPurger(
-                spec=ScalingGroupForDomainPurgerSpec(
-                    scaling_group=scaling_group,
-                    domain=domain,
-                ),
-            )
+            unbinder=SGDomainEntityUnbinder(
+                scaling_groups=[scaling_group],
+                domain=domain,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_domains.wait_for_complete(
             action
@@ -928,12 +926,10 @@ class DisassociateScalingGroupsWithDomain(graphene.Mutation):  # type: ignore[mi
     ) -> DisassociateScalingGroupsWithDomain:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithDomainsAction(
-            purger=BatchPurger(
-                spec=ScalingGroupsForDomainPurgerSpec(
-                    scaling_groups=list(scaling_groups),
-                    domain=domain,
-                ),
-            )
+            unbinder=SGDomainEntityUnbinder(
+                scaling_groups=list(scaling_groups),
+                domain=domain,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_domains.wait_for_complete(
             action
@@ -959,11 +955,9 @@ class DisassociateAllScalingGroupsWithDomain(graphene.Mutation):  # type: ignore
     ) -> DisassociateAllScalingGroupsWithDomain:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithDomainsAction(
-            purger=BatchPurger(
-                spec=AllScalingGroupsForDomainPurgerSpec(
-                    domain=domain,
-                ),
-            )
+            unbinder=AllSGsFromDomainUnbinder(
+                domain=domain,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_domains.wait_for_complete(
             action
@@ -1064,12 +1058,10 @@ class DisassociateScalingGroupWithUserGroup(graphene.Mutation):  # type: ignore[
     ) -> DisassociateScalingGroupWithUserGroup:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithUserGroupsAction(
-            purger=BatchPurger(
-                spec=ScalingGroupForProjectPurgerSpec(
-                    scaling_group=scaling_group,
-                    project=user_group,
-                ),
-            )
+            unbinder=SGProjectEntityUnbinder(
+                scaling_groups=[scaling_group],
+                project=user_group,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_user_groups.wait_for_complete(
             action
@@ -1099,12 +1091,10 @@ class DisassociateScalingGroupsWithUserGroup(graphene.Mutation):  # type: ignore
     ) -> DisassociateScalingGroupsWithUserGroup:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithUserGroupsAction(
-            purger=BatchPurger(
-                spec=ScalingGroupsForProjectPurgerSpec(
-                    scaling_groups=list(scaling_groups),
-                    project=user_group,
-                ),
-            )
+            unbinder=SGProjectEntityUnbinder(
+                scaling_groups=list(scaling_groups),
+                project=user_group,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_user_groups.wait_for_complete(
             action
@@ -1130,11 +1120,9 @@ class DisassociateAllScalingGroupsWithGroup(graphene.Mutation):  # type: ignore[
     ) -> DisassociateAllScalingGroupsWithGroup:
         graph_ctx: GraphQueryContext = info.context
         action = DisassociateScalingGroupWithUserGroupsAction(
-            purger=BatchPurger(
-                spec=AllScalingGroupsForProjectPurgerSpec(
-                    project=user_group,
-                ),
-            )
+            unbinder=AllSGsFromProjectUnbinder(
+                project=user_group,
+            ),
         )
         await graph_ctx.processors.scaling_group.disassociate_scaling_group_with_user_groups.wait_for_complete(
             action

--- a/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
+++ b/src/ai/backend/manager/repositories/base/rbac/scope_unbinder.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.permission.types import RBACElementRef, RBACElementType
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
@@ -26,16 +26,16 @@ from ai.backend.manager.repositories.base.purger import (
 )
 
 # =============================================================================
-# Entity Unbinder
+# Scope-Wide Entity Unbinder
 # =============================================================================
 
 
-class RBACEntityUnbinder[TRow: Base](ABC):
-    """Unbind entities from a scope.
+class RBACScopeWideEntityUnbinder[TRow: Base](ABC):
+    """Unbind entities from a scope, with optional entity filtering.
 
-    Use when removing entity-scope associations from the entity side.
-    - entity_refs: Entities to unbind (batch support).
-    - scope_ref: The scope to unbind from.
+    Use when removing entity-scope associations from the scope side.
+    - entity_ids=None: delete ALL entities of entity_type within the scope.
+    - entity_ids=Sequence[str]: delete only the specified entities.
     """
 
     @abstractmethod
@@ -45,14 +45,24 @@ class RBACEntityUnbinder[TRow: Base](ABC):
 
     @property
     @abstractmethod
-    def entity_refs(self) -> Sequence[RBACElementRef]:
-        """RBAC element refs for the entities to unbind."""
+    def entity_type(self) -> RBACElementType:
+        """RBAC element type of the entities to unbind."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def scope_ref(self) -> RBACElementRef:
         """RBAC element ref for the scope to unbind from."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def entity_ids(self) -> Sequence[str] | None:
+        """Entity IDs to unbind.
+
+        None means delete all entities of entity_type within the scope.
+        A sequence means delete only the specified entity IDs.
+        """
         raise NotImplementedError
 
 
@@ -110,18 +120,19 @@ class RBACUnbinderResult:
 # =============================================================================
 
 
-async def execute_rbac_entity_unbinder[TRow: Base](
+async def execute_rbac_scope_wide_entity_unbinder[TRow: Base](
     db_sess: SASession,
-    unbinder: RBACEntityUnbinder[TRow],
+    unbinder: RBACScopeWideEntityUnbinder[TRow],
 ) -> RBACUnbinderResult:
-    """Delete N:N mapping rows and RBAC associations for entities.
+    """Delete N:N mapping rows and RBAC associations for entities within a scope.
 
     Removes the business rows and the RBAC association rows
-    tied to the given entities and scope.
+    tied to the given entities and scope.  When entity_ids is None,
+    all entities of the given entity_type within the scope are deleted.
 
     Args:
         db_sess: Async SQLAlchemy session (must be writable).
-        unbinder: Entity unbinder specifying purger spec and RBAC element refs.
+        unbinder: Scope-wide entity unbinder specifying purger spec and RBAC element refs.
 
     Returns:
         RBACUnbinderResult with deletion counts and removed associations.
@@ -129,20 +140,21 @@ async def execute_rbac_entity_unbinder[TRow: Base](
     purge_result = await execute_batch_purger(
         db_sess, BatchPurger(spec=unbinder.build_purger_spec())
     )
-    entity_refs = unbinder.entity_refs
-    if not entity_refs:
-        return RBACUnbinderResult(deleted_count=purge_result.deleted_count, association_rows=[])
 
     scope_ref = unbinder.scope_ref
+    where_clauses: list[sa.ColumnElement[bool]] = [
+        AssociationScopesEntitiesRow.entity_type == unbinder.entity_type.to_entity_type(),
+        AssociationScopesEntitiesRow.scope_type == scope_ref.element_type.to_scope_type(),
+        AssociationScopesEntitiesRow.scope_id == scope_ref.element_id,
+    ]
+    if unbinder.entity_ids is not None:
+        where_clauses.append(
+            AssociationScopesEntitiesRow.entity_id.in_(unbinder.entity_ids),
+        )
+
     assoc_stmt = (
         sa.delete(AssociationScopesEntitiesRow)
-        .where(
-            AssociationScopesEntitiesRow.entity_type
-            == entity_refs[0].element_type.to_entity_type(),
-            AssociationScopesEntitiesRow.entity_id.in_([ref.element_id for ref in entity_refs]),
-            AssociationScopesEntitiesRow.scope_type == scope_ref.element_type.to_scope_type(),
-            AssociationScopesEntitiesRow.scope_id == scope_ref.element_id,
-        )
+        .where(*where_clauses)
         .returning(AssociationScopesEntitiesRow)
     )
     association_rows = list((await db_sess.scalars(assoc_stmt)).all())

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -40,6 +40,10 @@ from ai.backend.manager.repositories.base.purger import (
     execute_batch_purger,
     execute_purger,
 )
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    RBACScopeWideEntityUnbinder,
+    execute_rbac_scope_wide_entity_unbinder,
+)
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 from ai.backend.manager.repositories.resource_slot.types import subtract_quantities
 
@@ -199,11 +203,11 @@ class ScalingGroupDBSource:
 
     async def disassociate_scaling_group_with_domains(
         self,
-        purger: BatchPurger[ScalingGroupForDomainRow],
+        unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForDomainRow],
     ) -> None:
         """Disassociates a scaling group from multiple domains."""
         async with self._db.begin_session() as session:
-            await execute_batch_purger(session, purger)
+            await execute_rbac_scope_wide_entity_unbinder(session, unbinder)
 
     async def check_scaling_group_domain_association_exists(
         self,
@@ -269,11 +273,11 @@ class ScalingGroupDBSource:
 
     async def disassociate_scaling_group_with_user_groups(
         self,
-        purger: BatchPurger[ScalingGroupForProjectRow],
+        unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForProjectRow],
     ) -> None:
         """Disassociates a single scaling group from a user group (project)."""
         async with self._db.begin_session() as session:
-            await execute_batch_purger(session, purger)
+            await execute_rbac_scope_wide_entity_unbinder(session, unbinder)
 
     async def check_scaling_group_user_group_association_exists(
         self,

--- a/src/ai/backend/manager/repositories/scaling_group/repository.py
+++ b/src/ai/backend/manager/repositories/scaling_group/repository.py
@@ -26,6 +26,9 @@ from ai.backend.manager.models.scaling_group import (
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.creator import BulkCreator, Creator
 from ai.backend.manager.repositories.base.purger import BatchPurger, Purger
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    RBACScopeWideEntityUnbinder,
+)
 from ai.backend.manager.repositories.base.updater import Updater
 
 from .db_source import ScalingGroupDBSource
@@ -131,10 +134,10 @@ class ScalingGroupRepository:
 
     async def disassociate_scaling_group_with_domains(
         self,
-        purger: BatchPurger[ScalingGroupForDomainRow],
+        unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForDomainRow],
     ) -> None:
         """Disassociates a scaling group from multiple domains."""
-        await self._db_source.disassociate_scaling_group_with_domains(purger)
+        await self._db_source.disassociate_scaling_group_with_domains(unbinder)
 
     async def check_scaling_group_domain_association_exists(
         self,
@@ -180,10 +183,10 @@ class ScalingGroupRepository:
 
     async def disassociate_scaling_group_with_user_groups(
         self,
-        purger: BatchPurger[ScalingGroupForProjectRow],
+        unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForProjectRow],
     ) -> None:
         """Disassociates a single scaling group from a user group (project)."""
-        await self._db_source.disassociate_scaling_group_with_user_groups(purger)
+        await self._db_source.disassociate_scaling_group_with_user_groups(unbinder)
 
     async def check_scaling_group_user_group_association_exists(
         self,

--- a/src/ai/backend/manager/repositories/scaling_group/scope_binders.py
+++ b/src/ai/backend/manager/repositories/scaling_group/scope_binders.py
@@ -1,0 +1,157 @@
+"""Scope-wide entity unbinders for scaling group associations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+from ai.backend.manager.data.permission.types import RBACElementRef, RBACElementType
+from ai.backend.manager.models.scaling_group import (
+    ScalingGroupForDomainRow,
+    ScalingGroupForProjectRow,
+)
+from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    RBACScopeWideEntityUnbinder,
+)
+from ai.backend.manager.repositories.scaling_group.purgers import (
+    AllScalingGroupsForDomainPurgerSpec,
+    AllScalingGroupsForProjectPurgerSpec,
+    ScalingGroupForDomainPurgerSpec,
+    ScalingGroupForProjectPurgerSpec,
+    ScalingGroupsForDomainPurgerSpec,
+    ScalingGroupsForProjectPurgerSpec,
+)
+
+# =============================================================================
+# Domain Unbinders
+# =============================================================================
+
+
+@dataclass
+class SGDomainEntityUnbinder(RBACScopeWideEntityUnbinder[ScalingGroupForDomainRow]):
+    """Unbind specific scaling groups from a domain."""
+
+    scaling_groups: Sequence[str]
+    domain: str
+
+    @override
+    def build_purger_spec(self) -> BatchPurgerSpec[ScalingGroupForDomainRow]:
+        if len(self.scaling_groups) == 1:
+            return ScalingGroupForDomainPurgerSpec(
+                scaling_group=self.scaling_groups[0],
+                domain=self.domain,
+            )
+        return ScalingGroupsForDomainPurgerSpec(
+            scaling_groups=list(self.scaling_groups),
+            domain=self.domain,
+        )
+
+    @property
+    @override
+    def entity_type(self) -> RBACElementType:
+        return RBACElementType.RESOURCE_GROUP
+
+    @property
+    @override
+    def scope_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.DOMAIN, self.domain)
+
+    @property
+    @override
+    def entity_ids(self) -> Sequence[str]:
+        return list(self.scaling_groups)
+
+
+@dataclass
+class AllSGsFromDomainUnbinder(RBACScopeWideEntityUnbinder[ScalingGroupForDomainRow]):
+    """Unbind ALL scaling groups from a domain."""
+
+    domain: str
+
+    @override
+    def build_purger_spec(self) -> BatchPurgerSpec[ScalingGroupForDomainRow]:
+        return AllScalingGroupsForDomainPurgerSpec(domain=self.domain)
+
+    @property
+    @override
+    def entity_type(self) -> RBACElementType:
+        return RBACElementType.RESOURCE_GROUP
+
+    @property
+    @override
+    def scope_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.DOMAIN, self.domain)
+
+    @property
+    @override
+    def entity_ids(self) -> None:
+        return None
+
+
+# =============================================================================
+# Project Unbinders
+# =============================================================================
+
+
+@dataclass
+class SGProjectEntityUnbinder(RBACScopeWideEntityUnbinder[ScalingGroupForProjectRow]):
+    """Unbind specific scaling groups from a project (user group)."""
+
+    scaling_groups: Sequence[str]
+    project: UUID
+
+    @override
+    def build_purger_spec(self) -> BatchPurgerSpec[ScalingGroupForProjectRow]:
+        if len(self.scaling_groups) == 1:
+            return ScalingGroupForProjectPurgerSpec(
+                scaling_group=self.scaling_groups[0],
+                project=self.project,
+            )
+        return ScalingGroupsForProjectPurgerSpec(
+            scaling_groups=list(self.scaling_groups),
+            project=self.project,
+        )
+
+    @property
+    @override
+    def entity_type(self) -> RBACElementType:
+        return RBACElementType.RESOURCE_GROUP
+
+    @property
+    @override
+    def scope_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.PROJECT, str(self.project))
+
+    @property
+    @override
+    def entity_ids(self) -> Sequence[str]:
+        return list(self.scaling_groups)
+
+
+@dataclass
+class AllSGsFromProjectUnbinder(RBACScopeWideEntityUnbinder[ScalingGroupForProjectRow]):
+    """Unbind ALL scaling groups from a project (user group)."""
+
+    project: UUID
+
+    @override
+    def build_purger_spec(self) -> BatchPurgerSpec[ScalingGroupForProjectRow]:
+        return AllScalingGroupsForProjectPurgerSpec(project=self.project)
+
+    @property
+    @override
+    def entity_type(self) -> RBACElementType:
+        return RBACElementType.RESOURCE_GROUP
+
+    @property
+    @override
+    def scope_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.PROJECT, str(self.project))
+
+    @property
+    @override
+    def entity_ids(self) -> None:
+        return None

--- a/src/ai/backend/manager/services/scaling_group/actions/disassociate_with_domain.py
+++ b/src/ai/backend/manager/services/scaling_group/actions/disassociate_with_domain.py
@@ -6,7 +6,9 @@ from typing import override
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
-from ai.backend.manager.repositories.base.purger import BatchPurger
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    RBACScopeWideEntityUnbinder,
+)
 
 from .domain_base import ScalingGroupDomainAction
 
@@ -15,7 +17,7 @@ from .domain_base import ScalingGroupDomainAction
 class DisassociateScalingGroupWithDomainsAction(ScalingGroupDomainAction):
     """Action to disassociate a scaling group from multiple domains."""
 
-    purger: BatchPurger[ScalingGroupForDomainRow]
+    unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForDomainRow]
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scaling_group/actions/disassociate_with_user_group.py
+++ b/src/ai/backend/manager/services/scaling_group/actions/disassociate_with_user_group.py
@@ -6,7 +6,9 @@ from typing import override
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.scaling_group import ScalingGroupForProjectRow
-from ai.backend.manager.repositories.base.purger import BatchPurger
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    RBACScopeWideEntityUnbinder,
+)
 
 from .user_group_base import ScalingGroupUserGroupAction
 
@@ -15,7 +17,7 @@ from .user_group_base import ScalingGroupUserGroupAction
 class DisassociateScalingGroupWithUserGroupsAction(ScalingGroupUserGroupAction):
     """Action to disassociate a single scaling group from a user group (project)."""
 
-    purger: BatchPurger[ScalingGroupForProjectRow]
+    unbinder: RBACScopeWideEntityUnbinder[ScalingGroupForProjectRow]
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scaling_group/service.py
+++ b/src/ai/backend/manager/services/scaling_group/service.py
@@ -120,7 +120,7 @@ class ScalingGroupService:
         self, action: DisassociateScalingGroupWithDomainsAction
     ) -> DisassociateScalingGroupWithDomainsActionResult:
         """Disassociates a scaling group from multiple domains."""
-        await self._repository.disassociate_scaling_group_with_domains(action.purger)
+        await self._repository.disassociate_scaling_group_with_domains(action.unbinder)
         return DisassociateScalingGroupWithDomainsActionResult()
 
     async def associate_scaling_group_with_keypairs(
@@ -148,7 +148,7 @@ class ScalingGroupService:
         self, action: DisassociateScalingGroupWithUserGroupsAction
     ) -> DisassociateScalingGroupWithUserGroupsActionResult:
         """Disassociates a single scaling group from a user group (project)."""
-        await self._repository.disassociate_scaling_group_with_user_groups(action.purger)
+        await self._repository.disassociate_scaling_group_with_user_groups(action.unbinder)
         return DisassociateScalingGroupWithUserGroupsActionResult()
 
     async def get_resource_info(self, action: GetResourceInfoAction) -> GetResourceInfoActionResult:

--- a/tests/unit/manager/repositories/base/rbac/test_scope_unbinder.py
+++ b/tests/unit/manager/repositories/base/rbac/test_scope_unbinder.py
@@ -6,7 +6,6 @@ import uuid
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 import pytest
 import sqlalchemy as sa
@@ -24,11 +23,11 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
-    RBACEntityUnbinder,
     RBACScopeUnbinder,
+    RBACScopeWideEntityUnbinder,
     RBACUnbinderResult,
-    execute_rbac_entity_unbinder,
     execute_rbac_scope_unbinder,
+    execute_rbac_scope_wide_entity_unbinder,
 )
 from ai.backend.testutils.db import with_tables
 
@@ -47,7 +46,7 @@ class ScopeUnbinderMappingRow(Base):  # type: ignore[misc]
     __tablename__ = "test_scope_unbinder_mapping"
     __table_args__ = {"extend_existing": True}
 
-    id: Mapped[UUID] = mapped_column(
+    id: Mapped[uuid.UUID] = mapped_column(
         GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
     )
     entity_id: Mapped[str] = mapped_column(sa.String(64), nullable=False)
@@ -59,41 +58,49 @@ class ScopeUnbinderMappingRow(Base):  # type: ignore[misc]
 # =============================================================================
 
 
-class TestEntityUnbinder(RBACEntityUnbinder[ScopeUnbinderMappingRow]):
-    """Entity unbinder: delete entities from a scope."""
+class TestScopeWideEntityUnbinder(RBACScopeWideEntityUnbinder[ScopeUnbinderMappingRow]):
+    """Scope-wide entity unbinder for testing: delete entities from a scope."""
 
     def __init__(
         self,
-        entity_ids: Sequence[str],
+        _entity_ids: Sequence[str] | None,
         entity_element_type: RBACElementType,
         scope_id: str,
         scope_element_type: RBACElementType,
     ) -> None:
-        self._entity_ids = entity_ids
+        self._entity_ids_value = _entity_ids
         self._entity_element_type = entity_element_type
         self._scope_id = scope_id
         self._scope_element_type = scope_element_type
 
     def build_purger_spec(self) -> BatchPurgerSpec[ScopeUnbinderMappingRow]:
-        entity_ids = self._entity_ids
+        entity_ids = self._entity_ids_value
         scope_id = self._scope_id
 
         class _Spec(BatchPurgerSpec[ScopeUnbinderMappingRow]):
             def build_subquery(self) -> sa.sql.Select[tuple[ScopeUnbinderMappingRow]]:
-                return sa.select(ScopeUnbinderMappingRow).where(
-                    ScopeUnbinderMappingRow.entity_id.in_(entity_ids),
+                stmt = sa.select(ScopeUnbinderMappingRow).where(
                     ScopeUnbinderMappingRow.scope_id == scope_id,
                 )
+                if entity_ids is not None:
+                    stmt = stmt.where(
+                        ScopeUnbinderMappingRow.entity_id.in_(entity_ids),
+                    )
+                return stmt
 
         return _Spec()
 
     @property
-    def entity_refs(self) -> Sequence[RBACElementRef]:
-        return [RBACElementRef(self._entity_element_type, eid) for eid in self._entity_ids]
+    def entity_type(self) -> RBACElementType:
+        return self._entity_element_type
 
     @property
     def scope_ref(self) -> RBACElementRef:
         return RBACElementRef(self._scope_element_type, self._scope_id)
+
+    @property
+    def entity_ids(self) -> Sequence[str] | None:
+        return self._entity_ids_value
 
 
 class TestScopeUnbinder(RBACScopeUnbinder[ScopeUnbinderMappingRow]):
@@ -201,12 +208,12 @@ async def seed_data(
 
 
 # =============================================================================
-# Entity Unbinder Tests
+# Scope-Wide Entity Unbinder Tests
 # =============================================================================
 
 
-class TestRBACEntityUnbinder:
-    """Tests for entity-centric unbinding (RBACEntityUnbinder)."""
+class TestRBACScopeWideEntityUnbinder:
+    """Tests for scope-wide entity unbinding (RBACScopeWideEntityUnbinder)."""
 
     async def test_unbind_single_entity_from_scope(
         self,
@@ -217,13 +224,13 @@ class TestRBACEntityUnbinder:
         ctx = seed_data
 
         async with database_connection.begin_session_read_committed() as db_sess:
-            unbinder = TestEntityUnbinder(
-                entity_ids=[ctx.entity_id_1],
+            unbinder = TestScopeWideEntityUnbinder(
+                _entity_ids=[ctx.entity_id_1],
                 entity_element_type=RBACElementType.RESOURCE_GROUP,
                 scope_id=ctx.scope_id_a,
                 scope_element_type=RBACElementType.DOMAIN,
             )
-            result = await execute_rbac_entity_unbinder(db_sess, unbinder)
+            result = await execute_rbac_scope_wide_entity_unbinder(db_sess, unbinder)
 
             assert isinstance(result, RBACUnbinderResult)
             assert result.deleted_count == 1
@@ -249,18 +256,50 @@ class TestRBACEntityUnbinder:
         ctx = seed_data
 
         async with database_connection.begin_session_read_committed() as db_sess:
-            unbinder = TestEntityUnbinder(
-                entity_ids=[ctx.entity_id_1, ctx.entity_id_2],
+            unbinder = TestScopeWideEntityUnbinder(
+                _entity_ids=[ctx.entity_id_1, ctx.entity_id_2],
                 entity_element_type=RBACElementType.RESOURCE_GROUP,
                 scope_id=ctx.scope_id_a,
                 scope_element_type=RBACElementType.DOMAIN,
             )
-            result = await execute_rbac_entity_unbinder(db_sess, unbinder)
+            result = await execute_rbac_scope_wide_entity_unbinder(db_sess, unbinder)
 
             assert result.deleted_count == 2
             assert len(result.association_rows) == 2
 
-            # 2 mapping rows remain (both entities × scope_b)
+            # 2 mapping rows remain (both entities x scope_b)
+            mapping_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(ScopeUnbinderMappingRow)
+            )
+            assert mapping_count == 2
+
+            assoc_count = await db_sess.scalar(
+                sa.select(sa.func.count()).select_from(AssociationScopesEntitiesRow)
+            )
+            assert assoc_count == 2
+
+    async def test_unbind_all_entities_from_scope(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        seed_data: UnbinderSeedContext,
+    ) -> None:
+        """When entity_ids is None, all entities of that type in the scope are removed."""
+        ctx = seed_data
+
+        async with database_connection.begin_session_read_committed() as db_sess:
+            unbinder = TestScopeWideEntityUnbinder(
+                _entity_ids=None,
+                entity_element_type=RBACElementType.RESOURCE_GROUP,
+                scope_id=ctx.scope_id_a,
+                scope_element_type=RBACElementType.DOMAIN,
+            )
+            result = await execute_rbac_scope_wide_entity_unbinder(db_sess, unbinder)
+
+            # Both entities in scope_a deleted
+            assert result.deleted_count == 2
+            assert len(result.association_rows) == 2
+
+            # 2 mapping rows remain (both entities x scope_b)
             mapping_count = await db_sess.scalar(
                 sa.select(sa.func.count()).select_from(ScopeUnbinderMappingRow)
             )
@@ -278,13 +317,31 @@ class TestRBACEntityUnbinder:
     ) -> None:
         """Unbinding a non-existent entity returns zero counts."""
         async with database_connection.begin_session_read_committed() as db_sess:
-            unbinder = TestEntityUnbinder(
-                entity_ids=[str(uuid.uuid4())],
+            unbinder = TestScopeWideEntityUnbinder(
+                _entity_ids=[str(uuid.uuid4())],
                 entity_element_type=RBACElementType.RESOURCE_GROUP,
                 scope_id=str(uuid.uuid4()),
                 scope_element_type=RBACElementType.DOMAIN,
             )
-            result = await execute_rbac_entity_unbinder(db_sess, unbinder)
+            result = await execute_rbac_scope_wide_entity_unbinder(db_sess, unbinder)
+
+            assert result.deleted_count == 0
+            assert len(result.association_rows) == 0
+
+    async def test_unbind_all_entities_no_rows(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        create_tables: None,
+    ) -> None:
+        """Unbinding all entities from a non-existent scope returns zero counts."""
+        async with database_connection.begin_session_read_committed() as db_sess:
+            unbinder = TestScopeWideEntityUnbinder(
+                _entity_ids=None,
+                entity_element_type=RBACElementType.RESOURCE_GROUP,
+                scope_id=str(uuid.uuid4()),
+                scope_element_type=RBACElementType.DOMAIN,
+            )
+            result = await execute_rbac_scope_wide_entity_unbinder(db_sess, unbinder)
 
             assert result.deleted_count == 0
             assert len(result.association_rows) == 0
@@ -349,7 +406,7 @@ class TestRBACScopeUnbinder:
             assert result.deleted_count == 2
             assert len(result.association_rows) == 2
 
-            # 2 mapping rows remain (entity_2 × both scopes)
+            # 2 mapping rows remain (entity_2 x both scopes)
             mapping_count = await db_sess.scalar(
                 sa.select(sa.func.count()).select_from(ScopeUnbinderMappingRow)
             )
@@ -397,7 +454,7 @@ class TestRBACScopeUnbinder:
 
             remaining = (await db_sess.scalars(sa.select(AssociationScopesEntitiesRow))).all()
             assert len(remaining) == 3
-            # entity_1 × scope_b, entity_2 × scope_a, entity_2 × scope_b remain
+            # entity_1 x scope_b, entity_2 x scope_a, entity_2 x scope_b remain
             entity1_remaining = [r for r in remaining if r.entity_id == ctx.entity_id_1]
             assert len(entity1_remaining) == 1
             assert entity1_remaining[0].scope_id == ctx.scope_id_b


### PR DESCRIPTION
## Summary
- Replace `RBACEntityUnbinder` (unused in production) with `RBACScopeWideEntityUnbinder` supporting nullable `entity_ids` — `None` deletes all entities of a type within a scope, `Sequence[str]` targets specific entities
- Migrate scaling group domain/project disassociate operations from `BatchPurger` to the new unbinder, ensuring `association_scopes_entities` RBAC rows are deleted atomically alongside business N:N rows
- Add concrete unbinders: `SGDomainEntityUnbinder`, `AllSGsFromDomainUnbinder`, `SGProjectEntityUnbinder`, `AllSGsFromProjectUnbinder`

## Test plan
- [x] Existing entity unbinder tests migrated to `RBACScopeWideEntityUnbinder`
- [x] Added `test_unbind_all_entities_from_scope` (entity_ids=None) test case
- [x] Added `test_unbind_all_entities_no_rows` edge case
- [x] `pants fmt/fix/lint/check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)