### PR TITLE
fix(BA-5009): Apply endpoint filter to `cnt_query` in `EndpointAutoScalingRuleNode` (#9990)

### DIFF
--- a/changes/9990.fix.md
+++ b/changes/9990.fix.md
@@ -1,0 +1,1 @@
+Fix `endpoint_auto_scaling_rule_nodes` count field ignoring endpoint filter and returning total row count instead of per-endpoint count.

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -295,6 +295,7 @@ class EndpointAutoScalingRuleNode(graphene.ObjectType):  # type: ignore[misc]
                         raise GenericForbidden
 
             query = query.filter(EndpointAutoScalingRuleRow.endpoint == _endpoint_id)
+            cnt_query = cnt_query.where(EndpointAutoScalingRuleRow.endpoint == _endpoint_id)
             group_rows = (await db_session.scalars(query)).all()
             result = [cls.from_row(graph_ctx, row) for row in group_rows]
             total_cnt = await db_session.scalar(cnt_query)


### PR DESCRIPTION
This is an auto-generated backport PR of #9990 to the 26.2 release.