### PR TITLE
fix(BA-5693): add missing container.show() in cuda_open gather_container_measures

### DIFF
--- a/changes/11006.fix.md
+++ b/changes/11006.fix.md
@@ -1,0 +1,1 @@
+Fix per-container CUDA metric collection failing due to missing `container.show()` call in `gather_container_measures`

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -282,7 +282,11 @@ class CUDAPlugin(AbstractComputePlugin):
 
                 async with aiodocker.Docker() as docker:
                     for cid in container_ids:
-                        container_info = await docker.containers.get(cid)
+                        try:
+                            container = await docker.containers.get(cid)
+                            container_info = await container.show()
+                        except DockerError:
+                            continue
                         nvidia_device_reqs = [
                             x
                             for x in container_info.get("HostConfig", {}).get("DeviceRequests", [])

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -285,7 +285,12 @@ class CUDAPlugin(AbstractComputePlugin):
                         try:
                             container = await docker.containers.get(cid)
                             container_info = await container.show()
-                        except DockerError:
+                        except DockerError as e:
+                            log.warning(
+                                "gather_container_measures(): container {} skipped: {!r}",
+                                cid,
+                                e,
+                            )
                             continue
                         nvidia_device_reqs = [
                             x

--- a/tests/unit/accelerator/cuda_open/BUILD
+++ b/tests/unit/accelerator/cuda_open/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/accelerator/cuda_open/test_gather_container_measures.py
+++ b/tests/unit/accelerator/cuda_open/test_gather_container_measures.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiodocker.exceptions import DockerError
+
+from ai.backend.accelerator.cuda_open.plugin import CUDAPlugin
+from ai.backend.agent.stats import StatModes
+from ai.backend.common.types import MetricKey
+
+
+@dataclass
+class FakeDeviceStat:
+    mem_used: int
+    mem_total: int
+    gpu_util: int
+
+
+class TestGatherContainerMeasures:
+    """Tests for CUDAPlugin.gather_container_measures (BA-5693 regression)."""
+
+    @pytest.fixture
+    def cuda_plugin(self) -> CUDAPlugin:
+        plugin = CUDAPlugin.__new__(CUDAPlugin)
+        plugin.plugin_config = {}
+        plugin.local_config = {}
+        plugin.enabled = True
+        plugin.device_mask = []
+        return plugin
+
+    @pytest.fixture
+    def stat_context(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.mode = StatModes.DOCKER
+        return ctx
+
+    @pytest.fixture
+    def mock_libnvml(self) -> MagicMock:
+        nvml = MagicMock()
+        nvml.get_device_count.return_value = 2
+        nvml.get_device_stats.side_effect = lambda dev_id: FakeDeviceStat(
+            mem_used=1024 * 1024 * 512,
+            mem_total=1024 * 1024 * 1024 * 8,
+            gpu_util=45,
+        )
+        return nvml
+
+    def _make_container_info(self, device_ids: list[str]) -> dict[str, Any]:
+        return {
+            "HostConfig": {
+                "DeviceRequests": [
+                    {
+                        "Driver": "nvidia",
+                        "DeviceIDs": device_ids,
+                        "Capabilities": [["utility", "compute"]],
+                    },
+                ],
+            },
+        }
+
+    async def test_container_show_is_called(
+        self,
+        cuda_plugin: CUDAPlugin,
+        stat_context: MagicMock,
+        mock_libnvml: MagicMock,
+    ) -> None:
+        """container.show() must be called to get the inspect dict (BA-5693)."""
+        mock_container = AsyncMock()
+        mock_container.show.return_value = self._make_container_info(["0"])
+
+        mock_docker = AsyncMock()
+        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
+        mock_docker.__aexit__ = AsyncMock(return_value=False)
+        mock_docker.containers.get.return_value = mock_container
+
+        with (
+            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
+            patch(
+                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
+            ),
+        ):
+            results = await cuda_plugin.gather_container_measures(stat_context, ["container_001"])
+
+        mock_docker.containers.get.assert_called_once_with("container_001")
+        mock_container.show.assert_called_once()
+
+        cuda_mem, cuda_util = results
+        assert cuda_mem.key == MetricKey("cuda_mem")
+        assert cuda_util.key == MetricKey("cuda_util")
+        assert "container_001" in cuda_mem.per_container
+        assert cuda_mem.per_container["container_001"].value == Decimal(1024 * 1024 * 512)
+
+    async def test_docker_error_skips_container(
+        self,
+        cuda_plugin: CUDAPlugin,
+        stat_context: MagicMock,
+        mock_libnvml: MagicMock,
+    ) -> None:
+        """DockerError on a vanished container should be skipped, not crash the loop."""
+        mock_good_container = AsyncMock()
+        mock_good_container.show.return_value = self._make_container_info(["0"])
+
+        mock_docker = AsyncMock()
+        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
+        mock_docker.__aexit__ = AsyncMock(return_value=False)
+        mock_docker.containers.get.side_effect = [
+            DockerError(status=404, data={"message": "No such container"}),
+            mock_good_container,
+        ]
+
+        with (
+            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
+            patch(
+                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
+            ),
+        ):
+            results = await cuda_plugin.gather_container_measures(
+                stat_context, ["vanished_cid", "good_cid"]
+            )
+
+        cuda_mem, cuda_util = results
+        assert "vanished_cid" not in cuda_mem.per_container
+        assert "good_cid" in cuda_mem.per_container
+
+    async def test_multi_gpu_container(
+        self,
+        cuda_plugin: CUDAPlugin,
+        stat_context: MagicMock,
+        mock_libnvml: MagicMock,
+    ) -> None:
+        """Container with multiple GPUs should aggregate metrics from all devices."""
+        mock_container = AsyncMock()
+        mock_container.show.return_value = self._make_container_info(["0", "1"])
+
+        mock_docker = AsyncMock()
+        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
+        mock_docker.__aexit__ = AsyncMock(return_value=False)
+        mock_docker.containers.get.return_value = mock_container
+
+        with (
+            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
+            patch(
+                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
+            ),
+        ):
+            results = await cuda_plugin.gather_container_measures(stat_context, ["multi_gpu_cid"])
+
+        cuda_mem, cuda_util = results
+        mem = cuda_mem.per_container["multi_gpu_cid"]
+        assert mem.value == Decimal(1024 * 1024 * 512 * 2)
+        assert mem.capacity == Decimal(1024 * 1024 * 1024 * 8 * 2)
+        util = cuda_util.per_container["multi_gpu_cid"]
+        assert util.value == Decimal(45 * 2)
+        assert util.capacity == Decimal(200)
+
+    async def test_no_nvidia_device_requests(
+        self,
+        cuda_plugin: CUDAPlugin,
+        stat_context: MagicMock,
+        mock_libnvml: MagicMock,
+    ) -> None:
+        """Container without nvidia DeviceRequests should be skipped."""
+        mock_container = AsyncMock()
+        mock_container.show.return_value = {"HostConfig": {"DeviceRequests": []}}
+
+        mock_docker = AsyncMock()
+        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
+        mock_docker.__aexit__ = AsyncMock(return_value=False)
+        mock_docker.containers.get.return_value = mock_container
+
+        with (
+            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
+            patch(
+                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
+            ),
+        ):
+            results = await cuda_plugin.gather_container_measures(stat_context, ["no_gpu_cid"])
+
+        cuda_mem, _ = results
+        assert "no_gpu_cid" not in cuda_mem.per_container
+
+    async def test_disabled_plugin_returns_empty(
+        self,
+        cuda_plugin: CUDAPlugin,
+        stat_context: MagicMock,
+    ) -> None:
+        """Disabled plugin should return empty measurements without querying Docker."""
+        cuda_plugin.enabled = False
+        results = await cuda_plugin.gather_container_measures(stat_context, ["any_cid"])
+
+        cuda_mem, cuda_util = results
+        assert len(cuda_mem.per_container) == 0
+        assert len(cuda_util.per_container) == 0

--- a/tests/unit/accelerator/cuda_open/test_gather_container_measures.py
+++ b/tests/unit/accelerator/cuda_open/test_gather_container_measures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
@@ -18,6 +19,33 @@ class FakeDeviceStat:
     mem_used: int
     mem_total: int
     gpu_util: int
+
+
+def _make_container_info(device_ids: list[str]) -> dict[str, Any]:
+    return {
+        "HostConfig": {
+            "DeviceRequests": [
+                {
+                    "Driver": "nvidia",
+                    "DeviceIDs": device_ids,
+                    "Capabilities": [["utility", "compute"]],
+                },
+            ],
+        },
+    }
+
+
+def _make_mock_docker() -> AsyncMock:
+    mock = AsyncMock()
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+def _make_mock_container(container_info: dict[str, Any]) -> AsyncMock:
+    mock = AsyncMock()
+    mock.show.return_value = container_info
+    return mock
 
 
 class TestGatherContainerMeasures:
@@ -49,44 +77,52 @@ class TestGatherContainerMeasures:
         )
         return nvml
 
-    def _make_container_info(self, device_ids: list[str]) -> dict[str, Any]:
-        return {
-            "HostConfig": {
-                "DeviceRequests": [
-                    {
-                        "Driver": "nvidia",
-                        "DeviceIDs": device_ids,
-                        "Capabilities": [["utility", "compute"]],
-                    },
-                ],
-            },
-        }
+    @pytest.fixture
+    def mock_docker(self) -> AsyncMock:
+        return _make_mock_docker()
+
+    @pytest.fixture
+    def single_gpu_container(self) -> AsyncMock:
+        return _make_mock_container(_make_container_info(["0"]))
+
+    @pytest.fixture
+    def multi_gpu_container(self) -> AsyncMock:
+        return _make_mock_container(_make_container_info(["0", "1"]))
+
+    @pytest.fixture
+    def no_gpu_container(self) -> AsyncMock:
+        return _make_mock_container({"HostConfig": {"DeviceRequests": []}})
+
+    @pytest.fixture
+    def patched_env(
+        self,
+        mock_libnvml: MagicMock,
+        mock_docker: AsyncMock,
+    ) -> Iterator[None]:
+        with (
+            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
+            patch(
+                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker",
+                return_value=mock_docker,
+            ),
+        ):
+            yield
 
     async def test_container_show_is_called(
         self,
         cuda_plugin: CUDAPlugin,
         stat_context: MagicMock,
-        mock_libnvml: MagicMock,
+        mock_docker: AsyncMock,
+        single_gpu_container: AsyncMock,
+        patched_env: None,
     ) -> None:
         """container.show() must be called to get the inspect dict (BA-5693)."""
-        mock_container = AsyncMock()
-        mock_container.show.return_value = self._make_container_info(["0"])
+        mock_docker.containers.get.return_value = single_gpu_container
 
-        mock_docker = AsyncMock()
-        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
-        mock_docker.__aexit__ = AsyncMock(return_value=False)
-        mock_docker.containers.get.return_value = mock_container
-
-        with (
-            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
-            patch(
-                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
-            ),
-        ):
-            results = await cuda_plugin.gather_container_measures(stat_context, ["container_001"])
+        results = await cuda_plugin.gather_container_measures(stat_context, ["container_001"])
 
         mock_docker.containers.get.assert_called_once_with("container_001")
-        mock_container.show.assert_called_once()
+        single_gpu_container.show.assert_called_once()
 
         cuda_mem, cuda_util = results
         assert cuda_mem.key == MetricKey("cuda_mem")
@@ -98,29 +134,19 @@ class TestGatherContainerMeasures:
         self,
         cuda_plugin: CUDAPlugin,
         stat_context: MagicMock,
-        mock_libnvml: MagicMock,
+        mock_docker: AsyncMock,
+        single_gpu_container: AsyncMock,
+        patched_env: None,
     ) -> None:
         """DockerError on a vanished container should be skipped, not crash the loop."""
-        mock_good_container = AsyncMock()
-        mock_good_container.show.return_value = self._make_container_info(["0"])
-
-        mock_docker = AsyncMock()
-        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
-        mock_docker.__aexit__ = AsyncMock(return_value=False)
         mock_docker.containers.get.side_effect = [
             DockerError(status=404, data={"message": "No such container"}),
-            mock_good_container,
+            single_gpu_container,
         ]
 
-        with (
-            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
-            patch(
-                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
-            ),
-        ):
-            results = await cuda_plugin.gather_container_measures(
-                stat_context, ["vanished_cid", "good_cid"]
-            )
+        results = await cuda_plugin.gather_container_measures(
+            stat_context, ["vanished_cid", "good_cid"]
+        )
 
         cuda_mem, cuda_util = results
         assert "vanished_cid" not in cuda_mem.per_container
@@ -130,24 +156,14 @@ class TestGatherContainerMeasures:
         self,
         cuda_plugin: CUDAPlugin,
         stat_context: MagicMock,
-        mock_libnvml: MagicMock,
+        mock_docker: AsyncMock,
+        multi_gpu_container: AsyncMock,
+        patched_env: None,
     ) -> None:
         """Container with multiple GPUs should aggregate metrics from all devices."""
