### PR TITLE
fix(BA-5665): apply VFolder model-definition.yaml override for all runtime variants on Agent

### DIFF
--- a/changes/10984.fix.md
+++ b/changes/10984.fix.md
@@ -1,0 +1,1 @@
+Apply VFolder model-definition.yaml health_check overrides for non-custom runtime variants (vllm, tgi, nim, sglang, modular-max) on the Agent side, mirroring Manager's existing merge behavior.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -3417,15 +3417,23 @@ class AbstractAgent[
                 model_folder, kernel_config
             )
             if vfolder_override is not None:
-                base = ModelDefinition.model_validate(raw_definition)
-                override = ModelDefinition.model_validate(vfolder_override)
-                merged = base.merge(override)
-                raw_definition = merged.model_dump(mode="json")
-                log.info(
-                    "load_model_definition(): applied VFolder model-definition.yaml override"
-                    " (runtime_variant={})",
-                    runtime_variant,
-                )
+                try:
+                    base = ModelDefinition.model_validate(raw_definition)
+                    override = ModelDefinition.model_validate(vfolder_override)
+                    merged = base.merge(override)
+                    raw_definition = merged.model_dump(mode="json")
+                    log.info(
+                        "load_model_definition(): applied VFolder model-definition.yaml override"
+                        " (runtime_variant={})",
+                        runtime_variant,
+                    )
+                except Exception:
+                    log.warning(
+                        "load_model_definition(): failed to merge VFolder override,"
+                        " using variant defaults (runtime_variant={})",
+                        runtime_variant,
+                        exc_info=True,
+                    )
         try:
             model_definition = model_definition_iv.check(raw_definition)
             if model_definition is None:
@@ -3490,10 +3498,15 @@ class AbstractAgent[
             ) from e
         try:
             yaml = YAML()
-            result: dict[str, Any] = yaml.load(content)
-            return result
+            result = yaml.load(content)
         except YAMLError as e:
             raise ModelDefinitionInvalidYAMLError(f"Invalid YAML syntax: {e}") from e
