### PR TITLE
fix(BA-4882): fix sessionresult enum type migration for coexisting types

### DIFF
--- a/changes/9670.fix.md
+++ b/changes/9670.fix.md
@@ -1,0 +1,1 @@
+Fix sessionresult enum type migration that silently skipped rename when both singular and plural types coexisted

--- a/src/ai/backend/manager/models/alembic/versions/0b1efbb2db84_fix_sessionresult_enum_type_coexistence.py
+++ b/src/ai/backend/manager/models/alembic/versions/0b1efbb2db84_fix_sessionresult_enum_type_coexistence.py
@@ -1,7 +1,7 @@
 """fix sessionresult enum type when both singular and plural coexist
 
 Revision ID: 0b1efbb2db84
-Revises: 3f5c20f7bb07
+Revises: 7h4m7ygnaao1
 Create Date: 2026-03-05 00:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0b1efbb2db84"
-down_revision = "3f5c20f7bb07"
+down_revision = "7h4m7ygnaao1"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Migration `ffcf0ed13a26` silently skips the `sessionresults` → `sessionresult` rename on databases with full migration history, because both enum types coexist (`sessionresult` from `405aa2c39458` and `sessionresults` from `b6b884fbae1f`)
- Add a new migration that handles the both-exist case: ALTER `sessions.result` to use `sessionresult`, then DROP `sessionresults`
- Cannot modify `ffcf0ed13a26` as it has already been applied on some sites

## DB Enum Type History

### Case 1: Full migration path (BUG → FIX)

```mermaid
graph LR
    A["<b>405aa2c39458</b> (2019)<br/>CREATE TYPE <b>sessionresult</b><br/>→ kernels.result"]
    B["<b>b6b884fbae1f</b> (2022)<br/>CREATE TYPE <b>sessionresults</b><br/>→ sessions.result"]
    C["<b>ffcf0ed13a26</b><br/>both exist → <b>SKIP</b> ❌"]
    D["<b>0b1efbb2db84</b><br/>ALTER sessions.result<br/>→ sessionresult<br/>DROP sessionresults ✅"]
    A --> B --> C --> D
    style C fill:#f96,stroke:#333
    style D fill:#6f6,stroke:#333
```

### Case 2: Already fixed DB

```mermaid
graph LR
    A["DB has only<br/><b>sessionresult</b>"]
    B["<b>ffcf0ed13a26</b><br/>no-op ✅"]
    C["<b>0b1efbb2db84</b><br/>no-op ✅"]
    A --> B --> C
    style B fill:#6f6,stroke:#333
    style C fill:#6f6,stroke:#333
```

### Case 3: Oneshot (fresh DB)

```mermaid
graph LR
    A["<b>metadata.create_all()</b><br/>EnumType(SessionResult)<br/>→ <b>sessionresult</b>"]
    B["<b>stamp HEAD</b><br/>all migrations<br/>marked applied ✅"]
    A --> B
    style A fill:#6f6,stroke:#333
    style B fill:#6f6,stroke:#333
```

## Test plan
- [ ] Verify on a DB with both `sessionresult` and `sessionresults` types (full migration history)
- [ ] Verify on a DB with only `sessionresult` (oneshot or already fixed)
- [ ] Verify on a DB with only `sessionresults` (edge case)

Resolves BA-4882

🤖 Generated with [Claude Code](https://claude.com/claude-code)