### PR TITLE
fix: Add safe Prometheus metric wrappers to prevent mmap error death spiral (#10443)

### DIFF
--- a/changes/10395.fix.md
+++ b/changes/10395.fix.md
@@ -1,0 +1,1 @@
+Add safe Prometheus metric wrappers to prevent mmap error propagation into business logic

--- a/src/ai/backend/agent/metrics/metric.py
+++ b/src/ai/backend/agent/metrics/metric.py
@@ -7,8 +7,15 @@ import uuid
 from collections.abc import Iterable, MutableMapping
 from typing import TYPE_CHECKING, Any, Self
 
-from prometheus_client import Counter, Gauge, Histogram
-
+from ai.backend.common.metrics.safe import (
+    SafeCounter as Counter,
+)
+from ai.backend.common.metrics.safe import (
+    SafeGauge as Gauge,
+)
+from ai.backend.common.metrics.safe import (
+    SafeHistogram as Histogram,
+)
 from ai.backend.common.metrics.types import (
     CONTAINER_UTILIZATION_METRIC_LABEL_NAME,
     DEVICE_UTILIZATION_METRIC_LABEL_NAME,

--- a/src/ai/backend/appproxy/worker/types.py
+++ b/src/ai/backend/appproxy/worker/types.py
@@ -37,6 +37,11 @@ from ai.backend.common.metrics.metric import (
     SystemMetricObserver,
 )
 from ai.backend.common.metrics.multiprocess import generate_latest_multiprocess
+from ai.backend.common.metrics.safe import (
+    SafeCounter,
+    SafeGauge,
+    SafeHistogram,
+)
 from ai.backend.common.types import (
     MetricKey,
     MetricValue,
@@ -78,107 +83,107 @@ class ProxyMetricObserver:
     _connection_total_traffics_tcp: prometheus_client.Histogram
 
     def __init__(self) -> None:
-        self._upstream_request_sent_http = prometheus_client.Counter(
+        self._upstream_request_sent_http = SafeCounter(
             name="appproxy_upstream_request_sent_http",
             labelnames=["remote"],
             documentation="Total number of HTTP requests sent to upstream",
         )
         self._upstream_request_sent_http.labels(remote="").inc(0)
-        self._upstream_response_received_http = prometheus_client.Counter(
+        self._upstream_response_received_http = SafeCounter(
             name="appproxy_upstream_response_received_http",
             labelnames=["remote"],
             documentation="Total number of HTTP responses received from upstream",
         )
         self._upstream_response_received_http.labels(remote="").inc(0)
-        self._requests_received_http = prometheus_client.Counter(
+        self._requests_received_http = SafeCounter(
             name="appproxy_requests_received_http",
             labelnames=["remote"],
             documentation="Total number of HTTP requests received from downstream",
         )
         self._requests_received_http.labels(remote="").inc(0)
-        self._responses_sent_http = prometheus_client.Counter(
+        self._responses_sent_http = SafeCounter(
             name="appproxy_responses_sent_http",
             labelnames=["remote"],
             documentation="Total number of HTTP responses sent to downstream",
         )
         self._responses_sent_http.labels(remote="").inc(0)
-        self._pending_requests_http = prometheus_client.Gauge(
+        self._pending_requests_http = SafeGauge(
             name="appproxy_pending_requests_http",
             labelnames=["remote"],
             documentation="Ongoing HTTP proxy requests initiated by downstream",
             multiprocess_mode="livesum",
         )
         self._pending_requests_http.labels(remote="").set(0)
-        self._proxy_request_iteration_duration_http = prometheus_client.Histogram(
+        self._proxy_request_iteration_duration_http = SafeHistogram(
             name="appproxy_proxy_request_iteration_duration_http",
             labelnames=["remote"],
             documentation="Total seconds taken to complete each HTTP proxy request",
         )
-        self._request_body_size_http = prometheus_client.Histogram(
+        self._request_body_size_http = SafeHistogram(
             name="appproxy_request_body_size_http",
             labelnames=["remote"],
             documentation="Request body size measured for each HTTP proxy request",
         )
-        self._response_body_size_http = prometheus_client.Histogram(
+        self._response_body_size_http = SafeHistogram(
             name="appproxy_response_body_size_http",
             labelnames=["remote"],
             documentation="Byte length of the response body generated from upstream HTTP response",
         )
-        self._connections_established_ws = prometheus_client.Counter(
+        self._connections_established_ws = SafeCounter(
             name="appproxy_connections_established_ws",
             documentation="Total number of WebSocket connections established",
         )
         self._connections_established_ws.inc(0)
-        self._connections_closed_ws = prometheus_client.Counter(
+        self._connections_closed_ws = SafeCounter(
             name="appproxy_connections_closed_ws",
             documentation="Total number of WebSocket connections closed",
         )
         self._connections_closed_ws.inc(0)
-        self._pending_connections_ws = prometheus_client.Gauge(
+        self._pending_connections_ws = SafeGauge(
             name="appproxy_pending_connections_ws",
             documentation="Ongoing WebSocket proxy connections",
             multiprocess_mode="livesum",
         )
         self._pending_connections_ws.set(0)
-        self._proxy_request_iteration_duration_ws = prometheus_client.Histogram(
+        self._proxy_request_iteration_duration_ws = SafeHistogram(
             name="appproxy_proxy_request_iteration_duration_ws",
             documentation="Total seconds taken to complete each WebSocket proxy request",
         )
-        self._connection_processed_traffics_ws = prometheus_client.Counter(
+        self._connection_processed_traffics_ws = SafeCounter(
             name="appproxy_connection_processed_traffics_ws",
             documentation="Number of bytes transferred from each WebSocket connection bidirectionally, updated on-the-fly",
         )
         self._connection_processed_traffics_ws.inc(0)
-        self._connection_total_traffics_ws = prometheus_client.Histogram(
+        self._connection_total_traffics_ws = SafeHistogram(
             name="appproxy_connection_total_traffics_ws",
             documentation="Number of bytes transferred from each WebSocket connection bidirectionally, updated after WebSocket connection closes",
         )
-        self._connections_established_tcp = prometheus_client.Counter(
+        self._connections_established_tcp = SafeCounter(
             name="appproxy_connections_established_tcp",
             documentation="Total number of TCP connections established",
         )
         self._connections_established_tcp.inc(0)
-        self._connections_closed_tcp = prometheus_client.Counter(
+        self._connections_closed_tcp = SafeCounter(
             name="appproxy_connections_closed_tcp",
             documentation="Total number of TCP connections closed",
         )
         self._connections_closed_tcp.inc(0)
-        self._pending_connections_tcp = prometheus_client.Gauge(
+        self._pending_connections_tcp = SafeGauge(
             name="appproxy_pending_connections_tcp",
             documentation="Ongoing TCP proxy connections",
             multiprocess_mode="livesum",
         )
         self._pending_connections_tcp.set(0)
-        self._proxy_request_iteration_duration_tcp = prometheus_client.Histogram(
+        self._proxy_request_iteration_duration_tcp = SafeHistogram(
             name="appproxy_proxy_request_iteration_duration_tcp",
             documentation="Total seconds taken to complete each TCP proxy request",
         )
-        self._connection_processed_traffics_tcp = prometheus_client.Counter(
+        self._connection_processed_traffics_tcp = SafeCounter(
             name="appproxy_connection_processed_traffics_tcp",
             documentation="Number of bytes transferred from each TCP connection bidirectionally, updated on-the-fly",
         )
         self._connection_processed_traffics_tcp.inc(0)
-        self._connection_total_traffics_tcp = prometheus_client.Histogram(
+        self._connection_total_traffics_tcp = SafeHistogram(
             name="appproxy_connection_total_traffics_tcp",
             documentation="Number of bytes transferred from each TCP connection bidirectionally, updated on-the-fly",
         )
@@ -245,13 +250,13 @@ class CircuitMetricObserver:
     _alive_circuits: prometheus_client.Gauge
 
     def __init__(self) -> None:
-        self._circuits_created = prometheus_client.Counter(
+        self._circuits_created = SafeCounter(
             name="appproxy_circuits_created",
             labelnames=["protocol"],
             documentation="Total number of AppProxy circuits created on this Worker. `endpoint_id` is provided only when circuit is INFERENCE type. `user_id` is provided only when circuit is INTERACTIVE type.",
         )
         self._circuits_created.labels(protocol="").inc(0)
-        self._alive_circuits = prometheus_client.Gauge(
+        self._alive_circuits = SafeGauge(
             name="appproxy_alive_circuits",
             labelnames=["protocol"],
             documentation="Total number of AppProxy circuits created on this Worker. `endpoint_id` is provided only when circuit is INFERENCE type. `user_id` is provided only when circuit is INTERACTIVE type.",

--- a/src/ai/backend/common/health_checker/__init__.py
+++ b/src/ai/backend/common/health_checker/__init__.py
@@ -9,6 +9,7 @@ from .abc import (
 from .checkers import (
     EtcdHealthChecker,
     HttpHealthChecker,
+    PrometheusHealthChecker,
     ValkeyHealthChecker,
 )
 from .exceptions import (
@@ -23,6 +24,7 @@ from .types import (
     CID_DOCKER,
     CID_ETCD,
     CID_POSTGRES,
+    CID_PROMETHEUS_METRICS,
     CID_REDIS_ARTIFACT,
     CID_REDIS_BGTASK,
     CID_REDIS_CONTAINER_LOG,
@@ -36,6 +38,7 @@ from .types import (
     DATABASE,
     ETCD,
     MANAGER,
+    PROMETHEUS,
     REDIS,
     STORAGE_PROXY,
     AllServicesHealth,
@@ -54,6 +57,7 @@ __all__ = [
     # Checkers
     "EtcdHealthChecker",
     "HttpHealthChecker",
+    "PrometheusHealthChecker",
     "ValkeyHealthChecker",
     # Exceptions
     "HealthCheckError",
@@ -72,6 +76,7 @@ __all__ = [
     "APPPROXY",
     "DATABASE",
     "ETCD",
+    "PROMETHEUS",
     "REDIS",
     # Built-in ComponentIds
     "CID_POSTGRES",
@@ -87,6 +92,7 @@ __all__ = [
     "CID_REDIS_CORE_LIVE",
     "CID_ETCD",
     "CID_DOCKER",
+    "CID_PROMETHEUS_METRICS",
     # Probe
     "HealthProbe",
     "HealthProbeOptions",

--- a/src/ai/backend/common/health_checker/checkers/__init__.py
+++ b/src/ai/backend/common/health_checker/checkers/__init__.py
@@ -1,9 +1,11 @@
 from .etcd import EtcdHealthChecker
 from .http import HttpHealthChecker
+from .prometheus import PrometheusHealthChecker
 from .valkey import ValkeyHealthChecker
 
 __all__ = [
     "EtcdHealthChecker",
     "HttpHealthChecker",
+    "PrometheusHealthChecker",
     "ValkeyHealthChecker",
 ]

--- a/src/ai/backend/common/health_checker/checkers/prometheus.py
+++ b/src/ai/backend/common/health_checker/checkers/prometheus.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ai.backend.common.health_checker.abc import StaticServiceHealthChecker
+from ai.backend.common.health_checker.types import (
+    CID_PROMETHEUS_METRICS,
+    PROMETHEUS,
+    ComponentHealthStatus,
+    ServiceGroup,
+    ServiceHealth,
+)
+
+
+class PrometheusHealthChecker(StaticServiceHealthChecker):
+    """Health checker for the Prometheus metric recording subsystem.
+
+    Reports unhealthy when the metric circuit breaker has tripped
+    (e.g., due to mmap corruption after OS sleep/wake).
+    """
+
+    _timeout: float
+
+    def __init__(self, timeout: float = 1.0) -> None:
+        self._timeout = timeout
+
+    @property
+    def target_service_group(self) -> ServiceGroup:
+        return PROMETHEUS
+
+    async def check_service(self) -> ServiceHealth:
+        from ai.backend.common.metrics.safe import is_metrics_disabled, metrics_trip_info
+
+        disabled = is_metrics_disabled()
+        tripped_at, error_msg = metrics_trip_info()
+        return ServiceHealth(
+            results={
+                CID_PROMETHEUS_METRICS: ComponentHealthStatus(
+                    is_healthy=not disabled,
+                    last_checked_at=tripped_at or datetime.now(UTC),
+                    error_message=error_msg if disabled else None,
+                ),
+            }
+        )
+
+    @property
+    def timeout(self) -> float:
+        return self._timeout

--- a/src/ai/backend/common/health_checker/types.py
+++ b/src/ai/backend/common/health_checker/types.py
@@ -45,6 +45,10 @@ CID_ETCD: ComponentId = ComponentId("etcd")
 # Built-in component IDs for container
 CID_DOCKER: ComponentId = ComponentId("docker")
 
+# Prometheus metrics
+PROMETHEUS: ServiceGroup = ServiceGroup("prometheus")
+CID_PROMETHEUS_METRICS: ComponentId = ComponentId("metrics")
+
 
 @dataclass(frozen=True)
 class HealthCheckKey:

--- a/src/ai/backend/common/metrics/http.py
+++ b/src/ai/backend/common/metrics/http.py
@@ -55,13 +55,19 @@ def build_api_metric_middleware(metric: APIMetricObserverProtocol) -> Middleware
         finally:
             end = time.perf_counter()
             elapsed = end - start
-            metric.observe_request(
-                method=method,
-                endpoint=endpoint,
-                error_code=error_code,
-                status_code=status_code,
-                duration=elapsed,
-            )
+            try:
+                metric.observe_request(
+                    method=method,
+                    endpoint=endpoint,
+                    error_code=error_code,
+                    status_code=status_code,
+                    duration=elapsed,
+                )
+            except Exception:
+                # Defense-in-depth: safe metric types handle mmap errors
+                # internally, but this ensures metric failures never mask
+                # the original request exception in the finally block.
+                pass
 
     return metric_middleware
 

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -4,11 +4,19 @@ import os
 from typing import Self
 
 import psutil
-from prometheus_client import Counter, Gauge, Histogram
 
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.common.exception import BackendAIError, ErrorCode
 from ai.backend.common.metrics.multiprocess import generate_latest_multiprocess
+from ai.backend.common.metrics.safe import (
+    SafeCounter as Counter,
+)
+from ai.backend.common.metrics.safe import (
+    SafeGauge as Gauge,
+)
+from ai.backend.common.metrics.safe import (
+    SafeHistogram as Histogram,
+)
 
 
 class APIMetricObserver:

--- a/src/ai/backend/common/metrics/safe.py
+++ b/src/ai/backend/common/metrics/safe.py
@@ -1,0 +1,214 @@
+"""Best-effort Prometheus metric wrappers.
+
+Provides SafeCounter, SafeGauge, and SafeHistogram that wrap
+prometheus_client metric types. On mmap corruption (ValueError from
+corrupted multiprocess .db files after OS sleep/wake), all metric
+recording is globally disabled so that metric failures never propagate
+into business logic or trigger retries.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import UTC, datetime
+from typing import Any
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from ai.backend.logging.utils import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+# ---------------------------------------------------------------------------
+# Global circuit-breaker state
+# ---------------------------------------------------------------------------
+
+_metrics_disabled: bool = False
+_disable_lock = threading.Lock()
+_error_logged: bool = False
+_tripped_at: datetime | None = None
+_trip_error_message: str | None = None
+
+
+def is_metrics_disabled() -> bool:
+    """Return True if metric recording has been disabled due to mmap error."""
+    return _metrics_disabled
+
+
+def metrics_trip_info() -> tuple[datetime | None, str | None]:
+    """Return (tripped_at, error_message) for health check reporting."""
+    return _tripped_at, _trip_error_message
+
+
+def _trip(error: Exception) -> None:
+    """Disable all metric recording globally. Logs a warning once."""
+    global _metrics_disabled, _error_logged, _tripped_at, _trip_error_message
+    with _disable_lock:
+        if _metrics_disabled:
+            return
+        _metrics_disabled = True
+        _tripped_at = datetime.now(UTC)
+        _trip_error_message = str(error)
+    if not _error_logged:
+        _error_logged = True
+        log.warning(
+            "Prometheus metric recording disabled due to mmap error: {}",
+            error,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Noop sentinel (returned when metrics are disabled)
+# ---------------------------------------------------------------------------
+
+
+class _NoopLabeledMetric:
+    """Sentinel no-op returned when metrics are disabled."""
+
+    __slots__ = ()
+
+    def inc(self, amount: float = 1) -> None:
+        pass
+
+    def dec(self, amount: float = 1) -> None:
+        pass
+
+    def set(self, value: float) -> None:
+        pass
+
+    def observe(self, amount: float) -> None:
+        pass
+
+
+_NOOP_LABELED = _NoopLabeledMetric()
+
+
+# ---------------------------------------------------------------------------
+# Safe labeled metric wrapper
+# ---------------------------------------------------------------------------
+
+
+class SafeLabeledMetric:
+    """Wraps a labeled prometheus metric child, catching ValueError."""
+
+    __slots__ = ("_child",)
+
+    def __init__(self, child: Any) -> None:
+        self._child = child
+
+    def inc(self, amount: float = 1) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            self._child.inc(amount)
+        except ValueError as e:
+            _trip(e)
+
+    def dec(self, amount: float = 1) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            self._child.dec(amount)
+        except ValueError as e:
+            _trip(e)
+
+    def set(self, value: float) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            self._child.set(value)
+        except ValueError as e:
+            _trip(e)
+
+    def observe(self, amount: float) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            self._child.observe(amount)
+        except ValueError as e:
+            _trip(e)
+
+
+# ---------------------------------------------------------------------------
+# Safe metric types (drop-in replacements for prometheus_client types)
+# ---------------------------------------------------------------------------
+
+
+class SafeCounter(Counter):
+    """Counter that becomes no-op on mmap corruption."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> Any:
+        if _metrics_disabled:
+            return _NOOP_LABELED
+        try:
+            return SafeLabeledMetric(super().labels(*args, **kwargs))
+        except ValueError as e:
+            _trip(e)
+            return _NOOP_LABELED
+
+    def inc(self, amount: float = 1, exemplar: dict[str, str] | None = None) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            super().inc(amount, exemplar)
+        except ValueError as e:
+            _trip(e)
+
+
+class SafeGauge(Gauge):
+    """Gauge that becomes no-op on mmap corruption."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> Any:
+        if _metrics_disabled:
+            return _NOOP_LABELED
+        try:
+            return SafeLabeledMetric(super().labels(*args, **kwargs))
+        except ValueError as e:
+            _trip(e)
+            return _NOOP_LABELED
+
+    def inc(self, amount: float = 1) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            super().inc(amount)
+        except ValueError as e:
+            _trip(e)
+
+    def dec(self, amount: float = 1) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            super().dec(amount)
+        except ValueError as e:
+            _trip(e)
+
+    def set(self, value: float) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            super().set(value)
+        except ValueError as e:
+            _trip(e)
+
+
+class SafeHistogram(Histogram):
+    """Histogram that becomes no-op on mmap corruption."""
+
+    def labels(self, *args: Any, **kwargs: Any) -> Any:
+        if _metrics_disabled:
+            return _NOOP_LABELED
+        try:
+            return SafeLabeledMetric(super().labels(*args, **kwargs))
+        except ValueError as e:
+            _trip(e)
+            return _NOOP_LABELED
+
+    def observe(self, amount: float, exemplar: dict[str, str] | None = None) -> None:
+        if _metrics_disabled:
+            return
+        try:
+            super().observe(amount, exemplar)
+        except ValueError as e:
+            _trip(e)

--- a/src/ai/backend/manager/dependencies/system/health_probe.py
+++ b/src/ai/backend/manager/dependencies/system/health_probe.py
@@ -18,6 +18,7 @@ from ai.backend.common.health_checker import (
     EtcdHealthChecker,
     HealthProbe,
     HealthProbeOptions,
+    PrometheusHealthChecker,
     ServiceHealthChecker,
     ValkeyHealthChecker,
 )
@@ -48,6 +49,7 @@ class HealthProbeDependency(DependencyProvider[HealthProbeInput, HealthProbe]):
 
         await probe.register(DatabaseHealthChecker(db=setup_input.db))
         await probe.register(EtcdHealthChecker(etcd=setup_input.etcd))
+        await probe.register(PrometheusHealthChecker())
         await probe.register(
             ValkeyHealthChecker(
                 clients={

--- a/src/ai/backend/manager/metrics/scheduler.py
+++ b/src/ai/backend/manager/metrics/scheduler.py
@@ -5,7 +5,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Self
 
-from prometheus_client import Counter, Histogram
+from ai.backend.common.metrics.safe import (
+    SafeCounter as Counter,
+)
+from ai.backend.common.metrics.safe import (
+    SafeHistogram as Histogram,
+)
 
 
 class SchedulerOperationMetricObserver:

--- a/src/ai/backend/storage/metrics/volume_perf.py
+++ b/src/ai/backend/storage/metrics/volume_perf.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Self
 
-from prometheus_client import Gauge
+from ai.backend.common.metrics.safe import SafeGauge as Gauge
 
 
 class VolumePerfMetricObserver:

--- a/src/ai/backend/storage/metrics/volume_stats.py
+++ b/src/ai/backend/storage/metrics/volume_stats.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Self
 
-from prometheus_client import Counter, Histogram
+from ai.backend.common.metrics.safe import (
+    SafeCounter as Counter,
+)
+from ai.backend.common.metrics.safe import (
+    SafeHistogram as Histogram,
+)
 
 
 class VolumeStatsMetricObserver:

--- a/tests/unit/common/health_checker/checkers/test_prometheus.py
+++ b/tests/unit/common/health_checker/checkers/test_prometheus.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+import ai.backend.common.metrics.safe as safe_mod
+from ai.backend.common.health_checker.checkers.prometheus import PrometheusHealthChecker
+from ai.backend.common.health_checker.types import CID_PROMETHEUS_METRICS, PROMETHEUS
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breaker() -> None:
+    """Reset global circuit breaker state before each test."""
+    safe_mod._metrics_disabled = False
+    safe_mod._error_logged = False
+    safe_mod._tripped_at = None
+    safe_mod._trip_error_message = None
+
+
+class TestPrometheusHealthChecker:
+    def test_target_service_group(self) -> None:
+        checker = PrometheusHealthChecker()
+        assert checker.target_service_group == PROMETHEUS
+
+    def test_timeout_default(self) -> None:
+        checker = PrometheusHealthChecker()
+        assert checker.timeout == 1.0
+
+    def test_timeout_custom(self) -> None:
+        checker = PrometheusHealthChecker(timeout=5.0)
+        assert checker.timeout == 5.0
+
+    async def test_healthy_when_metrics_enabled(self) -> None:
+        checker = PrometheusHealthChecker()
+        result = await checker.check_service()
+        status = result.results[CID_PROMETHEUS_METRICS]
+        assert status.is_healthy is True
+        assert status.error_message is None
+
+    async def test_unhealthy_when_metrics_disabled(self) -> None:
+        trip_time = datetime(2026, 3, 24, 12, 0, 0, tzinfo=UTC)
+        safe_mod._metrics_disabled = True
+        safe_mod._tripped_at = trip_time
+        safe_mod._trip_error_message = "mmap slice assignment is wrong size"
+
+        checker = PrometheusHealthChecker()
+        result = await checker.check_service()
+        status = result.results[CID_PROMETHEUS_METRICS]
+        assert status.is_healthy is False
+        assert status.error_message == "mmap slice assignment is wrong size"
+        assert status.last_checked_at == trip_time

--- a/tests/unit/common/metrics/BUILD
+++ b/tests/unit/common/metrics/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/common/metrics/test_safe.py
+++ b/tests/unit/common/metrics/test_safe.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import ai.backend.common.metrics.safe as safe_mod
+from ai.backend.common.metrics.safe import (
+    SafeCounter,
+    SafeGauge,
+    SafeHistogram,
+    SafeLabeledMetric,
+    _NoopLabeledMetric,
+    _trip,
+    is_metrics_disabled,
+    metrics_trip_info,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breaker() -> None:
+    """Reset global circuit breaker state before each test."""
+    safe_mod._metrics_disabled = False
+    safe_mod._error_logged = False
+    safe_mod._tripped_at = None
+    safe_mod._trip_error_message = None
+
+
+class TestCircuitBreakerState:
+    def test_initially_not_disabled(self) -> None:
+        assert is_metrics_disabled() is False
+
+    def test_trip_disables_metrics(self) -> None:
+        _trip(ValueError("mmap slice assignment is wrong size"))
+        assert is_metrics_disabled() is True
+
+    def test_trip_stores_error_info(self) -> None:
+        _trip(ValueError("mmap slice assignment is wrong size"))
+        tripped_at, error_msg = metrics_trip_info()
+        assert tripped_at is not None
+        assert error_msg == "mmap slice assignment is wrong size"
+
+    def test_trip_is_idempotent(self) -> None:
+        _trip(ValueError("first error"))
+        first_tripped_at, first_msg = metrics_trip_info()
+        _trip(ValueError("second error"))
+        second_tripped_at, second_msg = metrics_trip_info()
+        assert first_tripped_at == second_tripped_at
+        assert first_msg == second_msg == "first error"
+
+    def test_trip_logs_warning_once(self) -> None:
+        with patch.object(safe_mod, "log") as mock_log:
+            _trip(ValueError("error 1"))
+            _trip(ValueError("error 2"))
+            assert mock_log.warning.call_count == 1
+
+
+class TestSafeLabeledMetric:
+    def test_inc_delegates_to_child(self) -> None:
+        child = MagicMock()
+        metric = SafeLabeledMetric(child)
+        metric.inc(2)
+        child.inc.assert_called_once_with(2)
+
+    def test_dec_delegates_to_child(self) -> None:
+        child = MagicMock()
+        metric = SafeLabeledMetric(child)
+        metric.dec(3)
+        child.dec.assert_called_once_with(3)
+
+    def test_set_delegates_to_child(self) -> None:
+        child = MagicMock()
+        metric = SafeLabeledMetric(child)
+        metric.set(42.0)
+        child.set.assert_called_once_with(42.0)
+
+    def test_observe_delegates_to_child(self) -> None:
+        child = MagicMock()
+        metric = SafeLabeledMetric(child)
+        metric.observe(1.5)
+        child.observe.assert_called_once_with(1.5)
+
+    def test_inc_trips_on_valueerror(self) -> None:
+        child = MagicMock()
+        child.inc.side_effect = ValueError("mmap error")
+        metric = SafeLabeledMetric(child)
+        metric.inc()
+        assert is_metrics_disabled() is True
+
+    def test_noop_after_trip(self) -> None:
+        child = MagicMock()
+        child.inc.side_effect = ValueError("mmap error")
+        metric = SafeLabeledMetric(child)
+        metric.inc()  # trips
+        child.reset_mock()
+        metric.inc()  # should be no-op
+        child.inc.assert_not_called()
+
+    def test_observe_trips_on_valueerror(self) -> None:
+        child = MagicMock()
+        child.observe.side_effect = ValueError("mmap error")
+        metric = SafeLabeledMetric(child)
+        metric.observe(1.0)
+        assert is_metrics_disabled() is True
+
+    def test_other_exceptions_propagate(self) -> None:
+        child = MagicMock()
+        child.inc.side_effect = TypeError("unexpected")
+        metric = SafeLabeledMetric(child)
+        with pytest.raises(TypeError, match="unexpected"):
+            metric.inc()
+        assert is_metrics_disabled() is False
+
+
+class TestNoopLabeledMetric:
+    def test_all_methods_are_noop(self) -> None:
+        noop = _NoopLabeledMetric()
+        noop.inc()
+        noop.dec()
+        noop.set(0)
+        noop.observe(0)
+
+
+class TestSafeCounter:
+    def test_labels_returns_safe_labeled(self) -> None:
+        counter = SafeCounter(
+            name="test_counter",
+            documentation="test",
+            labelnames=["a"],
+        )
+        result = counter.labels(a="x")
+        assert isinstance(result, SafeLabeledMetric)
+
+    def test_labels_returns_noop_after_trip(self) -> None:
+        _trip(ValueError("broken"))
+        counter = SafeCounter(
+            name="test_counter_tripped",
+            documentation="test",
+            labelnames=["a"],
+        )
+        result = counter.labels(a="x")
+        assert isinstance(result, _NoopLabeledMetric)
+
+    def test_labels_catches_valueerror(self) -> None:
+        counter = SafeCounter(
+            name="test_counter_err",
+            documentation="test",
+            labelnames=["a"],
+        )
+        with patch.object(
+            type(counter).__bases__[0], "labels", side_effect=ValueError("mmap error")
+        ):
+            result = counter.labels(a="x")
+            assert isinstance(result, _NoopLabeledMetric)
+            assert is_metrics_disabled() is True
+
+    def test_direct_inc_catches_valueerror(self) -> None:
+        counter = SafeCounter(
+            name="test_counter_direct",
+            documentation="test",
+        )
+        with patch.object(type(counter).__bases__[0], "inc", side_effect=ValueError("mmap error")):
+            counter.inc()
+            assert is_metrics_disabled() is True
+
+    def test_direct_inc_noop_after_trip(self) -> None:
+        _trip(ValueError("broken"))
+        counter = SafeCounter(
+            name="test_counter_noop",
+            documentation="test",
+        )
+        # Should not raise
+        counter.inc()
+
+
+class TestSafeGauge:
+    def test_direct_set_catches_valueerror(self) -> None:
+        gauge = SafeGauge(
+            name="test_gauge_set",
+            documentation="test",
+            multiprocess_mode="livesum",
+        )
+        with patch.object(type(gauge).__bases__[0], "set", side_effect=ValueError("mmap error")):
+            gauge.set(42.0)
+            assert is_metrics_disabled() is True
+
+    def test_direct_inc_dec_noop_after_trip(self) -> None:
+        _trip(ValueError("broken"))
+        gauge = SafeGauge(
+            name="test_gauge_noop",
+            documentation="test",
+            multiprocess_mode="livesum",
+        )
+        gauge.inc()
+        gauge.dec()
+        gauge.set(0)
+
+
+class TestSafeHistogram:
+    def test_direct_observe_catches_valueerror(self) -> None:
+        histogram = SafeHistogram(
+            name="test_histogram_obs",
+            documentation="test",
+        )
+        with patch.object(
+            type(histogram).__bases__[0], "observe", side_effect=ValueError("mmap error")
+        ):
+            histogram.observe(1.0)
+            assert is_metrics_disabled() is True
+
+    def test_direct_observe_noop_after_trip(self) -> None:
+        _trip(ValueError("broken"))
+        histogram = SafeHistogram(
+            name="test_histogram_noop",
+            documentation="test",
+        )
+        histogram.observe(1.0)


### PR DESCRIPTION
This is an auto-generated backport PR of #10443 to the 26.3 release.