### PR TITLE
fix(BA-5413): restore wsproxy v1 fallback in scaling group service (#10514)

### DIFF
--- a/changes/10514.fix.md
+++ b/changes/10514.fix.md
@@ -1,0 +1,1 @@
+Restore wsproxy v1 fallback when AppProxy address is not configured in scaling group service

--- a/src/ai/backend/manager/services/scaling_group/service.py
+++ b/src/ai/backend/manager/services/scaling_group/service.py
@@ -79,6 +79,8 @@ from ai.backend.manager.types import TriState
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
+WSPROXY_V1_VERSION = "v1"
+
 
 class ScalingGroupService:
     _repository: ScalingGroupRepository
@@ -124,7 +126,7 @@ class ScalingGroupService:
         sgroup = sgroup_filtered[0]
 
         if not sgroup.network.wsproxy_addr:
-            raise ObjectNotFound(object_name="AppProxy address")
+            return GetWsproxyVersionActionResult(wsproxy_version=WSPROXY_V1_VERSION)
         client = self._appproxy_client_pool.load_client(
             sgroup.network.wsproxy_addr, sgroup.network.wsproxy_api_token or ""
         )

--- a/tests/unit/manager/services/scaling_group/test_scaling_group_service.py
+++ b/tests/unit/manager/services/scaling_group/test_scaling_group_service.py
@@ -97,7 +97,10 @@ from ai.backend.manager.services.scaling_group.actions.list_scaling_groups impor
 from ai.backend.manager.services.scaling_group.actions.modify import (
     ModifyScalingGroupAction,
 )
-from ai.backend.manager.services.scaling_group.service import ScalingGroupService
+from ai.backend.manager.services.scaling_group.service import (
+    WSPROXY_V1_VERSION,
+    ScalingGroupService,
+)
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -766,13 +769,13 @@ class TestGetWsproxyVersion:
         with pytest.raises(ObjectNotFound):
             await scaling_group_service.get_wsproxy_version(action)
 
-    async def test_wsproxy_addr_not_set_raises_object_not_found(
+    async def test_wsproxy_addr_not_set_returns_v1(
         self,
         scaling_group_service: ScalingGroupService,
         mock_repository: MagicMock,
         sample_sgroup_with_wsproxy: ScalingGroupData,
     ) -> None:
-        """wsproxy_addr not set raises ObjectNotFound."""
+        """wsproxy_addr not set returns v1 version."""
         no_wsproxy = ScalingGroupData(
             name="gpu-group",
             status=sample_sgroup_with_wsproxy.status,
@@ -795,8 +798,8 @@ class TestGetWsproxyVersion:
             access_key="AKTEST123",
         )
 
-        with pytest.raises(ObjectNotFound):
-            await scaling_group_service.get_wsproxy_version(action)
+        result = await scaling_group_service.get_wsproxy_version(action)
+        assert result.wsproxy_version == WSPROXY_V1_VERSION
 
     async def test_appproxy_pool_none_raises_object_not_found(
         self,


### PR DESCRIPTION
This is an auto-generated backport PR of #10514 to the 26.3 release.