### PR TITLE
fix(BA-5659): skip deserialization for events with no registered consumer

### DIFF
--- a/changes/10941.fix.md
+++ b/changes/10941.fix.md
@@ -1,0 +1,1 @@
+Skip event deserialization in `_consume_loop` when no consumer is registered, preventing `ModuleNotFoundError` in appproxy coordinator

--- a/changes/10941.fix.md
+++ b/changes/10941.fix.md
@@ -1,1 +1,1 @@
-Skip event deserialization in `_consume_loop` when no consumer is registered, preventing `ModuleNotFoundError` in appproxy coordinator
+Skip event deserialization in event dispatcher when no consumer or subscriber is registered, preventing `ModuleNotFoundError` in appproxy coordinator

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -650,6 +650,10 @@ class EventDispatcher(EventDispatcherGroup):
                 return
             try:
                 msg = cast(BroadcastMessage, msg)
+                # Check the event name before full deserialization (ref: BA-5659)
+                event_name = msg.payload["name"]
+                if not self._subscribers[event_name]:
+                    continue
                 msg_payload = MessagePayload.from_broadcast(msg.payload)
                 await self.dispatch_subscribers(
                     msg_payload.name,

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -616,6 +616,12 @@ class EventDispatcher(EventDispatcherGroup):
                 return
             try:
                 mq_msg = cast(MQMessage, msg)
+                # Check the event name before full deserialization to avoid
+                # deserializing messages that have no registered consumer.
+                event_name = mq_msg.payload[b"name"].decode("utf-8")
+                if not self._consumers[event_name]:
+                    await self._msg_queue.done(mq_msg.msg_id)
+                    continue
                 msg_payload = MessagePayload.from_anycast(mq_msg.payload)
                 post_callback = _ConsumerPostCallback(
                     mq_msg.msg_id,

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -619,7 +619,7 @@ class EventDispatcher(EventDispatcherGroup):
                 # Check the event name before full deserialization to avoid
                 # deserializing messages that have no registered consumer.
                 event_name = mq_msg.payload[b"name"].decode("utf-8")
-                if not self._consumers[event_name]:
+                if event_name not in self._consumers:
                     await self._msg_queue.done(mq_msg.msg_id)
                     continue
                 msg_payload = MessagePayload.from_anycast(mq_msg.payload)
@@ -650,9 +650,10 @@ class EventDispatcher(EventDispatcherGroup):
                 return
             try:
                 msg = cast(BroadcastMessage, msg)
-                # Check the event name before full deserialization (ref: BA-5659)
+                # Check the event name before full deserialization to avoid
+                # deserializing messages that have no registered subscriber.
                 event_name = msg.payload["name"]
-                if not self._subscribers[event_name]:
+                if event_name not in self._subscribers:
                     continue
                 msg_payload = MessagePayload.from_broadcast(msg.payload)
                 await self.dispatch_subscribers(

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -579,18 +579,19 @@ class EventDispatcher(EventDispatcherGroup):
         mq_msg: MQMessage,
     ) -> None:
         event_name = deserialize_event_name_for_anycast(mq_msg.payload)
+        consumer_handlers = self._consumers.get(event_name)
         post_callback = _ConsumerPostCallback(
             mq_msg.msg_id,
             self._msg_queue,
-            len(self._consumers[event_name]) if event_name in self._consumers else 0,
+            len(consumer_handlers) if consumer_handlers else 0,
         )
-        if event_name not in self._consumers or not self._consumers[event_name]:
+        if not consumer_handlers:
             await post_callback.done()
             return
         if self._log_events:
-            log.debug("DISPATCH_CONSUMERS(ev:{})}", event_name)
+            log.debug("DISPATCH_CONSUMERS(ev:{})", event_name)
         msg_payload = MessagePayload.from_anycast(mq_msg.payload)
-        for consumer in self._consumers[event_name].copy():
+        for consumer in consumer_handlers.copy():
             self._consumer_taskgroup.create_task(
                 self._handle(
                     consumer,
@@ -607,12 +608,13 @@ class EventDispatcher(EventDispatcherGroup):
         broadcast_msg: BroadcastMessage,
     ) -> None:
         event_name = deserialize_event_name_for_broadcast(broadcast_msg.payload)
-        if event_name not in self._subscribers or not self._subscribers[event_name]:
+        subscriber_handlers = self._subscribers.get(event_name)
+        if not subscriber_handlers:
             return
         if self._log_events:
             log.debug("DISPATCH_SUBSCRIBERS(ev:{})", event_name)
         msg_payload = MessagePayload.from_broadcast(broadcast_msg.payload)
-        for subscriber in self._subscribers[event_name].copy():
+        for subscriber in subscriber_handlers.copy():
             self._subscriber_taskgroup.create_task(
                 self._handle(
                     subscriber,

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -32,6 +32,8 @@ from ai.backend.common.message_queue.types import (
     MessageMetadata,
     MessagePayload,
     MQMessage,
+    deserialize_event_name_for_anycast,
+    deserialize_event_name_for_broadcast,
 )
 from ai.backend.common.types import (
     AgentId,
@@ -572,40 +574,53 @@ class EventDispatcher(EventDispatcherGroup):
         for complete in evh.event_complete_reporters:
             await complete.complete_event_report(event, CompleteEventReportArgs(duration))
 
-    async def dispatch_consumers(
+    async def _dispatch_consumers(
         self,
-        event_name: str,
-        source: AgentId,
-        args: tuple[Any, ...],
-        post_callbacks: Sequence[PostCallback] = tuple(),
-        metadata: MessageMetadata | None = None,
+        mq_msg: MQMessage,
     ) -> None:
-        if self._log_events:
-            log.debug("DISPATCH_CONSUMERS(ev:{}, ag:{})", event_name, source)
-        consumers_handlers = self._consumers[event_name].copy()
-        if not consumers_handlers:
-            # If there are no consumer handlers, we can just call post callbacks and return.
-            for post_callback in post_callbacks:
-                await post_callback.done()
+        event_name = deserialize_event_name_for_anycast(mq_msg.payload)
+        post_callback = _ConsumerPostCallback(
+            mq_msg.msg_id,
+            self._msg_queue,
+            len(self._consumers[event_name]) if event_name in self._consumers else 0,
+        )
+        if event_name not in self._consumers or not self._consumers[event_name]:
+            await post_callback.done()
             return
-        for consumer in consumers_handlers:
+        if self._log_events:
+            log.debug("DISPATCH_CONSUMERS(ev:{})}", event_name)
+        msg_payload = MessagePayload.from_anycast(mq_msg.payload)
+        for consumer in self._consumers[event_name].copy():
             self._consumer_taskgroup.create_task(
-                self._handle(consumer, source, args, post_callbacks, metadata),
+                self._handle(
+                    consumer,
+                    AgentId(msg_payload.source),
+                    msg_payload.args,
+                    [post_callback],
+                    msg_payload.metadata,
+                ),
             )
             await asyncio.sleep(0)
 
-    async def dispatch_subscribers(
+    async def _dispatch_subscribers(
         self,
-        event_name: str,
-        source: AgentId,
-        args: tuple[Any, ...],
-        metadata: MessageMetadata | None = None,
+        broadcast_msg: BroadcastMessage,
     ) -> None:
+        event_name = deserialize_event_name_for_broadcast(broadcast_msg.payload)
+        if event_name not in self._subscribers or not self._subscribers[event_name]:
+            return
         if self._log_events:
-            log.debug("DISPATCH_SUBSCRIBERS(ev:{}, ag:{})", event_name, source)
+            log.debug("DISPATCH_SUBSCRIBERS(ev:{})", event_name)
+        msg_payload = MessagePayload.from_broadcast(broadcast_msg.payload)
         for subscriber in self._subscribers[event_name].copy():
             self._subscriber_taskgroup.create_task(
-                self._handle(subscriber, source, args, tuple(), metadata),
+                self._handle(
+                    subscriber,
+                    AgentId(msg_payload.source),
+                    msg_payload.args,
+                    tuple(),
+                    msg_payload.metadata,
+                ),
             )
             await asyncio.sleep(0)
 
@@ -615,26 +630,7 @@ class EventDispatcher(EventDispatcherGroup):
             if self._closed:
                 return
             try:
-                mq_msg = cast(MQMessage, msg)
-                # Check the event name before full deserialization to avoid
-                # deserializing messages that have no registered consumer.
-                event_name = mq_msg.payload[b"name"].decode("utf-8")
-                if event_name not in self._consumers:
-                    await self._msg_queue.done(mq_msg.msg_id)
-                    continue
-                msg_payload = MessagePayload.from_anycast(mq_msg.payload)
-                post_callback = _ConsumerPostCallback(
-                    mq_msg.msg_id,
-                    self._msg_queue,
-                    len(self._consumers[msg_payload.name]),
-                )
-                await self.dispatch_consumers(
-                    msg_payload.name,
-                    AgentId(msg_payload.source),
-                    msg_payload.args,
-                    [post_callback],
-                    msg_payload.metadata,
-                )
+                await self._dispatch_consumers(cast(MQMessage, msg))
             except Exception as e:
                 log.exception(
                     "EventDispatcher._consume_loop: unexpected-error, {}",
@@ -649,19 +645,7 @@ class EventDispatcher(EventDispatcherGroup):
             if self._closed:
                 return
             try:
-                msg = cast(BroadcastMessage, msg)
-                # Check the event name before full deserialization to avoid
-                # deserializing messages that have no registered subscriber.
-                event_name = msg.payload["name"]
-                if event_name not in self._subscribers:
-                    continue
-                msg_payload = MessagePayload.from_broadcast(msg.payload)
-                await self.dispatch_subscribers(
-                    msg_payload.name,
-                    AgentId(msg_payload.source),
-                    msg_payload.args,
-                    msg_payload.metadata,
-                )
+                await self._dispatch_subscribers(cast(BroadcastMessage, msg))
             except Exception as e:
                 log.exception(
                     "EventDispatcher._subscribe_loop: unexpected-error, {}",

--- a/src/ai/backend/common/message_queue/types.py
+++ b/src/ai/backend/common/message_queue/types.py
@@ -100,6 +100,14 @@ class MessageMetadata:
             yield
 
 
+def deserialize_event_name_for_anycast(payload: Mapping[bytes, bytes]) -> str:
+    return payload[b"name"].decode("utf-8")
+
+
+def deserialize_event_name_for_broadcast(payload: Mapping[str, str]) -> str:
+    return payload["name"]
+
+
 @dataclass
 class MessagePayload:
     name: str
@@ -145,7 +153,7 @@ class MessagePayload:
         if b"metadata" in payload:
             metadata = MessageMetadata.deserialize(payload[b"metadata"])
         return cls(
-            name=payload[b"name"].decode("utf-8"),
+            name=deserialize_event_name_for_anycast(payload),
             source=payload[b"source"].decode("utf-8"),
             args=cast(tuple[bytes, ...], msgpack.unpackb(payload[b"args"])),
             metadata=metadata,
@@ -162,7 +170,7 @@ class MessagePayload:
         if "metadata" in payload:
             metadata = MessageMetadata.deserialize(payload["metadata"])
         return cls(
-            name=payload["name"],
+            name=deserialize_event_name_for_broadcast(payload),
             source=payload["source"],
             args=cast(tuple[bytes, ...], msgpack.unpackb(args_bytes)),
             metadata=metadata,

--- a/tests/unit/common/events/test_dispatcher.py
+++ b/tests/unit/common/events/test_dispatcher.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+import msgpack
+import pytest
+
+from ai.backend.common.events.dispatcher import EventDispatcher
+from ai.backend.common.events.types import (
+    AbstractAnycastEvent,
+    AbstractBroadcastEvent,
+    EventDomain,
+)
+from ai.backend.common.events.user_event.user_event import UserEvent
+from ai.backend.common.message_queue.types import (
+    BroadcastMessage,
+    MQMessage,
+)
+from ai.backend.common.types import AgentId
+
+
+@dataclass
+class DummyAnycastEvent(AbstractAnycastEvent):
+    value: int
+
+    def serialize(self) -> tuple[Any, ...]:
+        return (self.value,)
+
+    @classmethod
+    def deserialize(cls, value: tuple[Any, ...]) -> DummyAnycastEvent:
+        return cls(value[0])
+
+    @classmethod
+    def event_domain(cls) -> EventDomain:
+        return EventDomain.AGENT
+
+    def domain_id(self) -> str | None:
+        return None
+
+    def user_event(self) -> UserEvent | None:
+        return None
+
+    @classmethod
+    def event_name(cls) -> str:
+        return "test_anycast"
+
+
+@dataclass
+class DummyBroadcastEvent(AbstractBroadcastEvent):
+    value: int
+
+    def serialize(self) -> tuple[Any, ...]:
+        return (self.value,)
+
+    @classmethod
+    def deserialize(cls, value: tuple[Any, ...]) -> DummyBroadcastEvent:
+        return cls(value[0])
+
+    @classmethod
+    def event_domain(cls) -> EventDomain:
+        return EventDomain.AGENT
+
+    def domain_id(self) -> str | None:
+        return None
+
+    def user_event(self) -> UserEvent | None:
+        return None
+
+    @classmethod
+    def event_name(cls) -> str:
+        return "test_broadcast"
+
+
+def _make_anycast_mq_message(event: AbstractAnycastEvent) -> MQMessage:
+    return MQMessage(
+        msg_id=b"test-msg-id",
+        payload={
+            b"name": event.event_name().encode("utf-8"),
+            b"source": b"i-test",
+            b"args": msgpack.packb(event.serialize()),
+        },
+    )
+
+
+def _make_broadcast_message(event: AbstractBroadcastEvent) -> BroadcastMessage:
+    args = base64.b64encode(msgpack.packb(event.serialize())).decode("ascii")
+    return BroadcastMessage(
+        payload={
+            "name": event.event_name(),
+            "source": "i-test",
+            "args": args,
+        },
+    )
+
+
+class StubMessageQueue:
+    """A minimal stub that satisfies EventDispatcher's runtime usage."""
+
+    def __init__(
+        self,
+        anycast_messages: list[MQMessage] | None = None,
+        broadcast_messages: list[BroadcastMessage] | None = None,
+    ) -> None:
+        self._anycast_messages = anycast_messages or []
+        self._broadcast_messages = broadcast_messages or []
+        self.done_calls: list[bytes] = []
+
+    async def consume_queue(self) -> AsyncGenerator[MQMessage, None]:
+        for msg in self._anycast_messages:
+            yield msg
+
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:
+        for msg in self._broadcast_messages:
+            yield msg
+
+    async def done(self, msg_id: bytes) -> None:
+        self.done_calls.append(msg_id)
+
+    async def close(self) -> None:
+        pass
+
+
+class TestDispatchConsumers:
+    """Tests for consumer dispatch with and without registered handlers."""
+
+    @pytest.fixture
+    def received(self) -> list[DummyAnycastEvent]:
+        return []
+
+    @pytest.fixture
+    def mq(self) -> StubMessageQueue:
+        return StubMessageQueue(
+            anycast_messages=[_make_anycast_mq_message(DummyAnycastEvent(value=42))],
+        )
+
+    @pytest.fixture
+    async def consumer_dispatcher(
+        self,
+        mq: StubMessageQueue,
+        received: list[DummyAnycastEvent],
+    ) -> EventDispatcher:
+        dispatcher = EventDispatcher(mq)  # type: ignore[arg-type]
+
+        async def handler(ctx: object, source: AgentId, ev: DummyAnycastEvent) -> None:
+            received.append(ev)
+
+        dispatcher.consume(DummyAnycastEvent, object(), handler)
+        return dispatcher
+
+    @pytest.fixture
+    async def no_consumer_dispatcher(
+        self,
+        mq: StubMessageQueue,
+    ) -> EventDispatcher:
+        return EventDispatcher(mq)  # type: ignore[arg-type]
+
+    async def test_registered_consumer_receives_event(
+        self,
+        consumer_dispatcher: EventDispatcher,
+        received: list[DummyAnycastEvent],
+    ) -> None:
+        await consumer_dispatcher.start()
+        await asyncio.sleep(0.1)
+        await consumer_dispatcher.close()
+
+        assert len(received) == 1
+        assert received[0].value == 42
+
+    async def test_no_error_when_no_consumer_registered(
+        self,
+        no_consumer_dispatcher: EventDispatcher,
+        mq: StubMessageQueue,
+    ) -> None:
+        await no_consumer_dispatcher.start()
+        await asyncio.sleep(0.1)
+        await no_consumer_dispatcher.close()
+
+        assert mq.done_calls == [b"test-msg-id"]
+
+
+class TestDispatchSubscribers:
+    """Tests for subscriber dispatch with and without registered handlers."""
+
+    @pytest.fixture
+    def received(self) -> list[DummyBroadcastEvent]:
+        return []
+
+    @pytest.fixture
+    def mq(self) -> StubMessageQueue:
+        return StubMessageQueue(
+            broadcast_messages=[_make_broadcast_message(DummyBroadcastEvent(value=7))],
+        )
+
+    @pytest.fixture
+    async def subscriber_dispatcher(
+        self,
+        mq: StubMessageQueue,
+        received: list[DummyBroadcastEvent],
+    ) -> EventDispatcher:
+        dispatcher = EventDispatcher(mq)  # type: ignore[arg-type]
+
+        async def handler(ctx: object, source: AgentId, ev: DummyBroadcastEvent) -> None:
+            received.append(ev)
+
+        dispatcher.subscribe(DummyBroadcastEvent, object(), handler)
+        return dispatcher
+
+    @pytest.fixture
+    async def no_subscriber_dispatcher(
+        self,
+        mq: StubMessageQueue,
+    ) -> EventDispatcher:
+        return EventDispatcher(mq)  # type: ignore[arg-type]
+
+    async def test_registered_subscriber_receives_event(
+        self,
+        subscriber_dispatcher: EventDispatcher,
+        received: list[DummyBroadcastEvent],
+    ) -> None:
+        await subscriber_dispatcher.start()
+        await asyncio.sleep(0.1)
+        await subscriber_dispatcher.close()
+
+        assert len(received) == 1
+        assert received[0].value == 7
+
+    async def test_no_error_when_no_subscriber_registered(
+        self,
+        no_subscriber_dispatcher: EventDispatcher,
+    ) -> None:
+        await no_subscriber_dispatcher.start()
+        await asyncio.sleep(0.1)
+        await no_subscriber_dispatcher.close()


### PR DESCRIPTION
## Summary
- In `_consume_loop`, check the event name from the raw payload before calling `from_anycast()` to avoid full deserialization of messages with no registered consumer
- This prevents `ModuleNotFoundError` when a component (e.g., appproxy coordinator) receives events containing types from other components' packages (e.g., `ai.backend.manager`)
- The coordinator shares the `"events"` Redis stream with the manager via a separate consumer group, so it receives all manager events but only needs `EndpointRouteListUpdatedEvent`

## Test plan
- [x] Deploy appproxy coordinator in a separate venv (without `ai.backend.manager`) and verify no `ModuleNotFoundError` in `_consume_loop`
- [x] Verify `EndpointRouteListUpdatedEvent` is still consumed and processed correctly
- [x] Confirm unhandled events are properly acknowledged (no PEL buildup in Redis)

Resolves BA-5659