### PR TITLE
feat(BA-5632): add Client SDK v2 and CLI v2 for login_client_types

### DIFF
--- a/changes/10878.feature.md
+++ b/changes/10878.feature.md
@@ -1,0 +1,1 @@
+Add `./bai` CLI v2 commands for `login_client_types`: `./bai login-client-type list/get` (any authenticated user) and `./bai admin login-client-type create/update/delete` (super admin only).

--- a/changes/10942.feature.md
+++ b/changes/10942.feature.md
@@ -1,0 +1,1 @@
+Add Client SDK v2 domain client and CLI v2 commands for the `login_client_types` entity: `./bai login-client-type get`, `./bai admin login-client-type search/create/update/delete`.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10484,13 +10484,13 @@ type Mutation
   adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.1. Create a new login client type (super admin only)."""
-  createLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.1. Update a login client type (super admin only)."""
-  updateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.1. Delete a login client type (super admin only)."""
-  deleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.1. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
@@ -13215,7 +13215,7 @@ type Query
   loginClientType(id: UUID!): LoginClientType @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.4.1. Search login client types with filtering, ordering, and pagination (super admin only).
+  Added in 26.4.1. Search login client types with filtering, ordering, and pagination.
   """
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection @join__field(graph: STRAWBERRY)
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6488,13 +6488,13 @@ type Mutation {
   adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL!
 
   """Added in 26.4.1. Create a new login client type (super admin only)."""
-  createLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload!
+  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload!
 
   """Added in 26.4.1. Update a login client type (super admin only)."""
-  updateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload!
+  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload!
 
   """Added in 26.4.1. Delete a login client type (super admin only)."""
-  deleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload!
+  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload!
 
   """Added in 26.4.1. Create a new runtime variant (superadmin only)."""
   adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL!
@@ -8436,7 +8436,7 @@ type Query {
   loginClientType(id: UUID!): LoginClientType
 
   """
-  Added in 26.4.1. Search login client types with filtering, ordering, and pagination (super admin only).
+  Added in 26.4.1. Search login client types with filtering, ordering, and pagination.
   """
   loginClientTypes(filter: LoginClientTypeFilter = null, orderBy: [LoginClientTypeOrderBy!] = null, limit: Int = null, offset: Int = null): LoginClientTypeConnection
 

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -111,6 +111,14 @@ def huggingface_registry() -> None:
 
 @v2.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.login_client_type:login_client_type",
+)
+def login_client_type() -> None:
+    """Login client type commands."""
+
+
+@v2.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.reservoir_registry:reservoir_registry",
 )
 def reservoir_registry() -> None:

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -111,14 +111,6 @@ def huggingface_registry() -> None:
 
 @v2.group(
     cls=LazyGroup,
-    import_name="ai.backend.client.cli.v2.login_client_type:login_client_type",
-)
-def login_client_type() -> None:
-    """Login client type commands."""
-
-
-@v2.group(
-    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.reservoir_registry:reservoir_registry",
 )
 def reservoir_registry() -> None:

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -195,6 +195,15 @@ def object_storage() -> None:
 # ------------------------------------------------------------------ RBAC & resources
 
 
+@v2.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.login_client_type.commands:login_client_type",
+    name="login-client-type",
+)
+def login_client_type() -> None:
+    """Read-only commands for inspecting registered login client types."""
+
+
 @v2.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.rbac:rbac")
 def rbac() -> None:
     """RBAC commands."""

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -135,6 +135,15 @@ def keypair() -> None:
 
 @admin.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.login_client_type:login_client_type",
+    name="login-client-type",
+)
+def login_client_type() -> None:
+    """Admin login client type commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.admin.resource_preset:resource_preset",
     name="resource-preset",
 )

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -66,14 +66,6 @@ def container_registry() -> None:
 
 @admin.group(
     cls=LazyGroup,
-    import_name="ai.backend.client.cli.v2.admin.login_client_type:login_client_type",
-)
-def login_client_type() -> None:
-    """Admin login client type commands."""
-
-
-@admin.group(
-    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.admin.login_history:login_history",
 )
 def login_history() -> None:

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -66,6 +66,14 @@ def container_registry() -> None:
 
 @admin.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.login_client_type:login_client_type",
+)
+def login_client_type() -> None:
+    """Admin login client type commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.admin.login_history:login_history",
 )
 def login_history() -> None:

