### PR TITLE
fix(BA-5674): remove duplicate /func/ prefix from session GQL path

### DIFF
--- a/changes/11007.fix.md
+++ b/changes/11007.fix.md
@@ -1,0 +1,1 @@
+Fix double /func/ prefix in session-mode GQL path causing HTTP 404

--- a/src/ai/backend/client/v2/domains_v2/gql.py
+++ b/src/ai/backend/client/v2/domains_v2/gql.py
@@ -6,7 +6,7 @@ from typing import Any, Final
 
 from ai.backend.client.v2.base_domain import BaseDomainClient
 
-_GQL_PATH_SESSION: Final = "/func/admin/gql"
+_GQL_PATH_SESSION: Final = "/admin/gql"
 _GQL_PATH_API_LEGACY: Final = "/admin/gql"
 _GQL_PATH_API_V2: Final = "/admin/gql/strawberry"
 

--- a/tests/unit/client/v2/test_gql_client.py
+++ b/tests/unit/client/v2/test_gql_client.py
@@ -12,45 +12,49 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.domains_v2.gql import V2GQLClient
 
 
-@pytest.fixture
-def session_config() -> ClientConfig:
-    return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="session")
-
-
-@pytest.fixture
-def api_config() -> ClientConfig:
-    return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="api")
-
-
-def _make_gql_client(config: ClientConfig) -> V2GQLClient:
-    mock_client = MagicMock(spec=BackendAIAuthClient)
-    mock_client._config = config
-    return V2GQLClient(mock_client)
-
-
 class TestV2GQLClientPath:
     """Verify _gql_path() x _build_url() produce correct final URLs."""
 
-    def test_session_v2_url(self, session_config: ClientConfig) -> None:
-        gql = _make_gql_client(session_config)
-        path = gql._gql_path(v2=True)
+    @pytest.fixture
+    def session_config(self) -> ClientConfig:
+        return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="session")
+
+    @pytest.fixture
+    def api_config(self) -> ClientConfig:
+        return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="api")
+
+    @pytest.fixture
+    def session_gql_client(self, session_config: ClientConfig) -> V2GQLClient:
+        mock_client = MagicMock(spec=BackendAIAuthClient)
+        mock_client._config = session_config
+        return V2GQLClient(mock_client)
+
+    @pytest.fixture
+    def api_gql_client(self, api_config: ClientConfig) -> V2GQLClient:
+        mock_client = MagicMock(spec=BackendAIAuthClient)
+        mock_client._config = api_config
+        return V2GQLClient(mock_client)
+
+    def test_session_v2_url(
+        self, session_config: ClientConfig, session_gql_client: V2GQLClient
+    ) -> None:
+        path = session_gql_client._gql_path(v2=True)
         url = BackendAIAuthClient._build_url(MagicMock(_config=session_config), path)
         assert url == "http://localhost:8090/func/admin/gql"
 
-    def test_session_legacy_url(self, session_config: ClientConfig) -> None:
-        gql = _make_gql_client(session_config)
-        path = gql._gql_path(v2=False)
+    def test_session_legacy_url(
+        self, session_config: ClientConfig, session_gql_client: V2GQLClient
+    ) -> None:
+        path = session_gql_client._gql_path(v2=False)
         url = BackendAIAuthClient._build_url(MagicMock(_config=session_config), path)
         assert url == "http://localhost:8090/func/admin/gql"
 
-    def test_api_v2_url(self, api_config: ClientConfig) -> None:
-        gql = _make_gql_client(api_config)
-        path = gql._gql_path(v2=True)
+    def test_api_v2_url(self, api_config: ClientConfig, api_gql_client: V2GQLClient) -> None:
+        path = api_gql_client._gql_path(v2=True)
         url = BackendAIAuthClient._build_url(MagicMock(_config=api_config), path)
         assert url == "http://localhost:8090/admin/gql/strawberry"
 
-    def test_api_legacy_url(self, api_config: ClientConfig) -> None:
-        gql = _make_gql_client(api_config)
-        path = gql._gql_path(v2=False)
+    def test_api_legacy_url(self, api_config: ClientConfig, api_gql_client: V2GQLClient) -> None:
+        path = api_gql_client._gql_path(v2=False)
         url = BackendAIAuthClient._build_url(MagicMock(_config=api_config), path)
         assert url == "http://localhost:8090/admin/gql"

--- a/tests/unit/client/v2/test_gql_client.py
+++ b/tests/unit/client/v2/test_gql_client.py
@@ -1,0 +1,56 @@
+"""Tests for V2GQLClient._gql_path() and URL construction."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from yarl import URL
+
+from ai.backend.client.v2.base_client import BackendAIAuthClient
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.domains_v2.gql import V2GQLClient
+
+
+@pytest.fixture
+def session_config() -> ClientConfig:
+    return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="session")
+
+
+@pytest.fixture
+def api_config() -> ClientConfig:
+    return ClientConfig(endpoint=URL("http://localhost:8090"), endpoint_type="api")
+
+
+def _make_gql_client(config: ClientConfig) -> V2GQLClient:
+    mock_client = MagicMock(spec=BackendAIAuthClient)
+    mock_client._config = config
+    return V2GQLClient(mock_client)
+
+
+class TestV2GQLClientPath:
+    """Verify _gql_path() x _build_url() produce correct final URLs."""
+
+    def test_session_v2_url(self, session_config: ClientConfig) -> None:
+        gql = _make_gql_client(session_config)
+        path = gql._gql_path(v2=True)
+        url = BackendAIAuthClient._build_url(MagicMock(_config=session_config), path)
+        assert url == "http://localhost:8090/func/admin/gql"
+
+    def test_session_legacy_url(self, session_config: ClientConfig) -> None:
+        gql = _make_gql_client(session_config)
+        path = gql._gql_path(v2=False)
+        url = BackendAIAuthClient._build_url(MagicMock(_config=session_config), path)
+        assert url == "http://localhost:8090/func/admin/gql"
+
+    def test_api_v2_url(self, api_config: ClientConfig) -> None:
+        gql = _make_gql_client(api_config)
+        path = gql._gql_path(v2=True)
+        url = BackendAIAuthClient._build_url(MagicMock(_config=api_config), path)
+        assert url == "http://localhost:8090/admin/gql/strawberry"
+
+    def test_api_legacy_url(self, api_config: ClientConfig) -> None:
+        gql = _make_gql_client(api_config)
+        path = gql._gql_path(v2=False)
+        url = BackendAIAuthClient._build_url(MagicMock(_config=api_config), path)
+        assert url == "http://localhost:8090/admin/gql"


### PR DESCRIPTION
## Summary
- Fix double `/func/` prefix in session-mode GQL URL (`/func/func/admin/gql` → `/func/admin/gql`)
- `_GQL_PATH_SESSION` incorrectly included `/func/` which `_build_url()` already prepends in session mode
- Add unit tests covering all 4 combinations of `endpoint_type × v2` flag

## Test plan
- [x] `pants test tests/unit/client/v2/test_gql_client.py` — all 4 cases pass
- [x] `pants lint` / `pants check` — clean
- [ ] `./bai gql --v2 '{ ... }'` against webserver (session mode) returns valid response
- [ ] `./bai gql '{ ... }'` (legacy) still works — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)