### PR TITLE
fix: Restore missing installer resource patterns lost in Pants upgrade (#10479)

### DIFF
--- a/changes/10479.fix.md
+++ b/changes/10479.fix.md
@@ -1,0 +1,1 @@
+Restore missing `.yml`, `.conf`, and `.ini` resource patterns for TUI installer configs lost during Pants toolchain upgrade

--- a/src/ai/backend/install/BUILD
+++ b/src/ai/backend/install/BUILD
@@ -86,5 +86,13 @@ resources(
     sources=[
         "**/py.typed",
         "app.tcss",
+        "configs/**/*.toml",
+        "configs/**/*.yml",
+        "configs/**/*.yaml",
+        "configs/**/*.json",
+        "configs/**/*.conf",
+        "configs/**/*.ini",
+        "configs/**/*.ts",
+        "fixtures/**/*.json",
     ],
 )


### PR DESCRIPTION
This is an auto-generated backport PR of #10479 to the 25.6 release.