### PR TITLE
fix(BA-5687): re-read model_definition from vfolder and trigger CHECK_REPLICA on revision changes in legacy modify_endpoint

### DIFF
--- a/changes/10994.fix.md
+++ b/changes/10994.fix.md
@@ -1,0 +1,1 @@
+Trigger deployment lifecycle (CHECK_REPLICA) when revision-level fields are changed in the legacy `modify_endpoint` API, so the new revision is actually deployed.

--- a/changes/10994.fix.md
+++ b/changes/10994.fix.md
@@ -1,1 +1,1 @@
-Trigger deployment lifecycle (CHECK_REPLICA) when revision-level fields are changed in the legacy `modify_endpoint` API, so the new revision is actually deployed.
+Re-read model definition from vfolder when legacy `modify_endpoint` creates a new revision, so on-disk file changes are reflected. Also trigger `CHECK_REPLICA` lifecycle on revision-level field changes to notify the deployment controller.

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import sqlalchemy as sa
 from pydantic import HttpUrl
+from ruamel.yaml import YAML
 from sqlalchemy.exc import IntegrityError, NoResultFound, StatementError
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import selectinload
@@ -20,7 +21,9 @@ from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryAr
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import (
     AccessKey,
+    QuotaScopeID,
     ResourceSlot,
+    VFolderID,
 )
 from ai.backend.manager.config.loader.legacy_etcd_loader import LegacyEtcdLoader
 from ai.backend.manager.data.deployment.types import RouteHealthStatus
@@ -828,6 +831,15 @@ class ModelServingRepository:
                     if current_rev is None:
                         raise InvalidAPIParameters("Endpoint has no current revision")
 
+                    # Re-read model definition from vfolder to pick up file changes
+                    refreshed_model_definition = await self._fetch_model_definition_from_vfolder(
+                        db_session,
+                        storage_manager,
+                        current_rev.model,
+                        spec.model_definition_path.optional_value()
+                        or current_rev.model_definition_path,
+                    )
+
                     # Resolve image if changed
                     image_id = current_rev.image
                     image_ref = spec.image.optional_value()
@@ -860,7 +872,7 @@ class ModelServingRepository:
                             if spec.model_definition_path.optional_value() is not None
                             else current_rev.model_definition_path
                         ),
