### PR TITLE
fix(BA-4871): Strip `GPU-` prefix at `gpu_alloc_map` resolver (#9642)

### DIFF
--- a/changes/9642.fix.md
+++ b/changes/9642.fix.md
@@ -1,0 +1,1 @@
+Strip `GPU-` prefix from DeviceId keys at the GQL resolver level when resolving the `gpu_alloc_map` field, fixing UUIDFloatMap validation errors.

--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -106,10 +106,14 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
 }
 
 
+def _strip_gpu_prefix(alloc_map: dict[str, float]) -> dict[str, float]:
+    return {k.removeprefix("GPU-"): v for k, v in alloc_map.items()}
+
+
 async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> dict[str, float]:
     raw_alloc_map = await ctx.valkey_stat.get_gpu_allocation_map(str(agent_id))
     if raw_alloc_map:
-        return UUIDFloatMap.parse_value({k: float(v) for k, v in raw_alloc_map.items()})
+        return UUIDFloatMap.parse_value(_strip_gpu_prefix(raw_alloc_map))
     return {}
 
 

--- a/tests/unit/manager/api/test_gql_legacy_gpu_alloc_map.py
+++ b/tests/unit/manager/api/test_gql_legacy_gpu_alloc_map.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.types import AgentId
+from ai.backend.manager.api.gql_legacy.agent import (
+    _resolve_gpu_alloc_map,
+)
+
+
+class TestResolveGpuAllocMap:
+    @pytest.fixture
+    def mock_ctx(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.valkey_stat.get_gpu_allocation_map = AsyncMock(
+            return_value={
+                "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
+                "GPU-11111111-2222-3333-4444-555555555555": 1.0,
+            }
+        )
+        return ctx
+
+    async def test_gpu_prefixed_keys_are_resolved_as_valid_uuids(self, mock_ctx: MagicMock) -> None:
+        result = await _resolve_gpu_alloc_map(mock_ctx, AgentId("i-test"))
+        assert result == {
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
+            "11111111-2222-3333-4444-555555555555": 1.0,
+        }


### PR DESCRIPTION
This is an auto-generated backport PR of #9642 to the 26.2 release.