### PR TITLE
fix(BA-5667): replace deep_merge with Pydantic-aware field-by-field merge in ModelDefinition

### DIFF
--- a/changes/10959.fix.md
+++ b/changes/10959.fix.md
@@ -1,0 +1,1 @@
+Fix `ModelDefinition.merge()` corrupting `start_command` via index-based list merging by replacing `deep_merge()` with Pydantic-aware field-by-field merge functions

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -338,8 +338,12 @@ class ModelConfig(BaseConfigModel):
 
 
 def _pick(base_val: Any, override_val: Any, override_set: bool) -> Any:
-    """Return the override value if explicitly set and non-None, otherwise the base."""
-    if not override_set or override_val is None:
+    """Return the override value if explicitly set, otherwise the base.
+
+    Distinguishes between unset (not in model_fields_set → keep base)
+    and explicitly set to None (in model_fields_set → replace with None).
+    """
+    if not override_set:
         return base_val
     return override_val
 
@@ -433,9 +437,9 @@ def merge_definition(base: ModelDefinition, override: ModelDefinition) -> ModelD
     via :func:`merge_config`.  All other fields are replaced atomically.
     """
     models: list[ModelConfig]
-    if "models" not in override.model_fields_set or not override.models:
+    if "models" not in override.model_fields_set:
         models = base.models
-    elif not base.models:
+    elif not base.models or not override.models:
         models = override.models
     else:
         models = []

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -26,10 +26,6 @@ __all__ = (
     "check",
     "etcd_config_iv",
     "merge",
-    "merge_config",
-    "merge_definition",
-    "merge_metadata",
-    "merge_service_config",
     "model_definition_iv",
     "override_key",
     "override_with_env",
@@ -348,7 +344,7 @@ def _pick(base_val: Any, override_val: Any, override_set: bool) -> Any:
     return override_val
 
 
-def merge_metadata(base: ModelMetadata, override: ModelMetadata) -> ModelMetadata:
+def _merge_metadata(base: ModelMetadata, override: ModelMetadata) -> ModelMetadata:
     """Merge two ModelMetadata instances. All fields are atomic."""
     s = override.model_fields_set
     return ModelMetadata.model_construct(
@@ -368,7 +364,7 @@ def merge_metadata(base: ModelMetadata, override: ModelMetadata) -> ModelMetadat
     )
 
 
-def merge_service_config(
+def _merge_service_config(
     base: ModelServiceConfig,
     override: ModelServiceConfig,
 ) -> ModelServiceConfig:
@@ -405,7 +401,7 @@ def merge_service_config(
     )
 
 
-def merge_config(base: ModelConfig, override: ModelConfig) -> ModelConfig:
+def _merge_config(base: ModelConfig, override: ModelConfig) -> ModelConfig:
     """Merge two ModelConfig instances.
 
     ``service`` and ``metadata`` sub-models are merged recursively;
@@ -414,12 +410,12 @@ def merge_config(base: ModelConfig, override: ModelConfig) -> ModelConfig:
     s = override.model_fields_set
     service: ModelServiceConfig | None
     if "service" in s and base.service is not None and override.service is not None:
-        service = merge_service_config(base.service, override.service)
+        service = _merge_service_config(base.service, override.service)
     else:
         service = _pick(base.service, override.service, "service" in s)
     metadata: ModelMetadata | None
     if "metadata" in s and base.metadata is not None and override.metadata is not None:
-        metadata = merge_metadata(base.metadata, override.metadata)
+        metadata = _merge_metadata(base.metadata, override.metadata)
     else:
         metadata = _pick(base.metadata, override.metadata, "metadata" in s)
     return ModelConfig.model_construct(
@@ -430,11 +426,11 @@ def merge_config(base: ModelConfig, override: ModelConfig) -> ModelConfig:
     )
 
 
