### PR TITLE
feat(BA-4746): implement RBACEntityScopeSyncer for declarative scope association

### DIFF
--- a/changes/9429.feature.md
+++ b/changes/9429.feature.md
@@ -1,1 +1,1 @@
-Add RBACEntityScopeSyncer that declaratively syncs scope-entity associations (create, rebind, or no-op) and integrate it with agent heartbeat for automatic Agent→ResourceGroup RBAC binding
+Add RBACEntityScopeSyncer that declaratively syncs scope-entity associations (create, rebind, or no-op) in a single idempotent operation

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -364,7 +364,6 @@ class RBACElementType(enum.StrEnum):
     APP_CONFIG = "app_config"
 
     # === Root-query-enabled entities (superadmin-only) ===
-    AGENT = "agent"
     RESOURCE_PRESET = "resource_preset"
     USER_RESOURCE_POLICY = "user_resource_policy"
     KEYPAIR_RESOURCE_POLICY = "keypair_resource_policy"

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -5,7 +5,6 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
-from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import AgentNotFound
 from ai.backend.common.types import AgentId, ImageID
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -18,7 +17,6 @@ from ai.backend.manager.data.agent.types import (
     UpsertResult,
 )
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
-from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import ADMIN_PERMISSIONS as ADMIN_AGENT_PERMISSIONS
 from ai.backend.manager.models.agent import AgentRow, agents
@@ -29,10 +27,6 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.agent.updaters import AgentStatusUpdaterSpec
 from ai.backend.manager.repositories.base import BulkUpserter, execute_bulk_upserter
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
-from ai.backend.manager.repositories.base.rbac.scope_syncer import (
-    RBACEntityScopeSyncer,
-    execute_rbac_entity_scope_syncer,
-)
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -120,20 +114,6 @@ class AgentDBSource:
             )
 
             await session.execute(final_query)
-
-            await execute_rbac_entity_scope_syncer(
-                session,
-                RBACEntityScopeSyncer(
-                    entity_ref=RBACElementRef(
-                        element_type=RBACElementType.AGENT,
-                        element_id=str(upsert_data.metadata.id),
-                    ),
-                    desired_scope_ref=RBACElementRef(
-                        element_type=RBACElementType.RESOURCE_GROUP,
-                        element_id=upsert_data.metadata.scaling_group,
-                    ),
-                ),
-            )
 
             return upsert_result
 


### PR DESCRIPTION
## Summary
- Add `RBACEntityScopeSyncer` that declaratively syncs scope-entity associations (create, rebind, or no-op) in a single idempotent operation
- 2-query algorithm: DELETE stale associations + INSERT ON CONFLICT DO NOTHING
- `SyncAction` enum reports outcome: `CREATED`, `REBOUND`, `UNCHANGED`

## Test plan
- [x] `TestRBACEntityScopeSyncerCreate` — first association (CREATED action, correct fields, REF relation_type)
- [x] `TestRBACEntityScopeSyncerUnchanged` — same scope repeated (UNCHANGED action, idempotent)
- [x] `TestRBACEntityScopeSyncerRebind` — scope migration (REBOUND action, old removed, new created, multiple stale cleanup)
- [x] `TestRBACEntityScopeSyncerIsolation` — different entity/scope_type unaffected

Resolves BA-4746