### PR TITLE
fix(BA-5496): Change session rename endpoint to use request body instead of query params (#10653)

### DIFF
--- a/changes/10653.fix.md
+++ b/changes/10653.fix.md
@@ -1,0 +1,1 @@
+Fix session rename endpoint to accept request body instead of query parameters

--- a/src/ai/backend/client/v2/domains/session.py
+++ b/src/ai/backend/client/v2/domains/session.py
@@ -143,11 +143,10 @@ class SessionClient(BaseDomainClient):
         session_name: str,
         request: RenameSessionRequest,
     ) -> None:
-        params = request.model_dump(mode="json", exclude_none=True)
         await self._client.typed_request_no_content(
             "POST",
             f"{_BASE_PATH}/{session_name}/rename",
-            params={k: str(v) for k, v in params.items()},
+            request=request,
         )
 
     async def interrupt(

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -1077,11 +1077,11 @@ class SessionHandler:
 
     async def rename_session(
         self,
-        query: QueryParam[RenameSessionRequest],
+        body: BodyParam[RenameSessionRequest],
         ctx: RequestCtx,
     ) -> web.Response:
         request = ctx.request
-        params = query.parsed
+        params = body.parsed
         session_name = request.match_info["session_name"]
         new_name = params.session_name
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(

--- a/tests/unit/client_v2/test_session.py
+++ b/tests/unit/client_v2/test_session.py
@@ -204,11 +204,11 @@ class TestSessionLifecycle:
 
         await sc.rename("old-name", RenameSessionRequest(session_name="new-name"))
 
-        method, url, _ = _last_request_call(mock_session)
+        method, url, body = _last_request_call(mock_session)
         assert method == "POST"
         assert "/session/old-name/rename" in url
-        call_kwargs = mock_session.request.call_args.kwargs
-        assert call_kwargs["params"]["session_name"] == "new-name"
+        assert body is not None
+        assert body["session_name"] == "new-name"
 
     async def test_interrupt(self) -> None:
         resp = _no_content_response()


### PR DESCRIPTION
This is an auto-generated backport PR of #10653 to the 26.3 release.