### PR TITLE
ci(BA-4850): separate labeler workflow to fix 403 on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,6 @@ concurrency:
 
 jobs:
 
-  labeler:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: lablup/auto-labeler@main
-
-
   lint-and-typecheck:
     if: |
       !contains(github.event.pull_request.labels.*.name, 'skip:ci')

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: lablup/auto-labeler@main

--- a/changes/9610.misc.md
+++ b/changes/9610.misc.md
@@ -1,0 +1,1 @@
+Separate labeler workflow into standalone file to fix 403 permission errors on fork PRs


### PR DESCRIPTION
## Summary
- Extract labeler job from ci.yml into standalone labeler.yml workflow
- Use pull_request_target trigger instead of pull_request to fix permission issues
- Fixes 403 "Resource not accessible by integration" errors on fork PRs

## Test plan
- [x] Quality checks pass (pants fmt, fix, lint)
- [ ] Verify labeler runs successfully on fork PR (will be tested after merge)

Resolves BA-4850