### PR TITLE
fix(BA-5672): expose AND/OR/NOT composition on ModelCardV2Filter

### DIFF
--- a/changes/10970.fix.md
+++ b/changes/10970.fix.md
@@ -1,0 +1,1 @@
+Expose `AND`/`OR`/`NOT` composition on the `ModelCardV2Filter` GraphQL input so composed filter queries no longer fail with `Field "AND" is not defined`

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8303,6 +8303,15 @@ input ModelCardV2Filter
   Filter by the storage host backing the model card's VFolder. Matches via an EXISTS subquery against the VFolder host column.
   """
   storageHost: StringFilter = null
+
+  """Combine nested filters with logical AND."""
+  AND: [ModelCardV2Filter!] = null
+
+  """Combine nested filters with logical OR."""
+  OR: [ModelCardV2Filter!] = null
+
+  """Negate the combined result of nested filters."""
+  NOT: [ModelCardV2Filter!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5231,6 +5231,15 @@ input ModelCardV2Filter {
   Filter by the storage host backing the model card's VFolder. Matches via an EXISTS subquery against the VFolder host column.
   """
   storageHost: StringFilter = null
+
+  """Combine nested filters with logical AND."""
+  AND: [ModelCardV2Filter!] = null
+
+  """Combine nested filters with logical OR."""
+  OR: [ModelCardV2Filter!] = null
+
+  """Negate the combined result of nested filters."""
+  NOT: [ModelCardV2Filter!] = null
 }
 
 """

--- a/src/ai/backend/manager/api/adapters/model_card.py
+++ b/src/ai/backend/manager/api/adapters/model_card.py
@@ -66,7 +66,12 @@ from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUp
 from ai.backend.manager.models.model_card.conditions import ModelCardConditions
 from ai.backend.manager.models.model_card.orders import ModelCardOrders
 from ai.backend.manager.models.model_card.row import ModelCardRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder, combine_conditions_or
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.model_card.creators import ModelCardCreatorSpec
@@ -549,6 +554,12 @@ class ModelCardAdapter(BaseAdapter):
                 or_conds.extend(self._convert_filter(sub))
             if or_conds:
                 conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     def _convert_orders(self, orders: list[ModelCardOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/gql/model_card/types.py
+++ b/src/ai/backend/manager/api/gql/model_card/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Self
 from uuid import UUID
 
 import strawberry
@@ -324,6 +324,15 @@ class ModelCardFilterGQL(PydanticInputMixin[FilterDTO]):
             "Filter by the storage host backing the model card's VFolder. "
             "Matches via an EXISTS subquery against the VFolder host column."
         ),
+    )
+    AND: list[Self] | None = gql_field(
+        default=None, description="Combine nested filters with logical AND."
+    )
+    OR: list[Self] | None = gql_field(
+        default=None, description="Combine nested filters with logical OR."
+    )
+    NOT: list[Self] | None = gql_field(
+        default=None, description="Negate the combined result of nested filters."
     )
 
 


### PR DESCRIPTION
## Summary

The Strawberry `ModelCardV2Filter` GraphQL input does not expose the `AND`/`OR`/`NOT` composition fields, so composed filter queries from the frontend fail before reaching the adapter:

```
Field "AND" is not defined by type "ModelCardV2Filter"
```

The underlying Pydantic DTO (`common/dto/manager/v2/model_card/request.py:73-86`) already declares recursive `AND`/`OR`/`NOT`, and the adapter already wires up `AND` and `OR` — only the GQL wrapper and the adapter's `NOT` branch were missing.

## Changes

- `api/gql/model_card/types.py`: add `AND`/`OR`/`NOT: list[Self] | None` to `ModelCardFilterGQL`, mirroring the pattern used by `DomainV2Filter`, `UserFilterGQL`, and `ProjectV2Filter`.
- `api/adapters/model_card.py`: handle the `filter_.NOT` branch in `_convert_filter` via `negate_conditions`, matching `DomainAdapter._convert_domain_filter`.

## Related

- Jira: [BA-5672](https://lablup.atlassian.net/browse/BA-5672)
- Reported during review of lablup/backend.ai-webui#6535 — model store listing fails when users apply multiple name filter chips.

[BA-5672]: https://lablup.atlassian.net/browse/BA-5672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