### PR TITLE
feat(BA-5154): Relay NodeID compatibility layer for Pydantic UUID

### DIFF
--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -144,6 +144,8 @@ __all__ = (
     "VFolderMount",
     "VFolderUsageMode",
     "VolumeMountableNodeType",
+    "NodeIDMarker",
+    "NodeUUID",
     "aobject",
     "check_typed_dict",
     "check_typed_tuple",
@@ -2105,3 +2107,22 @@ class StreamReader(ABC):
     @abstractmethod
     def content_type(self) -> str | None:
         raise GenericNotImplementedError
+
+
+class NodeIDMarker:
+    """Pydantic field metadata marker indicating a UUID field should be converted
+    to a Relay Global ID (NodeID) in GraphQL responses, and vice versa."""
+
+
+NodeUUID = Annotated[UUID, NodeIDMarker()]
+"""A UUID field annotated with NodeIDMarker.
+
+Use this type in Pydantic DTOs to indicate that the field represents a Relay
+Node ID. When converted via ``pydantic_node_type()``, the UUID value is
+automatically serialized as a base64-encoded Relay Global ID string.
+
+Example::
+
+    class UserDTO(BaseModel):
+        id: NodeUUID = Field(description="User UUID")
+"""

--- a/src/ai/backend/manager/api/gql/relay_compat.py
+++ b/src/ai/backend/manager/api/gql/relay_compat.py
@@ -1,0 +1,273 @@
+"""Relay NodeID compatibility layer for Pydantic UUID fields in GraphQL types.
+
+This module provides utilities for bridging Pydantic DTOs and Strawberry Relay
+Node types, with automatic UUID ↔ Relay Global ID conversion for fields
+annotated with ``NodeUUID``.
+
+Usage::
+
+    from ai.backend.common.types import NodeUUID
+    from ai.backend.manager.api.gql.relay_compat import pydantic_node_type
+
+    class UserDTO(BaseModel):
+        id: NodeUUID
+        name: str
+
+    @pydantic_node_type(model=UserDTO)
+    class UserDemoGQL:
+        pass  # all fields auto-mapped; NodeUUID → NodeID[str]
+
+    # Convert DTO → GQL
+    gql_obj = UserDemoGQL.from_pydantic(user_dto)
+    # Convert GQL → DTO
+    user_dto = gql_obj.to_pydantic()
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import types as pytypes
+from collections.abc import Callable
+from typing import (
+    Annotated,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+from uuid import UUID
+
+import strawberry
+from graphql_relay.utils import base64, unbase64
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefinedType
+from strawberry.relay import Node, NodeID
+
+from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.types import NodeIDMarker
+
+__all__ = (
+    "NodeGQLMixin",
+    "node_id_to_uuid",
+    "pydantic_node_type",
+    "uuid_to_node_id",
+)
+
+_ClsT = TypeVar("_ClsT")
+
+# Global registry: Pydantic model class → Strawberry GQL type created by pydantic_node_type.
+# Used for automatic nested-model conversion inside from_pydantic().
+_pydantic_to_gql_registry: dict[type[BaseModel], type[NodeGQLMixin]] = {}
+
+
+class NodeGQLMixin:
+    """Mixin that exposes ``from_pydantic`` / ``to_pydantic`` on GQL Node types.
+
+    Concrete implementations are injected by :func:`pydantic_node_type`.
+    This class exists so that static type-checkers can resolve the methods
+    on the decorated class.
+    """
+
+    @classmethod
+    def from_pydantic(cls, instance: BaseModel) -> Any:
+        """Convert a Pydantic DTO to this GQL type (overridden by pydantic_node_type)."""
+        raise NotImplementedError
+
+    def to_pydantic(self) -> BaseModel:
+        """Convert this GQL type instance to a Pydantic DTO (overridden by pydantic_node_type)."""
+        raise NotImplementedError
+
+
+def uuid_to_node_id(type_name: str, value: UUID) -> str:
+    """Encode a UUID into a Relay Global ID string (base64 ``TypeName:uuid``)."""
+    return base64(f"{type_name}:{value}")
+
+
+def node_id_to_uuid(global_id: str) -> UUID:
+    """Decode a Relay Global ID string and return the embedded UUID.
+
+    Raises:
+        InvalidAPIParameters: when *global_id* is not a valid Relay Global ID.
+    """
+    try:
+        raw = unbase64(global_id)
+        _, _, id_part = raw.partition(":")
+        return UUID(id_part)
+    except (ValueError, AttributeError) as exc:
+        raise InvalidAPIParameters(f"Invalid Relay Global ID format: {global_id!r}") from exc
+
+
+def _check_node_uuid(annotation: Any) -> tuple[bool, bool]:
+    """Inspect a type annotation, returning ``(is_node_uuid, is_optional)``.
+
+    *is_node_uuid* is True when the annotation is ``NodeUUID``
+    (``Annotated[UUID, NodeIDMarker()]``) or ``Optional[NodeUUID]``.
+    *is_optional* is True for the ``Optional[NodeUUID]`` case.
+    """
+    # Direct: Annotated[UUID, NodeIDMarker()]
+    if get_origin(annotation) is Annotated:
+        args = get_args(annotation)
+        if args[0] is UUID and any(isinstance(m, NodeIDMarker) for m in args[1:]):
+            return True, False
+
+    # Optional[NodeUUID] → Union[Annotated[UUID, NodeIDMarker()], None]
+    origin = get_origin(annotation)
+    if origin is Union or isinstance(annotation, pytypes.UnionType):
+        inner_args = get_args(annotation)
+        non_none = [a for a in inner_args if a is not type(None)]
+        if len(non_none) == 1:
+            is_node, _ = _check_node_uuid(non_none[0])
+            if is_node:
+                return True, True
+
+    return False, False
+
+
+def pydantic_node_type(
+    model: type[BaseModel],
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> Callable[[type[_ClsT]], type[_ClsT]]:
+    """Decorator factory that creates a Strawberry Relay Node type from a Pydantic model.
+
+    The decorated class **must inherit from** :class:`NodeGQLMixin` so that
+    static type-checkers can resolve ``from_pydantic`` and ``to_pydantic``:
+
+    .. code-block:: python
+
+        @pydantic_node_type(model=UserDTO, name="UserV2Demo")
+        class UserV2DemoGQL(NodeGQLMixin):
+            pass
+
+    At runtime the decorated class is replaced by a new ``@strawberry.type``
+    dataclass that inherits from both :class:`~strawberry.relay.Node` and
+    :class:`NodeGQLMixin`.  All fields are inferred automatically from *model*;
+    ``NodeUUID`` fields are mapped to ``NodeID[str]`` in the GraphQL schema.
+
+    The resulting class provides two conversion helpers:
+
+    * ``from_pydantic(instance)`` — classmethod; converts a DTO instance to this
+      GQL type, encoding ``NodeUUID`` values as Relay Global IDs.
+    * ``to_pydantic()`` — instance method; converts back to the Pydantic DTO,
+      decoding Relay Global IDs back to UUIDs.
+
+    The mapping is registered globally so that nested Pydantic models (whose
+    own GQL type was also created with ``pydantic_node_type``) are converted
+    automatically during ``from_pydantic``.
+
+    Args:
+        model: Pydantic ``BaseModel`` subclass to derive fields from.
+        name: Override the GraphQL type name (defaults to the decorated class name).
+        description: Optional GraphQL type description.
+    """
+
+    def decorator(cls: type[_ClsT]) -> type[_ClsT]:
+        type_name = name or cls.__name__
+        hints = get_type_hints(model, include_extras=True)
+
+        # --- Build field list ------------------------------------------------
+        # Strawberry (dataclass) requires fields without defaults before those
+        # with defaults, so we collect them in two buckets.
+        node_uuid_fields: dict[str, bool] = {}  # field_name → is_optional
+        required_fields: list[tuple[str, Any, dataclasses.Field[Any]]] = []
+        optional_fields: list[tuple[str, Any, dataclasses.Field[Any]]] = []
+
+        for field_name, field_type in hints.items():
+            is_node, is_opt = _check_node_uuid(field_type)
+
+            if is_node:
+                node_uuid_fields[field_name] = is_opt
+                gql_type: Any = NodeID[str] | None if is_opt else NodeID[str]
+            else:
+                gql_type = field_type
+
+            pydantic_field = model.model_fields.get(field_name)
+            if pydantic_field is None:
+                # Computed / private field — skip
+                continue
+
+            default = pydantic_field.default
+            default_factory = pydantic_field.default_factory
+
+            if isinstance(default, PydanticUndefinedType) and default_factory is None:
+                sf: dataclasses.Field[Any] = dataclasses.field()
+                required_fields.append((field_name, gql_type, sf))
+            elif default_factory is not None:
+                sf = dataclasses.field(default_factory=cast("Callable[[], Any]", default_factory))
+                optional_fields.append((field_name, gql_type, sf))
+            else:
+                sf = dataclasses.field(default=default)
+                optional_fields.append((field_name, gql_type, sf))
+
+        all_fields = required_fields + optional_fields
+
+        # --- Build dataclass inheriting from Node and NodeGQLMixin -----------
+        # NodeGQLMixin provides the stub methods that type-checkers can resolve.
+        new_cls = dataclasses.make_dataclass(type_name, all_fields, bases=(Node, NodeGQLMixin))
+
+        # Preserve any methods defined on the original decorated class
+        for attr_name, attr_val in vars(cls).items():
+            if attr_name.startswith("__") and attr_name.endswith("__"):
+                continue
+            setattr(new_cls, attr_name, attr_val)
+
+        # --- Capture context for closures ------------------------------------
+        _model = model
+        _node_uuid_fields = node_uuid_fields
+        _type_name = type_name
+
+        # --- from_pydantic implementation ------------------------------------
+        def _from_pydantic_impl(cls_inner: type, instance: BaseModel) -> Any:
+            """Convert a Pydantic DTO to this Strawberry GQL type.
+
+            NodeUUID fields are encoded as Relay Global IDs.
+            Nested BaseModel fields whose type is registered in
+            ``_pydantic_to_gql_registry`` are converted recursively.
+            """
+            kwargs: dict[str, Any] = {}
+            for fname in get_type_hints(_model, include_extras=True):
+                value = getattr(instance, fname)
+                if fname in _node_uuid_fields:
+                    kwargs[fname] = None if value is None else uuid_to_node_id(_type_name, value)
+                elif isinstance(value, BaseModel):
+                    nested_gql_cls = _pydantic_to_gql_registry.get(type(value))
+                    if nested_gql_cls is not None:
+                        kwargs[fname] = nested_gql_cls.from_pydantic(value)
+                    else:
+                        kwargs[fname] = value
+                else:
+                    kwargs[fname] = value
+            return cls_inner(**kwargs)
+
+        # --- to_pydantic implementation --------------------------------------
+        def _to_pydantic_impl(self: Any) -> BaseModel:
+            """Convert this GQL type instance to a Pydantic DTO.
+
+            NodeID[str] fields are decoded back to UUID values.
+            """
+            kwargs: dict[str, Any] = {}
+            for fname in get_type_hints(_model, include_extras=True):
+                value = getattr(self, fname)
+                if fname in _node_uuid_fields:
+                    kwargs[fname] = None if value is None else node_id_to_uuid(str(value))
+                else:
+                    kwargs[fname] = value
+            return _model(**kwargs)
+
+        setattr(new_cls, "from_pydantic", classmethod(_from_pydantic_impl))
+        setattr(new_cls, "to_pydantic", _to_pydantic_impl)
+
+        # --- Apply @strawberry.type ------------------------------------------
+        result = strawberry.type(new_cls, name=type_name, description=description or "")
+
+        # Register so nested models can be auto-converted
+        gql_type_result = cast(type[NodeGQLMixin], result)
+        _pydantic_to_gql_registry[model] = gql_type_result
+
+        return cast(type[_ClsT], result)
+
+    return decorator

--- a/tests/unit/manager/api/gql/test_relay_compat.py
+++ b/tests/unit/manager/api/gql/test_relay_compat.py
@@ -1,0 +1,399 @@
+"""Tests for the Relay NodeID compatibility layer (relay_compat module)."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterable
+from typing import Any, Self, cast
+from uuid import UUID
+
+import pytest
+from graphql_relay.utils import base64, unbase64
+from pydantic import BaseModel, Field
+
+from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.types import NodeUUID
+from ai.backend.manager.api.gql.relay_compat import (
+    NodeGQLMixin,
+    _pydantic_to_gql_registry,
+    node_id_to_uuid,
+    pydantic_node_type,
+    uuid_to_node_id,
+)
+
+_TEST_UUID = UUID("550e8400-e29b-41d4-a716-446655440000")
+
+
+# ---------------------------------------------------------------------------
+# Demo Pydantic DTOs
+# ---------------------------------------------------------------------------
+
+
+class FlatDTO(BaseModel):
+    """Simple flat DTO with one required NodeUUID and one plain UUID field."""
+
+    id: NodeUUID = Field(description="Node UUID")
+    ref_id: UUID = Field(description="Regular UUID — must NOT be encoded as NodeID")
+    name: str
+
+
+class OptionalNodeDTO(BaseModel):
+    """DTO with Optional[NodeUUID] to verify None handling."""
+
+    id: NodeUUID
+    opt_id: NodeUUID | None = None
+
+
+class NestedChildDTO(BaseModel):
+    """Nested model whose id is a NodeUUID."""
+
+    id: NodeUUID
+    label: str
+
+
+class NestedParentDTO(BaseModel):
+    """Parent model referencing a nested DTO."""
+
+    id: NodeUUID
+    child: NestedChildDTO
+
+
+# ---------------------------------------------------------------------------
+# Demo GQL types (created once at module level)
+# Decorated classes inherit from NodeGQLMixin so that static type-checkers
+# can resolve from_pydantic() and to_pydantic().
+# ---------------------------------------------------------------------------
+
+
+@pydantic_node_type(model=FlatDTO, name="FlatGQL")
+class FlatGQL(NodeGQLMixin):
+    pass
+
+
+@pydantic_node_type(model=OptionalNodeDTO, name="OptionalNodeGQL")
+class OptionalNodeGQL(NodeGQLMixin):
+    pass
+
+
+@pydantic_node_type(model=NestedChildDTO, name="NestedChildGQL")
+class NestedChildGQL(NodeGQLMixin):
+    pass
+
+
+@pydantic_node_type(model=NestedParentDTO, name="NestedParentGQL")
+class NestedParentGQL(NodeGQLMixin):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode_global_id(global_id: str) -> tuple[str, str]:
+    raw = unbase64(global_id)
+    type_name, _, local_id = raw.partition(":")
+    return type_name, local_id
+
+
+# ---------------------------------------------------------------------------
+# uuid_to_node_id
+# ---------------------------------------------------------------------------
+
+
+class TestUuidToNodeId:
+    def test_encodes_type_and_uuid(self) -> None:
+        result = uuid_to_node_id("UserGQL", _TEST_UUID)
+        assert isinstance(result, str)
+        type_name, local_id = _decode_global_id(result)
+        assert type_name == "UserGQL"
+        assert local_id == str(_TEST_UUID)
+
+    def test_base64_encoded(self) -> None:
+        result = uuid_to_node_id("X", _TEST_UUID)
+        assert result == base64(f"X:{_TEST_UUID}")
+
+
+# ---------------------------------------------------------------------------
+# node_id_to_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestNodeIdToUuid:
+    def test_roundtrip(self) -> None:
+        global_id = uuid_to_node_id("UserGQL", _TEST_UUID)
+        recovered = node_id_to_uuid(global_id)
+        assert recovered == _TEST_UUID
+
+    def test_invalid_global_id_raises(self) -> None:
+        with pytest.raises(InvalidAPIParameters):
+            node_id_to_uuid("not-valid-base64!!!")
+
+    def test_malformed_uuid_raises(self) -> None:
+        # Valid base64 but UUID part is not a valid UUID
+        bad = base64("TypeName:not-a-uuid")
+        with pytest.raises(InvalidAPIParameters):
+            node_id_to_uuid(bad)
+
+
+# ---------------------------------------------------------------------------
+# from_pydantic — UUID → NodeID conversion
+# ---------------------------------------------------------------------------
+
+
+class TestFromPydanticUuidToNodeId:
+    def test_node_uuid_field_encoded_as_global_id(self) -> None:
+        dto = FlatDTO(id=_TEST_UUID, ref_id=_TEST_UUID, name="alice")
+        gql = FlatGQL.from_pydantic(dto)
+        type_name, local_id = _decode_global_id(str(gql.id))
+        assert type_name == "FlatGQL"
+        assert local_id == str(_TEST_UUID)
+
+    def test_plain_uuid_field_not_encoded(self) -> None:
+        dto = FlatDTO(id=_TEST_UUID, ref_id=_TEST_UUID, name="alice")
+        gql = FlatGQL.from_pydantic(dto)
+        # ref_id is a plain UUID — it must not be converted to a Global ID
+        assert gql.ref_id == _TEST_UUID
+        assert isinstance(gql.ref_id, UUID)
+
+    def test_optional_node_uuid_with_value(self) -> None:
+        dto = OptionalNodeDTO(id=_TEST_UUID, opt_id=_TEST_UUID)
+        gql = OptionalNodeGQL.from_pydantic(dto)
+        assert gql.opt_id is not None
+        type_name, local_id = _decode_global_id(str(gql.opt_id))
+        assert type_name == "OptionalNodeGQL"
+        assert local_id == str(_TEST_UUID)
+
+    def test_optional_node_uuid_none_stays_none(self) -> None:
+        dto = OptionalNodeDTO(id=_TEST_UUID, opt_id=None)
+        gql = OptionalNodeGQL.from_pydantic(dto)
+        assert gql.opt_id is None
+
+    def test_non_uuid_fields_preserved(self) -> None:
+        dto = FlatDTO(id=_TEST_UUID, ref_id=_TEST_UUID, name="bob")
+        gql = FlatGQL.from_pydantic(dto)
+        assert gql.name == "bob"
+
+
+# ---------------------------------------------------------------------------
+# to_pydantic — NodeID → UUID back-conversion
+# ---------------------------------------------------------------------------
+
+
+class TestToPydanticNodeIdToUuid:
+    def test_roundtrip_uuid(self) -> None:
+        dto = FlatDTO(id=_TEST_UUID, ref_id=_TEST_UUID, name="alice")
+        gql = FlatGQL.from_pydantic(dto)
+        recovered = gql.to_pydantic()
+        assert recovered.id == _TEST_UUID
+
+    def test_optional_node_uuid_restored(self) -> None:
+        dto = OptionalNodeDTO(id=_TEST_UUID, opt_id=_TEST_UUID)
+        gql = OptionalNodeGQL.from_pydantic(dto)
+        recovered = gql.to_pydantic()
+        assert recovered.opt_id == _TEST_UUID
+
+    def test_optional_none_preserved(self) -> None:
+        dto = OptionalNodeDTO(id=_TEST_UUID, opt_id=None)
+        gql = OptionalNodeGQL.from_pydantic(dto)
+        recovered = gql.to_pydantic()
+        assert recovered.opt_id is None
+
+    def test_invalid_global_id_raises(self) -> None:
+        # Build a valid GQL instance, then replace opt_id with a malformed value
+        gql: Any = OptionalNodeGQL.from_pydantic(OptionalNodeDTO(id=_TEST_UUID, opt_id=_TEST_UUID))
+        gql_bad = dataclasses.replace(gql, opt_id="not-valid-base64!!!")
+        with pytest.raises(InvalidAPIParameters):
+            gql_bad.to_pydantic()
+
+
+# ---------------------------------------------------------------------------
+# Reusability — arbitrary Pydantic DTOs
+# ---------------------------------------------------------------------------
+
+
+class TestReusability:
+    def test_can_apply_to_arbitrary_model(self) -> None:
+        class ArbitraryDTO(BaseModel):
+            id: NodeUUID
+            value: int
+
+        @pydantic_node_type(model=ArbitraryDTO, name="ArbitraryGQL")
+        class ArbitraryGQL(NodeGQLMixin):
+            pass
+
+        uuid = UUID("12345678-1234-5678-1234-567812345678")
+        dto = ArbitraryDTO(id=uuid, value=42)
+        gql = ArbitraryGQL.from_pydantic(dto)
+        _, local_id = _decode_global_id(str(gql.id))
+        assert local_id == str(uuid)
+        assert gql.value == 42
+
+    def test_multiple_independent_types(self) -> None:
+        """Two different DTOs → two independent GQL types with correct names."""
+
+        class ADTO(BaseModel):
+            id: NodeUUID
+
+        class BGQL_DTO(BaseModel):
+            id: NodeUUID
+
+        @pydantic_node_type(model=ADTO, name="AGQL")
+        class AGQL(NodeGQLMixin):
+            pass
+
+        @pydantic_node_type(model=BGQL_DTO, name="BGQL")
+        class BGQL(NodeGQLMixin):
+            pass
+
+        a_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        b_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+        a_gql = AGQL.from_pydantic(ADTO(id=a_uuid))
+        b_gql = BGQL.from_pydantic(BGQL_DTO(id=b_uuid))
+
+        a_type, a_local = _decode_global_id(str(a_gql.id))
+        b_type, b_local = _decode_global_id(str(b_gql.id))
+
+        assert a_type == "AGQL"
+        assert b_type == "BGQL"
+        assert a_local == str(a_uuid)
+        assert b_local == str(b_uuid)
+
+
+# ---------------------------------------------------------------------------
+# Nested model recursive conversion
+# ---------------------------------------------------------------------------
+
+
+class TestNestedModelConversion:
+    def test_nested_node_uuid_converted(self) -> None:
+        child_uuid = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        parent_uuid = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        child_dto = NestedChildDTO(id=child_uuid, label="child")
+        parent_dto = NestedParentDTO(id=parent_uuid, child=child_dto)
+
+        gql = NestedParentGQL.from_pydantic(parent_dto)
+
+        # Parent id is encoded
+        p_type, p_local = _decode_global_id(str(gql.id))
+        assert p_type == "NestedParentGQL"
+        assert p_local == str(parent_uuid)
+
+        # Nested child id is also encoded
+        c_type, c_local = _decode_global_id(str(gql.child.id))
+        assert c_type == "NestedChildGQL"
+        assert c_local == str(child_uuid)
+
+    def test_registry_populated(self) -> None:
+        """pydantic_node_type registers models in the global registry."""
+        assert FlatDTO in _pydantic_to_gql_registry
+        assert NestedChildDTO in _pydantic_to_gql_registry
+        assert NestedParentDTO in _pydantic_to_gql_registry
+
+
+# ---------------------------------------------------------------------------
+# Relay Node resolve_nodes integration
+# ---------------------------------------------------------------------------
+
+
+class TestRelayNodeIntegration:
+    def test_resolve_nodes_can_be_overridden(self) -> None:
+        """GQL type produced by pydantic_node_type accepts a resolve_nodes override."""
+
+        class MyDTO(BaseModel):
+            id: NodeUUID
+
+        @pydantic_node_type(model=MyDTO, name="MyGQL")
+        class MyGQL(NodeGQLMixin):
+            @classmethod
+            async def resolve_nodes(
+                cls,
+                *,
+                info: object,
+                node_ids: Iterable[str],
+                required: bool = False,
+            ) -> Iterable[Self | None]:
+                return [None for _ in node_ids]
+
+        # Verify resolve_nodes is present and is a classmethod
+        assert callable(MyGQL.resolve_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Adapter sharing pattern
+# ---------------------------------------------------------------------------
+#
+# Demonstrates the recommended flow for GQL resolvers:
+#   Output: DataLayer type → SharedAdapter.to_dto() → DTO → from_pydantic() → GQL
+#   Input:  GQL object  → to_pydantic()             → DTO → SharedAdapter.action()
+# ---------------------------------------------------------------------------
+
+
+class ProjectDataStub:
+    """Minimal stand-in for a Data Layer type (replaces a frozen dataclass)."""
+
+    def __init__(self, id: UUID, title: str) -> None:
+        self.id = id
+        self.title = title
+
+
+class ProjectDTO(BaseModel):
+    """Demo DTO using NodeUUID to participate in the relay_compat pattern."""
+
+    id: NodeUUID = Field(description="Project UUID")
+    title: str
+
+
+@pydantic_node_type(model=ProjectDTO, name="ProjectDemoGQL")
+class ProjectDemoGQL(NodeGQLMixin):
+    pass
+
+
+class SharedProjectAdapter:
+    """Shared adapter callable from both REST and GQL resolvers.
+
+    Demonstrates the converter pattern:
+    * ``to_dto``  — Data Layer type → Pydantic DTO (shared across REST + GQL)
+    * ``from_gql`` — GQL object → Pydantic DTO via ``to_pydantic()``
+    """
+
+    def to_dto(self, data: ProjectDataStub) -> ProjectDTO:
+        return ProjectDTO(id=data.id, title=data.title)
+
+    def from_gql(self, gql_obj: NodeGQLMixin) -> ProjectDTO:
+        return cast(ProjectDTO, gql_obj.to_pydantic())
+
+
+class TestAdapterSharingPattern:
+    """Verify that the pydantic_node_type pattern integrates with a shared adapter."""
+
+    def test_output_flow_data_to_gql(self) -> None:
+        """Output flow: Data → adapter.to_dto() → from_pydantic() → GQL object."""
+        project_uuid = UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+        data = ProjectDataStub(id=project_uuid, title="My Project")
+        adapter = SharedProjectAdapter()
+
+        dto = adapter.to_dto(data)
+        gql = ProjectDemoGQL.from_pydantic(dto)
+
+        # GQL resolver does NOT call data layer directly — it goes through adapter
+        p_type, p_local = _decode_global_id(str(gql.id))
+        assert p_type == "ProjectDemoGQL"
+        assert p_local == str(project_uuid)
+        assert gql.title == "My Project"
+
+    def test_input_flow_gql_to_adapter(self) -> None:
+        """Input flow: GQL object → to_pydantic() → adapter (DTO) → service."""
+        project_uuid = UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+        data = ProjectDataStub(id=project_uuid, title="Original")
+        adapter = SharedProjectAdapter()
+
+        # Simulate a round-trip: data comes in, gets converted to GQL, then back
+        dto = adapter.to_dto(data)
+        gql = ProjectDemoGQL.from_pydantic(dto)
+
+        # A mutation handler would call to_pydantic() and pass the DTO to the service
+        recovered_dto = adapter.from_gql(gql)
+        assert recovered_dto.id == project_uuid
+        assert recovered_dto.title == "Original"


### PR DESCRIPTION
## Summary

- Adds `NodeUUID` annotated type (`Annotated[UUID, NodeIDMarker()]`) to `common/types.py` for marking DTO UUID fields that should map to Relay Global IDs in GraphQL
- Implements `relay_compat.py` in the manager GQL layer with `pydantic_node_type()` decorator factory that automatically maps `NodeUUID → NodeID[str]` and provides bidirectional `from_pydantic()` / `to_pydantic()` conversion
- Establishes shared-adapter pattern: Data Layer → Adapter → Pydantic DTO → `from_pydantic()` → GQL output (and reverse for mutations)
- Nested Pydantic models are converted recursively via a global model registry

## Test plan

- [x] `pants lint` passes (ruff check + format + visibility)
- [x] `pants check` passes (mypy)
- [x] `pants test tests/unit/manager/api/gql/test_relay_compat.py` passes
  - UUID → NodeID encoding via `from_pydantic()`
  - NodeID → UUID decoding via `to_pydantic()`
  - `Optional[NodeUUID]` None handling
  - Plain UUID fields are not encoded as NodeID
  - Nested model recursive conversion
  - Invalid Global ID raises `InvalidAPIParameters`
  - Shared adapter pattern (output flow + input flow)
  - `resolve_nodes` override compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)