### PR TITLE
fix(BA-5655): use denormalized permissions schema in backfill migration

### DIFF
--- a/changes/10933.fix.md
+++ b/changes/10933.fix.md
@@ -1,0 +1,1 @@
+Fix backfill migration referencing dropped `permission_groups` table; use denormalized permissions schema instead.

--- a/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
@@ -2,7 +2,7 @@
 
 Users created via the signup or OpenID flows after migration a4d56e86d9ee
 were not assigned RBAC system roles. This idempotent migration creates
-system roles, permission groups, permissions, and user_roles mappings
+system roles, permissions, and user_roles mappings
 for any user that lacks a user_roles entry.
 
 Revision ID: 2c9000848b6e
@@ -19,21 +19,17 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine import Connection, Row
 
-from ai.backend.manager.models.base import EnumValueType, IDColumn
+from ai.backend.manager.models.base import GUID, EnumValueType, IDColumn
 from ai.backend.manager.models.rbac_models.migration.enums import (
     RoleSource,
     ScopeType,
 )
 from ai.backend.manager.models.rbac_models.migration.models import (
-    get_permission_groups_table,
-    get_permissions_table,
     get_roles_table,
     get_user_roles_table,
     mapper_registry,
 )
 from ai.backend.manager.models.rbac_models.migration.types import (
-    PermissionCreateInput,
-    PermissionGroupCreateInput,
     UserRoleCreateInput,
 )
 from ai.backend.manager.models.rbac_models.migration.user import (
@@ -43,7 +39,6 @@ from ai.backend.manager.models.rbac_models.migration.user import (
 )
 from ai.backend.manager.models.rbac_models.migration.utils import (
     insert_skip_on_conflict,
-    query_permission_groups_by_scope_ids,
     query_role_rows_by_name,
 )
 
@@ -52,6 +47,22 @@ revision = "2c9000848b6e"
 down_revision = "4f08ccd6cb8e"
 branch_labels = None
 depends_on = None
+
+
+def _get_permissions_table() -> sa.Table:
+    """Local definition matching the current schema (post-f41bbe0c0f12)
+    where permission_group_id has been replaced by direct role_id/scope columns."""
+    return sa.Table(
+        "permissions",
+        mapper_registry.metadata,
+        IDColumn(),
+        sa.Column("role_id", GUID, nullable=False),
+        sa.Column("scope_type", sa.VARCHAR(length=32), nullable=False),
+        sa.Column("scope_id", sa.String(length=64), nullable=False),
+        sa.Column("entity_type", sa.String(32), nullable=False),
+        sa.Column("operation", sa.String(32), nullable=False),
+        extend_existing=True,
+    )
 
 
 def _get_users_table() -> sa.Table:
@@ -118,33 +129,20 @@ def _backfill_roles_and_permissions(db_conn: Connection, rows: Sequence[Row[Any]
         r.id: uuid_by_role_name[r.name] for r in role_rows
     }
 
-    # Create permission groups
-    pg_inputs: list[dict[str, Any]] = []
-    for role_id, user_id in role_id_user_id_map.items():
-        pg_inputs.append(
-            PermissionGroupCreateInput(
-                role_id=role_id,
-                scope_type=ScopeType.USER,
-                scope_id=str(user_id),
-            ).to_dict()
-        )
-    insert_skip_on_conflict(db_conn, get_permission_groups_table(), pg_inputs)
-
-    # Create permissions
-    str_user_ids = [str(uid) for uid in role_id_user_id_map.values()]
-    pg_ids = query_permission_groups_by_scope_ids(db_conn, str_user_ids)
+    # Create permissions directly (post-f41bbe0c0f12 denormalized schema)
+    permissions_table = _get_permissions_table()
     perm_inputs: list[dict[str, Any]] = []
-    for pg_id in pg_ids:
+    for role_id, user_id in role_id_user_id_map.items():
         for entity_type in ENTITY_TYPES_IN_ROLE:
             for operation in OPERATIONS_IN_ROLE:
-                perm_inputs.append(
-                    PermissionCreateInput(
-                        permission_group_id=pg_id,
-                        entity_type=entity_type,
-                        operation=operation,
-                    ).to_dict()
-                )
-    insert_skip_on_conflict(db_conn, get_permissions_table(), perm_inputs)
+                perm_inputs.append({
+                    "role_id": role_id,
+                    "scope_type": ScopeType.USER,
+                    "scope_id": str(user_id),
+                    "entity_type": entity_type,
+                    "operation": operation,
+                })
+    insert_skip_on_conflict(db_conn, permissions_table, perm_inputs)
 
     # Create user-role mappings
     ur_inputs: list[dict[str, Any]] = []

--- a/src/ai/backend/manager/models/rbac_models/migration/models.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/models.py
@@ -4,6 +4,11 @@ Any models defined here SHOULD NOT be used in the main RBAC system.
 
 All models are defined in functional style.
 The reason for this is to prevent some test code fixtures from incorrectly inferring SQLAlchemy model types.
+
+NOTE: Several table definitions below are DEPRECATED because the underlying tables
+or columns have been dropped or redesigned by later migrations. They are kept solely
+to allow old Alembic migration files to remain importable. New migrations should
+define tables inline or use raw SQL instead of calling these shared helpers.
 """
 
 import sqlalchemy as sa
@@ -43,6 +48,9 @@ def get_roles_table() -> sa.Table:
 
 
 def get_permission_groups_table() -> sa.Table:
+    """DEPRECATED: The ``permission_groups`` table was dropped by migration
+    ``f41bbe0c0f12``. Retained only for old migration imports. New migrations
+    should define tables inline or use raw SQL."""
     return sa.Table(
         "permission_groups",
         mapper_registry.metadata,
@@ -55,6 +63,11 @@ def get_permission_groups_table() -> sa.Table:
 
 
 def get_permissions_table() -> sa.Table:
+    """DEPRECATED: This definition uses the pre-``f41bbe0c0f12`` schema
+    (``permission_group_id`` column). The current ``permissions`` table has
+    ``role_id``, ``scope_type``, ``scope_id`` instead. Retained only for
+    old migration imports. New migrations should define the table inline
+    or use raw SQL."""
     return sa.Table(
         "permissions",
         mapper_registry.metadata,
@@ -67,6 +80,9 @@ def get_permissions_table() -> sa.Table:
 
 
 def get_object_permissions_table() -> sa.Table:
+    """DEPRECATED: The ``object_permissions`` table is deprecated. This
+    definition uses a legacy schema. Retained only for old migration imports.
+    New migrations should define the table inline or use raw SQL."""
     return sa.Table(
         "object_permissions",
         mapper_registry.metadata,
@@ -80,6 +96,8 @@ def get_object_permissions_table() -> sa.Table:
 
 
 def get_association_scopes_entities_table() -> sa.Table:
+    """Table definition for old migrations. New migrations should define
+    the table inline or use raw SQL to avoid schema drift."""
     return sa.Table(
         "association_scopes_entities",
         mapper_registry.metadata,

--- a/src/ai/backend/manager/models/rbac_models/migration/types.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/types.py
@@ -56,6 +56,9 @@ class RoleCreateInput:
 
 @dataclass
 class PermissionGroupCreateInput:
+    """DEPRECATED: The ``permission_groups`` table was dropped by migration
+    ``f41bbe0c0f12``. Retained only for old migration imports."""
+
     role_id: uuid.UUID
     scope_type: ScopeType
     scope_id: str
@@ -70,6 +73,9 @@ class PermissionGroupCreateInput:
 
 @dataclass
 class PermissionCreateInput:
+    """DEPRECATED: Uses the pre-``f41bbe0c0f12`` schema with
+    ``permission_group_id``. Retained only for old migration imports."""
+
     permission_group_id: uuid.UUID
     entity_type: str
     operation: str
@@ -84,6 +90,9 @@ class PermissionCreateInput:
 
 @dataclass
 class ObjectPermissionCreateInput:
+    """DEPRECATED: Uses a legacy schema. Retained only for old migration
+    imports. Use ``data.permission.object_permission`` types for current code."""
+
     role_id: uuid.UUID
     entity_id: str
     entity_type: str

--- a/src/ai/backend/manager/models/rbac_models/migration/utils.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/utils.py
@@ -59,9 +59,8 @@ def query_role_rows_by_name(db_conn: Connection, role_names: Collection[str]) ->
 def query_permission_groups_by_scope_ids(
     db_conn: Connection, scope_ids: Collection[str]
 ) -> list[uuid.UUID]:
-    """
-    Query permission groups by scope IDs.
-    """
+    """DEPRECATED: The ``permission_groups`` table was dropped by migration
+    ``f41bbe0c0f12``. Retained only for old migration imports."""
     permission_groups_table = get_permission_groups_table()
     query = sa.select(permission_groups_table.c.id).where(
         permission_groups_table.c.scope_id.in_(scope_ids)
@@ -95,10 +94,8 @@ class PermissionUpdateUtil:
     def get_or_create_global_permission_group(
         db_conn: Connection, role_id: uuid.UUID
     ) -> tuple[uuid.UUID, bool]:
-        """
-        Get or create a global permission group for the given role ID.
-        Returns a tuple of (permission_group_id, already_exists).
-        """
+        """DEPRECATED: References the ``permission_groups`` table dropped by
+        ``f41bbe0c0f12``. Retained only for old migration imports."""
         permission_groups_table = get_permission_groups_table()
         result = db_conn.execute(
             sa.select(permission_groups_table.c.id).where(
@@ -132,6 +129,8 @@ class PermissionUpdateUtil:
         entity_types: Collection[EntityType],
         operations: Collection[OperationType],
     ) -> None:
+        """DEPRECATED: Uses the pre-``f41bbe0c0f12`` ``permission_group_id``
+        schema. Retained only for old migration imports."""
         permissions_table = get_permissions_table()
         permission_inputs: list[dict[str, Any]] = []
         for entity_type in entity_types:

--- a/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
@@ -43,6 +43,8 @@ def _get_scope_association_join_condition() -> sa.ColumnElement[bool]:
 
 
 class ObjectPermissionRow(Base):  # type: ignore[misc]
+    """DEPRECATED: The ``object_permissions`` table is no longer used and scheduled for removal."""
+
     __tablename__ = "object_permissions"
     __table_args__ = (
         sa.Index("ix_id_role_id_entity_id", "id", "role_id", "entity_id"),


### PR DESCRIPTION
## Summary
- Fix migration `2c9000848b6e` (backfill_missing_user_system_roles) which referenced the `permission_groups` table and `permission_group_id` column already dropped by `f41bbe0c0f12`
- Rewrite to insert permissions directly using the current denormalized schema (`role_id`, `scope_type`, `scope_id`)
- Add DEPRECATED docstrings to legacy migration helpers (`models.py`, `types.py`, `utils.py`) and `ObjectPermissionRow`, guiding new migrations to define tables inline or use raw SQL

## Test plan
- [x] Run `alembic upgrade head` on a fresh DB — verify `2c9000848b6e` succeeds after `f41bbe0c0f12`
- [x] Verify users without system roles are correctly backfilled with roles, permissions, and user_roles
- [x] `pants lint` and `pants check` pass

Resolves BA-5655