### PR TITLE
fix(BA-5287): Expose db and config_provider to webapp plugins in webapp_plugin_ctx (#10292)

### DIFF
--- a/changes/10292.fix.md
+++ b/changes/10292.fix.md
@@ -1,0 +1,1 @@
+Restore `db` and `config_provider` access for webapp plugins (OpenID, TOTP) after DI refactoring by injecting them into the root app context

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -582,7 +582,9 @@ async def webapp_plugin_ctx(root_app: web.Application) -> AsyncIterator[None]:
         allowlist=root_ctx.config_provider.config.manager.allowed_plugins,
         blocklist=root_ctx.config_provider.config.manager.disabled_plugins,
     )
-    root_ctx.webapp_plugin_ctx = plugin_ctx
+    cors_options = r.system.cors_options
+    root_app["_db"] = r.infrastructure.db
+    root_app["_config_provider"] = r.bootstrap.config_provider
     for plugin_name, plugin_instance in plugin_ctx.plugins.items():
         if root_ctx.pidx == 0:
             log.info("Loading webapp plugin: {0}", plugin_name)


### PR DESCRIPTION
This is an auto-generated backport PR of #10292 to the 26.2 release.