### PR TITLE
feat(BA-5630): add login_client_types table and data layer

### DIFF
--- a/changes/10822.feature.md
+++ b/changes/10822.feature.md
@@ -1,0 +1,1 @@
+Add the `login_client_types` table, model, data dataclass, and repository so administrators can register and manage login client types at runtime.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -102,6 +102,7 @@ class EntityType(enum.StrEnum):
     GROUP = "group"
     KERNEL = "kernel"
     KEYPAIR = "keypair"
+    LOGIN_CLIENT_TYPE = "login_client_type"
     LOGIN_SESSION = "login_session"
     MODEL_SERVICE = "model_service"
     NETWORK = "network"

--- a/src/ai/backend/manager/data/login_client_type/__init__.py
+++ b/src/ai/backend/manager/data/login_client_type/__init__.py
@@ -1,0 +1,3 @@
+from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
+
+__all__ = ("LoginClientTypeData",)

--- a/src/ai/backend/manager/data/login_client_type/types.py
+++ b/src/ai/backend/manager/data/login_client_type/types.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+__all__ = ("LoginClientTypeData",)
+
+
+@dataclass(frozen=True)
+class LoginClientTypeData:
+    id: UUID
+    name: str
+    description: str | None
+    created_at: datetime
+    modified_at: datetime

--- a/src/ai/backend/manager/errors/auth.py
+++ b/src/ai/backend/manager/errors/auth.py
@@ -171,6 +171,29 @@ class LoginBlockedError(BackendAIError, web.HTTPTooManyRequests):
         )
 
 
+class LoginClientTypeNotFound(ObjectNotFound):
+    object_name = "login_client_type"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AUTH,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
+class LoginClientTypeConflict(BackendAIError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/login-client-type-conflict"
+    error_title = "A login client type with the same name already exists."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AUTH,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
 class TooManyConcurrentLoginSessions(BackendAIError, web.HTTPTooManyRequests):
     error_type = "https://api.backend.ai/probs/too-many-concurrent-logins"
     error_title = "Too many concurrent login sessions for this user."

--- a/src/ai/backend/manager/models/alembic/versions/be1ac9308056_add_login_client_types_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/be1ac9308056_add_login_client_types_table.py
@@ -1,0 +1,95 @@
+"""add login_client_types table
+
+Revision ID: be1ac9308056
+Revises: 2c9000848b6e
+Create Date: 2026-04-09
+
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "be1ac9308056"
+down_revision = "2c9000848b6e"
+# Part of: 26.3.0
+branch_labels = None
+depends_on = None
+
+
+# Fixed UUIDs for seed rows so references (tests, GQL selections) stay stable.
+_SEED_CORE_ID = uuid.UUID("00000000-0000-0000-0000-00000000c02e")
+_SEED_WEBUI_ID = uuid.UUID("00000000-0000-0000-0000-0000000000eb")
+_SEED_FASTTRACK_ID = uuid.UUID("00000000-0000-0000-0000-00000000fa57")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "login_client_types" not in inspector.get_table_names():
+        op.create_table(
+            "login_client_types",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("uuid_generate_v4()"),
+            ),
+            sa.Column("name", sa.String(length=64), nullable=False, unique=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "modified_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                onupdate=sa.func.now(),
+                nullable=False,
+            ),
+        )
+
+        # Seed the three well-known client types so existing login flows keep working
+        # right after the migration. Administrators can add/remove types afterwards
+        # via the login_client_type CRUD APIs.
+        login_client_types_table = sa.table(
+            "login_client_types",
+            sa.column("id", postgresql.UUID(as_uuid=True)),
+            sa.column("name", sa.String),
+            sa.column("description", sa.Text),
+        )
+        op.bulk_insert(
+            login_client_types_table,
+            [
+                {
+                    "id": _SEED_CORE_ID,
+                    "name": "core",
+                    "description": "Backend.AI CLI / core SDK clients.",
+                },
+                {
+                    "id": _SEED_WEBUI_ID,
+                    "name": "webui",
+                    "description": "Backend.AI web console.",
+                },
+                {
+                    "id": _SEED_FASTTRACK_ID,
+                    "name": "fasttrack",
+                    "description": "Backend.AI FastTrack workflow client.",
+                },
+            ],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "login_client_types" in inspector.get_table_names():
+        op.drop_table("login_client_types")

--- a/src/ai/backend/manager/models/login_client_type/__init__.py
+++ b/src/ai/backend/manager/models/login_client_type/__init__.py
@@ -1,0 +1,3 @@
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+
+__all__ = ("LoginClientTypeRow",)

--- a/src/ai/backend/manager/models/login_client_type/row.py
+++ b/src/ai/backend/manager/models/login_client_type/row.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.manager.models.base import GUID, Base
+
+if TYPE_CHECKING:
+    from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
+
+__all__ = ("LoginClientTypeRow",)
+
+
+class LoginClientTypeRow(Base):  # type: ignore[misc]
+    __tablename__ = "login_client_types"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+    modified_at: Mapped[datetime] = mapped_column(
+        "modified_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )
+
+    def to_dataclass(self) -> LoginClientTypeData:
+        from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
+
+        return LoginClientTypeData(
+            id=self.id,
+            name=self.name,
+            description=self.description,
+            created_at=self.created_at,
+            modified_at=self.modified_at,
+        )

--- a/src/ai/backend/manager/repositories/login_client_type/__init__.py
+++ b/src/ai/backend/manager/repositories/login_client_type/__init__.py
@@ -1,0 +1,5 @@
+from ai.backend.manager.repositories.login_client_type.repository import (
+    LoginClientTypeRepository,
+)
+
+__all__ = ("LoginClientTypeRepository",)

--- a/src/ai/backend/manager/repositories/login_client_type/creators.py
+++ b/src/ai/backend/manager/repositories/login_client_type/creators.py
@@ -1,0 +1,40 @@
+"""CreatorSpec implementations for login_client_type repository."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.errors.auth import LoginClientTypeConflict
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.repositories.base import CreatorSpec
+from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
+
+
+@dataclass
+class LoginClientTypeCreatorSpec(CreatorSpec[LoginClientTypeRow]):
+    """CreatorSpec for login client type creation."""
+
+    name: str
+    description: str | None
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=UniqueConstraintViolationError,
+                error=LoginClientTypeConflict(
+                    f"A login client type with name '{self.name}' already exists."
+                ),
+            ),
+        )
+
+    @override
+    def build_row(self) -> LoginClientTypeRow:
+        return LoginClientTypeRow(
+            name=self.name,
+            description=self.description,
+        )

