### PR TITLE
fix(BA-5690): read sToken from hook params before falling back to cookies

### DIFF
--- a/changes/11002.fix.md
+++ b/changes/11002.fix.md
@@ -1,0 +1,1 @@
+Fix OIDC AUTHORIZE hook to read sToken from hook params before falling back to cookies, enabling token-login flow via JSON body.

--- a/src/ai/backend/manager/plugin/openid/hook.py
+++ b/src/ai/backend/manager/plugin/openid/hook.py
@@ -58,10 +58,10 @@ class OIDCHookPlugin(HookPlugin):
         db = root_app["_db"]
         secret = self._config.secret
 
-        stoken = request.cookies.get("sToken")
+        stoken = params.get("stoken") or params.get("sToken") or request.cookies.get("sToken")
         if not stoken:
             log.debug(
-                "AUTHORIZE_HOOK(openid): no auth cookie found. proceeded with normal auth steps"
+                "AUTHORIZE_HOOK(openid): no sToken found in params or cookies. proceeded with normal auth steps"
             )
             return None
         try:

--- a/tests/component/openid/test_hook.py
+++ b/tests/component/openid/test_hook.py
@@ -132,6 +132,63 @@ class TestOIDCHookPreAuth:
         with pytest.raises(Reject, match="user is inactivated"):
             await hook_plugin.pre_auth_hook(request_with_inactive_user_stoken, {})
 
+    # -----------------------------------------------------------------------
+    # Tests — sToken via params (token-login flow)
+    # -----------------------------------------------------------------------
+
+    async def test_stoken_in_params_authenticates(
+        self,
+        hook_plugin: OIDCHookPlugin,
+        request_without_stoken: MagicMock,
+        active_user_uuid: uuid.UUID,
+        make_stoken: Callable[..., str],
+    ) -> None:
+        stoken = make_stoken(active_user_uuid, "alice@example.com")
+        params: dict[str, Any] = {"sToken": stoken}
+        raw_result: Any = await hook_plugin.pre_auth_hook(request_without_stoken, params)
+        assert raw_result is not None
+        assert raw_result["email"] == "alice@example.com"
+        assert raw_result["status"] == UserStatus.ACTIVE
+
+    async def test_stoken_lowercase_key_in_params_authenticates(
+        self,
+        hook_plugin: OIDCHookPlugin,
+        request_without_stoken: MagicMock,
+        active_user_uuid: uuid.UUID,
+        make_stoken: Callable[..., str],
+    ) -> None:
+        stoken = make_stoken(active_user_uuid, "alice@example.com")
+        params: dict[str, Any] = {"stoken": stoken}
+        raw_result: Any = await hook_plugin.pre_auth_hook(request_without_stoken, params)
+        assert raw_result is not None
+        assert raw_result["email"] == "alice@example.com"
+
+    async def test_expired_stoken_in_params_rejects(
+        self,
+        hook_plugin: OIDCHookPlugin,
+        request_without_stoken: MagicMock,
+        make_stoken: Callable[..., str],
+    ) -> None:
+        stoken = make_stoken(uuid.uuid4(), "alice@example.com", expired=True)
+        params: dict[str, Any] = {"sToken": stoken}
+        with pytest.raises(Reject, match="Expired authentication token"):
+            await hook_plugin.pre_auth_hook(request_without_stoken, params)
+
+    async def test_invalid_stoken_in_params_rejects(
+        self,
+        hook_plugin: OIDCHookPlugin,
+        request_without_stoken: MagicMock,
+    ) -> None:
+        now = int(time.time())
+        stoken = pyjwt.encode(
+            {"user": str(uuid.uuid4()), "email": "x@x.com", "exp": now + 3600},
+            "wrong-secret",
+            algorithm="HS256",
+        )
+        params: dict[str, Any] = {"sToken": stoken}
+        with pytest.raises(Reject, match="Invalid authentication token"):
+            await hook_plugin.pre_auth_hook(request_without_stoken, params)
+
 
 # ===========================================================================
 # TestOIDCHookLifecycle


### PR DESCRIPTION
## Summary
- OIDC AUTHORIZE hook (`openid/hook.py`) only read `sToken` from `request.cookies`, ignoring the `params` argument from the hook dispatcher
- In the token-login flow, `sToken` arrives via JSON body/params (not cookies), causing authentication to silently fail and fall through to password auth
- Now reads from `params` first (`stoken` / `sToken` keys), with cookie as fallback for the legacy path — consistent with TOTP hook behavior

## Test plan
- [x] `test_stoken_in_params_authenticates` — sToken via params (camelCase key)
- [x] `test_stoken_lowercase_key_in_params_authenticates` — sToken via params (lowercase key)
- [x] `test_expired_stoken_in_params_rejects` — expired token in params → Reject
- [x] `test_invalid_stoken_in_params_rejects` — wrong-secret token in params → Reject
- [x] Existing cookie-based tests still pass (legacy path)

Resolves BA-5690