### PR TITLE
feat: add PROMETHEUS auto-scaling metric source

### DIFF
--- a/changes/10993.feature.md
+++ b/changes/10993.feature.md
@@ -1,0 +1,1 @@
+Add PROMETHEUS auto-scaling metric source that queries Prometheus directly via query presets, with bidirectional scaling support (scale-out/in thresholds in a single rule).

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -2101,6 +2101,7 @@ type EndpointAutoScalingRuleNode implements Node @key(fields: "id") {
 enum AutoScalingMetricSource {
   KERNEL
   INFERENCE_FRAMEWORK
+  PROMETHEUS
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1623,6 +1623,7 @@ enum AutoScalingMetricSource
 {
   KERNEL @join__enumValue(graph: GRAPHENE) @join__enumValue(graph: STRAWBERRY)
   INFERENCE_FRAMEWORK @join__enumValue(graph: GRAPHENE) @join__enumValue(graph: STRAWBERRY)
+  PROMETHEUS @join__enumValue(graph: GRAPHENE) @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 25.19.0. An auto-scaling rule for a model deployment."""
@@ -1656,6 +1657,11 @@ type AutoScalingRule implements Node
 
   """The maximum number of replicas (e.g. 10)."""
   maxReplicas: Int
+
+  """
+  Added in 26.4.1. The Prometheus query preset ID for PROMETHEUS metric source.
+  """
+  prometheusQueryPresetId: ID
   createdAt: DateTime!
   lastTriggeredAt: DateTime!
 }
@@ -2838,6 +2844,7 @@ input CreateAutoScalingRuleInput
   timeWindow: Int!
   minReplicas: Int
   maxReplicas: Int
+  prometheusQueryPresetId: ID = null
 }
 
 """Added in 25.19.0. Payload for creating an auto-scaling rule."""
@@ -16467,6 +16474,7 @@ input UpdateAutoScalingRuleInput
   timeWindow: Int
   minReplicas: Int
   maxReplicas: Int
+  prometheusQueryPresetId: ID
 }
 
 """Added in 25.19.0. Payload for updating an auto-scaling rule."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1102,6 +1102,7 @@ type AuditLogV2Edge {
 enum AutoScalingMetricSource {
   KERNEL
   INFERENCE_FRAMEWORK
+  PROMETHEUS
 }
 
 """Added in 25.19.0. An auto-scaling rule for a model deployment."""
@@ -1132,6 +1133,11 @@ type AutoScalingRule implements Node {
 
   """The maximum number of replicas (e.g. 10)."""
   maxReplicas: Int
+
+  """
+  Added in 26.4.1. The Prometheus query preset ID for PROMETHEUS metric source.
+  """
+  prometheusQueryPresetId: ID
   createdAt: DateTime!
   lastTriggeredAt: DateTime!
 }
@@ -1746,6 +1752,7 @@ input CreateAutoScalingRuleInput {
   timeWindow: Int!
   minReplicas: Int
   maxReplicas: Int
+  prometheusQueryPresetId: ID = null
 }
 
 """Added in 25.19.0. Payload for creating an auto-scaling rule."""
@@ -10929,6 +10936,7 @@ input UpdateAutoScalingRuleInput {
   timeWindow: Int
   minReplicas: Int
   maxReplicas: Int
+  prometheusQueryPresetId: ID
 }
 
 """Added in 25.19.0. Payload for updating an auto-scaling rule."""

--- a/src/ai/backend/common/dto/manager/auto_scaling_rule/request.py
+++ b/src/ai/backend/common/dto/manager/auto_scaling_rule/request.py
@@ -42,6 +42,10 @@ class CreateAutoScalingRuleRequest(BaseRequestModel):
     time_window: int = Field(description="Time window in seconds for scaling evaluation")
     min_replicas: int | None = Field(default=None, description="Minimum number of replicas")
     max_replicas: int | None = Field(default=None, description="Maximum number of replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None,
+        description="ID of Prometheus query preset (required when metric_source is PROMETHEUS)",
+    )
 
 
 class UpdateAutoScalingRuleRequest(BaseRequestModel):
@@ -57,6 +61,9 @@ class UpdateAutoScalingRuleRequest(BaseRequestModel):
     time_window: int | None = Field(default=None, description="Updated time window in seconds")
     min_replicas: int | None = Field(default=None, description="Updated minimum replicas")
     max_replicas: int | None = Field(default=None, description="Updated maximum replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None, description="Updated Prometheus query preset ID"
+    )
 
 
 class AutoScalingRuleFilter(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
+++ b/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
@@ -39,6 +39,9 @@ class AutoScalingRuleDTO(BaseModel):
     time_window: int = Field(description="Time window in seconds")
     min_replicas: int | None = Field(default=None, description="Minimum replicas")
     max_replicas: int | None = Field(default=None, description="Maximum replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None, description="Prometheus query preset ID"
+    )
     created_at: datetime = Field(description="Creation timestamp")
     last_triggered_at: datetime = Field(description="Last triggered timestamp")
 

--- a/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/request.py
+++ b/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/request.py
@@ -37,6 +37,10 @@ class CreateAutoScalingRuleInput(BaseRequestModel):
     time_window: int = Field(ge=1, description="Time window in seconds for scaling evaluation")
     min_replicas: int | None = Field(default=None, ge=0, description="Minimum number of replicas")
     max_replicas: int | None = Field(default=None, ge=1, description="Maximum number of replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None,
+        description="ID of Prometheus query preset (required when metric_source is PROMETHEUS)",
+    )
 
 
 class UpdateAutoScalingRuleInput(BaseRequestModel):
@@ -74,6 +78,10 @@ class UpdateAutoScalingRuleInput(BaseRequestModel):
     max_replicas: int | Sentinel | None = Field(
         default=SENTINEL,
         description="Updated maximum replicas. SENTINEL = no change, None = clear.",
+    )
+    prometheus_query_preset_id: UUID | Sentinel | None = Field(
+        default=SENTINEL,
+        description="Updated Prometheus query preset ID. SENTINEL = no change, None = clear.",
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/response.py
+++ b/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/response.py
@@ -38,6 +38,9 @@ class AutoScalingRuleNode(BaseResponseModel):
     time_window: int = Field(description="Time window in seconds for scaling evaluation")
     min_replicas: int | None = Field(default=None, description="Minimum number of replicas")
     max_replicas: int | None = Field(default=None, description="Maximum number of replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None, description="Prometheus query preset ID"
+    )
     created_at: datetime = Field(description="Creation timestamp")
     last_triggered_at: datetime = Field(description="Last triggered timestamp")
 

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -207,6 +207,9 @@ class AutoScalingRuleNode(BaseResponseModel):
     time_window: int = Field(description="Time window in seconds")
     min_replicas: int | None = Field(default=None, description="Minimum replicas")
     max_replicas: int | None = Field(default=None, description="Maximum replicas")
+    prometheus_query_preset_id: UUID | None = Field(
+        default=None, description="Prometheus query preset ID"
+    )
     created_at: datetime = Field(description="Creation timestamp")
     last_triggered_at: datetime = Field(description="Last triggered timestamp")
 

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -2058,6 +2058,7 @@ class PromMetricGroup[MetricType: PromMetric](metaclass=ABCMeta):
 class AutoScalingMetricSource(CIStrEnum):
     KERNEL = enum.auto()
     INFERENCE_FRAMEWORK = enum.auto()
+    PROMETHEUS = enum.auto()
 
 
 class AutoScalingMetricComparator(CIStrEnum):

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -801,6 +801,7 @@ class DeploymentAdapter(BaseAdapter):
             time_window=input.time_window,
             min_replicas=input.min_replicas,
             max_replicas=input.max_replicas,
+            prometheus_query_preset_id=input.prometheus_query_preset_id,
         )
         action_result = (
             await self._processors.deployment.create_auto_scaling_rule.wait_for_complete(
@@ -883,6 +884,12 @@ class DeploymentAdapter(BaseAdapter):
             max_replicas=(
                 OptionalState.update(input.max_replicas)
                 if not isinstance(input.max_replicas, Sentinel) and input.max_replicas is not None
+                else OptionalState.nop()
+            ),
+            prometheus_query_preset_id=(
+                OptionalState.update(input.prometheus_query_preset_id)
+                if not isinstance(input.prometheus_query_preset_id, Sentinel)
+                and input.prometheus_query_preset_id is not None
                 else OptionalState.nop()
             ),
         )
@@ -1846,6 +1853,7 @@ class DeploymentAdapter(BaseAdapter):
             time_window=data.time_window,
             min_replicas=data.min_replicas,
             max_replicas=data.max_replicas,
+            prometheus_query_preset_id=data.prometheus_query_preset_id,
             created_at=data.created_at,
             last_triggered_at=data.last_triggered_at,
         )

--- a/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
@@ -39,10 +39,12 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     UpdateAutoScalingRulePayload as UpdateAutoScalingRulePayloadDTO,
 )
+from ai.backend.common.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -63,6 +65,7 @@ from ai.backend.manager.data.deployment.types import (
 class AutoScalingMetricSource(StrEnum):
     KERNEL = "KERNEL"
     INFERENCE_FRAMEWORK = "INFERENCE_FRAMEWORK"
+    PROMETHEUS = "PROMETHEUS"
 
 
 @gql_pydantic_input(
@@ -114,6 +117,13 @@ class AutoScalingRule(PydanticNodeMixin[AutoScalingRuleNodeDTO]):
     min_replicas: int | None = gql_field(description="The minimum number of replicas (e.g. 1).")
     max_replicas: int | None = gql_field(description="The maximum number of replicas (e.g. 10).")
 
+    prometheus_query_preset_id: ID | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The Prometheus query preset ID for PROMETHEUS metric source.",
+        ),
+    )
+
     created_at: datetime
     last_triggered_at: datetime
 
@@ -161,6 +171,7 @@ class CreateAutoScalingRuleInput(PydanticInputMixin[CreateAutoScalingRuleInputDT
     time_window: int
     min_replicas: int | None
     max_replicas: int | None
+    prometheus_query_preset_id: ID | None = None
 
 
 @gql_pydantic_input(
@@ -180,6 +191,7 @@ class UpdateAutoScalingRuleInput(PydanticInputMixin[UpdateAutoScalingRuleInputDT
     time_window: int | None = UNSET
     min_replicas: int | None = UNSET
     max_replicas: int | None = UNSET
+    prometheus_query_preset_id: ID | None = UNSET
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
+++ b/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
@@ -7,6 +7,7 @@ Also provides data-to-DTO conversion functions.
 from __future__ import annotations
 
 from decimal import Decimal
+from uuid import UUID
 
 from ai.backend.common.dto.manager.auto_scaling_rule import (
     AutoScalingRuleDTO,
@@ -50,6 +51,7 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
             time_window=data.time_window,
             min_replicas=data.min_replicas,
             max_replicas=data.max_replicas,
+            prometheus_query_preset_id=data.prometheus_query_preset_id,
             created_at=data.created_at,
             last_triggered_at=data.last_triggered_at,
         )
@@ -66,6 +68,7 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
         time_window = OptionalState[int].nop()
         min_replicas = OptionalState[int].nop()
         max_replicas = OptionalState[int].nop()
+        prometheus_query_preset_id = OptionalState[UUID].nop()
 
         if request.metric_source is not None:
             metric_source = OptionalState.update(request.metric_source)
@@ -83,6 +86,8 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
             min_replicas = OptionalState.update(request.min_replicas)
         if request.max_replicas is not None:
             max_replicas = OptionalState.update(request.max_replicas)
+        if request.prometheus_query_preset_id is not None:
+            prometheus_query_preset_id = OptionalState.update(request.prometheus_query_preset_id)
 
         return ModelDeploymentAutoScalingRuleModifier(
             metric_source=metric_source,
@@ -93,6 +98,7 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
             time_window=time_window,
             min_replicas=min_replicas,
             max_replicas=max_replicas,
+            prometheus_query_preset_id=prometheus_query_preset_id,
         )
 
     def build_querier(self, request: SearchAutoScalingRulesRequest) -> BatchQuerier:

--- a/src/ai/backend/manager/api/rest/auto_scaling_rule/handler.py
+++ b/src/ai/backend/manager/api/rest/auto_scaling_rule/handler.py
@@ -79,6 +79,7 @@ class AutoScalingRuleHandler:
             time_window=body.parsed.time_window,
             min_replicas=body.parsed.min_replicas,
             max_replicas=body.parsed.max_replicas,
+            prometheus_query_preset_id=body.parsed.prometheus_query_preset_id,
         )
 
         action_result = await self._deployment.create_auto_scaling_rule.wait_for_complete(

--- a/src/ai/backend/manager/data/deployment/scale.py
+++ b/src/ai/backend/manager/data/deployment/scale.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from ai.backend.common.types import AutoScalingMetricComparator, AutoScalingMetricSource
+from ai.backend.common.types import AutoScalingMetricSource
 
 
 # Dataclasses for auto scaling rules used in Model Service (legacy)
@@ -11,8 +11,9 @@ from ai.backend.common.types import AutoScalingMetricComparator, AutoScalingMetr
 class AutoScalingCondition:
     metric_source: AutoScalingMetricSource
     metric_name: str
-    threshold: str
-    comparator: AutoScalingMetricComparator
+    scale_up_threshold: Decimal | None
+    scale_down_threshold: Decimal | None
+    prometheus_query_preset_id: UUID | None = None
 
 
 @dataclass
@@ -50,6 +51,7 @@ class ModelDeploymentAutoScalingRuleCreator:
     time_window: int
     min_replicas: int | None
     max_replicas: int | None
+    prometheus_query_preset_id: UUID | None = None
 
 
 @dataclass
@@ -64,3 +66,4 @@ class ModelDeploymentAutoScalingRule:
     time_window: int
     min_replicas: int | None
     max_replicas: int | None
+    prometheus_query_preset_id: UUID | None = None

--- a/src/ai/backend/manager/data/deployment/scale_modifier.py
+++ b/src/ai/backend/manager/data/deployment/scale_modifier.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, override
+from uuid import UUID
 
 from ai.backend.common.types import AutoScalingMetricComparator, AutoScalingMetricSource
 from ai.backend.manager.types import OptionalState, PartialModifier, TriState
@@ -71,6 +72,7 @@ class ModelDeploymentAutoScalingRuleModifier(PartialModifier):
     time_window: OptionalState[int] = field(default_factory=OptionalState[int].nop)
     min_replicas: OptionalState[int] = field(default_factory=OptionalState[int].nop)
     max_replicas: OptionalState[int] = field(default_factory=OptionalState[int].nop)
+    prometheus_query_preset_id: OptionalState[UUID] = field(default_factory=OptionalState[UUID].nop)
 
     @override
     def fields_to_update(self) -> dict[str, Any]:
@@ -83,4 +85,5 @@ class ModelDeploymentAutoScalingRuleModifier(PartialModifier):
         self.time_window.update_dict(to_update, "time_window")
         self.min_replicas.update_dict(to_update, "min_replicas")
         self.max_replicas.update_dict(to_update, "max_replicas")
+        self.prometheus_query_preset_id.update_dict(to_update, "prometheus_query_preset_id")
         return to_update

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -607,6 +607,7 @@ class ModelDeploymentAutoScalingRuleData:
     max_replicas: int | None
     created_at: datetime
     last_triggered_at: datetime
+    prometheus_query_preset_id: UUID | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/dependencies/composer.py
+++ b/src/ai/backend/manager/dependencies/composer.py
@@ -266,6 +266,8 @@ class ManagerDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
                 deployment_controller=agents.deployment_controller,
                 route_controller=agents.route_controller,
                 service_discovery=system.service_discovery,
+                prometheus_client=system.prometheus_client,
+                prometheus_query_preset_repository=domain.repositories.prometheus_query_preset.repository,
             ),
         )
 

--- a/src/ai/backend/manager/dependencies/orchestration/composer.py
+++ b/src/ai/backend/manager/dependencies/orchestration/composer.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
+from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
@@ -18,6 +19,9 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.fair_share import FairShareRepository
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
+)
 from ai.backend.manager.repositories.resource_usage_history import (
     ResourceUsageHistoryRepository,
 )
@@ -61,6 +65,9 @@ class OrchestrationInput:
     deployment_controller: DeploymentController
     route_controller: RouteController
     service_discovery: ServiceDiscovery
+    # Prometheus
+    prometheus_client: PrometheusClient
+    prometheus_query_preset_repository: PrometheusQueryPresetRepository
 
 
 @dataclass
@@ -134,6 +141,8 @@ class OrchestrationComposer(DependencyComposer[OrchestrationInput, Orchestration
             route_controller=setup_input.route_controller,
             distributed_lock_factory=setup_input.distributed_lock_factory,
             service_discovery=setup_input.service_discovery,
+            prometheus_client=setup_input.prometheus_client,
+            prometheus_query_preset_repository=setup_input.prometheus_query_preset_repository,
         )
         sokovan_orchestrator = await stack.enter_dependency(
             sokovan_dep,

--- a/src/ai/backend/manager/dependencies/orchestration/sokovan.py
+++ b/src/ai/backend/manager/dependencies/orchestration/sokovan.py
@@ -9,6 +9,7 @@ from ai.backend.common.clients.http_client.client_pool import (
     ClientPool,
     tcp_client_session_factory,
 )
+from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
@@ -20,6 +21,9 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.fair_share import FairShareRepository
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
+)
 from ai.backend.manager.repositories.resource_usage_history import (
     ResourceUsageHistoryRepository,
 )
@@ -68,6 +72,9 @@ class SokovanOrchestratorInput:
     distributed_lock_factory: DistributedLockFactory
     # Service discovery
     service_discovery: ServiceDiscovery
+    # Prometheus
+    prometheus_client: PrometheusClient
+    prometheus_query_preset_repository: PrometheusQueryPresetRepository
 
 
 class SokovanOrchestratorDependency(
@@ -123,6 +130,8 @@ class SokovanOrchestratorDependency(
             client_pool=client_pool,
             valkey_stat=setup_input.valkey_stat,
             route_controller=setup_input.route_controller,
+            prometheus_client=setup_input.prometheus_client,
+            prometheus_query_preset_repository=setup_input.prometheus_query_preset_repository,
         )
 
         # Create route coordinator

--- a/src/ai/backend/manager/models/alembic/versions/ecc4b93d7907_add_prometheus_preset_to_auto_scaling.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc4b93d7907_add_prometheus_preset_to_auto_scaling.py
@@ -1,0 +1,34 @@
+"""add prometheus_query_preset_id to endpoint_auto_scaling_rules
+
+Revision ID: ecc4b93d7907
+Revises: 4b0128c49210
+Create Date: 2026-04-10
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "ecc4b93d7907"
+down_revision = "4b0128c49210"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "endpoint_auto_scaling_rules",
+        sa.Column(
+            "prometheus_query_preset_id",
+            GUID(),
+            sa.ForeignKey("prometheus_query_presets.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("endpoint_auto_scaling_rules", "prometheus_query_preset_id")

--- a/src/ai/backend/manager/models/alembic/versions/ecc4b93d7907_add_prometheus_preset_to_auto_scaling.py
+++ b/src/ai/backend/manager/models/alembic/versions/ecc4b93d7907_add_prometheus_preset_to_auto_scaling.py
@@ -1,7 +1,7 @@
 """add prometheus_query_preset_id to endpoint_auto_scaling_rules
 
 Revision ID: ecc4b93d7907
-Revises: 4b0128c49210
+Revises: be1ac9308056
 Create Date: 2026-04-10
 
 """
@@ -13,7 +13,7 @@ from ai.backend.manager.models.base import GUID
 
 # revision identifiers, used by Alembic.
 revision = "ecc4b93d7907"
-down_revision = "4b0128c49210"
+down_revision = "be1ac9308056"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -939,6 +939,13 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
     min_replicas: Mapped[int | None] = mapped_column("min_replicas", sa.Integer(), nullable=True)
     max_replicas: Mapped[int | None] = mapped_column("max_replicas", sa.Integer(), nullable=True)
 
+    prometheus_query_preset_id: Mapped[UUID | None] = mapped_column(
+        "prometheus_query_preset_id",
+        GUID,
+        sa.ForeignKey("prometheus_query_presets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     created_at: Mapped[datetime | None] = mapped_column(
         "created_at",
         sa.DateTime(timezone=True),
@@ -1026,45 +1033,29 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
 
     @classmethod
     def from_creator(cls, endpoint_id: UUID, creator: AutoScalingRuleCreator) -> Self:
-        min_threshold: Decimal | None = None
-        max_threshold: Decimal | None = None
-        if creator.condition.comparator in (
-            AutoScalingMetricComparator.GREATER_THAN,
-            AutoScalingMetricComparator.GREATER_THAN_OR_EQUAL,
-        ):
-            max_threshold = Decimal(creator.condition.threshold)
-        else:
-            min_threshold = Decimal(creator.condition.threshold)
         return cls(
             id=uuid4(),
             endpoint=endpoint_id,
             metric_source=creator.condition.metric_source,
             metric_name=creator.condition.metric_name,
-            min_threshold=min_threshold,
-            max_threshold=max_threshold,
+            min_threshold=creator.condition.scale_down_threshold,
+            max_threshold=creator.condition.scale_up_threshold,
             step_size=creator.action.step_size,
             cooldown_seconds=creator.action.cooldown_seconds,
             min_replicas=creator.action.min_replicas,
             max_replicas=creator.action.max_replicas,
+            prometheus_query_preset_id=creator.condition.prometheus_query_preset_id,
         )
 
     def to_autoscaling_rule(self) -> AutoScalingRule:
-        if self.max_threshold is not None:
-            threshold_str = str(self.max_threshold)
-            comparator = AutoScalingMetricComparator.GREATER_THAN
-        elif self.min_threshold is not None:
-            threshold_str = str(self.min_threshold)
-            comparator = AutoScalingMetricComparator.LESS_THAN
-        else:
-            threshold_str = "0"
-            comparator = AutoScalingMetricComparator.GREATER_THAN
         return AutoScalingRule(
             id=self.id,
             condition=AutoScalingCondition(
                 metric_source=self.metric_source,
                 metric_name=self.metric_name,
-                threshold=threshold_str,
-                comparator=comparator,
+                scale_up_threshold=self.max_threshold,
+                scale_down_threshold=self.min_threshold,
+                prometheus_query_preset_id=self.prometheus_query_preset_id,
             ),
             action=AutoScalingAction(
                 step_size=self.step_size,
@@ -1092,6 +1083,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             cooldown_seconds=creator.time_window,
             min_replicas=creator.min_replicas,
             max_replicas=creator.max_replicas,
+            prometheus_query_preset_id=creator.prometheus_query_preset_id,
         )
 
     def to_model_deployment_data(self) -> ModelDeploymentAutoScalingRuleData:
@@ -1109,6 +1101,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             max_replicas=self.max_replicas,
             created_at=self.created_at or datetime.now(UTC),
             last_triggered_at=self.last_triggered_at or datetime.now(UTC),
+            prometheus_query_preset_id=self.prometheus_query_preset_id,
         )
 
     def apply_model_deployment_modifier(
@@ -1136,6 +1129,10 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             self.max_threshold = max_threshold
         if (min_threshold := modifier.min_threshold.optional_value()) is not None:
             self.min_threshold = min_threshold
+        if (
+            prometheus_query_preset_id := modifier.prometheus_query_preset_id.optional_value()
+        ) is not None:
+            self.prometheus_query_preset_id = prometheus_query_preset_id
 
 
 class ModelServiceHelper:

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -25,7 +25,6 @@ from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPoli
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import (
-    AutoScalingMetricComparator,
     AutoScalingMetricSource,
     KernelId,
     SessionId,
@@ -113,6 +112,7 @@ class AutoScalingMetricsData:
     endpoint_statistics: dict[uuid.UUID, Mapping[str, Any] | None] = field(default_factory=dict)
     routes_by_endpoint: Mapping[uuid.UUID, list[RouteInfo]] = field(default_factory=dict)
     kernels_by_session: dict[SessionId, list[KernelId]] = field(default_factory=dict)
+    prometheus_metrics: dict[uuid.UUID, Decimal] = field(default_factory=dict)
 
 
 deployment_repository_resilience = Resilience(
@@ -842,6 +842,9 @@ class DeploymentRepository:
                 elif rule.condition.metric_source == AutoScalingMetricSource.INFERENCE_FRAMEWORK:
                     # Need to fetch endpoint metrics
                     metric_requested_endpoints.append(deployment.id)
+                elif rule.condition.metric_source == AutoScalingMetricSource.PROMETHEUS:
+                    # Prometheus metrics are fetched in the executor, not from Valkey
+                    pass
 
         # Fetch kernel data if needed
         if metric_requested_sessions:
@@ -986,32 +989,62 @@ class DeploymentRepository:
                             )
                             continue
 
-            # Evaluate threshold comparison
+            elif rule.condition.metric_source == AutoScalingMetricSource.PROMETHEUS:
+                # Use pre-fetched Prometheus metrics (populated by executor)
+                pre_fetched = metrics_data.prometheus_metrics.get(rule.id)
+                if pre_fetched is None:
+                    log.warning(
+                        "AUTOSCALE(e:{}, rule:{}): skipping - no prometheus metric",
+                        deployment.id,
+                        rule.id,
+                    )
+                    continue
+                current_value = pre_fetched
+
+            # Evaluate threshold comparison (scale-up and scale-down)
+            scale_direction: int = 0  # +1 for scale-out, -1 for scale-in
             if current_value is not None:
-                threshold = Decimal(rule.condition.threshold)
-
-                if rule.condition.comparator == AutoScalingMetricComparator.LESS_THAN:
-                    should_trigger = current_value < threshold
-                elif rule.condition.comparator == AutoScalingMetricComparator.LESS_THAN_OR_EQUAL:
-                    should_trigger = current_value <= threshold
-                elif rule.condition.comparator == AutoScalingMetricComparator.GREATER_THAN:
-                    should_trigger = current_value > threshold
-                elif rule.condition.comparator == AutoScalingMetricComparator.GREATER_THAN_OR_EQUAL:
-                    should_trigger = current_value >= threshold
-
-                log.debug(
-                    "AUTOSCALE(e:{}, rule:{}): {} {} {}: {}",
-                    deployment.id,
-                    rule.id,
-                    current_value,
-                    rule.condition.comparator.value,
-                    threshold,
-                    should_trigger,
-                )
+                if (
+                    rule.condition.scale_up_threshold is not None
+                    and current_value > rule.condition.scale_up_threshold
+                ):
+                    scale_direction = 1
+                    should_trigger = True
+                    log.debug(
+                        "AUTOSCALE(e:{}, rule:{}): {} > {} → scale out",
+                        deployment.id,
+                        rule.id,
+                        current_value,
+                        rule.condition.scale_up_threshold,
+                    )
+                elif (
+                    rule.condition.scale_down_threshold is not None
+                    and current_value < rule.condition.scale_down_threshold
+                ):
+                    scale_direction = -1
+                    should_trigger = True
+                    log.debug(
+                        "AUTOSCALE(e:{}, rule:{}): {} < {} → scale in",
+                        deployment.id,
+                        rule.id,
+                        current_value,
+                        rule.condition.scale_down_threshold,
+                    )
+                else:
+                    log.debug(
+                        "AUTOSCALE(e:{}, rule:{}): {} in range [{}, {}] → no action",
+                        deployment.id,
+                        rule.id,
+                        current_value,
+                        rule.condition.scale_down_threshold,
+                        rule.condition.scale_up_threshold,
+                    )
 
             if should_trigger:
                 # Calculate new replica count
-                new_replica_count = max(0, current_replica_count + rule.action.step_size)
+                new_replica_count = max(
+                    0, current_replica_count + scale_direction * rule.action.step_size
+                )
 
                 # Check min/max limits
                 if (

--- a/src/ai/backend/manager/sokovan/deployment/coordinator.py
+++ b/src/ai/backend/manager/sokovan/deployment/coordinator.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from ai.backend.common.clients.http_client.client_pool import ClientPool
+from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
@@ -46,6 +47,9 @@ from ai.backend.manager.repositories.base.updater import BatchUpdater
 from ai.backend.manager.repositories.deployment import DeploymentRepository
 from ai.backend.manager.repositories.deployment.creators import (
     EndpointLifecycleBatchUpdaterSpec,
+)
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
 )
 from ai.backend.manager.repositories.scheduling_history.creators import DeploymentHistoryCreatorSpec
 from ai.backend.manager.sokovan.deployment.recorder import DeploymentRecorderContext
@@ -219,6 +223,8 @@ class DeploymentCoordinator:
         client_pool: ClientPool,
         valkey_stat: ValkeyStatClient,
         route_controller: RouteController,
+        prometheus_client: PrometheusClient,
+        prometheus_query_preset_repository: PrometheusQueryPresetRepository,
     ) -> None:
         """Initialize the deployment coordinator."""
         self._valkey_schedule = valkey_schedule
@@ -236,6 +242,8 @@ class DeploymentCoordinator:
             config_provider=self._config_provider,
             client_pool=client_pool,
             valkey_stat=valkey_stat,
+            prometheus_client=prometheus_client,
+            preset_repo=prometheus_query_preset_repository,
         )
 
         # Create strategy components for deploying handlers

--- a/src/ai/backend/manager/sokovan/deployment/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/executor.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
+from decimal import Decimal, DecimalException
 from typing import cast
 from uuid import UUID
 
@@ -10,11 +11,18 @@ from ai.backend.common.clients.http_client.client_pool import (
     ClientKey,
     ClientPool,
 )
+from ai.backend.common.clients.prometheus.client import PrometheusClient
+from ai.backend.common.clients.prometheus.preset import MetricPreset
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.data.permission.types import RBACElementType
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import (
+    BackendAIError,
+    FailedToGetMetric,
+    PrometheusConnectionError,
+)
 from ai.backend.common.types import (
+    AutoScalingMetricSource,
     RuntimeVariant,
 )
 from ai.backend.logging import BraceStyleAdapter
@@ -34,6 +42,7 @@ from ai.backend.manager.data.deployment.types import (
     RouteTrafficStatus,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.prometheus_query_preset import PrometheusQueryPresetData
 from ai.backend.manager.data.resource.types import ScalingGroupProxyTarget
 from ai.backend.manager.errors.deployment import ReplicaCountMismatch
 from ai.backend.manager.models.routing import RoutingRow
@@ -47,6 +56,9 @@ from ai.backend.manager.repositories.deployment.creators import (
 from ai.backend.manager.repositories.deployment.repository import (
     AutoScalingMetricsData,
     DeploymentRepository,
+)
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
 )
 from ai.backend.manager.sokovan.deployment.recorder.context import DeploymentRecorderContext
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
@@ -84,6 +96,8 @@ class DeploymentExecutor:
     _config_provider: ManagerConfigProvider
     _client_pool: ClientPool
     _valkey_stat: ValkeyStatClient
+    _prometheus_client: PrometheusClient
+    _preset_repo: PrometheusQueryPresetRepository
 
     def __init__(
         self,
@@ -92,6 +106,8 @@ class DeploymentExecutor:
         config_provider: ManagerConfigProvider,
         client_pool: ClientPool,
         valkey_stat: ValkeyStatClient,
+        prometheus_client: PrometheusClient,
+        preset_repo: PrometheusQueryPresetRepository,
     ) -> None:
         """Initialize the deployment executor."""
         self._deployment_repo = deployment_repo
@@ -99,6 +115,8 @@ class DeploymentExecutor:
         self._config_provider = config_provider
         self._client_pool = client_pool
         self._valkey_stat = valkey_stat
+        self._prometheus_client = prometheus_client
+        self._preset_repo = preset_repo
 
     async def check_pending_deployments(
         self, deployments: Sequence[DeploymentWithHistory]
@@ -352,6 +370,11 @@ class DeploymentExecutor:
                 deployment_infos = [dep.deployment_info for dep in deployments]
                 metrics_data = await self._deployment_repo.fetch_metrics_for_autoscaling(
                     deployment_infos, auto_scaling_rules
+                )
+
+            with DeploymentRecorderContext.shared_step("load_prometheus_metrics"):
+                await self._fetch_prometheus_metrics(
+                    deployment_infos, auto_scaling_rules, metrics_data
                 )
 
         successes: list[DeploymentWithHistory] = []
@@ -676,6 +699,110 @@ class DeploymentExecutor:
                     scale_in_route_ids.extend(r.route_id for r in candidates)
 
         return scale_out_creators, scale_in_route_ids
+
+    async def _fetch_prometheus_metrics(
+        self,
+        deployments: Sequence[DeploymentInfo],
+        auto_scaling_rules: Mapping[UUID, Sequence[AutoScalingRule]],
+        metrics_data: AutoScalingMetricsData,
+    ) -> None:
+        """Fetch Prometheus metrics for rules with PROMETHEUS metric source.
+
+        Results are stored in metrics_data.prometheus_metrics keyed by rule ID.
+        """
+        prometheus_rules: list[tuple[DeploymentInfo, AutoScalingRule]] = []
+        for dep in deployments:
+            for rule in auto_scaling_rules.get(dep.id, []):
+                if rule.condition.metric_source == AutoScalingMetricSource.PROMETHEUS:
+                    prometheus_rules.append((dep, rule))
+
+        if not prometheus_rules:
+            return
+
+        # Batch-load unique presets via existing repository
+        preset_ids = {
+            rule.condition.prometheus_query_preset_id
+            for _, rule in prometheus_rules
+            if rule.condition.prometheus_query_preset_id is not None
+        }
+        presets: dict[UUID, PrometheusQueryPresetData] = {}
+        for pid in preset_ids:
+            try:
+                presets[pid] = await self._preset_repo.get_by_id(pid)
+            except Exception:
+                log.warning("AUTOSCALE: failed to load preset {}", pid)
+
+        # Execute queries concurrently
+        tasks = [
+            self._fetch_prometheus_metric(dep, rule, presets) for dep, rule in prometheus_rules
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for (_, rule), result in zip(prometheus_rules, results, strict=True):
+            if isinstance(result, BaseException):
+                log.warning("AUTOSCALE(rule:{}): prometheus query failed: {}", rule.id, result)
+            elif result is not None:
+                metrics_data.prometheus_metrics[rule.id] = result
+
+    async def _fetch_prometheus_metric(
+        self,
+        deployment: DeploymentInfo,
+        rule: AutoScalingRule,
+        presets: Mapping[UUID, PrometheusQueryPresetData],
+    ) -> Decimal | None:
+        """Execute a single Prometheus query for an auto-scaling rule.
+
+        Returns the scalar metric value, or None if unavailable.
+        """
+        preset_id = rule.condition.prometheus_query_preset_id
+        if preset_id is None or preset_id not in presets:
+            log.warning("AUTOSCALE(rule:{}): preset {} not found", rule.id, preset_id)
+            return None
+
+        preset_data: PrometheusQueryPresetData = presets[preset_id]
+
+        # Auto-inject deployment-specific label for scoping
+        labels: dict[str, str] = {"model_service_name": deployment.metadata.name}
+
+        # time_window: preset default → fallback to "5m"
+        time_window = preset_data.time_window or "5m"
+
+        metric_preset = MetricPreset(
+            template=preset_data.query_template,
+            labels=labels,
+            window=time_window,
+        )
+
+        try:
+            response = await self._prometheus_client.query_instant(preset=metric_preset)
+        except (PrometheusConnectionError, FailedToGetMetric) as e:
+            log.warning(
+                "AUTOSCALE(e:{}, rule:{}): prometheus query failed: {}",
+                deployment.id,
+                rule.id,
+                e,
+            )
+            return None
+
+        if not response.data.result:
+            log.debug(
+                "AUTOSCALE(e:{}, rule:{}): prometheus query returned empty result",
+                deployment.id,
+                rule.id,
+            )
+            return None
+
+        _, value_str = response.data.result[0].values[0]
+        try:
+            return Decimal(value_str)
+        except DecimalException:
+            log.warning(
+                "AUTOSCALE(e:{}, rule:{}): failed to parse prometheus value '{}'",
+                deployment.id,
+                rule.id,
+                value_str,
+            )
+            return None
 
     async def _calculate_deployment_replicas(
         self,

--- a/tests/unit/common/dto/manager/v2/auto_scaling_rule/test_types.py
+++ b/tests/unit/common/dto/manager/v2/auto_scaling_rule/test_types.py
@@ -57,7 +57,7 @@ class TestAutoScalingMetricSourceReExport:
         assert ExportedAutoScalingMetricSource.INFERENCE_FRAMEWORK.value == "inference_framework"
 
     def test_enum_members_count(self) -> None:
-        assert len(list(ExportedAutoScalingMetricSource)) == 2
+        assert len(list(ExportedAutoScalingMetricSource)) == 3
 
     def test_case_insensitive_lookup_kernel(self) -> None:
         # CIStrEnum is case-insensitive

--- a/tests/unit/manager/dependencies/orchestration/test_composer.py
+++ b/tests/unit/manager/dependencies/orchestration/test_composer.py
@@ -53,6 +53,8 @@ class TestOrchestrationComposer:
             deployment_controller=MagicMock(),
             route_controller=MagicMock(),
             service_discovery=MagicMock(),
+            prometheus_client=MagicMock(),
+            prometheus_query_preset_repository=MagicMock(),
         )
 
         async with DependencyBuilderStack() as stack:
@@ -126,6 +128,8 @@ class TestOrchestrationComposer:
             deployment_controller=MagicMock(),
             route_controller=MagicMock(),
             service_discovery=MagicMock(),
+            prometheus_client=MagicMock(),
+            prometheus_query_preset_repository=MagicMock(),
         )
 
         async with DependencyBuilderStack() as stack:

--- a/tests/unit/manager/dependencies/orchestration/test_sokovan.py
+++ b/tests/unit/manager/dependencies/orchestration/test_sokovan.py
@@ -62,6 +62,8 @@ class TestSokovanOrchestratorDependency:
             route_controller=MagicMock(),
             distributed_lock_factory=MagicMock(),
             service_discovery=MagicMock(),
+            prometheus_client=MagicMock(),
+            prometheus_query_preset_repository=MagicMock(),
         )
 
         async with dependency.provide(sokovan_input) as orchestrator:
@@ -121,6 +123,8 @@ class TestSokovanOrchestratorDependency:
             route_controller=MagicMock(),
             distributed_lock_factory=MagicMock(),
             service_discovery=MagicMock(),
+            prometheus_client=MagicMock(),
+            prometheus_query_preset_repository=MagicMock(),
         )
 
         async with dependency.provide(sokovan_input):

--- a/tests/unit/manager/repositories/model_serving/test_search_auto_scaling_rule_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_search_auto_scaling_rule_validated.py
@@ -38,6 +38,9 @@ from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.prometheus_query_preset.row import (
+    PrometheusQueryPresetRow,
+)
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
@@ -95,6 +98,7 @@ class TestSearchAutoScalingRulesValidated:
                 KernelRow,
                 RoutingRow,
                 ResourcePresetRow,
+                PrometheusQueryPresetRow,
                 EndpointAutoScalingRuleRow,
             ],
         ):

--- a/tests/unit/manager/sokovan/deployment/executor/conftest.py
+++ b/tests/unit/manager/sokovan/deployment/executor/conftest.py
@@ -79,12 +79,26 @@ def mock_valkey_stat() -> AsyncMock:
 
 
 @pytest.fixture
+def mock_prometheus_client() -> AsyncMock:
+    """Mock PrometheusClient for Prometheus-based auto-scaling."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_preset_repo() -> AsyncMock:
+    """Mock PrometheusQueryPresetRepository for Prometheus-based auto-scaling."""
+    return AsyncMock()
+
+
+@pytest.fixture
 def deployment_executor(
     mock_deployment_repo: AsyncMock,
     mock_scheduling_controller: AsyncMock,
     mock_config_provider: MagicMock,
     mock_client_pool: MagicMock,
     mock_valkey_stat: AsyncMock,
+    mock_prometheus_client: AsyncMock,
+    mock_preset_repo: AsyncMock,
 ) -> DeploymentExecutor:
     """Create DeploymentExecutor with mocked dependencies."""
     return DeploymentExecutor(
@@ -93,6 +107,8 @@ def deployment_executor(
         config_provider=mock_config_provider,
         client_pool=mock_client_pool,
         valkey_stat=mock_valkey_stat,
+        prometheus_client=mock_prometheus_client,
+        preset_repo=mock_preset_repo,
     )
 
 

--- a/tests/unit/manager/sokovan/deployment/test_coordinator_history.py
+++ b/tests/unit/manager/sokovan/deployment/test_coordinator_history.py
@@ -275,6 +275,8 @@ def coordinator_with_pending_deployments(
         client_pool=mock_client_pool,
         valkey_stat=mock_valkey_stat,
         route_controller=mock_route_controller,
+        prometheus_client=MagicMock(),
+        prometheus_query_preset_repository=MagicMock(),
     )
     yield coordinator
 
@@ -306,6 +308,8 @@ def coordinator_without_deployments(
         client_pool=mock_client_pool,
         valkey_stat=mock_valkey_stat,
         route_controller=mock_route_controller,
+        prometheus_client=MagicMock(),
+        prometheus_query_preset_repository=MagicMock(),
     )
     yield coordinator
 


### PR DESCRIPTION
## Summary
- Add `PROMETHEUS` as a new `AutoScalingMetricSource` that queries Prometheus directly via existing `prometheus_query_presets`, bypassing the unreliable app proxy metrics collection path
- Refactor threshold evaluation to support bidirectional scaling in a single rule: `scale_up_threshold` / `scale_down_threshold` replace the old single threshold + comparator model
- Wire `PrometheusClient` + `PrometheusQueryPresetRepository` through DI chain to the deployment executor

## Test plan
- [x] `pants fmt/fix/lint/check/test` all pass
- [x] E2E verified: deployment with Python image running mock metrics server
- [x] Service discovery auto-registration → Prometheus scrape → PromQL query
- [x] Scale-out: `avg(mock_rps) = 200 > max_threshold(100)` → desired 1→2
- [x] No-op: `avg(mock_rps) = 75` in range [50, 100] → desired unchanged
- [x] Scale-in: `avg(mock_rps) = 10 < min_threshold(50)` → desired 2→1
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--10993.org.readthedocs.build/en/10993/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--10993.org.readthedocs.build/ko/10993/

<!-- readthedocs-preview sorna-ko end -->