### PR TITLE
doc(BA-5657): extract data migration verification into a skill

### DIFF
--- a/changes/10936.doc.md
+++ b/changes/10936.doc.md
@@ -1,0 +1,1 @@
+Add data migration testing guideline to alembic CLAUDE.md.

--- a/src/ai/backend/manager/models/alembic/CLAUDE.md
+++ b/src/ai/backend/manager/models/alembic/CLAUDE.md
@@ -14,3 +14,26 @@
   `down_revision` of a migration that has already been released. Editing
   `down_revision` is allowed only when inserting a backport into the main chain
   before merge.
+
+## Data Migration Verification
+
+Static analysis (lint, mypy) cannot catch SQL-level errors in data migrations.
+When a migration does more than DDL — specifically value casting/transformation,
+cross-table joins in backfill queries, or conditional backfill logic — you **must**
+verify it against the local DB before committing.
+
+### Steps
+
+1. `alembic downgrade` to the parent revision
+2. `INSERT` representative test data into the source tables
+3. `alembic upgrade` to the target revision
+4. `SELECT` from the destination tables and verify converted values
+5. Clean up test data or `alembic upgrade head` to continue
+
+### What to cover
+
+- All value formats the application code can produce
+  (e.g. BinarySize suffixes like `"32g"`, plain numbers, fractional values like `"0.5"`)
+- Null and empty values where the column allows them
+- Cross-table references: confirm referenced tables/columns still exist at that
+  point in the migration chain


### PR DESCRIPTION
## Summary
- Add a new Claude Code skill at `.claude/skills/data-migration-verify/` containing the full manual verification procedure (downgrade → insert test data → upgrade → verify → cleanup) and coverage checklist
- Keep only the trigger condition in `src/ai/backend/manager/models/alembic/CLAUDE.md`, linking to the skill so the full procedure loads on demand instead of consuming context on every manager session
- Motivated by BA-5655 (dropped table reference) and BA-5656 (BinarySize cast failure), both undetectable by static analysis

## Test plan
- [x] Skill content reviewed for clarity and completeness
- [x] Alembic CLAUDE.md trigger condition retained and links to the skill
- [ ] CI passes

Resolves BA-5657