--- a/src/ai/backend/manager/repositories/login_client_type/db_source.py
+++ b/src/ai/backend/manager/repositories/login_client_type/db_source.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
+from ai.backend.manager.errors.auth import LoginClientTypeNotFound
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+
+__all__ = ("LoginClientTypeDBSource",)
+
+
+class LoginClientTypeDBSource:
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    async def create(
+        self,
+        creator: Creator[LoginClientTypeRow],
+    ) -> LoginClientTypeData:
+        async with self._db.begin_session() as session:
+            result = await execute_creator(session, creator)
+            return result.row.to_dataclass()
+
+    async def get_by_id(self, type_id: UUID) -> LoginClientTypeData:
+        async with self._db.begin_readonly_session() as session:
+            row = cast(
+                LoginClientTypeRow | None,
+                await session.scalar(
+                    sa.select(LoginClientTypeRow).where(LoginClientTypeRow.id == type_id)
+                ),
+            )
+            if row is None:
+                raise LoginClientTypeNotFound(
+                    extra_msg=f"Login client type with id {type_id} not found."
+                )
+            return row.to_dataclass()
+
+    async def get_by_name(self, name: str) -> LoginClientTypeData:
+        async with self._db.begin_readonly_session() as session:
+            row = cast(
+                LoginClientTypeRow | None,
+                await session.scalar(
+                    sa.select(LoginClientTypeRow).where(LoginClientTypeRow.name == name)
+                ),
+            )
+            if row is None:
+                raise LoginClientTypeNotFound(
+                    extra_msg=f"Login client type with name '{name}' not found."
+                )
+            return row.to_dataclass()
+
+    async def update(
+        self,
+        updater: Updater[LoginClientTypeRow],
+    ) -> LoginClientTypeData:
+        async with self._db.begin_session() as session:
+            result = await execute_updater(session, updater)
+            if result is None:
+                raise LoginClientTypeNotFound(
+                    extra_msg=f"Login client type with id {updater.pk_value} not found."
+                )
+            return result.row.to_dataclass()
+
+    async def delete(self, type_id: UUID) -> LoginClientTypeData:
+        async with self._db.begin_session() as session:
+            row = cast(
+                LoginClientTypeRow | None,
+                await session.scalar(
+                    sa.select(LoginClientTypeRow).where(LoginClientTypeRow.id == type_id)
+                ),
+            )
+            if row is None:
+                raise LoginClientTypeNotFound(
+                    extra_msg=f"Login client type with id {type_id} not found."
+                )
+            data = row.to_dataclass()
+            await session.delete(row)
+            return data

