### PR TITLE
fix: resolve alembic multi-head by linearizing migration chain

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/df13b2272b61_add_server_default_to_roles_updated_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/df13b2272b61_add_server_default_to_roles_updated_at.py
@@ -1,7 +1,7 @@
 """Add server_default to roles.updated_at
 
 Revision ID: df13b2272b61
-Revises: b1009fe7f865
+Revises: 6f2f5d828a52
 Create Date: 2026-03-10 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = "df13b2272b61"
-down_revision = "b1009fe7f865"
+down_revision = "6f2f5d828a52"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Resolve alembic multi-head by changing `df13b2272b61` (roles.updated_at server_default) to chain after `6f2f5d828a52` (session is_preemptible) instead of both branching from `b1009fe7f865`
- Ensures deterministic linear migration order

## Test plan
- [ ] Verify `alembic heads` returns a single head
- [ ] Run `alembic upgrade head` on a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)