### PR TITLE
fix(BA-4863): Handle DOWNSTREAM_SERVICE_ERROR from Hive Gateway for GraphQL errors

### DIFF
--- a/changes/9737.fix.md
+++ b/changes/9737.fix.md
@@ -1,0 +1,1 @@
+Fix WebUI not handling DOWNSTREAM_SERVICE_ERROR from Hive Gateway by preserving original error codes in the gateway plugin and transforming remaining gateway-specific error codes in the web proxy

--- a/configs/graphql/gateway.config.ts
+++ b/configs/graphql/gateway.config.ts
@@ -1,0 +1,115 @@
+import { defineConfig, type GatewayPlugin } from '@graphql-hive/gateway';
+
+// Custom plugin to forward headers from context to subgraph requests
+// This ensures headers (including JWT tokens) are included in each GraphQL operation
+// execution after the WebSocket connection is established.
+// Note: For WebSocket handshake authentication, the 'headers' option in transportEntries is used.
+const useConnectionParamsToHeadersPlugin = (): GatewayPlugin => {
+  return {
+    onSubgraphExecute({ executionRequest, executor, setExecutor }) {
+      // Always wrap executor to forward headers from context
+      const originalExecutor = executor;
+      const wrappedExecutor = async (execRequest: any) => {
+        // Extract headers from execution request context
+        let reqHeaders = execRequest.context.headers || {};
+        let new_headers = {};
+        if (reqHeaders["x-backendai-token"]) {
+          new_headers = {
+            "x-backendai-token": reqHeaders["x-backendai-token"]
+          };
+        }
+
+        const modifiedRequest = {
+          ...execRequest,
+          extensions: {
+            headers: new_headers,
+          },
+        };
+        return originalExecutor(modifiedRequest);
+      };
+
+      setExecutor(wrappedExecutor);
+    },
+  };
+};
+
+// Custom plugin to preserve original error extensions from subgraph responses.
+// Without this plugin, Hive Gateway rewrites extensions.code to
+// "DOWNSTREAM_SERVICE_ERROR" and adds a serviceName field, which the WebUI
+// does not recognize.
+const usePreserveSubgraphErrorExtensions = (): GatewayPlugin => {
+  return {
+    onSubgraphExecute({ executionRequest, executor, setExecutor }) {
+      const originalExecutor = executor;
+      const wrappedExecutor = async (execRequest: any) => {
+        const result = await originalExecutor(execRequest);
+        if (Symbol.asyncIterator in Object(result)) {
+          return result;
+        }
+        const singleResult = result as any;
+        if (singleResult?.errors) {
+          for (const error of singleResult.errors) {
+            if (error.extensions?.code === 'DOWNSTREAM_SERVICE_ERROR') {
+              // Restore the original error code from upstream extensions if available,
+              // otherwise mark as unknown downstream error.
+              const upstreamCode = error.extensions?.upstream?.extensions?.code;
+              if (upstreamCode) {
+                error.extensions.code = upstreamCode;
+              }
+            }
+          }
+        }
+        return singleResult;
+      };
+
+      setExecutor(wrappedExecutor);
+    },
+  };
+};
+
+export const gatewayConfig = defineConfig({
+  plugins: (ctx) => [
+    useConnectionParamsToHeadersPlugin(),
+    usePreserveSubgraphErrorExtensions(),
+  ],
+  propagateHeaders: {
+    fromClientToSubgraphs({ context }) {
+      let headers = context.headers || {};
+      delete headers['content-length'];
+      return headers;
+    },
+  },
+  disableIntrospection: {
+    disableIf: () => true
+  },
+  maskedErrors: false,
+  logging: false,
+  supergraph: '/gateway/supergraph.graphql',
+  graphqlEndpoint: '/admin/gql',
+  skipValidation: true,
+  transportEntries: {
+    GRAPHENE: {
+      // Location points to the manager's GraphQL path
+      // This is configured for halfstack's Docker environment
+      // NOTE: This must be changed in production environments
+      location: 'http://host.docker.internal:8091/admin/gql',
+    },
+    STRAWBERRY: {
+      // Location points to the manager's GraphQL path
+      // This is configured for halfstack's Docker environment
+      // NOTE: This must be changed in production environments
+      // NOTE: STRAWBERRY supports WebSocket subscriptions
+      location: 'http://host.docker.internal:8091/admin/gql/strawberry',
+    },
+    '*.http': {
+      options: {
+        subscriptions: {
+          kind: 'ws',
+          headers: [
+            ['x-backendai-token', '{context.headers.x-backendai-token}']
+          ]
+        },
+      }
+    },
+  },
+});

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -5,7 +5,7 @@ import base64
 import json
 import logging
 import random
