### PR TITLE
fix(gql): revert RouteFilter.status to list type to restore backward compatibility

### DIFF
--- a/src/ai/backend/manager/api/gql/deployment/resolver/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/route.py
@@ -9,9 +9,15 @@ from strawberry import ID, Info
 from strawberry.relay import PageInfo
 
 from ai.backend.common.data.model_deployment.types import (
+    RouteStatus as RouteStatusCommon,
     RouteTrafficStatus as RouteTrafficStatusCommon,
 )
-from ai.backend.common.dto.manager.v2.deployment.request import SearchRoutesInput
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    RouteFilter as RouteFilterDTO,
+    RouteStatusFilter as RouteStatusFilterDTO,
+    RouteTrafficStatusFilter as RouteTrafficStatusFilterDTO,
+    SearchRoutesInput,
+)
 from ai.backend.manager.api.gql.base import encode_cursor, resolve_global_id
 from ai.backend.manager.api.gql.deployment.types.route import (
     Route,
@@ -26,6 +32,25 @@ from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.data.deployment.types import (
     RouteSearchScope,
 )
+
+
+def _route_filter_to_dto(filter: RouteFilter) -> RouteFilterDTO:
+    return RouteFilterDTO(
+        status=RouteStatusFilterDTO(
+            in_=[RouteStatusCommon(s.value) for s in filter.status]
+        )
+        if filter.status
+        else None,
+        traffic_status=RouteTrafficStatusFilterDTO(
+            in_=[RouteTrafficStatusCommon(s.value) for s in filter.traffic_status]
+        )
+        if filter.traffic_status
+        else None,
+        AND=[_route_filter_to_dto(f) for f in filter.AND] if filter.AND else None,
+        OR=[_route_filter_to_dto(f) for f in filter.OR] if filter.OR else None,
+        NOT=[_route_filter_to_dto(f) for f in filter.NOT] if filter.NOT else None,
+    )
+
 
 # Query resolvers
 
@@ -47,7 +72,7 @@ async def routes(
 ) -> RouteConnection | None:
     """List routes for a deployment with optional filters."""
     _, endpoint_id = resolve_global_id(deployment_id)
-    pydantic_filter = filter.to_pydantic() if filter else None
+    pydantic_filter = _route_filter_to_dto(filter) if filter else None
     pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
     payload = await info.context.adapters.deployment.search_routes(
         scope=RouteSearchScope(deployment_id=UUID(endpoint_id)),

--- a/src/ai/backend/manager/api/gql/deployment/types/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/route.py
@@ -15,16 +15,7 @@ from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
 from ai.backend.common.dto.manager.v2.deployment.request import (
-    RouteFilter as RouteFilterDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment.request import (
     RouteOrder as RouteOrderDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment.request import (
-    RouteStatusFilter as RouteStatusFilterDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment.request import (
-    RouteTrafficStatusFilter as RouteTrafficStatusFilterDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
     UpdateRouteTrafficStatusInput as UpdateRouteTrafficStatusInputDTO,
@@ -173,50 +164,6 @@ class RouteConnection(Connection[Route]):
 # Filter and OrderBy types
 
 
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        description="Filter for route status with equality and membership operators.",
-        added_version="26.3.0",
-    ),
-    name="RouteStatusFilter",
-)
-class RouteStatusFilterGQL(PydanticInputMixin[RouteStatusFilterDTO]):
-    equals: RouteStatusGQL | None = strawberry.field(
-        default=None, description="Matches routes with this exact status."
-    )
-    in_: list[RouteStatusGQL] | None = strawberry.field(
-        name="in", default=None, description="Matches routes whose status is in this list."
-    )
-    not_equals: RouteStatusGQL | None = strawberry.field(
-        default=None, description="Excludes routes with this exact status."
-    )
-    not_in: list[RouteStatusGQL] | None = strawberry.field(
-        default=None, description="Excludes routes whose status is in this list."
-    )
-
-
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        description="Filter for route traffic status with equality and membership operators.",
-        added_version="26.3.0",
-    ),
-    name="RouteTrafficStatusFilter",
-)
-class RouteTrafficStatusFilterGQL(PydanticInputMixin[RouteTrafficStatusFilterDTO]):
-    equals: RouteTrafficStatusGQL | None = strawberry.field(
-        default=None, description="Matches routes with this exact traffic status."
-    )
-    in_: list[RouteTrafficStatusGQL] | None = strawberry.field(
-        name="in", default=None, description="Matches routes whose traffic status is in this list."
-    )
-    not_equals: RouteTrafficStatusGQL | None = strawberry.field(
-        default=None, description="Excludes routes with this exact traffic status."
-    )
-    not_in: list[RouteTrafficStatusGQL] | None = strawberry.field(
-        default=None, description="Excludes routes whose traffic status is in this list."
-    )
-
-
 @strawberry.enum
 class RouteOrderField(StrEnum):
     CREATED_AT = "created_at"
@@ -228,9 +175,9 @@ class RouteOrderField(StrEnum):
     BackendAIGQLMeta(description="Filter for routes.", added_version="25.19.0"),
     name="RouteFilter",
 )
-class RouteFilter(PydanticInputMixin[RouteFilterDTO]):
-    status: RouteStatusFilterGQL | None = None
-    traffic_status: RouteTrafficStatusFilterGQL | None = None
+class RouteFilter:
+    status: list[RouteStatusGQL] | None = None
+    traffic_status: list[RouteTrafficStatusGQL] | None = None
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None


### PR DESCRIPTION
## Summary

- The pydantic migration (BA-5127, #10299) changed `RouteFilter.status` from `list[RouteStatus]` to a `RouteStatusFilter` mapping type, breaking existing clients that pass status as a plain array
- Reverts the GQL schema for `RouteFilter` to accept `list[RouteStatus]` and `list[RouteTrafficStatus]` directly (original behavior)
- Adapter conversion from list → `RouteStatusFilter` DTO is now handled in the resolver via `_route_filter_to_dto()`

## Changes

- `types/route.py`: Remove `RouteStatusFilterGQL` / `RouteTrafficStatusFilterGQL` classes; revert `RouteFilter.status` and `traffic_status` fields to plain list types
- `resolver/route.py`: Add `_route_filter_to_dto()` to manually convert list fields into `RouteStatusFilterDTO(in_=[...])` before passing to the adapter

## Test plan

- [ ] Verify `routes(filter: { status: ["HEALTHY", "PROVISIONING"] })` query works without error
- [ ] Verify existing clients sending `status` as a list no longer get `Expected type 'RouteStatusFilter' to be a mapping` error

> No changelog entry — this is a regression fix for the current unreleased version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)