### PR TITLE
fix(BA-5691): rename TooManyConcurrentLoginSessions error type to active-login-session-exists

### DIFF
--- a/changes/5691.fix.md
+++ b/changes/5691.fix.md
@@ -1,0 +1,1 @@
+Rename `TooManyConcurrentLoginSessions` error type from `too-many-concurrent-logins` to `active-login-session-exists` to match actual error semantics

--- a/src/ai/backend/manager/errors/auth.py
+++ b/src/ai/backend/manager/errors/auth.py
@@ -195,7 +195,7 @@ class LoginClientTypeConflict(BackendAIError, web.HTTPConflict):
 
 
 class TooManyConcurrentLoginSessions(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/too-many-concurrent-logins"
+    error_type = "https://api.backend.ai/probs/active-login-session-exists"
     error_title = "Too many concurrent login sessions for this user."
 
     def error_code(self) -> ErrorCode:


### PR DESCRIPTION
## Summary
- Rename `TooManyConcurrentLoginSessions` error_type from `too-many-concurrent-logins` to `active-login-session-exists` to accurately reflect the error condition
- The previous name implied rate-limiting, but the actual semantics is that an active login session already exists

## Test plan
- [ ] Existing unit tests pass (`tests/unit/manager/services/auth/test_max_concurrent_logins.py`)
- [ ] Verify WebUI handles the new error type correctly

Fixes [BA-5691](https://lablup.atlassian.net/browse/BA-5691)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5691]: https://lablup.atlassian.net/browse/BA-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