### PR TITLE
fix(BA-5420): Return plain JSON values for backward-compatible user-config API responses (#10541)

### DIFF
--- a/changes/10541.fix.md
+++ b/changes/10541.fix.md
@@ -1,0 +1,1 @@
+Fix user-config API endpoints to return backward-compatible plain JSON values instead of wrapped objects

--- a/src/ai/backend/client/v2/base_client.py
+++ b/src/ai/backend/client/v2/base_client.py
@@ -102,7 +102,7 @@ class BackendAIAuthClient:
         json: Any | None = None,
         params: dict[str, str] | None = None,
         extra_headers: Mapping[str, str] | None = None,
-    ) -> dict[str, Any] | list[Any] | None:
+    ) -> dict[str, Any] | list[Any] | str | None:
         session = self._session
         content_type = "application/json"
         rel_url = "/" + path.lstrip("/")
@@ -128,7 +128,7 @@ class BackendAIAuthClient:
                 raise map_status_to_exception(resp.status, resp.reason or "", data)
             if resp.status == 204:
                 return None
-            result: dict[str, Any] | list[Any] = await resp.json()
+            result: dict[str, Any] | list[Any] | str = await resp.json()
             return result
 
     async def typed_request(
@@ -370,7 +370,7 @@ class BackendAIAnonymousClient:
         json: Any | None = None,
         params: dict[str, str] | None = None,
         extra_headers: Mapping[str, str] | None = None,
-    ) -> dict[str, Any] | list[Any] | None:
+    ) -> dict[str, Any] | list[Any] | str | None:
         content_type = "application/json"
         rel_url = "/" + path.lstrip("/")
         headers = self._build_headers(method, rel_url, content_type)
@@ -392,7 +392,7 @@ class BackendAIAnonymousClient:
                 raise map_status_to_exception(resp.status, resp.reason or "", data)
             if resp.status == 204:
                 return None
-            result: dict[str, Any] | list[Any] = await resp.json()
+            result: dict[str, Any] | list[Any] | str = await resp.json()
             return result
 
     async def typed_request(

--- a/src/ai/backend/client/v2/domains/session.py
+++ b/src/ai/backend/client/v2/domains/session.py
@@ -353,13 +353,13 @@ class SessionClient(BaseDomainClient):
         self,
         request: SyncAgentRegistryRequest,
     ) -> dict[str, Any] | None:
-        result: dict[str, Any] | list[Any] | None = await self._client._request(
+        result: dict[str, Any] | list[Any] | str | None = await self._client._request(
             "POST",
             f"{_BASE_PATH}/_/sync-agent-registry",
             json=request.model_dump(exclude_none=True),
         )
-        if isinstance(result, list):
-            raise TypeError("Unexpected list response from sync_agent_registry")
+        if isinstance(result, (list, str)):
+            raise TypeError("Unexpected list/str response from sync_agent_registry")
         return result
 
     async def transit_session_status(

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -203,7 +203,7 @@ class APIResponse:
         return cls(_status_code=status_code, _data=None)
 
     @property
-    def to_json(self) -> JSONDict | list[Any] | None:
+    def to_json(self) -> JSONDict | list[Any] | str | None:
         return self._data.model_dump(mode="json", by_alias=True) if self._data else None
 
     @property

--- a/src/ai/backend/common/dto/manager/config/response.py
+++ b/src/ai/backend/common/dto/manager/config/response.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.api_handlers import BaseResponseModel, BaseRootResponseModel
 
 __all__ = (
     "DotfileItem",
+    "DotfileListItem",
     "CreateDotfileResponse",
     "UpdateDotfileResponse",
     "DeleteDotfileResponse",
@@ -26,6 +27,14 @@ class DotfileItem(BaseModel):
 
     path: str = Field(description="Dotfile path")
     perm: str = Field(description="Unix file permission in octal notation")
+    data: str = Field(description="Dotfile content")
+
+
+class DotfileListItem(BaseModel):
+    """A dotfile entry for list responses (backward compatible field names)."""
+
+    path: str = Field(description="Dotfile path")
+    permission: str = Field(description="Unix file permission in octal notation")
     data: str = Field(description="Dotfile content")
 
 
@@ -51,16 +60,12 @@ class GetDotfileResponse(BaseResponseModel):
     data: str = Field(description="Dotfile content")
 
 
-class ListDotfilesResponse(BaseResponseModel):
-    """Response for listing dotfiles."""
-
-    items: list[DotfileItem] = Field(description="List of dotfile entries")
+class ListDotfilesResponse(BaseRootResponseModel[list[DotfileListItem]]):
+    """Response for listing dotfiles (plain array for backward compatibility)."""
 
 
-class GetBootstrapScriptResponse(BaseResponseModel):
-    """Response for retrieving the bootstrap script."""
-
-    script: str = Field(description="Bootstrap script content")
+class GetBootstrapScriptResponse(BaseRootResponseModel[str]):
+    """Response for retrieving the bootstrap script (plain string for backward compatibility)."""
 
 
 class UpdateBootstrapScriptResponse(BaseResponseModel):

--- a/src/ai/backend/manager/api/rest/domainconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/domainconfig/handler.py
@@ -22,7 +22,7 @@ from ai.backend.common.dto.manager.config.request import (
 from ai.backend.common.dto.manager.config.response import (
     CreateDotfileResponse,
     DeleteDotfileResponse,
-    DotfileItem,
+    DotfileListItem,
     GetDotfileResponse,
     ListDotfilesResponse,
     UpdateDotfileResponse,
@@ -88,8 +88,10 @@ class DomainConfigHandler:
                 HTTPStatus.OK,
                 GetDotfileResponse(path=entry.path, perm=entry.perm, data=entry.data),
             )
-        items = [DotfileItem(path=e.path, perm=e.perm, data=e.data) for e in result.entries]
-        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(items=items))
+        items = [
+            DotfileListItem(path=e.path, permission=e.perm, data=e.data) for e in result.entries
+        ]
+        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(root=items))
 
     async def update(
         self,

--- a/src/ai/backend/manager/api/rest/groupconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/groupconfig/handler.py
@@ -22,7 +22,7 @@ from ai.backend.common.dto.manager.config.request import (
 from ai.backend.common.dto.manager.config.response import (
     CreateDotfileResponse,
     DeleteDotfileResponse,
-    DotfileItem,
+    DotfileListItem,
     GetDotfileResponse,
     ListDotfilesResponse,
     UpdateDotfileResponse,
@@ -114,8 +114,10 @@ class GroupConfigHandler:
                 HTTPStatus.OK,
                 GetDotfileResponse(path=entry.path, perm=entry.perm, data=entry.data),
             )
-        items = [DotfileItem(path=e.path, perm=e.perm, data=e.data) for e in result.entries]
-        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(items=items))
+        items = [
+            DotfileListItem(path=e.path, permission=e.perm, data=e.data) for e in result.entries
+        ]
+        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(root=items))
 
     async def update(
         self,

--- a/src/ai/backend/manager/api/rest/userconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/userconfig/handler.py
@@ -23,7 +23,7 @@ from ai.backend.common.dto.manager.config.request import (
 from ai.backend.common.dto.manager.config.response import (
     CreateDotfileResponse,
     DeleteDotfileResponse,
-    DotfileItem,
+    DotfileListItem,
     GetBootstrapScriptResponse,
     GetDotfileResponse,
     ListDotfilesResponse,
@@ -126,8 +126,10 @@ class UserConfigHandler:
                 HTTPStatus.OK,
                 GetDotfileResponse(path=entry.path, perm=entry.perm, data=entry.data),
             )
-        items = [DotfileItem(path=e.path, perm=e.perm, data=e.data) for e in result.entries]
-        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(items=items))
+        items = [
+            DotfileListItem(path=e.path, permission=e.perm, data=e.data) for e in result.entries
+        ]
+        return APIResponse.build(HTTPStatus.OK, ListDotfilesResponse(root=items))
 
     async def update(
         self,
@@ -216,5 +218,5 @@ class UserConfigHandler:
         result = await self._dotfile.get_bootstrap.wait_for_complete(action)
         return APIResponse.build(
             HTTPStatus.OK,
-            GetBootstrapScriptResponse(script=result.script),
+            GetBootstrapScriptResponse(root=result.script),
         )

--- a/tests/component/config/test_config.py
+++ b/tests/component/config/test_config.py
@@ -108,9 +108,46 @@ class TestUserDotfileGet:
         await user_dotfile_factory(path=f".list-b-{unique2}", data="b", permission="644")
         result = await admin_registry.config.list_user_dotfiles()
         assert isinstance(result, ListDotfilesResponse)
-        paths = [item.path for item in result.items]
+        # List response is a plain array (via BaseRootResponseModel)
+        paths = [item.path for item in result.root]
         assert f".list-a-{unique1}" in paths
         assert f".list-b-{unique2}" in paths
+
+    async def test_list_user_dotfiles_returns_plain_array_json(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        user_dotfile_factory: UserDotfileFactory,
+    ) -> None:
+        """Verify the API returns a plain JSON array with 'permission' field.
+
+        This is a regression test for BA-5420 to ensure the response format
+        matches the legacy behavior (plain array with 'permission' field,
+        not {"items": [...]} with 'perm' field).
+        """
+        unique = secrets.token_hex(4)
+        path = f".list-test-{unique}"
+        await user_dotfile_factory(path=path, data="test-data", permission="755")
+        try:
+            result = await admin_registry.config.list_user_dotfiles()
+            # The response should be a plain array
+            assert isinstance(result.root, list)
+            # Verify model_dump returns the plain array (not wrapped)
+            dumped = result.model_dump()
+            assert isinstance(dumped, list)
+            # Find the test item and verify it has 'permission' field
+            test_items = [
+                item for item in dumped if isinstance(item, dict) and item.get("path") == path
+            ]
+            assert len(test_items) == 1
+            test_item = test_items[0]
+            # Verify field name is 'permission' (not 'perm')
+            assert "permission" in test_item
+            assert test_item["permission"] == "755"
+            # Verify no 'perm' field (should be renamed to 'permission')
+            assert "perm" not in test_item
+        finally:
+            # Cleanup
+            await admin_registry.config.delete_user_dotfile(DeleteUserDotfileRequest(path=path))
 
     async def test_get_nonexistent_user_dotfile(
         self,
@@ -190,7 +227,8 @@ class TestBootstrapScript:
     ) -> None:
         result = await admin_registry.config.get_bootstrap_script()
         assert isinstance(result, GetBootstrapScriptResponse)
-        assert result.script == ""
+        # Bootstrap script response is a plain string (via BaseRootResponseModel)
+        assert result.root == ""
 
     async def test_update_and_get_bootstrap_script(
         self,
@@ -203,9 +241,37 @@ class TestBootstrapScript:
         )
         assert isinstance(update_result, UpdateBootstrapScriptResponse)
         get_result = await admin_registry.config.get_bootstrap_script()
-        assert get_result.script == script_content
+        assert get_result.root == script_content
         # Reset to empty for cleanup
         await admin_registry.config.update_bootstrap_script(UpdateBootstrapScriptRequest(script=""))
+
+    async def test_get_bootstrap_script_returns_plain_string_json(
+        self,
+        admin_registry: BackendAIClientRegistry,
+    ) -> None:
+        """Verify the API returns a plain JSON string, not wrapped in an object.
+
+        This is a regression test for BA-5420 to ensure the response format
+        matches the legacy behavior (plain string, not {"script": "..."}).
+        """
+        unique = secrets.token_hex(4)
+        script_content = f"echo test-{unique}"
+        await admin_registry.config.update_bootstrap_script(
+            UpdateBootstrapScriptRequest(script=script_content)
+        )
+        try:
+            result = await admin_registry.config.get_bootstrap_script()
+            # The response should be a plain string
+            assert result.root == script_content
+            # Verify model_dump returns the plain string (not wrapped)
+            dumped = result.model_dump()
+            assert dumped == script_content
+            assert isinstance(dumped, str)
+        finally:
+            # Cleanup
+            await admin_registry.config.update_bootstrap_script(
+                UpdateBootstrapScriptRequest(script="")
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -276,9 +342,51 @@ class TestGroupDotfileGet:
             GetGroupDotfileRequest(group=str(group_fixture))
         )
         assert isinstance(result, ListDotfilesResponse)
-        paths = [item.path for item in result.items]
+        # List response is a plain array (via BaseRootResponseModel)
+        paths = [item.path for item in result.root]
         assert f".glist-a-{unique1}" in paths
         assert f".glist-b-{unique2}" in paths
+
+    async def test_list_group_dotfiles_returns_plain_array_json(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        group_fixture: uuid.UUID,
+        group_dotfile_factory: GroupDotfileFactory,
+    ) -> None:
+        """Verify the API returns a plain JSON array with 'permission' field.
+
+        This is a regression test for BA-5420 to ensure the response format
+        matches the legacy behavior (plain array with 'permission' field,
+        not {"items": [...]} with 'perm' field).
+        """
+        unique = secrets.token_hex(4)
+        path = f".glist-test-{unique}"
+        await group_dotfile_factory(path=path, data="test-data", permission="755")
+        try:
+            result = await admin_registry.config.list_group_dotfiles(
+                GetGroupDotfileRequest(group=str(group_fixture))
+            )
+            # The response should be a plain array
+            assert isinstance(result.root, list)
+            # Verify model_dump returns the plain array (not wrapped)
+            dumped = result.model_dump()
+            assert isinstance(dumped, list)
+            # Find the test item and verify it has 'permission' field
+            test_items = [
+                item for item in dumped if isinstance(item, dict) and item.get("path") == path
+            ]
+            assert len(test_items) == 1
+            test_item = test_items[0]
+            # Verify field name is 'permission' (not 'perm')
+            assert "permission" in test_item
+            assert test_item["permission"] == "755"
+            # Verify no 'perm' field (should be renamed to 'permission')
+            assert "perm" not in test_item
+        finally:
+            # Cleanup
+            await admin_registry.config.delete_group_dotfile(
+                DeleteGroupDotfileRequest(group=str(group_fixture), path=path)
+            )
 
 
 class TestGroupDotfileUpdate:
@@ -396,9 +504,51 @@ class TestDomainDotfileGet:
             GetDomainDotfileRequest(domain=domain_fixture)
         )
         assert isinstance(result, ListDotfilesResponse)
-        paths = [item.path for item in result.items]
+        # List response is a plain array (via BaseRootResponseModel)
+        paths = [item.path for item in result.root]
         assert f".dlist-a-{unique1}" in paths
         assert f".dlist-b-{unique2}" in paths
+
+    async def test_list_domain_dotfiles_returns_plain_array_json(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        domain_fixture: str,
+        domain_dotfile_factory: DomainDotfileFactory,
+    ) -> None:
+        """Verify the API returns a plain JSON array with 'permission' field.
+
+        This is a regression test for BA-5420 to ensure the response format
+        matches the legacy behavior (plain array with 'permission' field,
+        not {"items": [...]} with 'perm' field).
+        """
+        unique = secrets.token_hex(4)
+        path = f".dlist-test-{unique}"
+        await domain_dotfile_factory(path=path, data="test-data", permission="755")
+        try:
+            result = await admin_registry.config.list_domain_dotfiles(
+                GetDomainDotfileRequest(domain=domain_fixture)
+            )
+            # The response should be a plain array
+            assert isinstance(result.root, list)
+            # Verify model_dump returns the plain array (not wrapped)
+            dumped = result.model_dump()
+            assert isinstance(dumped, list)
+            # Find the test item and verify it has 'permission' field
+            test_items = [
+                item for item in dumped if isinstance(item, dict) and item.get("path") == path
+            ]
+            assert len(test_items) == 1
+            test_item = test_items[0]
+            # Verify field name is 'permission' (not 'perm')
+            assert "permission" in test_item
+            assert test_item["permission"] == "755"
+            # Verify no 'perm' field (should be renamed to 'permission')
+            assert "perm" not in test_item
+        finally:
+            # Cleanup
+            await admin_registry.config.delete_domain_dotfile(
+                DeleteDomainDotfileRequest(domain=domain_fixture, path=path)
+            )
 
 
 class TestDomainDotfileUpdate:

--- a/tests/integration/config/test_config.py
+++ b/tests/integration/config/test_config.py
@@ -81,7 +81,7 @@ class TestBootstrapScriptLifecycle:
             UpdateBootstrapScriptRequest(script=script_v1)
         )
         result_v1 = await admin_registry.config.get_bootstrap_script()
-        assert result_v1.script == script_v1
+        assert result_v1.root == script_v1
 
         # Second update
         script_v2 = f"#!/bin/bash\necho 'v2-{unique}'\nexit 0"
@@ -89,7 +89,7 @@ class TestBootstrapScriptLifecycle:
             UpdateBootstrapScriptRequest(script=script_v2)
         )
         result_v2 = await admin_registry.config.get_bootstrap_script()
-        assert result_v2.script == script_v2
+        assert result_v2.root == script_v2
 
         # Cleanup: reset to empty
         await admin_registry.config.update_bootstrap_script(UpdateBootstrapScriptRequest(script=""))

--- a/tests/unit/client_v2/test_config_client.py
+++ b/tests/unit/client_v2/test_config_client.py
@@ -50,7 +50,7 @@ def _make_request_session(resp: AsyncMock) -> MagicMock:
     return mock_session
 
 
-def _ok_response(data: dict[str, object]) -> AsyncMock:
+def _ok_response(data: dict[str, object] | list[object] | str) -> AsyncMock:
     resp = AsyncMock()
     resp.status = 200
     resp.json = AsyncMock(return_value=data)
@@ -90,12 +90,10 @@ class TestConfigClientUserDotfiles:
         assert result.data == "alias ll='ls -la'"
 
     async def test_list_user_dotfiles(self) -> None:
-        mock_resp = _ok_response({
-            "items": [
-                {"path": ".bashrc", "perm": "644", "data": "content1"},
-                {"path": ".vimrc", "perm": "644", "data": "content2"},
-            ]
-        })
+        mock_resp = _ok_response([
+            {"path": ".bashrc", "permission": "644", "data": "content1"},
+            {"path": ".vimrc", "permission": "644", "data": "content2"},
+        ])
         mock_session = _make_request_session(mock_resp)
         client = _make_client(mock_session)
         config_client = ConfigClient(client)
@@ -103,8 +101,8 @@ class TestConfigClientUserDotfiles:
         result = await config_client.list_user_dotfiles()
 
         assert isinstance(result, ListDotfilesResponse)
-        assert len(result.items) == 2
-        assert result.items[0].path == ".bashrc"
+        assert len(result.root) == 2
+        assert result.root[0].path == ".bashrc"
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "GET"
         assert call_args.kwargs["json"] is None
@@ -139,7 +137,7 @@ class TestConfigClientUserDotfiles:
 
 class TestConfigClientBootstrap:
     async def test_get_bootstrap_script(self) -> None:
-        resp = _ok_response({"script": "#!/bin/bash\necho hello"})
+        resp = _ok_response("#!/bin/bash\necho hello")
         mock_session = _make_request_session(resp)
         client = _make_client(mock_session)
         config_client = ConfigClient(client)
@@ -147,7 +145,7 @@ class TestConfigClientBootstrap:
         result = await config_client.get_bootstrap_script()
 
         assert isinstance(result, GetBootstrapScriptResponse)
-        assert result.script == "#!/bin/bash\necho hello"
+        assert result.root == "#!/bin/bash\necho hello"
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "GET"
         assert "/user-config/bootstrap-script" in str(call_args[0][1])
@@ -198,7 +196,7 @@ class TestConfigClientGroupDotfiles:
         assert result.path == ".bashrc"
 
     async def test_list_group_dotfiles(self) -> None:
-        mock_resp = _ok_response({"items": [{"path": ".bashrc", "perm": "644", "data": "content"}]})
+        mock_resp = _ok_response([{"path": ".bashrc", "permission": "644", "data": "content"}])
         mock_session = _make_request_session(mock_resp)
         client = _make_client(mock_session)
         config_client = ConfigClient(client)
@@ -207,7 +205,7 @@ class TestConfigClientGroupDotfiles:
         result = await config_client.list_group_dotfiles(request)
 
         assert isinstance(result, ListDotfilesResponse)
-        assert len(result.items) == 1
+        assert len(result.root) == 1
 
     async def test_update_group_dotfile(self) -> None:
         mock_resp = _ok_response({})
@@ -267,7 +265,7 @@ class TestConfigClientDomainDotfiles:
         assert result.data == "domain content"
 
     async def test_list_domain_dotfiles(self) -> None:
-        mock_resp = _ok_response({"items": [{"path": ".bashrc", "perm": "644", "data": "content"}]})
+        mock_resp = _ok_response([{"path": ".bashrc", "permission": "644", "data": "content"}])
         mock_session = _make_request_session(mock_resp)
         client = _make_client(mock_session)
         config_client = ConfigClient(client)
@@ -276,7 +274,7 @@ class TestConfigClientDomainDotfiles:
         result = await config_client.list_domain_dotfiles(request)
 
         assert isinstance(result, ListDotfilesResponse)
-        assert len(result.items) == 1
+        assert len(result.root) == 1
 
     async def test_update_domain_dotfile(self) -> None:
         mock_resp = _ok_response({})

--- a/tests/unit/common/dto/manager/config/test_config_dto.py
+++ b/tests/unit/common/dto/manager/config/test_config_dto.py
@@ -29,6 +29,7 @@ from ai.backend.common.dto.manager.config.response import (
     CreateDotfileResponse,
     DeleteDotfileResponse,
     DotfileItem,
+    DotfileListItem,
     GetBootstrapScriptResponse,
     GetDotfileResponse,
     ListDotfilesResponse,
@@ -330,17 +331,17 @@ class TestResponseModels:
 
     def test_list_dotfiles_response(self) -> None:
         items = [
-            DotfileItem(path=".bashrc", perm="644", data="content1"),
-            DotfileItem(path=".vimrc", perm="755", data="content2"),
+            DotfileListItem(path=".bashrc", permission="644", data="content1"),
+            DotfileListItem(path=".vimrc", permission="755", data="content2"),
         ]
-        resp = ListDotfilesResponse(items=items)
-        assert len(resp.items) == 2
-        assert resp.items[0].path == ".bashrc"
-        assert resp.items[1].path == ".vimrc"
+        resp = ListDotfilesResponse(root=items)
+        assert len(resp.root) == 2
+        assert resp.root[0].path == ".bashrc"
+        assert resp.root[1].path == ".vimrc"
 
     def test_get_bootstrap_script_response(self) -> None:
-        resp = GetBootstrapScriptResponse(script="#!/bin/bash\necho hello")
-        assert resp.script == "#!/bin/bash\necho hello"
+        resp = GetBootstrapScriptResponse(root="#!/bin/bash\necho hello")
+        assert resp.root == "#!/bin/bash\necho hello"
 
     def test_update_bootstrap_script_response(self) -> None:
         resp = UpdateBootstrapScriptResponse()
@@ -353,12 +354,12 @@ class TestResponseModels:
         assert restored.success == resp.success
 
     def test_list_dotfiles_response_serialization_roundtrip(self) -> None:
-        items = [DotfileItem(path=".bashrc", perm="644", data="content")]
-        resp = ListDotfilesResponse(items=items)
+        items = [DotfileListItem(path=".bashrc", permission="644", data="content")]
+        resp = ListDotfilesResponse(root=items)
         json_data = resp.model_dump_json()
         restored = ListDotfilesResponse.model_validate_json(json_data)
-        assert len(restored.items) == 1
-        assert restored.items[0].path == ".bashrc"
+        assert len(restored.root) == 1
+        assert restored.root[0].path == ".bashrc"
 
 
 # ---- Field descriptions ----


### PR DESCRIPTION
This is an auto-generated backport PR of #10541 to the 26.3 release.