-                        model_definition=current_rev.model_definition,
+                        model_definition=refreshed_model_definition or current_rev.model_definition,
                         resource_group=endpoint_row.resource_group,
                         resource_opts=(
                             spec.resource_opts.optional_value()
@@ -941,6 +953,54 @@ class ModelServingRepository:
             raise
         except Exception:
             raise
+
+    async def _fetch_model_definition_from_vfolder(
+        self,
+        db_session: SASession,
+        storage_manager: StorageSessionManager,
+        vfolder_id: uuid.UUID | None,
+        model_definition_path: str | None,
+    ) -> dict[str, Any] | None:
+        """Re-read model definition file from the vfolder storage.
+
+        Returns the parsed YAML content, or None if the file cannot be read.
+        """
+        if vfolder_id is None:
+            return None
+        try:
+            vf_query = sa.select(
+                VFolderRow.id,
+                VFolderRow.host,
+                VFolderRow.quota_scope_id,
+            ).where(VFolderRow.id == vfolder_id)
+            vf_result = await db_session.execute(vf_query)
+            vf_row = vf_result.one_or_none()
+            if vf_row is None:
+                return None
+
+            quota_scope_id: QuotaScopeID | None = vf_row.quota_scope_id
+            vfid = VFolderID(quota_scope_id, vf_row.id)
+            proxy_name, volume_name = storage_manager.get_proxy_and_volume(vf_row.host)
+            manager_client = storage_manager.get_manager_facing_client(proxy_name)
+
+            candidates = (
+                [model_definition_path]
+                if model_definition_path
+                else ["model-definition.yaml", "model-definition.yml"]
+            )
+            for candidate in candidates:
+                try:
+                    content = await manager_client.fetch_file_content(
+                        volume_name, str(vfid), candidate
+                    )
+                    if content:
+                        yaml = YAML()
+                        return cast(dict[str, Any], yaml.load(content))
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return None
 
     @model_serving_repository_resilience.apply()
     async def search_auto_scaling_rules(

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -860,6 +860,7 @@ class ModelServingRepository:
                             if spec.model_definition_path.optional_value() is not None
                             else current_rev.model_definition_path
                         ),
+                        model_definition=current_rev.model_definition,
                         resource_group=endpoint_row.resource_group,
                         resource_opts=(
                             spec.resource_opts.optional_value()

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -21,9 +21,7 @@ from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryAr
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.common.types import (
     AccessKey,
-    QuotaScopeID,
     ResourceSlot,
-    VFolderID,
 )
 from ai.backend.manager.config.loader.legacy_etcd_loader import LegacyEtcdLoader
 from ai.backend.manager.data.deployment.types import RouteHealthStatus
@@ -42,7 +40,7 @@ from ai.backend.manager.data.model_serving.types import (
     UserData,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.data.vfolder.types import VFolderOwnershipType
+from ai.backend.manager.data.vfolder.types import VFolderLocation, VFolderOwnershipType
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.resource import DatabaseConnectionUnavailable
 from ai.backend.manager.errors.service import EndpointNotFound
@@ -83,6 +81,9 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import (
     execute_rbac_entity_creator,
 )
 from ai.backend.manager.repositories.deployment.creators import DeploymentPolicyCreatorSpec
+from ai.backend.manager.repositories.deployment.storage_source.storage_source import (
+    DeploymentStorageSource,
+)
 from ai.backend.manager.repositories.model_serving.updaters import EndpointUpdaterSpec
 from ai.backend.manager.services.model_serving.actions.modify_endpoint import ModifyEndpointAction
 from ai.backend.manager.services.model_serving.exceptions import (
@@ -972,35 +973,32 @@ class ModelServingRepository:
                 VFolderRow.id,
                 VFolderRow.host,
                 VFolderRow.quota_scope_id,
+                VFolderRow.ownership_type,
+                VFolderRow.usage_mode,
             ).where(VFolderRow.id == vfolder_id)
             vf_result = await db_session.execute(vf_query)
             vf_row = vf_result.one_or_none()
             if vf_row is None:
                 return None
 
-            quota_scope_id: QuotaScopeID | None = vf_row.quota_scope_id
-            vfid = VFolderID(quota_scope_id, vf_row.id)
-            proxy_name, volume_name = storage_manager.get_proxy_and_volume(vf_row.host)
-            manager_client = storage_manager.get_manager_facing_client(proxy_name)
-
+            vfolder_location = VFolderLocation(
+                id=vf_row.id,
+                quota_scope_id=vf_row.quota_scope_id,
+                host=vf_row.host,
+                ownership_type=vf_row.ownership_type,
+                usage_mode=vf_row.usage_mode,
+            )
             candidates = (
                 [model_definition_path]
                 if model_definition_path
                 else ["model-definition.yaml", "model-definition.yml"]
             )
-            for candidate in candidates:
-                try:
-                    content = await manager_client.fetch_file_content(
-                        volume_name, str(vfid), candidate
-                    )
-                    if content:
-                        yaml = YAML()
-                        return cast(dict[str, Any], yaml.load(content))
-                except Exception:
-                    continue
+            storage_source = DeploymentStorageSource(storage_manager)
+            content = await storage_source.fetch_definition_file(vfolder_location, candidates)
+            yaml = YAML()
+            return cast(dict[str, Any], yaml.load(content))
         except Exception:
-            pass
-        return None
+            return None
 
     @model_serving_repository_resilience.apply()
     async def search_auto_scaling_rules(

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -897,6 +897,9 @@ class ModelServingService:
         )
         spec = cast(EndpointUpdaterSpec, action.updater.spec)
         if spec.replica_count_modified() or spec.has_revision_changes():
+            # Trigger CHECK_REPLICA for both cases:
+            # - replica count change: reconcile running session count
+            # - revision change: rotate sessions to use the newly activated revision
             await self._deployment_controller.mark_lifecycle_needed(
                 DeploymentLifecycleType.CHECK_REPLICA,
             )

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -896,8 +896,7 @@ class ModelServingService:
             self._storage_manager,
         )
         spec = cast(EndpointUpdaterSpec, action.updater.spec)
-        if spec.replica_count_modified():
-            # Notify appproxy to update routing info
+        if spec.replica_count_modified() or spec.has_revision_changes():
             await self._deployment_controller.mark_lifecycle_needed(
                 DeploymentLifecycleType.CHECK_REPLICA,
             )

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -37,7 +37,9 @@ from ai.backend.manager.models.resource_slot.row import (
     DeploymentRevisionResourceSlotRow,
     ResourceSlotTypeRow,
 )
+from ai.backend.manager.models.routing.row import RoutingRow
 from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
@@ -78,7 +80,9 @@ class TestModifyEndpointModelDefinitionRefresh:
                 ContainerRegistryRow,
                 ImageRow,
                 VFolderRow,
+                SessionRow,
                 EndpointRow,
+                RoutingRow,
                 DeploymentRevisionRow,
                 ResourceSlotTypeRow,
                 DeploymentRevisionResourceSlotRow,

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -14,7 +14,8 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.contexts.user import UserData, with_user
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.user.types import UserData
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.image.types import ImageType

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -111,6 +111,7 @@ class TestModifyEndpointModelDefinitionRefresh:
         self, db_with_cleanup: ExtendedAsyncSAEngine, test_domain: str
     ) -> uuid.UUID:
         user_id = uuid.uuid4()
+        email = f"test-{uuid.uuid4().hex[:8]}@test.com"
         async with db_with_cleanup.begin_session() as sess:
             sess.add(
                 UserResourcePolicyRow(
@@ -122,10 +123,11 @@ class TestModifyEndpointModelDefinitionRefresh:
                 )
             )
             await sess.flush()
+            # Create user without main_access_key first (FK to keypairs)
             sess.add(
                 UserRow(
                     uuid=user_id,
-                    email=f"test-{uuid.uuid4().hex[:8]}@test.com",
+                    email=email,
                     username=f"testuser-{uuid.uuid4().hex[:8]}",
                     password=PasswordInfo(
                         password="pw",
@@ -137,7 +139,6 @@ class TestModifyEndpointModelDefinitionRefresh:
                     resource_policy="default",
                     role=UserRole.SUPERADMIN,
                     status=UserStatus.ACTIVE,
-                    main_access_key="TESTKEY",
                 )
             )
             await sess.flush()
@@ -145,7 +146,7 @@ class TestModifyEndpointModelDefinitionRefresh:
             await sess.flush()
             sess.add(
                 KeyPairRow(
-                    user_id=f"test-{uuid.uuid4().hex[:8]}@test.com",
+                    user_id=email,
                     access_key="TESTKEY",
                     secret_key="TESTSECRET",
                     is_active=True,
@@ -153,6 +154,11 @@ class TestModifyEndpointModelDefinitionRefresh:
                     user=user_id,
                     resource_policy="default",
                 )
+            )
+            await sess.flush()
+            # Now set main_access_key after keypair exists
+            await sess.execute(
+                sa.update(UserRow).where(UserRow.uuid == user_id).values(main_access_key="TESTKEY")
             )
             await sess.flush()
         return user_id

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -142,7 +142,17 @@ class TestModifyEndpointModelDefinitionRefresh:
                 )
             )
             await sess.flush()
