### PR TITLE
fix(BA-5686): return HTTP 409 for TooManyConcurrentLoginSessions

### DIFF
--- a/changes/10992.fix.md
+++ b/changes/10992.fix.md
@@ -1,0 +1,1 @@
+Return HTTP 409 (Conflict) instead of 429 (Too Many Requests) for `TooManyConcurrentLoginSessions` error

--- a/src/ai/backend/manager/errors/auth.py
+++ b/src/ai/backend/manager/errors/auth.py
@@ -194,7 +194,7 @@ class LoginClientTypeConflict(BackendAIError, web.HTTPConflict):
         )
 
 
-class TooManyConcurrentLoginSessions(BackendAIError, web.HTTPTooManyRequests):
+class TooManyConcurrentLoginSessions(BackendAIError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/too-many-concurrent-logins"
     error_title = "Too many concurrent login sessions for this user."
 


### PR DESCRIPTION
## Summary
- `TooManyConcurrentLoginSessions` was returning HTTP 429 (Too Many Requests) instead of 409 (Conflict)
- Changed parent class from `web.HTTPTooManyRequests` to `web.HTTPConflict` since this error represents a resource state conflict, not rate-limiting

## Test plan
- [ ] Verify that exceeding concurrent login session limit returns HTTP 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves BA-5686