### PR TITLE
feat(BA-4816): add model folder pre-validation for inference sessions (#9557)

### DIFF
--- a/changes/9557.fix.md
+++ b/changes/9557.fix.md
@@ -1,0 +1,1 @@
+Validate that inference sessions have at least one model-type virtual folder mounted before dispatching RPC to the agent.

--- a/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/scheduling_controller.py
@@ -45,6 +45,7 @@ from .resolvers.scaling_group_resolver import ScalingGroupResolver
 from .validators import (
     ClusterValidationRule,
     ContainerLimitRule,
+    InferenceModelFolderRule,
     MountNameValidationRule,
     PublicPrivateFilterRule,
     ScalingGroupFilter,
@@ -119,6 +120,7 @@ class SchedulingController:
             ServicePortRule(),
             ClusterValidationRule(),
             MountNameValidationRule(),
+            InferenceModelFolderRule(),
         ]
         self._validator = SessionValidator(validator_rules)
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/__init__.py
@@ -7,6 +7,7 @@ from .base import (
     SessionValidatorRule,
 )
 from .cluster import ClusterValidationRule
+from .inference import InferenceModelFolderRule
 from .mount import MountNameValidationRule
 from .rules import (
     ContainerLimitRule,
@@ -23,6 +24,7 @@ from .validator import SessionValidator
 __all__ = [
     "ClusterValidationRule",
     "ContainerLimitRule",
+    "InferenceModelFolderRule",
     "MountNameValidationRule",
     "PublicPrivateFilterRule",
     "ResourceLimitRule",

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/inference.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/inference.py
@@ -1,0 +1,34 @@
+"""Inference session validation rule."""
+
+from typing import override
+
+from ai.backend.common.types import SessionTypes, VFolderUsageMode
+from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.repositories.scheduler.types.session_creation import (
+    SessionCreationContext,
+    SessionCreationSpec,
+)
+
+from .base import SessionValidatorRule
+
+
+class InferenceModelFolderRule(SessionValidatorRule):
+    """Validates that inference sessions have at least one model-type virtual folder mounted."""
+
+    @override
+    def name(self) -> str:
+        return "inference_model_folder"
+
+    @override
+    def validate(
+        self,
+        spec: SessionCreationSpec,
+        context: SessionCreationContext,
+    ) -> None:
+        if spec.session_type != SessionTypes.INFERENCE:
+            return
+
+        if not any(m.usage_mode == VFolderUsageMode.MODEL for m in context.vfolder_mounts):
+            raise InvalidAPIParameters(
+                "At least one model-type virtual folder must be mounted for inference sessions."
+            )

--- a/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
@@ -459,7 +459,17 @@ class TestMultiContainerSession:
                     },
                 ),
             },
-            vfolder_mounts=[],
+            vfolder_mounts=[
+                VFolderMount(
+                    name="my-model",
+                    vfid=VFolderID(quota_scope_id=None, folder_id=uuid.uuid4()),
+                    vfsubpath=PurePosixPath("."),
+                    host_path=PurePosixPath("/data/vfolders/model"),
+                    kernel_path=PurePosixPath("/home/work/model"),
+                    mount_perm=MountPermission.READ_ONLY,
+                    usage_mode=VFolderUsageMode.MODEL,
+                ),
+            ],
             dotfile_data={},
             container_user_info=ContainerUserInfo(),
         )
@@ -1002,7 +1012,17 @@ class TestMultiClusterScenarios:
                     },
                 )
             },