-from typing import Final, Iterable, Optional, Tuple, Union, cast
+from typing import Any, Final, Iterable, Optional, Tuple, Union, cast
 
 import aiohttp
 from aiohttp import web
@@ -32,6 +32,9 @@ HTTP_HEADERS_TO_FORWARD = [
 ]
 
 CHUNK_SIZE: Final[int] = 64 * 1024
+
+DOWNSTREAM_SERVICE_ERROR: Final[str] = "DOWNSTREAM_SERVICE_ERROR"
+DEFAULT_BACKEND_ERROR_CODE: Final[str] = "backendai_generic_internal-error"
 
 HOP_ONLY_HEADERS: Final[CIMultiDict[int]] = CIMultiDict([
     ("Connection", 1),
@@ -274,6 +277,138 @@ async def web_handler(
         )
     except Exception:
         log.exception("web_handler: unexpected error")
+        return web.HTTPInternalServerError(
+            text=json.dumps({
+                "type": "https://api.backend.ai/probs/internal-server-error",
+                "title": "Something has gone wrong.",
+            }),
+            content_type="application/problem+json",
+        )
+    finally:
+        await api_session.close()
+
+
+def _transform_downstream_service_errors(
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Transform DOWNSTREAM_SERVICE_ERROR codes in GraphQL error responses.
+
+    When GraphQL errors pass through Hive Gateway, the gateway rewrites
+    ``extensions.code`` to ``DOWNSTREAM_SERVICE_ERROR``.  The WebUI does not
+    recognise this code and the page breaks.  Replace it with the default
+    Backend.AI error code so the frontend falls back to message-based handling.
+    """
+    errors = data.get("errors")
+    if not errors or not isinstance(errors, list):
+        return data
+    for error in errors:
+        extensions = error.get("extensions")
+        if not isinstance(extensions, dict):
+            continue
+        if extensions.get("code") == DOWNSTREAM_SERVICE_ERROR:
+            extensions["code"] = DEFAULT_BACKEND_ERROR_CODE
+            extensions.pop("serviceName", None)
+    return data
+
+
+async def graphql_gateway_handler(
+    frontend_rqst: web.Request,
+    *,
+    api_endpoint: Optional[str] = None,
+) -> web.Response:
+    """Handle GraphQL requests routed through a federated gateway.
+
+    Unlike :func:`web_handler` which streams the response, this handler buffers
+    the full response body so it can transform ``DOWNSTREAM_SERVICE_ERROR``
+    codes injected by the Hive Gateway before returning the response to the
+    frontend.
+    """
+    stats: WebStats = frontend_rqst.app["stats"]
+    stats.active_proxy_api_handlers.add(asyncio.current_task())  # type: ignore
+    path = frontend_rqst.match_info.get("path", "")
+    api_session = await asyncio.shield(get_api_session(frontend_rqst, api_endpoint))
+    try:
+        async with api_session:
+            backend_rqst_hdrs = extra_config_headers.check(frontend_rqst.headers)
+            request_api_version = backend_rqst_hdrs.get("X-BackendAI-Version", None)
+            secure_context = backend_rqst_hdrs.get("X-BackendAI-Encoded", None)
+            decrypted_payload_length = 0
+            content: RequestContent = None
+            if frontend_rqst.body_exists:
+                if secure_context:
+                    content = cast(bytes, frontend_rqst["payload"])
+                    decrypted_payload_length = len(content)
+                else:
+                    content = frontend_rqst.content
+            fill_forwarding_hdrs_to_api_session(frontend_rqst, api_session)
+            api_session.aiohttp_session.cookie_jar.update_cookies(frontend_rqst.cookies)
+            backend_rqst = Request(
+                frontend_rqst.method,
+                path,
+                content,
+                params=frontend_rqst.query,
+                override_api_version=request_api_version,
+                session_mode=SessionMode.PROXY if api_session.proxy_mode else SessionMode.CLIENT,
+            )
+            if "Content-Type" in frontend_rqst.headers:
+                backend_rqst.content_type = frontend_rqst.content_type
+                backend_rqst.headers["Content-Type"] = frontend_rqst.headers["Content-Type"]
+            if "Content-Length" in frontend_rqst.headers and not secure_context:
+                backend_rqst.headers["Content-Length"] = frontend_rqst.headers["Content-Length"]
+            if "Content-Length" in frontend_rqst.headers and secure_context:
+                backend_rqst.headers["Content-Length"] = str(decrypted_payload_length)
+            for key in HTTP_HEADERS_TO_FORWARD:
+                if key in backend_rqst.headers:
+                    continue
+                if (value := frontend_rqst.headers.get(key)) is not None:
+                    backend_rqst.headers[key] = value
+            async with backend_rqst.fetch() as backend_resp:
+                body = b""
+                while True:
+                    chunk = await backend_resp.read(CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    body += chunk
+                frontend_resp_hdrs = {
+                    key: value
+                    for key, value in backend_resp.headers.items()
+                    if key not in HOP_ONLY_HEADERS
+                }
+                try:
+                    data = json.loads(body)
+                    data = _transform_downstream_service_errors(data)
+                    return web.json_response(
+                        data,
+                        status=backend_resp.status,
+                        headers=frontend_resp_hdrs,
+                    )
+                except json.JSONDecodeError:
+                    return web.Response(
+                        body=body,
+                        status=backend_resp.status,
+                        headers=frontend_resp_hdrs,
+                        content_type=backend_resp.content_type,
+                    )
+    except asyncio.CancelledError:
+        raise
+    except BackendAPIError as e:
+        return web.Response(
+            body=json.dumps(e.data),
+            content_type="application/problem+json",
+            status=e.status,
+            reason=e.reason,
+        )
+    except BackendClientError:
+        log.exception("graphql_gateway_handler: BackendClientError")
+        return web.HTTPBadGateway(
+            text=json.dumps({
+                "type": "https://api.backend.ai/probs/bad-gateway",
+                "title": "The proxy target server is inaccessible.",
+            }),
+            content_type="application/problem+json",
+        )
+    except Exception:
+        log.exception("graphql_gateway_handler: unexpected error")
         return web.HTTPInternalServerError(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/internal-server-error",

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -55,7 +55,13 @@ from ai.backend.web.security import SecurityPolicy, security_policy_middleware
 
 from . import __version__, user_agent
 from .auth import fill_forwarding_hdrs_to_api_session, get_client_ip
-from .proxy import decrypt_payload, web_handler, web_plugin_handler, websocket_handler
+from .proxy import (
+    decrypt_payload,
+    graphql_gateway_handler,
+    web_handler,
+    web_plugin_handler,
+    websocket_handler,
+)
 from .stats import WebStats, track_active_handlers, view_stats
 from .template import toml_scalar
 
@@ -807,9 +813,12 @@ async def server_main(
     cors.add(app.router.add_route("GET", "/func/{path:stream/.*$}", websocket_handler))
     cors.add(app.router.add_route("GET", "/func/", anon_web_handler))
 
-    # Feature flag for using Apollo Router(Graphql Federation)
+    # Feature flag for using GraphQL Federation gateway (Hive Gateway / Apollo Router)
     if config.apollo_router.enabled:
-        supergraph_handler = partial(web_handler, api_endpoint=str(config.apollo_router.endpoint))
+        supergraph_handler = partial(
+            graphql_gateway_handler,
+            api_endpoint=str(config.apollo_router.endpoint),
+        )
         cors.add(app.router.add_route("POST", "/func/admin/gql", supergraph_handler))
 
     cors.add(app.router.add_route("HEAD", "/func/{path:.*$}", web_handler))

--- a/tests/webserver/test_proxy.py
+++ b/tests/webserver/test_proxy.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from ai.backend.web.proxy import (
+    _transform_downstream_service_errors,
+)
+
+
+class TestTransformDownstreamServiceErrors:
+    def test_no_errors_key(self) -> None:
+        data: dict = {"data": {"user": {"id": "1"}}}
+        result = _transform_downstream_service_errors(data)
+        assert result == data
+
+    def test_empty_errors_list(self) -> None:
+        data: dict = {"data": None, "errors": []}
+        result = _transform_downstream_service_errors(data)
+        assert result == data
+
+    def test_errors_is_none(self) -> None:
+        data: dict = {"data": None, "errors": None}
+        result = _transform_downstream_service_errors(data)
+        assert result == data
+
+    def test_replaces_downstream_service_error(self) -> None:
+        data: dict = {
+            "data": None,
+            "errors": [
+                {
+                    "message": "Resource not found.",
+                    "extensions": {
+                        "code": "DOWNSTREAM_SERVICE_ERROR",
+                        "serviceName": "graphene",
+                    },
+                }
+            ],
+        }
+        result = _transform_downstream_service_errors(data)
+        error = result["errors"][0]
+        assert error["extensions"]["code"] == "backendai_generic_internal-error"
+        assert "serviceName" not in error["extensions"]
+        assert error["message"] == "Resource not found."
+
+    def test_preserves_non_downstream_error(self) -> None:
+        data: dict = {
+            "data": None,
+            "errors": [
+                {
+                    "message": "Forbidden",
+                    "extensions": {
+                        "code": "api_auth_forbidden",
+                    },
+                }
+            ],
+        }
+        result = _transform_downstream_service_errors(data)
+        assert result["errors"][0]["extensions"]["code"] == "api_auth_forbidden"
+
+    def test_handles_multiple_errors(self) -> None:
+        data: dict = {
+            "data": None,
+            "errors": [
+                {
+                    "message": "Error one",
+                    "extensions": {
+                        "code": "DOWNSTREAM_SERVICE_ERROR",
+                        "serviceName": "graphene",
+                    },
+                },
+                {
+                    "message": "Error two",
+                    "extensions": {
+                        "code": "backendai_read_not-found",
+                    },
+                },
+                {
+                    "message": "Error three",
+                    "extensions": {
+                        "code": "DOWNSTREAM_SERVICE_ERROR",
+                        "serviceName": "strawberry",
+                    },
+                },
+            ],
+        }
+        result = _transform_downstream_service_errors(data)
+        assert result["errors"][0]["extensions"]["code"] == "backendai_generic_internal-error"
+        assert "serviceName" not in result["errors"][0]["extensions"]
+        assert result["errors"][1]["extensions"]["code"] == "backendai_read_not-found"
+        assert result["errors"][2]["extensions"]["code"] == "backendai_generic_internal-error"
+        assert "serviceName" not in result["errors"][2]["extensions"]
+
+    def test_error_without_extensions(self) -> None:
+        data: dict = {
+            "data": None,
+            "errors": [
+                {
+                    "message": "Some error",
+                }
+            ],
+        }
+        result = _transform_downstream_service_errors(data)
+        assert result == data
+
+    def test_error_with_non_dict_extensions(self) -> None:
+        data: dict = {
+            "data": None,
+            "errors": [
+                {
+                    "message": "Some error",
+                    "extensions": "invalid",
+                }
+            ],
+        }
+        result = _transform_downstream_service_errors(data)
+        assert result == data


### PR DESCRIPTION
## Summary
- Add `usePreserveSubgraphErrorExtensions` plugin to Hive Gateway config that preserves original `extensions.code` from subgraph error responses instead of rewriting them to `DOWNSTREAM_SERVICE_ERROR`
- Add `graphql_gateway_handler` in the web proxy that buffers GraphQL gateway responses and transforms any remaining `DOWNSTREAM_SERVICE_ERROR` codes to the default Backend.AI error code, enabling message-based fallback handling in the WebUI
- Add unit tests for the error transformation logic

## Test plan
- [x] Unit tests for `_transform_downstream_service_errors` covering all edge cases
- [ ] Verify WebUI correctly handles errors when using Hive Gateway with the new plugin
- [ ] Verify WebUI falls back to message-based error handling when DOWNSTREAM_SERVICE_ERROR is transformed by the proxy

Resolves BA-4863