### PR TITLE
fix(BA-5608): attribute delegated sessions to the owner, not the requester (#10837)

### DIFF
--- a/changes/10837.fix.md
+++ b/changes/10837.fix.md
@@ -1,0 +1,1 @@
+Attribute delegated sessions (`owner_access_key`) to the owner so session ownership, container UID/GID, and scaling group access are resolved against the owner instead of the requester.

--- a/src/ai/backend/manager/data/user/types.py
+++ b/src/ai/backend/manager/data/user/types.py
@@ -62,6 +62,16 @@ class UserInfoContext:
     main_access_key: AccessKey
 
 
+@dataclass(frozen=True)
+class SessionOwnerContext:
+    """Resolved owner context for session creation."""
+
+    owner_uuid: UUID
+    group_id: UUID
+    resource_policy: dict[str, Any]
+    owner_role: UserRole
+
+
 @dataclass
 class UserData:
     id: UUID = field(compare=False)

--- a/src/ai/backend/manager/event_dispatcher/handlers/model_serving.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/model_serving.py
@@ -105,7 +105,7 @@ class ModelServingEventHandler:
                 else:
                     session_owner = created_user
 
-                _, group_id, resource_policy = await query_userinfo_from_session(
+                user_info = await query_userinfo_from_session(
                     db_sess,
                     created_user.uuid,
                     created_user.access_key,
@@ -116,6 +116,8 @@ class ModelServingEventHandler:
                     endpoint.project,
                     query_on_behalf_of=session_owner.access_key,
                 )
+                group_id = user_info.group_id
+                resource_policy = user_info.resource_policy
 
                 if endpoint.image_row is None:
                     raise ValueError(f"Image not found for endpoint {endpoint.id}")

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -1829,7 +1829,7 @@ class DeploymentDBSource:
 
             # Use query_userinfo_from_session to get group_id and resource_policy
             # This also validates domain, group access permissions
-            owner_uuid, group_id, resource_policy = await query_userinfo_from_session(
+            user_info = await query_userinfo_from_session(
                 db_sess,
                 created_user_row.UserRow.uuid,
                 AccessKey(created_user_row.access_key),
@@ -1842,6 +1842,8 @@ class DeploymentDBSource:
                 if session_owner_row != created_user_row
                 else None,
             )
+            group_id = user_info.group_id
+            resource_policy = user_info.resource_policy
 
             # Resolve image
             target_revision = deployment_info.target_revision()

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -40,7 +40,6 @@ from ai.backend.manager.data.model_serving.types import (
     UserData,
 )
 from ai.backend.manager.data.vfolder.types import VFolderOwnershipType
-from ai.backend.manager.errors.auth import InvalidAuthParameters
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.resource import DatabaseConnectionUnavailable
 from ai.backend.manager.errors.service import EndpointNotFound
@@ -1063,7 +1062,7 @@ class ModelServingRepository:
             )
 
             try:
-                owner_uuid, group_id, resource_policy = await query_userinfo(
+                user_info = await query_userinfo(
                     conn,
                     requester_uuid,
                     requester_access_key,
@@ -1076,11 +1075,10 @@ class ModelServingRepository:
                 )
             except ValueError as e:
                 raise InvalidAPIParameters(str(e)) from e
-
-            owner_role_query = sa.select(UserRow.role).where(UserRow.uuid == owner_uuid)
-            owner_role = (await conn.execute(owner_role_query)).scalar()
-            if not owner_role:
-                raise InvalidAuthParameters("Owner role is required to create a model service")
+            owner_uuid = user_info.owner_uuid
+            group_id = user_info.group_id
+            resource_policy = user_info.resource_policy
+            owner_role = user_info.owner_role
 
             allowed_vfolder_types = await legacy_etcd_loader.get_vfolder_types()
             try:

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -13,8 +13,8 @@ from ai.backend.common.docker import ImageRef
 from ai.backend.common.types import AccessKey, ImageAlias, SessionId
 from ai.backend.manager.data.image.types import ImageIdentifier, ImageStatus
 from ai.backend.manager.data.kernel.types import KernelListResult
-from ai.backend.manager.data.session.types import SessionListResult
-from ai.backend.manager.data.user.types import UserData
+from ai.backend.manager.data.session.types import SessionData, SessionListResult
+from ai.backend.manager.data.user.types import SessionOwnerContext, UserData
 from ai.backend.manager.errors.common import GenericBadRequest
 from ai.backend.manager.errors.kernel import SessionAlreadyExists, SessionNotFound
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
@@ -345,7 +345,7 @@ class SessionDBSource:
         query_domain_name: str,
         group_name: str | None,
         query_on_behalf_of: AccessKey | None = None,
-    ) -> tuple[uuid.UUID, uuid.UUID, dict[str, Any]]:
+    ) -> SessionOwnerContext:
         if group_name is None:
             raise GenericBadRequest("group_name cannot be None")
         async with self._db.begin_readonly() as conn:

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -15,8 +15,8 @@ from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import AccessKey, ImageAlias, SessionId
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelListResult
-from ai.backend.manager.data.session.types import SessionListResult
-from ai.backend.manager.data.user.types import UserData
+from ai.backend.manager.data.session.types import SessionData, SessionListResult
+from ai.backend.manager.data.user.types import SessionOwnerContext, UserData
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.session import KernelLoadingStrategy, SessionRow
@@ -192,7 +192,7 @@ class SessionRepository:
         query_domain_name: str,
         group_name: str | None,
         query_on_behalf_of: AccessKey | None = None,
-    ) -> tuple[uuid.UUID, uuid.UUID, dict[str, Any]]:
+    ) -> SessionOwnerContext:
         return await self._db_source.query_userinfo(
             user_id,
             requester_access_key,

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -397,7 +397,7 @@ class SessionService:
             raise TaskTemplateNotFound
 
         try:
-            _, group_id, resource_policy = await self._session_repository.query_userinfo(
+            user_info = await self._session_repository.query_userinfo(
                 user_id,
                 requester_access_key,
                 user_role,
@@ -416,12 +416,12 @@ class SessionService:
                 session_name,
                 UserScope(
                     domain_name=domain_name,
-                    group_id=group_id,
-                    user_uuid=user_id,
-                    user_role=user_role,
+                    group_id=user_info.group_id,
+                    user_uuid=user_info.owner_uuid,
+                    user_role=user_info.owner_role.value,
                 ),
                 owner_access_key,
-                resource_policy,
+                user_info.resource_policy,
                 scaling_group_name,
                 session_type,
                 tag,
@@ -473,7 +473,7 @@ class SessionService:
         callback_url = action.params.callback_url
         reuse_if_exists = action.params.reuse_if_exists
 
-        owner_uuid, group_id, resource_policy = await self._session_repository.query_userinfo(
+        user_info = await self._session_repository.query_userinfo(
             user_id,
             requester_access_key,
             user_role,
@@ -498,12 +498,12 @@ class SessionService:
                 image_row.image_ref,
                 UserScope(
                     domain_name=domain_name,
-                    group_id=group_id,
-                    user_uuid=user_id,
-                    user_role=user_role,
+                    group_id=user_info.group_id,
+                    user_uuid=user_info.owner_uuid,
+                    user_role=user_info.owner_role.value,
                 ),
                 owner_access_key,
-                resource_policy,
+                user_info.resource_policy,
                 session_type,
                 config,
                 cluster_mode,
@@ -530,7 +530,7 @@ class SessionService:
         except BackendAIError:
             raise
         except Exception as e:
-            await self._error_monitor.capture_exception(context={"user": owner_uuid})
+            await self._error_monitor.capture_exception(context={"user": user_info.owner_uuid})
             log.exception("GET_OR_CREATE: unexpected error!", e)
             raise InternalServerError from e
 
@@ -674,7 +674,7 @@ class SessionService:
         reuse_if_exists = params["reuse_if_exists"]
         domain_name = params["domain_name"]
 
-        owner_uuid, group_id, resource_policy = await self._session_repository.query_userinfo(
+        user_info = await self._session_repository.query_userinfo(
             user_id,
             requester_access_key,
             user_role,
@@ -699,12 +699,12 @@ class SessionService:
                 image_row.image_ref,
                 UserScope(
                     domain_name=domain_name,
-                    group_id=group_id,
-                    user_uuid=user_id,
-                    user_role=user_role,
+                    group_id=user_info.group_id,
+                    user_uuid=user_info.owner_uuid,
+                    user_role=user_info.owner_role.value,
                 ),
                 owner_access_key,
-                resource_policy,
+                user_info.resource_policy,
                 session_type,
                 config,
                 cluster_mode,
@@ -729,7 +729,7 @@ class SessionService:
         except BackendAIError:
             raise
         except Exception as e:
-            await self._error_monitor.capture_exception(context={"user": owner_uuid})
+            await self._error_monitor.capture_exception(context={"user": user_info.owner_uuid})
             log.exception("GET_OR_CREATE: unexpected error!", e)
             raise InternalServerError from e
 

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.types import AccessKey
 
+from .data.user.types import SessionOwnerContext
+from .errors.common import InternalServerError
 from .models.domain import domains
 from .models.group import association_groups_users as agus
 from .models.group import groups
@@ -101,7 +103,7 @@ async def query_userinfo(
     requesting_domain: str,
     requesting_group: str | UUID,
     query_on_behalf_of: AccessKey | None = None,
-) -> tuple[UUID, UUID, dict[str, Any]]:
+) -> SessionOwnerContext:
     if query_on_behalf_of is not None and query_on_behalf_of != requester_access_key:
         await check_if_requester_is_eligible_to_act_as_target_access_key(
             conn,
@@ -134,9 +136,13 @@ async def query_userinfo(
         row = result.first()
         if row is None:
             raise ValueError("Unknown owner access key")
+        if row.role is None:
+            raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name
         owner_uuid = row.user
-        owner_role = row.role
+        actual_owner_role: UserRole = row.role
+        # For delegated sessions, the owner's actual role determines group access.
+        role_for_group_resolution: UserRole = actual_owner_role
         query = (
             sa.select(keypair_resource_policies)
             .select_from(keypair_resource_policies)
@@ -149,7 +155,11 @@ async def query_userinfo(
         # Normal case when the user is creating her/his own session.
         owner_domain = requester_domain
         owner_uuid = requester_uuid
-        owner_role = UserRole.USER
+        actual_owner_role = requester_role
+        # Own-session creation always goes through the USER path to enforce
+        # explicit project membership via the agus table, regardless of the
+        # requester's actual role.
+        role_for_group_resolution = UserRole.USER
         resource_policy = keypair_resource_policy or {}
 
     query = (
@@ -168,7 +178,7 @@ async def query_userinfo(
         group_match_query = groups.c.name == requesting_group
     else:
         group_match_query = groups.c.id == requesting_group
-    if owner_role == UserRole.SUPERADMIN:
+    if role_for_group_resolution == UserRole.SUPERADMIN:
         # superadmin can spawn container in any designated domain/group.
         query = (
             sa.select(groups.c.id)
@@ -181,7 +191,7 @@ async def query_userinfo(
         )
         qresult = await conn.execute(query)
         group_id = qresult.scalar()
-    elif owner_role == UserRole.ADMIN:
+    elif role_for_group_resolution == UserRole.ADMIN:
         # domain-admin can spawn container in any group in the same domain.
         if requesting_domain != owner_domain:
             raise ValueError("You can only set the domain to the owner's domain.")
@@ -213,9 +223,15 @@ async def query_userinfo(
     if group_id is None:
         raise ValueError("Invalid group")
 
-    return owner_uuid, group_id, resource_policy
+    return SessionOwnerContext(
+        owner_uuid=owner_uuid,
+        group_id=group_id,
+        resource_policy=resource_policy,
+        owner_role=actual_owner_role,
+    )
 
 
+# TODO: Replace this with query_userinfo() by obtaining the underlying connection
 async def query_userinfo_from_session(
     db_sess: SASession,
     requester_uuid: UUID,
@@ -226,7 +242,7 @@ async def query_userinfo_from_session(
     requesting_domain: str,
     requesting_group: str | UUID,
     query_on_behalf_of: AccessKey | None = None,
-) -> tuple[UUID, UUID, dict[str, Any]]:
+) -> SessionOwnerContext:
     """Version of query_userinfo that accepts SASession instead of SAConnection."""
     if query_on_behalf_of is not None and query_on_behalf_of != requester_access_key:
         # Need to check privileges - convert session operations
@@ -272,9 +288,13 @@ async def query_userinfo_from_session(
         row = result.first()
         if row is None:
             raise ValueError("Unknown owner access key")
+        if row.role is None:
+            raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name
         owner_uuid = row.user
-        owner_role = row.role
+        actual_owner_role: UserRole = row.role
+        # For delegated sessions, the owner's actual role determines group access.
+        role_for_group_resolution: UserRole = actual_owner_role
         query = (
             sa.select(keypair_resource_policies)
             .select_from(keypair_resource_policies)
@@ -287,7 +307,11 @@ async def query_userinfo_from_session(
         # Normal case when the user is creating her/his own session.
         owner_domain = requester_domain
         owner_uuid = requester_uuid
-        owner_role = UserRole.USER
+        actual_owner_role = requester_role
+        # Own-session creation always goes through the USER path to enforce
+        # explicit project membership via the agus table, regardless of the
+        # requester's actual role.
+        role_for_group_resolution = UserRole.USER
         resource_policy = keypair_resource_policy or {}
 
     query = (
@@ -306,7 +330,7 @@ async def query_userinfo_from_session(
         group_match_query = groups.c.name == requesting_group
     else:
         group_match_query = groups.c.id == requesting_group
-    if owner_role == UserRole.SUPERADMIN:
+    if role_for_group_resolution == UserRole.SUPERADMIN:
         # superadmin can spawn container in any designated domain/group.
         query = (
             sa.select(groups.c.id)
@@ -319,7 +343,7 @@ async def query_userinfo_from_session(
         )
         qresult = await db_sess.execute(query)
         group_id = qresult.scalar()
-    elif owner_role == UserRole.ADMIN:
+    elif role_for_group_resolution == UserRole.ADMIN:
         # domain-admin can spawn container in any group in the same domain.
         if requesting_domain != owner_domain:
             raise ValueError("You can only set the domain to the owner's domain.")
@@ -351,4 +375,9 @@ async def query_userinfo_from_session(
     if group_id is None:
         raise ValueError("Invalid group")
 
-    return owner_uuid, group_id, resource_policy
+    return SessionOwnerContext(
+        owner_uuid=owner_uuid,
+        group_id=group_id,
+        resource_policy=resource_policy,
+        owner_role=actual_owner_role,
+    )

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -62,15 +62,24 @@ class SessionSeedData:
 
 
 @pytest.fixture()
-async def session_processors(
+def session_repository(
     database_engine: ExtendedAsyncSAEngine,
+) -> SessionRepository:
+    """Real ``SessionRepository`` exposed as a fixture so individual tests can
+    override or stub specific methods (e.g., ``resolve_image``) without
+    monkey-patching the class globally."""
+    return SessionRepository(database_engine)
+
+
+@pytest.fixture()
+async def session_processors(
+    session_repository: SessionRepository,
     agent_registry: AsyncMock,
     background_task_manager: BackgroundTaskManager,
     error_monitor: ErrorPluginContext,
     appproxy_client_pool: AsyncMock,
 ) -> SessionProcessors:
     """Real SessionProcessors with real SessionService and SessionRepository."""
-    session_repo = SessionRepository(database_engine)
     args = SessionServiceArgs(
         agent_registry=agent_registry,
         event_fetcher=AsyncMock(),
@@ -78,8 +87,8 @@ async def session_processors(
         event_hub=AsyncMock(),
         error_monitor=error_monitor,
         idle_checker_host=AsyncMock(),
-        session_repository=session_repo,
-        scheduling_controller=AsyncMock(),
+        session_repository=session_repository,
+        scheduling_controller=scheduling_controller_mock,
         appproxy_client_pool=appproxy_client_pool,
     )
     service = SessionService(args)

--- a/tests/component/session/test_session_create_delegation.py
+++ b/tests/component/session/test_session_create_delegation.py
@@ -1,0 +1,144 @@
+"""BA-5608: ``POST /session`` with ``owner_access_key`` must build ``UserScope``
+from the owner, not the requester admin."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+
+from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.common.dto.manager.session.request import CreateFromParamsRequest
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.registry import AgentRegistry
+from ai.backend.manager.repositories.session.repository import SessionRepository
+from ai.backend.manager.types import UserScope
+
+if TYPE_CHECKING:
+    from tests.component.conftest import UserFixtureData
+
+
+class TestDelegatedSessionCreation:
+    """Tests for legacy ``POST /session`` with ``owner_access_key`` (BA-5608)."""
+
+    @pytest.fixture()
+    def stub_image_row(self) -> MagicMock:
+        """Fake image row that satisfies ``SessionService.create_from_params``.
+
+        The real ``resolve_image`` would query the ``images`` table; we bypass
+        it because seeding a fully-valid ImageRow (with registry, labels,
+        architecture) is out of scope for this test.
+        """
+        image_row = MagicMock()
+        image_row.id = uuid.uuid4()
+        image_row.image_ref = MagicMock()
+        return image_row
+
+    @pytest.fixture()
+    def session_repository_with_stub_image(
+        self,
+        session_repository: SessionRepository,
+        stub_image_row: MagicMock,
+    ) -> SessionRepository:
+        """Stub ``resolve_image`` on the injected ``SessionRepository`` instance."""
+        session_repository.resolve_image = AsyncMock(  # type: ignore[method-assign]
+            return_value=stub_image_row
+        )
+        return session_repository
+
+    @pytest.fixture()
+    def mock_create_session(self, agent_registry: AgentRegistry) -> AsyncMock:
+        """Make the mocked ``AgentRegistry.create_session`` return a successful response."""
+        mock = AsyncMock(
+            return_value={
+                "sessionId": "00000000-0000-0000-0000-000000000001",
+                "sessionName": "delegated-session",
+                "status": "PENDING",
+                "service_ports": [],
+                "servicePorts": [],
+                "created": True,
+            }
+        )
+        # ``agent_registry`` from the shared fixture is ``AsyncMock(spec=AgentRegistry)``,
+        # so attribute assignment is enough — no class-level patching required.
+        agent_registry.create_session = mock  # type: ignore[method-assign]
+        return mock
+
+    @pytest.fixture()
+    async def group_name_for_fixture(
+        self,
+        db_engine: SAEngine,
+        group_fixture: uuid.UUID,
+    ) -> str:
+        """Resolve the group name corresponding to ``group_fixture`` (a UUID)."""
+        async with db_engine.begin() as conn:
+            result = await conn.execute(
+                sa.select(GroupRow.__table__.c.name).where(GroupRow.__table__.c.id == group_fixture)
+            )
+            name = result.scalar()
+        assert name is not None, "group_fixture row missing name"
+        return str(name)
+
+    async def test_admin_create_with_owner_access_key_routes_owner_into_user_scope(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        domain_fixture: str,
+        group_name_for_fixture: str,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+        session_repository_with_stub_image: SessionRepository,
+        mock_create_session: AsyncMock,
+    ) -> None:
+        """
+        POST /session signed by the admin keypair, with
+        ``owner_access_key=<regular user's access key>``, must reach
+        ``AgentRegistry.create_session`` with a ``UserScope`` carrying the
+        regular user's uuid — not the admin's.
+        """
+        request = CreateFromParamsRequest(
+            session_name="deleg-session-component",
+            image="python:latest",
+            architecture="x86_64",
+            session_type=SessionTypes.INTERACTIVE,
+            domain=domain_fixture,
+            group=group_name_for_fixture,
+            owner_access_key=regular_user_fixture.keypair.access_key,
+            # ``reuse=False`` skips the existing-session lookup branch in
+            # ``AgentRegistry.create_session`` so we exercise the new
+            # session creation path.
+            reuse=False,
+            enqueue_only=True,
+        )
+
+        # Reuse the v2 client's signed transport for a v1 endpoint
+        # (same pattern as ``tests/component/user/test_keypair_ops.py``).
+        await admin_registry._client._request(
+            "POST",
+            "/session",
+            json=request.model_dump(mode="json", exclude_none=True),
+        )
+
+        # Stubbed ``resolve_image`` having been called confirms we reached the
+        # image lookup, i.e. ``query_userinfo`` + scope resolution succeeded
+        # for the admin acting on behalf of the regular user.
+        session_repository_with_stub_image.resolve_image.assert_awaited()  # type: ignore[attr-defined]
+
+        # Core invariant: ``AgentRegistry.create_session`` received the owner's
+        # identity in the ``UserScope``, not the admin's.
+        mock_create_session.assert_awaited_once()
+        call_args = mock_create_session.call_args
+        # Service calls: create_session(name, image_ref, UserScope(...), owner_access_key, ...)
+        passed_user_scope: Any = call_args.args[2]
+        passed_owner_access_key: Any = call_args.args[3]
+
+        assert isinstance(passed_user_scope, UserScope)
+        assert passed_user_scope.user_uuid == regular_user_fixture.user_uuid, (
+            "UserScope.user_uuid must be the owner's UUID, not the requester admin's"
+        )
+        assert passed_user_scope.user_uuid != admin_user_fixture.user_uuid
+        assert passed_owner_access_key == regular_user_fixture.keypair.access_key

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -5,6 +5,7 @@ Tests the service layer with mocked repositories.
 
 from __future__ import annotations
 
+import inspect
 import uuid
 from datetime import datetime
 from typing import Any
@@ -27,6 +28,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.api.utils import undefined
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
+from ai.backend.manager.data.user.types import SessionOwnerContext
 from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.image import UnknownImageReferenceError
 from ai.backend.manager.errors.kernel import (
@@ -40,6 +42,7 @@ from ai.backend.manager.errors.kernel import (
 from ai.backend.manager.errors.resource import AppNotFound, TaskTemplateNotFound
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.models.user import UserRole
+from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.services.session.actions.check_and_transit_status import (
     CheckAndTransitStatusBatchAction,
@@ -84,6 +87,7 @@ from ai.backend.manager.services.session.actions.start_service import (
     StartServiceAction,
 )
 from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
+from ai.backend.manager.types import UserScope
 
 # ==================== Shared Fixtures ====================
 
@@ -692,6 +696,59 @@ class TestExecuteSession:
 
 
 class TestCreateFromParams:
+    @pytest.fixture
+    def delegated_owner_id(self) -> UUID:
+        """UUID of the user who will own the delegated session (different from requester)."""
+        return uuid4()
+
+    @pytest.fixture
+    def delegated_owner_access_key(self) -> AccessKey:
+        """Access key of the delegation target (the actual session owner)."""
+        return AccessKey("AKIAOWNEREXAMPLE0000")
+
+    @pytest.fixture
+    def delegated_session_action(
+        self,
+        sample_access_key: AccessKey,
+        sample_user_id: UUID,
+        delegated_owner_access_key: AccessKey,
+    ) -> CreateFromParamsAction:
+        """
+        CreateFromParamsAction representing an admin (sample_user_id) creating
+        a session on behalf of another user via owner_access_key.
+        """
+        return CreateFromParamsAction(
+            params=CreateFromParamsActionParams(
+                session_name="delegated-session",
+                image="python:latest",
+                architecture="x86_64",
+                session_type=SessionTypes.INTERACTIVE,
+                group_name="default",
+                domain_name="default",
+                cluster_size=1,
+                cluster_mode=ClusterMode.SINGLE_NODE,
+                config={},
+                tag="",
+                priority=0,
+                is_preemptible=True,
+                owner_access_key=delegated_owner_access_key,
+                enqueue_only=False,
+                max_wait_seconds=0,
+                starts_at=None,
+                reuse_if_exists=False,
+                startup_command=None,
+                batch_timeout=None,
+                bootstrap_script=None,
+                dependencies=None,
+                callback_url=None,
+            ),
+            user_id=sample_user_id,  # requester (admin)
+            user_role=UserRole.SUPERADMIN,
+            sudo_session_enabled=False,
+            requester_access_key=sample_access_key,
+            keypair_resource_policy=None,
+        )
+
     async def test_image_resolve_failure_raises(
         self,
         session_service: SessionService,
@@ -701,7 +758,12 @@ class TestCreateFromParams:
         sample_group_id: UUID,
     ) -> None:
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_session_repository.resolve_image = AsyncMock(
             side_effect=UnknownImageReference("unknown image")
@@ -799,7 +861,12 @@ class TestCreateFromParams:
     ) -> None:
         new_session_id = str(uuid4())
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_image_row = MagicMock()
         mock_image_row.image_ref = MagicMock()
@@ -855,7 +922,12 @@ class TestCreateFromParams:
     ) -> None:
         existing_session_id = str(uuid4())
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_image_row = MagicMock()
         mock_image_row.image_ref = MagicMock()
@@ -912,7 +984,12 @@ class TestCreateFromParams:
         sample_group_id: UUID,
     ) -> None:
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_image_row = MagicMock()
         mock_image_row.image_ref = MagicMock()
@@ -953,6 +1030,58 @@ class TestCreateFromParams:
 
         with pytest.raises(QuotaExceeded):
             await session_service.create_from_params(action)
+
+    async def test_owner_access_key_uses_owner_user_scope(
+        self,
+        session_service: SessionService,
+        mock_session_repository: MagicMock,
+        mock_agent_registry: MagicMock,
+        sample_user_id: UUID,
+        sample_group_id: UUID,
+        delegated_owner_id: UUID,
+        delegated_owner_access_key: AccessKey,
+        delegated_session_action: CreateFromParamsAction,
+    ) -> None:
+        """
+        Regression test for BA-5608.
+
+        When an admin creates a session on behalf of another user via
+        ``owner_access_key``, the ``UserScope`` passed to
+        ``agent_registry.create_session`` must carry the OWNER's ``user_uuid``
+        and ``user_role`` — not the requester's. Previously the requester's
+        identity leaked into the session row, causing scaling group access
+        checks and container UID/GID lookups to use the wrong user.
+        """
+        new_session_id = str(uuid4())
+        mock_session_repository.query_userinfo = AsyncMock(
+            return_value=SessionOwnerContext(
+                owner_uuid=delegated_owner_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
+        )
+        mock_image_row = MagicMock()
+        mock_image_row.image_ref = MagicMock()
+        mock_session_repository.resolve_image = AsyncMock(return_value=mock_image_row)
+        mock_agent_registry.create_session = AsyncMock(return_value={"sessionId": new_session_id})
+
+        await session_service.create_from_params(delegated_session_action)
+
+        mock_agent_registry.create_session.assert_called_once()
+        call_args = mock_agent_registry.create_session.call_args
+        bound = inspect.signature(AgentRegistry.create_session).bind(
+            None, *call_args.args, **call_args.kwargs
+        )
+        passed_user_scope: UserScope = bound.arguments["user_scope"]
+        assert passed_user_scope.user_uuid == delegated_owner_id, (
+            "UserScope.user_uuid must be the owner's UUID, not the requester's"
+        )
+        assert passed_user_scope.user_uuid != sample_user_id
+        assert passed_user_scope.user_role == UserRole.USER.value, (
+            "UserScope.user_role must be the owner's role, not the requester's"
+        )
+        assert bound.arguments["owner_access_key"] == delegated_owner_access_key
 
 
 # ==================== CreateFromTemplate Tests ====================
@@ -1002,7 +1131,12 @@ class TestCreateFromTemplate:
         )
         mock_session_repository.get_group_name_by_domain_and_id = AsyncMock(return_value="default")
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_image_row = MagicMock()
         mock_image_row.image_ref = MagicMock()
@@ -1111,7 +1245,12 @@ class TestCreateCluster:
             return_value={"template": "some-template"}
         )
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_agent_registry.create_cluster = AsyncMock(return_value={"kernelId": kernel_id})
 
@@ -1181,7 +1320,12 @@ class TestCreateCluster:
             return_value={"template": "some-template"}
         )
         mock_session_repository.query_userinfo = AsyncMock(
-            return_value=(sample_user_id, sample_group_id, {})
+            return_value=SessionOwnerContext(
+                owner_uuid=sample_user_id,
+                group_id=sample_group_id,
+                resource_policy={},
+                owner_role=UserRole.USER,
+            )
         )
         mock_agent_registry.create_cluster = AsyncMock(
             side_effect=TooManySessionsMatched("too many")

--- a/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from dateutil.tz import tzutc
 
+from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.plugin.hook import HookResult, HookResults
 from ai.backend.common.types import (
     AccessKey,
@@ -1107,3 +1108,109 @@ class TestMarkSessionsForTermination:
         broadcast_events = event_producer.broadcast_events_batch.call_args[0][0]
         assert len(broadcast_events) == 1
         assert broadcast_events[0].status_transition == str(SessionStatus.TERMINATING)
+
+
+class TestOwnerOnlyScalingGroupForDelegation:
+    """
+    Regression tests for BA-5608.
+
+    When a session is created via ``owner_access_key`` (delegation), scaling
+    group access MUST be resolved using the owner's permissions only — never
+    the requester's, and never the union of both. The policy decision:
+    delegation lets an admin act *as* the owner, not grant the owner extra
+    access the admin happens to hold.
+
+    These tests lock the current behavior in place so that a future refactor
+    cannot silently reintroduce a union / requester-fallback path.
+    """
+
+    def _build_delegated_spec(
+        self,
+        *,
+        owner_access_key: AccessKey,
+        scaling_group: str | None,
+    ) -> SessionCreationSpec:
+        return SessionCreationSpec(
+            session_creation_id="deleg-sg-test",
+            session_name="deleg-sg-test",
+            # The service layer passes the *owner's* access key down into the
+            # spec for delegated sessions; this mirrors that wiring.
+            access_key=owner_access_key,
+            user_scope=UserScope(
+                domain_name="default",
+                group_id=uuid.uuid4(),
+                user_uuid=uuid.uuid4(),
+                user_role="user",
+            ),
+            session_type=SessionTypes.INTERACTIVE,
+            cluster_mode=ClusterMode.SINGLE_NODE,
+            cluster_size=1,
+            priority=10,
+            resource_policy={},
+            kernel_specs=[
+                cast(
+                    KernelEnqueueingConfig,
+                    {
+                        "image_ref": MagicMock(canonical="python:3.9"),
+                        "resources": {"cpu": "1", "mem": "1g"},
+                    },
+                )
+            ],
+            creation_spec={},
+            scaling_group=scaling_group,
+        )
+
+    async def test_requested_sg_inaccessible_to_owner_raises(
+        self,
+        scheduling_controller: Any,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """
+        The requester (admin) has access to ``admin-only`` via their own
+        keypair, but the owner does not. The resolver must query using the
+        owner's access key, see an empty list, and reject the request.
+        """
+        owner_access_key = AccessKey("AKIAOWNERONLY00000000")
+        spec = self._build_delegated_spec(
+            owner_access_key=owner_access_key,
+            scaling_group="admin-only",
+        )
+
+        # Owner has no scaling groups at all.
+        mock_repository.query_allowed_scaling_groups = AsyncMock(return_value=[])
+
+        with pytest.raises(InvalidAPIParameters, match="admin-only"):
+            await scheduling_controller._resolve_scaling_group(spec)
+
+        # The query MUST be scoped to the owner's access key — not the
+        # requester's. This is the core invariant.
+        mock_repository.query_allowed_scaling_groups.assert_awaited_once()
+        call_args = mock_repository.query_allowed_scaling_groups.call_args
+        assert call_args.args[2] == owner_access_key, (
+            "Scaling group lookup must use the owner's access key"
+        )
+
+    async def test_requested_sg_accessible_to_owner_succeeds(
+        self,
+        scheduling_controller: Any,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Sanity: delegation succeeds when the owner has access to the SG."""
+        owner_access_key = AccessKey("AKIAOWNERGOOD00000000")
+        spec = self._build_delegated_spec(
+            owner_access_key=owner_access_key,
+            scaling_group="shared",
+        )
+
+        mock_repository.query_allowed_scaling_groups = AsyncMock(
+            return_value=[
+                AllowedScalingGroup(
+                    name="shared",
+                    is_private=False,
+                    scheduler_opts=ScalingGroupOpts(),
+                ),
+            ]
+        )
+
+        resolved = await scheduling_controller._resolve_scaling_group(spec)
+        assert resolved.name == "shared"


### PR DESCRIPTION
This is an auto-generated backport PR of #10837 to the 26.3 release.