### PR TITLE
fix(BA-5664): fix empty routings treated as None in endpoint resolvers

### DIFF
--- a/changes/10948.fix.md
+++ b/changes/10948.fix.md
@@ -1,0 +1,1 @@
+Fix legacy GQL endpoint resolvers crashing when routings is empty by using `is not None` check instead of truthiness check, and return DEGRADED instead of READY for empty routings.

--- a/src/ai/backend/manager/models/endpoint.py
+++ b/src/ai/backend/manager/models/endpoint.py
@@ -589,7 +589,9 @@ class EndpointRow(Base):
             lifecycle_stage=self.lifecycle_stage,
             runtime_variant=self.runtime_variant,
             extra_mounts=self.extra_mounts,
-            routings=[routing.to_data() for routing in self.routings] if self.routings else None,
+            routings=[routing.to_data() for routing in self.routings]
+            if self.routings is not None
+            else None,
         )
 
     @classmethod

--- a/src/ai/backend/manager/models/gql_models/endpoint.py
+++ b/src/ai/backend/manager/models/gql_models/endpoint.py
@@ -759,7 +759,9 @@ class Endpoint(graphene.ObjectType):
             created_at=dto.created_at,
             destroyed_at=dto.destroyed_at,
             retries=dto.retries,
-            routings=[Routing.from_dto(r) for r in dto.routings] if dto.routings else None,
+            routings=[Routing.from_dto(r) for r in dto.routings]
+            if dto.routings is not None
+            else None,
             lifecycle_stage=dto.lifecycle_stage,
             runtime_variant=RuntimeVariantInfo.from_enum(dto.runtime_variant),
         )
@@ -904,8 +906,8 @@ class Endpoint(graphene.ObjectType):
             case EndpointLifecycle.DESTROYING.name:
                 return EndpointStatus.DESTROYING
             case _:
-                if len(self.routings) == 0:
-                    return EndpointStatus.READY
+                if not self.routings:
+                    return EndpointStatus.DEGRADED
                 elif self.retries > SERVICE_MAX_RETRIES:
                     return EndpointStatus.UNHEALTHY
                 elif (spawned_service_count := len([r for r in self.routings])) > 0:

--- a/tests/manager/models/gql_models/test_endpoint_resolve_status.py
+++ b/tests/manager/models/gql_models/test_endpoint_resolve_status.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.common.data.endpoint.types import EndpointStatus
+from ai.backend.manager.data.deployment.types import EndpointLifecycle, RouteStatus
+from ai.backend.manager.models.gql_models.endpoint import Endpoint
+
+
+class TestEndpointResolveStatus:
+    """Regression test for BA-5664: empty routings must not resolve to HEALTHY."""
+
+    @pytest.fixture
+    def info(self) -> MagicMock:
+        return MagicMock()
+
+    async def test_empty_routings_returns_degraded(self, info: MagicMock) -> None:
+        ep = Endpoint()
+        ep.lifecycle_stage = EndpointLifecycle.READY.name
+        ep.routings = []
+        result = await ep.resolve_status(info)
+        assert result == EndpointStatus.DEGRADED
+
+    async def test_all_healthy_routings_returns_healthy(self, info: MagicMock) -> None:
+        routing = MagicMock()
+        routing.status = RouteStatus.HEALTHY.name
+        ep = Endpoint()
+        ep.lifecycle_stage = EndpointLifecycle.READY.name
+        ep.retries = 0
+        ep.routings = [routing]
+        result = await ep.resolve_status(info)
+        assert result == EndpointStatus.HEALTHY


### PR DESCRIPTION
## Summary
This is a manual backport PR of #10948 to the 25.15 release.

- Fix legacy GQL endpoint resolvers crashing when routings is empty by using `is not None` check instead of truthiness check
- Return `DEGRADED` instead of `READY` for empty routings in `resolve_status`
- Preserve empty list `[]` through `to_data()` / `from_dto()` conversion instead of converting to `None`

## Test plan
- [x] Unit tests for `resolve_status` with empty routings (DEGRADED) and healthy routings (HEALTHY)
- [x] `pants lint` / `pants check` / `pants test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)