### PR TITLE
fix(BA-5298): Expose etcd and valkey_stat to webapp plugins in webapp_plugin_ctx (#10318)

### DIFF
--- a/changes/10318.fix.md
+++ b/changes/10318.fix.md
@@ -1,0 +1,1 @@
+Restore `etcd` and `valkey_stat` access for webapp plugins (Cloud) after DI refactoring by injecting them into the root app context

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -92,6 +92,8 @@ async def webapp_plugin_ctx(
     cors_options = r.system.cors_options
     root_app["_db"] = r.infrastructure.db
     root_app["_config_provider"] = r.bootstrap.config_provider
+    root_app["_etcd"] = r.bootstrap.etcd
+    root_app["_valkey_stat"] = r.infrastructure.valkey.stat
     for plugin_name, plugin_instance in plugin_ctx.plugins.items():
         if pidx == 0:
             log.info("Loading webapp plugin: {0}", plugin_name)


### PR DESCRIPTION
This is an auto-generated backport PR of #10318 to the 26.3 release.