### PR TITLE
fix(BA-4965): sync circuit route_info on route updates for accurate metric collection (#9760)

### DIFF
--- a/changes/9760.fix.md
+++ b/changes/9760.fix.md
@@ -1,0 +1,1 @@
+Sync `circuit.route_info` on route updates so that inference metric collection always targets the current set of routes, fixing auto-scaling scale-out failing to re-trigger after the first scale-in cycle

--- a/src/ai/backend/appproxy/worker/metrics.py
+++ b/src/ai/backend/appproxy/worker/metrics.py
@@ -85,9 +85,21 @@ async def gather_prometheus_inference_measures(
         )
         client_session = client_pool.load_client_session(client_key)
 
-        async with client_session.get(request_path) as resp:
-            resp.raise_for_status()
-            metrics_text = await resp.text()
+        try:
+            async with client_session.get(request_path) as resp:
+                resp.raise_for_status()
+                metrics_text = await resp.text()
+        except Exception:
+            log.warning(
+                "Failed to collect metrics from route {} ({}:{}), skipping",
+                route.route_id,
+                route.current_kernel_host,
+                route.kernel_port,
+                exc_info=True,
+            )
+            continue
+
+        try:
             metric_families = text_string_to_metric_families(metrics_text)
             for metric_family in metric_families:
                 metric_name = metric_family.name
@@ -121,6 +133,15 @@ async def gather_prometheus_inference_measures(
                         except IndexError:
                             continue
                         counter_metrics[metric_name][route.route_id] = Decimal(value)
+        except Exception:
+            log.warning(
+                "Failed to parse metrics from route {} ({}:{}), skipping",
+                route.route_id,
+                route.current_kernel_host,
+                route.kernel_port,
+                exc_info=True,
+            )
+            continue
 
     measures: list[InferenceMeasurement[Measurement | HistogramMeasurement]] = []
     for metric_name, per_route_histogram_metrics in histogram_bucket_metrics.items():

--- a/src/ai/backend/appproxy/worker/proxy/frontend/base.py
+++ b/src/ai/backend/appproxy/worker/proxy/frontend/base.py
@@ -43,6 +43,7 @@ class BaseFrontend[TBackend: BaseBackend, TCircuitKeyType: (int, str)](metaclass
             log.warning("Tried to update an inactive slot: {}", key)
             return
         await self.update_backend(self.backends[key], new_routes)
+        self.circuits[key].route_info = new_routes
 
     async def break_circuit(self, circuit: Circuit) -> None:
         metrics = self.root_context.metrics

--- a/tests/unit/appproxy/worker/BUILD
+++ b/tests/unit/appproxy/worker/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
 )
+
+python_test_utils(
+    name="testutils",
+)

--- a/tests/unit/appproxy/worker/conftest.py
+++ b/tests/unit/appproxy/worker/conftest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+
+@asynccontextmanager
+async def _mock_metrics_client_pool(
+    responses: dict[str, str | Exception],
+) -> AsyncGenerator[tuple[MagicMock, aioresponses], None]:
+    """Set up aioresponses mocks and a mock ClientPool for metrics endpoint scraping.
+
+    Args:
+        responses: mapping of endpoint base URL (e.g. "http://10.0.0.1:8080")
+                   to response body text or Exception to raise.
+
+    Yields:
+        (client_pool, mocked) where client_pool has load_client_session configured
+        and mocked is the aioresponses instance for request assertion.
+    """
+    with aioresponses() as mocked:
+        for endpoint, response in responses.items():
+            url = f"{endpoint}/metrics"
+            if isinstance(response, Exception):
+                mocked.get(url, exception=response)
+            else:
+                mocked.get(url, body=response)
+
+        async with AsyncExitStack() as stack:
+            sessions: dict[str, aiohttp.ClientSession] = {}
+            for endpoint in responses:
+                session = await stack.enter_async_context(aiohttp.ClientSession(base_url=endpoint))
+                sessions[endpoint] = session
+
+            client_pool = MagicMock()
+            client_pool.load_client_session = lambda key: sessions[key.endpoint]
+            yield client_pool, mocked
+
+
+@pytest.fixture
+def mock_metrics_client_pool() -> Any:
+    """Factory fixture: returns an async context manager for mock metrics ClientPool setup."""
+    return _mock_metrics_client_pool

--- a/tests/unit/appproxy/worker/test_frontend_route_sync.py
+++ b/tests/unit/appproxy/worker/test_frontend_route_sync.py
@@ -1,0 +1,318 @@
+"""
+Regression tests for circuit route_info synchronization on route updates.
+
+The bug: when `update_circuit_route_info()` was called (e.g., during scale-in),
+only the backend was updated but `circuit.route_info` remained stale.
+This caused the metric collector to try scraping terminated routes,
+ultimately breaking the auto-scaling feedback loop.
+
+The fix: `self.circuits[key].route_info = new_routes` is now called
+after updating the backend, keeping the circuit's route_info in sync.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, NamedTuple
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_mock
+
+from ai.backend.appproxy.common.types import (
+    AppMode,
+    FrontendMode,
+    ProxyProtocol,
+    RouteInfo,
+)
+from ai.backend.appproxy.worker.metrics import gather_inference_measures
+from ai.backend.appproxy.worker.proxy.frontend.http.port import PortFrontend
+from ai.backend.appproxy.worker.types import (
+    Circuit,
+    InferenceAppInfo,
+    PortFrontendInfo,
+)
+from ai.backend.common.types import ModelServiceStatus, RuntimeVariant
+
+SAMPLE_PROMETHEUS_OUTPUT = """\
+# HELP vllm:num_requests_running Number of requests running
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running 3
+"""
+
+
+def _make_route(
+    route_id: UUID | None = None,
+    session_id: UUID | None = None,
+    kernel_host: str = "10.0.0.1",
+    kernel_port: int = 8080,
+) -> RouteInfo:
+    return RouteInfo(
+        route_id=route_id or uuid4(),
+        session_id=session_id or uuid4(),
+        session_name=None,
+        kernel_host=kernel_host,
+        kernel_port=kernel_port,
+        protocol=ProxyProtocol.HTTP,
+        traffic_ratio=1.0,
+        health_status=ModelServiceStatus.HEALTHY,
+        last_health_check=None,
+        consecutive_failures=0,
+    )
+
+
+def _make_circuit(routes: list[RouteInfo], port: int = 10200) -> Circuit:
+    return Circuit(
+        id=uuid4(),
+        app="vllm",
+        protocol=ProxyProtocol.HTTP,
+        worker=UUID("00000000-0000-0000-0000-000000000000"),
+        app_mode=AppMode.INFERENCE,
+        frontend_mode=FrontendMode.PORT,
+        frontend=PortFrontendInfo(port),
+        port=port,
+        app_info=InferenceAppInfo(
+            endpoint_id=uuid4(),
+            runtime_variant=RuntimeVariant.VLLM,
+        ),
+        subdomain=None,
+        runtime_variant=RuntimeVariant.VLLM,
+        envs={},
+        arguments=None,
+        open_to_public=False,
+        allowed_client_ips=None,
+        user_id=uuid4(),
+        access_key="TESTKEY",
+        endpoint_id=None,
+        route_info=routes,
+        session_ids=[r.session_id for r in routes],
+        created_at=datetime(2024, 7, 16, 5, 45, 45, tzinfo=UTC),
+        updated_at=datetime(2024, 7, 16, 5, 45, 45, tzinfo=UTC),
+    )
+
+
+class TwoReplicaScenario(NamedTuple):
+    """A circuit with two healthy replicas registered in the frontend."""
+
+    circuit: Circuit
+    healthy_route: RouteInfo
+    scaled_in_route: RouteInfo
+
+
+class SingleReplicaScenario(NamedTuple):
+    """A circuit with a single healthy replica."""
+
+    circuit: Circuit
+    route: RouteInfo
+
+
+class TestUpdateCircuitRouteInfo:
+    """Regression tests for circuit.route_info synchronization."""
+
+    FRONTEND_PORT = 10200
+
+    @pytest.fixture
+    def port_frontend(self, mocker: pytest_mock.MockerFixture) -> PortFrontend:
+        frontend = PortFrontend(root_context=mocker.MagicMock())
+        frontend.circuits = {}
+        frontend.backends = {}
+        return frontend
+
+    @pytest.fixture
+    def two_replica_scenario(self) -> TwoReplicaScenario:
+        """Two-replica circuit: healthy_route stays, scaled_in_route gets removed on scale-in."""
+        healthy_route = _make_route(kernel_host="10.0.0.1", kernel_port=8080)
+        scaled_in_route = _make_route(kernel_host="10.0.0.2", kernel_port=8081)
+        circuit = _make_circuit([healthy_route, scaled_in_route], port=self.FRONTEND_PORT)
+        return TwoReplicaScenario(circuit, healthy_route, scaled_in_route)
+
+    @pytest.fixture
+    def single_replica_scenario(self) -> SingleReplicaScenario:
+        """Single-replica circuit for full scale-in and inactive circuit tests."""
+        route = _make_route(kernel_host="10.0.0.1", kernel_port=8080)
+        circuit = _make_circuit([route], port=self.FRONTEND_PORT)
+        return SingleReplicaScenario(circuit, route)
+
+    @pytest.fixture
+    def registered_two_replica_frontend(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        port_frontend: PortFrontend,
+        two_replica_scenario: TwoReplicaScenario,
+    ) -> tuple[PortFrontend, TwoReplicaScenario]:
+        """Frontend with the two-replica circuit already registered."""
+        port_frontend.circuits[self.FRONTEND_PORT] = two_replica_scenario.circuit
+        port_frontend.backends[self.FRONTEND_PORT] = mocker.MagicMock()
+        mocker.patch.object(port_frontend, "update_backend", new_callable=AsyncMock)
+        return port_frontend, two_replica_scenario
+
+    async def test_route_info_synced_on_update(
+        self,
+        registered_two_replica_frontend: tuple[PortFrontend, TwoReplicaScenario],
+    ) -> None:
+        """Regression: circuit.route_info must reflect new routes after update.
+
+        Before the fix, only the backend was updated while circuit.route_info
+        kept stale routes, causing the metric collector to target terminated
+        endpoints.
+        """
+        frontend, scenario = registered_two_replica_frontend
+
+        # Scale-in: remove scaled_in_route
+        new_routes = [scenario.healthy_route]
+        await frontend.update_circuit_route_info(scenario.circuit, new_routes)
+
+        assert frontend.circuits[self.FRONTEND_PORT].route_info == new_routes
+        assert len(frontend.circuits[self.FRONTEND_PORT].route_info) == 1
+        assert (
+            frontend.circuits[self.FRONTEND_PORT].route_info[0].session_id
+            == scenario.healthy_route.session_id
+        )
+
+    async def test_route_info_synced_after_backend_update(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        port_frontend: PortFrontend,
+        two_replica_scenario: TwoReplicaScenario,
+    ) -> None:
+        """Verify route_info is updated only after backend update succeeds.
+
+        Circuit starts with [healthy_route, scaled_in_route].
+        Scale-in removes scaled_in_route -> new_routes = [healthy_route].
+        During update_backend, route_info should still be the old 2-route list.
+        """
+        scenario = two_replica_scenario
+        initial_routes = list(scenario.circuit.route_info)
+        port_frontend.circuits[self.FRONTEND_PORT] = scenario.circuit
+        port_frontend.backends[self.FRONTEND_PORT] = mocker.MagicMock()
+
+        captured_route_info: list[list[RouteInfo]] = []
+
+        async def capture_update_backend(backend: object, routes: list[RouteInfo]) -> object:
+            # Capture route_info at the moment update_backend is called
+            captured_route_info.append(list(port_frontend.circuits[self.FRONTEND_PORT].route_info))
+            return backend
+
+        mocker.patch.object(port_frontend, "update_backend", side_effect=capture_update_backend)
+
+        # Scale-in: remove scaled_in_route
+        new_routes = [scenario.healthy_route]
+        await port_frontend.update_circuit_route_info(scenario.circuit, new_routes)
+
+        # At the time update_backend was called, route_info should still be the old 2-route list
+        assert len(captured_route_info) == 1
+        assert captured_route_info[0] == initial_routes
+        assert len(captured_route_info[0]) == 2
+        # After the call completes, route_info should be updated to new_routes
+        assert port_frontend.circuits[self.FRONTEND_PORT].route_info == new_routes
+        assert len(port_frontend.circuits[self.FRONTEND_PORT].route_info) == 1
+
+    async def test_route_info_unchanged_on_backend_update_failure(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        port_frontend: PortFrontend,
+        two_replica_scenario: TwoReplicaScenario,
+    ) -> None:
+        """If update_backend raises, route_info must remain unchanged.
+
+        This ensures consistency: the backend keeps the old routes, and
+        circuit.route_info matches that state.
+        """
+        scenario = two_replica_scenario
+        initial_routes = list(scenario.circuit.route_info)
+        port_frontend.circuits[self.FRONTEND_PORT] = scenario.circuit
+        port_frontend.backends[self.FRONTEND_PORT] = mocker.MagicMock()
+
+        mocker.patch.object(
+            port_frontend,
+            "update_backend",
+            side_effect=RuntimeError("backend update failed"),
+        )
+
+        with pytest.raises(RuntimeError, match="backend update failed"):
+            await port_frontend.update_circuit_route_info(
+                scenario.circuit, [scenario.healthy_route]
+            )
+
+        # route_info must still be the original 2-route list
+        assert port_frontend.circuits[self.FRONTEND_PORT].route_info == initial_routes
+        assert len(port_frontend.circuits[self.FRONTEND_PORT].route_info) == 2
+
+    async def test_route_info_empty_after_full_scale_in(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        port_frontend: PortFrontend,
+        single_replica_scenario: SingleReplicaScenario,
+    ) -> None:
+        """When all routes are removed, circuit.route_info should be empty."""
+        scenario = single_replica_scenario
+        port_frontend.circuits[self.FRONTEND_PORT] = scenario.circuit
+        port_frontend.backends[self.FRONTEND_PORT] = mocker.MagicMock()
+        mocker.patch.object(port_frontend, "update_backend", new_callable=AsyncMock)
+
+        await port_frontend.update_circuit_route_info(scenario.circuit, [])
+
+        assert port_frontend.circuits[self.FRONTEND_PORT].route_info == []
+
+    async def test_inactive_circuit_update_is_noop(
+        self,
+        mocker: pytest_mock.MockerFixture,
+        port_frontend: PortFrontend,
+        single_replica_scenario: SingleReplicaScenario,
+    ) -> None:
+        """Updating an unregistered circuit should log warning and do nothing."""
+        mock_update_backend = mocker.patch.object(
+            port_frontend, "update_backend", new_callable=AsyncMock
+        )
+
+        await port_frontend.update_circuit_route_info(single_replica_scenario.circuit, [])
+
+        mock_update_backend.assert_not_called()
+
+    async def test_metric_collection_uses_updated_route_info(
+        self,
+        registered_two_replica_frontend: tuple[PortFrontend, TwoReplicaScenario],
+        mock_metrics_client_pool: Any,
+    ) -> None:
+        """Regression: the full bug chain from stale route_info to metric failure.
+
+        This test verifies the end-to-end scenario:
+        1. Scale-in removes scaled_in_route via update_circuit_route_info
+        2. Metric collector (gather_inference_measures) reads circuit.route_info
+        3. Only healthy_route's endpoint is accessed; scaled_in_route's is never contacted
+
+        Before the fix, circuit.route_info stayed [healthy, scaled_in] after
+        scale-in, so the metric collector would try to scrape the terminated
+        scaled_in_route's /metrics endpoint, causing collection failure.
+        """
+        frontend, scenario = registered_two_replica_frontend
+
+        # Step 1: Scale-in removes scaled_in_route
+        await frontend.update_circuit_route_info(scenario.circuit, [scenario.healthy_route])
+
+        # Step 2: Metric collector runs with mocked HTTP responses
+        healthy_endpoint = (
+            f"http://{scenario.healthy_route.current_kernel_host}"
+            f":{scenario.healthy_route.kernel_port}"
+        )
+        scaled_in_endpoint = (
+            f"http://{scenario.scaled_in_route.current_kernel_host}"
+            f":{scenario.scaled_in_route.kernel_port}"
+        )
+
+        responses: dict[str, str | Exception] = {
+            healthy_endpoint: SAMPLE_PROMETHEUS_OUTPUT,
+            scaled_in_endpoint: SAMPLE_PROMETHEUS_OUTPUT,
+        }
+
+        async with mock_metrics_client_pool(responses) as (client_pool, mocked):
+            updated_circuit = frontend.circuits[self.FRONTEND_PORT]
+            measures = await gather_inference_measures(client_pool, updated_circuit)
+
+            # Step 3: Verify only healthy_route was accessed, scaled_in_route was NOT
+            called_urls = {str(url) for (_, url) in mocked.requests.keys()}
+            assert f"{healthy_endpoint}/metrics" in called_urls
+            assert f"{scaled_in_endpoint}/metrics" not in called_urls
+            assert measures is not None
+            assert len(measures) > 0

--- a/tests/unit/appproxy/worker/test_metrics_resilience.py
+++ b/tests/unit/appproxy/worker/test_metrics_resilience.py
@@ -1,0 +1,250 @@
+"""
+Regression tests for inference metric collection resilience.
+
+The bug: when a single route's /metrics endpoint was unreachable
+(e.g., after scale-in removed a replica), the entire metric collection
+for that circuit failed. This caused app-level metrics to go stale,
+preventing auto-scaling from re-triggering scale-out.
+
+The fix: each route's HTTP request and response parsing is wrapped in
+try/except that logs a warning and continues to the next route on failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.appproxy.common.types import ProxyProtocol, RouteInfo
+from ai.backend.appproxy.worker.metrics import gather_prometheus_inference_measures
+from ai.backend.appproxy.worker.types import Measurement
+from ai.backend.common.types import ModelServiceStatus
+
+SAMPLE_PROMETHEUS_OUTPUT = """\
+# HELP vllm:num_requests_running Number of requests running
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running 3
+# HELP vllm:num_requests_waiting Number of requests waiting
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting 0
+"""
+
+MALFORMED_PROMETHEUS_OUTPUT = "this is not valid prometheus metrics {{{{"
+
+
+def _make_route(
+    kernel_host: str = "10.0.0.1",
+    kernel_port: int = 8080,
+    health_status: ModelServiceStatus | None = ModelServiceStatus.HEALTHY,
+) -> RouteInfo:
+    return RouteInfo(
+        route_id=uuid4(),
+        session_id=uuid4(),
+        session_name=None,
+        kernel_host=kernel_host,
+        kernel_port=kernel_port,
+        protocol=ProxyProtocol.HTTP,
+        traffic_ratio=1.0,
+        health_status=health_status,
+        last_health_check=None,
+        consecutive_failures=0,
+    )
+
+
+def _route_endpoint(route: RouteInfo) -> str:
+    return f"http://{route.current_kernel_host}:{route.kernel_port}"
+
+
+@dataclass(frozen=True)
+class RouteInput:
+    """Configuration for a single route in a test scenario."""
+
+    kernel_host: str
+    kernel_port: int
+    health_status: ModelServiceStatus | None
+    mock_response: str | Exception
+
+
+@dataclass(frozen=True)
+class MetricsScenario:
+    """Describes a metric collection test case."""
+
+    routes: list[RouteInfo]
+    responses: dict[str, str | Exception]
+    # None means measures should be empty
+    expected_num_requests_running: Decimal | None
+    expected_collected_replica_count: int
+
+
+def _create_metrics_scenario(
+    route_configs: list[RouteInput],
+    *,
+    expected_num_requests_running: Decimal | None,
+    expected_collected_replica_count: int,
+) -> MetricsScenario:
+    """Build a scenario from (host, port, health_status, response) tuples."""
+    routes: list[RouteInfo] = []
+    responses: dict[str, str | Exception] = {}
+    for cfg in route_configs:
+        route = _make_route(
+            kernel_host=cfg.kernel_host,
+            kernel_port=cfg.kernel_port,
+            health_status=cfg.health_status,
+        )
+        routes.append(route)
+        responses[_route_endpoint(route)] = cfg.mock_response
+    return MetricsScenario(
+        routes=routes,
+        responses=responses,
+        expected_num_requests_running=expected_num_requests_running,
+        expected_collected_replica_count=expected_collected_replica_count,
+    )
+
+
+class TestGatherPrometheusInferenceMeasures:
+    """Regression tests for per-route error resilience in metric collection."""
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            pytest.param(
+                _create_metrics_scenario(
+                    [
+                        RouteInput(
+                            kernel_host="10.0.0.1",
+                            kernel_port=8080,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                        RouteInput(
+                            kernel_host="10.0.0.2",
+                            kernel_port=8081,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=ConnectionError("Connection refused"),
+                        ),
+                    ],
+                    expected_num_requests_running=Decimal(3),
+                    expected_collected_replica_count=1,
+                ),
+                id="partial-failure-connection-error",
+            ),
+            pytest.param(
+                _create_metrics_scenario(
+                    [
+                        RouteInput(
+                            kernel_host="10.0.0.1",
+                            kernel_port=8080,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=ConnectionError("Connection refused"),
+                        ),
+                        RouteInput(
+                            kernel_host="10.0.0.2",
+                            kernel_port=8081,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=TimeoutError("Timed out"),
+                        ),
+                    ],
+                    expected_num_requests_running=None,
+                    expected_collected_replica_count=0,
+                ),
+                id="all-routes-unreachable",
+            ),
+            pytest.param(
+                _create_metrics_scenario(
+                    [
+                        RouteInput(
+                            kernel_host="10.0.0.1",
+                            kernel_port=8080,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                        RouteInput(
+                            kernel_host="10.0.0.2",
+                            kernel_port=8081,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                    ],
+                    expected_num_requests_running=Decimal(6),
+                    expected_collected_replica_count=2,
+                ),
+                id="two-healthy-routes",
+            ),
+            pytest.param(
+                _create_metrics_scenario(
+                    [
+                        RouteInput(
+                            kernel_host="10.0.0.1",
+                            kernel_port=8080,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                        RouteInput(
+                            kernel_host="10.0.0.2",
+                            kernel_port=8081,
+                            health_status=ModelServiceStatus.UNHEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                    ],
+                    expected_num_requests_running=Decimal(3),
+                    expected_collected_replica_count=1,
+                ),
+                id="unhealthy-route-skipped",
+            ),
+            pytest.param(
+                _create_metrics_scenario(
+                    [
+                        RouteInput(
+                            kernel_host="10.0.0.1",
+                            kernel_port=8080,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=SAMPLE_PROMETHEUS_OUTPUT,
+                        ),
+                        RouteInput(
+                            kernel_host="10.0.0.3",
+                            kernel_port=8082,
+                            health_status=ModelServiceStatus.HEALTHY,
+                            mock_response=MALFORMED_PROMETHEUS_OUTPUT,
+                        ),
+                    ],
+                    expected_num_requests_running=Decimal(3),
+                    expected_collected_replica_count=1,
+                ),
+                id="malformed-payload",
+            ),
+        ],
+    )
+    async def test_metric_collection(
+        self, scenario: MetricsScenario, mock_metrics_client_pool: Any
+    ) -> None:
+        async with mock_metrics_client_pool(scenario.responses) as (client_pool, _):
+            measures = await gather_prometheus_inference_measures(client_pool, scenario.routes)
+
+            if scenario.expected_num_requests_running is None:
+                assert measures == []
+            else:
+                running_measures = [m for m in measures if m.key == "vllm:num_requests_running"]
+                assert len(running_measures) == 1, (
+                    f"Expected exactly 1 'vllm:num_requests_running' measure, "
+                    f"got {len(running_measures)}"
+                )
+                running_measure = running_measures[0]
+                assert isinstance(running_measure.per_app, Measurement)
+                assert running_measure.per_app.value == scenario.expected_num_requests_running
+                assert len(running_measure.per_replica) == scenario.expected_collected_replica_count
+
+    async def test_route_without_route_id_skipped(self) -> None:
+        """Routes with route_id=None (temporary) should be skipped."""
+        route = _make_route()
+        route.route_id = None
+
+        client_pool = MagicMock()
+
+        measures = await gather_prometheus_inference_measures(client_pool, [route])
+
+        assert measures == []


### PR DESCRIPTION
This is an auto-generated backport PR of #9760 to the 26.2 release.