### PR TITLE
fix(BA-5697): replace ValueError with proper BackendAIError in query_userinfo

### DIFF
--- a/changes/11012.fix.md
+++ b/changes/11012.fix.md
@@ -1,0 +1,1 @@
+Fix 500 Internal Server Error when creating a session with an invalid or non-member project group by replacing plain `ValueError` with proper `BackendAIError` subclasses in `query_userinfo()`.

--- a/src/ai/backend/manager/errors/auth.py
+++ b/src/ai/backend/manager/errors/auth.py
@@ -112,6 +112,17 @@ class UserNotFound(ObjectNotFound):
         )
 
 
+class AccessKeyNotFound(ObjectNotFound):
+    object_name = "access key"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.USER,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
 class GroupMembershipNotFoundError(BackendAIError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/group-membership-not-found"
     error_title = "User is not a member of the specified group."

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -8,7 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from ai.backend.common.types import AccessKey
 
 from .data.user.types import SessionOwnerContext
-from .errors.common import InternalServerError
+from .errors.api import InvalidAPIParameters
+from .errors.common import InternalServerError, ObjectNotFound
 from .models.domain import domains
 from .models.group import association_groups_users as agus
 from .models.group import groups
@@ -135,7 +136,7 @@ async def query_userinfo(
         result = await conn.execute(query)
         row = result.first()
         if row is None:
-            raise ValueError("Unknown owner access key")
+            raise ObjectNotFound("Unknown owner access key", object_name="access key")
         if row.role is None:
             raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name
@@ -172,7 +173,7 @@ async def query_userinfo(
     qresult = await conn.execute(query)
     domain_name = qresult.scalar()
     if domain_name is None:
-        raise ValueError("Invalid domain")
+        raise InvalidAPIParameters(f"Invalid or inactive domain: {owner_domain}")
 
     if isinstance(requesting_group, str):
         group_match_query = groups.c.name == requesting_group
@@ -194,7 +195,7 @@ async def query_userinfo(
     elif role_for_group_resolution == UserRole.ADMIN:
         # domain-admin can spawn container in any group in the same domain.
         if requesting_domain != owner_domain:
-            raise ValueError("You can only set the domain to the owner's domain.")
+            raise InvalidAPIParameters("You can only set the domain to the owner's domain.")
         query = (
             sa.select(groups.c.id)
             .select_from(groups)
@@ -207,7 +208,7 @@ async def query_userinfo(
     else:
         # normal users can spawn containers in their group and domain.
         if requesting_domain != owner_domain:
-            raise ValueError("You can only set the domain to your domain.")
+            raise InvalidAPIParameters("You can only set the domain to your domain.")
         query = (
             sa.select(agus.c.group_id)
             .select_from(agus.join(groups, agus.c.group_id == groups.c.id))
@@ -221,7 +222,10 @@ async def query_userinfo(
         qresult = await conn.execute(query)
         group_id = qresult.scalar()
     if group_id is None:
-        raise ValueError("Invalid group")
+        raise InvalidAPIParameters(
+            f"Invalid group ({requesting_group}): "
+            "the group does not exist, is inactive, or the user is not a member."
+        )
 
     return SessionOwnerContext(
         owner_uuid=owner_uuid,
@@ -254,7 +258,7 @@ async def query_userinfo_from_session(
         result = await db_sess.execute(query)
         row = result.first()
         if row is None:
-            raise ValueError("Unknown owner access key")
+            raise ObjectNotFound("Unknown owner access key", object_name="access key")
         owner_domain = row.domain_name
         owner_role = row.role
         check_if_requester_is_eligible_to_act_as_target_user(
@@ -287,7 +291,7 @@ async def query_userinfo_from_session(
         result = await db_sess.execute(query)
         row = result.first()
         if row is None:
-            raise ValueError("Unknown owner access key")
+            raise ObjectNotFound("Unknown owner access key", object_name="access key")
         if row.role is None:
             raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name
@@ -324,7 +328,7 @@ async def query_userinfo_from_session(
     qresult = await db_sess.execute(query)
     domain_name = qresult.scalar()
     if domain_name is None:
-        raise ValueError("Invalid domain")
+        raise InvalidAPIParameters(f"Invalid or inactive domain: {owner_domain}")
 
     if isinstance(requesting_group, str):
         group_match_query = groups.c.name == requesting_group
@@ -346,7 +350,7 @@ async def query_userinfo_from_session(
     elif role_for_group_resolution == UserRole.ADMIN:
         # domain-admin can spawn container in any group in the same domain.
         if requesting_domain != owner_domain:
-            raise ValueError("You can only set the domain to the owner's domain.")
+            raise InvalidAPIParameters("You can only set the domain to the owner's domain.")
         query = (
             sa.select(groups.c.id)
             .select_from(groups)
@@ -359,7 +363,7 @@ async def query_userinfo_from_session(
     else:
         # normal users can spawn containers in their group and domain.
         if requesting_domain != owner_domain:
-            raise ValueError("You can only set the domain to your domain.")
+            raise InvalidAPIParameters("You can only set the domain to your domain.")
         query = (
             sa.select(agus.c.group_id)
             .select_from(agus.join(groups, agus.c.group_id == groups.c.id))
@@ -373,7 +377,10 @@ async def query_userinfo_from_session(
         qresult = await db_sess.execute(query)
         group_id = qresult.scalar()
     if group_id is None:
-        raise ValueError("Invalid group")
+        raise InvalidAPIParameters(
+            f"Invalid group ({requesting_group}): "
+            "the group does not exist, is inactive, or the user is not a member."
+        )
 
     return SessionOwnerContext(
         owner_uuid=owner_uuid,

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -9,7 +9,8 @@ from ai.backend.common.types import AccessKey
 
 from .data.user.types import SessionOwnerContext
 from .errors.api import InvalidAPIParameters
-from .errors.common import InternalServerError, ObjectNotFound
+from .errors.auth import AccessKeyNotFound, UserNotFound
+from .errors.common import InternalServerError
 from .models.domain import domains
 from .models.group import association_groups_users as agus
 from .models.group import groups
@@ -58,7 +59,7 @@ async def check_if_requester_is_eligible_to_act_as_target_access_key(
     result = await conn.execute(query)
     row = result.first()
     if row is None:
-        raise ObjectNotFound("Unknown owner access key", object_name="access key")
+        raise AccessKeyNotFound("Unknown owner access key")
     owner_domain = row.domain_name
     owner_role = row.role
     return check_if_requester_is_eligible_to_act_as_target_user(
@@ -83,7 +84,7 @@ async def check_if_requester_is_eligible_to_act_as_target_user_uuid(
     result = await conn.execute(query)
     row = result.first()
     if row is None:
-        raise ObjectNotFound("Unknown target user", object_name="user")
+        raise UserNotFound("Unknown target user")
     owner_domain = row.domain_name
     owner_role = row.role
     return check_if_requester_is_eligible_to_act_as_target_user(
@@ -136,7 +137,7 @@ async def query_userinfo(
         result = await conn.execute(query)
         row = result.first()
         if row is None:
-            raise ObjectNotFound("Unknown owner access key", object_name="access key")
+            raise AccessKeyNotFound("Unknown owner access key")
         if row.role is None:
             raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name
@@ -258,7 +259,7 @@ async def query_userinfo_from_session(
         result = await db_sess.execute(query)
         row = result.first()
         if row is None:
-            raise ObjectNotFound("Unknown owner access key", object_name="access key")
+            raise AccessKeyNotFound("Unknown owner access key")
         owner_domain = row.domain_name
         owner_role = row.role
         check_if_requester_is_eligible_to_act_as_target_user(
@@ -291,7 +292,7 @@ async def query_userinfo_from_session(
         result = await db_sess.execute(query)
         row = result.first()
         if row is None:
-            raise ObjectNotFound("Unknown owner access key", object_name="access key")
+            raise AccessKeyNotFound("Unknown owner access key")
         if row.role is None:
             raise InternalServerError(f"Owner user has no role assigned (owner_uuid={row.user})")
         owner_domain = row.domain_name

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -58,7 +58,7 @@ async def check_if_requester_is_eligible_to_act_as_target_access_key(
     result = await conn.execute(query)
     row = result.first()
     if row is None:
-        raise ValueError("Unknown owner access key")
+        raise ObjectNotFound("Unknown owner access key", object_name="access key")
     owner_domain = row.domain_name
     owner_role = row.role
     return check_if_requester_is_eligible_to_act_as_target_user(
@@ -83,7 +83,7 @@ async def check_if_requester_is_eligible_to_act_as_target_user_uuid(
     result = await conn.execute(query)
     row = result.first()
     if row is None:
-        raise ValueError("Unknown owner access key")
+        raise ObjectNotFound("Unknown target user", object_name="user")
     owner_domain = row.domain_name
     owner_role = row.role
     return check_if_requester_is_eligible_to_act_as_target_user(

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -1,0 +1,646 @@
+"""
+Tests for query_userinfo() and query_userinfo_from_session() in manager/utils.py.
+
+These functions validate user/domain/group ownership when creating sessions.
+They raise BackendAIError subclasses for invalid parameters (previously ValueError → 500).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+
+from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
+from ai.backend.common.types import AccessKey, ResourceSlot
+from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRole, UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, create_async_engine
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.utils import query_userinfo, query_userinfo_from_session
+from ai.backend.testutils.db import with_tables
+
+ALL_ROWS = [
+    DomainRow,
+    ScalingGroupRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    RoleRow,
+    UserRoleRow,
+    UserRow,
+    KeyPairRow,
+    GroupRow,
+    AssocGroupUserRow,
+    ImageRow,
+    VFolderRow,
+    EndpointRow,
+    DeploymentPolicyRow,
+    DeploymentAutoScalingPolicyRow,
+    DeploymentRevisionRow,
+    SessionRow,
+    AgentRow,
+    KernelRow,
+    RoutingRow,
+    ResourcePresetRow,
+]
+
+
+@dataclass
+class SeedData:
+    domain_name: str
+    group_id: UUID
+    group_name: str
+    user_uuid: UUID
+    access_key: AccessKey
+    kp_policy_name: str
+    user_policy_name: str
+    proj_policy_name: str
+
+
+@dataclass
+class ExtraUserData:
+    user_uuid: UUID
+    access_key: AccessKey
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def database_connection(
+    postgres_container: tuple[str, HostPortPairModel],
+) -> AsyncIterator[ExtendedAsyncSAEngine]:
+    _, addr = postgres_container
+    url = f"postgresql+asyncpg://postgres:develove@{addr.host}:{addr.port}/testing"
+    engine = create_async_engine(url, pool_size=8, pool_pre_ping=False, max_overflow=64)
+    yield engine
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# TestQueryUserinfo — SAConnection path
+# ---------------------------------------------------------------------------
+
+
+class TestQueryUserinfo:
+    """Tests for query_userinfo() using SAConnection."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, ALL_ROWS):
+            yield database_connection
+
+    @pytest.fixture
+    async def seed(self, db: ExtendedAsyncSAEngine) -> AsyncGenerator[SeedData, None]:
+        """Create a normal user who is a member of a group."""
+        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        group_id = uuid.uuid4()
+        group_name = f"test-group-{uuid.uuid4().hex[:8]}"
+        user_uuid = uuid.uuid4()
+        access_key = AccessKey(f"AK{uuid.uuid4().hex[:16]}")
+        kp_policy = f"kp-policy-{uuid.uuid4().hex[:8]}"
+        user_policy = f"user-policy-{uuid.uuid4().hex[:8]}"
+        proj_policy = f"proj-policy-{uuid.uuid4().hex[:8]}"
+
+        async with db.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=user_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=proj_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_network_count=10,
+                )
+            )
+            sess.add(
+                KeyPairResourcePolicyRow(
+                    name=kp_policy,
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=2,
+                    max_containers_per_session=10,
+                    idle_timeout=3600,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"user-{uuid.uuid4().hex[:8]}",
+                    email=f"test-{uuid.uuid4().hex[:8]}@test.io",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_policy,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                KeyPairRow(
+                    access_key=access_key,
+                    secret_key="secret",
+                    user=user_uuid,
+                    is_active=True,
+                    resource_policy=kp_policy,
+                )
+            )
+            sess.add(
+                GroupRow(
+                    id=group_id,
+                    name=group_name,
+                    domain_name=domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    resource_policy=proj_policy,
+                )
+            )
+            await sess.flush()
+            sess.add(AssocGroupUserRow(user_id=user_uuid, group_id=group_id))
+            await sess.commit()
+
+        yield SeedData(
+            domain_name=domain_name,
+            group_id=group_id,
+            group_name=group_name,
+            user_uuid=user_uuid,
+            access_key=access_key,
+            kp_policy_name=kp_policy,
+            user_policy_name=user_policy,
+            proj_policy_name=proj_policy,
+        )
+
+    @pytest.fixture
+    async def non_member_group(
+        self, db: ExtendedAsyncSAEngine, seed: SeedData
+    ) -> AsyncGenerator[str, None]:
+        """A group in the same domain that the seed user is NOT a member of."""
+        name = f"other-group-{uuid.uuid4().hex[:8]}"
+        async with db.begin_session() as sess:
+            sess.add(
+                GroupRow(
+                    id=uuid.uuid4(),
+                    name=name,
+                    domain_name=seed.domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    resource_policy=seed.proj_policy_name,
+                )
+            )
+            await sess.commit()
+        yield name
+
+    @pytest.fixture
+    async def inactive_domain_user(
+        self, db: ExtendedAsyncSAEngine, seed: SeedData
+    ) -> AsyncGenerator[ExtraUserData, None]:
+        """A user belonging to an inactive domain."""
+        domain = f"inactive-{uuid.uuid4().hex[:8]}"
+        user_uuid = uuid.uuid4()
+        ak = AccessKey(f"AK{uuid.uuid4().hex[:16]}")
+        user_policy = f"inactive-up-{uuid.uuid4().hex[:8]}"
+
+        async with db.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=domain,
+                    is_active=False,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=user_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"inactive-{uuid.uuid4().hex[:8]}",
+                    email=f"inactive-{uuid.uuid4().hex[:8]}@test.io",
+                    domain_name=domain,
+                    role=UserRole.USER,
+                    resource_policy=user_policy,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                KeyPairRow(
+                    access_key=ak,
+                    secret_key="secret",
+                    user=user_uuid,
+                    is_active=True,
+                    resource_policy=seed.kp_policy_name,
+                )
+            )
+            await sess.commit()
+        yield ExtraUserData(user_uuid=user_uuid, access_key=ak)
+
+    @pytest.fixture
+    async def superadmin(
+        self, db: ExtendedAsyncSAEngine, seed: SeedData
+    ) -> AsyncGenerator[ExtraUserData, None]:
+        """A superadmin in the same domain as seed."""
+        admin_uuid = uuid.uuid4()
+        admin_ak = AccessKey(f"AK{uuid.uuid4().hex[:16]}")
+        async with db.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=admin_uuid,
+                    username=f"admin-{uuid.uuid4().hex[:8]}",
+                    email=f"admin-{uuid.uuid4().hex[:8]}@test.io",
+                    domain_name=seed.domain_name,
+                    role=UserRole.SUPERADMIN,
+                    resource_policy=seed.user_policy_name,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                KeyPairRow(
+                    access_key=admin_ak,
+                    secret_key="secret",
+                    user=admin_uuid,
+                    is_active=True,
+                    resource_policy=seed.kp_policy_name,
+                )
+            )
+            await sess.commit()
+        yield ExtraUserData(user_uuid=admin_uuid, access_key=admin_ak)
+
+    # -- success cases --
+
+    async def test_success_with_group_name(self, db: ExtendedAsyncSAEngine, seed: SeedData) -> None:
+        async with db.begin() as conn:
+            result = await query_userinfo(
+                conn,
+                seed.user_uuid,
+                seed.access_key,
+                UserRole.USER,
+                seed.domain_name,
+                {"some": "policy"},
+                seed.domain_name,
+                seed.group_name,
+            )
+        assert result.owner_uuid == seed.user_uuid
+        assert result.group_id == seed.group_id
+        assert result.owner_role == UserRole.USER
+
+    async def test_success_with_group_id(self, db: ExtendedAsyncSAEngine, seed: SeedData) -> None:
+        async with db.begin() as conn:
+            result = await query_userinfo(
+                conn,
+                seed.user_uuid,
+                seed.access_key,
+                UserRole.USER,
+                seed.domain_name,
+                {"some": "policy"},
+                seed.domain_name,
+                seed.group_id,
+            )
+        assert result.group_id == seed.group_id
+
+    async def test_superadmin_delegation_resolves_group(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+        superadmin: ExtraUserData,
+    ) -> None:
+        """Superadmin creating session on behalf of user uses owner's role for group resolution."""
+        async with db.begin() as conn:
+            result = await query_userinfo(
+                conn,
+                superadmin.user_uuid,
+                superadmin.access_key,
+                UserRole.SUPERADMIN,
+                seed.domain_name,
+                None,
+                seed.domain_name,
+                seed.group_name,
+                query_on_behalf_of=seed.access_key,
+            )
+        assert result.owner_uuid == seed.user_uuid
+        assert result.group_id == seed.group_id
+
+    # -- error cases --
+
+    async def test_invalid_group_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="Invalid group"):
+            async with db.begin() as conn:
+                await query_userinfo(
+                    conn,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    {"some": "policy"},
+                    seed.domain_name,
+                    "nonexistent-group",
+                )
+
+    async def test_non_member_group_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+        non_member_group: str,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="Invalid group"):
+            async with db.begin() as conn:
+                await query_userinfo(
+                    conn,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    {"some": "policy"},
+                    seed.domain_name,
+                    non_member_group,
+                )
+
+    async def test_inactive_domain_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+        inactive_domain_user: ExtraUserData,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="Invalid or inactive domain"):
+            async with db.begin() as conn:
+                await query_userinfo(
+                    conn,
+                    inactive_domain_user.user_uuid,
+                    inactive_domain_user.access_key,
+                    UserRole.USER,
+                    "inactive",  # will match the user's own domain
+                    {"some": "policy"},
+                    "inactive",
+                    seed.group_name,
+                )
+
+    async def test_unknown_access_key_raises_not_found(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(ObjectNotFound):
+            async with db.begin() as conn:
+                await query_userinfo(
+                    conn,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    None,
+                    seed.domain_name,
+                    seed.group_name,
+                    query_on_behalf_of=AccessKey("BOGUS_KEY"),
+                )
+
+    async def test_domain_mismatch_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="domain"):
+            async with db.begin() as conn:
+                await query_userinfo(
+                    conn,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    {"some": "policy"},
+                    "wrong-domain",
+                    seed.group_name,
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestQueryUserinfoFromSession — SASession path
+# ---------------------------------------------------------------------------
+
+
+class TestQueryUserinfoFromSession:
+    """Tests for query_userinfo_from_session() using SASession."""
+
+    @pytest.fixture
+    async def db(
+        self, database_connection: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, ALL_ROWS):
+            yield database_connection
+
+    @pytest.fixture
+    async def seed(self, db: ExtendedAsyncSAEngine) -> AsyncGenerator[SeedData, None]:
+        domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
+        group_id = uuid.uuid4()
+        group_name = f"test-group-{uuid.uuid4().hex[:8]}"
+        user_uuid = uuid.uuid4()
+        access_key = AccessKey(f"AK{uuid.uuid4().hex[:16]}")
+        kp_policy = f"kp-policy-{uuid.uuid4().hex[:8]}"
+        user_policy = f"user-policy-{uuid.uuid4().hex[:8]}"
+        proj_policy = f"proj-policy-{uuid.uuid4().hex[:8]}"
+
+        async with db.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    allowed_docker_registries=[],
+                )
+            )
+            sess.add(
+                UserResourcePolicyRow(
+                    name=user_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=10,
+                    max_customized_image_count=10,
+                )
+            )
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=proj_policy,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=-1,
+                    max_network_count=10,
+                )
+            )
+            sess.add(
+                KeyPairResourcePolicyRow(
+                    name=kp_policy,
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=2,
+                    max_containers_per_session=10,
+                    idle_timeout=3600,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"user-{uuid.uuid4().hex[:8]}",
+                    email=f"test-{uuid.uuid4().hex[:8]}@test.io",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_policy,
+                )
+            )
+            await sess.flush()
+            sess.add(
+                KeyPairRow(
+                    access_key=access_key,
+                    secret_key="secret",
+                    user=user_uuid,
+                    is_active=True,
+                    resource_policy=kp_policy,
+                )
+            )
+            sess.add(
+                GroupRow(
+                    id=group_id,
+                    name=group_name,
+                    domain_name=domain_name,
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    resource_policy=proj_policy,
+                )
+            )
+            await sess.flush()
+            sess.add(AssocGroupUserRow(user_id=user_uuid, group_id=group_id))
+            await sess.commit()
+
+        yield SeedData(
+            domain_name=domain_name,
+            group_id=group_id,
+            group_name=group_name,
+            user_uuid=user_uuid,
+            access_key=access_key,
+            kp_policy_name=kp_policy,
+            user_policy_name=user_policy,
+            proj_policy_name=proj_policy,
+        )
+
+    async def test_success(self, db: ExtendedAsyncSAEngine, seed: SeedData) -> None:
+        async with db.begin_session() as sess:
+            result = await query_userinfo_from_session(
+                sess,
+                seed.user_uuid,
+                seed.access_key,
+                UserRole.USER,
+                seed.domain_name,
+                {"some": "policy"},
+                seed.domain_name,
+                seed.group_name,
+            )
+        assert result.owner_uuid == seed.user_uuid
+        assert result.group_id == seed.group_id
+
+    async def test_invalid_group_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="Invalid group"):
+            async with db.begin_session() as sess:
+                await query_userinfo_from_session(
+                    sess,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    {"some": "policy"},
+                    seed.domain_name,
+                    "nonexistent-group",
+                )
+
+    async def test_unknown_access_key_raises_not_found(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(ObjectNotFound):
+            async with db.begin_session() as sess:
+                await query_userinfo_from_session(
+                    sess,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    None,
+                    seed.domain_name,
+                    seed.group_name,
+                    query_on_behalf_of=AccessKey("BOGUS_KEY"),
+                )
+
+    async def test_domain_mismatch_raises_bad_request(
+        self,
+        db: ExtendedAsyncSAEngine,
+        seed: SeedData,
+    ) -> None:
+        with pytest.raises(InvalidAPIParameters, match="domain"):
+            async with db.begin_session() as sess:
+                await query_userinfo_from_session(
+                    sess,
+                    seed.user_uuid,
+                    seed.access_key,
+                    UserRole.USER,
+                    seed.domain_name,
+                    {"some": "policy"},
+                    "wrong-domain",
+                    seed.group_name,
+                )

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -17,7 +17,7 @@ import pytest
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import AccessKey, ResourceSlot
 from ai.backend.manager.errors.api import InvalidAPIParameters
-from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.errors.auth import AccessKeyNotFound
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
@@ -434,7 +434,7 @@ class TestQueryUserinfo:
         db: ExtendedAsyncSAEngine,
         seed: SeedData,
     ) -> None:
-        with pytest.raises(ObjectNotFound):
+        with pytest.raises(AccessKeyNotFound):
             async with db.begin() as conn:
                 await query_userinfo(
                     conn,
@@ -613,7 +613,7 @@ class TestQueryUserinfoFromSession:
         db: ExtendedAsyncSAEngine,
         seed: SeedData,
     ) -> None:
-        with pytest.raises(ObjectNotFound):
+        with pytest.raises(AccessKeyNotFound):
             async with db.begin_session() as sess:
                 await query_userinfo_from_session(
                     sess,


### PR DESCRIPTION
## Summary
- `query_userinfo()` and `query_userinfo_from_session()` in `manager/utils.py` raised plain `ValueError` for invalid group, domain, and access key errors. Since `ValueError` does not inherit from `BackendAIError`, the exception middleware converted these to **500 Internal Server Error** instead of descriptive 4xx responses.
- Replace `ValueError("Invalid group")` → `InvalidAPIParameters` (400), `ValueError("Invalid domain")` → `InvalidAPIParameters` (400), `ValueError("Unknown owner access key")` → `ObjectNotFound` (404), and domain mismatch errors → `InvalidAPIParameters` (400).
- The "Invalid group" error message now includes the requested group name and explains possible causes (non-existent, inactive, or not a member).

## Test plan
- [x] Create a session as superadmin who is NOT a member of the target project group → should return 400 with descriptive message instead of 500
- [x] Create a session with a non-existent group name → should return 400
- [x] Create a session with a valid group membership → should succeed as before

Resolves BA-5697