### PR TITLE
fix(BA-4392): Share single Docker client across container stats collection (#9469)

### DIFF
--- a/changes/9469.fix.md
+++ b/changes/9469.fix.md
@@ -1,0 +1,1 @@
+Share a single Docker client instance across all containers during stats collection. Previously each container created its own Docker() instance, causing file descriptor exhaustion at scale.

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -44,7 +44,7 @@ from ai.backend.agent.stats import (
     StatModes,
 )
 from ai.backend.agent.types import Container, MountInfo
-from ai.backend.agent.utils import closing_async, read_sysfs
+from ai.backend.agent.utils import read_sysfs
 from ai.backend.agent.vendor.linux import libnuma
 from ai.backend.common.asyncio import current_loop
 from ai.backend.common.json import dump_json
@@ -171,11 +171,13 @@ class CPUPlugin(AbstractComputePlugin):
         (SlotName("cpu"), SlotTypes.COUNT),
     ]
 
+    _docker: Docker
+
     async def init(self, context: Any | None = None) -> None:
-        pass
+        self._docker = Docker()
 
     async def cleanup(self) -> None:
-        pass
+        await self._docker.close()
 
     async def update_plugin_config(self, new_plugin_config: Mapping[str, Any]) -> None:
         pass
@@ -245,6 +247,9 @@ class CPUPlugin(AbstractComputePlugin):
         ctx: StatContext,
         container_ids: Sequence[str],
     ) -> Sequence[ContainerMeasurement]:
+        if not container_ids:
+            return []
+
         async def sysfs_impl(container_id: str) -> float | None:
             cpu_path = ctx.agent.get_cgroup_path("cpuacct", container_id)
             version = ctx.agent.docker_info["CgroupVersion"]  # type: ignore[attr-defined]
@@ -273,17 +278,16 @@ class CPUPlugin(AbstractComputePlugin):
             return cpu_used
 
         async def api_impl(container_id: str) -> float | None:
-            async with closing_async(Docker()) as docker:
-                container = DockerContainer(docker, id=container_id)
-                try:
-                    async with async_timeout.timeout(2.0):
-                        ret = await fetch_api_stats(container)
-                except TimeoutError:
-                    return None
-                if ret is None:
-                    return None
-                cpu_usage = cast(float, nmget(ret, "cpu_stats.cpu_usage.total_usage", 0))
-                return cpu_usage / 1e6
+            container = DockerContainer(self._docker, id=container_id)
+            try:
+                async with async_timeout.timeout(2.0):
+                    ret = await fetch_api_stats(container)
+            except TimeoutError:
+                return None
+            if ret is None:
+                return None
+            cpu_usage = cast(float, nmget(ret, "cpu_stats.cpu_usage.total_usage", 0))
+            return cpu_usage / 1e6
 
         if ctx.mode == StatModes.CGROUP:
             impl = sysfs_impl
@@ -292,13 +296,14 @@ class CPUPlugin(AbstractComputePlugin):
         else:
             raise RuntimeError("should not reach here")
 
-        q = Decimal("0.000")
-        per_container_cpu_used = {}
-        per_container_cpu_util = {}
         tasks = []
         for cid in container_ids:
             tasks.append(asyncio.create_task(impl(cid)))
         results = await asyncio.gather(*tasks)
+
+        q = Decimal("0.000")
+        per_container_cpu_used = {}
+        per_container_cpu_util = {}
         for cid, cpu_used in zip(container_ids, results, strict=True):
             if cpu_used is None:
                 continue
@@ -493,11 +498,13 @@ class MemoryPlugin(AbstractComputePlugin):
         (SlotName("mem"), SlotTypes.BYTES),
     ]
 
+    _docker: Docker
+
     async def init(self, context: Any | None = None) -> None:
-        pass
+        self._docker = Docker()
 
     async def cleanup(self) -> None:
-        pass
+        await self._docker.close()
 
     async def update_plugin_config(self, new_plugin_config: Mapping[str, Any]) -> None:
         pass
@@ -601,6 +608,9 @@ class MemoryPlugin(AbstractComputePlugin):
     async def gather_container_measures(
         self, ctx: StatContext, container_ids: Sequence[str]
     ) -> Sequence[ContainerMeasurement]:
+        if not container_ids:
+            return []
+
         def get_scratch_size(_container_id: str) -> int:
             # Temporarily disabled as this function incurs too much delay with
             # a large number of files in scratch dirs, causing indefinite accumulation of
