### PR TITLE
fix(BA-5673): guard None routings in legacy GQL endpoint errors resolver

### DIFF
--- a/changes/10969.fix.md
+++ b/changes/10969.fix.md
@@ -1,0 +1,1 @@
+Guard `None` routings in the legacy GQL `endpoint.errors` resolver to prevent `'NoneType' object is not iterable` on newly-deployed endpoints.

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -915,6 +915,8 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
             return [VirtualFolderNode.from_row(info, r) for r in (await sess.scalars(query))]
 
     async def resolve_errors(self, info: graphene.ResolveInfo) -> Any:
+        if not self.routings:
+            return []
         error_routes = [r for r in self.routings if r.status == RouteStatus.FAILED_TO_START.name]
         errors = []
         for route in error_routes:

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -915,7 +915,7 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
             return [VirtualFolderNode.from_row(info, r) for r in (await sess.scalars(query))]
 
     async def resolve_errors(self, info: graphene.ResolveInfo) -> Any:
-        if not self.routings:
+        if self.routings is None:
             return []
         error_routes = [r for r in self.routings if r.status == RouteStatus.FAILED_TO_START.name]
         errors = []


### PR DESCRIPTION
## Summary

The legacy GraphQL `endpoint.errors` resolver crashes with `'NoneType' object is not iterable` when an endpoint's `routings` field is `None`, surfacing as `DOWNSTREAM_SERVICE_ERROR` on the client.

`Endpoint.from_dto` explicitly allows `routings=None` (`gql_legacy/endpoint.py:723-725`), but `resolve_errors` iterated it directly without a guard. BA-5664 (#10948) fixed the same pattern in `resolve_status` and the ORM conversion path but did not cover `resolve_errors`.

## Changes

- `src/ai/backend/manager/api/gql_legacy/endpoint.py`: short-circuit `resolve_errors` to return an empty list when `self.routings` is `None`, matching the guard style introduced in BA-5664.

## Related

- Jira: [BA-5673](https://lablup.atlassian.net/browse/BA-5673)
- Follows: #10948 (BA-5664)
- Reported during review of lablup/backend.ai-webui#6535 — empty fields on the endpoint detail page immediately after deploy until a manual refresh.

[BA-5673]: https://lablup.atlassian.net/browse/BA-5673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