### PR TITLE
feat(BA-3511): migrate Agent entity data to RBAC DB

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
@@ -10,11 +10,6 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine import Connection
 
-from ai.backend.manager.models.rbac_models.migration.enums import (
-    EntityType,
-    OperationType,
-)
-
 # revision identifiers, used by Alembic.
 revision = "091d0274c2e3"
 down_revision = "359f0bbd936c"
@@ -23,7 +18,21 @@ depends_on = None
 
 # Constants
 BATCH_SIZE = 1000
+ENTITY_TYPE_AGENT = "agent"
 MEMBER_ROLE_SUFFIX = "member"
+MEMBER_OPS = ["read"]
+OWNER_OPS = sorted([
+    "create",
+    "read",
+    "update",
+    "soft-delete",
+    "hard-delete",
+    "grant:all",
+    "grant:read",
+    "grant:update",
+    "grant:soft-delete",
+    "grant:hard-delete",
+])
 
 
 def _add_entity_type_permissions(db_conn: Connection) -> None:
@@ -32,10 +41,6 @@ def _add_entity_type_permissions(db_conn: Connection) -> None:
     Uses a single set-based INSERT ... SELECT to derive AGENT permissions
     for all role+scope combinations without application-side pagination.
     """
-    # Precompute operation lists (sorted for deterministic ordering)
-    member_ops = sorted(o.value for o in OperationType.member_operations())
-    owner_ops = sorted(o.value for o in OperationType.owner_operations())
-
     insert_query = sa.text("""
         WITH role_scopes AS (
             SELECT DISTINCT
@@ -82,10 +87,10 @@ def _add_entity_type_permissions(db_conn: Connection) -> None:
     db_conn.execute(
         insert_query,
         {
-            "member_ops": member_ops,
-            "owner_ops": owner_ops,
+            "member_ops": MEMBER_OPS,
+            "owner_ops": OWNER_OPS,
             "member_pattern": f"%{MEMBER_ROLE_SUFFIX}",
-            "entity_type": EntityType.AGENT.value,
+            "entity_type": ENTITY_TYPE_AGENT,
         },
     )
 
@@ -96,9 +101,6 @@ def _associate_agent_to_domain_scope(db_conn: Connection) -> None:
     Pages by agent IDs first, then JOINs to get all scope associations
     for each batch to avoid skipping rows in 1:N JOINs.
     """
-    entity_type = EntityType.AGENT.value
-    relation_type = "auto"
-
     insert_query = sa.text("""
         INSERT INTO association_scopes_entities
             (scope_type, scope_id, entity_type, entity_id, relation_type)
@@ -133,9 +135,9 @@ def _associate_agent_to_domain_scope(db_conn: Connection) -> None:
             {
                 "scope_type": "domain",
                 "scope_id": str(row.scope_id),
-                "entity_type": entity_type,
+                "entity_type": ENTITY_TYPE_AGENT,
                 "entity_id": str(row.entity_id),
-                "relation_type": relation_type,
+                "relation_type": "auto",
             }
             for row in rows
         ]
@@ -150,9 +152,6 @@ def _associate_agent_to_project_scope(db_conn: Connection) -> None:
     Pages by agent IDs first, then JOINs to get all scope associations
     for each batch to avoid skipping rows in 1:N JOINs.
     """
-    entity_type = EntityType.AGENT.value
-    relation_type = "auto"
-
     insert_query = sa.text("""
         INSERT INTO association_scopes_entities
             (scope_type, scope_id, entity_type, entity_id, relation_type)
@@ -187,9 +186,9 @@ def _associate_agent_to_project_scope(db_conn: Connection) -> None:
             {
                 "scope_type": "project",
                 "scope_id": str(row.scope_id),
-                "entity_type": entity_type,
+                "entity_type": ENTITY_TYPE_AGENT,
                 "entity_id": str(row.entity_id),
-                "relation_type": relation_type,
+                "relation_type": "auto",
             }
             for row in rows
         ]
@@ -200,9 +199,6 @@ def _associate_agent_to_project_scope(db_conn: Connection) -> None:
 
 def _remove_agent_edges(db_conn: Connection) -> None:
     """Remove all AGENT AUTO edges from association_scopes_entities."""
-    entity_type = EntityType.AGENT.value
-    relation_type = "auto"
-
     while True:
         delete_query = sa.text("""
             DELETE FROM association_scopes_entities
@@ -215,7 +211,7 @@ def _remove_agent_edges(db_conn: Connection) -> None:
         """)
         result = db_conn.execute(
             delete_query,
-            {"entity_type": entity_type, "relation_type": relation_type, "limit": BATCH_SIZE},
+            {"entity_type": ENTITY_TYPE_AGENT, "relation_type": "auto", "limit": BATCH_SIZE},
         )
         if result.rowcount == 0:
             break
@@ -223,8 +219,6 @@ def _remove_agent_edges(db_conn: Connection) -> None:
 
 def _remove_agent_permissions(db_conn: Connection) -> None:
     """Remove all AGENT entity-type permissions."""
-    entity_type = EntityType.AGENT.value
-
     while True:
         delete_query = sa.text("""
             DELETE FROM permissions
@@ -236,7 +230,7 @@ def _remove_agent_permissions(db_conn: Connection) -> None:
         """)
         result = db_conn.execute(
             delete_query,
-            {"entity_type": entity_type, "limit": BATCH_SIZE},
+            {"entity_type": ENTITY_TYPE_AGENT, "limit": BATCH_SIZE},
         )
         if result.rowcount == 0:
             break

--- a/src/ai/backend/manager/models/rbac_models/migration/enums.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/enums.py
@@ -118,7 +118,6 @@ class EntityType(enum.StrEnum):
     NOTIFICATION_CHANNEL = "notification_channel"
     NOTIFICATION_RULE = "notification_rule"
     MODEL_DEPLOYMENT = "model_deployment"
-    AGENT = "agent"
 
     def to_original(self) -> OriginalEntityType:
         return OriginalEntityType(self.value)


### PR DESCRIPTION
## Summary
- Add `AGENT` to EntityType migration enum
- Add alembic migration (`091d0274c2e3`) to populate RBAC permissions and scope associations for Agent entities
- Uses Pattern D (indirect via scaling group junction tables) for both domain and project scopes

## Test plan
- [x] Run `alembic upgrade head` against a test database with existing agent data
- [x] Verify `permissions` table has AGENT entries for all role+scope combinations
- [x] Verify `association_scopes_entities` has correct agent→domain and agent→project scope edges
- [x] Run `alembic downgrade` and verify clean rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)