-def merge_definition(base: ModelDefinition, override: ModelDefinition) -> ModelDefinition:
+def _merge_definition(base: ModelDefinition, override: ModelDefinition) -> ModelDefinition:
     """Merge two ModelDefinition instances.
 
     The ``models`` list is merged by index — each element pair is merged
-    via :func:`merge_config`.  All other fields are replaced atomically.
+    via :func:`_merge_config`.  All other fields are replaced atomically.
     """
     models: list[ModelConfig]
     if "models" not in override.model_fields_set:
@@ -449,7 +445,7 @@ def merge_definition(base: ModelDefinition, override: ModelDefinition) -> ModelD
             elif i >= len(override.models):
                 models.append(base.models[i])
             else:
-                models.append(merge_config(base.models[i], override.models[i]))
+                models.append(_merge_config(base.models[i], override.models[i]))
     return ModelDefinition.model_construct(models=models)
 
 
@@ -461,7 +457,7 @@ class ModelDefinition(BaseConfigModel):
 
     def merge(self, override: ModelDefinition) -> ModelDefinition:
         """Merge the given override into this definition, returning a new instance."""
-        return merge_definition(self, override)
+        return _merge_definition(self, override)
 
     def health_check_config(self) -> ModelHealthCheck | None:
         for model in self.models:

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -20,13 +20,16 @@ from . import validators as tx
 from .etcd import AsyncEtcd, ConfigScopes
 from .exception import ConfigurationError
 from .types import RedisHelperConfig
-from .utils import deep_merge
 
 __all__ = (
     "ConfigurationError",
     "check",
     "etcd_config_iv",
     "merge",
+    "merge_config",
+    "merge_definition",
+    "merge_metadata",
+    "merge_service_config",
     "model_definition_iv",
     "override_key",
     "override_with_env",
@@ -334,6 +337,118 @@ class ModelConfig(BaseConfigModel):
     )
 
 