--- a/src/ai/backend/manager/repositories/login_client_type/repository.py
+++ b/src/ai/backend/manager/repositories/login_client_type/repository.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.updater import Updater
+from ai.backend.manager.repositories.login_client_type.db_source import (
+    LoginClientTypeDBSource,
+)
+
+__all__ = ("LoginClientTypeRepository",)
+
+
+class LoginClientTypeRepository:
+    _db_source: LoginClientTypeDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = LoginClientTypeDBSource(db)
+
+    async def create(self, creator: Creator[LoginClientTypeRow]) -> LoginClientTypeData:
+        return await self._db_source.create(creator)
+
+    async def get_by_id(self, type_id: UUID) -> LoginClientTypeData:
+        return await self._db_source.get_by_id(type_id)
+
+    async def get_by_name(self, name: str) -> LoginClientTypeData:
+        return await self._db_source.get_by_name(name)
+
+    async def update(self, updater: Updater[LoginClientTypeRow]) -> LoginClientTypeData:
+        return await self._db_source.update(updater)
+
+    async def delete(self, type_id: UUID) -> LoginClientTypeData:
+        return await self._db_source.delete(type_id)

--- a/src/ai/backend/manager/repositories/login_client_type/updaters.py
+++ b/src/ai/backend/manager/repositories/login_client_type/updaters.py
@@ -1,0 +1,30 @@
+"""UpdaterSpec implementations for login_client_type repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, override
+
+from ai.backend.manager.models.login_client_type.row import LoginClientTypeRow
+from ai.backend.manager.repositories.base.updater import UpdaterSpec
+from ai.backend.manager.types import OptionalState, TriState
+
+
+@dataclass
+class LoginClientTypeUpdaterSpec(UpdaterSpec[LoginClientTypeRow]):
+    """UpdaterSpec for login client type updates."""
+
+    name: OptionalState[str] = field(default_factory=OptionalState[str].nop)
+    description: TriState[str] = field(default_factory=TriState[str].nop)
+
+    @property
+    @override
+    def row_class(self) -> type[LoginClientTypeRow]:
+        return LoginClientTypeRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        to_update: dict[str, Any] = {}
+        self.name.update_dict(to_update, "name")
+        self.description.update_dict(to_update, "description")
+        return to_update


### PR DESCRIPTION
## Summary

Split from the original +1517/-56 BA-5630 scope per reviewer feedback on size. This PR is slice **1/4** and contains only the database foundation: no runtime behavior changes.

## What changed

- Alembic migration `be1ac9308056_add_login_client_types_table`: create `login_client_types` and seed `core` / `webui` / `fasttrack`. Does NOT touch `login_sessions`.
- Model `Row`, frozen `Data` dataclass, and `Repository` (with `db_source`) for login_client_types.
- New errors: `LoginClientTypeNotFound`, `LoginClientTypeConflict`.

## Slice dependency chain

1. **#10822 (this PR) — slice 1/4:** DB foundation (migration + model + repository). Pure addition.
2. **#10923 — slice 2/4:** Service, Actions, Processor, v2 DTOs. Depends on 1.
3. **#10924 — slice 3/4:** REST v2 CRUD handler + Adapter. Depends on 2.
4. **#10925 — slice 4/4:** Auth flow cutover, second migration (FK swap), `factory.py` wiring, tests. Depends on 3.

Each follow-up slice targets the previous slice's branch as its base, so merging top-to-bottom cleanly delivers the whole feature.

## Notes for the reviewer

- The original migration `e6036371b6b5` was split into two files: this slice ships `be1ac9308056` (table create + seed only). The `login_sessions.client_type` → FK column swap lands in slice 4 as `96f056c88d3d`.
- The BA-5631 (GraphQL, #10876) / BA-5632 (SDK) / BA-5633 (CLI) follow-up work stacks on top of slice 3 (#10924).
- Backup tag `backup/BA-5630-pre-split` exists locally pointing at the pre-split HEAD `7a91b131c` for recovery reference.

## Test plan

- [x] pants fmt/fix/lint/check green on changed files
- [ ] pants test for login_client_type repository (requires real db; reviewer to verify in CI)

Resolves BA-5630.

## 📚 Stack

- `main`
  - ✅ 👉 **#10822** — feat(BA-5630) DB foundation
    - ✅ #10923 — feat(BA-5630) service layer + DTO
      - #10924 — feat(BA-5630) REST v2 CRUD
        - ✅ #10925 — refactor(BA-5630) auth cutover
          - ✅ #10876 — feat(BA-5631) GraphQL schema
            - ✅ #10942 — feat(BA-5632) Client SDK + CLI

**Merge order:** top to bottom. This PR is marked with 👉.