### PR TITLE
fix(BA-5292): add otp alias to AuthorizeRequest.stoken for TOTP compatibility

### DIFF
--- a/changes/10305.fix.md
+++ b/changes/10305.fix.md
@@ -1,0 +1,1 @@
+Add otp field to AuthorizeRequest and AuthorizeAction for TOTP two-factor authentication compatibility.

--- a/src/ai/backend/common/dto/manager/auth/request.py
+++ b/src/ai/backend/common/dto/manager/auth/request.py
@@ -46,6 +46,10 @@ class AuthorizeRequest(BaseRequestModel):
         description="Secondary token forwarded to auth hook plugins (e.g., for 2FA)",
         validation_alias=AliasChoices("stoken", "sToken"),
     )
+    otp: str | None = Field(
+        default=None,
+        description="One-time password for TOTP-based two-factor authentication",
+    )
 
 
 class GetRoleRequest(BaseRequestModel):

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -135,6 +135,7 @@ class AuthHandler:
             email=params.username,
             password=params.password,
             stoken=params.stoken,
+            otp=params.otp,
         )
         result = await self._auth.authorize.wait_for_complete(action)
 

--- a/src/ai/backend/manager/services/auth/actions/authorize.py
+++ b/src/ai/backend/manager/services/auth/actions/authorize.py
@@ -18,6 +18,7 @@ class AuthorizeAction(AuthAction):
     email: str
     password: str
     stoken: str | None
+    otp: str | None
 
     @override
     def entity_id(self) -> str | None:
@@ -30,13 +31,15 @@ class AuthorizeAction(AuthAction):
 
     @property
     def hook_params(self) -> dict[str, str]:
+        otp_value = self.otp or self.stoken or ""
         return {
             "type": self.type.value,
             "domain": self.domain_name,
             "username": self.email,
             "password": self.password,
-            "stoken": self.stoken or "",
-            "sToken": self.stoken or "",
+            "stoken": otp_value,
+            "sToken": otp_value,
+            "otp": otp_value,
         }
 
 

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -92,6 +92,7 @@ async def test_authorize_success(
         password="correct_password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     result = await auth_service.authorize(action)
@@ -115,6 +116,7 @@ async def test_authorize_invalid_token_type(
         password="password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     with pytest.raises(InvalidAPIParameters):
@@ -140,6 +142,7 @@ async def test_authorize_invalid_credentials(
         password="wrong_password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     with pytest.raises(AuthorizationFailed):
@@ -159,6 +162,7 @@ async def test_authorize_with_hook_authorization(
         password="any_password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     # Hook returns user data as MagicMock for attribute access
@@ -208,6 +212,7 @@ async def test_authorize_with_password_expiry(
         password="old_password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     # Setup expired password
@@ -245,6 +250,7 @@ async def test_authorize_with_post_hook_response(
         password="password",
         request=MagicMock(),
         stoken=None,
+        otp=None,
     )
 
     # Setup successful credential check


### PR DESCRIPTION
## Summary
This is a manual backport PR of #10305 to the 26.3 release.

- Add `otp` field to `AuthorizeRequest` DTO
- Add `otp` field to `AuthorizeAction` and update `hook_params` to propagate OTP values
- Update authorize handler to extract and pass `otp` parameter
- Update tests with new `otp` parameter

Backport-of: #10305

🤖 Generated with [Claude Code](https://claude.com/claude-code)