### PR TITLE
fix(BA-5410): backport sessionresult enum type coexistence fix migration to 26.2 (#10509)

### DIFF
--- a/changes/10509.fix.md
+++ b/changes/10509.fix.md
@@ -1,0 +1,1 @@
+Fix `sessionresult` enum type migration to handle coexistence with `sessionresults` (backport to 26.2)

--- a/src/ai/backend/manager/models/alembic/versions/1cc9b47e0a8e_fix_sessionresult_enum_type_coexistence_backport.py
+++ b/src/ai/backend/manager/models/alembic/versions/1cc9b47e0a8e_fix_sessionresult_enum_type_coexistence_backport.py
@@ -1,0 +1,62 @@
+"""fix sessionresult enum type when both singular and plural coexist (backport)
+
+Revision ID: 1cc9b47e0a8e
+Revises: ffcf0ed13a26
+Create Date: 2026-03-25 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1cc9b47e0a8e"
+down_revision = "ffcf0ed13a26"
+# This migration is intended as a backport target for the 26.2 release branch.
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result_singular = conn.exec_driver_sql("SELECT 1 FROM pg_type WHERE typname = 'sessionresult'")
+    has_singular = result_singular.fetchone() is not None
+
+    result_plural = conn.exec_driver_sql("SELECT 1 FROM pg_type WHERE typname = 'sessionresults'")
+    has_plural = result_plural.fetchone() is not None
+
+    if has_plural and has_singular:
+        # Both types coexist (normal migration path):
+        #   - "sessionresult" was created by 405aa2c39458 (2019, kernels.result)
+        #   - "sessionresults" was created by b6b884fbae1f (2022, sessions.result)
+        #   - ffcf0ed13a26 skipped rename because both existed
+        # Fix: alter sessions.result to use the singular type, then drop plural.
+        conn.exec_driver_sql(
+            "ALTER TABLE sessions ALTER COLUMN result"
+            " TYPE sessionresult USING result::text::sessionresult"
+        )
+        conn.exec_driver_sql("DROP TYPE sessionresults")
+    elif has_plural and not has_singular:
+        # Only plural exists (ffcf0ed13a26 was never applied, or was skipped).
+        # Rename to singular to match EnumType(SessionResult) convention.
+        conn.exec_driver_sql("ALTER TYPE sessionresults RENAME TO sessionresult")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    result_singular = conn.exec_driver_sql("SELECT 1 FROM pg_type WHERE typname = 'sessionresult'")
+    has_singular = result_singular.fetchone() is not None
+
+    result_plural = conn.exec_driver_sql("SELECT 1 FROM pg_type WHERE typname = 'sessionresults'")
+    has_plural = result_plural.fetchone() is not None
+
+    if has_singular and not has_plural:
+        # Recreate the plural type and revert sessions.result to use it.
+        conn.exec_driver_sql(
+            "CREATE TYPE sessionresults AS ENUM ('UNDEFINED', 'SUCCESS', 'FAILURE')"
+        )
+        conn.exec_driver_sql(
+            "ALTER TABLE sessions ALTER COLUMN result"
+            " TYPE sessionresults USING result::text::sessionresults"
+        )

--- a/src/ai/backend/manager/models/alembic/versions/32ad43817452_add_prometheus_query_presets_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/32ad43817452_add_prometheus_query_presets_table.py
@@ -1,7 +1,7 @@
 """add_prometheus_query_presets_table
 
 Revision ID: 32ad43817452
-Revises: ffcf0ed13a26
+Revises: 1cc9b47e0a8e
 Create Date: 2026-02-24 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "32ad43817452"
-down_revision = "ffcf0ed13a26"
+down_revision = "1cc9b47e0a8e"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This is an auto-generated backport PR of #10509 to the 26.3 release.