### PR TITLE
fix(BA-4933): add per-call timeouts and error isolation to MemoryPlugin sysfs_impl (#9783)

### DIFF
--- a/changes/9783.fix.md
+++ b/changes/9783.fix.md
@@ -1,0 +1,1 @@
+Add per-call timeouts and error isolation to MemoryPlugin sysfs_impl stat collection to prevent permanent hangs from broken containers

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import aiohttp
-import async_timeout
 import psutil
 from aiodocker.docker import Docker, DockerContainer
 from aiodocker.exceptions import DockerError
@@ -72,6 +71,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 # Note that psutil's linux implementation automatically filters out "non-device" filesystems by
 # checking /proc/filesystems so we don't have to put all the details virtual filesystems like
 # "sockfs", "debugfs", etc.
+_CONTAINER_STAT_TIMEOUT: float = 2.0
+
+# The list of pruned fstype when checking the filesystem usage statistics.
 pruned_disk_types = frozenset([
     "vfat",
     "lxcfs",
@@ -280,7 +282,7 @@ class CPUPlugin(AbstractComputePlugin):
         async def api_impl(container_id: str) -> float | None:
             container = DockerContainer(self._docker, id=container_id)
             try:
-                async with async_timeout.timeout(2.0):
+                async with asyncio.timeout(_CONTAINER_STAT_TIMEOUT):
                     ret = await fetch_api_stats(container)
             except TimeoutError:
                 return None
@@ -711,8 +713,16 @@ class MemoryPlugin(AbstractComputePlugin):
                 )
                 return None
             container = DockerContainer(self._docker, id=container_id)
-            data = await container.show()
-            sandbox_key = data["NetworkSettings"]["SandboxKey"]
+            try:
+                async with asyncio.timeout(_CONTAINER_STAT_TIMEOUT):
+                    data = await container.show()
+                    sandbox_key = data["NetworkSettings"]["SandboxKey"]
+            except TimeoutError:
+                log.warning(
+                    "MemoryPlugin: timeout reading container info for container {0}",
+                    container_id[:7],
+                )
+                return None
             net_rx_bytes = 0
             net_tx_bytes = 0
             try:
@@ -723,12 +733,37 @@ class MemoryPlugin(AbstractComputePlugin):
                     container_id[:7],
                     e,
                 )
-                return None
-            for name, net_stat in nstat.items():
-                if name == "lo":
-                    continue
-                net_rx_bytes += net_stat.bytes_recv
-                net_tx_bytes += net_stat.bytes_sent
+            else:
+                ns_path = Path(sandbox_key)
+                if not ns_path.exists():
+                    log.warning(
+                        "MemoryPlugin: network namespace path does not exist for container"
+                        " {0} (sandbox_key={1!r}), skipping net stat collection",
+                        container_id[:7],
+                        sandbox_key,
+                    )
+                else:
+                    try:
+                        async with asyncio.timeout(_CONTAINER_STAT_TIMEOUT):
+                            nstat = await netstat_ns(ns_path)
+                    except TimeoutError:
+                        log.warning(
+                            "MemoryPlugin: timeout reading net stats for container {0}",
+                            container_id[:7],
+                        )
+                        return None
+                    except OSError as e:
+                        log.warning(
+                            "MemoryPlugin: cannot read net stats for container {0}: {1!r}",
+                            container_id[:7],
+                            e,
+                        )
+                        return None
+                    for name, net_stat in nstat.items():
+                        if name == "lo":
+                            continue
+                        net_rx_bytes += net_stat.bytes_recv
+                        net_tx_bytes += net_stat.bytes_sent
             loop = current_loop()
             scratch_sz = await loop.run_in_executor(None, get_scratch_size, container_id)
             return (
@@ -746,7 +781,7 @@ class MemoryPlugin(AbstractComputePlugin):
         ) -> tuple[int, int, int, int, int, int, int] | None:
             container = DockerContainer(self._docker, id=container_id)
             try:
-                async with async_timeout.timeout(2.0):
+                async with asyncio.timeout(_CONTAINER_STAT_TIMEOUT):
                     ret = await fetch_api_stats(container)
             except TimeoutError:
                 return None
@@ -794,10 +829,17 @@ class MemoryPlugin(AbstractComputePlugin):
         tasks = []
         for cid in container_ids:
             tasks.append(asyncio.create_task(impl(cid)))
-        results = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
         for cid, result in zip(container_ids, results, strict=True):
             if result is None:
                 continue
+            if isinstance(result, Exception):
+                log.warning(
+                    "gather_container_measures: error collecting stats for {}: {}", cid, result
+                )
+                continue
+            if isinstance(result, BaseException):
+                raise result
             per_container_mem_used_bytes[cid] = Measurement(
                 Decimal(result[0]), capacity=Decimal(result[1])
             )

--- a/tests/unit/agent/test_docker_intrinsic.py
+++ b/tests/unit/agent/test_docker_intrinsic.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
 import time
 from collections.abc import Generator, Iterator
 from concurrent.futures import ProcessPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -277,3 +280,169 @@ class TestNetstatNsWork:
             future = pool.submit(netstat_ns_work, Path("/dev/null"))
             with pytest.raises(OSError):
                 future.result()
+
+
+@dataclass
+class _SysfsMocks:
+    ctx: MagicMock
+    container: AsyncMock
+    netstat_ns: MagicMock
+    loop: MagicMock
+    container_data: dict[str, Any]
+
+
+class TestMemoryPluginSysfsTimeoutAndErrorIsolation(BaseDockerIntrinsicTest):
+    """Tests for timeout protection and error isolation in MemoryPlugin sysfs_impl."""
+
+    @pytest.fixture
+    def memory_plugin(self) -> MemoryPlugin:
+        plugin = MemoryPlugin.__new__(MemoryPlugin)
+        plugin.local_config = {"agent": {"docker-mode": "default"}}
+        plugin._docker = AsyncMock()
+        return plugin
+
+    @pytest.fixture
+    def sysfs_mocks(
+        self, cgroup_stat_context: MagicMock, tmp_path: Path
+    ) -> Generator[_SysfsMocks, None, None]:
+        """Fully patched sysfs_impl environment with default happy-path behavior.
+
+        Tests override specific mock side_effects before calling the target function.
+        """
+        ctx = cgroup_stat_context
+        ctx.agent.get_cgroup_version = MagicMock(return_value="2")
+
+        mem_path = MagicMock()
+        mem_stat = MagicMock()
+        mem_stat.read_text.return_value = "inactive_file 0\n"
+        mem_path.__truediv__ = MagicMock(return_value=mem_stat)
+        io_path = MagicMock()
+        io_stat = MagicMock()
+        io_stat.read_text.return_value = ""
+        io_path.__truediv__ = MagicMock(return_value=io_stat)
+        ctx.agent.get_cgroup_path = lambda subsys, cid: mem_path if subsys == "memory" else io_path
+
+        fake_ns = tmp_path / "fake_netns"
+        fake_ns.touch()
+        container_data: dict[str, Any] = {
+            "NetworkSettings": {"SandboxKey": str(fake_ns)},
+        }
+
+        with (
+            patch(
+                "ai.backend.agent.docker.intrinsic.DockerContainer",
+            ) as mock_container_cls,
+            patch("ai.backend.agent.docker.intrinsic.read_sysfs", return_value=1048576),
+            patch("ai.backend.agent.docker.intrinsic.netstat_ns", return_value={}) as mock_netstat,
+            patch("ai.backend.agent.docker.intrinsic.current_loop") as mock_loop,
+        ):
+            mock_container = AsyncMock()
+            mock_container.show.return_value = container_data
+            mock_container_cls.return_value = mock_container
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
+
+            yield _SysfsMocks(
+                ctx=ctx,
+                container=mock_container,
+                netstat_ns=mock_netstat,
+                loop=mock_loop,
+                container_data=container_data,
+            )
+
+    async def test_slow_container_show_times_out(
+        self,
+        memory_plugin: MemoryPlugin,
+        sysfs_mocks: _SysfsMocks,
+    ) -> None:
+        """When container.show() hangs, the call times out and returns None
+        for that container while other containers succeed."""
+        call_count = 0
+
+        async def slow_show_for_first(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                await asyncio.sleep(10)
+            return sysfs_mocks.container_data
+
+        sysfs_mocks.container.show.side_effect = slow_show_for_first
+
+        results = await memory_plugin.gather_container_measures(
+            sysfs_mocks.ctx, ["slow_container", "normal_container"]
+        )
+
+        assert "slow_container" not in results[0].per_container
+        assert "normal_container" in results[0].per_container
+
+    async def test_slow_netstat_ns_times_out(
+        self,
+        memory_plugin: MemoryPlugin,
+        sysfs_mocks: _SysfsMocks,
+    ) -> None:
+        """When netstat_ns() hangs, the call times out and returns None
+        for that container while other containers succeed."""
+        call_count = 0
+
+        async def slow_netstat_for_first(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                await asyncio.sleep(10)
+            return {}
+
+        sysfs_mocks.netstat_ns.side_effect = slow_netstat_for_first
+
+        results = await memory_plugin.gather_container_measures(
+            sysfs_mocks.ctx, ["slow_container", "normal_container"]
+        )
+
+        assert "slow_container" not in results[0].per_container
+        assert "normal_container" in results[0].per_container
+
+    async def test_gather_isolates_container_failures(
+        self,
+        memory_plugin: MemoryPlugin,
+        sysfs_mocks: _SysfsMocks,
+    ) -> None:
+        """When one container raises an Exception subclass, it is logged and
+        skipped while other containers are still collected.
+
+        Uses RuntimeError (not OSError) because OSError is caught inside
+        sysfs_impl and returns None — it never reaches the Exception
+        branch in the results loop.
+        """
+
+        async def selective_run_in_executor(executor: Any, fn: Any, *args: Any) -> int:
+            if args and args[0] == "broken_container":
+                raise RuntimeError("unexpected executor failure")
+            return 0
+
+        sysfs_mocks.loop.return_value.run_in_executor = selective_run_in_executor
+
+        results = await memory_plugin.gather_container_measures(
+            sysfs_mocks.ctx, ["broken_container", "healthy_container"]
+        )
+
+        assert "broken_container" not in results[0].per_container
+        assert "healthy_container" in results[0].per_container
+
+    async def test_cancelled_error_is_reraised(
+        self,
+        memory_plugin: MemoryPlugin,
+        sysfs_mocks: _SysfsMocks,
+    ) -> None:
+        """When a container task raises CancelledError (a BaseException but not
+        Exception), it must propagate instead of being silently skipped.
+        This ensures shutdown signals are not swallowed by return_exceptions=True."""
+
+        async def cancel_on_first(executor: Any, fn: Any, *args: Any) -> int:
+            if args and args[0] == "cancelled_container":
+                raise asyncio.CancelledError()
+            return 0
+
+        sysfs_mocks.loop.return_value.run_in_executor = cancel_on_first
+
+        with pytest.raises(asyncio.CancelledError):
+            await memory_plugin.gather_container_measures(
+                sysfs_mocks.ctx, ["cancelled_container", "healthy_container"]
+            )


### PR DESCRIPTION
This is an auto-generated backport PR of #9783 to the 26.2 release.