### PR TITLE
fix(BA-4891): Fix kernel container_id attribute shadowed by UserDict data dict in agent (#9790)

### DIFF
--- a/changes/9790.fix.md
+++ b/changes/9790.fix.md
@@ -1,0 +1,1 @@
+Fix kernel container_id attribute shadowed by UserDict data dict causing container stats collection to fail after agent restarts

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -1412,6 +1412,8 @@ class AbstractAgent[
             kernel_obj = self.kernel_registry.get(ev.kernel_id)
             if kernel_obj is not None:
                 kernel_obj.state = KernelLifecycleStatus.RUNNING
+                if ev.container_id is not None:
+                    kernel_obj.set_container_id(ev.container_id)
         log.info("Kernel {0} started", ev.kernel_id)
 
     async def _handle_destroy_event(self, ev: ContainerLifecycleEvent) -> None:
@@ -1759,7 +1761,7 @@ class AbstractAgent[
                     # This will be overwritten by create_kernel() soon, but
                     # updating here improves consistency of kernel_id to container_id
                     # mapping earlier.
-                    kernel_obj["container_id"] = container_id
+                    kernel_obj.set_container_id(container_id)
                 elif container_id != kernel_obj["container_id"]:
                     # This should not happen!
                     log.warning(
@@ -3014,7 +3016,7 @@ class AbstractAgent[
                         )
                         cid = e.container_id
                         async with self.registry_lock:
-                            self.kernel_registry[ctx.kernel_id]["container_id"] = cid
+                            self.kernel_registry[ctx.kernel_id].set_container_id(ContainerId(cid))
                         await self.inject_container_lifecycle_event(
                             kernel_id,
                             session_id,
@@ -3051,6 +3053,10 @@ class AbstractAgent[
                     )
                     async with self.registry_lock:
                         self.kernel_registry[kernel_id].data.update(container_data)
+                        if "container_id" in container_data:
+                            self.kernel_registry[kernel_id].set_container_id(
+                                container_data["container_id"]
+                            )
                     await kernel_obj.init(self.event_producer)
                     log.info(
                         "create_kernel(kernel:{}, session:{}, container:{}) kernel object initialized",

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1279,7 +1279,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 network = await docker.networks.get(name)
                 await network.connect({"Container": container._id})
 
-            kernel_obj.container_id = container._id
+            kernel_obj.set_container_id(ContainerId(cid))
             container_network_info: ContainerNetworkInfo | None = None
             if (mode := cluster_info["network_config"].get("mode")) and mode != "bridge":
                 try:

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -50,6 +50,7 @@ from ai.backend.common.json import load_json
 from ai.backend.common.types import (
     AgentId,
     CommitStatus,
+    ContainerId,
     KernelId,
     ServicePort,
     SessionId,
@@ -182,7 +183,7 @@ class AbstractKernel(UserDict[str, Any], aobject, metaclass=ABCMeta):
     kernel_id: KernelId
     agent_id: AgentId
     network_id: str
-    container_id: str | None
+    container_id: ContainerId | None
     image: ImageRef
     resource_spec: KernelResourceSpec
     service_ports: list[ServicePort]
@@ -232,6 +233,10 @@ class AbstractKernel(UserDict[str, Any], aobject, metaclass=ABCMeta):
         self.container_id = None
         self.state = KernelLifecycleStatus.PREPARING
         self.session_type = session_type
+
+    def set_container_id(self, cid: ContainerId) -> None:
+        self.container_id = cid
+        self["container_id"] = cid
 
     async def init(self, event_producer: EventProducer) -> None:
         log.debug(

--- a/tests/unit/agent/test_container_id_sync.py
+++ b/tests/unit/agent/test_container_id_sync.py
@@ -1,0 +1,81 @@
+"""
+Tests for BA-4891: AbstractKernel.set_container_id() method.
+
+Verifies that set_container_id() synchronizes both the instance attribute
+and the UserDict data dict in a single call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.agent.docker.kernel import DockerKernel
+from ai.backend.agent.types import KernelOwnershipData
+from ai.backend.common.docker import ImageRef
+from ai.backend.common.types import AgentId, ContainerId, KernelId, SessionId
+
+
+@pytest.fixture
+def mock_kernel_obj() -> DockerKernel:
+    """Create a mock kernel object for testing."""
+    kernel_id = KernelId(uuid4())
+    session_id = SessionId(uuid4())
+    agent_id = AgentId("test-agent-id")
+
+    ownership_data = KernelOwnershipData(
+        kernel_id=kernel_id,
+        session_id=session_id,
+        agent_id=agent_id,
+    )
+    image = ImageRef(
+        name="test-image",
+        project="test-project",
+        registry="registry.local",
+        tag="latest",
+        architecture="x86_64",
+        is_local=False,
+    )
+    return DockerKernel(
+        ownership_data=ownership_data,
+        network_id="test-network",
+        image=image,
+        version=1,
+        network_driver="bridge",
+        agent_config={},
+        resource_spec=Mock(),
+        service_ports=[],
+        environ={},
+        data={},
+    )
+
+
+class TestSetContainerId:
+    """Tests for AbstractKernel.set_container_id()."""
+
+    def test_sets_both_instance_attr_and_data_dict(self, mock_kernel_obj: DockerKernel) -> None:
+        """set_container_id() should update both the instance attribute and data dict."""
+        assert mock_kernel_obj.container_id is None
+        assert "container_id" not in mock_kernel_obj.data
+
+        cid = ContainerId("test-container-abc123")
+        mock_kernel_obj.set_container_id(cid)
+
+        assert mock_kernel_obj.container_id == cid
+        assert mock_kernel_obj["container_id"] == cid
+        assert mock_kernel_obj.data["container_id"] == cid
+
+    def test_second_call_updates_both_sources(self, mock_kernel_obj: DockerKernel) -> None:
+        """A second set_container_id() call should update both sources to the new value."""
+        first = ContainerId("first-container-111")
+        second = ContainerId("second-container-222")
+
+        mock_kernel_obj.set_container_id(first)
+        assert mock_kernel_obj.container_id == first
+        assert mock_kernel_obj["container_id"] == first
+
+        mock_kernel_obj.set_container_id(second)
+        assert mock_kernel_obj.container_id == second
+        assert mock_kernel_obj["container_id"] == second


### PR DESCRIPTION
This is an auto-generated backport PR of #9790 to the 26.2 release.