### PR TITLE
fix(BA-5665,BA-5680): pass Manager model_definition to Agent, remove Agent-side generation

### DIFF
--- a/changes/10951.fix.md
+++ b/changes/10951.fix.md
@@ -1,1 +1,1 @@
-Pass Manager-merged model definition to Agent so that VFolder health_check overrides (initial_delay, max_retries, max_wait_time) are respected for non-custom runtime variants (vllm, tgi, nim, sglang, modular-max).
+Pass Manager-generated model definition to Agent via internal_data and remove Agent-side model definition generation. Agent now uses the Manager-provided definition as the single source of truth, ensuring VFolder health_check overrides are respected for all runtime variants.

--- a/changes/10951.fix.md
+++ b/changes/10951.fix.md
@@ -1,0 +1,1 @@
+Pass Manager-merged model definition to Agent so that VFolder health_check overrides (initial_delay, max_retries, max_wait_time) are respected for non-custom runtime variants (vllm, tgi, nim, sglang, modular-max).

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -51,8 +51,6 @@ import zmq
 import zmq.asyncio
 from async_timeout import timeout
 from cachetools import LRUCache, cached
-from ruamel.yaml import YAML
-from ruamel.yaml.error import YAMLError
 from tenacity import (
     AsyncRetrying,
     RetryError,
@@ -186,7 +184,6 @@ from ai.backend.common.runner.types import Runner
 from ai.backend.common.service_ports import parse_service_ports
 from ai.backend.common.typed_validators import HostPortPair
 from ai.backend.common.types import (
-    MODEL_SERVICE_RUNTIME_PROFILES,
     AbuseReportValue,
     AgentId,
     AutoPullBehavior,
@@ -240,10 +237,8 @@ from .errors import (
     ContainerStartupFailedError,
     ContainerStartupTimeoutError,
     ImageArchitectureMismatchError,
-    ImageCommandRequiredError,
     ImagePullTimeoutError,
     ModelDefinitionEmptyError,
-    ModelDefinitionInvalidYAMLError,
     ModelDefinitionNotFoundError,
     ModelDefinitionValidationError,
     ModelFolderNotSpecifiedError,
@@ -3297,12 +3292,6 @@ class AbstractAgent[
         service_ports: list[ServicePort],
         kernel_config: KernelCreationConfig,
     ) -> Any:
-        image_command = await self.extract_image_command(kernel_config["image"]["canonical"])
-        if runtime_variant != "custom" and not image_command:
-            raise ImageCommandRequiredError(
-                "Image should have its own command when runtime variant is set to values other than CUSTOM"
-            )
-
         if len(model_folders) == 0:
             raise ModelFolderNotSpecifiedError(
                 "At least one model virtual folder must be specified"
@@ -3310,155 +3299,21 @@ class AbstractAgent[
 
         model_folder: VFolderMount = model_folders[0]
 
-        # Use model definition from Manager (via internal_data) if available.
-        # Present when created through sokovan deployment path (POST /deployments/).
-        # Absent for legacy path (POST /services/) or pre-fix Manager versions.
         internal_data = kernel_config.get("internal_data") or {}
-        if manager_model_definition := internal_data.get("model_definition"):
-            log.info(
-                "load_model_definition(): using model_definition from internal_data"
-                " (runtime_variant={})",
-                runtime_variant,
-            )
-            return self._apply_model_definition(
-                manager_model_definition, model_folder, environ, service_ports
+        model_definition = internal_data.get("model_definition")
+        if not model_definition:
+            raise ModelDefinitionNotFoundError(
+                "model_definition was not provided by Manager via internal_data."
+                f" (runtime_variant={runtime_variant},"
+                f" vfolder={model_folder.name}, ID={model_folder.vfid})"
             )
 
         log.info(
-            "load_model_definition(): internal_data has no model_definition, "
-            "falling back to Agent-generated defaults (runtime_variant={})",
+            "load_model_definition(): using model_definition from internal_data"
+            " (runtime_variant={})",
             runtime_variant,
         )
-        raw_definition: dict[str, Any]
-        match runtime_variant:
-            case "vllm":
-                _model = {
-                    "name": "vllm-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": MODEL_SERVICE_RUNTIME_PROFILES[runtime_variant].port,
-                        "health_check": {
-                            "path": MODEL_SERVICE_RUNTIME_PROFILES[
-                                runtime_variant
-                            ].health_check_endpoint,
-                        },
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "huggingface-tgi":
-                _model = {
-                    "name": "tgi-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": MODEL_SERVICE_RUNTIME_PROFILES[runtime_variant].port,
-                        "health_check": {
-                            "path": MODEL_SERVICE_RUNTIME_PROFILES[
-                                runtime_variant
-                            ].health_check_endpoint,
-                        },
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "nim":
-                _model = {
-                    "name": "nim-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": MODEL_SERVICE_RUNTIME_PROFILES[runtime_variant].port,
-                        "health_check": {
-                            "path": MODEL_SERVICE_RUNTIME_PROFILES[
-                                runtime_variant
-                            ].health_check_endpoint,
-                        },
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "sglang":
-                _model = {
-                    "name": "sglang-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": MODEL_SERVICE_RUNTIME_PROFILES[runtime_variant].port,
-                        "health_check": {
-                            "path": MODEL_SERVICE_RUNTIME_PROFILES[
-                                runtime_variant
-                            ].health_check_endpoint,
-                        },
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "modular-max":
-                _model = {
-                    "name": "max-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": MODEL_SERVICE_RUNTIME_PROFILES[runtime_variant].port,
-                        "health_check": {
-                            "path": MODEL_SERVICE_RUNTIME_PROFILES[
-                                runtime_variant
-                            ].health_check_endpoint,
-                        },
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "cmd":
-                _model = {
-                    "name": "image-model",
-                    "model_path": model_folder.kernel_path.as_posix(),
-                    "service": {
-                        "start_command": image_command,
-                        "port": 8000,
-                    },
-                }
-                raw_definition = {"models": [_model]}
-
-            case "custom":
-                if _fname := (kernel_config.get("internal_data") or {}).get(
-                    "model_definition_path"
-                ):
-                    model_definition_candidates = [_fname]
-                else:
-                    model_definition_candidates = [
-                        "model-definition.yaml",
-                        "model-definition.yml",
-                    ]
-
-                model_definition_path = None
-                for filename in model_definition_candidates:
-                    if (Path(model_folder.host_path) / filename).is_file():
-                        model_definition_path = Path(model_folder.host_path) / filename
-                        break
-
-                if not model_definition_path:
-                    raise ModelDefinitionNotFoundError(
-                        f"Model definition file ({' or '.join(model_definition_candidates)}) does not exist under vFolder"
-                        f" {model_folder.name} (ID {model_folder.vfid})",
-                    )
-                try:
-                    model_definition_yaml = await asyncio.get_running_loop().run_in_executor(
-                        None, model_definition_path.read_text
-                    )
-                except FileNotFoundError as e:
-                    raise ModelDefinitionNotFoundError(
-                        "Model definition file (model-definition.yml) does not exist under"
-                        f" vFolder {model_folder.name} (ID {model_folder.vfid})",
-                    ) from e
-                try:
-                    yaml = YAML()
-                    raw_definition = yaml.load(model_definition_yaml)
-                except YAMLError as e:
-                    raise ModelDefinitionInvalidYAMLError(f"Invalid YAML syntax: {e}") from e
-        return self._apply_model_definition(raw_definition, model_folder, environ, service_ports)
+        return self._apply_model_definition(model_definition, model_folder, environ, service_ports)
 
     def _apply_model_definition(
         self,

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -3310,13 +3310,25 @@ class AbstractAgent[
 
         model_folder: VFolderMount = model_folders[0]
 
-        # Use pre-merged model definition from Manager if available
+        # Use model definition from Manager (via internal_data) if available.
+        # Present when created through sokovan deployment path (POST /deployments/).
+        # Absent for legacy path (POST /services/) or pre-fix Manager versions.
         internal_data = kernel_config.get("internal_data") or {}
         if manager_model_definition := internal_data.get("model_definition"):
+            log.info(
+                "load_model_definition(): using model_definition from internal_data"
+                " (runtime_variant={})",
+                runtime_variant,
+            )
             return self._apply_model_definition(
                 manager_model_definition, model_folder, environ, service_ports
             )
 
+        log.info(
+            "load_model_definition(): internal_data has no model_definition, "
+            "falling back to Agent-generated defaults (runtime_variant={})",
+            runtime_variant,
+        )
         raw_definition: dict[str, Any]
         match runtime_variant:
             case "vllm":

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -3310,6 +3310,13 @@ class AbstractAgent[
 
         model_folder: VFolderMount = model_folders[0]
 
+        # Use pre-merged model definition from Manager if available
+        internal_data = kernel_config.get("internal_data") or {}
+        if manager_model_definition := internal_data.get("model_definition"):
+            return self._apply_model_definition(
+                manager_model_definition, model_folder, environ, service_ports
+            )
+
         raw_definition: dict[str, Any]
         match runtime_variant:
             case "vllm":
@@ -3439,6 +3446,15 @@ class AbstractAgent[
                     raw_definition = yaml.load(model_definition_yaml)
                 except YAMLError as e:
                     raise ModelDefinitionInvalidYAMLError(f"Invalid YAML syntax: {e}") from e
+        return self._apply_model_definition(raw_definition, model_folder, environ, service_ports)
+
+    def _apply_model_definition(
+        self,
+        raw_definition: dict[str, Any],
+        model_folder: VFolderMount,
+        environ: MutableMapping[str, Any],
+        service_ports: list[ServicePort],
+    ) -> Any:
         try:
             model_definition = model_definition_iv.check(raw_definition)
             if model_definition is None:

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -932,6 +932,15 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             timeout_seconds = (
                 health_check_info["max_retries"] * health_check_info["max_wait_time"] + 10
             )
+            log.info(
+                "feed_start_model_service({}): health_check config — "
+                "initial_delay={}, max_retries={}, max_wait_time={}, timeout={}s",
+                model_info.get("name", "?"),
+                health_check_info.get("initial_delay"),
+                health_check_info["max_retries"],
+                health_check_info["max_wait_time"],
+                timeout_seconds,
+            )
         else:
             timeout_seconds = 10
         try:

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/model_service.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/model_service.py
@@ -1,7 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast, override
+from typing import Any, cast, override
 
 from aiodocker.docker import Docker
 from pydantic import ValidationError
@@ -32,6 +32,7 @@ class ModelServiceSpecCheckArgs:
     session_type: SessionTypes
     runtime_variant: RuntimeVariant
     model_definition_path: str | None = None
+    model_definition: dict[str, Any] | None = None
 
     def to_model_service_spec(self, image_command: str | None) -> "ModelServiceSpec":
         return ModelServiceSpec(
@@ -39,6 +40,7 @@ class ModelServiceSpecCheckArgs:
             model_vfolder_mount=self.model_vfolder_mount,
             runtime_variant=self.runtime_variant,
             model_definition_path=self.model_definition_path,
+            model_definition=self.model_definition,
             image_command=image_command,
         )
 
@@ -49,6 +51,7 @@ class ModelServiceSpec:
     model_vfolder_mount: VFolderMount
     runtime_variant: RuntimeVariant
     model_definition_path: str | None
+    model_definition: dict[str, Any] | None
     image_command: str | None
 
 
@@ -130,6 +133,15 @@ class ModelServiceProvisioner(Provisioner[ModelServiceSpec, ModelServiceResult])
         )
 
     async def _get_model_definition(self, spec: ModelServiceSpec) -> ModelDefinition:
+        # Use pre-merged model definition from Manager if available
+        if spec.model_definition is not None:
+            try:
+                return ModelDefinition.model_validate(spec.model_definition)
+            except ValidationError as e:
+                raise InvalidModelConfigurationError(
+                    f"Invalid pre-merged model definition from Manager: {e}"
+                ) from e
+
         image_command = spec.image_command
         model_folder = spec.model_vfolder_mount
         match spec.runtime_variant:

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/model_service.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/model_service.py
@@ -1,22 +1,17 @@
-import asyncio
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, cast, override
 
 from aiodocker.docker import Docker
 from pydantic import ValidationError
-from ruamel.yaml import YAML
-from ruamel.yaml.error import YAMLError
 
 from ai.backend.agent.exception import InvalidModelConfigurationError
 from ai.backend.common.asyncio import closing_async
-from ai.backend.common.config import ModelConfig, ModelDefinition
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.stage.types import (
     Provisioner,
     SpecGenerator,
 )
 from ai.backend.common.types import (
-    MODEL_SERVICE_RUNTIME_PROFILES,
     RuntimeVariant,
     ServicePort,
     ServicePortProtocols,
@@ -31,7 +26,6 @@ class ModelServiceSpecCheckArgs:
     model_vfolder_mount: VFolderMount
     session_type: SessionTypes
     runtime_variant: RuntimeVariant
-    model_definition_path: str | None = None
     model_definition: dict[str, Any] | None = None
 
     def to_model_service_spec(self, image_command: str | None) -> "ModelServiceSpec":
@@ -39,7 +33,6 @@ class ModelServiceSpecCheckArgs:
             session_type=self.session_type,
             model_vfolder_mount=self.model_vfolder_mount,
             runtime_variant=self.runtime_variant,
-            model_definition_path=self.model_definition_path,
             model_definition=self.model_definition,
             image_command=image_command,
         )
@@ -50,7 +43,6 @@ class ModelServiceSpec:
     session_type: SessionTypes
     model_vfolder_mount: VFolderMount
     runtime_variant: RuntimeVariant
-    model_definition_path: str | None
     model_definition: dict[str, Any] | None
     image_command: str | None
 
@@ -78,7 +70,6 @@ class ModelServiceSpecCheckProvisioner(Provisioner[ModelServiceSpecCheckArgs, Mo
 
     @override
     async def teardown(self, resource: ModelServiceSpec) -> None:
-        # No teardown actions needed for this provisioner
         pass
 
 
@@ -107,7 +98,7 @@ class ModelServiceProvisioner(Provisioner[ModelServiceSpec, ModelServiceResult])
 
     @override
     async def setup(self, spec: ModelServiceSpec) -> ModelServiceResult:
-        model_definition = await self._get_model_definition(spec)
+        model_definition = self._get_model_definition(spec)
         if model_definition is None:
             raise InvalidModelConfigurationError(
                 "Model definition is empty. Please check your model definition file"
@@ -132,195 +123,18 @@ class ModelServiceProvisioner(Provisioner[ModelServiceSpec, ModelServiceResult])
             service_ports=service_ports,
         )
 
-    async def _get_model_definition(self, spec: ModelServiceSpec) -> ModelDefinition:
-        # Use pre-merged model definition from Manager if available
-        if spec.model_definition is not None:
-            try:
-                return ModelDefinition.model_validate(spec.model_definition)
-            except ValidationError as e:
-                raise InvalidModelConfigurationError(
-                    f"Invalid pre-merged model definition from Manager: {e}"
-                ) from e
-
-        image_command = spec.image_command
-        model_folder = spec.model_vfolder_mount
-        match spec.runtime_variant:
-            case "vllm":
-                return await self._get_model_definition_from_vllm(model_folder, image_command)
-            case "huggingface-tgi":
-                return await self._get_model_definition_from_tgi(model_folder, image_command)
-            case "nim":
-                return await self._get_model_definition_from_nim(model_folder, image_command)
-            case "sglang":
-                return await self._get_model_definition_from_sglang(model_folder, image_command)
-            case "modular-max":
-                return await self._get_model_definition_from_modular_max(
-                    model_folder, image_command
-                )
-            case "cmd":
-                return await self._get_model_definition_from_cmd(model_folder, image_command)
-            case "custom":
-                return await self._get_model_definition_from_custom(
-                    model_folder, spec.model_definition_path
-                )
-            case _:
-                raise InvalidModelConfigurationError(
-                    f"Unsupported runtime variant: {spec.runtime_variant}"
-                )
-
-    async def _get_model_definition_from_vllm(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "vllm-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": MODEL_SERVICE_RUNTIME_PROFILES["vllm"].port,
-                "health_check": {
-                    "path": MODEL_SERVICE_RUNTIME_PROFILES["vllm"].health_check_endpoint,
-                },
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition for VLLM: {e}") from e
-
-    async def _get_model_definition_from_tgi(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "tgi-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": MODEL_SERVICE_RUNTIME_PROFILES["huggingface-tgi"].port,
-                "health_check": {
-                    "path": MODEL_SERVICE_RUNTIME_PROFILES["huggingface-tgi"].health_check_endpoint,
-                },
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition for TGI: {e}") from e
-
-    async def _get_model_definition_from_nim(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "nim-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": MODEL_SERVICE_RUNTIME_PROFILES["nim"].port,
-                "health_check": {
-                    "path": MODEL_SERVICE_RUNTIME_PROFILES["nim"].health_check_endpoint,
-                },
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition for NIM: {e}") from e
-
-    async def _get_model_definition_from_sglang(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "sglang-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": MODEL_SERVICE_RUNTIME_PROFILES["sglang"].port,
-                "health_check": {
-                    "path": MODEL_SERVICE_RUNTIME_PROFILES["sglang"].health_check_endpoint,
-                },
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition for SGLang: {e}") from e
-
-    async def _get_model_definition_from_modular_max(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "max-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": MODEL_SERVICE_RUNTIME_PROFILES["modular-max"].port,
-                "health_check": {
-                    "path": MODEL_SERVICE_RUNTIME_PROFILES["modular-max"].health_check_endpoint,
-                },
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
+    def _get_model_definition(self, spec: ModelServiceSpec) -> ModelDefinition:
+        if spec.model_definition is None:
             raise InvalidModelConfigurationError(
-                f"Invalid model definition for Modular MAX: {e}"
-            ) from e
-
-    async def _get_model_definition_from_cmd(
-        self, model_folder: VFolderMount, image_command: str | None
-    ) -> ModelDefinition:
-        _model = {
-            "name": "image-model",
-            "model_path": model_folder.kernel_path.as_posix(),
-            "service": {
-                "start_command": image_command,
-                "port": 8000,
-            },
-        }
-        try:
-            return ModelDefinition(models=[ModelConfig.model_validate(_model)])
-        except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition for CMD: {e}") from e
-
-    async def _get_model_definition_from_custom(
-        self, model_folder: VFolderMount, model_definition_path: str | None
-    ) -> ModelDefinition:
-        if model_definition_path:
-            model_definition_candidates = [model_definition_path]
-        else:
-            model_definition_candidates = [
-                "model-definition.yaml",
-                "model-definition.yml",
-            ]
-
-        final_model_definition_path: Path | None = None
-        for filename in model_definition_candidates:
-            if (Path(model_folder.host_path) / filename).is_file():
-                final_model_definition_path = Path(model_folder.host_path) / filename
-                break
-
-        if not final_model_definition_path:
-            raise InvalidModelConfigurationError(
-                f"Model definition file ({' or '.join(model_definition_candidates)}) does not exist under VFolder"
-                f" {model_folder.name} (ID {model_folder.vfid})",
+                "model_definition was not provided by Manager via internal_data."
+                f" (runtime_variant={spec.runtime_variant})"
             )
         try:
-            model_definition_yaml = await asyncio.get_running_loop().run_in_executor(
-                None, final_model_definition_path.read_text
-            )
-        except FileNotFoundError as e:
-            raise InvalidModelConfigurationError(
-                "Model definition file (model-definition.yml) does not exist under"
-                f" vFolder {model_folder.name} (ID {model_folder.vfid})",
-            ) from e
-        try:
-            yaml = YAML()
-            raw_definition = yaml.load(model_definition_yaml)
-        except YAMLError as e:
-            raise InvalidModelConfigurationError(f"Invalid YAML syntax: {e}") from e
-        try:
-            return ModelDefinition(**raw_definition)
+            return ModelDefinition.model_validate(spec.model_definition)
         except ValidationError as e:
-            raise InvalidModelConfigurationError(f"Invalid model definition: {e}") from e
+            raise InvalidModelConfigurationError(
+                f"Invalid model definition from Manager: {e}"
+            ) from e
 
     @override
     async def teardown(self, resource: ModelServiceResult) -> None:

--- a/src/ai/backend/manager/event_dispatcher/handlers/model_serving.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/model_serving.py
@@ -206,6 +206,7 @@ class ModelServingEventHandler:
                             for m in current_rev.extra_mounts
                         },
                         "model_definition_path": current_rev.model_definition_path,
+                        "model_definition": current_rev.model_definition,
                         "runtime_variant": current_rev.runtime_variant,
                         "environ": environ,
                         "scaling_group": endpoint.resource_group,

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -188,6 +188,11 @@ class SessionCreationSpec:
                 "mount_map": mount_spec.mount_map,
                 "mount_options": mount_spec.mount_options,
                 "model_definition_path": target_revision.mounts.model_definition_path,
+                "model_definition": (
+                    target_revision.model_definition.model_dump(mode="json")
+                    if target_revision.model_definition
+                    else None
+                ),
                 "runtime_variant": target_revision.execution.runtime_variant,
                 "environ": environ,
                 "scaling_group": deployment_info.metadata.resource_group,

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -271,6 +271,9 @@ class ModelServingService:
         creation_config = action.creator.config.to_dict()
         # Override resource_opts with merged values from deployment config + API request
         creation_config["resource_opts"] = dict(revision.resource_spec.resource_opts or {})
+        # Pass merged model_definition to Agent via creation_config
+        if revision.model_definition:
+            creation_config["model_definition"] = revision.model_definition.model_dump(mode="json")
         creation_config["mounts"] = [
             model_vfolder_id,
             *[m.vfid.folder_id for m in service_prepare_ctx.extra_mounts],
@@ -592,6 +595,11 @@ class ModelServingService:
                 "mount_map": mount_map,
                 "mount_options": mount_options,
                 "model_definition_path": service_prepare_ctx.model_definition_path,
+                "model_definition": (
+                    revision.model_definition.model_dump(mode="json")
+                    if revision.model_definition
+                    else None
+                ),
                 "runtime_variant": action.runtime_variant,
                 "environ": environ,
                 "scaling_group": service_prepare_ctx.scaling_group,

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/internal_data.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/internal_data.py
@@ -34,6 +34,9 @@ class InternalDataRule(SessionPreparerRule):
         if model_def_path := spec.creation_spec.get("model_definition_path"):
             internal_data["model_definition_path"] = model_def_path
 
+        if model_definition := spec.creation_spec.get("model_definition"):
+            internal_data["model_definition"] = model_definition
+
         if runtime_variant := spec.creation_spec.get("runtime_variant"):
             internal_data["runtime_variant"] = runtime_variant
 

--- a/tests/unit/agent/stage/kernel_lifecycle/docker/test_model_service.py
+++ b/tests/unit/agent/stage/kernel_lifecycle/docker/test_model_service.py
@@ -1,0 +1,150 @@
+"""Tests for ModelServiceProvisioner with pre-merged model definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from ai.backend.agent.stage.kernel_lifecycle.docker.model_service import (
+    ModelServiceProvisioner,
+    ModelServiceSpec,
+)
+from ai.backend.common.config import ModelDefinition
+from ai.backend.common.types import (
+    RuntimeVariant,
+    SessionTypes,
+    VFolderMount,
+)
+
+
+def _make_vfolder_mount() -> VFolderMount:
+    mock = MagicMock(spec=VFolderMount)
+    mock.name = "test-model"
+    mock.kernel_path = MagicMock()
+    mock.kernel_path.as_posix.return_value = "/models"
+    mock.host_path = MagicMock()
+    return mock
+
+
+def _make_model_definition_dict(
+    initial_delay: float = 300,
+    max_retries: int = 30,
+    max_wait_time: float = 20,
+) -> dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "vllm-model",
+                "model_path": "/models",
+                "service": {
+                    "start_command": "vllm serve",
+                    "port": 8000,
+                    "health_check": {
+                        "path": "/health",
+                        "initial_delay": initial_delay,
+                        "max_retries": max_retries,
+                        "max_wait_time": max_wait_time,
+                    },
+                },
+            }
+        ]
+    }
+
+
+class TestModelServiceProvisionerWithPreMergedDefinition:
+    """Tests for ModelServiceProvisioner._get_model_definition() using pre-merged definitions."""
+
+    async def test_uses_pre_merged_definition_when_available(self) -> None:
+        """When spec.model_definition is set, it should be used instead of hardcoded values."""
+        model_definition_dict = _make_model_definition_dict(
+            initial_delay=300, max_retries=30, max_wait_time=20
+        )
+        spec = ModelServiceSpec(
+            session_type=SessionTypes.INFERENCE,
+            model_vfolder_mount=_make_vfolder_mount(),
+            runtime_variant=RuntimeVariant("vllm"),
+            model_definition_path="model-definition.yaml",
+            model_definition=model_definition_dict,
+            image_command="vllm serve",
+        )
+
+        provisioner = ModelServiceProvisioner()
+        result = await provisioner._get_model_definition(spec)
+
+        assert isinstance(result, ModelDefinition)
+        assert len(result.models) == 1
+        model = result.models[0]
+        assert model.name == "vllm-model"
+        assert model.service is not None
+        assert model.service.health_check is not None
+        assert model.service.health_check.initial_delay == 300
+        assert model.service.health_check.max_retries == 30
+        assert model.service.health_check.max_wait_time == 20
+
+    async def test_falls_back_to_hardcoded_when_no_pre_merged_definition(self) -> None:
+        """When spec.model_definition is None, fall back to variant-specific hardcoded logic."""
+        spec = ModelServiceSpec(
+            session_type=SessionTypes.INFERENCE,
+            model_vfolder_mount=_make_vfolder_mount(),
+            runtime_variant=RuntimeVariant("vllm"),
+            model_definition_path=None,
+            model_definition=None,
+            image_command="vllm serve",
+        )
+
+        provisioner = ModelServiceProvisioner()
+        result = await provisioner._get_model_definition(spec)
+
+        assert isinstance(result, ModelDefinition)
+        assert len(result.models) == 1
+        model = result.models[0]
+        assert model.name == "vllm-model"
+        # Hardcoded defaults: health_check only has path, no custom overrides
+        assert model.service is not None
+        assert model.service.health_check is not None
+        assert model.service.health_check.path is not None
+
+    async def test_pre_merged_definition_preserves_all_health_check_fields(self) -> None:
+        """All health_check fields from pre-merged definition should be preserved."""
+        model_definition_dict = {
+            "models": [
+                {
+                    "name": "test-model",
+                    "model_path": "/models",
+                    "service": {
+                        "start_command": "serve",
+                        "port": 9000,
+                        "health_check": {
+                            "path": "/v1/health",
+                            "interval": 5,
+                            "initial_delay": 600,
+                            "max_retries": 60,
+                            "max_wait_time": 30,
+                            "expected_status_code": 200,
+                        },
+                    },
+                }
+            ]
+        }
+        spec = ModelServiceSpec(
+            session_type=SessionTypes.INFERENCE,
+            model_vfolder_mount=_make_vfolder_mount(),
+            runtime_variant=RuntimeVariant("vllm"),
+            model_definition_path=None,
+            model_definition=model_definition_dict,
+            image_command="serve",
+        )
+
+        provisioner = ModelServiceProvisioner()
+        result = await provisioner._get_model_definition(spec)
+
+        service = result.models[0].service
+        assert service is not None
+        health_check = service.health_check
+        assert health_check is not None
+        assert health_check.path == "/v1/health"
+        assert health_check.interval == 5
+        assert health_check.initial_delay == 600
+        assert health_check.max_retries == 60
+        assert health_check.max_wait_time == 30
+        assert health_check.expected_status_code == 200

--- a/tests/unit/agent/stage/kernel_lifecycle/docker/test_model_service.py
+++ b/tests/unit/agent/stage/kernel_lifecycle/docker/test_model_service.py
@@ -1,10 +1,13 @@
-"""Tests for ModelServiceProvisioner with pre-merged model definitions."""
+"""Tests for ModelServiceProvisioner with model definitions from Manager."""
 
 from __future__ import annotations
 
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
+from ai.backend.agent.exception import InvalidModelConfigurationError
 from ai.backend.agent.stage.kernel_lifecycle.docker.model_service import (
     ModelServiceProvisioner,
     ModelServiceSpec,
@@ -51,11 +54,11 @@ def _make_model_definition_dict(
     }
 
 
-class TestModelServiceProvisionerWithPreMergedDefinition:
-    """Tests for ModelServiceProvisioner._get_model_definition() using pre-merged definitions."""
+class TestModelServiceProvisionerGetModelDefinition:
+    """Tests for ModelServiceProvisioner._get_model_definition()."""
 
-    async def test_uses_pre_merged_definition_when_available(self) -> None:
-        """When spec.model_definition is set, it should be used instead of hardcoded values."""
+    def test_uses_model_definition_from_spec(self) -> None:
+        """When spec.model_definition is set, it should be validated and returned."""
         model_definition_dict = _make_model_definition_dict(
             initial_delay=300, max_retries=30, max_wait_time=20
         )
@@ -63,13 +66,12 @@ class TestModelServiceProvisionerWithPreMergedDefinition:
             session_type=SessionTypes.INFERENCE,
             model_vfolder_mount=_make_vfolder_mount(),
             runtime_variant=RuntimeVariant("vllm"),
-            model_definition_path="model-definition.yaml",
             model_definition=model_definition_dict,
             image_command="vllm serve",
         )
 
         provisioner = ModelServiceProvisioner()
-        result = await provisioner._get_model_definition(spec)
+        result = provisioner._get_model_definition(spec)
 
         assert isinstance(result, ModelDefinition)
         assert len(result.models) == 1
@@ -81,31 +83,22 @@ class TestModelServiceProvisionerWithPreMergedDefinition:
         assert model.service.health_check.max_retries == 30
         assert model.service.health_check.max_wait_time == 20
 
-    async def test_falls_back_to_hardcoded_when_no_pre_merged_definition(self) -> None:
-        """When spec.model_definition is None, fall back to variant-specific hardcoded logic."""
+    def test_raises_error_when_model_definition_absent(self) -> None:
+        """When spec.model_definition is None, raise InvalidModelConfigurationError."""
         spec = ModelServiceSpec(
             session_type=SessionTypes.INFERENCE,
             model_vfolder_mount=_make_vfolder_mount(),
             runtime_variant=RuntimeVariant("vllm"),
-            model_definition_path=None,
             model_definition=None,
             image_command="vllm serve",
         )
 
         provisioner = ModelServiceProvisioner()
-        result = await provisioner._get_model_definition(spec)
+        with pytest.raises(InvalidModelConfigurationError):
+            provisioner._get_model_definition(spec)
 
-        assert isinstance(result, ModelDefinition)
-        assert len(result.models) == 1
-        model = result.models[0]
-        assert model.name == "vllm-model"
-        # Hardcoded defaults: health_check only has path, no custom overrides
-        assert model.service is not None
-        assert model.service.health_check is not None
-        assert model.service.health_check.path is not None
-
-    async def test_pre_merged_definition_preserves_all_health_check_fields(self) -> None:
-        """All health_check fields from pre-merged definition should be preserved."""
+    def test_preserves_all_health_check_fields(self) -> None:
+        """All health_check fields from model definition should be preserved."""
         model_definition_dict = {
             "models": [
                 {
@@ -130,13 +123,12 @@ class TestModelServiceProvisionerWithPreMergedDefinition:
             session_type=SessionTypes.INFERENCE,
             model_vfolder_mount=_make_vfolder_mount(),
             runtime_variant=RuntimeVariant("vllm"),
-            model_definition_path=None,
             model_definition=model_definition_dict,
             image_command="serve",
         )
 
         provisioner = ModelServiceProvisioner()
-        result = await provisioner._get_model_definition(spec)
+        result = provisioner._get_model_definition(spec)
 
         service = result.models[0].service
         assert service is not None

--- a/tests/unit/agent/test_model_definition.py
+++ b/tests/unit/agent/test_model_definition.py
@@ -1,0 +1,216 @@
+"""Tests for model definition loading with Manager-merged definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import UUID
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.common.types import (
+    RuntimeVariant,
+    ServicePort,
+    VFolderMount,
+)
+
+
+def _make_vfolder_mount(
+    name: str = "test-model",
+    folder_id: str = "00000000-0000-0000-0000-000000000001",
+) -> VFolderMount:
+    """Create a minimal VFolderMount for testing."""
+    mock = MagicMock(spec=VFolderMount)
+    mock.name = name
+    mock.vfid = MagicMock()
+    mock.vfid.folder_id = UUID(folder_id)
+    mock.kernel_path = MagicMock()
+    mock.kernel_path.as_posix.return_value = "/models"
+    mock.host_path = MagicMock()
+    return mock
+
+
+def _make_model_definition(
+    initial_delay: float = 300,
+    max_retries: int = 30,
+    max_wait_time: float = 20,
+) -> dict[str, Any]:
+    """Create a model definition dict with custom health_check values."""
+    return {
+        "models": [
+            {
+                "name": "vllm-model",
+                "model_path": "/models",
+                "service": {
+                    "start_command": "vllm serve",
+                    "port": 8000,
+                    "health_check": {
+                        "path": "/health",
+                        "initial_delay": initial_delay,
+                        "max_retries": max_retries,
+                        "max_wait_time": max_wait_time,
+                    },
+                },
+            }
+        ]
+    }
+
+
+class TestApplyModelDefinition:
+    """Tests for AbstractAgent._apply_model_definition()."""
+
+    def test_applies_custom_health_check_values(self) -> None:
+        """Model definition with custom health_check values should be applied correctly."""
+        raw_definition = _make_model_definition(
+            initial_delay=300,
+            max_retries=30,
+            max_wait_time=20,
+        )
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+
+        result = AbstractAgent._apply_model_definition(
+            Mock(), raw_definition, model_folder, environ, service_ports
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 300
+        assert health_check["max_retries"] == 30
+        assert health_check["max_wait_time"] == 20
+
+    def test_sets_environ_variables(self) -> None:
+        """Model definition should populate BACKEND_MODEL_NAME and BACKEND_MODEL_PATH."""
+        raw_definition = _make_model_definition()
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+
+        AbstractAgent._apply_model_definition(
+            Mock(), raw_definition, model_folder, environ, service_ports
+        )
+
+        assert environ["BACKEND_MODEL_NAME"] == "vllm-model"
+        assert environ["BACKEND_MODEL_PATH"] == "/models"
+
+    def test_appends_service_port(self) -> None:
+        """Model definition with service config should add a service port."""
+        raw_definition = _make_model_definition()
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+
+        AbstractAgent._apply_model_definition(
+            Mock(), raw_definition, model_folder, environ, service_ports
+        )
+
+        assert len(service_ports) == 1
+        assert service_ports[0]["container_ports"] == (8000,)
+        assert service_ports[0]["is_inference"] is True
+
+    def test_applies_default_health_check_values_when_omitted(self) -> None:
+        """Health check fields not specified should get trafaret defaults."""
+        raw_definition = {
+            "models": [
+                {
+                    "name": "vllm-model",
+                    "model_path": "/models",
+                    "service": {
+                        "start_command": "vllm serve",
+                        "port": 8000,
+                        "health_check": {
+                            "path": "/health",
+                        },
+                    },
+                }
+            ]
+        }
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+
+        result = AbstractAgent._apply_model_definition(
+            Mock(), raw_definition, model_folder, environ, service_ports
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 60
+        assert health_check["max_retries"] == 10
+        assert health_check["max_wait_time"] == 15
+
+
+class TestLoadModelDefinitionWithManagerDefinition:
+    """Tests for AbstractAgent.load_model_definition() preferring Manager-merged definition."""
+
+    async def test_uses_manager_definition_when_present(self) -> None:
+        """When internal_data contains model_definition, it should be used directly."""
+        model_definition = _make_model_definition(initial_delay=300, max_retries=30)
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test-image:latest"},
+            "internal_data": {
+                "model_definition": model_definition,
+                "runtime_variant": "vllm",
+            },
+        }
+
+        mock_agent = Mock(spec=AbstractAgent)
+        mock_agent.extract_image_command = AsyncMock(return_value="vllm serve")
+        mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
+            mock_agent
+        )
+        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"),
+            [model_folder],
+            environ,
+            service_ports,
+            kernel_config,
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 300
+        assert health_check["max_retries"] == 30
+
+    async def test_falls_back_to_hardcoded_when_no_manager_definition(self) -> None:
+        """When internal_data has no model_definition, fallback to hardcoded variant logic."""
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test-image:latest"},
+            "internal_data": {
+                "runtime_variant": "vllm",
+            },
+        }
+
+        mock_agent = Mock(spec=AbstractAgent)
+        mock_agent.extract_image_command = AsyncMock(return_value="vllm serve")
+        mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
+            mock_agent
+        )
+        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
+
+        with patch(
+            "ai.backend.agent.agent.MODEL_SERVICE_RUNTIME_PROFILES",
+            {
+                "vllm": MagicMock(
+                    port=8000,
+                    health_check_endpoint="/health",
+                ),
+            },
+        ):
+            result = await mock_agent.load_model_definition(
+                RuntimeVariant("vllm"),
+                [model_folder],
+                environ,
+                service_ports,
+                kernel_config,
+            )
+
+        # Fallback uses hardcoded defaults via trafaret
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 60
+        assert health_check["max_retries"] == 10

--- a/tests/unit/agent/test_model_definition.py
+++ b/tests/unit/agent/test_model_definition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock, Mock
 from uuid import UUID
@@ -17,19 +18,26 @@ from ai.backend.common.types import (
 )
 
 
-def _make_vfolder_mount(
-    name: str = "test-model",
-    folder_id: str = "00000000-0000-0000-0000-000000000001",
-) -> VFolderMount:
-    """Create a minimal VFolderMount for testing."""
+@pytest.fixture
+def model_folder() -> VFolderMount:
     mock = MagicMock(spec=VFolderMount)
-    mock.name = name
+    mock.name = "test-model"
     mock.vfid = MagicMock()
-    mock.vfid.folder_id = UUID(folder_id)
+    mock.vfid.folder_id = UUID("00000000-0000-0000-0000-000000000001")
     mock.kernel_path = MagicMock()
     mock.kernel_path.as_posix.return_value = "/models"
     mock.host_path = MagicMock()
     return mock
+
+
+@pytest.fixture
+def environ() -> dict[str, Any]:
+    return {}
+
+
+@pytest.fixture
+def service_ports() -> list[ServicePort]:
+    return []
 
 
 def _make_model_definition(
@@ -37,7 +45,6 @@ def _make_model_definition(
     max_retries: int = 30,
     max_wait_time: float = 20,
 ) -> dict[str, Any]:
-    """Create a model definition dict with custom health_check values."""
     return {
         "models": [
             {
@@ -58,81 +65,107 @@ def _make_model_definition(
     }
 
 
+def _make_model_definition_health_check_path_only() -> dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "vllm-model",
+                "model_path": "/models",
+                "service": {
+                    "start_command": "vllm serve",
+                    "port": 8000,
+                    "health_check": {"path": "/health"},
+                },
+            }
+        ]
+    }
+
+
+@dataclass
+class HealthCheckParams:
+    initial_delay: float
+    max_retries: int
+    max_wait_time: float
+
+
+@dataclass
+class MissingDefinitionCase:
+    internal_data: dict[str, Any] | None
+
+
 class TestApplyModelDefinition:
     """Tests for AbstractAgent._apply_model_definition()."""
 
-    def test_applies_custom_health_check_values(self) -> None:
-        """Model definition with custom health_check values should be applied correctly."""
+    @pytest.mark.parametrize(
+        "params",
+        [
+            HealthCheckParams(initial_delay=300, max_retries=30, max_wait_time=20),
+            HealthCheckParams(initial_delay=600, max_retries=60, max_wait_time=30),
+            HealthCheckParams(initial_delay=0, max_retries=1, max_wait_time=5),
+        ],
+        ids=["large-model", "very-large-model", "minimal"],
+    )
+    def test_applies_custom_health_check_values(
+        self,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+        params: HealthCheckParams,
+    ) -> None:
         raw_definition = _make_model_definition(
-            initial_delay=300,
-            max_retries=30,
-            max_wait_time=20,
+            initial_delay=params.initial_delay,
+            max_retries=params.max_retries,
+            max_wait_time=params.max_wait_time,
         )
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
 
         result = AbstractAgent._apply_model_definition(
             Mock(), raw_definition, model_folder, environ, service_ports
         )
 
         health_check = result["models"][0]["service"]["health_check"]
-        assert health_check["initial_delay"] == 300
-        assert health_check["max_retries"] == 30
-        assert health_check["max_wait_time"] == 20
+        assert health_check["initial_delay"] == params.initial_delay
+        assert health_check["max_retries"] == params.max_retries
+        assert health_check["max_wait_time"] == params.max_wait_time
 
-    def test_sets_environ_variables(self) -> None:
-        """Model definition should populate BACKEND_MODEL_NAME and BACKEND_MODEL_PATH."""
-        raw_definition = _make_model_definition()
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
-
+    def test_sets_environ_variables(
+        self,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
         AbstractAgent._apply_model_definition(
-            Mock(), raw_definition, model_folder, environ, service_ports
+            Mock(), _make_model_definition(), model_folder, environ, service_ports
         )
 
         assert environ["BACKEND_MODEL_NAME"] == "vllm-model"
         assert environ["BACKEND_MODEL_PATH"] == "/models"
 
-    def test_appends_service_port(self) -> None:
-        """Model definition with service config should add a service port."""
-        raw_definition = _make_model_definition()
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
-
+    def test_appends_service_port(
+        self,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
         AbstractAgent._apply_model_definition(
-            Mock(), raw_definition, model_folder, environ, service_ports
+            Mock(), _make_model_definition(), model_folder, environ, service_ports
         )
 
         assert len(service_ports) == 1
         assert service_ports[0]["container_ports"] == (8000,)
         assert service_ports[0]["is_inference"] is True
 
-    def test_applies_default_health_check_values_when_omitted(self) -> None:
-        """Health check fields not specified should get trafaret defaults."""
-        raw_definition = {
-            "models": [
-                {
-                    "name": "vllm-model",
-                    "model_path": "/models",
-                    "service": {
-                        "start_command": "vllm serve",
-                        "port": 8000,
-                        "health_check": {
-                            "path": "/health",
-                        },
-                    },
-                }
-            ]
-        }
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
-
+    def test_applies_trafaret_defaults_when_health_check_has_path_only(
+        self,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
         result = AbstractAgent._apply_model_definition(
-            Mock(), raw_definition, model_folder, environ, service_ports
+            Mock(),
+            _make_model_definition_health_check_path_only(),
+            model_folder,
+            environ,
+            service_ports,
         )
 
         health_check = result["models"][0]["service"]["health_check"]
@@ -141,84 +174,59 @@ class TestApplyModelDefinition:
         assert health_check["max_wait_time"] == 15
 
 
+@pytest.fixture
+def mock_agent() -> Mock:
+    agent = Mock(spec=AbstractAgent)
+    agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(agent)
+    agent.load_model_definition = AbstractAgent.load_model_definition.__get__(agent)
+    return agent
+
+
 class TestLoadModelDefinition:
     """Tests for AbstractAgent.load_model_definition()."""
 
-    async def test_uses_model_definition_from_internal_data(self) -> None:
-        """When internal_data contains model_definition, it should be used."""
+    async def test_uses_model_definition_from_internal_data(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
         model_definition = _make_model_definition(initial_delay=300, max_retries=30)
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
         kernel_config: dict[str, Any] = {
-            "image": {"canonical": "test-image:latest"},
-            "internal_data": {
-                "model_definition": model_definition,
-                "runtime_variant": "vllm",
-            },
+            "internal_data": {"model_definition": model_definition},
         }
 
-        mock_agent = Mock(spec=AbstractAgent)
-        mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
-            mock_agent
-        )
-        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
-
         result = await mock_agent.load_model_definition(
-            RuntimeVariant("vllm"),
-            [model_folder],
-            environ,
-            service_ports,
-            kernel_config,
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
         )
 
         health_check = result["models"][0]["service"]["health_check"]
         assert health_check["initial_delay"] == 300
         assert health_check["max_retries"] == 30
 
-    async def test_raises_error_when_model_definition_absent(self) -> None:
-        """When internal_data has no model_definition, raise ModelDefinitionNotFoundError."""
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
-        kernel_config: dict[str, Any] = {
-            "image": {"canonical": "test-image:latest"},
-            "internal_data": {
-                "runtime_variant": "vllm",
-            },
-        }
-
-        mock_agent = Mock(spec=AbstractAgent)
-        mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
-            mock_agent
-        )
-        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
+    @pytest.mark.parametrize(
+        "case",
+        [
+            MissingDefinitionCase(internal_data={"runtime_variant": "vllm"}),
+            MissingDefinitionCase(internal_data=None),
+            MissingDefinitionCase(internal_data={}),
+        ],
+        ids=["no-model-definition", "internal-data-none", "internal-data-empty"],
+    )
+    async def test_raises_error_when_model_definition_absent(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+        case: MissingDefinitionCase,
+    ) -> None:
+        kernel_config: dict[str, Any] = {"internal_data": case.internal_data}
 
         with pytest.raises(ModelDefinitionNotFoundError):
             await mock_agent.load_model_definition(
                 RuntimeVariant("vllm"),
-                [model_folder],
-                environ,
-                service_ports,
-                kernel_config,
-            )
-
-    async def test_raises_error_when_internal_data_missing(self) -> None:
-        """When internal_data is None, raise ModelDefinitionNotFoundError."""
-        model_folder = _make_vfolder_mount()
-        environ: dict[str, Any] = {}
-        service_ports: list[ServicePort] = []
-        kernel_config: dict[str, Any] = {
-            "image": {"canonical": "test-image:latest"},
-            "internal_data": None,
-        }
-
-        mock_agent = Mock(spec=AbstractAgent)
-        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
-
-        with pytest.raises(ModelDefinitionNotFoundError):
-            await mock_agent.load_model_definition(
-                RuntimeVariant("custom"),
                 [model_folder],
                 environ,
                 service_ports,

--- a/tests/unit/agent/test_model_definition.py
+++ b/tests/unit/agent/test_model_definition.py
@@ -1,12 +1,15 @@
-"""Tests for model definition loading with Manager-merged definitions."""
+"""Tests for model definition loading from Manager-provided internal_data."""
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 from uuid import UUID
 
+import pytest
+
 from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.errors.agent import ModelDefinitionNotFoundError
 from ai.backend.common.types import (
     RuntimeVariant,
     ServicePort,
@@ -138,11 +141,11 @@ class TestApplyModelDefinition:
         assert health_check["max_wait_time"] == 15
 
 
-class TestLoadModelDefinitionWithManagerDefinition:
-    """Tests for AbstractAgent.load_model_definition() preferring Manager-merged definition."""
+class TestLoadModelDefinition:
+    """Tests for AbstractAgent.load_model_definition()."""
 
-    async def test_uses_manager_definition_when_present(self) -> None:
-        """When internal_data contains model_definition, it should be used directly."""
+    async def test_uses_model_definition_from_internal_data(self) -> None:
+        """When internal_data contains model_definition, it should be used."""
         model_definition = _make_model_definition(initial_delay=300, max_retries=30)
         model_folder = _make_vfolder_mount()
         environ: dict[str, Any] = {}
@@ -156,7 +159,6 @@ class TestLoadModelDefinitionWithManagerDefinition:
         }
 
         mock_agent = Mock(spec=AbstractAgent)
-        mock_agent.extract_image_command = AsyncMock(return_value="vllm serve")
         mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
             mock_agent
         )
@@ -174,8 +176,8 @@ class TestLoadModelDefinitionWithManagerDefinition:
         assert health_check["initial_delay"] == 300
         assert health_check["max_retries"] == 30
 
-    async def test_falls_back_to_hardcoded_when_no_manager_definition(self) -> None:
-        """When internal_data has no model_definition, fallback to hardcoded variant logic."""
+    async def test_raises_error_when_model_definition_absent(self) -> None:
+        """When internal_data has no model_definition, raise ModelDefinitionNotFoundError."""
         model_folder = _make_vfolder_mount()
         environ: dict[str, Any] = {}
         service_ports: list[ServicePort] = []
@@ -187,22 +189,13 @@ class TestLoadModelDefinitionWithManagerDefinition:
         }
 
         mock_agent = Mock(spec=AbstractAgent)
-        mock_agent.extract_image_command = AsyncMock(return_value="vllm serve")
         mock_agent._apply_model_definition = AbstractAgent._apply_model_definition.__get__(
             mock_agent
         )
         mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
 
-        with patch(
-            "ai.backend.agent.agent.MODEL_SERVICE_RUNTIME_PROFILES",
-            {
-                "vllm": MagicMock(
-                    port=8000,
-                    health_check_endpoint="/health",
-                ),
-            },
-        ):
-            result = await mock_agent.load_model_definition(
+        with pytest.raises(ModelDefinitionNotFoundError):
+            await mock_agent.load_model_definition(
                 RuntimeVariant("vllm"),
                 [model_folder],
                 environ,
@@ -210,7 +203,24 @@ class TestLoadModelDefinitionWithManagerDefinition:
                 kernel_config,
             )
 
-        # Fallback uses hardcoded defaults via trafaret
-        health_check = result["models"][0]["service"]["health_check"]
-        assert health_check["initial_delay"] == 60
-        assert health_check["max_retries"] == 10
+    async def test_raises_error_when_internal_data_missing(self) -> None:
+        """When internal_data is None, raise ModelDefinitionNotFoundError."""
+        model_folder = _make_vfolder_mount()
+        environ: dict[str, Any] = {}
+        service_ports: list[ServicePort] = []
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test-image:latest"},
+            "internal_data": None,
+        }
+
+        mock_agent = Mock(spec=AbstractAgent)
+        mock_agent.load_model_definition = AbstractAgent.load_model_definition.__get__(mock_agent)
+
+        with pytest.raises(ModelDefinitionNotFoundError):
+            await mock_agent.load_model_definition(
+                RuntimeVariant("custom"),
+                [model_folder],
+                environ,
+                service_ports,
+                kernel_config,
+            )

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_internal_data.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_internal_data.py
@@ -1,0 +1,187 @@
+"""Tests for InternalDataRule."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from ai.backend.common.types import AccessKey, ClusterMode, KernelEnqueueingConfig, SessionTypes
+from ai.backend.manager.repositories.scheduler.types.session_creation import (
+    ContainerUserInfo,
+    ScalingGroupNetworkInfo,
+    SessionCreationContext,
+    SessionCreationSpec,
+)
+from ai.backend.manager.sokovan.scheduling_controller.preparers.internal_data import (
+    InternalDataRule,
+)
+from ai.backend.manager.types import UserScope
+
+
+@pytest.fixture
+def internal_data_rule() -> InternalDataRule:
+    return InternalDataRule()
+
+
+@pytest.fixture
+def test_user_scope() -> UserScope:
+    return UserScope(
+        domain_name="test-domain",
+        group_id=UUID("00000000-0000-0000-0000-000000000001"),
+        user_uuid=UUID("00000000-0000-0000-0000-000000000002"),
+        user_role="user",
+    )
+
+
+@pytest.fixture
+def basic_context() -> SessionCreationContext:
+    return SessionCreationContext(
+        scaling_group_network=ScalingGroupNetworkInfo(
+            use_host_network=False,
+            wsproxy_addr=None,
+        ),
+        allowed_scaling_groups=[],
+        image_infos={},
+        vfolder_mounts=[],
+        dotfile_data={},
+        container_user_info=ContainerUserInfo(),
+    )
+
+
+def _make_spec(
+    user_scope: UserScope,
+    creation_spec: dict[str, Any],
+    internal_data: dict[str, Any] | None = None,
+) -> SessionCreationSpec:
+    return SessionCreationSpec(
+        session_creation_id="test-001",
+        session_name="test-session",
+        access_key=AccessKey("test-key"),
+        user_scope=user_scope,
+        session_type=SessionTypes.INFERENCE,
+        cluster_mode=ClusterMode.SINGLE_NODE,
+        cluster_size=1,
+        priority=10,
+        resource_policy={},
+        kernel_specs=[
+            cast(KernelEnqueueingConfig, {"image_ref": MagicMock(canonical="test-image")})
+        ],
+        creation_spec=creation_spec,
+        internal_data=internal_data,
+    )
+
+
+class TestInternalDataRule:
+    """Tests for InternalDataRule.prepare()."""
+
+    def test_model_definition_forwarded_to_internal_data(
+        self,
+        internal_data_rule: InternalDataRule,
+        basic_context: SessionCreationContext,
+        test_user_scope: UserScope,
+    ) -> None:
+        """Model definition from creation_spec should be forwarded to internal_data."""
+        model_definition = {
+            "models": [
+                {
+                    "name": "vllm-model",
+                    "model_path": "/models",
+                    "service": {
+                        "start_command": "vllm serve",
+                        "port": 8000,
+                        "health_check": {
+                            "path": "/health",
+                            "initial_delay": 300,
+                            "max_retries": 30,
+                            "max_wait_time": 20,
+                        },
+                    },
+                }
+            ]
+        }
+        spec = _make_spec(
+            test_user_scope,
+            creation_spec={
+                "model_definition_path": "model-definition.yaml",
+                "model_definition": model_definition,
+                "runtime_variant": "vllm",
+            },
+        )
+        preparation_data: dict[str, Any] = {}
+
+        internal_data_rule.prepare(spec, basic_context, preparation_data)
+
+        result = preparation_data["internal_data"]
+        assert result["model_definition"] == model_definition
+        assert result["model_definition_path"] == "model-definition.yaml"
+        assert result["runtime_variant"] == "vllm"
+
+    def test_model_definition_absent_when_not_in_creation_spec(
+        self,
+        internal_data_rule: InternalDataRule,
+        basic_context: SessionCreationContext,
+        test_user_scope: UserScope,
+    ) -> None:
+        """When creation_spec has no model_definition, internal_data should not contain it."""
+        spec = _make_spec(
+            test_user_scope,
+            creation_spec={
+                "model_definition_path": "model-definition.yaml",
+                "runtime_variant": "vllm",
+            },
+        )
+        preparation_data: dict[str, Any] = {}
+
+        internal_data_rule.prepare(spec, basic_context, preparation_data)
+
+        result = preparation_data["internal_data"]
+        assert "model_definition" not in result
+        assert result["model_definition_path"] == "model-definition.yaml"
+
+    def test_model_definition_none_not_forwarded(
+        self,
+        internal_data_rule: InternalDataRule,
+        basic_context: SessionCreationContext,
+        test_user_scope: UserScope,
+    ) -> None:
+        """When model_definition is None, it should not be forwarded."""
+        spec = _make_spec(
+            test_user_scope,
+            creation_spec={
+                "model_definition": None,
+                "runtime_variant": "vllm",
+            },
+        )
+        preparation_data: dict[str, Any] = {}
+
+        internal_data_rule.prepare(spec, basic_context, preparation_data)
+
+        result = preparation_data["internal_data"]
+        assert "model_definition" not in result
+
+    def test_existing_internal_data_preserved(
+        self,
+        internal_data_rule: InternalDataRule,
+        basic_context: SessionCreationContext,
+        test_user_scope: UserScope,
+    ) -> None:
+        """Pre-existing internal_data fields should be preserved."""
+        model_definition = {"models": [{"name": "test", "model_path": "/models"}]}
+        spec = _make_spec(
+            test_user_scope,
+            creation_spec={
+                "model_definition": model_definition,
+                "runtime_variant": "vllm",
+            },
+            internal_data={"existing_key": "existing_value"},
+        )
+        preparation_data: dict[str, Any] = {}
+
+        internal_data_rule.prepare(spec, basic_context, preparation_data)
+
+        result = preparation_data["internal_data"]
+        assert result["existing_key"] == "existing_value"
+        assert result["model_definition"] == model_definition

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_internal_data.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_internal_data.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, cast
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -27,7 +28,7 @@ def internal_data_rule() -> InternalDataRule:
 
 
 @pytest.fixture
-def test_user_scope() -> UserScope:
+def user_scope() -> UserScope:
     return UserScope(
         domain_name="test-domain",
         group_id=UUID("00000000-0000-0000-0000-000000000001"),
@@ -37,7 +38,7 @@ def test_user_scope() -> UserScope:
 
 
 @pytest.fixture
-def basic_context() -> SessionCreationContext:
+def context() -> SessionCreationContext:
     return SessionCreationContext(
         scaling_group_network=ScalingGroupNetworkInfo(
             use_host_network=False,
@@ -49,6 +50,33 @@ def basic_context() -> SessionCreationContext:
         dotfile_data={},
         container_user_info=ContainerUserInfo(),
     )
+
+
+@pytest.fixture
+def model_definition() -> dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "vllm-model",
+                "model_path": "/models",
+                "service": {
+                    "start_command": "vllm serve",
+                    "port": 8000,
+                    "health_check": {
+                        "path": "/health",
+                        "initial_delay": 300,
+                        "max_retries": 30,
+                        "max_wait_time": 20,
+                    },
+                },
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def preparation_data() -> dict[str, Any]:
+    return {}
 
 
 def _make_spec(
@@ -74,90 +102,70 @@ def _make_spec(
     )
 
 
+@dataclass
+class NotForwardedCase:
+    creation_spec: dict[str, Any]
+    description: str
+
+
 class TestInternalDataRule:
     """Tests for InternalDataRule.prepare()."""
 
     def test_model_definition_forwarded_to_internal_data(
         self,
         internal_data_rule: InternalDataRule,
-        basic_context: SessionCreationContext,
-        test_user_scope: UserScope,
+        context: SessionCreationContext,
+        user_scope: UserScope,
+        model_definition: dict[str, Any],
+        preparation_data: dict[str, Any],
     ) -> None:
-        """Model definition from creation_spec should be forwarded to internal_data."""
-        model_definition = {
-            "models": [
-                {
-                    "name": "vllm-model",
-                    "model_path": "/models",
-                    "service": {
-                        "start_command": "vllm serve",
-                        "port": 8000,
-                        "health_check": {
-                            "path": "/health",
-                            "initial_delay": 300,
-                            "max_retries": 30,
-                            "max_wait_time": 20,
-                        },
-                    },
-                }
-            ]
-        }
         spec = _make_spec(
-            test_user_scope,
+            user_scope,
             creation_spec={
                 "model_definition_path": "model-definition.yaml",
                 "model_definition": model_definition,
                 "runtime_variant": "vllm",
             },
         )
-        preparation_data: dict[str, Any] = {}
 
-        internal_data_rule.prepare(spec, basic_context, preparation_data)
+        internal_data_rule.prepare(spec, context, preparation_data)
 
         result = preparation_data["internal_data"]
         assert result["model_definition"] == model_definition
         assert result["model_definition_path"] == "model-definition.yaml"
         assert result["runtime_variant"] == "vllm"
 
-    def test_model_definition_absent_when_not_in_creation_spec(
+    @pytest.mark.parametrize(
+        "case",
+        [
+            NotForwardedCase(
+                creation_spec={
+                    "model_definition_path": "model-definition.yaml",
+                    "runtime_variant": "vllm",
+                },
+                description="model_definition key absent from creation_spec",
+            ),
+            NotForwardedCase(
+                creation_spec={
+                    "model_definition": None,
+                    "runtime_variant": "vllm",
+                },
+                description="model_definition explicitly set to None",
+            ),
+        ],
+        ids=["absent", "explicit-none"],
+    )
+    def test_model_definition_not_forwarded_when_missing_or_none(
         self,
         internal_data_rule: InternalDataRule,
-        basic_context: SessionCreationContext,
-        test_user_scope: UserScope,
+        context: SessionCreationContext,
+        user_scope: UserScope,
+        preparation_data: dict[str, Any],
+        case: NotForwardedCase,
     ) -> None:
-        """When creation_spec has no model_definition, internal_data should not contain it."""
-        spec = _make_spec(
-            test_user_scope,
-            creation_spec={
-                "model_definition_path": "model-definition.yaml",
-                "runtime_variant": "vllm",
-            },
-        )
-        preparation_data: dict[str, Any] = {}
+        spec = _make_spec(user_scope, creation_spec=case.creation_spec)
 
-        internal_data_rule.prepare(spec, basic_context, preparation_data)
-
-        result = preparation_data["internal_data"]
-        assert "model_definition" not in result
-        assert result["model_definition_path"] == "model-definition.yaml"
-
-    def test_model_definition_none_not_forwarded(
-        self,
-        internal_data_rule: InternalDataRule,
-        basic_context: SessionCreationContext,
-        test_user_scope: UserScope,
-    ) -> None:
-        """When model_definition is None, it should not be forwarded."""
-        spec = _make_spec(
-            test_user_scope,
-            creation_spec={
-                "model_definition": None,
-                "runtime_variant": "vllm",
-            },
-        )
-        preparation_data: dict[str, Any] = {}
-
-        internal_data_rule.prepare(spec, basic_context, preparation_data)
+        internal_data_rule.prepare(spec, context, preparation_data)
 
         result = preparation_data["internal_data"]
         assert "model_definition" not in result
@@ -165,22 +173,21 @@ class TestInternalDataRule:
     def test_existing_internal_data_preserved(
         self,
         internal_data_rule: InternalDataRule,
-        basic_context: SessionCreationContext,
-        test_user_scope: UserScope,
+        context: SessionCreationContext,
+        user_scope: UserScope,
+        model_definition: dict[str, Any],
+        preparation_data: dict[str, Any],
     ) -> None:
-        """Pre-existing internal_data fields should be preserved."""
-        model_definition = {"models": [{"name": "test", "model_path": "/models"}]}
         spec = _make_spec(
-            test_user_scope,
+            user_scope,
             creation_spec={
                 "model_definition": model_definition,
                 "runtime_variant": "vllm",
             },
             internal_data={"existing_key": "existing_value"},
         )
-        preparation_data: dict[str, Any] = {}
 
-        internal_data_rule.prepare(spec, basic_context, preparation_data)
+        internal_data_rule.prepare(spec, context, preparation_data)
 
         result = preparation_data["internal_data"]
         assert result["existing_key"] == "existing_value"


### PR DESCRIPTION
> **⚠️ DRAFT — Do not merge.**
> This PR passes `model_definition` from Manager → Agent via `internal_data`. However, the WebUI uses the legacy `POST /services` path which does not store `model_definition` in DB, so Agent would get `ModelDefinitionNotFoundError` for WebUI-created services.
>
> **Superseded by #10984** — simpler approach where Agent reads VFolder `model-definition.yaml` directly (same as Manager), requiring no Manager-side changes and working for both legacy and sokovan paths.

## Summary
- Agent was generating model definitions independently per runtime variant, ignoring Manager's VFolder-merged health_check overrides (initial_delay, max_retries, max_wait_time)
- Pass Manager-generated `ModelDefinition` through `creation_spec` → `internal_data` to Agent
- Remove Agent-side model definition generation entirely (~400 lines) — Agent now uses Manager-provided definition as single source of truth
- Add Agent logging for health_check source and actual timeout values

## Jira
- [BA-5665](https://lablup.atlassian.net/browse/BA-5665) — Agent ignores VFolder health_check override
- [BA-5680](https://lablup.atlassian.net/browse/BA-5680) — Remove Agent-side model definition generation

## Why this approach was abandoned
The WebUI calls `POST /services` (legacy path), which does NOT go through sokovan's `ModelDefinitionGeneratorRegistry`. Legacy endpoints have `deployment_revisions.model_definition = NULL`, so `internal_data.model_definition` is never set. After the BA-5680 refactor that removed Agent-side fallback, Agent raises `ModelDefinitionNotFoundError` for all WebUI-created services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5665]: https://lablup.atlassian.net/browse/BA-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