### PR TITLE
fix: Merge multiple alembic heads f5338adb2de1 and 0a200d0fc480

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/21ce28a1c771_merge_f5338adb2de1_and_0a200d0fc480.py
+++ b/src/ai/backend/manager/models/alembic/versions/21ce28a1c771_merge_f5338adb2de1_and_0a200d0fc480.py
@@ -1,0 +1,21 @@
+"""merge f5338adb2de1 and 0a200d0fc480
+
+Revision ID: 21ce28a1c771
+Revises: f5338adb2de1, 0a200d0fc480
+Create Date: 2026-03-26
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "21ce28a1c771"
+down_revision = ("f5338adb2de1", "0a200d0fc480")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Add merge migration to resolve diverged Alembic heads (`f5338adb2de1` and `0a200d0fc480`)
- Both heads shared `cff56a8381dd` as a common ancestor

## Test plan
- [x] `python ./scripts/check-multiple-alembic-heads.py` passes with single head

🤖 Generated with [Claude Code](https://claude.com/claude-code)