### PR TITLE
feat(BA-5681): auto-sync user-scope entries on role assign/unassign

### DIFF
--- a/changes/10990.feature.md
+++ b/changes/10990.feature.md
@@ -1,1 +1,1 @@
-Auto-sync user-project membership entries in `association_scopes_entities` when project-scoped roles are assigned or revoked
+Auto-sync user-scope membership entries in `association_scopes_entities` when roles are assigned or revoked

--- a/changes/10990.feature.md
+++ b/changes/10990.feature.md
@@ -1,0 +1,1 @@
+Auto-sync user-project membership entries in `association_scopes_entities` when project-scoped roles are assigned or revoked

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -858,6 +858,9 @@ class GroupDBSource:
         """Add a user to a project (business association + RBAC scope binding).
 
         Skips if the user is already a member of the project.
+
+        TODO: Remove once association_groups_users is fully migrated to
+        association_scopes_entities.
         """
         async with self._db.begin_session() as session:
             already_bound = await session.scalar(
@@ -878,7 +881,11 @@ class GroupDBSource:
             await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=[pair]))
 
     async def unbind_user_from_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Remove a user from a project (business association + RBAC scope binding)."""
+        """Remove a user from a project (business association + RBAC scope binding).
+
+        TODO: Remove once association_groups_users is fully migrated to
+        association_scopes_entities.
+        """
         async with self._db.begin_session() as session:
             await session.execute(
                 sa.delete(AssocGroupUserRow).where(

--- a/src/ai/backend/manager/repositories/group/repository.py
+++ b/src/ai/backend/manager/repositories/group/repository.py
@@ -144,12 +144,19 @@ class GroupRepository:
         """Add a user to a project (business association + RBAC scope binding).
 
         Skips if the user is already a member of the project.
+
+        TODO: Remove once association_groups_users is fully migrated to
+        association_scopes_entities.
         """
         await self._db_source.bind_user_to_project(user_id, project_id)
 
     @group_repository_resilience.apply()
     async def unbind_user_from_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Remove a user from a project (business association + RBAC scope binding)."""
+        """Remove a user from a project (business association + RBAC scope binding).
+
+        TODO: Remove once association_groups_users is fully migrated to
+        association_scopes_entities.
+        """
         await self._db_source.unbind_user_from_project(user_id, project_id)
 
     @group_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -148,11 +148,12 @@ class PermissionDBSource:
         for row in rows:
             try:
                 key = uuid.UUID(row.entity_id)
-            except ValueError:
+            except (ValueError, TypeError):
                 log.warning(
-                    "Skipping scope entry with non-UUID entity_id: {}"
-                    " (entity_type: {}, expected: {})",
+                    "Skipping scope entry with non-UUID entity_id: {!r}"
+                    " (type: {}, entity_type: {}, expected: {})",
                     row.entity_id,
+                    type(row.entity_id).__name__,
                     row.entity_type,
                     EntityType.ROLE,
                 )

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -92,19 +92,6 @@ from ai.backend.manager.repositories.permission_controller.types import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
-@dataclass(frozen=True)
-class UserScopeBinding:
-    """A (user, scope) pair describing which scope a user should be synced to.
-
-    Built from a role's bound scopes during role assign/revoke to drive
-    user-scope membership entries in ``association_scopes_entities``.
-    """
-
-    user_id: uuid.UUID
-    scope_type: ScopeType
-    scope_id: str
-
-
 @dataclass
 class CreateRoleInput:
     """Input for creating a role with object permissions."""
@@ -120,129 +107,82 @@ class PermissionDBSource:
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
 
