### PR TITLE
fix(BA-4748): compute session occupied_slots from resource_allocations table (#9433)

### DIFF
--- a/changes/9433.fix.md
+++ b/changes/9433.fix.md
@@ -1,0 +1,1 @@
+Fix session `occupied_slots` returning empty by computing from the normalized `resource_allocations` table instead of the deprecated JSONB column that is no longer written to after Phase 3.

--- a/src/ai/backend/manager/api/gql_legacy/session.py
+++ b/src/ai/backend/manager/api/gql_legacy/session.py
@@ -53,6 +53,7 @@ from ai.backend.manager.models.session import (
     SessionDependencyRow,
     SessionRow,
     SessionTypes,
+    batch_populate_session_occupied_slots,
     by_domain_name,
     by_raw_filter,
     by_resource_group_name,
@@ -84,8 +85,6 @@ from .base import (
     OrderExprArg,
     PaginatedConnectionField,
     PaginatedList,
-    batch_multiresult_in_session,
-    batch_result_in_session,
     generate_sql_info_for_gql_connection,
 )
 from .gql_relay import (
@@ -297,7 +296,10 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 .options(selectinload(SessionRow.kernels), joinedload(SessionRow.user))
             )
             query_result = await db_session.scalar(stmt)
-            return cls.from_row(graphene_ctx, query_result) if query_result is not None else None
+            if query_result is None:
+                return None
+            await batch_populate_session_occupied_slots(db_session, [query_result])
+            return cls.from_row(graphene_ctx, query_result)
 
     @classmethod
     def _add_basic_options_to_query(
@@ -583,7 +585,8 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                     selectinload(SessionRow.user),
                 )
             )
-            session_rows = (await db_sess.execute(query)).scalars().all()
+            session_rows = list((await db_sess.execute(query)).scalars().all())
+            await batch_populate_session_occupied_slots(db_sess, session_rows)
 
         # Convert into GraphQL node objects
         sessions = [type(self).from_row(ctx, r) for r in session_rows]
@@ -617,14 +620,12 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 .select_from(j)
                 .where(SessionDependencyRow.session_id.in_(session_ids))
             )
-            return await batch_multiresult_in_session(
-                ctx,
-                db_sess,
-                query,
-                cls,
-                session_ids,
-                lambda row: row.id,
-            )
+            rows = (await db_sess.execute(query)).scalars().all()
+            await batch_populate_session_occupied_slots(db_sess, list(rows))
+            objs_per_key: dict[SessionId, list[Self]] = {sid: [] for sid in session_ids}
+            for row in rows:
+                objs_per_key[row.id].append(cls.from_row(ctx, row))
+            return [*objs_per_key.values()]
 
     @classmethod
     async def batch_load_by_dependent_id(
@@ -641,14 +642,12 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 .select_from(j)
                 .where(SessionDependencyRow.depends_on.in_(session_ids))
             )
