### PR TITLE
fix(BA-4871): Strip `GPU-` prefix at `gpu_alloc_map` resolver

### DIFF
--- a/changes/9642.fix.md
+++ b/changes/9642.fix.md
@@ -1,0 +1,1 @@
+Strip `GPU-` prefix from DeviceId keys at the GQL resolver level when resolving the `gpu_alloc_map` field, fixing UUIDFloatMap validation errors.

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -112,6 +112,10 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
 GPU_ALLOC_MAP_CACHE_PERIOD: Final[int] = 3600 * 24
 
 
+def _strip_gpu_prefix(alloc_map: dict[str, float]) -> dict[str, float]:
+    return {k.removeprefix("GPU-"): v for k, v in alloc_map.items()}
+
+
 async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> dict[str, float]:
     raw_alloc_map = await redis_helper.execute(
         ctx.redis_stat, lambda r: r.get(f"gpu_alloc_map.{agent_id}")
@@ -119,7 +123,9 @@ async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> d
 
     if raw_alloc_map:
         alloc_map = load_json(raw_alloc_map)
-        return UUIDFloatMap.parse_value({k: float(v) for k, v in alloc_map.items()})
+        return UUIDFloatMap.parse_value(
+            _strip_gpu_prefix({k: float(v) for k, v in alloc_map.items()})
+        )
     return {}
 
 

--- a/tests/manager/api/test_gql_legacy_gpu_alloc_map.py
+++ b/tests/manager/api/test_gql_legacy_gpu_alloc_map.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ai.backend.common.types import AgentId
+from ai.backend.manager.models.gql_models.agent import (
+    _resolve_gpu_alloc_map,
+)
+
+
+class TestResolveGpuAllocMap:
+    @pytest.fixture
+    def mock_ctx(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.redis_stat = MagicMock()
+        return ctx
+
+    async def test_gpu_prefixed_keys_are_resolved_as_valid_uuids(self, mock_ctx: MagicMock) -> None:
+        from ai.backend.common.json import dump_json_str
+
+        raw_data = {
+            "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
+            "GPU-11111111-2222-3333-4444-555555555555": 1.0,
+        }
+
+        with patch(
+            "ai.backend.manager.models.gql_models.agent.redis_helper.execute",
+            new_callable=AsyncMock,
+            return_value=dump_json_str(raw_data).encode(),
+        ):
+            result = await _resolve_gpu_alloc_map(mock_ctx, AgentId("i-test"))
+            assert result == {
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
+                "11111111-2222-3333-4444-555555555555": 1.0,
+            }


### PR DESCRIPTION
This is a manual backport PR of #9642 to the 25.6 release.

## Summary
- Strip `GPU-` prefix from DeviceId keys at the GQL resolver level when resolving the `gpu_alloc_map` field, fixing UUIDFloatMap validation errors.

Backported-from: main
Backported-to: 25.6
Backport-of: #9642