### PR TITLE
fix(BA-5498): Use vfolder last_used as fallback for ModelCard modified_at (#10654)

### DIFF
--- a/changes/10654.fix.md
+++ b/changes/10654.fix.md
@@ -1,0 +1,1 @@
+Fix ModelCard `modified_at` to fall back to `last_used` instead of always showing `created_at` when `model-definition.yml` lacks a `last_modified` field.

--- a/src/ai/backend/manager/api/gql_legacy/vfolder.py
+++ b/src/ai/backend/manager/api/gql_legacy/vfolder.py
@@ -587,7 +587,7 @@ class ModelCard(graphene.ObjectType):  # type: ignore[misc]
             title=metadata.get("title") or vfolder_row.name,
             version=metadata.get("version") or "",
             created_at=metadata.get("created") or vfolder_row.created_at,
-            modified_at=metadata.get("last_modified") or vfolder_row.created_at,
+            modified_at=metadata.get("last_modified") or vfolder_row.last_used,
             description=metadata.get("description") or "",
             task=metadata.get("task") or "",
             architecture=metadata.get("architecture") or "",

--- a/tests/unit/manager/api/gql_legacy/BUILD
+++ b/tests/unit/manager/api/gql_legacy/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql_legacy/test_model_card.py
+++ b/tests/unit/manager/api/gql_legacy/test_model_card.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable, Generator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai.backend.manager.api.gql_legacy.vfolder import ModelCard
+
+
+class TestModelCardParseModelModifiedAt:
+    """Tests for ModelCard.parse_model modified_at fallback chain."""
+
+    @pytest.fixture
+    def graph_ctx(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def vfolder_row(self) -> MagicMock:
+        row = MagicMock()
+        row.id = uuid.uuid4()
+        row.name = "test-model"
+        row.creator = "testuser"
+        row.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+        row.last_used = datetime(2025, 6, 15, tzinfo=UTC)
+        return row
+
+    @pytest.fixture
+    def model_def_with_metadata(self) -> Callable[[dict[str, Any]], dict[str, Any]]:
+        def _build(metadata: dict[str, Any]) -> dict[str, Any]:
+            return {"models": [{"name": "test-model", "metadata": metadata}]}
+
+        return _build
+
+    @pytest.fixture(autouse=True)
+    def _mock_vfolder_helpers(self) -> Generator[None]:
+        with (
+            patch(
+                "ai.backend.manager.api.gql_legacy.vfolder.VirtualFolderNode.from_row",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ai.backend.manager.api.gql_legacy.vfolder.VirtualFolder.from_orm_row",
+                return_value=MagicMock(),
+            ),
+        ):
+            yield
+
+    async def test_modified_at_uses_metadata_last_modified_when_present(
+        self,
+        graph_ctx: MagicMock,
+        vfolder_row: MagicMock,
+        model_def_with_metadata: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        expected = "2025-12-25T00:00:00Z"
+        model_def = model_def_with_metadata({"last_modified": expected})
+
+        card = ModelCard.parse_model(graph_ctx, vfolder_row, model_def=model_def)
+
+        assert card.modified_at == expected
+
+    async def test_modified_at_falls_back_to_last_used_when_metadata_missing(
+        self,
+        graph_ctx: MagicMock,
+        vfolder_row: MagicMock,
+        model_def_with_metadata: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        model_def = model_def_with_metadata({})
+
+        card = ModelCard.parse_model(graph_ctx, vfolder_row, model_def=model_def)
+
+        assert card.modified_at == vfolder_row.last_used
+
+    async def test_modified_at_is_none_when_both_metadata_and_last_used_missing(
+        self,
+        graph_ctx: MagicMock,
+        vfolder_row: MagicMock,
+        model_def_with_metadata: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        vfolder_row.last_used = None
+        model_def = model_def_with_metadata({})
+
+        card = ModelCard.parse_model(graph_ctx, vfolder_row, model_def=model_def)
+
+        assert card.modified_at is None


### PR DESCRIPTION
This is an auto-generated backport PR of #10654 to the 26.3 release.