### PR TITLE
fix(BA-5520): use target ownership policy for VFolder clone max_vfolder_count check (#10797)

### DIFF
--- a/changes/10797.fix.md
+++ b/changes/10797.fix.md
@@ -1,0 +1,1 @@
+Fix VFolder clone to check the target ownership's resource policy for max_vfolder_count instead of the source project's policy

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -684,11 +684,11 @@ class VFolderService:
             user_uuid=action.requester_user_uuid,
             resource_policy={"allowed_vfolder_hosts": allowed_vfolder_hosts},
             domain_name=user_domain_name,
-            group_id=source_vfolder_data.group,
+            group_id=None,
         )
 
         max_vfolder_count = await self._vfolder_repository.get_max_vfolder_count(
-            action.requester_user_uuid, source_vfolder_data.group
+            action.requester_user_uuid, None
         )
 
         # Check resource policy's max_vfolder_count
@@ -1301,3 +1301,361 @@ class VFolderService:
         if action.required_status is not None:
             await _check_vfolder_status(row["status"], action.required_status)
         return GetAccessibleVFolderActionResult(row=row)
+
+    async def create_v2(self, action: CreateVFolderV2Action) -> CreateVFolderV2ActionResult:
+        """Create a new vfolder (v2). Resolves policy internally from user_id."""
+        user_uuid = action.user_id
+        domain_name = action.domain_name
+        project_id = action.project_id
+
+        # Resolve user info from DB
+        user = await self._user_repository.get_user_by_uuid(user_uuid)
+        if user.role is None or user.domain_name is None:
+            raise ObjectNotFound(object_name="User")
+        user_role = user.role
+
+        # Resolve host
+        folder_host = action.host
+        if not folder_host:
+            folder_host = self._config_provider.config.volumes.default_host
+            if not folder_host:
+                raise VFolderInvalidParameter(
+                    "You must specify the vfolder host because the default host is not configured."
+                )
+
+        allowed_vfolder_types = (
+            await self._config_provider.legacy_etcd_config_loader.get_vfolder_types()
+        )
+
+        if action.name.startswith(".") and action.name != ".local":
+            if project_id is not None:
+                raise VFolderInvalidParameter("dot-prefixed vfolders cannot be a group folder.")
+
+        group_uuid: uuid.UUID | None = None
+        group_type: ProjectType | None = None
+        max_vfolder_count: int
+        max_quota_scope_size: int
+        container_uid: int | None = None
+
+        if project_id is not None:
+            group_info = await self._vfolder_repository.get_group_resource_info(
+                project_id, domain_name
+            )
+            if not group_info:
+                raise ProjectNotFound(f"Project with {project_id} not found.")
+            group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
+            container_uid = None
+        else:
+            user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
+            if not user_info:
+                raise ObjectNotFound(object_name="User")
+            max_vfolder_count, max_quota_scope_size, container_uid = user_info
+
+        vfolder_permission_mode = (
+            VFOLDER_GROUP_PERMISSION_MODE if container_uid is not None else None
+        )
+
+        # Determine ownership
+        if group_uuid is not None:
+            ownership_type = "group"
+            quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
+            if (
+                user_role not in (UserRole.SUPERADMIN, UserRole.ADMIN)
+                and group_type != ProjectType.MODEL_STORE
+            ):
+                raise Forbidden("no permission")
+        else:
+            ownership_type = "user"
+            quota_scope_id = QuotaScopeID(QuotaScopeType.USER, user_uuid)
+        if ownership_type not in allowed_vfolder_types:
+            raise VFolderInvalidParameter(
+                f"{ownership_type}-owned vfolder is not allowed in this cluster"
+            )
+
+        if group_type == ProjectType.MODEL_STORE:
+            if action.usage_mode != VFolderUsageMode.MODEL:
+                raise VFolderInvalidParameter(
+                    "Only Model VFolder can be created under the model store project"
+                )
+
+        # Host permission check — resolved from user_id, not passed resource_policy
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            folder_host,
+            permission=VFolderHostPermission.CREATE,
+            user_uuid=user_uuid,
+            group_id=group_uuid,
+        )
+
+        # Quota check
+        if max_vfolder_count > 0:
+            if ownership_type == "user":
+                current_count = await self._vfolder_repository.count_vfolders_by_user(user_uuid)
+            else:
+                if group_uuid is None:
+                    raise VFolderInvalidParameter("Group UUID is required for group-owned vfolders")
+                current_count = await self._vfolder_repository.count_vfolders_by_group(group_uuid)
+            if current_count >= max_vfolder_count:
+                raise VFolderInvalidParameter("You cannot create more vfolders.")
+
+        # Name uniqueness check
+        name_exists = await self._vfolder_repository.check_vfolder_name_exists(
+            action.name, user_uuid, user_role, domain_name, list(allowed_vfolder_types)
+        )
+        if name_exists:
+            raise VFolderAlreadyExists(
+                f"VFolder with the given name already exists. ({action.name})"
+            )
+
+        # Create in storage
+        folder_id = uuid.uuid4()
+        try:
+            vfid = VFolderID(quota_scope_id, folder_id)
+            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
+            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+            await manager_client.create_folder(
+                volume_name, str(vfid), max_quota_scope_size, vfolder_permission_mode
+            )
+        except aiohttp.ClientResponseError as e:
+            raise VFolderCreationFailure from e
+
+        mount_permission = action.permission
+        if group_type == ProjectType.MODEL_STORE:
+            mount_permission = VFolderPermission.READ_ONLY
+
+        # Create in DB
+        params = VFolderCreateParams(
+            id=folder_id,
+            name=action.name,
+            domain_name=domain_name,
+            quota_scope_id=str(quota_scope_id),
+            usage_mode=action.usage_mode,
+            permission=mount_permission,
+            host=folder_host,
+            creator=user.email,
+            ownership_type=VFolderOwnershipType(ownership_type),
+            user=user_uuid if ownership_type == "user" else None,
+            group=group_uuid if ownership_type == "group" else None,
+            unmanaged_path=None,
+            cloneable=action.cloneable,
+            status=VFolderOperationStatus.READY,
+        )
+
+        try:
+            create_owner_permission = group_type == ProjectType.MODEL_STORE
+            await self._vfolder_repository.create_vfolder_with_permission(
+                params, create_owner_permission=create_owner_permission
+            )
+        except sa_exc.DataError as e:
+            raise VFolderInvalidParameter from e
+
+        # Fetch created vfolder data for response
+        vfolder_data = await self._vfolder_repository.get_by_id_validated(
+            folder_id, user_uuid, domain_name
+        )
+        return CreateVFolderV2ActionResult(vfolder=vfolder_data)
+
+    async def create_upload_session_v2(
+        self, action: CreateUploadSessionV2Action
+    ) -> CreateUploadSessionV2ActionResult:
+        """Create an upload session (v2). Resolves policy internally from user_id."""
+        user = await self._user_repository.get_user_by_uuid(action.user_id)
+        if user.domain_name is None:
+            raise VFolderInvalidParameter("User has no domain assigned")
+        vfolder_data = await self._vfolder_repository.get_by_id_validated(
+            action.vfolder_id, user.id, user.domain_name
+        )
+        if not vfolder_data:
+            raise VFolderNotFound("VFolder not found")
+
+        # Host permission check — resolved from user_id
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            vfolder_data.host,
+            permission=VFolderHostPermission.UPLOAD_FILE,
+            user_uuid=action.user_id,
+        )
+
+        proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(
+            vfolder_data.host, is_unmanaged(vfolder_data.unmanaged_path)
+        )
+        vfolder_id = VFolderID(
+            quota_scope_id=vfolder_data.quota_scope_id,
+            folder_id=vfolder_data.id,
+        )
+        manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+        storage_reply = await manager_client.upload_file(
+            volume_name, str(vfolder_id), action.path, str(action.size)
+        )
+        client_api_url = self._storage_manager.get_client_api_url(proxy_name)
+        return CreateUploadSessionV2ActionResult(
+            token=storage_reply["token"],
+            url=str(client_api_url / "upload"),
+        )
+
+    async def delete_v2(self, action: DeleteVFolderV2Action) -> DeleteVFolderV2ActionResult:
+        """Delete (trash) a vfolder (v2). Resolves policy internally from user_id."""
+        user = await self._user_repository.get_user_by_uuid(action.user_id)
+        if not user.domain_name:
+            raise VFolderInvalidParameter("User has no domain assigned")
+        vfolder_data = await self._vfolder_repository.get_by_id_validated(
+            action.vfolder_id, user.id, user.domain_name
+        )
+
+        # Host permission check — resolved from user_id
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            vfolder_data.host,
+            permission=VFolderHostPermission.DELETE,
+            user_uuid=action.user_id,
+        )
+
+        await self._vfolder_repository.move_vfolders_to_trash([vfolder_data.id])
+        return DeleteVFolderV2ActionResult(vfolder_id=action.vfolder_id)
+
+    async def purge_v2(self, action: PurgeVFolderV2Action) -> PurgeVFolderV2ActionResult:
+        """Purge a vfolder permanently (v2). Resolves policy internally from user_id."""
+        user = await self._user_repository.get_user_by_uuid(action.user_id)
+        if not user.domain_name:
+            raise VFolderInvalidParameter("User has no domain assigned")
+        vfolder_data = await self._vfolder_repository.get_by_id_validated(
+            action.vfolder_id, user.id, user.domain_name
+        )
+
+        # Host permission check — resolved from user_id
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            vfolder_data.host,
+            permission=VFolderHostPermission.DELETE,
+            user_uuid=action.user_id,
+        )
+
+        await self._vfolder_repository.delete_vfolders_forever([action.vfolder_id])
+        await self._remove_vfolder_from_storage(vfolder_data)
+        return PurgeVFolderV2ActionResult(vfolder_id=action.vfolder_id)
+
+    async def clone_v2(self, action: CloneVFolderV2Action) -> CloneVFolderV2ActionResult:
+        """Clone a vfolder (v2). Resolves policy internally from user_id."""
+        allowed_vfolder_types = (
+            await self._config_provider.legacy_etcd_config_loader.get_vfolder_types()
+        )
+        if "user" not in allowed_vfolder_types:
+            raise VFolderInvalidParameter("user vfolder cannot be created in this host")
+
+        # Get requester user info
+        user_info = await self._vfolder_repository.get_user_info(action.user_id)
+        if not user_info:
+            raise VFolderInvalidParameter("No such user.")
+        user_role, user_domain_name = user_info
+
+        # Get accessible vfolders to find the source folder
+        vfolder_list_result = await self._vfolder_repository.list_accessible_vfolders(
+            user_id=action.user_id,
+            user_role=user_role,
+            domain_name=user_domain_name,
+            allowed_vfolder_types=list(allowed_vfolder_types),
+            extra_conditions=(VFolderRow.id == action.vfolder_id),
+        )
+
+        if not vfolder_list_result.vfolders:
+            raise VFolderInvalidParameter("No such vfolder.")
+
+        source_vfolder_access_info = vfolder_list_result.vfolders[0]
+        source_vfolder_data = source_vfolder_access_info.vfolder_data
+
+        # Check if the source vfolder is allowed to be cloned
+        if not source_vfolder_data.cloneable:
+            raise Forbidden("The source vfolder is not permitted to be cloned.")
+
+        if action.target_name.startswith("."):
+            for entry in vfolder_list_result.vfolders:
+                if entry.vfolder_data.name == action.target_name:
+                    raise VFolderAlreadyExists
+
+        # Get target host
+        target_folder_host = (
+            action.target_host
+            or source_vfolder_data.host
+            or self._config_provider.config.volumes.default_host
+        )
+        if not target_folder_host:
+            raise VFolderInvalidParameter(
+                "You must specify the vfolder host because the default host is not configured."
+            )
+
+        # Verify target vfolder name
+        if not verify_vfolder_name(action.target_name):
+            raise VFolderInvalidParameter(
+                f"{action.target_name} is reserved for internal operations."
+            )
+
+        # Check for duplicate vfolder names
+        duplication_exists = await self._vfolder_repository.check_vfolder_name_exists(
+            action.target_name,
+            action.user_id,
+            user_role,
+            user_domain_name,
+            list(allowed_vfolder_types),
+        )
+
+        if duplication_exists:
+            raise VFolderAlreadyExists(
+                f"VFolder with the given name already exists. ({action.target_name})"
+            )
+
+        # Host permission check — resolved from user_id, not passed resource_policy
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            target_folder_host,
+            permission=VFolderHostPermission.CREATE,
+            user_uuid=action.user_id,
+        )
+
+        # clone_v2 always creates user-owned vfolders, so check user resource policy (group_uuid=None)
+        max_vfolder_count = await self._vfolder_repository.get_max_vfolder_count(
+            action.user_id, None
+        )
+
+        # Check resource policy's max_vfolder_count
+        if max_vfolder_count > 0:
+            current_count = await self._vfolder_repository.count_vfolders_by_user(action.user_id)
+            if current_count >= max_vfolder_count:
+                raise VFolderInvalidParameter("You cannot create more vfolders.")
+
+        # Get user email for creator field
+        requester_email = await self._vfolder_repository.get_user_email_by_id(action.user_id)
+        if not requester_email:
+            raise VFolderInvalidParameter("No such user.")
+
+        # Create source VFolderID
+        source_folder_id = VFolderID(source_vfolder_data.quota_scope_id, source_vfolder_data.id)
+
+        # Target quota scope: default to requester's user scope
+        target_quota_scope_id = QuotaScopeID(QuotaScopeType.USER, action.user_id)
+
+        # Parse usage_mode and permission from action strings
+        usage_mode = VFolderUsageMode(action.usage_mode)
+        mount_permission = VFolderPermission(action.permission)
+
+        # Create VFolderCloneInfo for the cloning operation
+        vfolder_clone_info = VFolderCloneInfo(
+            source_vfolder_id=source_folder_id,
+            source_host=source_vfolder_data.host,
+            unmanaged_path=source_vfolder_data.unmanaged_path,
+            domain_name=user_domain_name,
+            target_quota_scope_id=target_quota_scope_id,
+            target_vfolder_name=action.target_name,
+            target_host=target_folder_host,
+            usage_mode=usage_mode,
+            permission=mount_permission,
+            email=requester_email,
+            user_id=action.user_id,
+            cloneable=action.cloneable,
+        )
+
+        # Initiate the actual vfolder cloning process using repository
+        _task_id, target_folder_id = await self._vfolder_repository.initiate_vfolder_clone(
+            vfolder_clone_info,
+            self._storage_manager,
+            self._background_task_manager,
+        )
+
+        return CloneVFolderV2ActionResult(
+            new_vfolder_id=target_folder_id,
+            bgtask_id=str(_task_id) if _task_id else None,
+        )

