### PR TITLE
fix(BA-4756): `ModifyContainerRegistryNode` fails with duplicate association error after global toggle (#9468)

### DIFF
--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.container_registry import AllowedGroupsModel
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import BackendAIError, ContainerRegistryGroupsAlreadyAssociated
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -29,18 +29,10 @@ from ai.backend.manager.models.container_registry import (
 )
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.base.creator import (
-    BulkCreator,
-    Creator,
-    execute_bulk_creator,
-    execute_creator,
-)
+from ai.backend.manager.repositories.base.creator import Creator, execute_creator
 from ai.backend.manager.repositories.base.purger import Purger, execute_purger
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
-from ai.backend.manager.repositories.container_registry.creators import (
-    ContainerRegistryCreatorSpec,
-    ContainerRegistryGroupCreatorSpec,
-)
+from ai.backend.manager.repositories.container_registry.creators import ContainerRegistryCreatorSpec
 from ai.backend.manager.repositories.container_registry.updaters import (
     ContainerRegistryUpdaterSpec,
 )
@@ -239,35 +231,6 @@ class ContainerRegistryRepository:
                 raise ContainerRegistryNotFound()
             return row
 
-    @container_registry_repository_resilience.apply()
-    async def search_container_registries(
-        self,
-        querier: BatchQuerier,
-    ) -> ContainerRegistrySearchResult:
-        """Search container registries with pagination and filtering.
-
-        Args:
-            querier: BatchQuerier containing conditions, orders, and pagination.
-
-        Returns:
-            ContainerRegistrySearchResult with items, total_count, and pagination info.
-        """
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            query = sa.select(ContainerRegistryRow)
-
-            result = await execute_batch_querier(
-                db_sess,
-                query,
-                querier,
-            )
-
-            return ContainerRegistrySearchResult(
-                items=[row.ContainerRegistryRow.to_dataclass() for row in result.rows],
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )
-
     async def _handle_allowed_groups_update(
         self,
         session: SASession,
@@ -287,15 +250,20 @@ class ContainerRegistryRepository:
             ContainerRegistryGroupsAssociationNotFound: If trying to remove non-existing associations
         """
         if allowed_group_updates.add:
-            specs = [
-                ContainerRegistryGroupCreatorSpec(
-                    registry_id=registry_id,
-                    group_id=uuid.UUID(group_id),
-                )
+            insert_values = [
+                {"registry_id": registry_id, "group_id": group_id}
                 for group_id in allowed_group_updates.add
             ]
-            bulk_creator = BulkCreator(specs=specs)
-            await execute_bulk_creator(session, bulk_creator)
+
+            try:
+                insert_query = sa.insert(AssociationContainerRegistriesGroupsRow).values(
+                    insert_values
+                )
+                await session.execute(insert_query)
+            except sa.exc.IntegrityError as e:
+                raise ContainerRegistryGroupsAlreadyAssociated(
+                    f"Already associated groups for registry_id: {registry_id}, group_ids: {allowed_group_updates.add}"
+                ) from e
 
         if allowed_group_updates.remove:
             delete_query = (

--- a/src/ai/backend/manager/repositories/container_registry/updaters.py
+++ b/src/ai/backend/manager/repositories/container_registry/updaters.py
@@ -11,9 +11,6 @@ from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
 
-if TYPE_CHECKING:
-    pass
-
 
 @dataclass
 class ContainerRegistryUpdaterSpec(UpdaterSpec[ContainerRegistryRow]):

--- a/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
+++ b/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
@@ -1214,46 +1214,7 @@ class TestContainerRegistryRepository:
                 )
             )
 
-    async def test_modify_registry_set_is_global_clears_allowed_groups(
-        self,
-        repository: ContainerRegistryRepository,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        registry_with_associated_groups: _RegistryWithGroups,
-    ) -> None:
-        """Test that setting is_global=True clears all group associations."""
-        # Given - Registry already has 3 groups associated
-        registry_id = registry_with_associated_groups.registry.id
-
-        # When - Set is_global to True
-        result = await repository.modify_registry(
-            Updater(
-                spec=ContainerRegistryUpdaterSpec(
-                    is_global=TriState.update(True),
-                ),
-                pk_value=registry_id,
-            )
-        )
-
-        # Then - Registry is updated
-        assert result is not None
-        assert result.is_global is True
-
-        # Then - All group associations are cleared
-        async with db_with_cleanup.begin_readonly_session() as session:
-            associations = (
-                (
-                    await session.execute(
-                        sa.select(AssociationContainerRegistriesGroupsRow).where(
-                            AssociationContainerRegistriesGroupsRow.registry_id == registry_id
-                        )
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-            assert len(associations) == 0
-
+    @pytest.mark.asyncio
     async def test_delete_registry_success(
         self,
         repository: ContainerRegistryRepository,


### PR DESCRIPTION
This is an auto-generated backport PR of #9468 to the 26.2 release.