### PR TITLE
fix(BA-5372): remove duplicate debug field in config.toml.j2 template (#10423)

### DIFF
--- a/changes/10423.fix.md
+++ b/changes/10423.fix.md
@@ -1,0 +1,1 @@
+Remove duplicate `debug` field in the webserver's `config.toml.j2` template

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -14,7 +14,6 @@ connectionMode = "SESSION"
 {% toml_field "alwaysEnqueueComputeSession" config["service"]["always-enqueue-compute-session"] %}
 {% toml_field "autoLogout" config["session"]["auto-logout"] %}
 {% toml_field "debug" config["service"]["webui-debug"] %}
-{% toml_field "debug" config["service"]["webui-debug"] %}
 {% toml_field "maskUserInfo" config["service"]["mask-user-info"] %}
 {% toml_strlist_field "singleSignOnVendors" config["service"]["single-sign-on-vendors"] %}
 {% toml_field "ssoRealmName" config["service"]["sso-realm-name"] %}


### PR DESCRIPTION
This is an auto-generated backport PR of #10423 to the 26.2 release.