### PR TITLE
fix: align alembic multi heads for rbac data migration

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/091d0274c2e3_migrate_agent_data_to_rbac.py
@@ -1,7 +1,7 @@
 """migrate_agent_data_to_rbac
 
 Revision ID: 091d0274c2e3
-Revises: 359f0bbd936c
+Revises: 21159a293dfb
 Create Date: 2026-03-11 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.engine import Connection
 
 # revision identifiers, used by Alembic.
 revision = "091d0274c2e3"
-down_revision = "359f0bbd936c"
+down_revision = "21159a293dfb"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/0e0723286a7a_migrate_image_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/0e0723286a7a_migrate_image_data_to_rbac.py
@@ -1,7 +1,7 @@
 """migrate_image_data_to_rbac
 
 Revision ID: 0e0723286a7a
-Revises: 359f0bbd936c
+Revises: 091d0274c2e3
 Create Date: 2026-03-11 00:00:00.000000
 
 """
@@ -19,7 +19,7 @@ from ai.backend.manager.models.rbac_models.migration.enums import (
 
 # revision identifiers, used by Alembic.
 revision = "0e0723286a7a"
-down_revision = "359f0bbd936c"
+down_revision = "091d0274c2e3"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Agent와 Image RBAC 데이터 마이그레이션의 `down_revision`을 수정하여 multiple heads 문제 해결
- 동시 PR 머지로 인해 agent/image 마이그레이션이 `359f0bbd936c`에서 분기된 상태였음
- 순차 체인으로 정렬: `resource_group → container_registry → keypair → agent → image`

## Test plan
- [ ] `alembic heads` 명령으로 single head 확인
- [ ] `alembic history` 명령으로 마이그레이션 순서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)