-            vfolder_mounts=[],
+            vfolder_mounts=[
+                VFolderMount(
+                    name="llm-weights",
+                    vfid=VFolderID(quota_scope_id=None, folder_id=uuid.uuid4()),
+                    vfsubpath=PurePosixPath("."),
+                    host_path=PurePosixPath("/data/vfolders/llm-weights"),
+                    kernel_path=PurePosixPath("/home/work/model"),
+                    mount_perm=MountPermission.READ_ONLY,
+                    usage_mode=VFolderUsageMode.MODEL,
+                ),
+            ],
             dotfile_data={},
             container_user_info=ContainerUserInfo(),
         )

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_inference.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_inference.py
@@ -1,0 +1,163 @@
+"""Tests for InferenceModelFolderRule."""
+
+import uuid
+from collections.abc import Callable
+from pathlib import PurePosixPath
+
+import pytest
+
+from ai.backend.common.types import (
+    MountPermission,
+    SessionTypes,
+    VFolderID,
+    VFolderMount,
+    VFolderUsageMode,
+)
+from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.models.scaling_group import ScalingGroupOpts
+from ai.backend.manager.repositories.scheduler.types.session_creation import (
+    AllowedScalingGroup,
+    ContainerUserInfo,
+    ScalingGroupNetworkInfo,
+    SessionCreationContext,
+    SessionCreationSpec,
+)
+from ai.backend.manager.sokovan.scheduling_controller.validators.inference import (
+    InferenceModelFolderRule,
+)
+
+
+def _make_vfolder_mount(
+    usage_mode: VFolderUsageMode = VFolderUsageMode.GENERAL,
+    name: str = "test-folder",
+) -> VFolderMount:
+    return VFolderMount(
+        name=name,
+        vfid=VFolderID(quota_scope_id=None, folder_id=uuid.uuid4()),
+        vfsubpath=PurePosixPath("."),
+        host_path=PurePosixPath("/mnt/vfolder"),
+        kernel_path=PurePosixPath("/home/work/folder"),
+        mount_perm=MountPermission.READ_ONLY,
+        usage_mode=usage_mode,
+    )
+
+
+@pytest.fixture
+def basic_context() -> SessionCreationContext:
+    return SessionCreationContext(
+        scaling_group_network=ScalingGroupNetworkInfo(use_host_network=False),
+        allowed_scaling_groups=[
+            AllowedScalingGroup(
+                name="default-sg", is_private=False, scheduler_opts=ScalingGroupOpts()
+            ),
+        ],
+        image_infos={},
+        vfolder_mounts=[],
+        dotfile_data={},
+        container_user_info=ContainerUserInfo(),
+    )
+
+
+class TestInferenceModelFolderRule:
+    """Test cases for InferenceModelFolderRule."""
+
+    def test_non_inference_session_skips_validation(
+        self,
+        basic_context: SessionCreationContext,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """Non-INFERENCE session types should pass without any model folder."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(session_type=SessionTypes.INTERACTIVE)
+
+        rule.validate(spec, basic_context)
+
+    def test_inference_with_model_folder_passes(
+        self,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """INFERENCE session with a model folder should pass."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(session_type=SessionTypes.INFERENCE)
+        context = SessionCreationContext(
+            scaling_group_network=ScalingGroupNetworkInfo(use_host_network=False),
+            allowed_scaling_groups=[],
+            image_infos={},
+            vfolder_mounts=[_make_vfolder_mount(VFolderUsageMode.MODEL, "my-model")],
+            dotfile_data={},
+            container_user_info=ContainerUserInfo(),
+        )
+
+        rule.validate(spec, context)
+
+    def test_inference_without_model_folder_raises(
+        self,
+        basic_context: SessionCreationContext,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """INFERENCE session without any model folder should raise InvalidAPIParameters."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(session_type=SessionTypes.INFERENCE)
+
+        with pytest.raises(InvalidAPIParameters) as exc_info:
+            rule.validate(spec, basic_context)
+        assert "model-type virtual folder" in str(exc_info.value)
+
+    def test_inference_custom_variant_without_model_folder_raises(
+        self,
+        basic_context: SessionCreationContext,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """INFERENCE session with runtime_variant=custom should also require a model folder."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(
+            session_type=SessionTypes.INFERENCE,
+            creation_spec={"runtime_variant": "custom"},
+        )
+
+        with pytest.raises(InvalidAPIParameters) as exc_info:
+            rule.validate(spec, basic_context)
+        assert "model-type virtual folder" in str(exc_info.value)
+
+    def test_inference_custom_variant_with_model_folder_passes(
+        self,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """INFERENCE session with runtime_variant=custom and a model folder should pass."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(
+            session_type=SessionTypes.INFERENCE,
+            creation_spec={"runtime_variant": "custom"},
+        )
+        context = SessionCreationContext(
+            scaling_group_network=ScalingGroupNetworkInfo(use_host_network=False),
+            allowed_scaling_groups=[],
+            image_infos={},
+            vfolder_mounts=[_make_vfolder_mount(VFolderUsageMode.MODEL, "my-model")],
+            dotfile_data={},
+            container_user_info=ContainerUserInfo(),
+        )
+
+        rule.validate(spec, context)
+
+    def test_inference_with_general_folder_only_raises(
+        self,
+        session_spec_factory: Callable[..., SessionCreationSpec],
+    ) -> None:
+        """INFERENCE session with only GENERAL folders (no MODEL) should raise."""
+        rule = InferenceModelFolderRule()
+        spec = session_spec_factory(session_type=SessionTypes.INFERENCE)
+        context = SessionCreationContext(
+            scaling_group_network=ScalingGroupNetworkInfo(use_host_network=False),
+            allowed_scaling_groups=[],
+            image_infos={},
+            vfolder_mounts=[
+                _make_vfolder_mount(VFolderUsageMode.GENERAL, "my-data"),
+                _make_vfolder_mount(VFolderUsageMode.DATA, "shared-data"),
+            ],
+            dotfile_data={},
+            container_user_info=ContainerUserInfo(),
+        )
+
+        with pytest.raises(InvalidAPIParameters):
+            rule.validate(spec, context)


### PR DESCRIPTION
This is an auto-generated backport PR of #9557 to the 26.2 release.