### PR TITLE
fix: replace bare except with except BaseException (E722)

### DIFF
--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -232,7 +232,7 @@ class HTTPBackend(BaseBackend):
             raise asyncio.CancelledError() from e
         except aiohttp.ClientOSError as e:
             raise ContainerConnectionRefused from e
-        except:
+        except BaseException:
             log.exception("Unhandled exception while proxying HTTP request")
             raise
 


### PR DESCRIPTION
## Summary

Replace bare `except:` with explicit `except BaseException:` in the HTTP proxy backend.

**Why:** Bare `except:` is a PEP 8 E722 violation. Since this catch block logs the exception and immediately re-raises it, `except BaseException:` is the correct explicit form — it preserves the existing behavior while making the intent clear that all exceptions (including `KeyboardInterrupt` and `SystemExit`) should be caught for logging before re-raising.

**Change:**
```python
# Before
except:
    log.exception("Unhandled exception while proxying HTTP request")
    raise

# After
except BaseException:
    log.exception("Unhandled exception while proxying HTTP request")
    raise
```

## Files Changed
- `src/ai/backend/appproxy/worker/proxy/backend/http.py` (1 instance)

## Testing
No behavior change — `except BaseException:` catches the same exceptions as bare `except:`. This is a style/correctness fix only.