### PR TITLE
fix: use paginated_list for service name lookup in CLI (#9745)

### DIFF
--- a/changes/9745.fix.md
+++ b/changes/9745.fix.md
@@ -1,0 +1,1 @@
+Fix service name lookup in CLI by replacing deprecated REST API with GraphQL-based paginated_list

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -49,11 +49,15 @@ def get_service_id(session: Session, name_or_id: str) -> UUID:
     try:
         session.Service(name_or_id).info()
     except (ValueError, BackendError):
-        services = session.Service.list(name=name_or_id)
+        result = session.Service.paginated_list(
+            fields=[service_fields["endpoint_id"], service_fields["name"]],
+            filter=f'name == "{name_or_id}"',
+            page_size=1,
+        )
         try:
-            return UUID(services[0]["id"])
-        except (KeyError, IndexError):
-            raise RuntimeError(f"Service {name_or_id!r} not found")
+            return UUID(result.items[0]["endpoint_id"])
+        except (KeyError, IndexError) as e:
+            raise RuntimeError(f"Service {name_or_id!r} not found") from e
     else:
         # When we can fetch the detail directly, it's a valid UUID.
         return UUID(name_or_id)


### PR DESCRIPTION
This is an auto-generated backport PR of #9745 to the 25.15 release.