### PR TITLE
fix(BA-3308): Support multi-GPU fractional allocation in anti-fragmentation guard (#10477)

### DIFF
--- a/changes/10477.fix.md
+++ b/changes/10477.fix.md
@@ -1,0 +1,1 @@
+Fix anti-fragmentation guard rejecting all multi-device fractional GPU allocations

--- a/src/ai/backend/agent/alloc_map.py
+++ b/src/ai/backend/agent/alloc_map.py
@@ -4,6 +4,7 @@ import enum
 import fnmatch
 import itertools
 import logging
+import math
 import operator
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
@@ -578,18 +579,51 @@ class FractionAllocMap(AbstractAllocMap):
                 requested_alloc=alloc,
                 dev_allocs=sorted_dev_allocs,
             )
-        most_free_dev_id, most_free_device_alloc = sorted_dev_allocs[0]
-        most_free_device_allocatable = (
-            self.device_slots[most_free_dev_id].amount - most_free_device_alloc
+
+        if alloc <= 0:
+            raise InvalidResourceArgument("Allocation amount must be positive.")
+
+        # NOTE: This logic assumes a single node with homogeneous devices (same capacity).
+        # Heterogeneous device mixes or multi-node setups require a separate strategy.
+        device_capacity = self.device_slots[sorted_dev_allocs[0][0]].amount
+        quantum = self.quantum_size
+        min_n = math.ceil(alloc / device_capacity)
+        total_devices = len(sorted_dev_allocs)
+
+        # Pre-compute free capacity for each device (sorted by free desc).
+        dev_free = [
+            self.device_slots[dev_id].amount - current_alloc
+            for dev_id, current_alloc in sorted_dev_allocs
+        ]
+
+        # - Single-device requests (alloc <= capacity): must fit on 1 device, no splitting.
+        # - Multi-device requests (alloc > capacity): try N = min_n, min_n+1, ..., total_devices.
+        #   For each N, compute per-device share D = round_down(alloc / N, quantum).
+        #   Some devices receive D + quantum (to cover the shortfall from rounding).
+        #   Accept if enough devices can hold their respective share.
+        max_n = min_n if alloc <= device_capacity else total_devices
+        for n in range(min_n, max_n + 1):
+            per_device_share = round_down(alloc / Decimal(n), quantum)
+            shortfall = alloc - per_device_share * n
+            extra_devices = math.ceil(shortfall / quantum) if shortfall > 0 else 0
+            high_share = per_device_share + quantum
+            high_count = 0
+            low_count = 0
+            for free in dev_free:
+                if free >= high_share:
+                    high_count += 1
+                elif free >= per_device_share:
+                    low_count += 1
+            if high_count >= extra_devices and (high_count + low_count) >= n:
+                return
+
+        raise FractionalResourceFragmented(
+            "FractionAllocMap: refusing to create kernel with fractional resource fragmented!",
+            context_tag=context_tag,
+            slot_name=slot_name,
+            requested_alloc=alloc,
+            dev_allocs=sorted_dev_allocs,
         )
-        if most_free_device_allocatable < alloc:
-            raise FractionalResourceFragmented(
-                "FractionAllocMap: refusing to create kernel with fractional resource fragmented!",
-                context_tag=context_tag,
-                slot_name=slot_name,
-                requested_alloc=alloc,
-                dev_allocs=sorted_dev_allocs,
-            )
 
     def _allocate_by_filling(
         self,

--- a/tests/unit/agent/test_alloc_map.py
+++ b/tests/unit/agent/test_alloc_map.py
@@ -1,4 +1,6 @@
+import math
 import random
+from dataclasses import dataclass
 from decimal import ROUND_DOWN, Decimal
 
 import attrs
@@ -9,8 +11,10 @@ from ai.backend.agent.alloc_map import (
     DeviceSlotInfo,
     DiscretePropertyAllocMap,
     FractionAllocMap,
+    round_down,
 )
 from ai.backend.agent.exception import (
+    FractionalResourceFragmented,
     InsufficientResource,
     InvalidResourceArgument,
     InvalidResourceCombination,
@@ -931,3 +935,820 @@ def test_heterogeneous_resource_slots_with_fractional_alloc_map() -> None:
     alloc_map.free(result1)
     alloc_map.free(result2)
     check_clean()
+
+
+@dataclass(frozen=True)
+class DefragAllocationExpectation:
+    """Expected values for anti-fragmentation allocation.
+
+    Attributes:
+        requested_resource: Total requested resource amount (e.g. Decimal("1.5"))
+        expected_num_devices: Number of devices needed (e.g. 2)
+        expected_density: Raw per-device density (e.g. Decimal("0.75"))
+        expected_quantized_density: Quantized density (e.g. Decimal("0.8"))
+    """
+
+    requested_resource: Decimal
+    expected_num_devices: int
+    expected_density: Decimal
+    expected_quantized_density: Decimal
+
+
+DEFRAG_ALLOCATION_CASES: list[DefragAllocationExpectation] = [
+    # single device - requested=0.1~1.0
+    DefragAllocationExpectation(Decimal("0.1"), 1, Decimal("0.1"), Decimal("0.1")),
+    DefragAllocationExpectation(Decimal("0.2"), 1, Decimal("0.2"), Decimal("0.2")),
+    DefragAllocationExpectation(Decimal("0.3"), 1, Decimal("0.3"), Decimal("0.3")),
+    DefragAllocationExpectation(Decimal("0.4"), 1, Decimal("0.4"), Decimal("0.4")),
+    DefragAllocationExpectation(Decimal("0.5"), 1, Decimal("0.5"), Decimal("0.5")),
+    DefragAllocationExpectation(Decimal("0.6"), 1, Decimal("0.6"), Decimal("0.6")),
+    DefragAllocationExpectation(Decimal("0.7"), 1, Decimal("0.7"), Decimal("0.7")),
+    DefragAllocationExpectation(Decimal("0.8"), 1, Decimal("0.8"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("0.9"), 1, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("1.0"), 1, Decimal("1.0"), Decimal("1.0")),
+    # two devices - requested=1.1~2.0
+    DefragAllocationExpectation(Decimal("1.1"), 2, Decimal("0.55"), Decimal("0.5")),
+    DefragAllocationExpectation(Decimal("1.2"), 2, Decimal("0.6"), Decimal("0.6")),
+    DefragAllocationExpectation(Decimal("1.3"), 2, Decimal("0.65"), Decimal("0.6")),
+    DefragAllocationExpectation(Decimal("1.4"), 2, Decimal("0.7"), Decimal("0.7")),
+    DefragAllocationExpectation(Decimal("1.5"), 2, Decimal("0.75"), Decimal("0.7")),
+    DefragAllocationExpectation(Decimal("1.6"), 2, Decimal("0.8"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("1.7"), 2, Decimal("0.85"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("1.8"), 2, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("1.9"), 2, Decimal("0.95"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("2.0"), 2, Decimal("1.0"), Decimal("1.0")),
+    # three devices - requested=2.1~3.0
+    DefragAllocationExpectation(Decimal("2.1"), 3, Decimal("0.7"), Decimal("0.7")),
+    DefragAllocationExpectation(
+        Decimal("2.2"), 3, Decimal("0.7333333333333333333333333333"), Decimal("0.7")
+    ),
+    DefragAllocationExpectation(
+        Decimal("2.3"), 3, Decimal("0.7666666666666666666666666667"), Decimal("0.7")
+    ),
+    DefragAllocationExpectation(Decimal("2.4"), 3, Decimal("0.8"), Decimal("0.8")),
+    DefragAllocationExpectation(
+        Decimal("2.5"), 3, Decimal("0.8333333333333333333333333333"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(
+        Decimal("2.6"), 3, Decimal("0.8666666666666666666666666667"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(Decimal("2.7"), 3, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(
+        Decimal("2.8"), 3, Decimal("0.9333333333333333333333333333"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("2.9"), 3, Decimal("0.9666666666666666666666666667"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(Decimal("3.0"), 3, Decimal("1.0"), Decimal("1.0")),
+    # four devices - requested=3.1~4.0
+    DefragAllocationExpectation(Decimal("3.1"), 4, Decimal("0.775"), Decimal("0.7")),
+    DefragAllocationExpectation(Decimal("3.2"), 4, Decimal("0.8"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("3.3"), 4, Decimal("0.825"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("3.4"), 4, Decimal("0.85"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("3.5"), 4, Decimal("0.875"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("3.6"), 4, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("3.7"), 4, Decimal("0.925"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("3.8"), 4, Decimal("0.95"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("3.9"), 4, Decimal("0.975"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("4.0"), 4, Decimal("1.0"), Decimal("1.0")),
+    # five devices - requested=4.1~5.0
+    DefragAllocationExpectation(Decimal("4.1"), 5, Decimal("0.82"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("4.2"), 5, Decimal("0.84"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("4.3"), 5, Decimal("0.86"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("4.4"), 5, Decimal("0.88"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("4.5"), 5, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("4.6"), 5, Decimal("0.92"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("4.7"), 5, Decimal("0.94"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("4.8"), 5, Decimal("0.96"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("4.9"), 5, Decimal("0.98"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("5.0"), 5, Decimal("1.0"), Decimal("1.0")),
+    # six devices - requested=5.1~6.0
+    DefragAllocationExpectation(Decimal("5.1"), 6, Decimal("0.85"), Decimal("0.8")),
+    DefragAllocationExpectation(
+        Decimal("5.2"), 6, Decimal("0.8666666666666666666666666667"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(
+        Decimal("5.3"), 6, Decimal("0.8833333333333333333333333333"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(Decimal("5.4"), 6, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(
+        Decimal("5.5"), 6, Decimal("0.9166666666666666666666666667"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("5.6"), 6, Decimal("0.9333333333333333333333333333"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(Decimal("5.7"), 6, Decimal("0.95"), Decimal("0.9")),
+    DefragAllocationExpectation(
+        Decimal("5.8"), 6, Decimal("0.9666666666666666666666666667"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("5.9"), 6, Decimal("0.9833333333333333333333333333"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(Decimal("6.0"), 6, Decimal("1.0"), Decimal("1.0")),
+    # seven devices - requested=6.1~7.0
+    DefragAllocationExpectation(
+        Decimal("6.1"), 7, Decimal("0.8714285714285714285714285714"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.2"), 7, Decimal("0.8857142857142857142857142857"), Decimal("0.8")
+    ),
+    DefragAllocationExpectation(Decimal("6.3"), 7, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(
+        Decimal("6.4"), 7, Decimal("0.9142857142857142857142857143"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.5"), 7, Decimal("0.9285714285714285714285714286"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.6"), 7, Decimal("0.9428571428571428571428571429"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.7"), 7, Decimal("0.9571428571428571428571428571"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.8"), 7, Decimal("0.9714285714285714285714285714"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(
+        Decimal("6.9"), 7, Decimal("0.9857142857142857142857142857"), Decimal("0.9")
+    ),
+    DefragAllocationExpectation(Decimal("7.0"), 7, Decimal("1.0"), Decimal("1.0")),
+    # eight devices - requested=7.1~8.0
+    DefragAllocationExpectation(Decimal("7.1"), 8, Decimal("0.8875"), Decimal("0.8")),
+    DefragAllocationExpectation(Decimal("7.2"), 8, Decimal("0.9"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.3"), 8, Decimal("0.9125"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.4"), 8, Decimal("0.925"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.5"), 8, Decimal("0.9375"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.6"), 8, Decimal("0.95"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.7"), 8, Decimal("0.9625"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.8"), 8, Decimal("0.975"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("7.9"), 8, Decimal("0.9875"), Decimal("0.9")),
+    DefragAllocationExpectation(Decimal("8.0"), 8, Decimal("1.0"), Decimal("1.0")),
+]
+
+
+class TestDefragDensityCalculation:
+    """Verify density calculations against the BA-3308 table (capacity=1.0, quantum=0.1)."""
+
+    @pytest.fixture
+    def device_capacity(self) -> Decimal:
+        return Decimal("1.0")
+
+    @pytest.fixture
+    def quantum(self) -> Decimal:
+        return Decimal("0.1")
+
+    @pytest.mark.parametrize(
+        "case",
+        DEFRAG_ALLOCATION_CASES,
+        ids=[f"requested={c.requested_resource}" for c in DEFRAG_ALLOCATION_CASES],
+    )
+    async def test_quantum_density_calculation(
+        self,
+        device_capacity: Decimal,
+        quantum: Decimal,
+        case: DefragAllocationExpectation,
+    ) -> None:
+        num_devices_needed = math.ceil(case.requested_resource / device_capacity)
+        assert num_devices_needed == case.expected_num_devices
+
+        per_device_density = case.requested_resource / Decimal(num_devices_needed)
+        assert per_device_density == case.expected_density
+
+        quantized_density = round_down(per_device_density, quantum)
+        assert quantized_density == case.expected_quantized_density
+
+
+class TestDefragAllocationStrategy:
+    """Verify FILL/EVENLY allocation strategies with 8 GPUs (capacity=1.0, quantum=0.1)."""
+
+    @pytest.fixture
+    def defrag_map_8_fill(self) -> FractionAllocMap:
+        """8 GPUs, capacity=1.0 each (total=8.0), FILL strategy, quantum=0.1."""
+        return FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                )
+                for i in range(8)
+            },
+            allocation_strategy=AllocationStrategy.FILL,
+            quantum_size=Decimal("0.1"),
+        )
+
+    @pytest.fixture
+    def defrag_map_8_evenly(self) -> FractionAllocMap:
+        """8 GPUs, capacity=1.0 each (total=8.0), EVENLY strategy, quantum=0.1."""
+        return FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                )
+                for i in range(8)
+            },
+            allocation_strategy=AllocationStrategy.EVENLY,
+            quantum_size=Decimal("0.1"),
+        )
+
+    @pytest.fixture
+    def quantum(self) -> Decimal:
+        return Decimal("0.1")
+
+    @pytest.mark.parametrize(
+        "case",
+        DEFRAG_ALLOCATION_CASES,
+        ids=[f"requested={c.requested_resource}" for c in DEFRAG_ALLOCATION_CASES],
+    )
+    async def test_fill_uses_expected_devices(
+        self,
+        defrag_map_8_fill: FractionAllocMap,
+        quantum: Decimal,
+        case: DefragAllocationExpectation,
+    ) -> None:
+        result = defrag_map_8_fill.allocate(
+            {SlotName("cuda.shares"): case.requested_resource},
+            allow_resource_fragmentation=False,
+        )
+
+        for dev_id, alloc_amount in result[SlotName("cuda.shares")].items():
+            if alloc_amount > 0:
+                # Each allocated amount should be a multiple of the quantum.
+                assert alloc_amount % quantum == 0
+
+        # Count devices that received non-zero allocation
+        used_devices = sum(1 for alloc in result[SlotName("cuda.shares")].values() if alloc > 0)
+        assert used_devices == case.expected_num_devices
+
+    @pytest.mark.parametrize(
+        "case",
+        DEFRAG_ALLOCATION_CASES,
+        ids=[f"requested={c.requested_resource}" for c in DEFRAG_ALLOCATION_CASES],
+    )
+    async def test_evenly_uses_at_least_expected_devices(
+        self,
+        defrag_map_8_evenly: FractionAllocMap,
+        quantum: Decimal,
+        case: DefragAllocationExpectation,
+    ) -> None:
+        result = defrag_map_8_evenly.allocate(
+            {SlotName("cuda.shares"): case.requested_resource},
+            allow_resource_fragmentation=False,
+        )
+
+        for dev_id, alloc_amount in result[SlotName("cuda.shares")].items():
+            if alloc_amount > 0:
+                # Each allocated amount should be a multiple of the quantum.
+                assert alloc_amount % quantum == 0
+
+        # EVENLY strategy may spread across more devices than the minimum needed,
+        # because quantum rounding reduces per-device density and the shortfall spills onto additional devices.
+        # Count devices that received non-zero allocation
+        used_devices = sum(1 for alloc in result[SlotName("cuda.shares")].values() if alloc > 0)
+        assert used_devices >= case.expected_num_devices
+
+    @pytest.mark.parametrize(
+        "requested",
+        [Decimal("0.1"), Decimal("0.5"), Decimal("1.0")],
+        ids=["requested=0.1", "requested=0.5", "requested=1.0"],
+    )
+    async def test_single_device_regression(
+        self, defrag_map_8_fill: FractionAllocMap, requested: Decimal
+    ) -> None:
+        """requested <= 1.0 to 8 device with 1.0 capacity should use exactly 1 device."""
+        result = defrag_map_8_fill.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )
+        # Count devices that received non-zero allocation
+        used = sum(1 for v in result[SlotName("cuda.shares")].values() if v > 0)
+        assert used == 1
+
+    async def test_fragmentation_allowed_bypasses_guard(
+        self, defrag_map_8_fill: FractionAllocMap
+    ) -> None:
+        """allow_resource_fragmentation=True bypasses the guard.
+        8 devices with 1.0 capacity can fulfill any request up to 8.0."""
+        result = defrag_map_8_fill.allocate(
+            {SlotName("cuda.shares"): Decimal("2.5")},
+            allow_resource_fragmentation=True,
+        )
+        total = sum(result[SlotName("cuda.shares")].values())
+        assert total == Decimal("2.5")
+
+
+class TestDefragWithOccupiedDevices:
+    """Verify anti-fragmentation allocation when some devices are already occupied.
+
+    Each scenario is expressed as a list of per-device *remaining* capacity
+    (index → device, value → free fraction) and a separate *requested* amount.
+    ``Decimal("1.0")`` means the device is fully free.
+    """
+
+    @staticmethod
+    def _make_map_with_remaining(
+        device_remaining: list[Decimal],
+        strategy: AllocationStrategy = AllocationStrategy.FILL,
+    ) -> FractionAllocMap:
+        """Create a map where each device has the given remaining capacity.
+
+        Each device has a total capacity of ``1.0``.  The occupied portion
+        (``1.0 - remaining``) is pre-allocated sequentially.
+        """
+        device_capacity = Decimal("1.0")
+        # Pre-occupation always uses FILL so that each amount lands on
+        # the next device in order, producing a deterministic layout.
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=device_capacity,
+                )
+                for i in range(len(device_remaining))
+            },
+            allocation_strategy=AllocationStrategy.FILL,
+            quantum_size=Decimal("0.1"),
+        )
+        for remaining in device_remaining:
+            occupied = device_capacity - remaining
+            if occupied > 0:
+                alloc_map.allocate(
+                    {SlotName("cuda.shares"): occupied},
+                    allow_resource_fragmentation=True,
+                )
+        # Switch to the target strategy for the actual test allocation.
+        alloc_map.allocation_strategy = strategy
+        return alloc_map
+
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 4 GPUs: gpu0 half-free, rest free → 2 GPUs × 0.7
+            ([Decimal("0.5"), Decimal("1.0"), Decimal("1.0"), Decimal("1.0")], Decimal("1.4")),
+            # 4 GPUs: gpu0, gpu1 mostly free → 2 GPUs × 1.0
+            ([Decimal("0.7"), Decimal("0.7"), Decimal("1.0"), Decimal("1.0")], Decimal("2.0")),
+            # 2 GPUs: both above threshold → 2 GPUs × 0.7
+            ([Decimal("0.9"), Decimal("1.0")], Decimal("1.4")),
+        ],
+    )
+    async def test_fill_succeeds(
+        self,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        alloc_map = self._make_map_with_remaining(device_remaining, AllocationStrategy.FILL)
+        alloc_map.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )
+
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 4 GPUs: 2 half-free → 4 GPUs × 0.7, but gpu0,1 only 0.5
+            ([Decimal("0.5"), Decimal("0.5"), Decimal("1.0"), Decimal("1.0")], Decimal("2.8")),
+            # 4 GPUs: all 0.8 free → 4 GPUs × 0.9 needed, but only 0.8 available
+            ([Decimal("0.8"), Decimal("0.8"), Decimal("0.8"), Decimal("0.8")], Decimal("3.6")),
+            # 2 GPUs: gpu0=0.2 free → 2 GPUs × 0.8, but gpu0 below threshold
+            ([Decimal("0.2"), Decimal("1.0")], Decimal("1.6")),
+        ],
+    )
+    async def test_fill_raises(
+        self,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        alloc_map = self._make_map_with_remaining(device_remaining, AllocationStrategy.FILL)
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): requested},
+                allow_resource_fragmentation=False,
+            )
+
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 2 GPUs: both can hold D=0.7 share
+            ([Decimal("0.7"), Decimal("0.8")], Decimal("1.4")),
+        ],
+    )
+    async def test_fill_succeeds_with_non_uniform_free(
+        self,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        """Fill strategy succeeds when each device can hold its per-device share D."""
+        alloc_map = self._make_map_with_remaining(device_remaining, AllocationStrategy.FILL)
+        alloc_map.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )
+
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 4 GPUs: gpu0 half-free, rest free → 2 GPUs × 0.7
+            ([Decimal("0.5"), Decimal("1.0"), Decimal("1.0"), Decimal("1.0")], Decimal("1.4")),
+            # 4 GPUs: gpu0, gpu1 mostly free → 2 GPUs × 1.0
+            ([Decimal("0.7"), Decimal("0.7"), Decimal("1.0"), Decimal("1.0")], Decimal("2.0")),
+            # 2 GPUs: both above threshold → 2 GPUs × 0.7
+            ([Decimal("0.9"), Decimal("1.0")], Decimal("1.4")),
+        ],
+    )
+    async def test_evenly_succeeds(
+        self,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        alloc_map = self._make_map_with_remaining(device_remaining, AllocationStrategy.EVENLY)
+        alloc_map.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )
+
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 4 GPUs: 2 half-free → 4 GPUs × 0.7, but gpu0,1 only 0.5
+            ([Decimal("0.5"), Decimal("0.5"), Decimal("1.0"), Decimal("1.0")], Decimal("2.8")),
+            # 4 GPUs: all 0.8 free → 4 GPUs × 0.9 needed, but only 0.8 available
+            ([Decimal("0.8"), Decimal("0.8"), Decimal("0.8"), Decimal("0.8")], Decimal("3.6")),
+            # 2 GPUs: gpu0=0.2 free → 2 GPUs × 0.8, but gpu0 below threshold
+            ([Decimal("0.2"), Decimal("1.0")], Decimal("1.6")),
+        ],
+    )
+    async def test_evenly_raises(
+        self,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        alloc_map = self._make_map_with_remaining(device_remaining, AllocationStrategy.EVENLY)
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): requested},
+                allow_resource_fragmentation=False,
+            )
+
+
+class TestDefragEdgeCases:
+    """Edge cases for the anti-fragmentation guard, verified for both strategies."""
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_zero_request_is_pruned(self, strategy: AllocationStrategy) -> None:
+        """Zero request is pruned before reaching the guard."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId("gpu0"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                ),
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("0")},
+            allow_resource_fragmentation=False,
+        )
+        assert SlotName("cuda.shares") not in result
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_insufficient_total_devices(self, strategy: AllocationStrategy) -> None:
+        """Raises FractionalResourceFragmented when total devices are insufficient."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                )
+                for i in range(2)
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): Decimal("3.0")},
+                allow_resource_fragmentation=False,
+            )
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_exact_capacity_boundary(self, strategy: AllocationStrategy) -> None:
+        """Request exactly matching device capacity (boundary value)."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                )
+                for i in range(4)
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        # exactly 1.0 -> 1 device
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("1.0")},
+            allow_resource_fragmentation=False,
+        )
+        # Count devices that received non-zero allocation
+        used = sum(1 for v in result[SlotName("cuda.shares")].values() if v > 0)
+        assert used == 1
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_all_capacity_allocation(self, strategy: AllocationStrategy) -> None:
+        """Requesting full capacity uses all devices."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                )
+                for i in range(4)
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("4.0")},
+            allow_resource_fragmentation=False,
+        )
+        total = sum(result[SlotName("cuda.shares")].values())
+        assert total == Decimal("4.0")
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_single_device_map(self, strategy: AllocationStrategy) -> None:
+        """Single device: allocation within capacity succeeds."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId("gpu0"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                ),
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("0.7")},
+            allow_resource_fragmentation=False,
+        )
+        assert result[SlotName("cuda.shares")][DeviceId("gpu0")] == Decimal("0.7")
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_single_device_over_capacity_raises(self, strategy: AllocationStrategy) -> None:
+        """Single device: request exceeding capacity raises."""
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId("gpu0"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=Decimal("1.0"),
+                ),
+            },
+            allocation_strategy=strategy,
+            quantum_size=Decimal("0.1"),
+        )
+
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): Decimal("1.1")},
+                allow_resource_fragmentation=False,
+            )
+
+
+class TestDefragGuardWithNonUniformFreeCapacity:
+    """Verify both strategies succeed with Algorithm 2's N-increment guard.
+
+    When the minimum N devices can't each hold D = R/N, the guard tries N+1, N+2...
+    with a smaller D until it finds enough devices.
+    """
+
+    @staticmethod
+    def _make_map_with_remaining(
+        device_remaining: list[Decimal],
+        strategy: AllocationStrategy,
+    ) -> FractionAllocMap:
+        device_capacity = Decimal("1.0")
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=device_capacity,
+                )
+                for i in range(len(device_remaining))
+            },
+            allocation_strategy=AllocationStrategy.FILL,
+            quantum_size=Decimal("0.1"),
+        )
+        for remaining in device_remaining:
+            occupied = device_capacity - remaining
+            if occupied > 0:
+                alloc_map.allocate(
+                    {SlotName("cuda.shares"): occupied},
+                    allow_resource_fragmentation=True,
+                )
+        alloc_map.allocation_strategy = strategy
+        return alloc_map
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    @pytest.mark.parametrize(
+        "device_remaining, requested",
+        [
+            # 2 GPUs: both can hold D=0.7, shortfall 0.1 covered by gpu1(0.8)
+            ([Decimal("0.7"), Decimal("0.8")], Decimal("1.5")),
+            # 3 GPUs: N=2, D=0.8, gpu1(0.8) + gpu2(1.0) qualify
+            ([Decimal("0.4"), Decimal("0.8"), Decimal("1.0")], Decimal("1.6")),
+            # 4 GPUs: N=2 succeeds, both 1.0-free devices can hold D=0.8
+            ([Decimal("0.5"), Decimal("0.5"), Decimal("1.0"), Decimal("1.0")], Decimal("1.6")),
+        ],
+    )
+    async def test_succeeds_with_non_uniform_free(
+        self,
+        strategy: AllocationStrategy,
+        device_remaining: list[Decimal],
+        requested: Decimal,
+    ) -> None:
+        alloc_map = self._make_map_with_remaining(device_remaining, strategy)
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )
+        total = sum(result[SlotName("cuda.shares")].values())
+        assert total == requested
+
+
+class TestDefragNIncrement:
+    """Verify Algorithm 2: guard increments N when min-N can't hold per-device share D."""
+
+    @staticmethod
+    def _make_map_with_remaining(
+        device_remaining: list[Decimal],
+        strategy: AllocationStrategy,
+    ) -> FractionAllocMap:
+        device_capacity = Decimal("1.0")
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=device_capacity,
+                )
+                for i in range(len(device_remaining))
+            },
+            allocation_strategy=AllocationStrategy.FILL,
+            quantum_size=Decimal("0.1"),
+        )
+        for remaining in device_remaining:
+            occupied = device_capacity - remaining
+            if occupied > 0:
+                alloc_map.allocate(
+                    {SlotName("cuda.shares"): occupied},
+                    allow_resource_fragmentation=True,
+                )
+        alloc_map.allocation_strategy = strategy
+        return alloc_map
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_n_increment_passes(self, strategy: AllocationStrategy) -> None:
+        """4 GPUs each free=0.5, R=1.5.
+        N=2: D=0.7, need 2 with 0.7 free → 0 → fail
+        N=3: D=0.5, shortfall=0, need 3 with 0.5 free → 4 have 0.5 → pass
+        """
+        alloc_map = self._make_map_with_remaining(
+            [Decimal("0.5")] * 4,
+            strategy,
+        )
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("1.5")},
+            allow_resource_fragmentation=False,
+        )
+        total = sum(result[SlotName("cuda.shares")].values())
+        assert total == Decimal("1.5")
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_n_increment_exhausted_rejects(self, strategy: AllocationStrategy) -> None:
+        """4 GPUs each free=0.2, R=1.4.
+        N=2: D=0.7 → fail, N=3: D=0.4 → fail, N=4: D=0.3 → fail (0.2 < 0.3)
+        """
+        alloc_map = self._make_map_with_remaining(
+            [Decimal("0.2")] * 4,
+            strategy,
+        )
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): Decimal("1.4")},
+                allow_resource_fragmentation=False,
+            )
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_n_increment_to_higher_n(self, strategy: AllocationStrategy) -> None:
+        """8 GPUs each free=0.3, R=1.8.
+        N=2: D=0.9 → fail (0.3 < 0.9)
+        N=3: D=0.6 → fail (0.3 < 0.6)
+        ...
+        N=6: D=0.3 → 8 have 0.3 → pass
+        """
+        alloc_map = self._make_map_with_remaining(
+            [Decimal("0.3")] * 8,
+            strategy,
+        )
+        result = alloc_map.allocate(
+            {SlotName("cuda.shares"): Decimal("1.8")},
+            allow_resource_fragmentation=False,
+        )
+        total = sum(result[SlotName("cuda.shares")].values())
+        assert total == Decimal("1.8")
+
+    @pytest.mark.parametrize("strategy", [AllocationStrategy.FILL, AllocationStrategy.EVENLY])
+    async def test_single_device_request_no_increment(self, strategy: AllocationStrategy) -> None:
+        """R <= capacity: N is fixed at 1, no increment allowed.
+        8 GPUs each free=0.3, R=0.8 → N=1 only, 0.3 < 0.8 → reject.
+        """
+        alloc_map = self._make_map_with_remaining(
+            [Decimal("0.3")] * 8,
+            strategy,
+        )
+        with pytest.raises(FractionalResourceFragmented):
+            alloc_map.allocate(
+                {SlotName("cuda.shares"): Decimal("0.8")},
+                allow_resource_fragmentation=False,
+            )
+
+
+class TestShortfallRemainder:
+    """Verify shortfall/remainder calculation matches distribute_evenly logic."""
+
+    @pytest.fixture
+    def device_capacity(self) -> Decimal:
+        return Decimal("1.0")
+
+    @pytest.fixture
+    def quantum(self) -> Decimal:
+        return Decimal("0.1")
+
+    @pytest.mark.parametrize(
+        "requested, expected_quantized_density, expected_extra_device_count",
+        [
+            # 1.5 / 2 devices = 0.75 -> quantized to 0.7, shortfall=0.1, 1 extra device
+            (Decimal("1.5"), Decimal("0.7"), 1),
+            # 2.5 / 3 devices = 0.833 -> quantized to 0.8, shortfall=0.1, 1 extra device
+            (Decimal("2.5"), Decimal("0.8"), 1),
+            # 1.1 / 2 devices = 0.55 -> quantized to 0.5, shortfall=0.1, 1 extra device
+            (Decimal("1.1"), Decimal("0.5"), 1),
+            # 1.2 / 2 devices = 0.6 -> quantized to 0.6, shortfall=0, no extra device
+            (Decimal("1.2"), Decimal("0.6"), 0),
+        ],
+        ids=["requested=1.5", "requested=2.5", "requested=1.1", "requested=1.2"],
+    )
+    async def test_shortfall_remainder_distribution(
+        self,
+        device_capacity: Decimal,
+        quantum: Decimal,
+        requested: Decimal,
+        expected_quantized_density: Decimal,
+        expected_extra_device_count: int,
+    ) -> None:
+        num_devices = math.ceil(requested / device_capacity)
+        per_device_density = requested / Decimal(num_devices)
+        quantized_density = round_down(per_device_density, quantum)
+        shortfall = requested - (quantized_density * num_devices)
+        extra_device_count = round(shortfall / quantum)
+
+        assert quantized_density == expected_quantized_density
+        assert extra_device_count == expected_extra_device_count
+
+        total = quantized_density * num_devices + extra_device_count * quantum
+        assert total == requested
+
+        # Verify actual allocation also succeeds
+        alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId(f"gpu{i}"): DeviceSlotInfo(
+                    slot_type=SlotTypes.COUNT,
+                    slot_name=SlotName("cuda.shares"),
+                    amount=device_capacity,
+                )
+                for i in range(8)
+            },
+            allocation_strategy=AllocationStrategy.FILL,
+            quantum_size=quantum,
+        )
+        alloc_map.allocate(
+            {SlotName("cuda.shares"): requested},
+            allow_resource_fragmentation=False,
+        )


### PR DESCRIPTION
This is an auto-generated backport PR of #10477 to the 26.2 release.