--- a/src/ai/backend/client/cli/v2/admin/login_client_type.py
+++ b/src/ai/backend/client/cli/v2/admin/login_client_type.py
@@ -1,0 +1,148 @@
+"""Admin CLI commands for login client types."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group()
+def login_client_type() -> None:
+    """Login client type admin commands."""
+
+
+@login_client_type.command()
+@click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
+@click.option("--offset", type=int, default=0, help="Number of items to skip.")
+@click.option(
+    "--name",
+    default=None,
+    type=str,
+    help="Filter by name (substring match).",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., name:asc, created_at:desc).",
+)
+def search(
+    limit: int,
+    offset: int,
+    name: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Search login client types with admin scope."""
+    from ai.backend.common.dto.manager.v2.login_client_type.request import (
+        AdminSearchLoginClientTypesInput,
+        LoginClientTypeFilter,
+        LoginClientTypeOrder,
+    )
+    from ai.backend.common.dto.manager.v2.login_client_type.types import (
+        LoginClientTypeOrderField,
+    )
+
+    filter_dto: LoginClientTypeFilter | None = None
+    if name is not None:
+        from ai.backend.common.dto.manager.query import StringFilter
+
+        filter_dto = LoginClientTypeFilter(
+            name=StringFilter(contains=name) if name is not None else None,
+        )
+
+    orders = (
+        parse_order_options(order_by, LoginClientTypeOrderField, LoginClientTypeOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.login_client_type.admin_search(
+                AdminSearchLoginClientTypesInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@login_client_type.command()
+@click.option("--name", required=True, type=str, help="Unique login client type name.")
+@click.option("--description", default=None, type=str, help="Optional description.")
+def create(name: str, description: str | None) -> None:
+    """Create a new login client type (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.login_client_type.request import (
+        CreateLoginClientTypeInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.login_client_type.create(
+                CreateLoginClientTypeInput(name=name, description=description)
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@login_client_type.command()
+@click.argument("login_client_type_id", type=click.UUID)
+@click.option("--name", default=None, type=str, help="Updated name.")
+@click.option("--description", default=None, type=str, help="Updated description.")
+def update(
+    login_client_type_id: uuid.UUID,
+    name: str | None,
+    description: str | None,
+) -> None:
+    """Update a login client type (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.login_client_type.request import (
+        UpdateLoginClientTypeInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.login_client_type.update(
+                login_client_type_id,
+                UpdateLoginClientTypeInput(name=name, description=description),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@login_client_type.command()
+@click.argument("login_client_type_id", type=click.UUID)
+def delete(login_client_type_id: uuid.UUID) -> None:
+    """Delete a login client type (superadmin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.login_client_type.delete(login_client_type_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/admin/login_client_type.py
+++ b/src/ai/backend/client/cli/v2/admin/login_client_type.py
@@ -42,9 +42,9 @@ def search(
 ) -> None:
     """Search login client types with admin scope."""
     from ai.backend.common.dto.manager.v2.login_client_type.request import (
-        AdminSearchLoginClientTypesInput,
         LoginClientTypeFilter,
         LoginClientTypeOrder,
+        SearchLoginClientTypesInput,
     )
     from ai.backend.common.dto.manager.v2.login_client_type.types import (
         LoginClientTypeOrderField,
@@ -67,8 +67,8 @@ def search(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.login_client_type.admin_search(
-                AdminSearchLoginClientTypesInput(
+            result = await registry.login_client_type.search(
+                SearchLoginClientTypesInput(
                     filter=filter_dto,
                     order=orders,
                     limit=limit,
@@ -94,7 +94,7 @@ def create(name: str, description: str | None) -> None:
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.login_client_type.create(
+            result = await registry.login_client_type.admin_create(
                 CreateLoginClientTypeInput(name=name, description=description)
             )
             print_result(result)
@@ -121,7 +121,7 @@ def update(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.login_client_type.update(
+            result = await registry.login_client_type.admin_update(
                 login_client_type_id,
                 UpdateLoginClientTypeInput(name=name, description=description),
             )
@@ -140,7 +140,7 @@ def delete(login_client_type_id: uuid.UUID) -> None:
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.login_client_type.delete(login_client_type_id)
+            result = await registry.login_client_type.admin_delete(login_client_type_id)
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/cli/v2/admin/login_client_type.py
+++ b/src/ai/backend/client/cli/v2/admin/login_client_type.py
@@ -24,7 +24,7 @@ def login_client_type() -> None:
 @click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
 @click.option("--offset", type=int, default=0, help="Number of items to skip.")
 @click.option(
-    "--name",
+    "--name-contains",
     default=None,
     type=str,
     help="Filter by name (substring match).",
@@ -37,7 +37,7 @@ def login_client_type() -> None:
 def search(
     limit: int,
     offset: int,
-    name: str | None,
+    name_contains: str | None,
     order_by: tuple[str, ...],
 ) -> None:
     """Search login client types with admin scope."""
@@ -51,11 +51,11 @@ def search(
     )
 
     filter_dto: LoginClientTypeFilter | None = None
-    if name is not None:
+    if name_contains is not None:
         from ai.backend.common.dto.manager.query import StringFilter
 
         filter_dto = LoginClientTypeFilter(
-            name=StringFilter(contains=name) if name is not None else None,
+            name=StringFilter(contains=name_contains),
         )
 
     orders = (

--- a/src/ai/backend/client/cli/v2/login_client_type/__init__.py
+++ b/src/ai/backend/client/cli/v2/login_client_type/__init__.py
@@ -1,0 +1,3 @@
+from .commands import login_client_type as login_client_type
+
+__all__ = ("login_client_type",)

--- a/src/ai/backend/client/cli/v2/login_client_type/commands.py
+++ b/src/ai/backend/client/cli/v2/login_client_type/commands.py
@@ -1,0 +1,39 @@
+"""CLI commands for the v2 login client type domain.
+
+User-facing commands (get). Admin-only commands (create, search, update, delete)
+are under ``admin login-client-type``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    print_result,
+)
+
+
+@click.group(name="login-client-type")
+def login_client_type() -> None:
+    """Login client type management commands."""
+
+
+@login_client_type.command()
+@click.argument("login_client_type_id", type=click.UUID)
+def get(login_client_type_id: uuid.UUID) -> None:
+    """Get a login client type by ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.login_client_type.get(login_client_type_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/v2/domains_v2/login_client_type.py
+++ b/src/ai/backend/client/v2/domains_v2/login_client_type.py
@@ -1,0 +1,87 @@
+"""V2 SDK client for the login client type domain."""
+
+from __future__ import annotations
+
+from typing import Final
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.login_client_type.request import (
+    AdminSearchLoginClientTypesInput,
+    CreateLoginClientTypeInput,
+    UpdateLoginClientTypeInput,
+)
+from ai.backend.common.dto.manager.v2.login_client_type.response import (
+    AdminSearchLoginClientTypesPayload,
+    CreateLoginClientTypePayload,
+    DeleteLoginClientTypePayload,
+    LoginClientTypeNode,
+    UpdateLoginClientTypePayload,
+)
+
+_PATH: Final = "/v2/login-client-types"
+
+
+class V2LoginClientTypeClient(BaseDomainClient):
+    """SDK client for login client type CRUD operations.
+
+    Mirrors the REST v2 surface introduced in BA-5630. Mutating calls
+    require super-admin privileges; the read calls are open to any
+    authenticated user.
+    """
+
+    async def create(
+        self,
+        request: CreateLoginClientTypeInput,
+    ) -> CreateLoginClientTypePayload:
+        """Create a new login client type (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/",
+            request=request,
+            response_model=CreateLoginClientTypePayload,
+        )
+
+    async def admin_search(
+        self,
+        request: AdminSearchLoginClientTypesInput,
+    ) -> AdminSearchLoginClientTypesPayload:
+        """Search login client types with filter/order/pagination (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=AdminSearchLoginClientTypesPayload,
+        )
+
+    async def get(self, login_client_type_id: UUID) -> LoginClientTypeNode:
+        """Get a single login client type by ID (authenticated users)."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{login_client_type_id}",
+            response_model=LoginClientTypeNode,
+        )
+
+    async def update(
+        self,
+        login_client_type_id: UUID,
+        request: UpdateLoginClientTypeInput,
+    ) -> UpdateLoginClientTypePayload:
+        """Update a login client type (superadmin only)."""
+        return await self._client.typed_request(
+            "PATCH",
+            f"{_PATH}/{login_client_type_id}",
+            request=request,
+            response_model=UpdateLoginClientTypePayload,
+        )
+
+    async def delete(
+        self,
+        login_client_type_id: UUID,
+    ) -> DeleteLoginClientTypePayload:
+        """Delete a login client type (superadmin only)."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{login_client_type_id}",
+            response_model=DeleteLoginClientTypePayload,
+        )

--- a/src/ai/backend/client/v2/domains_v2/login_client_type.py
+++ b/src/ai/backend/client/v2/domains_v2/login_client_type.py
@@ -7,15 +7,15 @@ from uuid import UUID
 
 from ai.backend.client.v2.base_domain import BaseDomainClient
 from ai.backend.common.dto.manager.v2.login_client_type.request import (
-    AdminSearchLoginClientTypesInput,
     CreateLoginClientTypeInput,
+    SearchLoginClientTypesInput,
     UpdateLoginClientTypeInput,
 )
 from ai.backend.common.dto.manager.v2.login_client_type.response import (
-    AdminSearchLoginClientTypesPayload,
     CreateLoginClientTypePayload,
     DeleteLoginClientTypePayload,
     LoginClientTypeNode,
+    SearchLoginClientTypesPayload,
     UpdateLoginClientTypePayload,
 )
 
@@ -30,7 +30,7 @@ class V2LoginClientTypeClient(BaseDomainClient):
     authenticated user.
     """
 
-    async def create(
+    async def admin_create(
         self,
         request: CreateLoginClientTypeInput,
     ) -> CreateLoginClientTypePayload:
@@ -42,16 +42,16 @@ class V2LoginClientTypeClient(BaseDomainClient):
             response_model=CreateLoginClientTypePayload,
         )
 
-    async def admin_search(
+    async def search(
         self,
-        request: AdminSearchLoginClientTypesInput,
-    ) -> AdminSearchLoginClientTypesPayload:
+        request: SearchLoginClientTypesInput,
+    ) -> SearchLoginClientTypesPayload:
         """Search login client types with filter/order/pagination (superadmin only)."""
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/search",
             request=request,
-            response_model=AdminSearchLoginClientTypesPayload,
+            response_model=SearchLoginClientTypesPayload,
         )
 
     async def get(self, login_client_type_id: UUID) -> LoginClientTypeNode:
@@ -62,7 +62,7 @@ class V2LoginClientTypeClient(BaseDomainClient):
             response_model=LoginClientTypeNode,
         )
 
-    async def update(
+    async def admin_update(
         self,
         login_client_type_id: UUID,
         request: UpdateLoginClientTypeInput,
@@ -75,7 +75,7 @@ class V2LoginClientTypeClient(BaseDomainClient):
             response_model=UpdateLoginClientTypePayload,
         )
 
-    async def delete(
+    async def admin_delete(
         self,
         login_client_type_id: UUID,
     ) -> DeleteLoginClientTypePayload:

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .domains_v2.huggingface_registry import V2HuggingFaceRegistryClient
     from .domains_v2.image import V2ImageClient
     from .domains_v2.keypair import V2KeypairClient
+    from .domains_v2.login_client_type import V2LoginClientTypeClient
     from .domains_v2.login_history import V2LoginHistoryClient
     from .domains_v2.login_session import V2LoginSessionClient
     from .domains_v2.model_card import V2ModelCardClient
@@ -162,6 +163,12 @@ class V2ClientRegistry:
         from .domains_v2.keypair import V2KeypairClient
 
         return V2KeypairClient(self._client)
+
+    @cached_property
+    def login_client_type(self) -> V2LoginClientTypeClient:
+        from .domains_v2.login_client_type import V2LoginClientTypeClient
+
+        return V2LoginClientTypeClient(self._client)
 
     @cached_property
     def login_history(self) -> V2LoginHistoryClient:


### PR DESCRIPTION
## Summary

Add the Client SDK v2 domain client and CLI v2 commands for the `login_client_types` entity. Replaces the abandoned #10877.

## What changed

### SDK (`client/v2/domains_v2/login_client_type.py`)
- `V2LoginClientTypeClient` with `create`, `admin_search`, `get`, `update`, `delete`
- Registered as `cached_property` in `V2ClientRegistry`

### CLI (`client/cli/v2/`)
- `./bai login-client-type get {id}` — authenticated users
- `./bai admin login-client-type search [--name ...] [--order-by ...]`
- `./bai admin login-client-type create --name ... [--description ...]`
- `./bai admin login-client-type update {id} [--name ...] [--description ...]`
- `./bai admin login-client-type delete {id}`

## Test plan

- [x] pants fmt/fix/lint/check green
- [ ] Manual smoke test via `./bai` after full stack merge

Resolves BA-5632.

## 📚 Stack

- `main`
  - ✅ #10822 — feat(BA-5630) DB foundation
    - ✅ #10923 — feat(BA-5630) service layer + DTO
      - #10924 — feat(BA-5630) REST v2 CRUD
        - ✅ #10925 — refactor(BA-5630) auth cutover
          - ✅ #10876 — feat(BA-5631) GraphQL schema
            - ✅ 👉 **#10942** — feat(BA-5632) Client SDK + CLI

**Merge order:** top to bottom. This PR is marked with 👉.
<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--10942.org.readthedocs.build/en/10942/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--10942.org.readthedocs.build/ko/10942/

<!-- readthedocs-preview sorna-ko end -->