### PR TITLE
feat(BA-4872): Add server-side API endpoint for searching deployment policies

### DIFF
--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -38,6 +38,7 @@ from ai.backend.common.dto.manager.deployment import (
     RouteDTO,
     RouteFilter,
     RouteOrder,
+    SearchDeploymentPoliciesRequest,
     SearchDeploymentsRequest,
     SearchRevisionsRequest,
     SearchRoutesRequest,
@@ -543,6 +544,11 @@ class DeploymentPolicyAdapter:
             created_at=data.created_at,
             updated_at=data.updated_at,
         )
+
+    def build_querier(self, request: SearchDeploymentPoliciesRequest) -> BatchQuerier:
+        """Build a BatchQuerier for deployment policies from search request."""
+        pagination = OffsetPagination(limit=request.limit, offset=request.offset)
+        return BatchQuerier(conditions=[], orders=[], pagination=pagination)
 
     def build_creator(
         self, request: CreateDeploymentPolicyRequest, deployment_id: UUID

--- a/src/ai/backend/manager/api/rest/deployment/handler.py
+++ b/src/ai/backend/manager/api/rest/deployment/handler.py
@@ -27,6 +27,7 @@ from ai.backend.common.dto.manager.deployment import (
     GetDeploymentPolicyResponse,
     GetDeploymentResponse,
     GetRevisionResponse,
+    ListDeploymentPoliciesResponse,
     ListDeploymentsResponse,
     ListRevisionsResponse,
     ListRoutesResponse,
@@ -35,6 +36,7 @@ from ai.backend.common.dto.manager.deployment import (
     RevisionPathParam,
     RouteFilter,
     RoutePathParam,
+    SearchDeploymentPoliciesRequest,
     SearchDeploymentsRequest,
     SearchRevisionsRequest,
     SearchRoutesRequest,
@@ -62,6 +64,9 @@ from ai.backend.manager.services.deployment.actions.deployment_policy.create_dep
 )
 from ai.backend.manager.services.deployment.actions.deployment_policy.get_deployment_policy import (
     GetDeploymentPolicyAction,
+)
+from ai.backend.manager.services.deployment.actions.deployment_policy.search_deployment_policies import (
+    SearchDeploymentPoliciesAction,
 )
 from ai.backend.manager.services.deployment.actions.deployment_policy.update_deployment_policy import (
     UpdateDeploymentPolicyAction,
@@ -454,6 +459,31 @@ class DeploymentAPIHandler:
 
         resp = UpdateDeploymentPolicyResponse(
             deployment_policy=self._policy_adapter.convert_to_dto(action_result.data)
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)
+
+    async def search_deployment_policies(
+        self,
+        body: BodyParam[SearchDeploymentPoliciesRequest],
+    ) -> APIResponse:
+        """Search deployment policies with pagination."""
+        deployment_processors = self._get_deployment_processors()
+
+        querier = self._policy_adapter.build_querier(body.parsed)
+
+        action_result = await deployment_processors.search_deployment_policies.wait_for_complete(
+            SearchDeploymentPoliciesAction(querier=querier)
+        )
+
+        resp = ListDeploymentPoliciesResponse(
+            deployment_policies=[
+                self._policy_adapter.convert_to_dto(policy) for policy in action_result.data
+            ],
+            pagination=PaginationInfo(
+                total=action_result.total_count,
+                offset=body.parsed.offset,
+                limit=body.parsed.limit,
+            ),
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)
 

--- a/src/ai/backend/manager/api/rest/deployment/registry.py
+++ b/src/ai/backend/manager/api/rest/deployment/registry.py
@@ -61,7 +61,13 @@ def register_deployment_routes(deps: ModuleDeps) -> RouteRegistry:
         middlewares=[auth_required],
     )
 
-    # Policy routes (nested under deployment)
+    # Policy routes
+    reg.add(
+        "POST",
+        "/policies/search",
+        handler.search_deployment_policies,
+        middlewares=[auth_required],
+    )
     reg.add(
         "POST",
         "/{deployment_id}/policy",


### PR DESCRIPTION
## Summary

- Add `POST /deployments/policies/search` REST API endpoint in the manager
- Wire the handler to the existing `search_deployment_policies` service/repository methods
- Add `build_querier` method to `DeploymentPolicyAdapter` for pagination support

Resolves BA-4872

## Test plan

- [x] Verified `backend.ai deployment policy list` returns all policies with correct data
- [x] Verified `--limit` and `--offset` pagination options work

🤖 Generated with [Claude Code](https://claude.com/claude-code)