### PR TITLE
fix: default group gid in AccountManagerConfig (#9571)

### DIFF
--- a/changes/9571.fix.md
+++ b/changes/9571.fix.md
@@ -1,0 +1,1 @@
+Fix incorrect default group gid in AccountManagerConfig (use st_gid instead of st_uid).

--- a/src/ai/backend/account_manager/config.py
+++ b/src/ai/backend/account_manager/config.py
@@ -334,7 +334,7 @@ class AccountManagerConfig(BaseSchema):
     group: Annotated[
         int,
         GroupID(default_gid=_file_perm.st_gid),
-        Field(default=_file_perm.st_uid, description="Process group."),
+        Field(default=_file_perm.st_gid, description="Process group."),
     ]
     ssl_enabled: Annotated[
         bool, Field(description="Use TLS to communicate. Default is false.", default=False)


### PR DESCRIPTION
This is an auto-generated backport PR of #9571 to the 26.2 release.