-            sess.add(KeyPairResourcePolicyRow(name="default"))
+            sess.add(
+                KeyPairResourcePolicyRow(
+                    name="default",
+                    total_resource_slots=ResourceSlot(),
+                    max_session_lifetime=0,
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=1,
+                    max_containers_per_session=1,
+                    idle_timeout=3600,
+                )
+            )
             await sess.flush()
             sess.add(
                 KeyPairRow(

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -1,0 +1,375 @@
+"""
+Regression test: when model-definition.yaml is updated on disk and
+modify_endpoint is called, the new revision must contain the fresh
+model_definition — not the previous revision's stale snapshot.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.container_registry import ContainerRegistryType
+from ai.backend.common.contexts.user import UserData, with_user
+from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.image.types import ImageType
+from ai.backend.manager.data.model_serving.types import EndpointLifecycle
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_slot.row import (
+    DeploymentRevisionResourceSlotRow,
+    ResourceSlotTypeRow,
+)
+from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.base import Updater
+from ai.backend.manager.repositories.model_serving.repository import ModelServingRepository
+from ai.backend.manager.repositories.model_serving.updaters import EndpointUpdaterSpec
+from ai.backend.manager.services.model_serving.actions.modify_endpoint import ModifyEndpointAction
+from ai.backend.manager.types import TriState
+from ai.backend.testutils.db import with_tables
+
+OLD_MODEL_DEF = {"models": [{"name": "old-snapshot"}]}
+NEW_MODEL_DEF = {"models": [{"name": "updated-from-disk"}]}
+
+
+class TestModifyEndpointModelDefinitionRefresh:
+    """Verify that modify_endpoint re-reads model_definition from vfolder."""
+
+    # =========================================================================
+    # Fixtures
+    # =========================================================================
+
+    @pytest.fixture()
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                ContainerRegistryRow,
+                ImageRow,
+                VFolderRow,
+                EndpointRow,
+                DeploymentRevisionRow,
+                ResourceSlotTypeRow,
+                DeploymentRevisionResourceSlotRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture()
+    async def test_domain(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+        name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(DomainRow(name=name, total_resource_slots=ResourceSlot()))
+            await sess.flush()
+        return name
+
+    @pytest.fixture()
+    async def test_scaling_group(self, db_with_cleanup: ExtendedAsyncSAEngine) -> str:
+        name = f"test-sg-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                ScalingGroupRow(
+                    name=name, driver="static", scheduler="fifo", scheduler_opts=ScalingGroupOpts()
+                )
+            )
+            await sess.flush()
+        return name
+
+    @pytest.fixture()
+    async def test_user_id(
+        self, db_with_cleanup: ExtendedAsyncSAEngine, test_domain: str
+    ) -> uuid.UUID:
+        user_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserResourcePolicyRow(
+                    name="default",
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                UserRow(
+                    uuid=user_id,
+                    email=f"test-{uuid.uuid4().hex[:8]}@test.com",
+                    username=f"testuser-{uuid.uuid4().hex[:8]}",
+                    password=PasswordInfo(
+                        password="pw",
+                        algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                        rounds=1,
+                        salt_size=16,
+                    ),
+                    domain_name=test_domain,
+                    resource_policy="default",
+                    role=UserRole.SUPERADMIN,
+                    status=UserStatus.ACTIVE,
+                    main_access_key="TESTKEY",
+                )
+            )
+            await sess.flush()
+            sess.add(KeyPairResourcePolicyRow(name="default"))
+            await sess.flush()
+            sess.add(
+                KeyPairRow(
+                    user_id=f"test-{uuid.uuid4().hex[:8]}@test.com",
+                    access_key="TESTKEY",
+                    secret_key="TESTSECRET",
+                    is_active=True,
+                    is_admin=True,
+                    user=user_id,
+                    resource_policy="default",
+                )
+            )
+            await sess.flush()
+        return user_id
+
+    @pytest.fixture()
+    async def test_group_id(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: str,
+    ) -> uuid.UUID:
+        group_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name="default",
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=3,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                GroupRow(
+                    id=group_id,
+                    name=f"test-grp-{uuid.uuid4().hex[:8]}",
+                    domain_name=test_domain,
+                    total_resource_slots=ResourceSlot(),
+                    resource_policy="default",
+                )
+            )
+            await sess.flush()
+        return group_id
+
+    @pytest.fixture()
+    async def test_image_id(self, db_with_cleanup: ExtendedAsyncSAEngine) -> uuid.UUID:
+        image_id = uuid.uuid4()
+        registry_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                ContainerRegistryRow(
+                    id=registry_id,
+                    url="http://test.local",
+                    registry_name=f"test-reg-{uuid.uuid4().hex[:8]}",
+                    type=ContainerRegistryType.DOCKER,
+                )
+            )
+            await sess.flush()
+            image = ImageRow(
+                name=f"test-img-{uuid.uuid4().hex[:8]}",
+                project=None,
+                image=f"test-img:{uuid.uuid4().hex[:8]}",
+                tag="latest",
+                registry=f"test-reg-{uuid.uuid4().hex[:8]}",
+                registry_id=registry_id,
+                architecture="aarch64",
+                config_digest="sha256:" + "a" * 64,
+                size_bytes=1024,
+                type=ImageType.COMPUTE,
+                labels={},
+                resources={"cpu": {"min": "1"}, "mem": {"min": "64m"}},
+            )
+            image.id = image_id
+            sess.add(image)
+            await sess.flush()
+        return image_id
+
+    @pytest.fixture()
+    async def endpoint_and_revision(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_user_id: uuid.UUID,
+        test_domain: str,
+        test_group_id: uuid.UUID,
+        test_scaling_group: str,
+        test_image_id: uuid.UUID,
+    ) -> tuple[uuid.UUID, uuid.UUID]:
+        """Create endpoint + revision with OLD model_definition. Returns (endpoint_id, revision_id)."""
+        endpoint_id = uuid.uuid4()
+        revision_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"test-ep-{uuid.uuid4().hex[:8]}",
+                    created_user=test_user_id,
+                    session_owner=test_user_id,
+                    domain=test_domain,
+                    project=test_group_id,
+                    resource_group=test_scaling_group,
+                    lifecycle_stage=EndpointLifecycle.READY,
+                    replicas=1,
+                )
+            )
+            await sess.flush()
+
+            sess.add(ResourceSlotTypeRow(slot_name="cpu", slot_type="count"))
+            sess.add(ResourceSlotTypeRow(slot_name="mem", slot_type="bytes"))
+            await sess.flush()
+
+            sess.add(
+                DeploymentRevisionRow(
+                    id=revision_id,
+                    endpoint=endpoint_id,
+                    revision_number=1,
+                    image=test_image_id,
+                    model_mount_destination="/models",
+                    model_definition_path="model-definition.yaml",
+                    model_definition=OLD_MODEL_DEF,
+                    resource_group=test_scaling_group,
+                    resource_opts={},
+                    cluster_mode="single-node",
+                    cluster_size=1,
+                    environ={},
+                    runtime_variant="custom",
+                    extra_mounts=[],
+                )
+            )
+            await sess.flush()
+
+            sess.add(
+                DeploymentRevisionResourceSlotRow(
+                    revision_id=revision_id,
+                    slot_name="cpu",
+                    quantity="1",
+                )
+            )
+            sess.add(
+                DeploymentRevisionResourceSlotRow(
+                    revision_id=revision_id,
+                    slot_name="mem",
+                    quantity="268435456",
+                )
+            )
+            await sess.flush()
+
+            await sess.execute(
+                sa.update(EndpointRow)
+                .where(EndpointRow.id == endpoint_id)
+                .values(current_revision=revision_id)
+            )
+            await sess.flush()
+        return endpoint_id, revision_id
+
+    @pytest.fixture()
+    def repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> ModelServingRepository:
+        return ModelServingRepository(db=db_with_cleanup)
+
+    @pytest.fixture()
+    def user_context(self, test_user_id: uuid.UUID) -> UserData:
+        return UserData(
+            user_id=test_user_id,
+            is_authorized=True,
+            is_admin=True,
+            is_superadmin=True,
+            role=UserRole.SUPERADMIN,
+            domain_name="default",
+        )
+
+    # =========================================================================
+    # Tests
+    # =========================================================================
+
+    async def test_new_revision_uses_refreshed_model_definition(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        repository: ModelServingRepository,
+        endpoint_and_revision: tuple[uuid.UUID, uuid.UUID],
+        user_context: UserData,
+    ) -> None:
+        """The new revision created by modify_endpoint must carry the model
+        definition re-read from the vfolder, not the old revision's copy."""
+
+        endpoint_id, _ = endpoint_and_revision
+        spec = EndpointUpdaterSpec(environ=TriState.update({"NEW_VAR": "1"}))
+        action = ModifyEndpointAction(
+            endpoint_id=endpoint_id,
+            updater=Updater(spec=spec, pk_value=endpoint_id),
+        )
+
+        with (
+            with_user(user_context),
+            patch.object(
+                repository,
+                "_fetch_model_definition_from_vfolder",
+                new_callable=AsyncMock,
+                return_value=NEW_MODEL_DEF,
+            ),
+            patch(
+                "ai.backend.manager.repositories.model_serving.repository.ModelServiceHelper",
+                check_scaling_group=AsyncMock(),
+            ),
+        ):
+            result = await repository.modify_endpoint(
+                action,
+                agent_registry=MagicMock(),
+                legacy_etcd_config_loader=MagicMock(),
+                storage_manager=MagicMock(),
+            )
+
+        assert result.success is True
+
+        # Verify the new revision in DB has the refreshed model_definition
+        async with db_with_cleanup.begin_readonly_session() as sess:
+            rows = (
+                (
+                    await sess.execute(
+                        sa.select(DeploymentRevisionRow)
+                        .where(DeploymentRevisionRow.endpoint == endpoint_id)
+                        .order_by(DeploymentRevisionRow.revision_number)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert len(rows) == 2
+        assert rows[0].model_definition == OLD_MODEL_DEF
+        assert rows[1].model_definition == NEW_MODEL_DEF, (
+            "New revision must use model_definition freshly read from vfolder, "
+            f"got {rows[1].model_definition!r}"
+        )

--- a/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
+++ b/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
@@ -228,7 +228,9 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             ),
         )
 
-    def _make_updater_spec(self, *, replicas: int | None = None) -> MagicMock:
+    def _make_updater_spec(
+        self, *, replicas: int | None = None, has_revision_changes: bool = False
+    ) -> MagicMock:
         spec = MagicMock(spec=EndpointUpdaterSpec)
         if replicas is not None:
             spec.replicas = OptionalState.update(replicas)
@@ -236,6 +238,7 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
         else:
             spec.replicas = OptionalState[int].nop()
             spec.replica_count_modified.return_value = False
+        spec.has_revision_changes.return_value = has_revision_changes
         return spec
 
     async def test_replica_count_change_marks_check_replica(
@@ -247,6 +250,33 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
     ) -> None:
         """replica_count change (2->5) returns success=true with CHECK_REPLICA marking."""
         updater_spec = self._make_updater_spec(replicas=5)
+        mock_updater = MagicMock()
+        mock_updater.spec = updater_spec
+
+        mock_endpoint_data = MagicMock()
+        mock_endpoint_data.id = endpoint_id
+        mock_modify_endpoint.return_value = MutationResult(
+            success=True, message="ok", data=mock_endpoint_data
+        )
+
+        action = ModifyEndpointAction(endpoint_id=endpoint_id, updater=mock_updater)
+        result = await model_serving_processors.modify_endpoint.wait_for_complete(action)
+
+        assert result.success is True
+        assert result.data == mock_endpoint_data
+        mock_deployment_controller.mark_lifecycle_needed.assert_called_once_with(
+            DeploymentLifecycleType.CHECK_REPLICA
+        )
+
+    async def test_revision_change_marks_check_replica(
+        self,
+        model_serving_processors: ModelServingProcessors,
+        mock_modify_endpoint: AsyncMock,
+        mock_deployment_controller: MagicMock,
+        endpoint_id: uuid.UUID,
+    ) -> None:
+        """Revision-level field change triggers CHECK_REPLICA to auto-activate the new revision."""
+        updater_spec = self._make_updater_spec(replicas=None, has_revision_changes=True)
         mock_updater = MagicMock()
         mock_updater.spec = updater_spec
 

--- a/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
+++ b/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
@@ -266,7 +266,7 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
 
         assert result.success is True
         assert result.data == mock_endpoint_data
-        mock_deployment_controller.mark_lifecycle_needed.assert_called_once_with(
+        mock_deployment_controller.mark_lifecycle_needed.assert_awaited_once_with(
             DeploymentLifecycleType.CHECK_REPLICA
         )
 
@@ -293,7 +293,7 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
 
         assert result.success is True
         assert result.data == mock_endpoint_data
-        mock_deployment_controller.mark_lifecycle_needed.assert_called_once_with(
+        mock_deployment_controller.mark_lifecycle_needed.assert_awaited_once_with(
             DeploymentLifecycleType.CHECK_REPLICA
         )
 

--- a/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
+++ b/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
@@ -124,6 +124,8 @@ class ModelServingCRUDBaseFixtures:
     def mock_deployment_repository(self) -> MagicMock:
         mock = MagicMock()
         mock.get_default_architecture_from_scaling_group = AsyncMock(return_value=None)
+        mock.get_endpoint_info = AsyncMock(return_value=MagicMock(current_revision_id=None))
+        mock.fetch_model_definition = AsyncMock(return_value=None)
         return mock
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
- When `modify_endpoint` (legacy GQL mutation) creates a new revision, it now **re-reads the model-definition file from the vfolder** instead of copying the stale snapshot from the previous revision. This ensures that any on-disk changes to `model-definition.yaml` are reflected in the new revision.
- Trigger `CHECK_REPLICA` deployment lifecycle when revision-level fields change, not only when replica count changes. Without this, the deployment controller was never notified of revision updates.

## Changes
1. **`repository.py`** — Added `_fetch_model_definition_from_vfolder()` that queries the vfolder location from DB and delegates to `DeploymentStorageSource.fetch_definition_file()` to read the model-definition file. Falls back to the current revision's snapshot if the file cannot be read.
2. **`model_serving.py`** — Extended the `CHECK_REPLICA` trigger condition from `spec.replica_count_modified()` to `spec.replica_count_modified() or spec.has_revision_changes()`.
3. **Tests** — Added `test_revision_change_marks_check_replica` and updated mock fixtures.

## Test plan
- [x] `test_revision_change_marks_check_replica` — verifies `CHECK_REPLICA` is triggered on revision-level field changes
- [x] `test_replica_count_change_marks_check_replica` — existing test still passes
- [x] `test_no_replica_change_no_marking` — no false positives
- [x] `pants lint/check/test` all pass
- [ ] E2E: update `model-definition.yaml` in vfolder, call `modify_endpoint` with a revision-level field change, verify the new revision contains the updated model definition

Fixes [BA-5687](https://lablup.atlassian.net/browse/BA-5687)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5687]: https://lablup.atlassian.net/browse/BA-5687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