### PR TITLE
fix(BA-4934): Apply missing wait_for wrapping in backport (#10296)

### DIFF
--- a/src/ai/backend/agent/stats.py
+++ b/src/ai/backend/agent/stats.py
@@ -596,7 +596,10 @@ class StatContext:
         for computer in self.agent.computers.values():
             _tasks.append(
                 asyncio.create_task(
-                    computer.instance.gather_container_measures(self, container_ids),
+                    asyncio.wait_for(
+                        computer.instance.gather_container_measures(self, container_ids),
+                        timeout=_PLUGIN_TIMEOUT,
+                    ),
                 )
             )
         self._stage_observer.observe_stage(


### PR DESCRIPTION
## Summary
- PR #10296 (backport of #9781 to 25.11) included the `_PLUGIN_TIMEOUT` constant and `UTILIZATION_METRIC_INTERVAL` import but missed the actual `asyncio.wait_for()` wrapping around `gather_container_measures()`
- This fix applies the missing `asyncio.wait_for(timeout=_PLUGIN_TIMEOUT)` to prevent individual compute plugins from blocking the entire stat collection cycle

## Test plan
- [x] Verify `pants lint` passes
- [ ] Verify agent stat collection handles plugin timeouts gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)