-            return await batch_multiresult_in_session(
-                ctx,
-                db_sess,
-                query,
-                cls,
-                session_ids,
-                lambda row: row.id,
-            )
+            rows = (await db_sess.execute(query)).scalars().all()
+            await batch_populate_session_occupied_slots(db_sess, list(rows))
+            objs_per_key: dict[SessionId, list[Self]] = {sid: [] for sid in session_ids}
+            for row in rows:
+                objs_per_key[row.id].append(cls.from_row(ctx, row))
+            return [*objs_per_key.values()]
 
     @classmethod
     async def get_accessible_node(
@@ -671,6 +670,8 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             query = cls._add_basic_options_to_query(query)
             async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
                 session_row = await db_session.scalar(query)
+                if session_row is not None:
+                    await batch_populate_session_occupied_slots(db_session, [session_row])
         if session_row is None:
             return None
         return cls.from_row(
@@ -735,8 +736,9 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             query = cls._add_basic_options_to_query(query.where(cond))
             cnt_query = cls._add_basic_options_to_query(cnt_query.where(cond), is_count=True)
             async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
-                session_rows = (await db_session.scalars(query)).all()
+                session_rows = list((await db_session.scalars(query)).all())
                 total_cnt = await db_session.scalar(cnt_query)
+                await batch_populate_session_occupied_slots(db_session, session_rows)
         result: list[Self] = [
             cls.from_row(
                 graph_ctx,
@@ -792,6 +794,8 @@ class TotalResourceSlot(graphene.ObjectType):  # type: ignore[misc]
         session_rows = await SessionRow.list_session_by_condition(
             query_conditions, query_options, db=ctx.db
         )
+        async with ctx.db.begin_readonly_session() as db_sess:
+            await batch_populate_session_occupied_slots(db_sess, session_rows)
         occupied_slots = ResourceSlot()
         requested_slots = ResourceSlot()
         for row in session_rows:
@@ -1291,7 +1295,10 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
         else:
             query = query.order_by(*DEFAULT_SESSION_ORDERING)
         async with ctx.db.begin_readonly_session() as db_sess:
-            return [cls.from_row(ctx, r) async for r in (await db_sess.stream(query))]
+            rows = (await db_sess.execute(query)).all()
+            session_rows = [r.SessionRow for r in rows]
+            await batch_populate_session_occupied_slots(db_sess, session_rows)
+            return [cls.from_row(ctx, r) for r in rows]
 
     @classmethod
     async def batch_load_detail(
@@ -1321,14 +1328,13 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
         if access_key is not None:
             query = query.where(SessionRow.access_key == access_key)
         async with ctx.db.begin_readonly_session() as db_sess:
-            return await batch_result_in_session(
-                ctx,
-                db_sess,
-                query,
-                cls,
-                session_ids,
-                lambda row: row.SessionRow.id,
-            )
+            rows = (await db_sess.execute(query)).all()
+            sr_list = [r.SessionRow for r in rows]
+            await batch_populate_session_occupied_slots(db_sess, sr_list)
+            objs_per_key: dict[SessionId, ComputeSession | None] = dict.fromkeys(session_ids)
+            for row in rows:
+                objs_per_key[row.SessionRow.id] = cls.from_row(ctx, row)
+            return [*objs_per_key.values()]
 
     @classmethod
     async def batch_load_by_dependency(
@@ -1348,14 +1354,15 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
             .options(selectinload(SessionRow.kernels))
         )
         async with ctx.db.begin_readonly_session() as db_sess:
-            return await batch_multiresult_in_session(
-                ctx,
-                db_sess,
-                query,
-                cls,
-                session_ids,
-                lambda row: row.SessionRow.id,
-            )
+            rows = (await db_sess.execute(query)).all()
+            sr_list = [r.SessionRow for r in rows]
+            await batch_populate_session_occupied_slots(db_sess, sr_list)
+            objs_per_key: dict[SessionId, list[ComputeSession]] = {sid: [] for sid in session_ids}
+            for row in rows:
+                obj = cls.from_row(ctx, row)
+                if obj is not None:
+                    objs_per_key[row.SessionRow.id].append(obj)
+            return [*objs_per_key.values()]
 
     @classmethod
     async def batch_load_commit_statuses(

--- a/src/ai/backend/manager/models/session/__init__.py
+++ b/src/ai/backend/manager/models/session/__init__.py
@@ -29,6 +29,9 @@ from .row import (
     _build_session_fetch_query as _build_session_fetch_query,
 )
 from .row import (
+    batch_populate_session_occupied_slots as batch_populate_session_occupied_slots,
+)
+from .row import (
     get_permission_ctx as get_permission_ctx,
 )
 

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -2220,3 +2220,49 @@ async def get_permission_ctx(
     async with ctx.db.begin_readonly_session(db_conn) as db_session:
         builder = ComputeSessionPermissionContextBuilder(db_session)
         return await builder.build(ctx, target_scope, requested_permission)
+
+
+async def batch_populate_session_occupied_slots(
+    db_session: SASession,
+    session_rows: Sequence[SessionRow],
+) -> None:
+    """Batch-compute occupied slots from the normalized resource_allocations table
+    and populate each SessionRow's occupying_slots attribute in-place.
+
+    This replaces the deprecated JSONB column read with a live computation
+    from the resource_allocations table (Phase 3, BA-4308).
+    """
+    if not session_rows:
+        return
+    session_ids = [row.id for row in session_rows]
+    ra = ResourceAllocationRow.__table__
+    kernels = KernelRow.__table__
+    effective = sa.func.coalesce(ra.c.used, ra.c.requested)
+    stmt = (
+        sa.select(
+            kernels.c.session_id,
+            ra.c.slot_name,
+            sa.func.sum(effective).label("total"),
+        )
+        .select_from(ra.join(kernels, ra.c.kernel_id == kernels.c.id))
+        .where(
+            kernels.c.session_id.in_(session_ids),
+            ra.c.free_at.is_(None),
+        )
+        .group_by(kernels.c.session_id, ra.c.slot_name)
+    )
+    rows = (await db_session.execute(stmt)).all()
+    slots_map: dict[SessionId, ResourceSlot] = {}
+    for r in rows:
+        sid = SessionId(r.session_id)
+        if sid not in slots_map:
+            slots_map[sid] = ResourceSlot()
+        slots_map[sid][r.slot_name] = r.total
+    for session_row in session_rows:
+        # Use set_committed_value to avoid marking the attribute as dirty
+        # in readonly sessions.
+        sa.orm.attributes.set_committed_value(
+            session_row,
+            "occupying_slots",
+            slots_map.get(SessionId(session_row.id), ResourceSlot()),
+        )

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.session import (
     KernelLoadingStrategy,
     SessionDependencyRow,
     SessionRow,
+    batch_populate_session_occupied_slots,
 )
 from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import UserRole, UserRow
@@ -512,7 +513,9 @@ class SessionDBSource:
                 querier,
             )
 
-            items = [row.SessionRow.to_dataclass() for row in result.rows]
+            session_rows = [row.SessionRow for row in result.rows]
+            await batch_populate_session_occupied_slots(db_sess, session_rows)
+            items = [row.to_dataclass() for row in session_rows]
 
             return SessionListResult(
                 items=items,

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -9,9 +9,12 @@ import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
+import sqlalchemy as sa
 from dateutil.tz import tzutc
+from sqlalchemy.orm import selectinload
 
 from ai.backend.common.types import (
     AccessKey,
@@ -34,8 +37,9 @@ from ai.backend.manager.models.resource_policy import (
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
+from ai.backend.manager.models.resource_slot import ResourceAllocationRow, ResourceSlotTypeRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
-from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.session import SessionRow, batch_populate_session_occupied_slots
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
@@ -75,6 +79,8 @@ class TestSessionRepository:
                 KeyPairRow,
                 SessionRow,
                 KernelRow,
+                ResourceSlotTypeRow,
+                ResourceAllocationRow,
             ],
         ):
             yield database_connection
@@ -389,3 +395,324 @@ class TestSessionRepository:
         assert len(result.items) == 0
         assert result.has_next_page is False
         assert result.has_previous_page is False
+
+
+class TestBatchPopulateSessionOccupiedSlots:
+    """Test batch_populate_session_occupied_slots computes occupied_slots
+    from the normalized resource_allocations table instead of the deprecated
+    JSONB column."""
+
+    @pytest.fixture
+    async def db_with_resource_tables(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                AgentRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                GroupRow,
+                KeyPairRow,
+                SessionRow,
+                KernelRow,
+                ResourceSlotTypeRow,
+                ResourceAllocationRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def session_with_allocations(
+        self, db_with_resource_tables: ExtendedAsyncSAEngine
+    ) -> SessionTestData:
+        """Create a session with resource_allocations (but empty JSONB occupying_slots)."""
+        domain_name = "test-domain"
+        user_id = uuid.uuid4()
+        group_id = uuid.uuid4()
+        session_id = SessionId(uuid.uuid4())
+        kernel_id = KernelId(uuid.uuid4())
+        access_key = AccessKey("TESTKEY12345678")
+
+        async with db_with_resource_tables.begin_session() as db_sess:
+            domain = DomainRow(
+                name=domain_name,
+                description="Test domain",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+                allowed_docker_registries=[],
+                integration_id=None,
+            )
+            db_sess.add(domain)
+
+            scaling_group = ScalingGroupRow(
+                name="default",
+                is_active=True,
+                is_public=True,
+                driver="static",
+                driver_opts={},
+                scheduler="fifo",
+                scheduler_opts=ScalingGroupOpts(),
+            )
+            db_sess.add(scaling_group)
+
+            user_resource_policy = UserResourcePolicyRow(
+                name="default-user-policy",
+                max_vfolder_count=100,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=10,
+                max_customized_image_count=10,
+            )
+            db_sess.add(user_resource_policy)
+
+            project_resource_policy = ProjectResourcePolicyRow(
+                name="default-project-policy",
+                max_vfolder_count=100,
+                max_quota_scope_size=-1,
+                max_network_count=10,
+            )
+            db_sess.add(project_resource_policy)
+
+            keypair_resource_policy = KeyPairResourcePolicyRow(
+                name="default-keypair-policy",
+                default_for_unspecified=DefaultForUnspecified.UNLIMITED,
+                total_resource_slots=ResourceSlot(),
+                max_session_lifetime=0,
+                max_concurrent_sessions=10,
+                max_concurrent_sftp_sessions=5,
+                max_containers_per_session=1,
+                idle_timeout=3600,
+            )
+            db_sess.add(keypair_resource_policy)
+            await db_sess.flush()
+
+            user = UserRow(
+                uuid=user_id,
+                username="testuser",
+                email="test@example.com",
+                password=None,
+                need_password_change=False,
+                full_name="Test User",
+                description="Test user",
+                status=UserStatus.ACTIVE,
+                status_info="",
+                domain_name=domain_name,
+                role=UserRole.USER,
+                resource_policy=user_resource_policy.name,
+                allowed_client_ip=None,
+                totp_key=None,
+                main_access_key=None,
+            )
+            db_sess.add(user)
+
+            group = GroupRow(
+                id=group_id,
+                name="test-group",
+                description="Test group",
+                is_active=True,
+                domain_name=domain_name,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+                resource_policy=project_resource_policy.name,
+                type=ProjectType.GENERAL,
+            )
+            db_sess.add(group)
+            await db_sess.flush()
+
+            keypair = KeyPairRow(
+                user_id="test@example.com",
+                user=user_id,
+                access_key=access_key,
+                secret_key="test-secret-key",
+                is_active=True,
+                is_admin=False,
+                resource_policy=keypair_resource_policy.name,
+                rate_limit=1000,
+            )
+            db_sess.add(keypair)
+            await db_sess.flush()
+
+            now = datetime.now(tzutc())
+            # Session with EMPTY occupying_slots (simulating post-Phase 3 state)
+            session = SessionRow(
+                id=session_id,
+                creation_id="test-creation-id",
+                name="test-session",
+                session_type=SessionTypes.INTERACTIVE,
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                cluster_size=1,
+                domain_name=domain_name,
+                group_id=group_id,
+                user_uuid=user_id,
+                access_key=access_key,
+                tag=None,
+                status=SessionStatus.RUNNING,
+                status_info=None,
+                status_data=None,
+                status_history={},
+                result=SessionResult.UNDEFINED,
+                created_at=now,
+                terminated_at=None,
+                starts_at=None,
+                startup_command=None,
+                callback_url=None,
+                occupying_slots=ResourceSlot(),  # Empty! (post-Phase 3)
+                requested_slots=ResourceSlot({"cpu": "2", "mem": "2147483648"}),
+                vfolder_mounts=[],
+                environ=None,
+                bootstrap_script=None,
+                use_host_network=False,
+                scaling_group_name="default",
+            )
+            db_sess.add(session)
+            await db_sess.flush()
+
+            kernel = KernelRow(
+                id=kernel_id,
+                session_id=session_id,
+                session_type=SessionTypes.INTERACTIVE,
+                domain_name=domain_name,
+                group_id=group_id,
+                user_uuid=user_id,
+                access_key=access_key,
+                cluster_mode=ClusterMode.SINGLE_NODE.value,
+                cluster_size=1,
+                cluster_role="main",
+                cluster_idx=0,
+                local_rank=0,
+                cluster_hostname="main",
+                image="cr.backend.ai/stable/python:latest",
+                architecture="x86_64",
+                registry="cr.backend.ai",
+                agent=None,
+                agent_addr=None,
+                container_id=None,
+                repl_in_port=2000,
+                repl_out_port=2001,
+                stdin_port=2002,
+                stdout_port=2003,
+                use_host_network=False,
+                status=KernelStatus.RUNNING,
+                status_info=None,
+                status_data=None,
+                status_history={},
+                status_changed=now,
+                result=SessionResult.UNDEFINED,
+                created_at=now,
+                terminated_at=None,
+                starts_at=None,
+                occupied_slots=ResourceSlot(),
+                requested_slots=ResourceSlot({"cpu": "2", "mem": "2147483648"}),
+                occupied_shares={},
+                environ=None,
+                vfolder_mounts=[],
+                attached_devices={},
+                resource_opts=None,
+                preopen_ports=None,
+                bootstrap_script=None,
+                startup_command=None,
+            )
+            db_sess.add(kernel)
+            await db_sess.flush()
+
+            # Seed resource_slot_types (required FK for resource_allocations)
+            for slot_name, slot_type in [("cpu", "count"), ("mem", "bytes")]:
+                db_sess.add(ResourceSlotTypeRow(slot_name=slot_name, slot_type=slot_type))
+            await db_sess.flush()
+
+            # Create normalized resource_allocations (the source of truth)
+            db_sess.add(
+                ResourceAllocationRow(
+                    kernel_id=kernel_id,
+                    slot_name="cpu",
+                    requested=Decimal("2.000000"),
+                    used=Decimal("1.500000"),
+                )
+            )
+            db_sess.add(
+                ResourceAllocationRow(
+                    kernel_id=kernel_id,
+                    slot_name="mem",
+                    requested=Decimal("2147483648"),
+                    used=None,  # NULL used -> falls back to requested
+                )
+            )
+            await db_sess.commit()
+
+        return SessionTestData(
+            domain_name=domain_name,
+            user_id=user_id,
+            group_id=group_id,
+            session_id=session_id,
+            kernel_id=kernel_id,
+            access_key=access_key,
+        )
+
+    @pytest.mark.asyncio
+    async def test_batch_populate_computes_slots_from_resource_allocations(
+        self,
+        db_with_resource_tables: ExtendedAsyncSAEngine,
+        session_with_allocations: SessionTestData,
+    ) -> None:
+        """Verify that batch_populate reads from resource_allocations
+        instead of the deprecated JSONB column."""
+        async with db_with_resource_tables.begin_readonly_session() as db_sess:
+            stmt = (
+                sa.select(SessionRow)
+                .where(SessionRow.id == session_with_allocations.session_id)
+                .options(selectinload(SessionRow.kernels))
+            )
+            session_row = await db_sess.scalar(stmt)
+            assert session_row is not None
+
+            # Before: JSONB column is empty (post-Phase 3)
+            assert session_row.occupying_slots == ResourceSlot()
+
+            # Act: batch_populate computes from resource_allocations
+            await batch_populate_session_occupied_slots(db_sess, [session_row])
+
+            # After: occupying_slots is populated from resource_allocations
+            slots = session_row.occupying_slots
+            assert slots is not None
+            assert len(slots) == 2
+            # cpu: used=1.5 takes precedence over requested=2.0
+            assert slots["cpu"] == Decimal("1.500000")
+            # mem: used=NULL -> requested=2147483648
+            assert slots["mem"] == Decimal("2147483648")
+
+    @pytest.mark.asyncio
+    async def test_batch_populate_empty_sessions(
+        self,
+        db_with_resource_tables: ExtendedAsyncSAEngine,
+    ) -> None:
+        """Verify that batch_populate handles empty list gracefully."""
+        async with db_with_resource_tables.begin_readonly_session() as db_sess:
+            await batch_populate_session_occupied_slots(db_sess, [])
+
+    @pytest.mark.asyncio
+    async def test_search_returns_computed_occupied_slots(
+        self,
+        db_with_resource_tables: ExtendedAsyncSAEngine,
+        session_with_allocations: SessionTestData,
+    ) -> None:
+        """Verify the search() repository method returns computed occupied_slots
+        from resource_allocations, not the empty JSONB column."""
+        repository = SessionRepository(db_with_resource_tables)
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=10, offset=0),
+            conditions=[],
+            orders=[],
+        )
+        result = await repository.search(querier=querier)
+
+        assert result.total_count == 1
+        session_data = result.items[0]
+        slots = session_data.occupying_slots
+        assert slots is not None
+        assert slots["cpu"] == Decimal("1.500000")
+        assert slots["mem"] == Decimal("2147483648")


### PR DESCRIPTION
This is an auto-generated backport PR of #9433 to the 26.2 release.