### PR TITLE
fix(BA-4938): Pre-validate namespace path before netstat_ns (#9782)

### DIFF
--- a/changes/9782.fix.md
+++ b/changes/9782.fix.md
@@ -1,0 +1,1 @@
+Pre-validate namespace path before `netstat_ns()` to prevent thread pool exhaustion from hung threads on stale network namespaces

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -692,12 +692,36 @@ class MemoryPlugin(AbstractComputePlugin):
                 sandbox_key = data["NetworkSettings"]["SandboxKey"]
             net_rx_bytes = 0
             net_tx_bytes = 0
-            nstat = await netstat_ns(sandbox_key)
-            for name, net_stat in nstat.items():
-                if name == "lo":
-                    continue
-                net_rx_bytes += net_stat.bytes_recv
-                net_tx_bytes += net_stat.bytes_sent
+            if not sandbox_key:
+                log.warning(
+                    "MemoryPlugin: empty SandboxKey for container {0},"
+                    " skipping net stat collection",
+                    container_id[:7],
+                )
+            else:
+                ns_path = Path(sandbox_key)
+                if not ns_path.exists():
+                    log.warning(
+                        "MemoryPlugin: network namespace path does not exist for container"
+                        " {0} (sandbox_key={1!r}), skipping net stat collection",
+                        container_id[:7],
+                        sandbox_key,
+                    )
+                else:
+                    try:
+                        nstat = await netstat_ns(ns_path)
+                    except OSError as e:
+                        log.warning(
+                            "MemoryPlugin: cannot read net stats for container {0}: {1!r}",
+                            container_id[:7],
+                            e,
+                        )
+                        return None
+                    for name, net_stat in nstat.items():
+                        if name == "lo":
+                            continue
+                        net_rx_bytes += net_stat.bytes_recv
+                        net_tx_bytes += net_stat.bytes_sent
             loop = current_loop()
             scratch_sz = await loop.run_in_executor(None, get_scratch_size, container_id)
             return (


### PR DESCRIPTION
## Summary
- Backport of #9782 (8df0ebf5d) from main to 25.11
- Pre-validate `sandbox_key` before calling `netstat_ns()` to prevent thread pool exhaustion:
  - Check if `sandbox_key` is empty → warning + skip
  - Check if namespace path exists → warning + skip
  - Wrap `netstat_ns()` with try/except OSError for graceful failure
- Pass `Path` object instead of raw string to `netstat_ns()`

## Test plan
- [ ] Verify `pants lint --changed-since=25.11` passes
- [ ] Verify `pants check --changed-since=25.11` passes
- [ ] Verify net stat collection skips containers with invalid/missing namespace paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)