-        mock_container = AsyncMock()
-        mock_container.show.return_value = self._make_container_info(["0", "1"])
+        mock_docker.containers.get.return_value = multi_gpu_container
 
-        mock_docker = AsyncMock()
-        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
-        mock_docker.__aexit__ = AsyncMock(return_value=False)
-        mock_docker.containers.get.return_value = mock_container
-
-        with (
-            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
-            patch(
-                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
-            ),
-        ):
-            results = await cuda_plugin.gather_container_measures(stat_context, ["multi_gpu_cid"])
+        results = await cuda_plugin.gather_container_measures(stat_context, ["multi_gpu_cid"])
 
         cuda_mem, cuda_util = results
         mem = cuda_mem.per_container["multi_gpu_cid"]
@@ -161,24 +177,14 @@ class TestGatherContainerMeasures:
         self,
         cuda_plugin: CUDAPlugin,
         stat_context: MagicMock,
-        mock_libnvml: MagicMock,
+        mock_docker: AsyncMock,
+        no_gpu_container: AsyncMock,
+        patched_env: None,
     ) -> None:
         """Container without nvidia DeviceRequests should be skipped."""
-        mock_container = AsyncMock()
-        mock_container.show.return_value = {"HostConfig": {"DeviceRequests": []}}
+        mock_docker.containers.get.return_value = no_gpu_container
 