@@ -700,10 +710,9 @@ class MemoryPlugin(AbstractComputePlugin):
                     e,
                 )
                 return None
-            async with closing_async(Docker()) as docker:
-                container = DockerContainer(docker, id=container_id)
-                data = await container.show()
-                sandbox_key = data["NetworkSettings"]["SandboxKey"]
+            container = DockerContainer(self._docker, id=container_id)
+            data = await container.show()
+            sandbox_key = data["NetworkSettings"]["SandboxKey"]
             net_rx_bytes = 0
             net_tx_bytes = 0
             nstat = await netstat_ns(sandbox_key)
@@ -724,41 +733,42 @@ class MemoryPlugin(AbstractComputePlugin):
                 scratch_sz,
             )
 
-        async def api_impl(container_id: str) -> tuple[int, int, int, int, int, int, int] | None:
-            async with closing_async(Docker()) as docker:
-                container = DockerContainer(docker, id=container_id)
-                try:
-                    async with async_timeout.timeout(2.0):
-                        ret = await fetch_api_stats(container)
-                except TimeoutError:
-                    return None
-                if ret is None:
-                    return None
-                mem_cur_bytes = nmget(ret, "memory_stats.usage", 0)
-                mem_total_bytes = nmget(ret, "memory_stats.limit", 0)
-                io_read_bytes = 0
-                io_write_bytes = 0
-                for item in nmget(ret, "blkio_stats.io_service_bytes_recursive", []):
-                    if item["op"] == "Read":
-                        io_read_bytes += item["value"]
-                    elif item["op"] == "Write":
-                        io_write_bytes += item["value"]
-                net_rx_bytes = 0
-                net_tx_bytes = 0
-                for name, stat in ret["networks"].items():
-                    net_rx_bytes += stat["rx_bytes"]
-                    net_tx_bytes += stat["tx_bytes"]
-                loop = current_loop()
-                scratch_sz = await loop.run_in_executor(None, get_scratch_size, container_id)
-                return (
-                    mem_cur_bytes,
-                    mem_total_bytes,
-                    io_read_bytes,
-                    io_write_bytes,
-                    net_rx_bytes,
-                    net_tx_bytes,
-                    scratch_sz,
-                )
+        async def api_impl(
+            container_id: str,
+        ) -> tuple[int, int, int, int, int, int, int] | None:
+            container = DockerContainer(self._docker, id=container_id)
+            try:
+                async with async_timeout.timeout(2.0):
+                    ret = await fetch_api_stats(container)
+            except TimeoutError:
+                return None
+            if ret is None:
+                return None
+            mem_cur_bytes = nmget(ret, "memory_stats.usage", 0)
+            mem_total_bytes = nmget(ret, "memory_stats.limit", 0)
+            io_read_bytes = 0
+            io_write_bytes = 0
+            for item in nmget(ret, "blkio_stats.io_service_bytes_recursive", []):
+                if item["op"] == "Read":
+                    io_read_bytes += item["value"]
+                elif item["op"] == "Write":
+                    io_write_bytes += item["value"]
+            net_rx_bytes = 0
+            net_tx_bytes = 0
+            for name, stat in ret["networks"].items():
+                net_rx_bytes += stat["rx_bytes"]
+                net_tx_bytes += stat["tx_bytes"]
+            loop = current_loop()
+            scratch_sz = await loop.run_in_executor(None, get_scratch_size, container_id)
+            return (
+                mem_cur_bytes,
+                mem_total_bytes,
+                io_read_bytes,
+                io_write_bytes,
+                net_rx_bytes,
+                net_tx_bytes,
+                scratch_sz,
+            )
 
         if ctx.mode == StatModes.CGROUP:
             impl = sysfs_impl

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -40,10 +40,12 @@ async def load_resources(
     if "cpu" not in compute_plugin_ctx.plugins:
         cpu_config = await etcd.get_prefix("config/plugins/cpu")
         cpu_plugin = CPUPlugin(cpu_config, local_config)
+        await cpu_plugin.init()
         compute_plugin_ctx.attach_intrinsic_device(cpu_plugin)
     if "mem" not in compute_plugin_ctx.plugins:
         memory_config = await etcd.get_prefix("config/plugins/memory")
         memory_plugin = MemoryPlugin(memory_config, local_config)
+        await memory_plugin.init()
         compute_plugin_ctx.attach_intrinsic_device(memory_plugin)
     for plugin_name, plugin_instance in compute_plugin_ctx.plugins.items():
         if not all(

--- a/tests/unit/agent/test_docker_intrinsic.py
+++ b/tests/unit/agent/test_docker_intrinsic.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ai.backend.agent.docker.intrinsic import CPUPlugin, MemoryPlugin
+from ai.backend.agent.stats import StatModes
+
+
+class BaseDockerIntrinsicTest:
+    """Shared fixtures for Docker intrinsic plugin tests."""
+
+    @pytest.fixture
+    def container_ids(self) -> list[str]:
+        return [f"container_{i:03d}" for i in range(5)]
+
+    @pytest.fixture
+    def docker_stats_response(self) -> dict[str, Any]:
+        return {
+            "read": "2024-01-01T00:00:00.000000000Z",
+            "preread": "2024-01-01T00:00:01.000000000Z",
+            "cpu_stats": {
+                "cpu_usage": {
+                    "total_usage": 1_000_000_000,
+                },
+            },
+            "memory_stats": {
+                "usage": 1024 * 1024 * 100,
+                "limit": 1024 * 1024 * 1024,
+            },
+            "blkio_stats": {
+                "io_service_bytes_recursive": [
+                    {"op": "Read", "value": 1024},
+                    {"op": "Write", "value": 2048},
+                ],
+            },
+            "networks": {
+                "eth0": {
+                    "rx_bytes": 4096,
+                    "tx_bytes": 8192,
+                },
+            },
+        }
+
+    @pytest.fixture
+    def docker_stat_context(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.mode = StatModes.DOCKER
+        return ctx
+
+    @pytest.fixture
+    def cgroup_stat_context(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.mode = StatModes.CGROUP
+        return ctx
+
+    @pytest.fixture
+    def mock_fetch_api_stats(
+        self, docker_stats_response: dict[str, Any]
+    ) -> Generator[MagicMock, None, None]:
+        with patch(
+            "ai.backend.agent.docker.intrinsic.fetch_api_stats",
+            return_value=docker_stats_response,
+        ) as mock:
+            yield mock
+
+
+class TestCPUPluginDockerClientLifecycle(BaseDockerIntrinsicTest):
+    """Tests for CPUPlugin Docker client lifecycle management."""
+
+    @pytest.fixture
+    def cpu_plugin(self) -> CPUPlugin:
+        plugin = CPUPlugin.__new__(CPUPlugin)
+        plugin.local_config = {"agent": {"docker-mode": "default"}}
+        plugin._docker = AsyncMock()
+        return plugin
+
+    @pytest.fixture
+    def cpu_cgroup_context(self, cgroup_stat_context: MagicMock) -> MagicMock:
+        """CGROUP stat context with CPU cgroup v2 path mocks."""
+        cgroup_stat_context.agent.docker_info = {"CgroupVersion": "2"}
+
+        def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+            path = MagicMock()
+            stat_file = MagicMock()
+            stat_file.read_text.return_value = "usage_usec 1000000\n"
+            path.__truediv__ = MagicMock(return_value=stat_file)
+            return path
+
+        cgroup_stat_context.agent.get_cgroup_path = mock_get_cgroup_path
+        return cgroup_stat_context
+
+    async def test_init_creates_docker_client(self, cpu_plugin: CPUPlugin) -> None:
+        """Verify init() creates a Docker client instance."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            mock_docker_cls.return_value = AsyncMock()
+            await cpu_plugin.init()
+            mock_docker_cls.assert_called_once()
+            assert cpu_plugin._docker is not None
+
+    async def test_cleanup_closes_docker_client(self, cpu_plugin: CPUPlugin) -> None:
+        """Verify cleanup() closes the Docker client."""
+        cpu_plugin._docker = AsyncMock()
+        await cpu_plugin.cleanup()
+        cpu_plugin._docker.close.assert_called_once()
+
+    async def test_api_mode_uses_instance_docker_client(
+        self,
+        cpu_plugin: CPUPlugin,
+        container_ids: list[str],
+        docker_stat_context: MagicMock,
+        mock_fetch_api_stats: MagicMock,
+    ) -> None:
+        """Verify API mode uses the plugin's Docker client, not a new one."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            await cpu_plugin.gather_container_measures(docker_stat_context, container_ids)
+            mock_docker_cls.assert_not_called()
+
+    async def test_sysfs_mode_does_not_use_docker(
+        self,
+        cpu_plugin: CPUPlugin,
+        container_ids: list[str],
+        cpu_cgroup_context: MagicMock,
+    ) -> None:
+        """Verify CGROUP mode doesn't create any new Docker instance."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            await cpu_plugin.gather_container_measures(cpu_cgroup_context, container_ids)
+            mock_docker_cls.assert_not_called()
+
+
+class TestMemoryPluginDockerClientLifecycle(BaseDockerIntrinsicTest):
+    """Tests for MemoryPlugin Docker client lifecycle management."""
+
+    @pytest.fixture
+    def memory_plugin(self) -> MemoryPlugin:
+        plugin = MemoryPlugin.__new__(MemoryPlugin)
+        plugin.local_config = {"agent": {"docker-mode": "default"}}
+        plugin._docker = AsyncMock()
+        return plugin
+
+    @pytest.fixture
+    def memory_cgroup_context(
+        self, cgroup_stat_context: MagicMock
+    ) -> Generator[MagicMock, None, None]:
+        """CGROUP stat context with memory/io cgroup v2 path mocks and related patches."""
+        ctx = cgroup_stat_context
+        ctx.agent.get_cgroup_version = MagicMock(return_value="2")
+
+        mem_path = MagicMock()
+        mem_stat = MagicMock()
+        mem_stat.read_text.return_value = "inactive_file 0\n"
+        mem_path.__truediv__ = MagicMock(return_value=mem_stat)
+        io_path = MagicMock()
+        io_stat = MagicMock()
+        io_stat.read_text.return_value = ""
+        io_path.__truediv__ = MagicMock(return_value=io_stat)
+
+        def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+            if subsys == "memory":
+                return mem_path
+            return io_path
+
+        ctx.agent.get_cgroup_path = mock_get_cgroup_path
+
+        mock_container_data = {
+            "NetworkSettings": {"SandboxKey": "/var/run/docker/netns/fake"},
+        }
+
+        with (
+            patch(
+                "ai.backend.agent.docker.intrinsic.DockerContainer",
+            ) as mock_container_cls,
+            patch(
+                "ai.backend.agent.docker.intrinsic.read_sysfs",
+                return_value=1048576,
+            ),
+            patch(
+                "ai.backend.agent.docker.intrinsic.netstat_ns",
+                return_value={},
+            ),
+            patch(
+                "ai.backend.agent.docker.intrinsic.current_loop",
+            ) as mock_loop,
+        ):
+            mock_container_instance = AsyncMock()
+            mock_container_instance.show.return_value = mock_container_data
+            mock_container_cls.return_value = mock_container_instance
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
+            yield ctx
+
+    async def test_init_creates_docker_client(self, memory_plugin: MemoryPlugin) -> None:
+        """Verify init() creates a Docker client instance."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            mock_docker_cls.return_value = AsyncMock()
+            await memory_plugin.init()
+            mock_docker_cls.assert_called_once()
+            assert memory_plugin._docker is not None
+
+    async def test_cleanup_closes_docker_client(self, memory_plugin: MemoryPlugin) -> None:
+        """Verify cleanup() closes the Docker client."""
+        memory_plugin._docker = AsyncMock()
+        await memory_plugin.cleanup()
+        memory_plugin._docker.close.assert_called_once()
+
+    async def test_api_mode_uses_instance_docker_client(
+        self,
+        memory_plugin: MemoryPlugin,
+        container_ids: list[str],
+        docker_stat_context: MagicMock,
+        mock_fetch_api_stats: MagicMock,
+    ) -> None:
+        """Verify API mode uses the plugin's Docker client, not a new one."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            await memory_plugin.gather_container_measures(docker_stat_context, container_ids)
+            mock_docker_cls.assert_not_called()
+
+    async def test_sysfs_mode_uses_instance_docker_client(
+        self,
+        memory_plugin: MemoryPlugin,
+        container_ids: list[str],
+        memory_cgroup_context: MagicMock,
+    ) -> None:
+        """Even in CGROUP mode, Docker is needed for SandboxKey. Verify instance client is used."""
+        with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
+            await memory_plugin.gather_container_measures(memory_cgroup_context, container_ids)
+            mock_docker_cls.assert_not_called()


### PR DESCRIPTION
This is an auto-generated backport PR of #9469 to the 26.2 release.