### PR TITLE
fix(BA-5658): grant admin permissions for vfolder RBAC visibility

### DIFF
--- a/changes/10939.fix.md
+++ b/changes/10939.fix.md
@@ -1,0 +1,1 @@
+Fix superadmin unable to see other users' vfolders via vfolder_nodes GQL query due to empty ADMIN_PERMISSIONS

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -1454,7 +1454,11 @@ type WhereClauseType = sa.sql.expression.BinaryExpression[Any] | sa.sql.expressi
 OWNER_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
     perm for perm in VFolderRBACPermission
 ])
-ADMIN_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset()
+ADMIN_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
+    VFolderRBACPermission.READ_ATTRIBUTE,
+    VFolderRBACPermission.UPDATE_ATTRIBUTE,
+    VFolderRBACPermission.DELETE_VFOLDER,
+])
 MONITOR_PERMISSIONS: frozenset[VFolderRBACPermission] = frozenset([
     VFolderRBACPermission.READ_ATTRIBUTE,
     VFolderRBACPermission.UPDATE_ATTRIBUTE,


### PR DESCRIPTION
## Summary
- `ADMIN_PERMISSIONS` for vfolder RBAC was an empty `frozenset()`, preventing superadmins from seeing other users' vfolders via `vfolder_nodes` GQL query
- Grant `READ_ATTRIBUTE`, `UPDATE_ATTRIBUTE`, and `DELETE_VFOLDER` permissions to the admin role so that domain-scoped entries pass `filter_by_permission` checks

## Test plan
- [x] Superadmin queries `vfolder_nodes` without `scope_id` → should see all vfolders across all domains
- [x] Superadmin queries `vfolder_nodes` with `SystemScope` → same result
- [x] Non-admin users should not be affected (their permissions come from other role maps)

Resolves BA-5658