### PR TITLE
fix(BA-4889): Fix container net_rx/net_tx stats reading host namespace (#9681)

### DIFF
--- a/changes/9681.fix.md
+++ b/changes/9681.fix.md
@@ -1,0 +1,1 @@
+Fix container net_rx/net_tx stats reading host namespace counters due to unchecked setns() return value

--- a/src/ai/backend/common/netns.py
+++ b/src/ai/backend/common/netns.py
@@ -1,29 +1,45 @@
+import ctypes
+import ctypes.util
+import logging
 import os
 from pathlib import Path
+from typing import Any
+
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-def setns(fd: int):
-    import ctypes
-    import ctypes.util
-
+def _get_libc() -> ctypes.CDLL:
     libc_path = ctypes.util.find_library("c")
-    libc = ctypes.CDLL(libc_path)
+    return ctypes.CDLL(libc_path, use_errno=True)
+
+
+def setns(fd: int) -> None:
+    libc = _get_libc()
     CLONE_NEWNET = 1 << 30
-    libc.setns(fd, CLONE_NEWNET)
+    ret = libc.setns(fd, CLONE_NEWNET)
+    if ret == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, f"setns() failed: {os.strerror(errno)}")
 
 
 class NetworkNamespaceManager:
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         self.self_ns = os.open("/proc/self/ns/net", os.O_RDONLY)
         self.new_ns = os.open(path, os.O_RDONLY)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         setns(self.new_ns)
 
-    def __exit__(self, *exc_info_args):
-        setns(self.self_ns)
-        os.close(self.new_ns)
-        os.close(self.self_ns)
+    def __exit__(self, *exc_info_args: Any) -> None:
+        try:
+            setns(self.self_ns)
+        except OSError:
+            log.warning("Failed to restore original network namespace")
+        finally:
+            os.close(self.new_ns)
+            os.close(self.self_ns)
 
 
 def nsenter(path: Path) -> NetworkNamespaceManager:


### PR DESCRIPTION
## Summary
- Backport of #9681 (985516b9a) from main to 25.11
- **netns.py**: Extract `_get_libc()` helper with `use_errno=True`, add return value check to `setns()` with proper OSError raising, make `__exit__` cleanup safe with try/except/finally
- **intrinsic.py**: Wrap `netstat_ns(sandbox_key)` call with try/except OSError to gracefully handle namespace access failures instead of crashing the stat collection

## Test plan
- [ ] Verify `pants lint --changed-since=25.11` passes
- [ ] Verify `pants check --changed-since=25.11` passes
- [ ] Verify net stats collection gracefully handles containers with inaccessible network namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)