+def _pick(base_val: Any, override_val: Any, override_set: bool) -> Any:
+    """Return the override value if explicitly set and non-None, otherwise the base."""
+    if not override_set or override_val is None:
+        return base_val
+    return override_val
+
+
+def merge_metadata(base: ModelMetadata, override: ModelMetadata) -> ModelMetadata:
+    """Merge two ModelMetadata instances. All fields are atomic."""
+    s = override.model_fields_set
+    return ModelMetadata.model_construct(
+        author=_pick(base.author, override.author, "author" in s),
+        title=_pick(base.title, override.title, "title" in s),
+        version=_pick(base.version, override.version, "version" in s),
+        created=_pick(base.created, override.created, "created" in s),
+        last_modified=_pick(base.last_modified, override.last_modified, "last_modified" in s),
+        description=_pick(base.description, override.description, "description" in s),
+        task=_pick(base.task, override.task, "task" in s),
+        category=_pick(base.category, override.category, "category" in s),
+        architecture=_pick(base.architecture, override.architecture, "architecture" in s),
+        framework=_pick(base.framework, override.framework, "framework" in s),
+        label=_pick(base.label, override.label, "label" in s),
+        license=_pick(base.license, override.license, "license" in s),
+        min_resource=_pick(base.min_resource, override.min_resource, "min_resource" in s),
+    )
+
+
+def merge_service_config(
+    base: ModelServiceConfig,
+    override: ModelServiceConfig,
+) -> ModelServiceConfig:
+    """Merge two ModelServiceConfig instances.
+
+    ``health_check`` is merged field-by-field; all other fields
+    (``start_command``, ``pre_start_actions``, etc.) are replaced atomically.
+    """
+    s = override.model_fields_set
+    health_check: ModelHealthCheck | None
+    if "health_check" in s and base.health_check is not None and override.health_check is not None:
+        hb, ho = base.health_check, override.health_check
+        hs = ho.model_fields_set
+        health_check = ModelHealthCheck.model_construct(
+            interval=_pick(hb.interval, ho.interval, "interval" in hs),
+            path=_pick(hb.path, ho.path, "path" in hs),
+            max_retries=_pick(hb.max_retries, ho.max_retries, "max_retries" in hs),
+            max_wait_time=_pick(hb.max_wait_time, ho.max_wait_time, "max_wait_time" in hs),
+            expected_status_code=_pick(
+                hb.expected_status_code, ho.expected_status_code, "expected_status_code" in hs
+            ),
+            initial_delay=_pick(hb.initial_delay, ho.initial_delay, "initial_delay" in hs),
+        )
+    else:
+        health_check = _pick(base.health_check, override.health_check, "health_check" in s)
+    return ModelServiceConfig.model_construct(
+        pre_start_actions=_pick(
+            base.pre_start_actions, override.pre_start_actions, "pre_start_actions" in s
+        ),
+        start_command=_pick(base.start_command, override.start_command, "start_command" in s),
+        shell=_pick(base.shell, override.shell, "shell" in s),
+        port=_pick(base.port, override.port, "port" in s),
+        health_check=health_check,
+    )
+
+
+def merge_config(base: ModelConfig, override: ModelConfig) -> ModelConfig:
+    """Merge two ModelConfig instances.
+
+    ``service`` and ``metadata`` sub-models are merged recursively;
+    all other fields are replaced atomically.
+    """
+    s = override.model_fields_set
+    service: ModelServiceConfig | None
+    if "service" in s and base.service is not None and override.service is not None:
+        service = merge_service_config(base.service, override.service)
+    else:
+        service = _pick(base.service, override.service, "service" in s)
+    metadata: ModelMetadata | None
+    if "metadata" in s and base.metadata is not None and override.metadata is not None:
+        metadata = merge_metadata(base.metadata, override.metadata)
+    else:
+        metadata = _pick(base.metadata, override.metadata, "metadata" in s)
+    return ModelConfig.model_construct(
+        name=_pick(base.name, override.name, "name" in s),
+        model_path=_pick(base.model_path, override.model_path, "model_path" in s),
+        service=service,
+        metadata=metadata,
+    )
+
+
+def merge_definition(base: ModelDefinition, override: ModelDefinition) -> ModelDefinition:
+    """Merge two ModelDefinition instances.
+
+    The ``models`` list is merged by index — each element pair is merged
+    via :func:`merge_config`.  All other fields are replaced atomically.
+    """
+    models: list[ModelConfig]
+    if "models" not in override.model_fields_set or not override.models:
+        models = base.models
+    elif not base.models:
+        models = override.models
+    else:
+        models = []
+        for i in range(max(len(base.models), len(override.models))):
+            if i >= len(base.models):
+                models.append(override.models[i])
+            elif i >= len(override.models):
+                models.append(base.models[i])
+            else:
+                models.append(merge_config(base.models[i], override.models[i]))
+    return ModelDefinition.model_construct(models=models)
+
+
 class ModelDefinition(BaseConfigModel):
     models: list[ModelConfig] = Field(
         default_factory=list,
@@ -341,11 +456,8 @@ class ModelDefinition(BaseConfigModel):
     )
 
     def merge(self, override: ModelDefinition) -> ModelDefinition:
-        """Deep merge the given override into this definition, returning a new instance."""
-        base_dict = self.model_dump(exclude_none=True, by_alias=True)
-        override_dict = override.model_dump(exclude_none=True, by_alias=True)
-        merged_dict = deep_merge(base_dict, override_dict)
-        return ModelDefinition.model_validate(merged_dict)
+        """Merge the given override into this definition, returning a new instance."""
+        return merge_definition(self, override)
 
     def health_check_config(self) -> ModelHealthCheck | None:
         for model in self.models:

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -9,11 +9,11 @@ from ai.backend.common.config import (
     ModelHealthCheck,
     ModelMetadata,
     ModelServiceConfig,
+    _merge_config,
+    _merge_definition,
+    _merge_metadata,
+    _merge_service_config,
     merge,
-    merge_config,
-    merge_definition,
-    merge_metadata,
-    merge_service_config,
     override_key,
 )
 
