### PR TITLE
fix(BA-5667): replace atomic list fields wholesale in ModelDefinition.merge()

### DIFF
--- a/changes/10955.fix.md
+++ b/changes/10955.fix.md
@@ -1,0 +1,1 @@
+Fix `ModelDefinition.merge()` corrupting `start_command` by replacing atomic list fields wholesale instead of merging element-by-element

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -4,7 +4,7 @@ import os
 import sys
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import humps
 import tomli
@@ -340,11 +340,40 @@ class ModelDefinition(BaseConfigModel):
         description="List of models in the model definition.",
     )
 
+    # Fields in ModelServiceConfig that are atomic (should be replaced wholesale,
+    # not merged element-by-element when both base and override are lists).
+    _ATOMIC_SERVICE_FIELDS: ClassVar[frozenset[str]] = frozenset({
+        "start_command",
+        "start-command",
+        "pre_start_actions",
+        "pre-start-actions",
+    })
+
     def merge(self, override: ModelDefinition) -> ModelDefinition:
-        """Deep merge the given override into this definition, returning a new instance."""
+        """Deep merge the given override into this definition, returning a new instance.
+
+        Atomic list fields such as ``start_command`` are replaced wholesale by
+        the override value rather than being merged element-by-element, because
+        they represent a single logical value (e.g. a complete shell command).
+        """
         base_dict = self.model_dump(exclude_none=True, by_alias=True)
         override_dict = override.model_dump(exclude_none=True, by_alias=True)
         merged_dict = deep_merge(base_dict, override_dict)
+        # Restore atomic list fields from the override so they are not
+        # partially merged with base values by deep_merge's index-based
+        # list merging strategy.
+        for idx, override_model in enumerate(override_dict.get("models", [])):
+            if idx >= len(merged_dict.get("models", [])):
+                break
+            override_service = override_model.get("service")
+            if override_service is None:
+                continue
+            merged_service = merged_dict["models"][idx].get("service")
+            if merged_service is None:
+                continue
+            for field_name in self._ATOMIC_SERVICE_FIELDS:
+                if field_name in override_service:
+                    merged_service[field_name] = override_service[field_name]
         return ModelDefinition.model_validate(merged_dict)
 
     def health_check_config(self) -> ModelHealthCheck | None:

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -3,7 +3,13 @@ from typing import Any
 
 import tomli
 
-from ai.backend.common.config import merge, override_key
+from ai.backend.common.config import (
+    ModelConfig,
+    ModelDefinition,
+    ModelServiceConfig,
+    merge,
+    override_key,
+)
 
 
 def test_override_key() -> None:
@@ -53,6 +59,86 @@ def test_merge() -> None:
         "c": 1,
         "x": 10,
     }
+
+
+def _make_model_definition(
+    start_command: list[str],
+    pre_start_actions: list[dict[str, Any]] | None = None,
+) -> ModelDefinition:
+    service_kwargs: dict[str, Any] = {
+        "start_command": start_command,
+        "port": 8080,
+    }
+    if pre_start_actions is not None:
+        service_kwargs["pre_start_actions"] = pre_start_actions
+    return ModelDefinition(
+        models=[
+            ModelConfig(
+                name="test-model",
+                model_path="/models",
+                service=ModelServiceConfig(**service_kwargs),
+            )
+        ]
+    )
+
+
+def test_model_definition_merge_replaces_start_command_wholesale() -> None:
+    """Atomic list fields like start_command must be replaced wholesale.
+
+    Regression test for index-based list merging that left tail elements
+    from the base when the override provided a shorter list.
+    """
+    base = _make_model_definition(
+        start_command=[
+            "python3",
+            "-m",
+            "vllm.entrypoints.openai.api_server",
+            "--model",
+            "/models",
+            "--served-model-name",
+            "test",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8080",
+        ],
+    )
+    override = _make_model_definition(
+        start_command=["python3", "-m", "http.server", "8080"],
+    )
+
+    merged = base.merge(override)
+
+    assert merged.models[0].service is not None
+    assert merged.models[0].service.start_command == [
+        "python3",
+        "-m",
+        "http.server",
+        "8080",
+    ]
+
+
+def test_model_definition_merge_replaces_pre_start_actions_wholesale() -> None:
+    """Atomic list fields like pre_start_actions must be replaced wholesale."""
+    base = _make_model_definition(
+        start_command=["python3", "app.py"],
+        pre_start_actions=[
+            {"action": "run_command", "args": {"command": ["echo", "base-1"]}},
+            {"action": "run_command", "args": {"command": ["echo", "base-2"]}},
+            {"action": "run_command", "args": {"command": ["echo", "base-3"]}},
+        ],
+    )
+    override = _make_model_definition(
+        start_command=["python3", "app.py"],
+        pre_start_actions=[
+            {"action": "run_command", "args": {"command": ["echo", "override"]}},
+        ],
+    )
+
+    merged = base.merge(override)
+
+    assert merged.models[0].service is not None
+    assert len(merged.models[0].service.pre_start_actions) == 1
 
 
 def test_sanitize_inline_dicts() -> None:


### PR DESCRIPTION
## Summary

- Fix `ModelDefinition.merge()` corrupting `start_command` via index-based list merging
- After `deep_merge`, restore atomic list fields (`start_command`, `pre_start_actions`) from the override dict
- Scoped to `ModelDefinition.merge()` — does not change the general-purpose `deep_merge` utility

## Motivation

`deep_merge` merges lists element-by-element by index, which is correct for structural lists (e.g., `models`) but wrong for atomic lists like `start_command` that represent a single logical value and should be replaced wholesale.

Closes BA-5667