### PR TITLE
fix(BA-5594): restrict agent_nodes queries to superadmin only (#10803)

### DIFF
--- a/changes/10803.fix.md
+++ b/changes/10803.fix.md
@@ -1,0 +1,1 @@
+Restrict `agent_nodes` GraphQL query to superadmin only, preventing regular users from accessing agent infrastructure details such as internal addresses, resource capacity, and hardware metadata.

--- a/src/ai/backend/manager/models/gql_models/agent.py
+++ b/src/ai/backend/manager/models/gql_models/agent.py
@@ -259,6 +259,8 @@ class AgentNode(graphene.ObjectType):
         last: Optional[int] = None,
     ) -> ConnectionResolverResult:
         graph_ctx: GraphQueryContext = info.context
+        if graph_ctx.user["role"] != UserRole.SUPERADMIN:
+            return ConnectionResolverResult([], None, None, None, 0)
         _filter_arg = (
             FilterExprArg(filter_expr, QueryFilterParser(_queryfilter_fieldspec))
             if filter_expr is not None

--- a/tests/manager/models/gql_models/test_agent_admin_only.py
+++ b/tests/manager/models/gql_models/test_agent_admin_only.py
@@ -1,0 +1,64 @@
+"""
+Regression test: agent_nodes must be restricted to superadmin only. (BA-5594)
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from enum import Enum, auto
+from unittest.mock import MagicMock
+
+import graphene
+import pytest
+
+from ai.backend.manager.models.gql_models.agent import AgentNode
+from ai.backend.manager.models.rbac import SystemScope
+from ai.backend.manager.models.rbac.permission_defs import AgentPermission
+from ai.backend.manager.models.user import UserRole
+
+
+class ExpectedResult(Enum):
+    ALLOWED = auto()
+    EMPTY = auto()
+
+
+class TestAgentNodesAdminOnly:
+    @pytest.fixture
+    def make_info(self) -> Callable[..., MagicMock]:
+        def _make(role: UserRole) -> graphene.ResolveInfo:
+            ctx = MagicMock()
+            ctx.user = {
+                "role": role,
+                "domain_name": "default",
+                "uuid": uuid.uuid4(),
+            }
+            info = MagicMock(spec=graphene.ResolveInfo)
+            info.context = ctx
+            return info
+
+        return _make
+
+    @pytest.mark.parametrize(
+        ("role", "expected_result"),
+        [
+            (UserRole.USER, ExpectedResult.EMPTY),
+            (UserRole.ADMIN, ExpectedResult.EMPTY),
+            (UserRole.MONITOR, ExpectedResult.EMPTY),
+        ],
+    )
+    async def test_non_superadmin_gets_empty_results(
+        self,
+        make_info: Callable[..., MagicMock],
+        role: UserRole,
+        expected_result: ExpectedResult,
+    ) -> None:
+        info = make_info(role)
+        result = await AgentNode.get_connection(
+            info,
+            SystemScope(),
+            AgentPermission.CREATE_COMPUTE_SESSION,
+        )
+        if expected_result == ExpectedResult.EMPTY:
+            assert result.node_list == []
+            assert result.total_count == 0


### PR DESCRIPTION
Manual backport of #10803 to the `25.15` release branch.

## Notes
- The original PR patched both the legacy `agent_nodes` resolver and the v2 `agents_v2` resolver.
- `25.15` does not have the v2 `agents_v2` GraphQL query, so only the legacy `agent_nodes` resolver (in `models/gql_models/agent.py`) is patched here.
- The regression test was relocated from `tests/unit/manager/api/gql_legacy/` to `tests/manager/models/gql_models/test_agent_admin_only.py` to match the 25.15 test layout, and the import path was updated accordingly.

Resolves BA-5594.