### PR TITLE
fix(BA-5393): Fix ON CONFLICT column mismatch in vfolder invitation remigration (#10471)

### DIFF
--- a/changes/10471.fix.md
+++ b/changes/10471.fix.md
@@ -1,0 +1,1 @@
+Fix ON CONFLICT column mismatch in vfolder invitation RBAC remigration causing InvalidColumnReferenceError during alembic upgrade.

--- a/src/ai/backend/manager/models/alembic/versions/7h4m7ygnaao1_remigrate_vfolder_invitation_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/7h4m7ygnaao1_remigrate_vfolder_invitation_data_to_rbac.py
@@ -66,7 +66,7 @@ def _upsert_ref_edges_for_invitations(db_conn: Connection) -> None:
                 INSERT INTO association_scopes_entities
                     (scope_type, scope_id, entity_type, entity_id, relation_type)
                 VALUES ('user', :user_id, :entity_type, :vfolder_id, 'ref')
-                ON CONFLICT (scope_type, scope_id, entity_type, entity_id)
+                ON CONFLICT (scope_type, scope_id, entity_id)
                     DO UPDATE SET relation_type = 'ref'
             """)
             db_conn.execute(


### PR DESCRIPTION
This is an auto-generated backport PR of #10471 to the 26.3 release.