### PR TITLE
feat(BA-5122): Add AND/OR/NOT logical operators to GraphQL filter types (Backport)

### DIFF
--- a/changes/10250.feature.md
+++ b/changes/10250.feature.md
@@ -1,0 +1,1 @@
+Add AND, OR, NOT logical operators to GraphQL filter types for complex boolean filter expressions.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -70,6 +70,9 @@ input AccessTokenFilter
   token: StringFilter = null
   validUntil: DateTimeFilter = null
   createdAt: DateTimeFilter = null
+  AND: [AccessTokenFilter!] = null
+  OR: [AccessTokenFilter!] = null
+  NOT: [AccessTokenFilter!] = null
 }
 
 """Added in 25.16.0"""
@@ -390,6 +393,9 @@ input AgentResourceSlotFilter
   @join__type(graph: STRAWBERRY)
 {
   slotName: StringFilter = null
+  AND: [AgentResourceSlotFilter!] = null
+  OR: [AgentResourceSlotFilter!] = null
+  NOT: [AgentResourceSlotFilter!] = null
 }
 
 """Added in 26.3.0. Ordering specification for agent resource slots."""
@@ -1398,6 +1404,9 @@ input AutoScalingRuleFilter
 {
   createdAt: DateTimeFilter = null
   lastTriggeredAt: DateTimeFilter = null
+  AND: [AutoScalingRuleFilter!] = null
+  OR: [AutoScalingRuleFilter!] = null
+  NOT: [AutoScalingRuleFilter!] = null
 }
 
 """Added in 25.19.0"""
@@ -3414,6 +3423,9 @@ input DeploymentHistoryFilter
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [DeploymentHistoryFilter!] = null
+  OR: [DeploymentHistoryFilter!] = null
+  NOT: [DeploymentHistoryFilter!] = null
 }
 
 """Order by specification for deployment history"""
@@ -4422,6 +4434,9 @@ input EntityFilter
 {
   entityType: RBACElementType = null
   entityId: StringFilter = null
+  AND: [EntityFilter!] = null
+  OR: [EntityFilter!] = null
+  NOT: [EntityFilter!] = null
 }
 
 union EntityNode
@@ -5188,6 +5203,9 @@ input ImageV2AliasFilterGQL
   @join__type(graph: STRAWBERRY)
 {
   alias: StringFilter = null
+  AND: [ImageV2AliasFilterGQL!] = null
+  OR: [ImageV2AliasFilterGQL!] = null
+  NOT: [ImageV2AliasFilterGQL!] = null
 }
 
 """
@@ -5674,6 +5692,9 @@ input KernelResourceAllocationFilter
   @join__type(graph: STRAWBERRY)
 {
   slotName: StringFilter = null
+  AND: [KernelResourceAllocationFilter!] = null
+  OR: [KernelResourceAllocationFilter!] = null
+  NOT: [KernelResourceAllocationFilter!] = null
 }
 
 """
@@ -5799,6 +5820,9 @@ input KernelV2Filter
   id: UUIDFilter = null
   status: KernelV2StatusFilter = null
   sessionId: UUIDFilter = null
+  AND: [KernelV2Filter!] = null
+  OR: [KernelV2Filter!] = null
+  NOT: [KernelV2Filter!] = null
 }
 
 """Added in 26.2.0. Lifecycle and status information for a kernel."""
@@ -8207,6 +8231,9 @@ input PermissionFilter
   roleId: UUID = null
   scopeType: RBACElementType = null
   entityType: RBACElementType = null
+  AND: [PermissionFilter!] = null
+  OR: [PermissionFilter!] = null
+  NOT: [PermissionFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for permissions"""
@@ -10858,6 +10885,9 @@ input ResourceSlotTypeFilter
   slotName: StringFilter = null
   slotType: StringFilter = null
   displayName: StringFilter = null
+  AND: [ResourceSlotTypeFilter!] = null
+  OR: [ResourceSlotTypeFilter!] = null
+  NOT: [ResourceSlotTypeFilter!] = null
 }
 
 """Added in 26.3.0. Ordering specification for resource slot types."""
@@ -11112,6 +11142,9 @@ input RoleAssignmentFilter
   role: RoleAssignmentRoleNestedFilter = null
   username: StringFilter = null
   email: StringFilter = null
+  AND: [RoleAssignmentFilter!] = null
+  OR: [RoleAssignmentFilter!] = null
+  NOT: [RoleAssignmentFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for role assignments"""
@@ -11140,6 +11173,9 @@ input RoleAssignmentRoleNestedFilter
   name: StringFilter = null
   source: [RoleSource!] = null
   status: [RoleStatus!] = null
+  AND: [RoleAssignmentRoleNestedFilter!] = null
+  OR: [RoleAssignmentRoleNestedFilter!] = null
+  NOT: [RoleAssignmentRoleNestedFilter!] = null
 }
 
 """Added in 26.3.0. Role connection"""
@@ -11174,7 +11210,7 @@ input RoleFilter
   status: [RoleStatus!] = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
