### PR TITLE
fix(BA-5101): Return MessageResponse for VFolder rename and update-options

### DIFF
--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -724,7 +724,8 @@ class VFolderHandler:
                 ),
             )
         )
-        return APIResponse.no_content(HTTPStatus.CREATED)
+        resp = MessageResponse(msg="")
+        return APIResponse.build(HTTPStatus.OK, resp)
 
     # ------------------------------------------------------------------
     # 13. update_vfolder_options (POST /{name}/update-options)
@@ -768,7 +769,8 @@ class VFolderHandler:
                 ),
             )
         )
-        return APIResponse.no_content(HTTPStatus.CREATED)
+        resp = MessageResponse(msg="")
+        return APIResponse.build(HTTPStatus.OK, resp)
 
     # ------------------------------------------------------------------
     # 14. mkdir (POST /{name}/mkdir)


### PR DESCRIPTION
## Summary
- VFolder `rename` and `update-options` handlers returned `APIResponse.no_content(HTTPStatus.CREATED)`, producing a `null` JSON body
- WebUI's `_wrapWithPromise` fetch wrapper accesses `.type` on every JSON response for error metadata, causing `TypeError: Cannot read properties of null (reading 'type')`
- Changed both handlers to return `APIResponse.build(HTTPStatus.OK, MessageResponse(msg=""))`, matching the pattern used by all other VFolder mutation endpoints

## Root Cause
During the REST handler migration to Pydantic/Handler class pattern (BA-4722, BA-4820), `web.Response(status=201)` (no Content-Type, empty body) was converted to `APIResponse.no_content(HTTPStatus.CREATED)` → `web.json_response(null, status=201)` (Content-Type: application/json, body: `null`). This caused the WebUI JSON parsing branch to execute where it previously didn't.

## Test plan
- [ ] Call `POST /folders/{name}/update-options` with `{"permission": "ro"}` — verify 200 OK with `{"msg": ""}` body
- [ ] Call `POST /folders/{name}/rename` with `{"new_name": "..."}` — verify 200 OK with `{"msg": ""}` body
- [ ] Verify WebUI Mount Permission dropdown in FolderExplorerModal works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)