### PR TITLE
fix(BA-4756): `ModifyContainerRegistryNode` fails with duplicate association error after global toggle

### DIFF
--- a/changes/9468.fix.md
+++ b/changes/9468.fix.md
@@ -1,0 +1,1 @@
+`ModifyContainerRegistryNode` fails with duplicate association error after global toggle

--- a/src/ai/backend/manager/models/gql_models/container_registry.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry.py
@@ -300,6 +300,17 @@ async def handle_allowed_groups_update(
                 )
 
 
+async def clear_all_allowed_groups(
+    db: ExtendedAsyncSAEngine,
+    registry_id: uuid.UUID,
+) -> None:
+    async with db.begin_session() as db_sess:
+        delete_query = sa.delete(AssociationContainerRegistriesGroupsRow).where(
+            AssociationContainerRegistriesGroupsRow.registry_id == registry_id
+        )
+        await db_sess.execute(delete_query)
+
+
 class CreateContainerRegistryNode(graphene.Mutation):
     """
     Deprecated since 25.3.0. use `CreateContainerRegistryNodeV2` instead

--- a/src/ai/backend/manager/models/gql_models/container_registry_v2.py
+++ b/src/ai/backend/manager/models/gql_models/container_registry_v2.py
@@ -21,6 +21,7 @@ from .container_registry import (
     AllowedGroups,
     ContainerRegistryNode,
     ContainerRegistryTypeField,
+    clear_all_allowed_groups,
     handle_allowed_groups_update,
 )
 
@@ -185,7 +186,9 @@ class ModifyContainerRegistryNodeV2(graphene.Mutation):
                 for field, val in input_config.items():
                     setattr(reg_row, field, val)
 
-            if props.allowed_groups:
+            if props.is_global is True:
+                await clear_all_allowed_groups(ctx.db, reg_id)
+            elif props.allowed_groups:
                 await handle_allowed_groups_update(ctx.db, reg_row.id, props.allowed_groups)
 
             return cls(container_registry=ContainerRegistryNode.from_row(ctx, reg_row))


### PR DESCRIPTION
This is a manual backport PR of #9468 to the 25.6 release.