-        mock_docker = AsyncMock()
-        mock_docker.__aenter__ = AsyncMock(return_value=mock_docker)
-        mock_docker.__aexit__ = AsyncMock(return_value=False)
-        mock_docker.containers.get.return_value = mock_container
-
-        with (
-            patch("ai.backend.accelerator.cuda_open.plugin.libnvml", mock_libnvml),
-            patch(
-                "ai.backend.accelerator.cuda_open.plugin.aiodocker.Docker", return_value=mock_docker
-            ),
-        ):
-            results = await cuda_plugin.gather_container_measures(stat_context, ["no_gpu_cid"])
+        results = await cuda_plugin.gather_container_measures(stat_context, ["no_gpu_cid"])
 
         cuda_mem, _ = results
         assert "no_gpu_cid" not in cuda_mem.per_container
@@ -190,6 +196,7 @@ class TestGatherContainerMeasures:
     ) -> None:
         """Disabled plugin should return empty measurements without querying Docker."""
         cuda_plugin.enabled = False
+
         results = await cuda_plugin.gather_container_measures(stat_context, ["any_cid"])
 
         cuda_mem, cuda_util = results


### PR DESCRIPTION
## Summary

- `docker.containers.get(cid)` returns a `DockerContainer` object, not a dict — calling `.get("HostConfig")` on it raises `AttributeError`
- Added `await container.show()` to get the inspect dict before accessing `HostConfig`/`DeviceRequests`
- Added `DockerError` guard per-container so a vanished container doesn't break the entire metric collection loop

Regression from PR #9787 (BA-4944).

## Test plan

- [ ] Verify `pants check` passes (mypy)
- [ ] Deploy on a GPU node and confirm per-container CUDA metrics are collected
- [ ] Kill a container mid-collection and confirm the loop continues for remaining containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)