-    async def _get_role_bound_scopes(
-        self,
-        db_session: SASession,
-        role_ids: Iterable[uuid.UUID],
-    ) -> dict[uuid.UUID, list[AssociationScopesEntitiesRow]]:
-        """Fetch scope entries bound to one or more roles, grouped by role ID."""
-        str_ids = [str(rid) for rid in role_ids]
-        if not str_ids:
-            return {}
-        ase = AssociationScopesEntitiesRow
-        rows = (
-            (
-                await db_session.execute(
-                    sa.select(ase).where(
-                        ase.entity_type == EntityType.ROLE,
-                        ase.entity_id.in_(str_ids),
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        )
-        result: dict[uuid.UUID, list[AssociationScopesEntitiesRow]] = {
-            uuid.UUID(sid): [] for sid in str_ids
-        }
-        for row in rows:
-            try:
-                key = uuid.UUID(row.entity_id)
-            except (ValueError, TypeError):
-                log.warning(
-                    "Skipping scope entry with non-UUID entity_id: {!r}"
-                    " (type: {}, entity_type: {}, expected: {})",
-                    row.entity_id,
-                    type(row.entity_id).__name__,
-                    row.entity_type,
-                    EntityType.ROLE,
-                )
-                continue
-            result[key].append(row)
-        return result
-
-    @staticmethod
-    def _build_bindings(
-        user_ids: Iterable[uuid.UUID],
-        role_scopes: Sequence[AssociationScopesEntitiesRow],
-    ) -> list[UserScopeBinding]:
-        """Expand role-bound scopes x users into individual binding entries."""
-        uid_list = list(user_ids)
-        return [
-            UserScopeBinding(
-                user_id=uid,
-                scope_type=entry.scope_type,
-                scope_id=entry.scope_id,
-            )
-            for entry in role_scopes
-            for uid in uid_list
-        ]
-
     @staticmethod
     async def _sync_user_scopes_on_assign(
         db_session: SASession,
-        bindings: Sequence[UserScopeBinding],
+        user_ids: Collection[uuid.UUID],
     ) -> None:
-        """Insert user-scope membership entries (idempotent).
+        """Ensure user-scope membership entries exist for all assigned roles.
 
-        For each binding, creates an ``association_scopes_entities`` row
-        mapping the user to the scope.  Existing entries are silently skipped.
+        For each user, finds every scope bound to any of their assigned roles
+        and inserts the corresponding user-scope entries.  Executed as a single
+        ``INSERT … SELECT`` so the role lookup and insert share the same snapshot.
         """
-        if not bindings:
+        if not user_ids:
             return
-        values = [
-            {
-                "scope_type": b.scope_type,
-                "scope_id": b.scope_id,
-                "entity_type": EntityType.USER,
-                "entity_id": str(b.user_id),
-                "relation_type": RelationType.AUTO,
-            }
-            for b in bindings
-        ]
+        ase = AssociationScopesEntitiesRow
+        str_user_ids = [str(uid) for uid in user_ids]
+        uid_subq = sa.select(
+            sa.func.unnest(sa.cast(sa.literal(str_user_ids), sa.ARRAY(sa.String))).label("uid")
+        ).subquery("u")
+        source = (
+            sa.select(
+                ase.scope_type,
+                ase.scope_id,
+                sa.literal(EntityType.USER.value).label("entity_type"),
+                uid_subq.c.uid.label("entity_id"),
+                sa.literal(RelationType.AUTO.value).label("relation_type"),
+            )
+            .join(
+                UserRoleRow,
+                sa.cast(UserRoleRow.role_id, sa.String) == ase.entity_id,
+            )
+            .where(
+                ase.entity_type == EntityType.ROLE,
+                sa.cast(UserRoleRow.user_id, sa.String) == uid_subq.c.uid,
+            )
+        )
         await db_session.execute(
-            pg_insert(AssociationScopesEntitiesRow).values(values).on_conflict_do_nothing()
+            pg_insert(ase)
+            .from_select(
+                ["scope_type", "scope_id", "entity_type", "entity_id", "relation_type"],
+                source,
+            )
+            .on_conflict_do_nothing()
         )
 
     @staticmethod
     async def _sync_user_scopes_on_revoke(
         db_session: SASession,
-        bindings: Sequence[UserScopeBinding],
+        user_ids: Collection[uuid.UUID],
     ) -> None:
-        """Remove user-scope entries no longer covered by any remaining role.
+        """Remove user-scope entries no longer covered by any assigned role.
 
-        For each binding, deletes the user-scope row only when no other role
-        still binds the same user to the same scope.
+        Deletes user-scope rows for *user_ids* when no assigned role binds
+        the user to that scope.  Executed as a single ``DELETE`` statement
+        so the coverage check and deletion share the same snapshot.
         """
-        if not bindings:
+        if not user_ids:
             return
-        str_user_ids = list({str(b.user_id) for b in bindings})
-        scope_filter = sa.or_(*[
-            sa.and_(
-                AssociationScopesEntitiesRow.scope_type == b.scope_type,
-                AssociationScopesEntitiesRow.scope_id == b.scope_id,
-            )
-            for b in bindings
-        ])
-        ase_role = sa.orm.aliased(AssociationScopesEntitiesRow, flat=True)
+        ase = AssociationScopesEntitiesRow
+        str_user_ids = [str(uid) for uid in user_ids]
+        ase_remaining = sa.orm.aliased(ase, flat=True)
         await db_session.execute(
-            sa.delete(AssociationScopesEntitiesRow).where(
-                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
-                AssociationScopesEntitiesRow.entity_id.in_(str_user_ids),
-                scope_filter,
+            sa.delete(ase).where(
+                ase.entity_type == EntityType.USER,
+                ase.entity_id.in_(str_user_ids),
                 ~sa.exists(
                     sa.select(sa.literal(1))
-                    .select_from(ase_role)
+                    .select_from(ase_remaining)
                     .join(
                         UserRoleRow,
-                        sa.cast(UserRoleRow.role_id, sa.String) == ase_role.entity_id,
+                        sa.cast(UserRoleRow.role_id, sa.String) == ase_remaining.entity_id,
                     )
                     .where(
-                        ase_role.entity_type == EntityType.ROLE,
-                        ase_role.scope_type == AssociationScopesEntitiesRow.scope_type,
-                        ase_role.scope_id == AssociationScopesEntitiesRow.scope_id,
-                        sa.cast(UserRoleRow.user_id, sa.String)
-                        == AssociationScopesEntitiesRow.entity_id,
+                        ase_remaining.entity_type == EntityType.ROLE,
+                        ase_remaining.scope_type == ase.scope_type,
+                        ase_remaining.scope_id == ase.scope_id,
+                        sa.cast(UserRoleRow.user_id, sa.String) == ase.entity_id,
                     )
                 ),
             )
@@ -410,7 +350,6 @@ class PermissionDBSource:
 
     async def assign_role(self, data: UserRoleAssignmentInput) -> UserRoleRow:
         async with self._db.begin_session() as db_session:
-            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
             creator = Creator(
                 spec=UserRoleCreatorSpec(
                     user_id=data.user_id,
@@ -419,8 +358,7 @@ class PermissionDBSource:
                 )
             )
             result = await execute_creator(db_session, creator)
-            bindings = self._build_bindings([data.user_id], scopes_map.get(data.role_id, []))
-            await self._sync_user_scopes_on_assign(db_session, bindings)
+            await self._sync_user_scopes_on_assign(db_session, [data.user_id])
             return result.row
 
     async def revoke_role(self, data: UserRoleRevocationInput) -> RoleRevocationResult:
@@ -431,7 +369,6 @@ class PermissionDBSource:
         holds in each project that this role belongs to.
         """
         async with self._db.begin_session() as db_session:
-            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
             user_role_row = await db_session.scalar(
                 sa.select(UserRoleRow)
                 .where(UserRoleRow.user_id == data.user_id)
@@ -445,11 +382,13 @@ class PermissionDBSource:
             await db_session.delete(user_role_row)
             await db_session.flush()
 
-            bindings = self._build_bindings([data.user_id], scopes_map.get(data.role_id, []))
-            await self._sync_user_scopes_on_revoke(db_session, bindings)
+            await self._sync_user_scopes_on_revoke(db_session, [data.user_id])
 
-            # Single query: find projects this role belongs to and count
-            # remaining user-role mappings per project
+            # Used by PermissionControllerService.revoke_role() to decide whether
+            # to call GroupDBSource.unbind_user_from_project().
+            # TODO: remove this query when unbind_user_from_project() is retired
+            # (i.e. association_groups_users is fully migrated to
+            # association_scopes_entities).
             ase = AssociationScopesEntitiesRow
             project_subq = (
                 sa.select(ase.scope_id).where(
@@ -1191,13 +1130,8 @@ class PermissionDBSource:
     ) -> BulkCreatorResultWithFailures[UserRoleRow]:
         async with self._db.begin_session() as db_session:
             result = await execute_bulk_creator_partial(db_session, bulk_creator)
-            users_by_role: dict[uuid.UUID, list[uuid.UUID]] = {}
-            for row in result.successes:
-                users_by_role.setdefault(row.role_id, []).append(row.user_id)
-            scopes_map = await self._get_role_bound_scopes(db_session, users_by_role.keys())
-            for role_id, user_ids in users_by_role.items():
-                bindings = self._build_bindings(user_ids, scopes_map.get(role_id, []))
-                await self._sync_user_scopes_on_assign(db_session, bindings)
+            all_user_ids = [row.user_id for row in result.successes]
+            await self._sync_user_scopes_on_assign(db_session, all_user_ids)
             return result
 
     async def bulk_revoke_role(
@@ -1207,8 +1141,6 @@ class PermissionDBSource:
         failures: list[BulkRoleRevocationFailure] = []
 
         async with self._db.begin_session() as db_session:
-            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
-            role_scopes = scopes_map.get(data.role_id, [])
             for user_id in data.user_ids:
                 try:
                     async with db_session.begin_nested():
@@ -1225,8 +1157,6 @@ class PermissionDBSource:
                         user_role_id = user_role_row.id
                         await db_session.delete(user_role_row)
                         await db_session.flush()
-                        revoke_bindings = self._build_bindings([user_id], role_scopes)
-                        await self._sync_user_scopes_on_revoke(db_session, revoke_bindings)
                         successes.append(
                             UserRoleRevocationData(
                                 user_role_id=user_role_id,
@@ -1242,5 +1172,7 @@ class PermissionDBSource:
                         str(e),
                     )
                     failures.append(BulkRoleRevocationFailure(user_id=user_id, message=str(e)))
+            revoked_user_ids = [s.user_id for s in successes]
+            await self._sync_user_scopes_on_revoke(db_session, revoked_user_ids)
 
         return BulkRoleRevocationResultData(successes=successes, failures=failures)

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import contains_eager, selectinload
 
@@ -91,6 +92,19 @@ from ai.backend.manager.repositories.permission_controller.types import (
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
+@dataclass(frozen=True)
+class UserScopeBinding:
+    """A (user, scope) pair describing which scope a user should be synced to.
+
+    Built from a role's bound scopes during role assign/revoke to drive
+    user-scope membership entries in ``association_scopes_entities``.
+    """
+
+    user_id: uuid.UUID
+    scope_type: ScopeType
+    scope_id: str
+
+
 @dataclass
 class CreateRoleInput:
     """Input for creating a role with object permissions."""
@@ -105,6 +119,122 @@ class PermissionDBSource:
 
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
+
+    async def _get_role_bound_scopes(
+        self,
+        db_session: SASession,
+        role_ids: Iterable[uuid.UUID],
+    ) -> dict[uuid.UUID, list[AssociationScopesEntitiesRow]]:
+        """Fetch scope entries bound to one or more roles, grouped by role ID."""
+        str_ids = [str(rid) for rid in role_ids]
+        if not str_ids:
+            return {}
+        ase = AssociationScopesEntitiesRow
+        rows = (
+            (
+                await db_session.execute(
+                    sa.select(ase).where(
+                        ase.entity_type == EntityType.ROLE,
+                        ase.entity_id.in_(str_ids),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        result: dict[uuid.UUID, list[AssociationScopesEntitiesRow]] = {
+            uuid.UUID(sid): [] for sid in str_ids
+        }
+        for row in rows:
+            result[uuid.UUID(row.entity_id)].append(row)
+        return result
+
+    @staticmethod
+    def _build_bindings(
+        user_ids: Iterable[uuid.UUID],
+        role_scopes: Sequence[AssociationScopesEntitiesRow],
+    ) -> list[UserScopeBinding]:
+        """Expand role-bound scopes x users into individual binding entries."""
+        uid_list = list(user_ids)
+        return [
+            UserScopeBinding(
+                user_id=uid,
+                scope_type=entry.scope_type,
+                scope_id=entry.scope_id,
+            )
+            for entry in role_scopes
+            for uid in uid_list
+        ]
+
+    @staticmethod
+    async def _sync_user_scopes_on_assign(
+        db_session: SASession,
+        bindings: Sequence[UserScopeBinding],
+    ) -> None:
+        """Insert user-scope membership entries (idempotent).
+
+        For each binding, creates an ``association_scopes_entities`` row
+        mapping the user to the scope.  Existing entries are silently skipped.
+        """
+        if not bindings:
+            return
+        values = [
+            {
+                "scope_type": b.scope_type,
+                "scope_id": b.scope_id,
+                "entity_type": EntityType.USER,
+                "entity_id": str(b.user_id),
+                "relation_type": RelationType.AUTO,
+            }
+            for b in bindings
+        ]
+        await db_session.execute(
+            pg_insert(AssociationScopesEntitiesRow).values(values).on_conflict_do_nothing()
+        )
+
+    @staticmethod
+    async def _sync_user_scopes_on_revoke(
+        db_session: SASession,
+        bindings: Sequence[UserScopeBinding],
+    ) -> None:
+        """Remove user-scope entries no longer covered by any remaining role.
+
+        For each binding, deletes the user-scope row only when no other role
+        still binds the same user to the same scope.
+        """
+        if not bindings:
+            return
+        str_user_ids = list({str(b.user_id) for b in bindings})
+        scope_filter = sa.or_(*[
+            sa.and_(
+                AssociationScopesEntitiesRow.scope_type == b.scope_type,
+                AssociationScopesEntitiesRow.scope_id == b.scope_id,
+            )
+            for b in bindings
+        ])
+        ase_role = sa.orm.aliased(AssociationScopesEntitiesRow, flat=True)
+        await db_session.execute(
+            sa.delete(AssociationScopesEntitiesRow).where(
+                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.entity_id.in_(str_user_ids),
+                scope_filter,
+                ~sa.exists(
+                    sa.select(sa.literal(1))
+                    .select_from(ase_role)
+                    .join(
+                        UserRoleRow,
+                        sa.cast(UserRoleRow.role_id, sa.String) == ase_role.entity_id,
+                    )
+                    .where(
+                        ase_role.entity_type == EntityType.ROLE,
+                        ase_role.scope_type == AssociationScopesEntitiesRow.scope_type,
+                        ase_role.scope_id == AssociationScopesEntitiesRow.scope_id,
+                        sa.cast(UserRoleRow.user_id, sa.String)
+                        == AssociationScopesEntitiesRow.entity_id,
+                    )
+                ),
+            )
+        )
 
     # ------------------------------------------------------------------ role CRUD
 
@@ -268,6 +398,7 @@ class PermissionDBSource:
 
     async def assign_role(self, data: UserRoleAssignmentInput) -> UserRoleRow:
         async with self._db.begin_session() as db_session:
+            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
             creator = Creator(
                 spec=UserRoleCreatorSpec(
                     user_id=data.user_id,
@@ -276,6 +407,8 @@ class PermissionDBSource:
                 )
             )
             result = await execute_creator(db_session, creator)
+            bindings = self._build_bindings([data.user_id], scopes_map.get(data.role_id, []))
+            await self._sync_user_scopes_on_assign(db_session, bindings)
             return result.row
 
     async def revoke_role(self, data: UserRoleRevocationInput) -> RoleRevocationResult:
@@ -286,6 +419,7 @@ class PermissionDBSource:
         holds in each project that this role belongs to.
         """
         async with self._db.begin_session() as db_session:
+            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
             user_role_row = await db_session.scalar(
                 sa.select(UserRoleRow)
                 .where(UserRoleRow.user_id == data.user_id)
@@ -298,6 +432,9 @@ class PermissionDBSource:
             user_role_id = user_role_row.id
             await db_session.delete(user_role_row)
             await db_session.flush()
+
+            bindings = self._build_bindings([data.user_id], scopes_map.get(data.role_id, []))
+            await self._sync_user_scopes_on_revoke(db_session, bindings)
 
             # Single query: find projects this role belongs to and count
             # remaining user-role mappings per project
@@ -1041,7 +1178,15 @@ class PermissionDBSource:
         self, bulk_creator: BulkCreator[UserRoleRow]
     ) -> BulkCreatorResultWithFailures[UserRoleRow]:
         async with self._db.begin_session() as db_session:
-            return await execute_bulk_creator_partial(db_session, bulk_creator)
+            result = await execute_bulk_creator_partial(db_session, bulk_creator)
+            users_by_role: dict[uuid.UUID, list[uuid.UUID]] = {}
+            for row in result.successes:
+                users_by_role.setdefault(row.role_id, []).append(row.user_id)
+            scopes_map = await self._get_role_bound_scopes(db_session, users_by_role.keys())
+            for role_id, user_ids in users_by_role.items():
+                bindings = self._build_bindings(user_ids, scopes_map.get(role_id, []))
+                await self._sync_user_scopes_on_assign(db_session, bindings)
+            return result
 
     async def bulk_revoke_role(
         self, data: BulkUserRoleRevocationInput
@@ -1050,6 +1195,8 @@ class PermissionDBSource:
         failures: list[BulkRoleRevocationFailure] = []
 
         async with self._db.begin_session() as db_session:
+            scopes_map = await self._get_role_bound_scopes(db_session, [data.role_id])
+            role_scopes = scopes_map.get(data.role_id, [])
             for user_id in data.user_ids:
                 try:
                     async with db_session.begin_nested():
@@ -1066,6 +1213,8 @@ class PermissionDBSource:
                         user_role_id = user_role_row.id
                         await db_session.delete(user_role_row)
                         await db_session.flush()
+                        revoke_bindings = self._build_bindings([user_id], role_scopes)
+                        await self._sync_user_scopes_on_revoke(db_session, revoke_bindings)
                         successes.append(
                             UserRoleRevocationData(
                                 user_role_id=user_role_id,

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -121,16 +121,12 @@ class PermissionDBSource:
         if not user_ids:
             return
         ase = AssociationScopesEntitiesRow
-        str_user_ids = [str(uid) for uid in user_ids]
-        uid_subq = sa.select(
-            sa.func.unnest(sa.cast(sa.literal(str_user_ids), sa.ARRAY(sa.String))).label("uid")
-        ).subquery("u")
         source = (
             sa.select(
                 ase.scope_type,
                 ase.scope_id,
                 sa.literal(EntityType.USER.value).label("entity_type"),
-                uid_subq.c.uid.label("entity_id"),
+                sa.cast(UserRoleRow.user_id, sa.String).label("entity_id"),
                 sa.literal(RelationType.AUTO.value).label("relation_type"),
             )
             .join(
@@ -139,7 +135,7 @@ class PermissionDBSource:
             )
             .where(
                 ase.entity_type == EntityType.ROLE,
-                sa.cast(UserRoleRow.user_id, sa.String) == uid_subq.c.uid,
+                UserRoleRow.user_id.in_(user_ids),
             )
         )
         await db_session.execute(

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -146,7 +146,18 @@ class PermissionDBSource:
             uuid.UUID(sid): [] for sid in str_ids
         }
         for row in rows:
-            result[uuid.UUID(row.entity_id)].append(row)
+            try:
+                key = uuid.UUID(row.entity_id)
+            except ValueError:
+                log.warning(
+                    "Skipping scope entry with non-UUID entity_id: {}"
+                    " (entity_type: {}, expected: {})",
+                    row.entity_id,
+                    row.entity_type,
+                    EntityType.ROLE,
+                )
+                continue
+            result[key].append(row)
         return result
 
     @staticmethod

--- a/tests/unit/manager/repositories/permission_controller/test_user_scope_sync.py
+++ b/tests/unit/manager/repositories/permission_controller/test_user_scope_sync.py
@@ -1,0 +1,498 @@
+"""Tests for user-scope auto-sync on role assign/unassign."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.data.permission.role import (
+    UserRoleAssignmentInput,
+    UserRoleRevocationInput,
+)
+from ai.backend.manager.data.permission.types import EntityType, ScopeType
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
+    PermissionDBSource,
+)
+from ai.backend.testutils.db import with_tables
+
+
+class TestUserScopeSync:
+    """Tests for auto-sync of user-scope entries on role assign/unassign."""
+
+    @pytest.fixture
+    def test_password_info(self) -> PasswordInfo:
+        return PasswordInfo(
+            password="test_password",
+            algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+            rounds=100_000,
+            salt_size=32,
+        )
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                AssocGroupUserRow,
+                AssociationScopesEntitiesRow,
+                ImageRow,
+                VFolderRow,
+                EndpointRow,
+                SessionRow,
+                AgentRow,
+                KernelRow,
+                RoutingRow,
+                ResourcePresetRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def test_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                DomainRow(
+                    name=domain_name,
+                    description="Test domain",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    allowed_docker_registries=[],
+                    dotfiles=b"",
+                    integration_id=None,
+                )
+            )
+            await session.commit()
+        return domain_name
+
+    @pytest.fixture
+    async def user_resource_policy(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+        policy_name = f"test-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                UserResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            await session.commit()
+        return policy_name
+
+    @pytest.fixture
+    async def test_project(
+        self, db_with_cleanup: ExtendedAsyncSAEngine, test_domain: str
+    ) -> uuid.UUID:
+        project_id = uuid.uuid4()
+        policy_name = f"test-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=3,
+                )
+            )
+            session.add(
+                GroupRow(
+                    id=project_id,
+                    name=f"test-project-{project_id.hex[:8]}",
+                    description="Test project",
+                    is_active=True,
+                    domain_name=test_domain,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    integration_id=None,
+                    resource_policy=policy_name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await session.commit()
+        return project_id
+
+    @pytest.fixture
+    async def second_project(
+        self, db_with_cleanup: ExtendedAsyncSAEngine, test_domain: str
+    ) -> uuid.UUID:
+        project_id = uuid.uuid4()
+        policy_name = f"test-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=3,
+                )
+            )
+            session.add(
+                GroupRow(
+                    id=project_id,
+                    name=f"test-project-{project_id.hex[:8]}",
+                    description="Second project",
+                    is_active=True,
+                    domain_name=test_domain,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    integration_id=None,
+                    resource_policy=policy_name,
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await session.commit()
+        return project_id
+
+    async def _create_user(
+        self,
+        db: ExtendedAsyncSAEngine,
+        domain_name: str,
+        policy_name: str,
+        password_info: PasswordInfo,
+    ) -> uuid.UUID:
+        user_uuid = uuid.uuid4()
+        async with db.begin_session() as session:
+            session.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"user-{user_uuid.hex[:8]}",
+                    email=f"user-{user_uuid.hex[:8]}@example.com",
+                    password=password_info,
+                    need_password_change=False,
+                    full_name="Test User",
+                    description="",
+                    status=UserStatus.ACTIVE,
+                    status_info="",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=policy_name,
+                )
+            )
+            await session.commit()
+        return user_uuid
+
+    @pytest.fixture
+    async def user_1(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: str,
+        user_resource_policy: str,
+        test_password_info: PasswordInfo,
+    ) -> uuid.UUID:
+        return await self._create_user(
+            db_with_cleanup, test_domain, user_resource_policy, test_password_info
+        )
+
+    @pytest.fixture
+    async def project_scoped_role(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_project: uuid.UUID,
+    ) -> uuid.UUID:
+        role_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as session:
+            session.add(RoleRow(id=role_id, name=f"project-role-{role_id.hex[:8]}"))
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(test_project),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+            await session.commit()
+        return role_id
+
+    @pytest.fixture
+    async def second_project_scoped_role(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_project: uuid.UUID,
+    ) -> uuid.UUID:
+        role_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as session:
+            session.add(RoleRow(id=role_id, name=f"project-role2-{role_id.hex[:8]}"))
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(test_project),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+            await session.commit()
+        return role_id
+
+    @pytest.fixture
+    async def multi_scope_role(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_project: uuid.UUID,
+        second_project: uuid.UUID,
+    ) -> uuid.UUID:
+        """A role bound to two different project scopes."""
+        role_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as session:
+            session.add(RoleRow(id=role_id, name=f"multi-role-{role_id.hex[:8]}"))
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(test_project),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(second_project),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+            await session.commit()
+        return role_id
+
+    @pytest.fixture
+    async def role_without_scope(self, db_with_cleanup: ExtendedAsyncSAEngine) -> uuid.UUID:
+        """A role with no scope binding."""
+        role_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as session:
+            session.add(RoleRow(id=role_id, name=f"no-scope-role-{role_id.hex[:8]}"))
+            await session.commit()
+        return role_id
+
+    @pytest.fixture
+    def perm_db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> PermissionDBSource:
+        return PermissionDBSource(db=db_with_cleanup)
+
+    async def _get_user_scope_entries(
+        self,
+        db: ExtendedAsyncSAEngine,
+        user_id: uuid.UUID,
+    ) -> list[tuple[ScopeType, str]]:
+        async with db.begin_readonly_session() as session:
+            rows = (
+                await session.execute(
+                    sa.select(
+                        AssociationScopesEntitiesRow.scope_type,
+                        AssociationScopesEntitiesRow.scope_id,
+                    ).where(
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id == str(user_id),
+                    )
+                )
+            ).all()
+        return [(r[0], r[1]) for r in rows]
+
+    # --- assign sync ---
+
+    async def test_assign_creates_user_scope_entry(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        project_scoped_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+    ) -> None:
+        """Assigning a project-scoped role creates a user-project scope entry."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=project_scoped_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert (ScopeType.PROJECT, str(test_project)) in entries
+
+    async def test_assign_multi_scope_role_creates_all_entries(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        multi_scope_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+        second_project: uuid.UUID,
+    ) -> None:
+        """Assigning a role bound to multiple scopes creates entries for all scopes."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=multi_scope_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert (ScopeType.PROJECT, str(test_project)) in entries
+        assert (ScopeType.PROJECT, str(second_project)) in entries
+
+    async def test_assign_role_without_scope_creates_no_entry(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        role_without_scope: uuid.UUID,
+        user_1: uuid.UUID,
+    ) -> None:
+        """Assigning a role with no scope binding creates no user-scope entries."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=role_without_scope)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert entries == []
+
+    async def test_assign_duplicate_scope_is_idempotent(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        project_scoped_role: uuid.UUID,
+        second_project_scoped_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+    ) -> None:
+        """Assigning two roles to the same scope does not create duplicate user-scope entries."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=project_scoped_role)
+        )
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=second_project_scoped_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        project_entries = [e for e in entries if e == (ScopeType.PROJECT, str(test_project))]
+        assert len(project_entries) == 1
+
+    # --- revoke sync ---
+
+    async def test_revoke_only_role_removes_user_scope_entry(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        project_scoped_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+    ) -> None:
+        """Revoking the only role for a scope removes the user-scope entry."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=project_scoped_role)
+        )
+        await perm_db_source.revoke_role(
+            UserRoleRevocationInput(user_id=user_1, role_id=project_scoped_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert (ScopeType.PROJECT, str(test_project)) not in entries
+
+    async def test_revoke_one_of_two_roles_keeps_user_scope_entry(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        project_scoped_role: uuid.UUID,
+        second_project_scoped_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+    ) -> None:
+        """Revoking one role when another covers the same scope keeps the entry."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=project_scoped_role)
+        )
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=second_project_scoped_role)
+        )
+        await perm_db_source.revoke_role(
+            UserRoleRevocationInput(user_id=user_1, role_id=project_scoped_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert (ScopeType.PROJECT, str(test_project)) in entries
+
+    async def test_revoke_multi_scope_role_removes_uncovered_scopes_only(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        project_scoped_role: uuid.UUID,
+        multi_scope_role: uuid.UUID,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+        second_project: uuid.UUID,
+    ) -> None:
+        """Revoking a multi-scope role removes only scopes not covered by other roles.
+
+        Setup: project_scoped_role covers test_project,
+               multi_scope_role covers test_project + second_project.
+        After revoking multi_scope_role, test_project should remain (covered by
+        project_scoped_role), but second_project should be removed.
+        """
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=project_scoped_role)
+        )
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=multi_scope_role)
+        )
+        await perm_db_source.revoke_role(
+            UserRoleRevocationInput(user_id=user_1, role_id=multi_scope_role)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert (ScopeType.PROJECT, str(test_project)) in entries
+        assert (ScopeType.PROJECT, str(second_project)) not in entries
+
+    async def test_revoke_role_without_scope_does_nothing(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+        role_without_scope: uuid.UUID,
+        user_1: uuid.UUID,
+    ) -> None:
+        """Revoking a role with no scope binding does not affect user-scope entries."""
+        await perm_db_source.assign_role(
+            UserRoleAssignmentInput(user_id=user_1, role_id=role_without_scope)
+        )
+        await perm_db_source.revoke_role(
+            UserRoleRevocationInput(user_id=user_1, role_id=role_without_scope)
+        )
+
+        entries = await self._get_user_scope_entries(db_with_cleanup, user_1)
+        assert entries == []


### PR DESCRIPTION
## Summary
- Auto-sync user-scope membership entries in `association_scopes_entities` when roles are assigned or revoked
- On assign: INSERT user-scope entries for all scopes bound to the role (`ON CONFLICT DO NOTHING`)
- On revoke: DELETE user-scope entries only when no other role covers the same scope (correlated `NOT EXISTS` check)
- Scope-type-agnostic — works for project, domain, and any future scope types
- Integrated into `assign_role()`, `revoke_role()`, `bulk_assign_role()`, and `bulk_revoke_role()`

## Test plan
- [x] Unit tests: assign creates user-scope entries (single scope, multi-scope, no-scope, idempotent)
- [x] Unit tests: revoke removes entries (only role, overlapping roles, multi-scope partial, no-scope)
- [x] Existing role assignment tests still pass

Resolves BA-5681