@@ -93,9 +93,9 @@ class TestMergeFieldCoverage:
             min_resource={"base": 1},
         )
         override = ModelMetadata.model_construct(_fields_set=set())
-        result = merge_metadata(base, override)
+        result = _merge_metadata(base, override)
         missing = set(ModelMetadata.model_fields) - result.model_fields_set
-        assert not missing, f"merge_metadata() does not handle: {missing}"
+        assert not missing, f"_merge_metadata() does not handle: {missing}"
 
     def test_merge_service_config(self) -> None:
         base = ModelServiceConfig.model_construct(
@@ -114,9 +114,9 @@ class TestMergeFieldCoverage:
             port=2,
             health_check=None,
         )
-        result = merge_service_config(base, override)
+        result = _merge_service_config(base, override)
         missing = set(ModelServiceConfig.model_fields) - result.model_fields_set
-        assert not missing, f"merge_service_config() does not handle: {missing}"
+        assert not missing, f"_merge_service_config() does not handle: {missing}"
 
     def test_merge_service_config_health_check_subfields(self) -> None:
         base_hc = ModelHealthCheck.model_construct(
@@ -144,7 +144,7 @@ class TestMergeFieldCoverage:
             port=2,
             health_check=override_hc,
         )
-        result = merge_service_config(base, override)
+        result = _merge_service_config(base, override)
         assert result.health_check is not None
         missing = set(ModelHealthCheck.model_fields) - result.health_check.model_fields_set
         assert not missing, f"health_check merge does not handle: {missing}"
@@ -162,9 +162,9 @@ class TestMergeFieldCoverage:
             name="",
             model_path="",
         )
-        result = merge_config(base, override)
+        result = _merge_config(base, override)
         missing = set(ModelConfig.model_fields) - result.model_fields_set
-        assert not missing, f"merge_config() does not handle: {missing}"
+        assert not missing, f"_merge_config() does not handle: {missing}"
 
     def test_merge_definition(self) -> None:
         base = ModelDefinition.model_construct(
@@ -172,9 +172,9 @@ class TestMergeFieldCoverage:
             models=[],
         )
         override = ModelDefinition.model_construct(_fields_set=set())
-        result = merge_definition(base, override)
+        result = _merge_definition(base, override)
         missing = set(ModelDefinition.model_fields) - result.model_fields_set
-        assert not missing, f"merge_definition() does not handle: {missing}"
+        assert not missing, f"_merge_definition() does not handle: {missing}"
 
 
 def test_sanitize_inline_dicts() -> None:

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -3,7 +3,19 @@ from typing import Any
 
 import tomli
 
-from ai.backend.common.config import merge, override_key
+from ai.backend.common.config import (
+    ModelConfig,
+    ModelDefinition,
+    ModelHealthCheck,
+    ModelMetadata,
+    ModelServiceConfig,
+    merge,
+    merge_config,
+    merge_definition,
+    merge_metadata,
+    merge_service_config,
+    override_key,
+)
 
 
 def test_override_key() -> None:
@@ -53,6 +65,116 @@ def test_merge() -> None:
         "c": 1,
         "x": 10,
     }
