### PR TITLE
fix: reset desired_replicas on manual service scale

### DIFF
--- a/changes/9746.fix.md
+++ b/changes/9746.fix.md
@@ -1,0 +1,1 @@
+Reset `desired_replicas` when manually scaling a service endpoint so that auto-scaling can re-trigger correctly

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -575,7 +575,7 @@ class ModelServingRepository:
             query = (
                 sa.update(EndpointRow)
                 .where(EndpointRow.id == endpoint_id)
-                .values({"replicas": replicas})
+                .values({"replicas": replicas, "desired_replicas": None})
             )
             await session.execute(query)
         return True


### PR DESCRIPTION
## Summary

- Clear `desired_replicas` (set to `NULL`) when a user manually scales a service endpoint via `POST /services/{id}/scale`

## Problem

The endpoint DB row has two replica-related columns:
- `replicas`: base count set by user (manual scaling)
- `desired_replicas`: count set by auto-scaling system

`target_replica_count` (used by the auto-scaler) prioritizes `desired_replicas` over `replicas`:
```python
@property
def target_replica_count(self) -> int:
    if self.desired_replica_count is not None:
        return self.desired_replica_count  # takes priority
    return self.replica_count
```

When `service scale` is called, only `replicas` is updated — `desired_replicas` retains its stale value from the previous auto-scaling event. This causes the auto-scaler to believe the replica count is already at the previously scaled value, preventing any future auto-scaling triggers.

**Reproduction:**
1. Endpoint starts with `replicas=1`, `desired_replicas=NULL` → `target=1`
2. Auto-scale-out triggers → `desired_replicas=2` → `target=2`
3. User runs `backend.ai service scale <id> 1` → `replicas=1`, but `desired_replicas` remains `2`
4. `target_replica_count` = `2` (stale) → scale-out rule: `2+1=3 > max(2)` → skipped forever

## Fix

Reset `desired_replicas` to `NULL` in `update_endpoint_replicas()`, so that manual scaling takes full precedence and the auto-scaler evaluates from the new baseline.

## Impact

- **Affected API**: `POST /services/{id}/scale` (used by CLI `backend.ai service scale` and WebUI)
- **Not affected**: Auto-scaling-initiated scaling (uses separate `update_desired_replicas_bulk` code path)

## Test plan
- [ ] Manual scale to 1 → verify `desired_replicas` is NULL in DB
- [ ] Run load test → verify auto-scale-out triggers correctly
- [ ] Verify auto-scaling still works independently (without manual scale intervention)
- [ ] `pants lint --changed-since=HEAD~1` passes
- [ ] `pants check --changed-since=HEAD~1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)