--- a/tests/component/vfolder/test_vfolder_clone.py
+++ b/tests/component/vfolder/test_vfolder_clone.py
@@ -1,0 +1,367 @@
+"""Component tests for VFolder clone policy enforcement.
+
+Verifies that clone operations check the *user's* resource policy for
+max_vfolder_count, not the source project's resource policy (BA-5520).
+
+Storage proxy is mocked; the database is real.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import sqlalchemy as sa
+import yarl
+from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.bgtask.types import TaskID
+from ai.backend.common.dto.manager.v2.vfolder.request import CloneVFolderInput
+from ai.backend.common.dto.manager.vfolder import CloneVFolderReq
+from ai.backend.common.types import QuotaScopeID, QuotaScopeType
+from ai.backend.manager.api.adapters.vfolder import VFolderAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.vfolder.handler import V2VFolderHandler
+from ai.backend.manager.api.rest.v2.vfolder.registry import register_v2_vfolder_routes
+from ai.backend.manager.api.rest.vfolder.handler import VFolderHandler
+from ai.backend.manager.api.rest.vfolder.registry import register_vfolder_routes
+from ai.backend.manager.data.vfolder.types import VFolderOwnershipType
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.storage import StorageSessionManager
+from ai.backend.manager.models.user import users
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.vfolder.admin_repository import VFolderAdminRepository
+from ai.backend.manager.services.auth.processors import AuthProcessors
+from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.vfolder.processors.file import VFolderFileProcessors
+from ai.backend.manager.services.vfolder.processors.invite import VFolderInviteProcessors
+from ai.backend.manager.services.vfolder.processors.sharing import VFolderSharingProcessors
+from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
+from ai.backend.manager.services.vfolder.processors.vfolder_admin import VFolderAdminProcessors
+from ai.backend.manager.services.vfolder.services.vfolder_admin import VFolderAdminService
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+VFolderFixtureData = dict[str, Any]
+VFolderFactory = Callable[..., Coroutine[Any, Any, VFolderFixtureData]]
+
+
+# ---------------------------------------------------------------------------
+# Override server_module_registries to include both v1 and v2 routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def vfolder_admin_processors(
+    database_engine: ExtendedAsyncSAEngine,
+) -> VFolderAdminProcessors:
+    repo = VFolderAdminRepository(database_engine)
+    service = VFolderAdminService(vfolder_admin_repository=repo)
+    return VFolderAdminProcessors(service=service, action_monitors=[])
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    auth_processors: AuthProcessors,
+    vfolder_processors: VFolderProcessors,
+    vfolder_admin_processors: VFolderAdminProcessors,
+    vfolder_file_processors: VFolderFileProcessors,
+    vfolder_invite_processors: VFolderInviteProcessors,
+    vfolder_sharing_processors: VFolderSharingProcessors,
+) -> list[RouteRegistry]:
+    """Register both v1 and v2 vfolder REST routes."""
+    # v1
+    v1_reg = register_vfolder_routes(
+        VFolderHandler(
+            auth=auth_processors,
+            vfolder=vfolder_processors,
+            vfolder_file=vfolder_file_processors,
+            vfolder_invite=vfolder_invite_processors,
+            vfolder_sharing=vfolder_sharing_processors,
+        ),
+        route_deps,
+        vfolder_processors=vfolder_processors,
+    )
+    # v2
+    processors = MagicMock(spec=Processors)
+    processors.vfolder = vfolder_processors
+    processors.vfolder_admin = vfolder_admin_processors
+    adapter = VFolderAdapter(processors)
+    handler = V2VFolderHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_vfolder_routes(handler, route_deps))
+    return [v1_reg, v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """Create a V2ClientRegistry with superadmin keypair."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers & fixtures
+# ---------------------------------------------------------------------------
+
+
+def _configure_clone_storage_mock(storage_manager: StorageSessionManager) -> AsyncMock:
+    """Configure the storage mock for clone operations.
+
+    Returns the mock client for further configuration if needed.
+    """
+    mock_client = AsyncMock()
+    storage_manager.get_proxy_and_volume.return_value = ("local", "volume1")  # type: ignore[attr-defined]
+    storage_manager.get_manager_facing_client.return_value = mock_client  # type: ignore[attr-defined]
+
+    clone_response = MagicMock()
+    clone_response.bgtask_id = TaskID(uuid.uuid4())
+    mock_client.clone_folder.return_value = clone_response
+
+    return mock_client
+
+
+@pytest.fixture()
+async def set_main_access_key(
+    db_engine: SAEngine,
+    admin_user_fixture: Any,
+) -> AsyncIterator[None]:
+    """Populate main_access_key on the admin user so that the
+    ``main_keypair`` ORM relationship resolves correctly.
+
+    The global ``admin_user_fixture`` does not set this column, but the
+    clone flow needs it to look up ``allowed_vfolder_hosts`` from the
+    user's keypair resource policy.
+    """
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(users)
+            .where(users.c.uuid == str(admin_user_fixture.user_uuid))
+            .values(main_access_key=admin_user_fixture.keypair.access_key)
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(users)
+            .where(users.c.uuid == str(admin_user_fixture.user_uuid))
+            .values(main_access_key=None)
+        )
+
+
+@pytest.fixture()
+async def cloneable_project_vfolder(
+    vfolder_factory: VFolderFactory,
+    admin_user_fixture: Any,
+    group_fixture: uuid.UUID,
+) -> VFolderFixtureData:
+    """A cloneable project-owned vfolder as the clone source."""
+    return await vfolder_factory(
+        name="project-source-clone",
+        cloneable=True,
+        ownership_type=VFolderOwnershipType.GROUP,
+        group=str(group_fixture),
+        user=str(admin_user_fixture.user_uuid),
+        quota_scope_id=str(QuotaScopeID(scope_type=QuotaScopeType.PROJECT, scope_id=group_fixture)),
+    )
+
+
+@pytest.fixture()
+async def user_policy_capped_at_1(
+    db_engine: SAEngine,
+    resource_policy_fixture: str,
+) -> AsyncIterator[None]:
+    """Set user max_vfolder_count=1 and project max_vfolder_count=100."""
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(UserResourcePolicyRow.__table__)
+            .where(UserResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=1)
+        )
+        await conn.execute(
+            sa.update(ProjectResourcePolicyRow.__table__)
+            .where(ProjectResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=100)
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(UserResourcePolicyRow.__table__)
+            .where(UserResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=0)
+        )
+        await conn.execute(
+            sa.update(ProjectResourcePolicyRow.__table__)
+            .where(ProjectResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=0)
+        )
+
+
+@pytest.fixture()
+async def user_policy_unlimited_project_capped_at_1(
+    db_engine: SAEngine,
+    resource_policy_fixture: str,
+) -> AsyncIterator[None]:
+    """Set user max_vfolder_count=0 (unlimited) and project max_vfolder_count=1."""
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(UserResourcePolicyRow.__table__)
+            .where(UserResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=0)
+        )
+        await conn.execute(
+            sa.update(ProjectResourcePolicyRow.__table__)
+            .where(ProjectResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=1)
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.update(ProjectResourcePolicyRow.__table__)
+            .where(ProjectResourcePolicyRow.__table__.c.name == resource_policy_fixture)
+            .values(max_vfolder_count=0)
+        )
+
+
+# ---------------------------------------------------------------------------
+# v1 clone tests (POST /folders/{name}/clone)
+# ---------------------------------------------------------------------------
+
+
+class TestVFolderClonePolicyCheck:
+    """Clone must enforce the *requester's user* resource policy, not the source project's."""
+
+    async def test_clone_project_vfolder_blocked_by_user_policy(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        vfolder_factory: VFolderFactory,
+        set_main_access_key: None,
+        user_policy_capped_at_1: None,
+        cloneable_project_vfolder: VFolderFixtureData,
+    ) -> None:
+        """Cloning a project vfolder should fail when the user's max_vfolder_count is reached.
+
+        Setup:
+          - user  resource policy: max_vfolder_count = 1
+          - project resource policy: max_vfolder_count = 100  (would NOT block if used)
+          - 1 existing user-owned vfolder  (hits the user limit)
+          - 1 cloneable project-owned vfolder (the source)
+
+        If the code incorrectly checked the project policy (max=100), the clone
+        would succeed.  The correct behaviour is to reject it because the user
+        already owns 1 vfolder and the user policy only allows 1.
+        """
+        await vfolder_factory(name="user-vf-occupying-slot")
+
+        with pytest.raises(BackendAPIError) as exc_info:
+            await admin_registry.vfolder.clone(
+                cloneable_project_vfolder["name"],
+                CloneVFolderReq(target_name="cloned-should-fail"),
+            )
+        assert exc_info.value.status == 400
+
+    async def test_clone_project_vfolder_allowed_by_user_policy(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        vfolder_factory: VFolderFactory,
+        set_main_access_key: None,
+        user_policy_unlimited_project_capped_at_1: None,
+        cloneable_project_vfolder: VFolderFixtureData,
+        storage_manager: StorageSessionManager,
+    ) -> None:
+        """Cloning a project vfolder should succeed when the user's policy allows it,
+        even if the project's max_vfolder_count would block (if it were used).
+
+        Setup:
+          - user  resource policy: max_vfolder_count = 0  (unlimited)
+          - project resource policy: max_vfolder_count = 1  (would block if used)
+          - 2 existing user-owned vfolders  (would exceed project limit of 1)
+          - 1 cloneable project-owned vfolder (the source)
+
+        If the code incorrectly checked the project policy (max=1), the clone
+        would fail.  The correct behaviour is to allow it because the user policy
+        is unlimited (max=0).
+        """
+        _configure_clone_storage_mock(storage_manager)
+
+        await vfolder_factory(name="user-vf-1-clone-ok")
+        await vfolder_factory(name="user-vf-2-clone-ok")
+
+        result = await admin_registry.vfolder.clone(
+            cloneable_project_vfolder["name"],
+            CloneVFolderReq(target_name="cloned-should-succeed"),
+        )
+        assert result.item.name == "cloned-should-succeed"
+
+
+# ---------------------------------------------------------------------------
+# v2 clone tests (POST /v2/vfolders/{vfolder_id}/clone)
+# ---------------------------------------------------------------------------
+
+
+class TestVFolderCloneV2PolicyCheck:
+    """clone_v2 must enforce the *requester's user* resource policy, not the source project's."""
+
+    async def test_clone_v2_project_vfolder_blocked_by_user_policy(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        vfolder_factory: VFolderFactory,
+        set_main_access_key: None,
+        user_policy_capped_at_1: None,
+        cloneable_project_vfolder: VFolderFixtureData,
+    ) -> None:
+        """v2 clone of a project vfolder should fail when the user's max_vfolder_count is reached."""
+        await vfolder_factory(name="user-vf-occupying-slot-v2")
+
+        with pytest.raises(BackendAPIError) as exc_info:
+            await admin_v2_registry.vfolder.clone(
+                cloneable_project_vfolder["id"],
+                CloneVFolderInput(name="cloned-v2-should-fail"),
+            )
+        assert exc_info.value.status == 400
+
+    async def test_clone_v2_project_vfolder_allowed_by_user_policy(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        vfolder_factory: VFolderFactory,
+        set_main_access_key: None,
+        user_policy_unlimited_project_capped_at_1: None,
+        cloneable_project_vfolder: VFolderFixtureData,
+        storage_manager: StorageSessionManager,
+    ) -> None:
+        """v2 clone of a project vfolder should succeed when the user's policy allows it."""
+        _configure_clone_storage_mock(storage_manager)
+
+        await vfolder_factory(name="user-vf-1-clone-ok-v2")
+        await vfolder_factory(name="user-vf-2-clone-ok-v2")
+
+        result = await admin_v2_registry.vfolder.clone(
+            cloneable_project_vfolder["id"],
+            CloneVFolderInput(name="cloned-v2-should-succeed"),
+        )
+        assert result.vfolder.metadata.name == "cloned-v2-should-succeed"