+
+
+class TestMergeFieldCoverage:
+    """Verify merge functions handle every declared field.
+
+    When a field is added to a config model but the corresponding merge
+    function is not updated, these tests will fail because the new field
+    will be missing from the result's model_fields_set.
+    """
+
+    def test_merge_metadata(self) -> None:
+        base = ModelMetadata.model_construct(
+            _fields_set=set(ModelMetadata.model_fields),
+            author="base",
+            title="base",
+            version="base",
+            created="base",
+            last_modified="base",
+            description="base",
+            task="base",
+            category="base",
+            architecture="base",
+            framework=["base"],
+            label=["base"],
+            license="base",
+            min_resource={"base": 1},
+        )
+        override = ModelMetadata.model_construct(_fields_set=set())
+        result = merge_metadata(base, override)
+        missing = set(ModelMetadata.model_fields) - result.model_fields_set
+        assert not missing, f"merge_metadata() does not handle: {missing}"
+
+    def test_merge_service_config(self) -> None:
+        base = ModelServiceConfig.model_construct(
+            _fields_set=set(ModelServiceConfig.model_fields),
+            pre_start_actions=[],
+            start_command="base-cmd",
+            shell="/bin/base",
+            port=9999,
+            health_check=None,
+        )
+        override = ModelServiceConfig.model_construct(
+            _fields_set=set(),
+            pre_start_actions=[],
+            start_command="",
+            shell="",
+            port=2,
+            health_check=None,
+        )
+        result = merge_service_config(base, override)
+        missing = set(ModelServiceConfig.model_fields) - result.model_fields_set
+        assert not missing, f"merge_service_config() does not handle: {missing}"
+
+    def test_merge_service_config_health_check_subfields(self) -> None:
+        base_hc = ModelHealthCheck.model_construct(
+            _fields_set=set(ModelHealthCheck.model_fields),
+            interval=99.0,
+            path="/base",
+            max_retries=99,
+            max_wait_time=99.0,
+            expected_status_code=201,
+            initial_delay=99.0,
+        )
+        override_hc = ModelHealthCheck.model_construct(
+            _fields_set=set(),
+            path="",
+        )
+        base = ModelServiceConfig.model_construct(
+            _fields_set={"health_check"},
+            start_command="",
+            port=2,
+            health_check=base_hc,
+        )
+        override = ModelServiceConfig.model_construct(
+            _fields_set={"health_check"},
+            start_command="",
+            port=2,
+            health_check=override_hc,
+        )
+        result = merge_service_config(base, override)
+        assert result.health_check is not None
+        missing = set(ModelHealthCheck.model_fields) - result.health_check.model_fields_set
+        assert not missing, f"health_check merge does not handle: {missing}"
+
+    def test_merge_config(self) -> None:
+        base = ModelConfig.model_construct(
+            _fields_set=set(ModelConfig.model_fields),
+            name="base",
+            model_path="/base",
+            service=None,
+            metadata=None,
+        )
+        override = ModelConfig.model_construct(
+            _fields_set=set(),
+            name="",
+            model_path="",
+        )
+        result = merge_config(base, override)
+        missing = set(ModelConfig.model_fields) - result.model_fields_set
+        assert not missing, f"merge_config() does not handle: {missing}"
+
+    def test_merge_definition(self) -> None:
+        base = ModelDefinition.model_construct(
+            _fields_set=set(ModelDefinition.model_fields),
+            models=[],
+        )
+        override = ModelDefinition.model_construct(_fields_set=set())
+        result = merge_definition(base, override)
+        missing = set(ModelDefinition.model_fields) - result.model_fields_set
+        assert not missing, f"merge_definition() does not handle: {missing}"
 
 
 def test_sanitize_inline_dicts() -> None:


### PR DESCRIPTION
## Summary
- Replace `ModelDefinition.merge()`'s dict-based `deep_merge()` with explicit per-model merge functions (`merge_definition`, `merge_config`, `merge_service_config`, `merge_metadata`) that use Pydantic `model_fields_set` to determine merge strategy
- Atomic list fields like `start_command` are now replaced wholesale instead of being corrupted by index-based list merging
- Properly distinguish between unset fields (keep base) and explicitly-set `None` (clear the field)
- Add field coverage tests that detect when a new field is added to a config model but the corresponding merge function is not updated

## Test plan
- [x] Existing `test_registry.py` merge tests pass (vfolder + user override scenario)
- [x] New `TestMergeFieldCoverage` tests verify all fields are handled by each merge function
- [x] `pants lint`, `pants check` pass

Resolves BA-5667