### PR TITLE
test(BA-5583): add unit tests for graphql-transport-ws module

### DIFF
--- a/changes/10773.test.md
+++ b/changes/10773.test.md
@@ -1,0 +1,1 @@
+Add unit tests for the graphql-transport-ws WebSocket protocol module.

--- a/tests/unit/manager/api/gql/graphql_ws/BUILD
+++ b/tests/unit/manager/api/gql/graphql_ws/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/graphql_ws/test_connection.py
+++ b/tests/unit/manager/api/gql/graphql_ws/test_connection.py
@@ -1,0 +1,284 @@
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from aiohttp import WSMsgType
+
+from ai.backend.manager.api.gql.graphql_ws.connection import (
+    GraphQLWSConnection,
+    WSReceiver,
+    WSSender,
+)
+from ai.backend.manager.api.gql.graphql_ws.types import GQLWSMessageType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_msg(*, msg_type: WSMsgType, data: dict[str, Any] | None = None) -> MagicMock:
+    """Create a mock aiohttp WSMessage."""
+    msg = MagicMock()
+    msg.type = msg_type
+    if data is not None:
+        msg.json.return_value = data
+    return msg
+
+
+def _make_mock_ws(*, closed: bool = False) -> AsyncMock:
+    """Create a mock ``web.WebSocketResponse``."""
+    ws = AsyncMock()
+    type(ws).closed = PropertyMock(return_value=closed)
+    return ws
+
+
+# ===========================================================================
+# WSReceiver
+# ===========================================================================
+
+
+class TestWSReceiver:
+    """Tests for the read-side WebSocket view."""
+
+    @pytest.fixture
+    def mock_ws(self) -> AsyncMock:
+        return _make_mock_ws()
+
+    @pytest.fixture
+    def receiver(self, mock_ws: AsyncMock) -> WSReceiver:
+        return WSReceiver(mock_ws)
+
+    # -- receive_init -------------------------------------------------------
+
+    async def test_receive_init_success(self, receiver: WSReceiver, mock_ws: AsyncMock) -> None:
+        mock_ws.receive.return_value = _make_ws_msg(
+            msg_type=WSMsgType.TEXT,
+            data={"type": GQLWSMessageType.CONNECTION_INIT},
+        )
+        assert await receiver.receive_init(wait_seconds=5.0) is True
+
+    async def test_receive_init_wrong_type(self, receiver: WSReceiver, mock_ws: AsyncMock) -> None:
+        mock_ws.receive.return_value = _make_ws_msg(
+            msg_type=WSMsgType.TEXT,
+            data={"type": "subscribe"},
+        )
+        assert await receiver.receive_init(wait_seconds=5.0) is False
+
+    async def test_receive_init_binary_message(
+        self, receiver: WSReceiver, mock_ws: AsyncMock
+    ) -> None:
+        mock_ws.receive.return_value = _make_ws_msg(msg_type=WSMsgType.BINARY)
+        assert await receiver.receive_init(wait_seconds=5.0) is False
+
+    async def test_receive_init_timeout(self, receiver: WSReceiver, mock_ws: AsyncMock) -> None:
+        mock_ws.receive.side_effect = TimeoutError
+        assert await receiver.receive_init(wait_seconds=0.01) is False
+
+    # -- __aiter__ ----------------------------------------------------------
+
+    async def test_aiter_yields_valid_messages(
+        self, receiver: WSReceiver, mock_ws: AsyncMock
+    ) -> None:
+        subscribe_msg = _make_ws_msg(
+            msg_type=WSMsgType.TEXT,
+            data={"type": "subscribe", "id": "1", "payload": {"query": "{ e }"}},
+        )
+        ping_msg = _make_ws_msg(msg_type=WSMsgType.TEXT, data={"type": "ping"})
+        close_msg = _make_ws_msg(msg_type=WSMsgType.CLOSE)
+
+        mock_ws.__aiter__ = lambda self: _async_iter_from([subscribe_msg, ping_msg, close_msg])
+
+        messages: list[Any] = []
+        async for m in receiver:
+            messages.append(m)
+        assert len(messages) == 2
+
+    async def test_aiter_skips_malformed_messages(
+        self, receiver: WSReceiver, mock_ws: AsyncMock
+    ) -> None:
+        bad_msg = _make_ws_msg(
+            msg_type=WSMsgType.TEXT,
+            data={"type": "unknown_garbage"},
+        )
+        good_msg = _make_ws_msg(
+            msg_type=WSMsgType.TEXT,
+            data={"type": "ping"},
+        )
+        close_msg = _make_ws_msg(msg_type=WSMsgType.CLOSE)
+
+        mock_ws.__aiter__ = lambda self: _async_iter_from([bad_msg, good_msg, close_msg])
+
+        messages: list[Any] = []
+        async for m in receiver:
+            messages.append(m)
+        assert len(messages) == 1
+
+    async def test_aiter_stops_on_error(self, receiver: WSReceiver, mock_ws: AsyncMock) -> None:
+        error_msg = _make_ws_msg(msg_type=WSMsgType.ERROR)
+
+        mock_ws.__aiter__ = lambda self: _async_iter_from([error_msg])
+
+        messages: list[Any] = []
+        async for m in receiver:
+            messages.append(m)
+        assert len(messages) == 0
+
+
+# ===========================================================================
+# WSSender
+# ===========================================================================
+
+
+class TestWSSender:
+    """Tests for the write-side WebSocket view."""
+
+    @pytest.fixture
+    def mock_ws(self) -> AsyncMock:
+        return _make_mock_ws()
+
+    @pytest.fixture
+    def sender(self, mock_ws: AsyncMock) -> WSSender:
+        return WSSender(mock_ws)
+
+    # -- send methods -------------------------------------------------------
+
+    async def test_send_ack(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.send_ack()
+        mock_ws.send_json.assert_awaited_once()
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.CONNECTION_ACK
+
+    async def test_send_next(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        result = MagicMock()
+        result.data = {"count": 42}
+        result.errors = None
+
+        await sender.send_next("sub-1", result)
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.NEXT
+        assert payload["id"] == "sub-1"
+        assert payload["payload"]["data"] == {"count": 42}
+
+    async def test_send_next_with_errors(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        error = MagicMock()
+        error.formatted = {"message": "field error", "locations": []}
+        result = MagicMock()
+        result.data = None
+        result.errors = [error]
+
+        await sender.send_next("sub-1", result)
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["payload"]["errors"] == [{"message": "field error", "locations": []}]
+
+    async def test_send_pre_execution_error(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        gql_err = MagicMock()
+        gql_err.formatted = {"message": "syntax error"}
+        error = MagicMock()
+        error.errors = [gql_err]
+
+        await sender.send_pre_execution_error("sub-1", error)
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.ERROR
+        assert payload["id"] == "sub-1"
+        assert payload["payload"] == [{"message": "syntax error"}]
+
+    async def test_send_internal_error(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.send_internal_error("sub-1")
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.ERROR
+        assert payload["payload"] == [{"message": "Internal server error"}]
+
+    async def test_send_complete(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.send_complete("sub-1")
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.COMPLETE
+        assert payload["id"] == "sub-1"
+
+    async def test_send_pong(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.send_pong()
+        payload = mock_ws.send_json.call_args[0][0]
+        assert payload["type"] == GQLWSMessageType.PONG
+
+    # -- close methods ------------------------------------------------------
+
+    async def test_close(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.close()
+        mock_ws.close.assert_awaited_once()
+
+    async def test_close_skipped_when_already_closed(self, sender: WSSender) -> None:
+        closed_ws = _make_mock_ws(closed=True)
+        s = WSSender(closed_ws)
+        await s.close()
+        closed_ws.close.assert_not_awaited()
+
+    async def test_close_init_timeout(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.close_init_timeout()
+        mock_ws.close.assert_awaited_once_with(
+            code=4408, message=b"Connection initialisation timeout"
+        )
+
+    async def test_close_unauthorized(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.close_unauthorized()
+        mock_ws.close.assert_awaited_once_with(code=4401, message=b"Unauthorized")
+
+    async def test_close_duplicate_subscriber(self, sender: WSSender, mock_ws: AsyncMock) -> None:
+        await sender.close_duplicate_subscriber()
+        mock_ws.close.assert_awaited_once_with(code=4409, message=b"Subscriber already exists")
+
+
+# ===========================================================================
+# GraphQLWSConnection
+# ===========================================================================
+
+
+class TestGraphQLWSConnection:
+    """Tests for the connection lifecycle wrapper."""
+
+    @pytest.fixture
+    def mock_ws(self) -> AsyncMock:
+        return _make_mock_ws()
+
+    @pytest.fixture
+    def conn(self, mock_ws: AsyncMock) -> GraphQLWSConnection:
+        return GraphQLWSConnection(mock_ws)
+
+    async def test_wait_connection_init_success(self, conn: GraphQLWSConnection) -> None:
+        with patch.object(conn.receiver, "receive_init", new_callable=AsyncMock) as recv_init:
+            recv_init.return_value = True
+            with patch.object(conn.sender, "send_ack", new_callable=AsyncMock) as send_ack:
+                result = await conn.wait_connection_init(wait_seconds=5.0)
+                assert result is True
+                recv_init.assert_awaited_once_with(wait_seconds=5.0)
+                send_ack.assert_awaited_once()
+
+    async def test_wait_connection_init_timeout(self, conn: GraphQLWSConnection) -> None:
+        with patch.object(conn.receiver, "receive_init", new_callable=AsyncMock) as recv_init:
+            recv_init.return_value = False
+            with patch.object(
+                conn.sender, "close_init_timeout", new_callable=AsyncMock
+            ) as close_timeout:
+                result = await conn.wait_connection_init(wait_seconds=1.0)
+                assert result is False
+                close_timeout.assert_awaited_once()
+
+    async def test_wait_connection_init_exception(self, conn: GraphQLWSConnection) -> None:
+        with patch.object(conn.receiver, "receive_init", new_callable=AsyncMock) as recv_init:
+            recv_init.side_effect = RuntimeError("boom")
+            with patch.object(conn.sender, "close", new_callable=AsyncMock) as close:
+                result = await conn.wait_connection_init(wait_seconds=1.0)
+                assert result is False
+                close.assert_awaited_once()
+
+    def test_handler_return(self, conn: GraphQLWSConnection, mock_ws: AsyncMock) -> None:
+        assert conn.handler_return is mock_ws
+
+
+# ---------------------------------------------------------------------------
+# Async iteration helper
+# ---------------------------------------------------------------------------
+
+
+async def _async_iter_from(items: list[Any]) -> AsyncIterator[Any]:
+    for item in items:
+        yield item

--- a/tests/unit/manager/api/gql/graphql_ws/test_handler.py
+++ b/tests/unit/manager/api/gql/graphql_ws/test_handler.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncIterator, Generator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from aiohttp import web
@@ -48,11 +48,15 @@ class TestGraphQLTransportWSHandler:
         return conn
 
     @pytest.fixture
-    def mock_subs(self) -> AsyncMock:
-        return AsyncMock()
+    def mock_subs(self) -> MagicMock:
+        subs = MagicMock()
+        subs.start = AsyncMock()
+        subs.cancel = Mock()
+        subs.cancel_all = AsyncMock()
+        return subs
 
     @pytest.fixture(autouse=True)
-    def _patch_handler(self, mock_conn: AsyncMock, mock_subs: AsyncMock) -> Generator[None]:
+    def _patch_handler(self, mock_conn: AsyncMock, mock_subs: MagicMock) -> Generator[None]:
         with (
             patch(
                 "ai.backend.manager.api.gql.graphql_ws.handler.GraphQLWSConnection.open",
@@ -84,7 +88,7 @@ class TestGraphQLTransportWSHandler:
         handler: GraphQLTransportWSHandler,
         request_ctx: MagicMock,
         mock_conn: AsyncMock,
-        mock_subs: AsyncMock,
+        mock_subs: MagicMock,
     ) -> None:
         msg = SubscribeMessage(
             type=GQLWSMessageType.SUBSCRIBE,
@@ -103,7 +107,7 @@ class TestGraphQLTransportWSHandler:
         handler: GraphQLTransportWSHandler,
         request_ctx: MagicMock,
         mock_conn: AsyncMock,
-        mock_subs: AsyncMock,
+        mock_subs: MagicMock,
     ) -> None:
         msg = ClientCompleteMessage(type=GQLWSMessageType.COMPLETE, id="1")
         mock_conn.receiver.__aiter__ = lambda self: _async_iter_from([msg])
@@ -130,7 +134,7 @@ class TestGraphQLTransportWSHandler:
         handler: GraphQLTransportWSHandler,
         request_ctx: MagicMock,
         mock_conn: AsyncMock,
-        mock_subs: AsyncMock,
+        mock_subs: MagicMock,
     ) -> None:
         async def _exploding_iter(_err: bool = True) -> AsyncIterator[Any]:
             if _err:

--- a/tests/unit/manager/api/gql/graphql_ws/test_handler.py
+++ b/tests/unit/manager/api/gql/graphql_ws/test_handler.py
@@ -1,0 +1,145 @@
+from collections.abc import AsyncIterator, Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from ai.backend.manager.api.gql.graphql_ws.handler import GraphQLTransportWSHandler
+from ai.backend.manager.api.gql.graphql_ws.types import (
+    ClientCompleteMessage,
+    GQLWSMessageType,
+    PingMessage,
+    SubscribeMessage,
+    SubscribePayload,
+)
+
+
+async def _async_iter_from(items: list[Any]) -> AsyncIterator[Any]:
+    for item in items:
+        yield item
+
+
+class TestGraphQLTransportWSHandler:
+    """Tests for the top-level WS protocol handler."""
+
+    @pytest.fixture
+    def handler(self) -> GraphQLTransportWSHandler:
+        return GraphQLTransportWSHandler(
+            schema=MagicMock(),
+            gql_deps=MagicMock(),
+            max_msg_size=4 * 1024 * 1024,
+            connection_init_timeout=5.0,
+        )
+
+    @pytest.fixture
+    def request_ctx(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.request = MagicMock(spec=web.Request)
+        return ctx
+
+    @pytest.fixture
+    def mock_conn(self) -> AsyncMock:
+        conn = AsyncMock()
+        conn.wait_connection_init.return_value = True
+        conn.sender = AsyncMock()
+        conn.handler_return = MagicMock(spec=web.WebSocketResponse)
+        conn.receiver.__aiter__ = lambda self: _async_iter_from([])
+        return conn
+
+    @pytest.fixture
+    def mock_subs(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture(autouse=True)
+    def _patch_handler(self, mock_conn: AsyncMock, mock_subs: AsyncMock) -> Generator[None]:
+        with (
+            patch(
+                "ai.backend.manager.api.gql.graphql_ws.handler.GraphQLWSConnection.open",
+                new_callable=AsyncMock,
+                return_value=mock_conn,
+            ),
+            patch(
+                "ai.backend.manager.api.gql.graphql_ws.handler.SubscriptionExecutor",
+                return_value=mock_subs,
+            ),
+        ):
+            yield
+
+    async def test_handle_returns_early_on_init_failure(
+        self,
+        handler: GraphQLTransportWSHandler,
+        request_ctx: MagicMock,
+        mock_conn: AsyncMock,
+    ) -> None:
+        mock_conn.wait_connection_init.return_value = False
+
+        result = await handler.handle(request_ctx)
+
+        assert result is mock_conn.handler_return
+        mock_conn.wait_connection_init.assert_awaited_once_with(wait_seconds=5.0)
+
+    async def test_handle_dispatches_subscribe(
+        self,
+        handler: GraphQLTransportWSHandler,
+        request_ctx: MagicMock,
+        mock_conn: AsyncMock,
+        mock_subs: AsyncMock,
+    ) -> None:
+        msg = SubscribeMessage(
+            type=GQLWSMessageType.SUBSCRIBE,
+            id="1",
+            payload=SubscribePayload(query="subscription { e }"),
+        )
+        mock_conn.receiver.__aiter__ = lambda self: _async_iter_from([msg])
+
+        await handler.handle(request_ctx)
+
+        mock_subs.start.assert_awaited_once()
+        mock_subs.cancel_all.assert_awaited_once()
+
+    async def test_handle_dispatches_complete(
+        self,
+        handler: GraphQLTransportWSHandler,
+        request_ctx: MagicMock,
+        mock_conn: AsyncMock,
+        mock_subs: AsyncMock,
+    ) -> None:
+        msg = ClientCompleteMessage(type=GQLWSMessageType.COMPLETE, id="1")
+        mock_conn.receiver.__aiter__ = lambda self: _async_iter_from([msg])
+
+        await handler.handle(request_ctx)
+
+        mock_subs.cancel.assert_called_once()
+        mock_subs.cancel_all.assert_awaited_once()
+
+    async def test_handle_dispatches_ping(
+        self,
+        handler: GraphQLTransportWSHandler,
+        request_ctx: MagicMock,
+        mock_conn: AsyncMock,
+    ) -> None:
+        mock_conn.receiver.__aiter__ = lambda self: _async_iter_from([PingMessage()])
+
+        await handler.handle(request_ctx)
+
+        mock_conn.sender.send_pong.assert_awaited_once()
+
+    async def test_handle_catches_exception_in_message_loop(
+        self,
+        handler: GraphQLTransportWSHandler,
+        request_ctx: MagicMock,
+        mock_conn: AsyncMock,
+        mock_subs: AsyncMock,
+    ) -> None:
+        async def _exploding_iter(_err: bool = True) -> AsyncIterator[Any]:
+            if _err:
+                raise RuntimeError("unexpected")
+            yield
+
+        mock_conn.receiver.__aiter__ = lambda self: _exploding_iter()
+
+        result = await handler.handle(request_ctx)
+
+        assert result is mock_conn.handler_return
+        mock_subs.cancel_all.assert_awaited_once()

--- a/tests/unit/manager/api/gql/graphql_ws/test_subscriptions.py
+++ b/tests/unit/manager/api/gql/graphql_ws/test_subscriptions.py
@@ -1,0 +1,229 @@
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from strawberry.types.execution import ExecutionResult, PreExecutionError
+
+from ai.backend.manager.api.gql.graphql_ws.subscriptions import SubscriptionExecutor
+from ai.backend.manager.api.gql.graphql_ws.types import (
+    ClientCompleteMessage,
+    GQLWSMessageType,
+    SubscribeMessage,
+    SubscribePayload,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sender(*, closed: bool = False) -> AsyncMock:
+    sender = AsyncMock()
+    type(sender).closed = PropertyMock(return_value=closed)
+    return sender
+
+
+def _make_gql_deps() -> MagicMock:
+    deps = MagicMock()
+    deps.processors.events.event_hub = MagicMock()
+    deps.processors.events.event_fetcher = MagicMock()
+    deps.strawberry_gql_adapter = MagicMock()
+    deps.strawberry_data_loaders = MagicMock()
+    deps.metric_observer = MagicMock()
+    deps.adapters = MagicMock()
+    deps.config_provider = MagicMock()
+    return deps
+
+
+def _subscribe_msg(sub_id: str = "1", query: str = "subscription { e }") -> SubscribeMessage:
+    return SubscribeMessage(
+        type=GQLWSMessageType.SUBSCRIBE,
+        id=sub_id,
+        payload=SubscribePayload(query=query),
+    )
+
+
+def _complete_msg(sub_id: str = "1") -> ClientCompleteMessage:
+    return ClientCompleteMessage(type=GQLWSMessageType.COMPLETE, id=sub_id)
+
+
+async def _async_iter_from(items: list[Any]) -> AsyncIterator[Any]:
+    for item in items:
+        yield item
+
+
+# ===========================================================================
+# SubscriptionExecutor
+# ===========================================================================
+
+
+class TestSubscriptionExecutor:
+    """Tests for per-connection subscription management."""
+
+    @pytest.fixture
+    def mock_sender(self) -> AsyncMock:
+        return _make_sender()
+
+    @pytest.fixture
+    def mock_schema(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_deps(self) -> MagicMock:
+        return _make_gql_deps()
+
+    @pytest.fixture
+    def executor(
+        self,
+        mock_sender: AsyncMock,
+        mock_schema: AsyncMock,
+        mock_deps: MagicMock,
+    ) -> SubscriptionExecutor:
+        return SubscriptionExecutor(mock_sender, mock_schema, mock_deps)
+
+    # -- start --------------------------------------------------------------
+
+    async def test_start_creates_task(self, executor: SubscriptionExecutor) -> None:
+        msg = _subscribe_msg("sub-1")
+        await executor.start(msg)
+        assert "sub-1" in executor._tasks
+        await executor.cancel_all()
+
+    async def test_start_duplicate_closes_connection(
+        self, executor: SubscriptionExecutor, mock_sender: AsyncMock
+    ) -> None:
+        msg = _subscribe_msg("dup")
+        await executor.start(msg)
+        # Second start with same id
+        await executor.start(msg)
+        mock_sender.close_duplicate_subscriber.assert_awaited_once()
+        await executor.cancel_all()
+
+    # -- cancel -------------------------------------------------------------
+
+    async def test_cancel_removes_task(self, executor: SubscriptionExecutor) -> None:
+        msg = _subscribe_msg("c1")
+        await executor.start(msg)
+        assert "c1" in executor._tasks
+
+        executor.cancel(_complete_msg("c1"))
+        assert "c1" not in executor._tasks
+
+    def test_cancel_nonexistent_is_noop(self, executor: SubscriptionExecutor) -> None:
+        executor.cancel(_complete_msg("nope"))
+
+    # -- cancel_all ---------------------------------------------------------
+
+    async def test_cancel_all_clears_tasks(self, executor: SubscriptionExecutor) -> None:
+        await executor.start(_subscribe_msg("a"))
+        await executor.start(_subscribe_msg("b"))
+        assert len(executor._tasks) == 2
+
+        await executor.cancel_all()
+        assert len(executor._tasks) == 0
+
+    # -- _run: streaming ----------------------------------------------------
+
+    async def test_run_streams_results_and_completes(
+        self,
+        executor: SubscriptionExecutor,
+        mock_schema: AsyncMock,
+        mock_sender: AsyncMock,
+    ) -> None:
+        result1 = MagicMock(spec=ExecutionResult)
+        result1.data = {"count": 1}
+        result1.errors = None
+        result2 = MagicMock(spec=ExecutionResult)
+        result2.data = {"count": 2}
+        result2.errors = None
+
+        mock_schema.subscribe.return_value = _async_iter_from([result1, result2])
+
+        with patch.object(executor, "_make_gql_context", return_value=MagicMock()):
+            # Run _run directly (not via start, to avoid task indirection)
+            await executor._run("s1", SubscribePayload(query="{ e }"))
+
+        assert mock_sender.send_next.await_count == 2
+        mock_sender.send_complete.assert_awaited_once_with("s1")
+
+    # -- _run: pre-execution error ------------------------------------------
+
+    async def test_run_pre_execution_error(
+        self,
+        executor: SubscriptionExecutor,
+        mock_schema: AsyncMock,
+        mock_sender: AsyncMock,
+    ) -> None:
+        pre_err = MagicMock(spec=PreExecutionError)
+        pre_err.errors = []
+
+        mock_schema.subscribe.return_value = _async_iter_from([pre_err])
+
+        with patch.object(executor, "_make_gql_context", return_value=MagicMock()):
+            await executor._run("s1", SubscribePayload(query="bad"))
+
+        mock_sender.send_pre_execution_error.assert_awaited_once()
+        # complete is still sent after pre-execution error
+        mock_sender.send_complete.assert_awaited_once_with("s1")
+
+    # -- _run: unexpected exception -----------------------------------------
+
+    async def test_run_exception_sends_internal_error(
+        self,
+        executor: SubscriptionExecutor,
+        mock_schema: AsyncMock,
+        mock_sender: AsyncMock,
+    ) -> None:
+        mock_schema.subscribe.side_effect = RuntimeError("boom")
+
+        with patch.object(executor, "_make_gql_context", return_value=MagicMock()):
+            await executor._run("s1", SubscribePayload(query="{ e }"))
+
+        mock_sender.send_internal_error.assert_awaited_once_with("s1")
+        mock_sender.send_complete.assert_awaited_once_with("s1")
+
+    # -- _run: cancellation -------------------------------------------------
+
+    async def test_run_cancellation_does_not_send_complete(
+        self,
+        executor: SubscriptionExecutor,
+        mock_schema: AsyncMock,
+        mock_sender: AsyncMock,
+    ) -> None:
+        started = asyncio.Event()
+
+        async def _hang_forever() -> AsyncIterator[Any]:
+            started.set()
+            await asyncio.sleep(999)
+            yield  # unreachable
+
+        mock_schema.subscribe.return_value = _hang_forever()
+
+        with patch.object(executor, "_make_gql_context", return_value=MagicMock()):
+            task = asyncio.create_task(executor._run("s1", SubscribePayload(query="{ e }")))
+            await started.wait()
+            task.cancel()
+            # _run catches CancelledError internally — task completes normally
+            await task
+
+        mock_sender.send_complete.assert_not_awaited()
+
+    # -- _run: sender closed mid-stream -------------------------------------
+
+    async def test_run_stops_when_sender_closed(
+        self,
+        executor: SubscriptionExecutor,
+        mock_schema: AsyncMock,
+    ) -> None:
+        closed_sender = _make_sender(closed=True)
+        executor._sender = closed_sender
+
+        result = MagicMock()
+        mock_schema.subscribe.return_value = _async_iter_from([result])
+
+        with patch.object(executor, "_make_gql_context", return_value=MagicMock()):
+            await executor._run("s1", SubscribePayload(query="{ e }"))
+
+        closed_sender.send_next.assert_not_awaited()

--- a/tests/unit/manager/api/gql/graphql_ws/test_types.py
+++ b/tests/unit/manager/api/gql/graphql_ws/test_types.py
@@ -1,0 +1,145 @@
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from ai.backend.manager.api.gql.graphql_ws.types import (
+    ClientCompleteMessage,
+    ClientMessage,
+    ConnectionAckMessage,
+    ErrorMessage,
+    GQLWSMessageType,
+    NextMessage,
+    NextPayload,
+    PingMessage,
+    PongMessage,
+    ServerCompleteMessage,
+    SubscribeMessage,
+    SubscribePayload,
+)
+
+_client_msg_adapter: TypeAdapter[ClientMessage] = TypeAdapter(ClientMessage)
+
+
+class TestClientMessageDeserialization:
+    """Discriminated union parsing for post-init client messages."""
+
+    def test_subscribe_message(self) -> None:
+        raw: dict[str, Any] = {
+            "type": "subscribe",
+            "id": "1",
+            "payload": {"query": "subscription { events }"},
+        }
+        msg = _client_msg_adapter.validate_python(raw)
+        assert isinstance(msg, SubscribeMessage)
+        assert msg.id == "1"
+        assert msg.payload.query == "subscription { events }"
+
+    def test_subscribe_message_with_variables(self) -> None:
+        raw: dict[str, Any] = {
+            "type": "subscribe",
+            "id": "2",
+            "payload": {
+                "query": "subscription($id: ID!) { events(id: $id) }",
+                "variables": {"id": "abc"},
+                "operationName": "Events",
+            },
+        }
+        msg = _client_msg_adapter.validate_python(raw)
+        assert isinstance(msg, SubscribeMessage)
+        assert msg.payload.variables == {"id": "abc"}
+        assert msg.payload.operationName == "Events"
+
+    def test_complete_message(self) -> None:
+        raw: dict[str, Any] = {"type": "complete", "id": "1"}
+        msg = _client_msg_adapter.validate_python(raw)
+        assert isinstance(msg, ClientCompleteMessage)
+        assert msg.id == "1"
+
+    def test_ping_message(self) -> None:
+        msg = _client_msg_adapter.validate_python({"type": "ping"})
+        assert isinstance(msg, PingMessage)
+        assert msg.payload is None
+
+    def test_ping_message_with_payload(self) -> None:
+        msg = _client_msg_adapter.validate_python({"type": "ping", "payload": {"key": "val"}})
+        assert isinstance(msg, PingMessage)
+        assert msg.payload == {"key": "val"}
+
+    def test_pong_message(self) -> None:
+        msg = _client_msg_adapter.validate_python({"type": "pong"})
+        assert isinstance(msg, PongMessage)
+
+    def test_unknown_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _client_msg_adapter.validate_python({"type": "connection_ack"})
+
+    def test_missing_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _client_msg_adapter.validate_python({"id": "1"})
+
+    def test_subscribe_missing_payload_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _client_msg_adapter.validate_python({"type": "subscribe", "id": "1"})
+
+
+class TestServerMessageSerialization:
+    """Server message model_dump produces protocol-compliant dicts."""
+
+    def test_connection_ack(self) -> None:
+        msg = ConnectionAckMessage()
+        d = msg.model_dump(exclude_none=True)
+        assert d == {"type": GQLWSMessageType.CONNECTION_ACK}
+
+    def test_next_message(self) -> None:
+        payload = NextPayload(data={"foo": "bar"})
+        msg = NextMessage(id="1", payload=payload)
+        d = msg.model_dump(exclude_none=True)
+        assert d == {
+            "type": GQLWSMessageType.NEXT,
+            "id": "1",
+            "payload": {"data": {"foo": "bar"}},
+        }
+
+    def test_next_message_with_errors(self) -> None:
+        payload = NextPayload(data=None, errors=[{"message": "oops"}])
+        msg = NextMessage(id="1", payload=payload)
+        d = msg.model_dump(exclude_none=True)
+        assert d["payload"]["errors"] == [{"message": "oops"}]
+
+    def test_error_message(self) -> None:
+        msg = ErrorMessage(id="1", payload=[{"message": "bad query"}])
+        d = msg.model_dump(exclude_none=True)
+        assert d == {
+            "type": GQLWSMessageType.ERROR,
+            "id": "1",
+            "payload": [{"message": "bad query"}],
+        }
+
+    def test_server_complete_message(self) -> None:
+        msg = ServerCompleteMessage(id="1")
+        d = msg.model_dump(exclude_none=True)
+        assert d == {"type": GQLWSMessageType.COMPLETE, "id": "1"}
+
+    def test_pong_message(self) -> None:
+        msg = PongMessage()
+        d = msg.model_dump(exclude_none=True)
+        assert d == {"type": GQLWSMessageType.PONG}
+
+
+class TestSubscribePayload:
+    """SubscribePayload defaults and construction."""
+
+    def test_minimal(self) -> None:
+        p = SubscribePayload(query="{ __typename }")
+        assert p.variables is None
+        assert p.operationName is None
+
+    def test_full(self) -> None:
+        p = SubscribePayload(
+            query="subscription { e }",
+            variables={"x": 1},
+            operationName="E",
+        )
+        assert p.variables == {"x": 1}
+        assert p.operationName == "E"


### PR DESCRIPTION
## Summary
- Add dedicated unit tests for the `graphql_ws` package (`src/ai/backend/manager/api/gql/graphql_ws/`) introduced in BA-5564
- Cover all 4 modules: message DTOs (`types.py`), connection wrapper (`connection.py`), subscription executor (`subscriptions.py`), and WS handler (`handler.py`)
- 48 test cases total, exercising happy paths, error paths, timeouts, cancellation, and edge cases

## Test plan
- [x] `pants lint` passes
- [x] `pants check` passes (no mypy errors in test files)
- [x] `pants test tests/unit/manager/api/gql/graphql_ws/` — all 48 tests pass

Resolves BA-5583