### PR TITLE
fix(BA-4889): fix container net_rx/net_tx stats reading host namespace counters (#9681)

### DIFF
--- a/changes/9681.fix.md
+++ b/changes/9681.fix.md
@@ -1,0 +1,1 @@
+Fix container net_rx/net_tx stats reading host namespace counters due to unchecked setns() return value

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -715,7 +715,15 @@ class MemoryPlugin(AbstractComputePlugin):
             sandbox_key = data["NetworkSettings"]["SandboxKey"]
             net_rx_bytes = 0
             net_tx_bytes = 0
-            nstat = await netstat_ns(sandbox_key)
+            try:
+                nstat = await netstat_ns(sandbox_key)
+            except OSError as e:
+                log.warning(
+                    "MemoryPlugin: cannot read net stats for container {0}: {1!r}",
+                    container_id[:7],
+                    e,
+                )
+                return None
             for name, net_stat in nstat.items():
                 if name == "lo":
                     continue

--- a/src/ai/backend/common/netns.py
+++ b/src/ai/backend/common/netns.py
@@ -1,15 +1,27 @@
 import ctypes
 import ctypes.util
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def _get_libc() -> ctypes.CDLL:
+    libc_path = ctypes.util.find_library("c")
+    return ctypes.CDLL(libc_path, use_errno=True)
+
 
 def setns(fd: int) -> None:
-    libc_path = ctypes.util.find_library("c")
-    libc = ctypes.CDLL(libc_path)
+    libc = _get_libc()
     CLONE_NEWNET = 1 << 30
-    libc.setns(fd, CLONE_NEWNET)
+    ret = libc.setns(fd, CLONE_NEWNET)
+    if ret == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, f"setns() failed: {os.strerror(errno)}")
 
 
 class NetworkNamespaceManager:
@@ -21,9 +33,13 @@ class NetworkNamespaceManager:
         setns(self.new_ns)
 
     def __exit__(self, *exc_info_args: Any) -> None:
-        setns(self.self_ns)
-        os.close(self.new_ns)
-        os.close(self.self_ns)
+        try:
+            setns(self.self_ns)
+        except OSError:
+            log.warning("Failed to restore original network namespace")
+        finally:
+            os.close(self.new_ns)
+            os.close(self.self_ns)
 
 
 def nsenter(path: Path) -> NetworkNamespaceManager:

--- a/tests/unit/agent/test_docker_intrinsic.py
+++ b/tests/unit/agent/test_docker_intrinsic.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+import subprocess
+import sys
+import time
+from collections.abc import Generator, Iterator
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ai.backend.agent.docker.intrinsic import CPUPlugin, MemoryPlugin
+from ai.backend.agent.docker.intrinsic import CPUPlugin, MemoryPlugin, netstat_ns_work
 from ai.backend.agent.stats import StatModes
 
 
@@ -227,3 +232,48 @@ class TestMemoryPluginDockerClientLifecycle(BaseDockerIntrinsicTest):
         with patch("ai.backend.agent.docker.intrinsic.Docker") as mock_docker_cls:
             await memory_plugin.gather_container_measures(memory_cgroup_context, container_ids)
             mock_docker_cls.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Network namespaces require Linux")
+class TestNetstatNsWork:
+    """Tests for netstat_ns_work with real namespace switching."""
+
+    @pytest.fixture
+    def netns_process(self) -> Iterator[subprocess.Popen[bytes]]:
+        """Spawn a sleep process in a new network namespace via unshare."""
+        proc = subprocess.Popen(
+            ["unshare", "--net", "sleep", "30"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(0.3)
+        if proc.poll() is not None:
+            pytest.skip("unshare --net failed (insufficient privileges)")
+        try:
+            yield proc
+        finally:
+            proc.terminate()
+            proc.wait()
+
+    def test_netstat_ns_work_reads_isolated_namespace(
+        self, netns_process: subprocess.Popen[bytes]
+    ) -> None:
+        """netstat_ns_work should read counters from the target namespace,
+        not from the host."""
+        pid = netns_process.pid
+        ns_path = Path(f"/proc/{pid}/ns/net")
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(netstat_ns_work, ns_path).result()
+        # A fresh network namespace only has loopback with zero counters.
+        assert "lo" in result
+        lo = result["lo"]
+        assert lo.bytes_recv == 0
+        assert lo.bytes_sent == 0
+
+    def test_netstat_ns_work_raises_on_invalid_namespace(self) -> None:
+        """netstat_ns_work should raise OSError when setns() fails
+        on a non-namespace fd (e.g. /dev/null)."""
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(netstat_ns_work, Path("/dev/null"))
+            with pytest.raises(OSError):
+                future.result()

--- a/tests/unit/common/test_netns.py
+++ b/tests/unit/common/test_netns.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai.backend.common.netns import setns
+
+
+class TestSetns:
+    """Tests for setns() return value checking."""
+
+    def test_setns_raises_on_failure(self) -> None:
+        """Verify setns() raises OSError when libc.setns() returns -1."""
+        mock_libc = MagicMock()
+        mock_libc.setns.return_value = -1
+
+        with (
+            patch("ai.backend.common.netns._get_libc", return_value=mock_libc),
+            patch("ctypes.get_errno", return_value=1),
+            pytest.raises(OSError, match="setns\\(\\) failed"),
+        ):
+            setns(42)
+
+    def test_setns_succeeds_on_zero_return(self) -> None:
+        """Verify setns() does not raise when libc.setns() returns 0."""
+        mock_libc = MagicMock()
+        mock_libc.setns.return_value = 0
+
+        with patch("ai.backend.common.netns._get_libc", return_value=mock_libc):
+            setns(42)
+
+        mock_libc.setns.assert_called_once()


### PR DESCRIPTION
This is an auto-generated backport PR of #9681 to the 26.2 release.