### PR TITLE
fix(BA-5121): fix UUIDFloatMap validation error on gpu_alloc_map

### DIFF
--- a/changes/10098.fix.md
+++ b/changes/10098.fix.md
@@ -1,0 +1,1 @@
+Fix `UUIDFloatMap` validation error on `gpu_alloc_map` by returning `Decimal` from Valkey client and converting to `float` at the GraphQL resolver layer.

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
+from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -112,8 +113,12 @@ _queryorder_colmap: Mapping[str, OrderSpecItem] = {
 GPU_ALLOC_MAP_CACHE_PERIOD: Final[int] = 3600 * 24
 
 
-def _strip_gpu_prefix(alloc_map: dict[str, float]) -> dict[str, float]:
+def _strip_gpu_prefix(alloc_map: dict[str, Decimal]) -> dict[str, Decimal]:
     return {k.removeprefix("GPU-"): v for k, v in alloc_map.items()}
+
+
+def _decimal_to_float(alloc_map: dict[str, Decimal]) -> dict[str, float]:
+    return {k: float(v) for k, v in alloc_map.items()}
 
 
 async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> dict[str, float]:
@@ -123,9 +128,8 @@ async def _resolve_gpu_alloc_map(ctx: GraphQueryContext, agent_id: AgentId) -> d
 
     if raw_alloc_map:
         alloc_map = load_json(raw_alloc_map)
-        return UUIDFloatMap.parse_value(
-            _strip_gpu_prefix({k: float(v) for k, v in alloc_map.items()})
-        )
+        decimal_map = {k: Decimal(v) for k, v in alloc_map.items()}
+        return UUIDFloatMap.parse_value(_decimal_to_float(_strip_gpu_prefix(decimal_map)))
     return {}
 
 

--- a/tests/manager/api/test_gql_legacy_gpu_alloc_map.py
+++ b/tests/manager/api/test_gql_legacy_gpu_alloc_map.py
@@ -21,8 +21,8 @@ class TestResolveGpuAllocMap:
         from ai.backend.common.json import dump_json_str
 
         raw_data = {
-            "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": 0.5,
-            "GPU-11111111-2222-3333-4444-555555555555": 1.0,
+            "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": "0.50",
+            "GPU-11111111-2222-3333-4444-555555555555": "1.00",
         }
 
         with patch(


### PR DESCRIPTION
This is a manual backport PR of #10098 to the 25.6 release.

## Summary
- Updated `_strip_gpu_prefix` to work with `dict[str, Decimal]` instead of `dict[str, float]`
- Added `_decimal_to_float` helper to convert Decimal values to float for `UUIDFloatMap.parse_value`
- Updated `_resolve_gpu_alloc_map` to parse raw JSON values as `Decimal` before stripping prefix and converting to float
- Updated test mock data to use realistic string values (matching actual agent behavior)

## Original PR
https://github.com/lablup/backend.ai/pull/10098