### PR TITLE
feat(BA-4749): allow configuring prometheus multiprocess base dir via env var (#9434)

### DIFF
--- a/changes/9434.fix.md
+++ b/changes/9434.fix.md
@@ -1,0 +1,1 @@
+Fix Prometheus multiprocess default directory from environment-dependent `tempfile.gettempdir()` to the hardcoded `/tmp/backend.ai/prometheus`, preventing permission issues across different deployment environments; also support overriding via `BACKENDAI_PROMETHEUS_DIR` env var or `base_dir` parameter.

--- a/src/ai/backend/common/metrics/multiprocess.py
+++ b/src/ai/backend/common/metrics/multiprocess.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 from prometheus_client import CollectorRegistry, generate_latest
@@ -29,12 +28,12 @@ log = logging.getLogger(__spec__.name)
 
 _multiprocess_dir: Path | None = None
 
-_uid = os.getuid() if hasattr(os, "getuid") else "common"
-_DEFAULT_BASE_DIR = Path(tempfile.gettempdir()) / f"backendai.{_uid}" / "prometheus"
+_DEFAULT_BASE_DIR = Path("/tmp/backend.ai/prometheus")
 
 
 def setup_prometheus_multiprocess_dir(
     component: str = "manager",
+    base_dir: Path | None = None,
 ) -> Path:
     """
     Set up the prometheus multiprocess directory and environment variable.
@@ -44,8 +43,15 @@ def setup_prometheus_multiprocess_dir(
     Creates a directory for prometheus multiprocess files and sets
     the PROMETHEUS_MULTIPROC_DIR environment variable.
 
+    The base directory is resolved in the following priority order:
+    1. ``base_dir`` argument (if provided)
+    2. ``BACKENDAI_PROMETHEUS_DIR`` environment variable (if set)
+    3. Default: ``/tmp/backend.ai/prometheus/``
+
     Args:
         component: Component name for directory naming (e.g., 'manager', 'agent')
+        base_dir: Optional override for the base directory. Takes precedence over
+            the ``BACKENDAI_PROMETHEUS_DIR`` environment variable.
 
     Returns:
         Path to the created multiprocess directory
@@ -55,15 +61,21 @@ def setup_prometheus_multiprocess_dir(
     if _multiprocess_dir is not None:
         return _multiprocess_dir
 
-    multiprocess_dir = _DEFAULT_BASE_DIR / component
+    if base_dir is not None:
+        resolved_base = base_dir
+    elif env_base := os.environ.get("BACKENDAI_PROMETHEUS_DIR"):
+        resolved_base = Path(env_base)
+    else:
+        resolved_base = _DEFAULT_BASE_DIR
+
+    multiprocess_dir = resolved_base / component
     try:
         multiprocess_dir.mkdir(parents=True, exist_ok=True)
     except PermissionError:
         log.error(
             "Cannot create prometheus multiprocess dir %s — permission denied. "
-            "Ensure the directory is writable by the current user (uid=%s).",
+            "Ensure the directory is writable by the current user.",
             multiprocess_dir,
-            _uid,
         )
         raise
 

--- a/tests/unit/common/test_prometheus_multiprocess.py
+++ b/tests/unit/common/test_prometheus_multiprocess.py
@@ -67,6 +67,30 @@ class TestSetupPrometheusMultiprocDir:
 
         assert first == second  # idempotent, returns first result
 
+    def test_base_dir_parameter_overrides_default(self, tmp_path: Path) -> None:
+        custom_base = tmp_path / "custom_base"
+        result = setup_prometheus_multiprocess_dir("manager", base_dir=custom_base)
+
+        assert result == custom_base / "manager"
+        assert result.is_dir()
+        assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == str(result)
+
+    def test_backendai_prometheus_dir_env_var_overrides_default(self, tmp_path: Path) -> None:
+        env_base = tmp_path / "env_base"
+        with patch.dict(os.environ, {"BACKENDAI_PROMETHEUS_DIR": str(env_base)}):
+            result = setup_prometheus_multiprocess_dir("agent")
+            assert result == env_base / "agent"
+            assert result.is_dir()
+            assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == str(result)
+
+    def test_base_dir_parameter_takes_priority_over_env_var(self, tmp_path: Path) -> None:
+        custom_base = tmp_path / "custom_base"
+        env_base = tmp_path / "env_base"
+        with patch.dict(os.environ, {"BACKENDAI_PROMETHEUS_DIR": str(env_base)}):
+            result = setup_prometheus_multiprocess_dir("manager", base_dir=custom_base)
+            assert result == custom_base / "manager"
+            assert result.is_dir()
+
 
 class TestGenerateLatestMultiprocess:
     def test_returns_bytes_normally(self, tmp_path: Path) -> None:
@@ -126,10 +150,8 @@ class TestCleanupPrometheusMultiprocDir:
 
 
 class TestDefaultBaseDirUid:
-    def test_default_base_dir_contains_uid(self) -> None:
-        uid = os.getuid() if hasattr(os, "getuid") else "common"
-        assert f"backendai.{uid}" in str(mp_mod._DEFAULT_BASE_DIR)
-        assert str(mp_mod._DEFAULT_BASE_DIR).endswith("/prometheus")
+    def test_default_base_dir_is_hardcoded(self) -> None:
+        assert Path("/tmp/backend.ai/prometheus") == mp_mod._DEFAULT_BASE_DIR
 
     def test_setup_raises_on_permission_error(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
This is an auto-generated backport PR of #9434 to the 26.2 release.