### PR TITLE
feat(BA-5481): add role_assignments field to UserV2GQL type

### DIFF
--- a/changes/10621.feature.md
+++ b/changes/10621.feature.md
@@ -1,0 +1,1 @@
+Add `role_assignments` field to `UserV2GQL` type exposing RBAC role assignments via DataLoader.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14593,6 +14593,9 @@ type UserV2 implements Node
   """The domain this user belongs to."""
   domain: DomainV2
 
+  """Added in UNRELEASED. RBAC roles assigned to this user."""
+  roleAssignments: [RoleAssignment!]!
+
   """Projects this user is a member of."""
   projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
 }

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9072,6 +9072,9 @@ type UserV2 implements Node @key(fields: "id") {
   """The domain this user belongs to."""
   domain: DomainV2
 
+  """Added in UNRELEASED. RBAC roles assigned to this user."""
+  roleAssignments: [RoleAssignment!]!
+
   """Projects this user is a member of."""
   projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
 }

--- a/src/ai/backend/manager/api/gql/user/types/node.py
+++ b/src/ai/backend/manager/api/gql/user/types/node.py
@@ -13,8 +13,10 @@ from strawberry.relay import Connection, Edge, NodeID
 from ai.backend.common.dto.manager.v2.user.response import UserNode
 from ai.backend.common.dto.manager.v2.user.types import UserFairShareScope, UserUsageScope
 from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_federation_type,
     gql_field,
@@ -45,6 +47,7 @@ if TYPE_CHECKING:
         ProjectV2OrderBy,
     )
     from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2Connection
+    from ai.backend.manager.api.gql.rbac.types.role import RoleAssignmentGQL
 
 
 @gql_pydantic_input(
@@ -210,6 +213,25 @@ class UserV2GQL(PydanticNodeMixin[UserNode]):
             self.organization.domain_name
         )
         return domain
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="RBAC roles assigned to this user.",
+        )
+    )  # type: ignore[misc]
+    async def role_assignments(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> list[
+        Annotated[
+            RoleAssignmentGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.rbac.types.role"),
+        ]
+    ]:
+        return await info.context.data_loaders.role_assignments_by_user_loader.load(
+            UUID(str(self.id))
+        )
 
     @gql_field(description="Projects this user is a member of.")  # type: ignore[misc]
     async def projects(


### PR DESCRIPTION
## Summary
- Add a `role_assignments` field to `UserV2GQL` that returns RBAC role assignments for the user
- Uses the existing `role_assignments_by_user_loader` DataLoader to prevent N+1 queries
- Decorated with `gql_added_field` using `NEXT_RELEASE_VERSION` for proper version tracking

## Test plan
- [ ] Verify `role_assignments` field resolves correctly in GraphQL playground
- [ ] Confirm DataLoader batches multiple user role assignment lookups

Resolves BA-5481