--- a/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
@@ -61,6 +61,7 @@ from ai.backend.manager.services.vfolder.actions.base import (
     UpdateVFolderAttributeAction,
     UpdateVFolderAttributeActionResult,
 )
+from ai.backend.manager.services.vfolder.actions.file_v2 import CloneVFolderV2Action
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
 
 
@@ -1091,6 +1092,260 @@ class TestCloneVFolderAction:
 
         with pytest.raises(VFolderInvalidParameter, match="cannot create more"):
             await vfolder_service.clone(action)
+
+    @pytest.fixture
+    def mock_repo_for_clone_quota(
+        self,
+        mock_vfolder_repository: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+    ) -> MagicMock:
+        """Set up common repository mocks for clone quota scope tests."""
+        source_data = _make_vfolder_data(vfolder_uuid, user_uuid, cloneable=True)
+
+        mock_vfolder_repository.get_user_info = AsyncMock(return_value=(UserRole.USER, "default"))
+        mock_vfolder_repository.list_accessible_vfolders = AsyncMock(
+            return_value=VFolderListResult(
+                vfolders=[
+                    VFolderAccessInfo(
+                        vfolder_data=source_data,
+                        is_owner=True,
+                        effective_permission=None,
+                    )
+                ]
+            )
+        )
+        mock_vfolder_repository.check_vfolder_name_exists = AsyncMock(return_value=False)
+        mock_vfolder_repository.get_allowed_vfolder_hosts = AsyncMock(
+            return_value={"local:volume1": set()}
+        )
+        mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()
+        mock_vfolder_repository.get_max_vfolder_count = AsyncMock(return_value=0)
+        mock_vfolder_repository.get_user_email_by_id = AsyncMock(return_value="test@example.com")
+        return mock_vfolder_repository
+
+    @pytest.fixture
+    def mock_clone_result_ids(
+        self,
+        mock_repo_for_clone_quota: MagicMock,
+    ) -> tuple[uuid.UUID, uuid.UUID]:
+        """Set up initiate_vfolder_clone mock and return (task_id, target_id)."""
+        task_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+        mock_repo_for_clone_quota.initiate_vfolder_clone = AsyncMock(
+            return_value=(task_id, target_id)
+        )
+        return task_id, target_id
+
+    async def test_clone_with_explicit_target_quota_scope_id(
+        self,
+        vfolder_service: VFolderService,
+        mock_repo_for_clone_quota: MagicMock,
+        mock_clone_result_ids: tuple[uuid.UUID, uuid.UUID],
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+    ) -> None:
+        task_id, target_id = mock_clone_result_ids
+        target_quota_scope_id = QuotaScopeID(QuotaScopeType.USER, user_uuid)
+        mock_repo_for_clone_quota.validate_quota_scope_access = AsyncMock()
+
+        action = CloneVFolderAction(
+            requester_user_uuid=user_uuid,
+            source_vfolder_uuid=vfolder_uuid,
+            target_name="cloned-vfolder",
+            target_host=None,
+            target_quota_scope_id=target_quota_scope_id,
+            cloneable=True,
+            usage_mode=VFolderUsageMode.GENERAL,
+            mount_permission=VFolderPermission.READ_WRITE,
+        )
+
+        result = await vfolder_service.clone(action)
+
+        assert isinstance(result, CloneVFolderActionResult)
+        assert result.bgtask_id == task_id
+        assert result.target_vfolder_id == target_id
+        mock_repo_for_clone_quota.validate_quota_scope_access.assert_called_once_with(
+            target_quota_scope_id,
+            UserIdentity(
+                user_uuid=user_uuid,
+                user_role=UserRole.USER,
+                user_email="test@example.com",
+                domain_name="default",
+            ),
+        )
+
+    async def test_clone_with_none_target_quota_scope_defaults_to_user_scope(
+        self,
+        vfolder_service: VFolderService,
+        mock_repo_for_clone_quota: MagicMock,
+        mock_clone_result_ids: tuple[uuid.UUID, uuid.UUID],
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+    ) -> None:
+        action = CloneVFolderAction(
+            requester_user_uuid=user_uuid,
+            source_vfolder_uuid=vfolder_uuid,
+            target_name="cloned-vfolder",
+            target_host=None,
+            target_quota_scope_id=None,
+            cloneable=True,
+            usage_mode=VFolderUsageMode.GENERAL,
+            mount_permission=VFolderPermission.READ_WRITE,
+        )
+
+        result = await vfolder_service.clone(action)
+
+        assert isinstance(result, CloneVFolderActionResult)
+        # When target_quota_scope_id is None, validate_quota_scope_access should not be called
+        mock_repo_for_clone_quota.validate_quota_scope_access.assert_not_called()
+        # The clone info passed to initiate_vfolder_clone should use the requester's user scope
+        clone_call_args = mock_repo_for_clone_quota.initiate_vfolder_clone.call_args
+        clone_info = clone_call_args[0][0]
+        assert clone_info.target_quota_scope_id == QuotaScopeID(QuotaScopeType.USER, user_uuid)
+
+    async def test_clone_with_unauthorized_quota_scope_raises_error(
+        self,
+        vfolder_service: VFolderService,
+        mock_repo_for_clone_quota: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+    ) -> None:
+        other_user_uuid = uuid.uuid4()
+        unauthorized_scope = QuotaScopeID(QuotaScopeType.USER, other_user_uuid)
+        mock_repo_for_clone_quota.validate_quota_scope_access = AsyncMock(
+            side_effect=InvalidAPIParameters
+        )
+
+        action = CloneVFolderAction(
+            requester_user_uuid=user_uuid,
+            source_vfolder_uuid=vfolder_uuid,
+            target_name="cloned-vfolder",
+            target_host=None,
+            target_quota_scope_id=unauthorized_scope,
+            cloneable=True,
+            usage_mode=VFolderUsageMode.GENERAL,
+            mount_permission=VFolderPermission.READ_WRITE,
+        )
+
+        with pytest.raises(InvalidAPIParameters):
+            await vfolder_service.clone(action)
+
+    async def test_clone_project_vfolder_checks_user_resource_policy(
+        self,
+        vfolder_service: VFolderService,
+        mock_vfolder_repository: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+        group_uuid: uuid.UUID,
+    ) -> None:
+        """Regression test for BA-5520: cloning a project-owned vfolder must check
+        the user's resource policy (group_uuid=None), not the source project's."""
+        source_data = _make_vfolder_data(
+            vfolder_uuid,
+            user_uuid,
+            cloneable=True,
+            ownership_type=VFolderOwnershipType.GROUP,
+            group=group_uuid,
+        )
+        task_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+
+        mock_vfolder_repository.get_user_info = AsyncMock(return_value=(UserRole.USER, "default"))
+        mock_vfolder_repository.list_accessible_vfolders = AsyncMock(
+            return_value=VFolderListResult(
+                vfolders=[
+                    VFolderAccessInfo(
+                        vfolder_data=source_data,
+                        is_owner=True,
+                        effective_permission=None,
+                    )
+                ]
+            )
+        )
+        mock_vfolder_repository.check_vfolder_name_exists = AsyncMock(return_value=False)
+        mock_vfolder_repository.get_allowed_vfolder_hosts = AsyncMock(
+            return_value={"local:volume1": set()}
+        )
+        mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()
+        mock_vfolder_repository.get_max_vfolder_count = AsyncMock(return_value=0)
+        mock_vfolder_repository.get_user_email_by_id = AsyncMock(return_value="test@example.com")
+        mock_vfolder_repository.initiate_vfolder_clone = AsyncMock(
+            return_value=(task_id, target_id)
+        )
+
+        action = CloneVFolderAction(
+            requester_user_uuid=user_uuid,
+            source_vfolder_uuid=vfolder_uuid,
+            target_name="cloned-vfolder",
+            target_host=None,
+            target_quota_scope_id=None,
+            cloneable=True,
+            usage_mode=VFolderUsageMode.GENERAL,
+            mount_permission=VFolderPermission.READ_WRITE,
+        )
+
+        await vfolder_service.clone(action)
+
+        # Must check user resource policy (None), not source project's group
+        mock_vfolder_repository.get_max_vfolder_count.assert_called_once_with(user_uuid, None)
+
+
+class TestCloneVFolderV2Action:
+    async def test_clone_v2_project_vfolder_checks_user_resource_policy(
+        self,
+        vfolder_service: VFolderService,
+        mock_vfolder_repository: MagicMock,
+        user_uuid: uuid.UUID,
+        vfolder_uuid: uuid.UUID,
+        group_uuid: uuid.UUID,
+    ) -> None:
+        """Regression test for BA-5520: clone_v2 must check the user's resource
+        policy (group_uuid=None), not the source project's."""
+        source_data = _make_vfolder_data(
+            vfolder_uuid,
+            user_uuid,
+            cloneable=True,
+            ownership_type=VFolderOwnershipType.GROUP,
+            group=group_uuid,
+        )
+        task_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+
+        mock_vfolder_repository.get_user_info = AsyncMock(return_value=(UserRole.USER, "default"))
+        mock_vfolder_repository.list_accessible_vfolders = AsyncMock(
+            return_value=VFolderListResult(
+                vfolders=[
+                    VFolderAccessInfo(
+                        vfolder_data=source_data,
+                        is_owner=True,
+                        effective_permission=None,
+                    )
+                ]
+            )
+        )
+        mock_vfolder_repository.check_vfolder_name_exists = AsyncMock(return_value=False)
+        mock_vfolder_repository.ensure_host_permission_allowed_by_user = AsyncMock()
+        mock_vfolder_repository.get_max_vfolder_count = AsyncMock(return_value=0)
+        mock_vfolder_repository.get_user_email_by_id = AsyncMock(return_value="test@example.com")
+        mock_vfolder_repository.initiate_vfolder_clone = AsyncMock(
+            return_value=(task_id, target_id)
+        )
+
+        action = CloneVFolderV2Action(
+            user_id=user_uuid,
+            vfolder_id=vfolder_uuid,
+            target_name="cloned-vfolder",
+            target_host=None,
+            usage_mode="general",
+            permission="rw",
+            cloneable=True,
+        )
+
+        await vfolder_service.clone_v2(action)
+
+        # Must check user resource policy (None), not source project's group
+        mock_vfolder_repository.get_max_vfolder_count.assert_called_once_with(user_uuid, None)
 
 
 class TestGetAccessibleVFolderAction:


### PR DESCRIPTION
This is an auto-generated backport PR of #10797 to the 26.3 release.