### PR TITLE
fix(BA-5310): Route authenticated TOTP endpoints through web_handler instead of anonymous handler (#10345)

### DIFF
--- a/changes/10345.fix.md
+++ b/changes/10345.fix.md
@@ -1,0 +1,1 @@
+Route authenticated TOTP endpoints through web_handler instead of anonymous handler

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -799,7 +799,9 @@ async def server_main(
     cors.add(app.router.add_route("GET", "/func/{path:openid/.*$}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:openid/.*$}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:saml/.*$}", anon_web_plugin_handler))
-    cors.add(app.router.add_route("POST", "/func/{path:totp/.*$}", anon_web_plugin_handler))
+    cors.add(
+        app.router.add_route("POST", "/func/{path:totp/anon(?:/.*)?$}", anon_web_plugin_handler)
+    )
     cors.add(app.router.add_route("POST", "/func/{path:auth/signup}", anon_web_plugin_handler))
     cors.add(app.router.add_route("POST", "/func/{path:auth/signout}", web_handler))
     cors.add(app.router.add_route("GET", "/func/{path:stream/kernel/_/events}", web_handler))


### PR DESCRIPTION
This is an auto-generated backport PR of #10345 to the 25.15 release.