### PR TITLE
fix(BA-5120): Fix `container_id` UUID parsing error in GET /session/{session_name} (#10096)

### DIFF
--- a/changes/10096.fix.md
+++ b/changes/10096.fix.md
@@ -1,0 +1,1 @@
+Fix `ValueError: badly formed hexadecimal UUID string` in `GET /session/{session_name}` caused by parsing Docker container IDs as UUIDs.

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -30,6 +30,7 @@ from ai.backend.common.exception import (
 from ai.backend.common.json import load_json
 from ai.backend.common.plugin.monitor import ErrorPluginContext
 from ai.backend.common.types import (
+    ContainerId,
     ImageAlias,
     SessionId,
     SessionTypes,
@@ -1085,9 +1086,9 @@ class SessionService:
             architecture=sess.main_kernel.architecture or "",
             registry=sess.main_kernel.registry,
             tag=sess.tag,
-            container_id=uuid.UUID(sess.main_kernel.container_id)
+            container_id=ContainerId(sess.main_kernel.container_id)
             if sess.main_kernel.container_id
-            else uuid.uuid4(),
+            else ContainerId(""),
             occupied_slots=str(sess.main_kernel.occupied_slots),  # legacy
             occupying_slots=str(sess.occupying_slots),
             requested_slots=str(sess.requested_slots),

--- a/src/ai/backend/manager/services/session/types.py
+++ b/src/ai/backend/manager/services/session/types.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import trafaret as t
 
 from ai.backend.common import validators as tx
-from ai.backend.common.types import ClusterMode, SessionTypes
+from ai.backend.common.types import ClusterMode, ContainerId, SessionTypes
 from ai.backend.manager.data.session.types import SessionStatus
 
 overwritten_param_check = t.Dict({
@@ -51,7 +51,7 @@ class LegacySessionInfo:
     architecture: str
     registry: str | None
     tag: str | None
-    container_id: UUID
+    container_id: ContainerId
     occupied_slots: str  # legacy
     occupying_slots: str
     requested_slots: str
@@ -81,7 +81,7 @@ class LegacySessionInfo:
             "architecture": self.architecture,
             "registry": self.registry,
             "tag": self.tag,
-            "containerId": str(self.container_id),
+            "containerId": self.container_id,
             "occupiedSlots": self.occupied_slots,
             "occupyingSlots": self.occupying_slots,
             "requestedSlots": self.requested_slots,

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -732,7 +732,7 @@ class TestGetSessionInfo:
         mock_kernel.image = "cr.backend.ai/stable/python:latest"
         mock_kernel.architecture = "x86_64"
         mock_kernel.registry = "cr.backend.ai"
-        mock_kernel.container_id = str(uuid4())
+        mock_kernel.container_id = "a" * 64  # Docker container ID format (64-char hex SHA-256)
         mock_kernel.occupied_slots = ResourceSlot({"cpu": 1, "mem": 1024})
         mock_kernel.occupied_shares = {}
 


### PR DESCRIPTION
This is an auto-generated backport PR of #10096 to the 26.2 release.