### PR TITLE
fix(BA-4934): Add per-plugin timeout to gather_container_measures (#9781)

### DIFF
--- a/changes/9781.enhance.md
+++ b/changes/9781.enhance.md
@@ -1,0 +1,1 @@
+Add per-plugin timeout (120s) to `gather_container_measures` calls so a single hung plugin does not block stat collection from all other plugins

--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -33,6 +33,7 @@ from redis.asyncio.client import Pipeline
 from ai.backend.common import msgpack, redis_helper
 from ai.backend.common.identity import is_containerized
 from ai.backend.common.metrics.metric import StageObserver
+from ai.backend.common.metrics.types import UTILIZATION_METRIC_INTERVAL
 from ai.backend.common.types import (
     PID,
     AgentId,
@@ -70,6 +71,8 @@ __all__ = (
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_PLUGIN_TIMEOUT: float = max(UTILIZATION_METRIC_INTERVAL - 1.0, 1.0)
 
 
 def check_cgroup_available():
@@ -604,7 +607,10 @@ class StatContext:
             for computer in self.agent.computers.values():
                 _tasks.append(
                     asyncio.create_task(
-                        computer.instance.gather_container_measures(self, container_ids),
+                        asyncio.wait_for(
+                            computer.instance.gather_container_measures(self, container_ids),
+                            timeout=_PLUGIN_TIMEOUT,
+                        ),
                     )
                 )
             self._stage_observer.observe_stage(


### PR DESCRIPTION
## Summary
- Backport of #9781 (a653e07ff) from main to 25.11
- Add `_PLUGIN_TIMEOUT` constant derived from `UTILIZATION_METRIC_INTERVAL`
- Wrap `gather_container_measures` calls with `asyncio.wait_for(timeout=_PLUGIN_TIMEOUT)` to prevent individual compute plugins from blocking the entire stat collection cycle

## Test plan
- [ ] Verify `pants lint --changed-since=25.11` passes
- [ ] Verify `pants check --changed-since=25.11` passes
- [ ] Verify agent stat collection handles plugin timeouts gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)