-  NOT: RoleFilter = null
+  NOT: [RoleFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for roles"""
@@ -11287,6 +11323,9 @@ input RouteFilter
 {
   status: [RouteStatus!] = null
   trafficStatus: [RouteTrafficStatus!] = null
+  AND: [RouteFilter!] = null
+  OR: [RouteFilter!] = null
+  NOT: [RouteFilter!] = null
 }
 
 """Route history record"""
@@ -11352,6 +11391,9 @@ input RouteHistoryFilter
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [RouteHistoryFilter!] = null
+  OR: [RouteHistoryFilter!] = null
+  NOT: [RouteHistoryFilter!] = null
 }
 
 """Order by specification for route history"""
@@ -11760,6 +11802,9 @@ input ServiceCatalogFilter
 
   """Filter by health status."""
   status: ServiceCatalogStatus = null
+  AND: [ServiceCatalogFilter!] = null
+  OR: [ServiceCatalogFilter!] = null
+  NOT: [ServiceCatalogFilter!] = null
 }
 
 """
@@ -11974,6 +12019,9 @@ input SessionSchedulingHistoryFilter
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [SessionSchedulingHistoryFilter!] = null
+  OR: [SessionSchedulingHistoryFilter!] = null
+  NOT: [SessionSchedulingHistoryFilter!] = null
 }
 
 """Order by specification for session scheduling history"""
@@ -12090,6 +12138,9 @@ input SessionV2Filter
   domainName: StringFilter = null
   projectId: UUIDFilter = null
   userUuid: UUIDFilter = null
+  AND: [SessionV2Filter!] = null
+  OR: [SessionV2Filter!] = null
+  NOT: [SessionV2Filter!] = null
 }
 
 """Added in 26.3.0. Lifecycle status and timestamps for a session."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -44,6 +44,9 @@ input AccessTokenFilter {
   token: StringFilter = null
   validUntil: DateTimeFilter = null
   createdAt: DateTimeFilter = null
+  AND: [AccessTokenFilter!] = null
+  OR: [AccessTokenFilter!] = null
+  NOT: [AccessTokenFilter!] = null
 }
 
 """Added in 25.16.0"""
@@ -212,6 +215,9 @@ type AgentResourceSlotEdge {
 """Added in 26.3.0. Filter criteria for querying agent resource slots."""
 input AgentResourceSlotFilter {
   slotName: StringFilter = null
+  AND: [AgentResourceSlotFilter!] = null
+  OR: [AgentResourceSlotFilter!] = null
+  NOT: [AgentResourceSlotFilter!] = null
 }
 
 """Added in 26.3.0. Ordering specification for agent resource slots."""
@@ -928,6 +934,9 @@ type AutoScalingRuleEdge {
 input AutoScalingRuleFilter {
   createdAt: DateTimeFilter = null
   lastTriggeredAt: DateTimeFilter = null
+  AND: [AutoScalingRuleFilter!] = null
+  OR: [AutoScalingRuleFilter!] = null
+  NOT: [AutoScalingRuleFilter!] = null
 }
 
 """Added in 25.19.0"""
@@ -1874,6 +1883,9 @@ input DeploymentHistoryFilter {
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [DeploymentHistoryFilter!] = null
+  OR: [DeploymentHistoryFilter!] = null
+  NOT: [DeploymentHistoryFilter!] = null
 }
 
 """Order by specification for deployment history"""
@@ -2492,6 +2504,9 @@ type EntityEdge {
 input EntityFilter {
   entityType: RBACElementType = null
   entityId: StringFilter = null
+  AND: [EntityFilter!] = null
+  OR: [EntityFilter!] = null
+  NOT: [EntityFilter!] = null
 }
 
 union EntityNode = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | Artifact | ArtifactRegistry | AppConfig | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ArtifactRevision | Role
@@ -2878,6 +2893,9 @@ Supports filtering by alias string.
 """
 input ImageV2AliasFilterGQL {
   alias: StringFilter = null
+  AND: [ImageV2AliasFilterGQL!] = null
+  OR: [ImageV2AliasFilterGQL!] = null
+  NOT: [ImageV2AliasFilterGQL!] = null
 }
 
 """
@@ -3207,6 +3225,9 @@ Added in 26.3.0. Filter criteria for querying kernel resource allocations.
 """
 input KernelResourceAllocationFilter {
   slotName: StringFilter = null
+  AND: [KernelResourceAllocationFilter!] = null
+  OR: [KernelResourceAllocationFilter!] = null
+  NOT: [KernelResourceAllocationFilter!] = null
 }
 
 """
@@ -3317,6 +3338,9 @@ input KernelV2Filter {
   id: UUIDFilter = null
   status: KernelV2StatusFilter = null
   sessionId: UUIDFilter = null
+  AND: [KernelV2Filter!] = null
+  OR: [KernelV2Filter!] = null
+  NOT: [KernelV2Filter!] = null
 }
 
 """Added in 26.2.0. Lifecycle and status information for a kernel."""
@@ -4473,6 +4497,9 @@ input PermissionFilter {
   roleId: UUID = null
   scopeType: RBACElementType = null
   entityType: RBACElementType = null
+  AND: [PermissionFilter!] = null
+  OR: [PermissionFilter!] = null
+  NOT: [PermissionFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for permissions"""
@@ -6409,6 +6436,9 @@ input ResourceSlotTypeFilter {
   slotName: StringFilter = null
   slotType: StringFilter = null
   displayName: StringFilter = null
+  AND: [ResourceSlotTypeFilter!] = null
+  OR: [ResourceSlotTypeFilter!] = null
+  NOT: [ResourceSlotTypeFilter!] = null
 }
 
 """Added in 26.3.0. Ordering specification for resource slot types."""