+        if not isinstance(result, dict):
+            raise ModelDefinitionValidationError(
+                "Model definition YAML must have a mapping at the top level,"
+                f" got {type(result).__name__}"
+            )
+        return result
 
     async def _try_read_model_definition_from_vfolder(
         self,
@@ -3503,7 +3516,15 @@ class AbstractAgent[
         """Try to read model-definition.yaml from VFolder. Returns None if not found."""
         try:
             return await self._read_model_definition_from_vfolder(model_folder, kernel_config)
-        except (ModelDefinitionNotFoundError, ModelDefinitionInvalidYAMLError):
+        except ModelDefinitionNotFoundError:
+            return None
+        except (ModelDefinitionInvalidYAMLError, ModelDefinitionValidationError):
+            log.warning(
+                "Invalid model definition override in vFolder {} (ID {}), ignoring",
+                model_folder.name,
+                model_folder.vfid,
+                exc_info=True,
+            )
             return None
 
     def get_public_service_ports(self, service_ports: list[ServicePort]) -> list[ServicePort]:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -86,7 +86,7 @@ from ai.backend.common.clients.valkey_client.valkey_image.client import ValkeyIm
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
-from ai.backend.common.config import model_definition_iv
+from ai.backend.common.config import ModelDefinition, model_definition_iv
 from ai.backend.common.data.agent.types import AgentInfo, ImageOpts
 from ai.backend.common.data.image.types import InstalledImageInfo, ScannedImage
 from ai.backend.common.defs import (
@@ -3404,41 +3404,28 @@ class AbstractAgent[
                 raw_definition = {"models": [_model]}
 
             case "custom":
-                if _fname := (kernel_config.get("internal_data") or {}).get(
-                    "model_definition_path"
-                ):
-                    model_definition_candidates = [_fname]
-                else:
-                    model_definition_candidates = [
-                        "model-definition.yaml",
-                        "model-definition.yml",
-                    ]
+                raw_definition = await self._read_model_definition_from_vfolder(
+                    model_folder, kernel_config
+                )
 
-                model_definition_path = None
-                for filename in model_definition_candidates:
-                    if (Path(model_folder.host_path) / filename).is_file():
-                        model_definition_path = Path(model_folder.host_path) / filename
-                        break
-
-                if not model_definition_path:
-                    raise ModelDefinitionNotFoundError(
-                        f"Model definition file ({' or '.join(model_definition_candidates)}) does not exist under vFolder"
-                        f" {model_folder.name} (ID {model_folder.vfid})",
-                    )
-                try:
-                    model_definition_yaml = await asyncio.get_running_loop().run_in_executor(
-                        None, model_definition_path.read_text
-                    )
-                except FileNotFoundError as e:
-                    raise ModelDefinitionNotFoundError(
-                        "Model definition file (model-definition.yml) does not exist under"
-                        f" vFolder {model_folder.name} (ID {model_folder.vfid})",
-                    ) from e
-                try:
-                    yaml = YAML()
-                    raw_definition = yaml.load(model_definition_yaml)
-                except YAMLError as e:
-                    raise ModelDefinitionInvalidYAMLError(f"Invalid YAML syntax: {e}") from e
+        # For non-custom variants, apply VFolder model-definition.yaml override if present.
+        # This mirrors the Manager's _apply_vfolder_override() in
+        # definition_generator/registry.py so that health_check values
+        # (initial_delay, max_retries, max_wait_time) set by the user are respected.
+        if runtime_variant != "custom":
+            vfolder_override = await self._try_read_model_definition_from_vfolder(
+                model_folder, kernel_config
+            )
+            if vfolder_override is not None:
+                base = ModelDefinition.model_validate(raw_definition)
+                override = ModelDefinition.model_validate(vfolder_override)
+                merged = base.merge(override)
+                raw_definition = merged.model_dump(mode="json")
+                log.info(
+                    "load_model_definition(): applied VFolder model-definition.yaml override"
+                    " (runtime_variant={})",
+                    runtime_variant,
+                )
         try:
             model_definition = model_definition_iv.check(raw_definition)
             if model_definition is None:
@@ -3471,6 +3458,53 @@ class AbstractAgent[
                 "Failed to validate model definition from vFolder"
                 f" {model_folder.name} (ID {model_folder.vfid})",
             ) from e
+
+    async def _read_model_definition_from_vfolder(
+        self,
+        model_folder: VFolderMount,
+        kernel_config: KernelCreationConfig,
+    ) -> dict[str, Any]:
+        """Read model-definition.yaml from VFolder. Raises on missing/invalid file."""
+        if _fname := (kernel_config.get("internal_data") or {}).get("model_definition_path"):
+            candidates = [_fname]
+        else:
+            candidates = ["model-definition.yaml", "model-definition.yml"]
+
+        found_path = None
+        for filename in candidates:
+            if (Path(model_folder.host_path) / filename).is_file():
+                found_path = Path(model_folder.host_path) / filename
+                break
+
+        if not found_path:
+            raise ModelDefinitionNotFoundError(
+                f"Model definition file ({' or '.join(candidates)}) does not exist"
+                f" under vFolder {model_folder.name} (ID {model_folder.vfid})",
+            )
+        try:
+            content = await asyncio.get_running_loop().run_in_executor(None, found_path.read_text)
+        except FileNotFoundError as e:
+            raise ModelDefinitionNotFoundError(
+                f"Model definition file does not exist under"
+                f" vFolder {model_folder.name} (ID {model_folder.vfid})",
+            ) from e
+        try:
+            yaml = YAML()
+            result: dict[str, Any] = yaml.load(content)
+            return result
+        except YAMLError as e:
+            raise ModelDefinitionInvalidYAMLError(f"Invalid YAML syntax: {e}") from e
+
+    async def _try_read_model_definition_from_vfolder(
+        self,
+        model_folder: VFolderMount,
+        kernel_config: KernelCreationConfig,
+    ) -> dict[str, Any] | None:
+        """Try to read model-definition.yaml from VFolder. Returns None if not found."""
+        try:
+            return await self._read_model_definition_from_vfolder(model_folder, kernel_config)
+        except (ModelDefinitionNotFoundError, ModelDefinitionInvalidYAMLError):
+            return None
 
     def get_public_service_ports(self, service_ports: list[ServicePort]) -> list[ServicePort]:
         return [port for port in service_ports if port["protocol"] != ServicePortProtocols.INTERNAL]

--- a/tests/unit/agent/test_model_definition.py
+++ b/tests/unit/agent/test_model_definition.py
@@ -1,0 +1,291 @@
+"""Tests for model definition loading with VFolder override for non-custom variants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock
+from uuid import UUID
+
+import pytest
+
+from ai.backend.agent.agent import AbstractAgent
+from ai.backend.agent.errors.agent import ModelDefinitionNotFoundError
+from ai.backend.common.types import (
+    RuntimeVariant,
+    ServicePort,
+    VFolderMount,
+)
+
+
+@pytest.fixture
+def vfolder_path(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def model_folder(vfolder_path: Path) -> VFolderMount:
+    mock = MagicMock(spec=VFolderMount)
+    mock.name = "test-model"
+    mock.vfid = MagicMock()
+    mock.vfid.folder_id = UUID("00000000-0000-0000-0000-000000000001")
+    mock.kernel_path = MagicMock()
+    mock.kernel_path.as_posix.return_value = "/models"
+    mock.host_path = vfolder_path
+    return mock
+
+
+@pytest.fixture
+def environ() -> dict[str, Any]:
+    return {}
+
+
+@pytest.fixture
+def service_ports() -> list[ServicePort]:
+    return []
+
+
+@pytest.fixture
+def mock_agent() -> Mock:
+    agent = Mock(spec=AbstractAgent)
+    agent.extract_image_command = AsyncMock(return_value="vllm serve")
+    agent.load_model_definition = AbstractAgent.load_model_definition.__get__(agent)
+    agent._read_model_definition_from_vfolder = (
+        AbstractAgent._read_model_definition_from_vfolder.__get__(agent)
+    )
+    agent._try_read_model_definition_from_vfolder = (
+        AbstractAgent._try_read_model_definition_from_vfolder.__get__(agent)
+    )
+    return agent
+
+
+def _write_model_definition_yaml(
+    vfolder_path: Path,
+    initial_delay: float = 300,
+    max_retries: int = 30,
+    max_wait_time: float = 20,
+) -> None:
+    (vfolder_path / "model-definition.yaml").write_text(f"""\
+models:
+  - name: "override-model"
+    model_path: "/models"
+    service:
+      start_command: "serve"
+      port: 8000
+      health_check:
+        path: /health
+        initial_delay: {initial_delay}
+        max_retries: {max_retries}
+        max_wait_time: {max_wait_time}
+""")
+
+
+@dataclass
+class HealthCheckOverrideCase:
+    initial_delay: float
+    max_retries: int
+    max_wait_time: float
+
+
+class TestVFolderOverrideForNonCustomVariants:
+    """Tests for VFolder model-definition.yaml override on non-custom variants."""
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            HealthCheckOverrideCase(initial_delay=300, max_retries=30, max_wait_time=20),
+            HealthCheckOverrideCase(initial_delay=600, max_retries=60, max_wait_time=30),
+        ],
+        ids=["large-model", "very-large-model"],
+    )
+    async def test_vfolder_override_applied_for_vllm(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+        case: HealthCheckOverrideCase,
+    ) -> None:
+        _write_model_definition_yaml(
+            vfolder_path,
+            initial_delay=case.initial_delay,
+            max_retries=case.max_retries,
+            max_wait_time=case.max_wait_time,
+        )
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test:latest"},
+            "internal_data": {"runtime_variant": "vllm"},
+        }
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == case.initial_delay
+        assert health_check["max_retries"] == case.max_retries
+        assert health_check["max_wait_time"] == case.max_wait_time
+
+    async def test_no_vfolder_yaml_uses_hardcoded_defaults(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
+        # No model-definition.yaml written to tmp_path
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test:latest"},
+            "internal_data": {"runtime_variant": "vllm"},
+        }
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        # trafaret defaults
+        assert health_check["initial_delay"] == 60
+        assert health_check["max_retries"] == 10
+        assert health_check["max_wait_time"] == 15
+
+    async def test_invalid_yaml_falls_back_to_defaults(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
+        (vfolder_path / "model-definition.yaml").write_text("not: [valid: yaml: {")
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test:latest"},
+            "internal_data": {"runtime_variant": "vllm"},
+        }
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
+        )
+
+        # Invalid yaml should be skipped, hardcoded defaults used
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 60
+
+    async def test_non_mapping_yaml_falls_back_to_defaults(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
+        (vfolder_path / "model-definition.yaml").write_text("- just\n- a\n- list\n")
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test:latest"},
+            "internal_data": {"runtime_variant": "vllm"},
+        }
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
+        )
+
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 60
+
+    async def test_merge_failure_falls_back_to_defaults(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+        environ: dict[str, Any],
+        service_ports: list[ServicePort],
+    ) -> None:
+        # Valid YAML, valid mapping, but invalid ModelDefinition structure
+        (vfolder_path / "model-definition.yaml").write_text("something: unexpected\n")
+        kernel_config: dict[str, Any] = {
+            "image": {"canonical": "test:latest"},
+            "internal_data": {"runtime_variant": "vllm"},
+        }
+
+        result = await mock_agent.load_model_definition(
+            RuntimeVariant("vllm"), [model_folder], environ, service_ports, kernel_config
+        )
+
+        # merge should fail, fall back to variant defaults
+        health_check = result["models"][0]["service"]["health_check"]
+        assert health_check["initial_delay"] == 60
+
+
+class TestVFolderReadHelpers:
+    """Tests for _read_model_definition_from_vfolder and _try variants."""
+
+    async def test_read_returns_parsed_yaml(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+    ) -> None:
+        _write_model_definition_yaml(vfolder_path)
+        kernel_config: dict[str, Any] = {"internal_data": {}}
+
+        result = await mock_agent._read_model_definition_from_vfolder(model_folder, kernel_config)
+
+        assert isinstance(result, dict)
+        assert result["models"][0]["name"] == "override-model"
+
+    async def test_read_raises_on_missing_file(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+    ) -> None:
+        kernel_config: dict[str, Any] = {"internal_data": {}}
+
+        with pytest.raises(ModelDefinitionNotFoundError):
+            await mock_agent._read_model_definition_from_vfolder(model_folder, kernel_config)
+
+    async def test_try_read_returns_none_on_missing_file(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+    ) -> None:
+        kernel_config: dict[str, Any] = {"internal_data": {}}
+
+        result = await mock_agent._try_read_model_definition_from_vfolder(
+            model_folder, kernel_config
+        )
+
+        assert result is None
+
+    async def test_try_read_returns_none_on_invalid_yaml(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+    ) -> None:
+        (vfolder_path / "model-definition.yaml").write_text("{invalid yaml")
+        kernel_config: dict[str, Any] = {"internal_data": {}}
+
+        result = await mock_agent._try_read_model_definition_from_vfolder(
+            model_folder, kernel_config
+        )
+
+        assert result is None
+
+    async def test_uses_model_definition_path_from_internal_data(
+        self,
+        mock_agent: Mock,
+        model_folder: VFolderMount,
+        vfolder_path: Path,
+    ) -> None:
+        (vfolder_path / "custom-name.yaml").write_text(
+            "models:\n  - name: custom\n    model_path: /m\n"
+        )
+        kernel_config: dict[str, Any] = {
+            "internal_data": {"model_definition_path": "custom-name.yaml"},
+        }
+
+        result = await mock_agent._read_model_definition_from_vfolder(model_folder, kernel_config)
+
+        assert result["models"][0]["name"] == "custom"


### PR DESCRIPTION
## Summary
- Agent was ignoring VFolder `model-definition.yaml` for non-custom runtime variants (vllm, tgi, nim, sglang, modular-max), using only hardcoded defaults
- Now reads VFolder yaml and deep-merges it on top of variant defaults using `ModelDefinition.merge()`, mirroring Manager's `_apply_vfolder_override()` in `definition_generator/registry.py`

## Jira
[BA-5665](https://lablup.atlassian.net/browse/BA-5665)

## Changes (1 file: `agent/agent.py`)
- Extract `_read_model_definition_from_vfolder()` (required, for custom) and `_try_read_model_definition_from_vfolder()` (optional, returns None if not found) from inline custom variant code
- After variant-specific base generation, call `_try_read_model_definition_from_vfolder()` and `base.merge(override)` for non-custom variants
- Custom variant uses the same extracted helper

## Approach
Agent reads VFolder yaml directly — same approach Manager already uses. Works for both legacy (`POST /services`) and sokovan (`POST /v2/deployments`) paths without Manager-side changes.

See #10951 for the alternative approach (Manager → Agent passing) which was drafted because it breaks the legacy WebUI path.

## Test plan
- [ ] Deploy custom variant service with VFolder health_check override → verify applied
- [ ] Deploy non-custom variant with VFolder health_check override → verify applied
- [ ] Deploy non-custom variant without VFolder yaml → verify defaults used
- [ ] Verify Agent log: "applied VFolder model-definition.yaml override"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5665]: https://lablup.atlassian.net/browse/BA-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