### PR TITLE
fix(BA-5121): fix UUIDFloatMap validation error on gpu_alloc_map (#10098)

### DIFF
--- a/changes/10098.fix.md
+++ b/changes/10098.fix.md
@@ -1,0 +1,1 @@
+Fix `UUIDFloatMap` validation error on `gpu_alloc_map` by returning `Decimal` from Valkey client and converting to `float` at the GraphQL resolver layer.

--- a/src/ai/backend/common/clients/valkey_client/valkey_stat/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_stat/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections.abc import Mapping, Sequence
+from decimal import Decimal
 from typing import (
     Any,
     Final,
@@ -181,7 +182,7 @@ class ValkeyStatClient:
             return None
 
     @valkey_stat_resilience.apply()
-    async def get_gpu_allocation_map(self, agent_id: str) -> dict[str, float] | None:
+    async def get_gpu_allocation_map(self, agent_id: str) -> dict[str, Decimal] | None:
         """
         Get GPU allocation mapping for an agent.
 
@@ -192,7 +193,8 @@ class ValkeyStatClient:
         if result is None:
             return None
         try:
-            return cast(dict[str, float], json.loads(result))
+            raw = json.loads(result)
+            return {k: Decimal(v) for k, v in raw.items()}
         except (json.JSONDecodeError, UnicodeDecodeError):
             log.warning(
                 "Failed to decode GPU allocation map for agent {}: {}",

--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Mapping, Sequence
+from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -106,14 +107,18 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
 }
 
 
-def _strip_gpu_prefix(alloc_map: dict[str, float]) -> dict[str, float]:
+def _strip_gpu_prefix(alloc_map: dict[str, Decimal]) -> dict[str, Decimal]:
     return {k.removeprefix("GPU-"): v for k, v in alloc_map.items()}
+
+
+def _decimal_to_float(alloc_map: dict[str, Decimal]) -> dict[str, float]:
+    return {k: float(v) for k, v in alloc_map.items()}
 
 
 async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> dict[str, float]:
     raw_alloc_map = await ctx.valkey_stat.get_gpu_allocation_map(str(agent_id))
     if raw_alloc_map:
-        return UUIDFloatMap.parse_value(_strip_gpu_prefix(raw_alloc_map))
+        return UUIDFloatMap.parse_value(_decimal_to_float(_strip_gpu_prefix(raw_alloc_map)))
     return {}
 
 

--- a/tests/unit/manager/api/test_gql_legacy_gpu_alloc_map.py
+++ b/tests/unit/manager/api/test_gql_legacy_gpu_alloc_map.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,8 +17,8 @@ class TestResolveGpuAllocMap:
         ctx = MagicMock()
         ctx.valkey_stat.get_gpu_allocation_map = AsyncMock(
             return_value={
-                "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
-                "GPU-11111111-2222-3333-4444-555555555555": 1.0,
+                "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": Decimal("0.5"),
+                "GPU-11111111-2222-3333-4444-555555555555": Decimal("1.0"),
             }
         )
         return ctx

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -567,14 +567,18 @@ class TestAgentRepositoryCache:
         """Test GPU allocation map update is stored in cache"""
         agent_id = AgentId("agent-001")
         alloc_map: Mapping[str, Any] = {
-            "cuda:0": {"session_id": "sess-001"},
-            "cuda:1": {"session_id": "sess-002"},
+            "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": "0.50",
+            "GPU-11111111-2222-3333-4444-555555555555": "1.00",
         }
 
         await agent_repository.update_gpu_alloc_map(agent_id, alloc_map)
 
         stored_map = await valkey_stat_client.get_gpu_allocation_map(str(agent_id))
-        assert stored_map == alloc_map
+        assert stored_map is not None
+        assert stored_map == {
+            "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": Decimal("0.50"),
+            "GPU-11111111-2222-3333-4444-555555555555": Decimal("1.00"),
+        }
 
 
 @dataclass


### PR DESCRIPTION
This is an auto-generated backport PR of #10098 to the 26.2 release.