### PR TITLE
feat: add user_id filter and admin_unblock_user for login sessions

### DIFF
--- a/changes/11011.feature.md
+++ b/changes/11011.feature.md
@@ -1,0 +1,1 @@
+Add `user_id` filter to login session admin search and `admin_unblock_user` API to clear failed-login rate limit blocks

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7961,6 +7961,7 @@ type LoginHistoryV2Edge
 input LoginSessionFilter
   @join__type(graph: STRAWBERRY)
 {
+  userId: UUIDFilter = null
   status: LoginSessionStatusFilter = null
   accessKey: StringFilter = null
   createdAt: DateTimeFilter = null
@@ -10285,6 +10286,11 @@ type Mutation
 
   """Added in 26.4.1. Revoke a login session owned by the current user."""
   myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.1. Clear the failed-login rate limit block for a user. (admin only)
+  """
+  adminUnblockUser(username: String!): UnblockUserPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention)
@@ -16326,6 +16332,16 @@ type UnassignUsersFromProjectPayload
 
   """List of errors for users that could not be unassigned."""
   failed: [UnassignUserError!]!
+}
+
+"""
+Added in 26.4.1. Payload returned after clearing a user's failed-login block.
+"""
+type UnblockUserPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Whether the unblock was successful"""
+  success: Boolean!
 }
 
 type UnloadImage

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5002,6 +5002,7 @@ type LoginHistoryV2Edge {
 
 """Added in 26.4.1. Filter criteria for querying login sessions."""
 input LoginSessionFilter {
+  userId: UUIDFilter = null
   status: LoginSessionStatusFilter = null
   accessKey: StringFilter = null
   createdAt: DateTimeFilter = null
@@ -6308,6 +6309,11 @@ type Mutation {
 
   """Added in 26.4.1. Revoke a login session owned by the current user."""
   myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload!
+
+  """
+  Added in 26.4.1. Clear the failed-login rate limit block for a user. (admin only)
+  """
+  adminUnblockUser(username: String!): UnblockUserPayload!
 
   """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention)
@@ -10833,6 +10839,14 @@ type UnassignUsersFromProjectPayload {
 
   """List of errors for users that could not be unassigned."""
   failed: [UnassignUserError!]!
+}
+
+"""
+Added in 26.4.1. Payload returned after clearing a user's failed-login block.
+"""
+type UnblockUserPayload {
+  """Whether the unblock was successful"""
+  success: Boolean!
 }
 
 """Added in 25.15.0. Input type for unregistering a storage namespace."""

--- a/src/ai/backend/common/clients/valkey_client/valkey_session/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_session/client.py
@@ -203,6 +203,17 @@ class ValkeySessionClient:
             )
 
     @valkey_session_resilience.apply()
+    async def clear_login_block(self, username: str) -> None:
+        """
+        Clear the login failure/block history for a user.
+
+        :param username: The username whose block to clear.
+        """
+        key = f"{LOGIN_HISTORY_KEY_PREFIX}{username}"
+        async with self._client.client() as conn:
+            await conn.delete([key])
+
+    @valkey_session_resilience.apply()
     async def flush_all_sessions(self) -> None:
         """
         Flush all data in the current database (typically used for session cleanup).

--- a/src/ai/backend/common/dto/manager/v2/login_session/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/__init__.py
@@ -3,6 +3,7 @@
 from ai.backend.common.dto.manager.v2.login_session.request import (
     AdminRevokeLoginSessionInput,
     AdminSearchLoginSessionsInput,
+    AdminUnblockUserInput,
     LoginSessionFilter,
     LoginSessionOrder,
     LoginSessionStatusFilter,
@@ -14,6 +15,7 @@ from ai.backend.common.dto.manager.v2.login_session.response import (
     LoginSessionNode,
     MySearchLoginSessionsPayload,
     RevokeLoginSessionPayload,
+    UnblockUserPayload,
 )
 from ai.backend.common.dto.manager.v2.login_session.types import (
     LoginSessionOrderField,
@@ -25,6 +27,7 @@ __all__ = (
     "AdminRevokeLoginSessionInput",
     "AdminSearchLoginSessionsInput",
     "AdminSearchLoginSessionsPayload",
+    "AdminUnblockUserInput",
     "LoginSessionFilter",
     "LoginSessionNode",
     "LoginSessionOrder",
@@ -36,4 +39,5 @@ __all__ = (
     "MySearchLoginSessionsPayload",
     "OrderDirection",
     "RevokeLoginSessionPayload",
+    "UnblockUserPayload",
 )

--- a/src/ai/backend/common/dto/manager/v2/login_session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/request.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
 
 from .types import LoginSessionOrderField, LoginSessionStatus, OrderDirection
 
@@ -37,6 +37,7 @@ class LoginSessionStatusFilter(BaseRequestModel):
 class LoginSessionFilter(BaseRequestModel):
     """Filter for login sessions."""
 
+    user_id: UUIDFilter | None = Field(default=None, description="User ID filter")
     status: LoginSessionStatusFilter | None = Field(default=None, description="Status filter")
     access_key: StringFilter | None = Field(default=None, description="Access key filter")
     created_at: DateTimeFilter | None = Field(

--- a/src/ai/backend/common/dto/manager/v2/login_session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/request.py
@@ -14,6 +14,7 @@ from .types import LoginSessionOrderField, LoginSessionStatus, OrderDirection
 __all__ = (
     "AdminRevokeLoginSessionInput",
     "AdminSearchLoginSessionsInput",
+    "AdminUnblockUserInput",
     "LoginSessionFilter",
     "LoginSessionOrder",
     "LoginSessionStatusFilter",
@@ -103,3 +104,9 @@ class AdminRevokeLoginSessionInput(BaseRequestModel):
     """Input for revoking a login session (admin)."""
 
     session_id: UUID = Field(description="ID of the login session to revoke")
+
+
+class AdminUnblockUserInput(BaseRequestModel):
+    """Input for clearing the failed-login rate limit block for a user (admin)."""
+
+    username: str = Field(description="Username of the user to unblock")

--- a/src/ai/backend/common/dto/manager/v2/login_session/response.py
+++ b/src/ai/backend/common/dto/manager/v2/login_session/response.py
@@ -16,6 +16,7 @@ __all__ = (
     "LoginSessionNode",
     "MySearchLoginSessionsPayload",
     "RevokeLoginSessionPayload",
+    "UnblockUserPayload",
 )
 
 
@@ -57,3 +58,9 @@ class RevokeLoginSessionPayload(BaseResponseModel):
     """Payload for login session revocation result."""
 
     success: bool = Field(description="Whether the revocation was successful")
+
+
+class UnblockUserPayload(BaseResponseModel):
+    """Payload returned after clearing a user's failed-login block."""
+
+    success: bool = Field(description="Whether the unblock was successful")

--- a/src/ai/backend/manager/api/adapters/login_session.py
+++ b/src/ai/backend/manager/api/adapters/login_session.py
@@ -141,6 +141,13 @@ class LoginSessionAdapter(BaseAdapter):
 
     def _convert_filter(self, f: LoginSessionFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
+        if f.user_id is not None:
+            condition = f.user_id.build_query_condition(
+                equals_factory=LoginSessionConditions.by_user_id_equals,
+                in_factory=LoginSessionConditions.by_user_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
         if f.status is not None:
             self._apply_status_filter(f.status, conditions)
         if f.access_key is not None:

--- a/src/ai/backend/manager/api/adapters/login_session.py
+++ b/src/ai/backend/manager/api/adapters/login_session.py
@@ -6,6 +6,7 @@ from ai.backend.common.contexts.user import current_user
 from ai.backend.common.dto.manager.v2.login_session.request import (
     AdminRevokeLoginSessionInput,
     AdminSearchLoginSessionsInput,
+    AdminUnblockUserInput,
     LoginSessionFilter,
     LoginSessionOrder,
     LoginSessionStatusFilter,
@@ -17,6 +18,7 @@ from ai.backend.common.dto.manager.v2.login_session.response import (
     LoginSessionNode,
     MySearchLoginSessionsPayload,
     RevokeLoginSessionPayload,
+    UnblockUserPayload,
 )
 from ai.backend.common.dto.manager.v2.login_session.types import (
     LoginSessionOrderField,
@@ -42,6 +44,7 @@ from ai.backend.manager.services.auth.actions.search_login_sessions import (
     AdminSearchLoginSessionsAction,
     SearchLoginSessionsAction,
 )
+from ai.backend.manager.services.auth.actions.unblock_user import AdminUnblockUserAction
 
 from .base import BaseAdapter
 from .pagination import PaginationSpec
@@ -138,6 +141,13 @@ class LoginSessionAdapter(BaseAdapter):
             )
         )
         return RevokeLoginSessionPayload(success=action_result.success)
+
+    async def admin_unblock_user(self, input: AdminUnblockUserInput) -> UnblockUserPayload:
+        """Clear the failed-login rate limit block for a user (admin only)."""
+        action_result = await self._processors.auth.admin_unblock_user.wait_for_complete(
+            AdminUnblockUserAction(username=input.username)
+        )
+        return UnblockUserPayload(success=action_result.success)
 
     def _convert_filter(self, f: LoginSessionFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/src/ai/backend/manager/api/gql/login_session/__init__.py
+++ b/src/ai/backend/manager/api/gql/login_session/__init__.py
@@ -3,6 +3,7 @@
 from .resolver import (
     admin_login_sessions_v2,
     admin_revoke_login_session,
+    admin_unblock_user,
     my_login_sessions_v2,
     my_revoke_login_session,
 )
@@ -10,6 +11,7 @@ from .resolver import (
 __all__ = [
     "admin_login_sessions_v2",
     "admin_revoke_login_session",
+    "admin_unblock_user",
     "my_login_sessions_v2",
     "my_revoke_login_session",
 ]

--- a/src/ai/backend/manager/api/gql/login_session/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/login_session/resolver/__init__.py
@@ -1,6 +1,7 @@
 from .query import (
     admin_login_sessions_v2,
     admin_revoke_login_session,
+    admin_unblock_user,
     my_login_sessions_v2,
     my_revoke_login_session,
 )
@@ -8,6 +9,7 @@ from .query import (
 __all__ = [
     "admin_login_sessions_v2",
     "admin_revoke_login_session",
+    "admin_unblock_user",
     "my_login_sessions_v2",
     "my_revoke_login_session",
 ]

--- a/src/ai/backend/manager/api/gql/login_session/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/login_session/resolver/query.py
@@ -10,6 +10,7 @@ from strawberry import Info
 from ai.backend.common.dto.manager.v2.login_session.request import (
     AdminRevokeLoginSessionInput,
     AdminSearchLoginSessionsInput,
+    AdminUnblockUserInput,
     MyRevokeLoginSessionInput,
     MySearchLoginSessionsInput,
 )
@@ -27,6 +28,7 @@ from ai.backend.manager.api.gql.login_session.types import (
     LoginSessionV2EdgeGQL,
     LoginSessionV2GQL,
     RevokeLoginSessionPayloadGQL,
+    UnblockUserPayloadGQL,
 )
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
@@ -150,3 +152,20 @@ async def my_revoke_login_session(
         MyRevokeLoginSessionInput(session_id=session_id)
     )
     return RevokeLoginSessionPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Clear the failed-login rate limit block for a user. (admin only)",
+    )
+)  # type: ignore[misc]
+async def admin_unblock_user(
+    info: Info[StrawberryGQLContext],
+    username: str,
+) -> UnblockUserPayloadGQL:
+    check_admin_only()
+    payload = await info.context.adapters.login_session.admin_unblock_user(
+        AdminUnblockUserInput(username=username)
+    )
+    return UnblockUserPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/login_session/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/__init__.py
@@ -8,7 +8,7 @@ from .node import (
     LoginSessionV2GQL,
 )
 from .order import LoginSessionOrderByGQL, LoginSessionOrderFieldGQL
-from .payloads import RevokeLoginSessionPayloadGQL
+from .payloads import RevokeLoginSessionPayloadGQL, UnblockUserPayloadGQL
 
 __all__ = [
     "LoginSessionFilterGQL",
@@ -20,4 +20,5 @@ __all__ = [
     "LoginSessionV2EdgeGQL",
     "LoginSessionV2GQL",
     "RevokeLoginSessionPayloadGQL",
+    "UnblockUserPayloadGQL",
 ]

--- a/src/ai/backend/manager/api/gql/login_session/types/filter.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/filter.py
@@ -9,7 +9,7 @@ from ai.backend.common.dto.manager.v2.login_session.request import (
     LoginSessionStatusFilter,
 )
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter
+from ai.backend.manager.api.gql.base import DateTimeFilter, StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_field,
@@ -43,6 +43,7 @@ class LoginSessionStatusFilterGQL(PydanticInputMixin[LoginSessionStatusFilter]):
     name="LoginSessionFilter",
 )
 class LoginSessionFilterGQL(PydanticInputMixin[LoginSessionFilter]):
+    user_id: UUIDFilter | None = None
     status: LoginSessionStatusFilterGQL | None = None
     access_key: StringFilter | None = None
     created_at: DateTimeFilter | None = None

--- a/src/ai/backend/manager/api/gql/login_session/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/payloads.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from ai.backend.common.dto.manager.v2.login_session.response import (
     RevokeLoginSessionPayload as RevokeLoginSessionPayloadDTO,
 )
+from ai.backend.common.dto.manager.v2.login_session.response import (
+    UnblockUserPayload as UnblockUserPayloadDTO,
+)
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -23,4 +26,17 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
     name="RevokeLoginSessionPayload",
 )
 class RevokeLoginSessionPayloadGQL(PydanticOutputMixin[RevokeLoginSessionPayloadDTO]):
+    pass
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload returned after clearing a user's failed-login block.",
+    ),
+    model=UnblockUserPayloadDTO,
+    all_fields=True,
+    name="UnblockUserPayload",
+)
+class UnblockUserPayloadGQL(PydanticOutputMixin[UnblockUserPayloadDTO]):
     pass

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -172,6 +172,7 @@ from .login_history import admin_login_history_v2, my_login_history_v2
 from .login_session import (
     admin_login_sessions_v2,
     admin_revoke_login_session,
+    admin_unblock_user,
     my_login_sessions_v2,
     my_revoke_login_session,
 )
@@ -763,6 +764,7 @@ class Mutation:
     # Login session mutations
     admin_revoke_login_session = admin_revoke_login_session
     my_revoke_login_session = my_revoke_login_session
+    admin_unblock_user = admin_unblock_user
     # IP allowlist self-service mutation
     update_my_allowed_client_ip = update_my_allowed_client_ip
     # Prometheus Query Preset - Admin APIs

--- a/src/ai/backend/manager/api/rest/v2/login_session/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/login_session/handler.py
@@ -10,6 +10,7 @@ from ai.backend.common.api_handlers import APIResponse, BodyParam
 from ai.backend.common.dto.manager.v2.login_session.request import (
     AdminRevokeLoginSessionInput,
     AdminSearchLoginSessionsInput,
+    AdminUnblockUserInput,
     MyRevokeLoginSessionInput,
     MySearchLoginSessionsInput,
 )
@@ -57,4 +58,12 @@ class V2LoginSessionHandler:
     ) -> APIResponse:
         """Revoke a login session owned by the current user."""
         result = await self._adapter.my_revoke(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_unblock_user(
+        self,
+        body: BodyParam[AdminUnblockUserInput],
+    ) -> APIResponse:
+        """Clear the failed-login rate limit block for a user (admin only)."""
+        result = await self._adapter.admin_unblock_user(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/login_session/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/login_session/registry.py
@@ -44,5 +44,11 @@ def register_v2_login_session_routes(
         handler.my_revoke,
         middlewares=[auth_required],
     )
+    registry.add(
+        "POST",
+        "/unblock-user",
+        handler.admin_unblock_user,
+        middlewares=[superadmin_required],
+    )
 
     return registry

--- a/src/ai/backend/manager/repositories/auth/options.py
+++ b/src/ai/backend/manager/repositories/auth/options.py
@@ -13,7 +13,11 @@ from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSe
 from ai.backend.manager.repositories.base.types import QueryCondition, QueryOrder
 
 if TYPE_CHECKING:
-    from ai.backend.common.data.filter_specs import StringMatchSpec
+    from ai.backend.common.data.filter_specs import (
+        StringMatchSpec,
+        UUIDEqualMatchSpec,
+        UUIDInMatchSpec,
+    )
 
 
 class LoginSessionConditions:
@@ -23,6 +27,28 @@ class LoginSessionConditions:
     def by_ids(session_ids: Collection[uuid.UUID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return LoginSessionRow.id.in_(session_ids)
+
+        return inner
+
+    # --- user_id UUID filters ---
+
+    @staticmethod
+    def by_user_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = LoginSessionRow.user_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_user_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = LoginSessionRow.user_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/src/ai/backend/manager/services/auth/actions/unblock_user.py
+++ b/src/ai/backend/manager/services/auth/actions/unblock_user.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.auth.actions.base import AuthAction
+
+
+@dataclass
+class AdminUnblockUserAction(AuthAction):
+    username: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return self.username
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.DELETE
+
+
+@dataclass
+class AdminUnblockUserActionResult(BaseActionResult):
+    success: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/auth/processors.py
+++ b/src/ai/backend/manager/services/auth/processors.py
@@ -45,6 +45,10 @@ from ai.backend.manager.services.auth.actions.search_login_sessions import (
 )
 from ai.backend.manager.services.auth.actions.signout import SignoutAction, SignoutActionResult
 from ai.backend.manager.services.auth.actions.signup import SignupAction, SignupActionResult
+from ai.backend.manager.services.auth.actions.unblock_user import (
+    AdminUnblockUserAction,
+    AdminUnblockUserActionResult,
+)
 from ai.backend.manager.services.auth.actions.update_full_name import (
     UpdateFullNameAction,
     UpdateFullNameActionResult,
@@ -100,6 +104,7 @@ class AuthProcessors(AbstractProcessorPackage):
     my_revoke_login_session: ActionProcessor[
         MyRevokeLoginSessionAction, RevokeLoginSessionActionResult
     ]
+    admin_unblock_user: ActionProcessor[AdminUnblockUserAction, AdminUnblockUserActionResult]
 
     def __init__(
         self,
@@ -144,6 +149,7 @@ class AuthProcessors(AbstractProcessorPackage):
         self.my_revoke_login_session = ActionProcessor(
             service.my_revoke_login_session, action_monitors
         )
+        self.admin_unblock_user = ActionProcessor(service.admin_unblock_user, action_monitors)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -167,4 +173,5 @@ class AuthProcessors(AbstractProcessorPackage):
             SearchLoginHistoryAction.spec(),
             AdminRevokeLoginSessionAction.spec(),
             MyRevokeLoginSessionAction.spec(),
+            AdminUnblockUserAction.spec(),
         ]

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -95,6 +95,10 @@ from ai.backend.manager.services.auth.actions.search_login_sessions import (
 )
 from ai.backend.manager.services.auth.actions.signout import SignoutAction, SignoutActionResult
 from ai.backend.manager.services.auth.actions.signup import SignupAction, SignupActionResult
+from ai.backend.manager.services.auth.actions.unblock_user import (
+    AdminUnblockUserAction,
+    AdminUnblockUserActionResult,
+)
 from ai.backend.manager.services.auth.actions.update_full_name import (
     UpdateFullNameAction,
     UpdateFullNameActionResult,
@@ -531,6 +535,12 @@ class AuthService:
         session_token = await self._auth_repository.revoke_login_session(action.session_id)
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
+
+    async def admin_unblock_user(
+        self, action: AdminUnblockUserAction
+    ) -> AdminUnblockUserActionResult:
+        await self._valkey_session_client.clear_login_block(action.username)
+        return AdminUnblockUserActionResult(success=True)
 
     async def signout(self, action: SignoutAction) -> SignoutActionResult:
         if action.email != action.requester_email:


### PR DESCRIPTION
## Summary
- Add `user_id` filter to `LoginSessionFilter` so admins can search login sessions by specific user
- Add `admin_unblock_user` API to clear Valkey-based failed-login rate limit block, enabling admins to immediately unblock users locked out by repeated login failures (previously required waiting for 20-min TTL expiry)

## Endpoints added
- **REST:** `POST /v2/login-sessions/unblock-user` (superadmin only)
- **GQL:** `mutation adminUnblockUser(username: String!) -> UnblockUserPayload`

## Test plan
- [ ] Admin search login sessions with `user_id` filter returns only sessions for the specified user
- [ ] `adminUnblockUser` mutation clears Valkey login block and user can log in again
- [ ] Non-admin users cannot access unblock endpoint (403)
- [ ] Unblock for a user with no active block succeeds gracefully (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)