@@ -6553,6 +6583,9 @@ input RoleAssignmentFilter {
   role: RoleAssignmentRoleNestedFilter = null
   username: StringFilter = null
   email: StringFilter = null
+  AND: [RoleAssignmentFilter!] = null
+  OR: [RoleAssignmentFilter!] = null
+  NOT: [RoleAssignmentFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for role assignments"""
@@ -6575,6 +6608,9 @@ input RoleAssignmentRoleNestedFilter {
   name: StringFilter = null
   source: [RoleSource!] = null
   status: [RoleStatus!] = null
+  AND: [RoleAssignmentRoleNestedFilter!] = null
+  OR: [RoleAssignmentRoleNestedFilter!] = null
+  NOT: [RoleAssignmentRoleNestedFilter!] = null
 }
 
 """Added in 26.3.0. Role connection"""
@@ -6603,7 +6639,7 @@ input RoleFilter {
   status: [RoleStatus!] = null
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
-  NOT: RoleFilter = null
+  NOT: [RoleFilter!] = null
 }
 
 """Added in 26.3.0. Order by specification for roles"""
@@ -6697,6 +6733,9 @@ type RouteEdge {
 input RouteFilter {
   status: [RouteStatus!] = null
   trafficStatus: [RouteTrafficStatus!] = null
+  AND: [RouteFilter!] = null
+  OR: [RouteFilter!] = null
+  NOT: [RouteFilter!] = null
 }
 
 """Route history record"""
@@ -6753,6 +6792,9 @@ input RouteHistoryFilter {
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [RouteHistoryFilter!] = null
+  OR: [RouteHistoryFilter!] = null
+  NOT: [RouteHistoryFilter!] = null
 }
 
 """Order by specification for route history"""
@@ -7004,6 +7046,9 @@ input ServiceCatalogFilter {
 
   """Filter by health status."""
   status: ServiceCatalogStatus = null
+  AND: [ServiceCatalogFilter!] = null
+  OR: [ServiceCatalogFilter!] = null
+  NOT: [ServiceCatalogFilter!] = null
 }
 
 """
@@ -7117,6 +7162,9 @@ input SessionSchedulingHistoryFilter {
   message: StringFilter = null
   createdAt: DateTimeFilter = null
   updatedAt: DateTimeFilter = null
+  AND: [SessionSchedulingHistoryFilter!] = null
+  OR: [SessionSchedulingHistoryFilter!] = null
+  NOT: [SessionSchedulingHistoryFilter!] = null
 }
 
 """Order by specification for session scheduling history"""
@@ -7216,6 +7264,9 @@ input SessionV2Filter {
   domainName: StringFilter = null
   projectId: UUIDFilter = null
   userUuid: UUIDFilter = null
+  AND: [SessionV2Filter!] = null
+  OR: [SessionV2Filter!] = null
+  NOT: [SessionV2Filter!] = null
 }
 
 """Added in 26.3.0. Lifecycle status and timestamps for a session."""

--- a/src/ai/backend/manager/api/gql/deployment/types/access_token.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/access_token.py
@@ -18,7 +18,12 @@ from ai.backend.manager.data.deployment.types import (
     AccessTokenOrderField,
     ModelDeploymentAccessTokenData,
 )
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.deployment.options import (
     AccessTokenConditions,
     AccessTokenOrders,
@@ -32,6 +37,10 @@ class AccessTokenFilter(GQLFilter):
     token: StringFilter | None = None
     valid_until: DateTimeFilter | None = None
     created_at: DateTimeFilter | None = None
+
+    AND: list[AccessTokenFilter] | None = None
+    OR: list[AccessTokenFilter] | None = None
+    NOT: list[AccessTokenFilter] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -61,6 +70,27 @@ class AccessTokenFilter(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
@@ -22,7 +22,12 @@ from ai.backend.manager.data.deployment.types import (
     AutoScalingRuleOrderField,
     ModelDeploymentAutoScalingRuleData,
 )
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.deployment.options import (
     AutoScalingRuleConditions,
     AutoScalingRuleOrders,
@@ -46,6 +51,10 @@ class AutoScalingRuleFilter(GQLFilter):
     created_at: DateTimeFilter | None = None
     last_triggered_at: DateTimeFilter | None = None
 
+    AND: list[AutoScalingRuleFilter] | None = None
+    OR: list[AutoScalingRuleFilter] | None = None
+    NOT: list[AutoScalingRuleFilter] | None = None
+
     @override
     def build_conditions(self) -> list[QueryCondition]:
         """Build query conditions from this filter."""
@@ -68,6 +77,27 @@ class AutoScalingRuleFilter(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/deployment/types/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/route.py
@@ -32,7 +32,12 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.errors.deployment import EndpointNotFound
 from ai.backend.manager.models.routing.row import RoutingRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.deployment.options import RouteConditions, RouteOrders
 
 if TYPE_CHECKING:
@@ -174,6 +179,10 @@ class RouteFilter(GQLFilter):
     status: list[RouteStatusGQL] | None = None
     traffic_status: list[RouteTrafficStatusGQL] | None = None
 
+    AND: list[RouteFilter] | None = None
+    OR: list[RouteFilter] | None = None
+    NOT: list[RouteFilter] | None = None
+
     @override
     def build_conditions(self) -> list[QueryCondition]:
         """Build query conditions from this filter."""
@@ -188,6 +197,27 @@ class RouteFilter(GQLFilter):
                 RouteTrafficStatusEnum(ts.value) for ts in self.traffic_status
             ]
             conditions.append(RouteConditions.by_traffic_statuses(internal_traffic_statuses))
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -720,6 +720,10 @@ class ImageV2AliasConnectionGQL(Connection[ImageV2AliasGQL]):
 class ImageV2AliasFilterGQL(GQLFilter):
     alias: StringFilter | None = None
 
+    AND: list[ImageV2AliasFilterGQL] | None = None
+    OR: list[ImageV2AliasFilterGQL] | None = None
+    NOT: list[ImageV2AliasFilterGQL] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         """Build query conditions from this filter."""
         field_conditions: list[QueryCondition] = []
@@ -733,6 +737,27 @@ class ImageV2AliasFilterGQL(GQLFilter):
             )
             if alias_condition:
                 field_conditions.append(alias_condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                field_conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                field_conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                field_conditions.append(negate_conditions(not_sub_conditions))
 
         return field_conditions
 

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
         ResourceAllocationConnectionGQL,
     )
     from ai.backend.manager.api.gql.session.types import SessionV2GQL
-    from ai.backend.manager.repositories.base import QueryCondition
 
 from ai.backend.manager.api.gql.agent.types import AgentV2GQL
 from ai.backend.manager.api.gql.common.types import (
@@ -39,7 +38,12 @@ from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQ
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 from ai.backend.manager.api.gql.utils import dedent_strip
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, KernelStatusInMatchSpec
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.scheduler.options import KernelConditions, KernelOrders
 
 
@@ -169,6 +173,10 @@ class KernelV2FilterGQL(GQLFilter):
     status: KernelV2StatusFilterGQL | None = None
     session_id: UUIDFilter | None = None
 
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if self.id:
@@ -191,6 +199,28 @@ class KernelV2FilterGQL(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
 

--- a/src/ai/backend/manager/api/gql/rbac/types/entity.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/entity.py
@@ -20,7 +20,12 @@ from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQ
 from ai.backend.manager.data.permission.association_scopes_entities import (
     AssociationScopesEntitiesData,
 )
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.permission_controller.options import (
     EntityScopeConditions,
     EntityScopeOrders,
@@ -190,6 +195,9 @@ class EntityRefGQL(Node):
 class EntityFilter(GQLFilter):
     entity_type: RBACElementTypeGQL | None = None
     entity_id: StringFilter | None = None
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -209,6 +217,27 @@ class EntityFilter(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/rbac/types/permission.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/permission.py
@@ -21,7 +21,12 @@ from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQ
 from ai.backend.manager.data.permission.permission import PermissionData
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.permission_controller.creators import PermissionCreatorSpec
@@ -277,6 +282,9 @@ class PermissionFilter(GQLFilter):
     role_id: uuid.UUID | None = None
     scope_type: RBACElementTypeGQL | None = None
     entity_type: RBACElementTypeGQL | None = None
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -298,6 +306,27 @@ class PermissionFilter(GQLFilter):
                     self.entity_type.to_element().to_entity_type()
                 )
             )
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -30,7 +30,12 @@ from ai.backend.manager.data.permission.role import (
 )
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import BulkCreator, Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.permission_controller.creators import (
@@ -317,7 +322,7 @@ class RoleFilter(GQLFilter):
 
     AND: list[RoleFilter] | None = None
     OR: list[RoleFilter] | None = None
-    NOT: RoleFilter | None = None
+    NOT: list[RoleFilter] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -339,6 +344,27 @@ class RoleFilter(GQLFilter):
         if self.status is not None and len(self.status) > 0:
             conditions.append(RoleConditions.by_statuses([s.to_internal() for s in self.status]))
 
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
 
@@ -357,6 +383,10 @@ class RoleAssignmentRoleNestedFilterGQL:
     source: list[RoleSourceGQL] | None = None
     status: list[RoleStatusGQL] | None = None
 
+    AND: list[RoleAssignmentRoleNestedFilterGQL] | None = None
+    OR: list[RoleAssignmentRoleNestedFilterGQL] | None = None
+    NOT: list[RoleAssignmentRoleNestedFilterGQL] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         raw_conditions: list[QueryCondition] = []
         if self.name:
@@ -374,9 +404,32 @@ class RoleAssignmentRoleNestedFilterGQL:
             raw_conditions.append(
                 RoleConditions.by_statuses([s.to_internal() for s in self.status])
             )
-        if not raw_conditions:
-            return []
-        return [AssignedUserConditions.exists_role_combined(raw_conditions)]
+        conditions: list[QueryCondition] = []
+        if raw_conditions:
+            conditions.append(AssignedUserConditions.exists_role_combined(raw_conditions))
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
+        return conditions
 
 
 @strawberry.input(description="Added in 26.3.0. Filter for role assignments")
@@ -385,6 +438,10 @@ class RoleAssignmentFilter(GQLFilter):
     role: RoleAssignmentRoleNestedFilterGQL | None = None
     username: StringFilter | None = None
     email: StringFilter | None = None
+
+    AND: list[RoleAssignmentFilter] | None = None
+    OR: list[RoleAssignmentFilter] | None = None
+    NOT: list[RoleAssignmentFilter] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -415,6 +472,27 @@ class RoleAssignmentFilter(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/resource_slot/types.py
+++ b/src/ai/backend/manager/api/gql/resource_slot/types.py
@@ -26,7 +26,12 @@ from ai.backend.manager.data.resource_slot.types import (
     ResourceAllocationData,
     ResourceSlotTypeData,
 )
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.resource_slot.query import (
     AgentResourceQueryConditions,
     AgentResourceQueryOrders,
@@ -162,6 +167,10 @@ class ResourceSlotTypeFilterGQL(GQLFilter):
     slot_type: StringFilter | None = None
     display_name: StringFilter | None = None
 
+    AND: list[ResourceSlotTypeFilterGQL] | None = None
+    OR: list[ResourceSlotTypeFilterGQL] | None = None
+    NOT: list[ResourceSlotTypeFilterGQL] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if self.slot_name:
@@ -191,6 +200,21 @@ class ResourceSlotTypeFilterGQL(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
         return conditions
 
 
@@ -310,6 +334,10 @@ class AgentResourceSlotOrderFieldGQL(StrEnum):
 class AgentResourceSlotFilterGQL(GQLFilter):
     slot_name: StringFilter | None = None
 
+    AND: list[AgentResourceSlotFilterGQL] | None = None
+    OR: list[AgentResourceSlotFilterGQL] | None = None
+    NOT: list[AgentResourceSlotFilterGQL] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if self.slot_name:
@@ -321,6 +349,21 @@ class AgentResourceSlotFilterGQL(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
         return conditions
 
 
@@ -425,6 +468,10 @@ class KernelResourceAllocationOrderFieldGQL(StrEnum):
 class KernelResourceAllocationFilterGQL(GQLFilter):
     slot_name: StringFilter | None = None
 
+    AND: list[KernelResourceAllocationFilterGQL] | None = None
+    OR: list[KernelResourceAllocationFilterGQL] | None = None
+    NOT: list[KernelResourceAllocationFilterGQL] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if self.slot_name:
@@ -436,6 +483,21 @@ class KernelResourceAllocationFilterGQL(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
         return conditions
 
 

--- a/src/ai/backend/manager/api/gql/scheduling_history/types.py
+++ b/src/ai/backend/manager/api/gql/scheduling_history/types.py
@@ -25,7 +25,12 @@ from ai.backend.manager.data.session.types import (
     SessionSchedulingHistoryData,
     SubStepResult,
 )
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.scheduling_history.options import (
     DeploymentHistoryConditions,
     DeploymentHistoryOrders,
@@ -349,6 +354,10 @@ class SessionSchedulingHistoryFilter(GQLFilter):
     created_at: DateTimeFilter | None = None
     updated_at: DateTimeFilter | None = None
 
+    AND: list[SessionSchedulingHistoryFilter] | None = None
+    OR: list[SessionSchedulingHistoryFilter] | None = None
+    NOT: list[SessionSchedulingHistoryFilter] | None = None
+
     @override
     def build_conditions(self) -> list[QueryCondition]:
         """Build query conditions from this filter."""
@@ -431,6 +440,27 @@ class SessionSchedulingHistoryFilter(GQLFilter):
             if condition:
                 conditions.append(condition)
 
+        # Handle AND logical operator - these are implicitly ANDed with field conditions
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
 
@@ -462,6 +492,10 @@ class DeploymentHistoryFilter(GQLFilter):
     message: StringFilter | None = None
     created_at: DateTimeFilter | None = None
     updated_at: DateTimeFilter | None = None
+
+    AND: list[DeploymentHistoryFilter] | None = None
+    OR: list[DeploymentHistoryFilter] | None = None
+    NOT: list[DeploymentHistoryFilter] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -543,6 +577,27 @@ class DeploymentHistoryFilter(GQLFilter):
             if condition:
                 conditions.append(condition)
 
+        # Handle AND logical operator - these are implicitly ANDed with field conditions
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
 
@@ -575,6 +630,10 @@ class RouteHistoryFilter(GQLFilter):
     message: StringFilter | None = None
     created_at: DateTimeFilter | None = None
     updated_at: DateTimeFilter | None = None
+
+    AND: list[RouteHistoryFilter] | None = None
+    OR: list[RouteHistoryFilter] | None = None
+    NOT: list[RouteHistoryFilter] | None = None
 
     @override
     def build_conditions(self) -> list[QueryCondition]:
@@ -663,6 +722,27 @@ class RouteHistoryFilter(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator - these are implicitly ANDed with field conditions
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/service_catalog/types.py
+++ b/src/ai/backend/manager/api/gql/service_catalog/types.py
@@ -20,7 +20,12 @@ from ai.backend.manager.data.service_catalog.types import (
     ServiceCatalogEndpointData,
 )
 from ai.backend.manager.models.service_catalog.row import ServiceCatalogRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 
 __all__ = (
     "ServiceCatalogEndpointGQL",
@@ -168,6 +173,9 @@ class ServiceCatalogFilterGQL(GQLFilter):
         default=None,
         description="Filter by health status.",
     )
+    AND: list[ServiceCatalogFilterGQL] | None = None
+    OR: list[ServiceCatalogFilterGQL] | None = None
+    NOT: list[ServiceCatalogFilterGQL] | None = None
 
     def build_conditions(self) -> list[QueryCondition]:
         """Build query conditions from filter fields."""
@@ -178,4 +186,26 @@ class ServiceCatalogFilterGQL(GQLFilter):
         if self.status is not None:
             status_val = ServiceCatalogStatus(self.status.value)
             conditions.append(lambda: ServiceCatalogRow.status == status_val)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -46,6 +46,8 @@ from ai.backend.manager.repositories.base import (
     NoPagination,
     QueryCondition,
     QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.repositories.scheduler.options import (
     KernelConditions,
@@ -167,6 +169,10 @@ class SessionV2FilterGQL(GQLFilter):
     project_id: UUIDFilter | None = None
     user_uuid: UUIDFilter | None = None
 
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
     def build_conditions(self) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if self.id:
@@ -212,6 +218,28 @@ class SessionV2FilterGQL(GQLFilter):
             )
             if condition:
                 conditions.append(condition)
+
+        # Handle AND logical operator
+        if self.AND:
+            for sub_filter in self.AND:
+                conditions.extend(sub_filter.build_conditions())
+
+        # Handle OR logical operator
+        if self.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.OR:
+                or_sub_conditions.extend(sub_filter.build_conditions())
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        # Handle NOT logical operator
+        if self.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in self.NOT:
+                not_sub_conditions.extend(sub_filter.build_conditions())
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
 

--- a/tests/unit/manager/api/gql/deployment/BUILD
+++ b/tests/unit/manager/api/gql/deployment/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/deployment/test_access_token_filter.py
+++ b/tests/unit/manager/api/gql/deployment/test_access_token_filter.py
@@ -1,0 +1,177 @@
+"""Unit tests verifying AND/OR/NOT logical operator behavior on AccessTokenFilter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter
+from ai.backend.manager.api.gql.deployment.types.access_token import AccessTokenFilter
+
+# Row imports to trigger mapper initialization (FK dependency order).
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import (
+    DeploymentAutoScalingPolicyRow,
+)
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.base import QueryCondition
+
+# Reference Row models to prevent unused-import removal.
+_MAPPER_ROWS = [
+    DomainRow,
+    ScalingGroupRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    UserRoleRow,
+    UserRow,
+    KeyPairRow,
+    GroupRow,
+    ImageRow,
+    VFolderRow,
+    EndpointRow,
+    EndpointTokenRow,
+    DeploymentPolicyRow,
+    DeploymentAutoScalingPolicyRow,
+    DeploymentRevisionRow,
+    SessionRow,
+    AgentRow,
+    KernelRow,
+    RoutingRow,
+    ResourcePresetRow,
+]
+
+
+def _compile(condition_callable: QueryCondition) -> str:
+    """Compile a QueryCondition callable to SQL string."""
+    return str(condition_callable().compile(compile_kwargs={"literal_binds": True}))
+
+
+class TestAccessTokenFilterAND:
+    """Tests for AND logical operator on AccessTokenFilter."""
+
+    def test_and_extends_conditions_from_sub_filter(self) -> None:
+        f = AccessTokenFilter(
+            AND=[AccessTokenFilter(token=StringFilter(equals="tok-abc"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "endpoint_tokens" in sql
+
+    def test_and_combines_multiple_sub_filters(self) -> None:
+        f = AccessTokenFilter(
+            AND=[
+                AccessTokenFilter(token=StringFilter(equals="tok-abc")),
+                AccessTokenFilter(token=StringFilter(equals="tok-xyz")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_and_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = AccessTokenFilter(AND=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_and_combined_with_field_filter(self) -> None:
+        f = AccessTokenFilter(
+            token=StringFilter(equals="tok-abc"),
+            AND=[AccessTokenFilter(token=StringFilter(equals="tok-xyz"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+
+class TestAccessTokenFilterOR:
+    """Tests for OR logical operator on AccessTokenFilter."""
+
+    def test_or_wraps_sub_filters_in_single_condition(self) -> None:
+        f = AccessTokenFilter(
+            OR=[
+                AccessTokenFilter(token=StringFilter(equals="tok-abc")),
+                AccessTokenFilter(token=StringFilter(equals="tok-xyz")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "OR" in sql
+
+    def test_or_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = AccessTokenFilter(OR=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_or_combined_with_field_filter(self) -> None:
+        f = AccessTokenFilter(
+            token=StringFilter(equals="tok-abc"),
+            OR=[
+                AccessTokenFilter(token=StringFilter(equals="tok-xyz")),
+                AccessTokenFilter(token=StringFilter(equals="tok-def")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_or_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = AccessTokenFilter(OR=[AccessTokenFilter()])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+
+class TestAccessTokenFilterNOT:
+    """Tests for NOT logical operator on AccessTokenFilter."""
+
+    def test_not_wraps_sub_filter_in_negated_condition(self) -> None:
+        # Use two sub-conditions so SQLAlchemy emits NOT (cond1 AND cond2) rather than !=
+        f = AccessTokenFilter(
+            NOT=[
+                AccessTokenFilter(
+                    token=StringFilter(equals="tok-revoked"),
+                    created_at=DateTimeFilter(
+                        before=datetime(2024, 1, 1, tzinfo=UTC),
+                    ),
+                )
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "NOT" in sql
+
+    def test_not_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = AccessTokenFilter(NOT=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_not_combined_with_field_filter(self) -> None:
+        f = AccessTokenFilter(
+            token=StringFilter(equals="tok-abc"),
+            NOT=[AccessTokenFilter(token=StringFilter(equals="tok-revoked"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_not_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = AccessTokenFilter(NOT=[AccessTokenFilter()])
+        conditions = f.build_conditions()
+        assert conditions == []

--- a/tests/unit/manager/api/gql/rbac/test_role_filter.py
+++ b/tests/unit/manager/api/gql/rbac/test_role_filter.py
@@ -1,0 +1,195 @@
+"""Unit tests verifying AND/OR/NOT logical operator behavior on RoleFilter."""
+
+from __future__ import annotations
+
+from ai.backend.manager.api.gql.base import StringFilter
+from ai.backend.manager.api.gql.rbac.types.role import RoleFilter, RoleSourceGQL
+
+# Row imports to trigger mapper initialization (FK dependency order).
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import (
+    DeploymentAutoScalingPolicyRow,
+)
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.base import QueryCondition
+
+# Reference Row models to prevent unused-import removal.
+_MAPPER_ROWS = [
+    DomainRow,
+    ScalingGroupRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    UserRoleRow,
+    RoleRow,
+    UserRow,
+    KeyPairRow,
+    GroupRow,
+    ImageRow,
+    VFolderRow,
+    EndpointRow,
+    DeploymentPolicyRow,
+    DeploymentAutoScalingPolicyRow,
+    DeploymentRevisionRow,
+    SessionRow,
+    AgentRow,
+    KernelRow,
+    RoutingRow,
+    ResourcePresetRow,
+]
+
+
+def _compile(condition_callable: QueryCondition) -> str:
+    """Compile a QueryCondition callable to SQL string."""
+    return str(condition_callable().compile(compile_kwargs={"literal_binds": True}))
+
+
+class TestRoleFilterNOTTypeAcceptsList:
+    """Tests that RoleFilter.NOT accepts a list (bug fix: was singular)."""
+
+    def test_not_accepts_list_of_filters(self) -> None:
+        f = RoleFilter(NOT=[RoleFilter(name=StringFilter(equals="admin"))])
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+
+    def test_not_accepts_multiple_filters_in_list(self) -> None:
+        f = RoleFilter(
+            NOT=[
+                RoleFilter(name=StringFilter(equals="admin")),
+                RoleFilter(name=StringFilter(equals="superuser")),
+            ]
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "NOT" in sql
+
+
+class TestRoleFilterAND:
+    """Tests for AND logical operator on RoleFilter."""
+
+    def test_and_extends_conditions_from_sub_filter(self) -> None:
+        f = RoleFilter(
+            AND=[RoleFilter(name=StringFilter(equals="admin"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "roles" in sql
+
+    def test_and_combines_multiple_sub_filters(self) -> None:
+        f = RoleFilter(
+            AND=[
+                RoleFilter(name=StringFilter(equals="admin")),
+                RoleFilter(name=StringFilter(equals="editor")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_and_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = RoleFilter(AND=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_and_combined_with_field_filter(self) -> None:
+        f = RoleFilter(
+            name=StringFilter(equals="admin"),
+            AND=[RoleFilter(name=StringFilter(equals="editor"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+
+class TestRoleFilterOR:
+    """Tests for OR logical operator on RoleFilter."""
+
+    def test_or_wraps_sub_filters_in_single_condition(self) -> None:
+        f = RoleFilter(
+            OR=[
+                RoleFilter(name=StringFilter(equals="admin")),
+                RoleFilter(name=StringFilter(equals="editor")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "OR" in sql
+
+    def test_or_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = RoleFilter(OR=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_or_combined_with_field_filter(self) -> None:
+        f = RoleFilter(
+            name=StringFilter(equals="admin"),
+            OR=[
+                RoleFilter(name=StringFilter(equals="editor")),
+                RoleFilter(name=StringFilter(equals="viewer")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_or_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = RoleFilter(OR=[RoleFilter()])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+
+class TestRoleFilterNOT:
+    """Tests for NOT logical operator on RoleFilter."""
+
+    def test_not_wraps_sub_filter_in_negated_condition(self) -> None:
+        # Use two sub-conditions so SQLAlchemy emits NOT (cond1 AND cond2) rather than !=
+        f = RoleFilter(
+            NOT=[
+                RoleFilter(
+                    name=StringFilter(equals="banned"),
+                    source=[RoleSourceGQL.CUSTOM],
+                )
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "NOT" in sql
+
+    def test_not_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = RoleFilter(NOT=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_not_combined_with_field_filter(self) -> None:
+        f = RoleFilter(
+            name=StringFilter(equals="admin"),
+            NOT=[RoleFilter(name=StringFilter(equals="banned"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_not_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = RoleFilter(NOT=[RoleFilter()])
+        conditions = f.build_conditions()
+        assert conditions == []

--- a/tests/unit/manager/api/gql/scheduling_history/BUILD
+++ b/tests/unit/manager/api/gql/scheduling_history/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/scheduling_history/test_filters.py
+++ b/tests/unit/manager/api/gql/scheduling_history/test_filters.py
@@ -1,0 +1,178 @@
+"""Unit tests verifying AND/OR/NOT logical operator behavior on SessionSchedulingHistoryFilter."""
+
+from __future__ import annotations
+
+from ai.backend.manager.api.gql.base import StringFilter
+from ai.backend.manager.api.gql.scheduling_history.types import SessionSchedulingHistoryFilter
+
+# Row imports to trigger mapper initialization (FK dependency order).
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import (
+    DeploymentAutoScalingPolicyRow,
+)
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.scheduling_history import SessionSchedulingHistoryRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.base import QueryCondition
+
+# Reference Row models to prevent unused-import removal.
+_MAPPER_ROWS = [
+    DomainRow,
+    ScalingGroupRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    UserRoleRow,
+    UserRow,
+    KeyPairRow,
+    GroupRow,
+    ImageRow,
+    VFolderRow,
+    EndpointRow,
+    DeploymentPolicyRow,
+    DeploymentAutoScalingPolicyRow,
+    DeploymentRevisionRow,
+    SessionRow,
+    AgentRow,
+    KernelRow,
+    RoutingRow,
+    ResourcePresetRow,
+    SessionSchedulingHistoryRow,
+]
+
+
+def _compile(condition_callable: QueryCondition) -> str:
+    """Compile a QueryCondition callable to SQL string."""
+    return str(condition_callable().compile(compile_kwargs={"literal_binds": True}))
+
+
+class TestSessionSchedulingHistoryFilterAND:
+    """Tests for AND logical operator on SessionSchedulingHistoryFilter."""
+
+    def test_and_extends_conditions_from_sub_filter(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            AND=[SessionSchedulingHistoryFilter(phase=StringFilter(equals="init"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "session_scheduling_history" in sql
+
+    def test_and_combines_multiple_sub_filters(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            AND=[
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="init")),
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="prepare")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_and_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = SessionSchedulingHistoryFilter(AND=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_and_combined_with_field_filter(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            phase=StringFilter(equals="init"),
+            AND=[SessionSchedulingHistoryFilter(phase=StringFilter(equals="prepare"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+
+class TestSessionSchedulingHistoryFilterOR:
+    """Tests for OR logical operator on SessionSchedulingHistoryFilter."""
+
+    def test_or_wraps_sub_filters_in_single_condition(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            OR=[
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="init")),
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="prepare")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "OR" in sql
+
+    def test_or_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = SessionSchedulingHistoryFilter(OR=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_or_combined_with_field_filter(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            phase=StringFilter(equals="init"),
+            OR=[
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="prepare")),
+                SessionSchedulingHistoryFilter(phase=StringFilter(equals="cleanup")),
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_or_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            OR=[SessionSchedulingHistoryFilter()],
+        )
+        conditions = f.build_conditions()
+        assert conditions == []
+
+
+class TestSessionSchedulingHistoryFilterNOT:
+    """Tests for NOT logical operator on SessionSchedulingHistoryFilter."""
+
+    def test_not_wraps_sub_filter_in_negated_condition(self) -> None:
+        # Use two sub-conditions so SQLAlchemy emits NOT (cond1 AND cond2) rather than !=
+        f = SessionSchedulingHistoryFilter(
+            NOT=[
+                SessionSchedulingHistoryFilter(
+                    phase=StringFilter(equals="init"),
+                    error_code=StringFilter(equals="TIMEOUT"),
+                )
+            ],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 1
+        sql = _compile(conditions[0])
+        assert "NOT" in sql
+
+    def test_not_with_empty_list_produces_no_extra_conditions(self) -> None:
+        f = SessionSchedulingHistoryFilter(NOT=[])
+        conditions = f.build_conditions()
+        assert conditions == []
+
+    def test_not_combined_with_field_filter(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            phase=StringFilter(equals="init"),
+            NOT=[SessionSchedulingHistoryFilter(phase=StringFilter(equals="failed"))],
+        )
+        conditions = f.build_conditions()
+        assert len(conditions) == 2
+
+    def test_not_sub_filter_with_no_conditions_skipped(self) -> None:
+        f = SessionSchedulingHistoryFilter(
+            NOT=[SessionSchedulingHistoryFilter()],
+        )
+        conditions = f.build_conditions()
+        assert conditions == []


### PR DESCRIPTION
## Summary

- Manual backport of #10250 (`feat(BA-5122)`) to `26.3`
- Adds `AND`, `OR`, `NOT` logical operators to all GraphQL filter types
- Excludes `audit_log` module changes (module does not exist in 26.3)

Backported-from: main
Backported-to: 26.3
Backport-of: #10250