### PR TITLE
feat(BA-5320): Define RBAC action for SESSION element type

### DIFF
--- a/changes/10417.feature.md
+++ b/changes/10417.feature.md
@@ -1,0 +1,1 @@
+Define valid operation combinations for SESSION element type as concrete `BaseRBACAction` subclasses with registry-based discovery.

--- a/src/ai/backend/manager/actions/action/rbac.py
+++ b/src/ai/backend/manager/actions/action/rbac.py
@@ -10,6 +10,18 @@ from ai.backend.common.data.permission.types import OperationType, RBACElementTy
 class RBACActionName(enum.StrEnum):
     """All known RBAC action names."""
 
+    CREATE = "create"
+    GET = "get"
+    SEARCH = "search"
+    UPDATE = "update"
+    SOFT_DELETE = "soft_delete"
+    HARD_DELETE = "hard_delete"
+    GRANT_ALL = "grant_all"
+    GRANT_READ = "grant_read"
+    GRANT_UPDATE = "grant_update"
+    GRANT_SOFT_DELETE = "grant_soft_delete"
+    GRANT_HARD_DELETE = "grant_hard_delete"
+
 
 @dataclass(frozen=True)
 class RBACRequiredPermission:

--- a/src/ai/backend/manager/actions/action/rbac_session.py
+++ b/src/ai/backend/manager/actions/action/rbac_session.py
@@ -1,0 +1,118 @@
+"""RBAC action declarations for the SESSION element type."""
+
+from typing import override
+
+from ai.backend.common.data.permission.types import OperationType, RBACElementType
+from ai.backend.manager.actions.action.rbac import (
+    BaseRBACAction,
+    RBACActionName,
+    RBACRequiredPermission,
+)
+
+
+class SessionCreateRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.CREATE
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.CREATE)
+
+
+class SessionGetRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GET
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.READ)
+
+
+class SessionSearchRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.SEARCH
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.READ)
+
+
+class SessionUpdateRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.UPDATE
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.UPDATE)
+
+
+class SessionHardDeleteRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.HARD_DELETE
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.HARD_DELETE)
+
+
+class SessionGrantAllRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GRANT_ALL
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.GRANT_ALL)
+
+
+class SessionGrantReadRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GRANT_READ
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.GRANT_READ)
+
+
+class SessionGrantUpdateRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GRANT_UPDATE
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.GRANT_UPDATE)
+
+
+class SessionGrantHardDeleteRBACAction(BaseRBACAction):
+    @classmethod
+    @override
+    def action_name(cls) -> RBACActionName:
+        return RBACActionName.GRANT_HARD_DELETE
+
+    @classmethod
+    @override
+    def required_permission(cls) -> RBACRequiredPermission:
+        return RBACRequiredPermission(RBACElementType.SESSION, OperationType.GRANT_HARD_DELETE)

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -1,3 +1,14 @@
+from ai.backend.manager.actions.action.rbac_session import (
+    SessionCreateRBACAction,
+    SessionGetRBACAction,
+    SessionGrantAllRBACAction,
+    SessionGrantHardDeleteRBACAction,
+    SessionGrantReadRBACAction,
+    SessionGrantUpdateRBACAction,
+    SessionHardDeleteRBACAction,
+    SessionSearchRBACAction,
+    SessionUpdateRBACAction,
+)
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.agent.processors import AgentProcessors
@@ -278,7 +289,17 @@ def create_services(args: ServiceArgs) -> Services:
         ),
         permission_controller=PermissionControllerService(
             repository=repositories.permission_controller.repository,
-            rbac_action_registry=[],
+            rbac_action_registry=[
+                SessionCreateRBACAction,
+                SessionGetRBACAction,
+                SessionSearchRBACAction,
+                SessionUpdateRBACAction,
+                SessionHardDeleteRBACAction,
+                SessionGrantAllRBACAction,
+                SessionGrantReadRBACAction,
+                SessionGrantUpdateRBACAction,
+                SessionGrantHardDeleteRBACAction,
+            ],
         ),
         vfs_storage=VFSStorageService(
             vfs_storage_repository=repositories.vfs_storage.repository,

--- a/tests/unit/manager/actions/test_rbac_session.py
+++ b/tests/unit/manager/actions/test_rbac_session.py
@@ -1,0 +1,134 @@
+"""Tests for SESSION RBAC action declarations."""
+
+import pytest
+
+from ai.backend.common.data.permission.types import OperationType, RBACElementType
+from ai.backend.manager.actions.action.rbac import (
+    BaseRBACAction,
+    RBACActionName,
+    RBACRequiredPermission,
+)
+from ai.backend.manager.actions.action.rbac_session import (
+    SessionCreateRBACAction,
+    SessionGetRBACAction,
+    SessionGrantAllRBACAction,
+    SessionGrantHardDeleteRBACAction,
+    SessionGrantReadRBACAction,
+    SessionGrantUpdateRBACAction,
+    SessionHardDeleteRBACAction,
+    SessionSearchRBACAction,
+    SessionUpdateRBACAction,
+)
+
+ALL_SESSION_ACTIONS: list[type[BaseRBACAction]] = [
+    SessionCreateRBACAction,
+    SessionGetRBACAction,
+    SessionSearchRBACAction,
+    SessionUpdateRBACAction,
+    SessionHardDeleteRBACAction,
+    SessionGrantAllRBACAction,
+    SessionGrantReadRBACAction,
+    SessionGrantUpdateRBACAction,
+    SessionGrantHardDeleteRBACAction,
+]
+
+
+class TestSessionRBACActionInheritance:
+    @pytest.mark.parametrize("action_cls", ALL_SESSION_ACTIONS)
+    def test_inherits_from_base_rbac_action(self, action_cls: type[BaseRBACAction]) -> None:
+        assert issubclass(action_cls, BaseRBACAction)
+
+    @pytest.mark.parametrize("action_cls", ALL_SESSION_ACTIONS)
+    def test_element_type_is_session(self, action_cls: type[BaseRBACAction]) -> None:
+        perm = action_cls.required_permission()
+        assert perm.element_type == RBACElementType.SESSION
+
+
+class TestSessionRBACActionUniqueness:
+    def test_action_names_are_unique(self) -> None:
+        names = [cls.action_name() for cls in ALL_SESSION_ACTIONS]
+        assert len(names) == len(set(names))
+
+
+class TestSessionRBACActionExclusions:
+    def test_no_soft_delete_action(self) -> None:
+        action_names = {cls.action_name() for cls in ALL_SESSION_ACTIONS}
+        assert RBACActionName.SOFT_DELETE not in action_names
+
+    def test_no_grant_soft_delete_action(self) -> None:
+        action_names = {cls.action_name() for cls in ALL_SESSION_ACTIONS}
+        assert RBACActionName.GRANT_SOFT_DELETE not in action_names
+
+    def test_no_soft_delete_operation(self) -> None:
+        operations = {cls.required_permission().operation for cls in ALL_SESSION_ACTIONS}
+        assert OperationType.SOFT_DELETE not in operations
+
+    def test_no_grant_soft_delete_operation(self) -> None:
+        operations = {cls.required_permission().operation for cls in ALL_SESSION_ACTIONS}
+        assert OperationType.GRANT_SOFT_DELETE not in operations
+
+
+class TestSessionRBACActionMapping:
+    @pytest.mark.parametrize(
+        ("action_cls", "expected_name", "expected_operation"),
+        [
+            (SessionCreateRBACAction, RBACActionName.CREATE, OperationType.CREATE),
+            (SessionGetRBACAction, RBACActionName.GET, OperationType.READ),
+            (SessionSearchRBACAction, RBACActionName.SEARCH, OperationType.READ),
+            (SessionUpdateRBACAction, RBACActionName.UPDATE, OperationType.UPDATE),
+            (SessionHardDeleteRBACAction, RBACActionName.HARD_DELETE, OperationType.HARD_DELETE),
+            (SessionGrantAllRBACAction, RBACActionName.GRANT_ALL, OperationType.GRANT_ALL),
+            (SessionGrantReadRBACAction, RBACActionName.GRANT_READ, OperationType.GRANT_READ),
+            (SessionGrantUpdateRBACAction, RBACActionName.GRANT_UPDATE, OperationType.GRANT_UPDATE),
+            (
+                SessionGrantHardDeleteRBACAction,
+                RBACActionName.GRANT_HARD_DELETE,
+                OperationType.GRANT_HARD_DELETE,
+            ),
+        ],
+    )
+    def test_action_name_and_operation(
+        self,
+        action_cls: type[BaseRBACAction],
+        expected_name: RBACActionName,
+        expected_operation: OperationType,
+    ) -> None:
+        assert action_cls.action_name() == expected_name
+        perm = action_cls.required_permission()
+        assert perm.element_type == RBACElementType.SESSION
+        assert perm.operation == expected_operation
+
+
+class TestGetEntityValidOperations:
+    def test_aggregation_produces_session_entry(self) -> None:
+        result: dict[RBACElementType, dict[RBACActionName, RBACRequiredPermission]] = {}
+        for action_cls in ALL_SESSION_ACTIONS:
+            perm = action_cls.required_permission()
+            actions = result.setdefault(perm.element_type, {})
+            actions[action_cls.action_name()] = perm
+
+        assert RBACElementType.SESSION in result
+        session_actions = result[RBACElementType.SESSION]
+        assert len(session_actions) == 9
+
+    def test_aggregation_maps_correct_operations(self) -> None:
+        result: dict[RBACElementType, dict[RBACActionName, RBACRequiredPermission]] = {}
+        for action_cls in ALL_SESSION_ACTIONS:
+            perm = action_cls.required_permission()
+            actions = result.setdefault(perm.element_type, {})
+            actions[action_cls.action_name()] = perm
+
+        session_actions = result[RBACElementType.SESSION]
+        expected_operations = {
+            RBACActionName.CREATE: OperationType.CREATE,
+            RBACActionName.GET: OperationType.READ,
+            RBACActionName.SEARCH: OperationType.READ,
+            RBACActionName.UPDATE: OperationType.UPDATE,
+            RBACActionName.HARD_DELETE: OperationType.HARD_DELETE,
+            RBACActionName.GRANT_ALL: OperationType.GRANT_ALL,
+            RBACActionName.GRANT_READ: OperationType.GRANT_READ,
+            RBACActionName.GRANT_UPDATE: OperationType.GRANT_UPDATE,
+            RBACActionName.GRANT_HARD_DELETE: OperationType.GRANT_HARD_DELETE,
+        }
+        for action_name, expected_op in expected_operations.items():
+            assert session_actions[action_name].operation == expected_op


### PR DESCRIPTION
## Summary
- Add SESSION entry with 8 valid operations (CREATE, READ, UPDATE, HARD_DELETE, and their GRANT_* equivalents)
- Exclude SOFT_DELETE and GRANT_SOFT_DELETE (sessions are terminated/destroyed, not soft-deleted)
- Define `OPERATION_DESCRIPTIONS` mapping with human-readable descriptions for all 10 OperationType enum members

## Test plan
- [x] pants fmt/fix/lint checks pass

Resolves BA-5320