### PR TITLE
feat: delete login sessions on termination and record lifecycle in history

### DIFF
--- a/changes/11013.enhance.md
+++ b/changes/11013.enhance.md
@@ -1,0 +1,1 @@
+Delete login session rows on termination and record full session lifecycle events in login history

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7864,6 +7864,11 @@ enum LoginAttemptResult
   FAILED_PASSWORD_EXPIRED @join__enumValue(graph: STRAWBERRY)
   FAILED_REJECTED_BY_HOOK @join__enumValue(graph: STRAWBERRY)
   FAILED_SESSION_ALREADY_EXISTS @join__enumValue(graph: STRAWBERRY)
+  LOGOUT @join__enumValue(graph: STRAWBERRY)
+  REVOKED_BY_ADMIN @join__enumValue(graph: STRAWBERRY)
+  REVOKED_BY_USER @join__enumValue(graph: STRAWBERRY)
+  EVICTED @join__enumValue(graph: STRAWBERRY)
+  EXPIRED @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 26.4.1. Filter criteria for querying login history."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4922,6 +4922,11 @@ enum LoginAttemptResult {
   FAILED_PASSWORD_EXPIRED
   FAILED_REJECTED_BY_HOOK
   FAILED_SESSION_ALREADY_EXISTS
+  LOGOUT
+  REVOKED_BY_ADMIN
+  REVOKED_BY_USER
+  EVICTED
+  EXPIRED
 }
 
 """Added in 26.4.1. Filter criteria for querying login history."""

--- a/src/ai/backend/common/dto/manager/v2/login_history/types.py
+++ b/src/ai/backend/common/dto/manager/v2/login_history/types.py
@@ -23,6 +23,11 @@ class LoginAttemptResult(StrEnum):
     FAILED_PASSWORD_EXPIRED = "failed_password_expired"
     FAILED_REJECTED_BY_HOOK = "failed_rejected_by_hook"
     FAILED_SESSION_ALREADY_EXISTS = "failed_session_already_exists"
+    LOGOUT = "logout"
+    REVOKED_BY_ADMIN = "revoked_by_admin"
+    REVOKED_BY_USER = "revoked_by_user"
+    EVICTED = "evicted"
+    EXPIRED = "expired"
 
 
 class LoginHistoryOrderField(StrEnum):

--- a/src/ai/backend/manager/api/gql/login_history/types/node.py
+++ b/src/ai/backend/manager/api/gql/login_history/types/node.py
@@ -33,6 +33,11 @@ class LoginAttemptResultGQL(StrEnum):
     FAILED_PASSWORD_EXPIRED = "failed_password_expired"
     FAILED_REJECTED_BY_HOOK = "failed_rejected_by_hook"
     FAILED_SESSION_ALREADY_EXISTS = "failed_session_already_exists"
+    LOGOUT = "logout"
+    REVOKED_BY_ADMIN = "revoked_by_admin"
+    REVOKED_BY_USER = "revoked_by_user"
+    EVICTED = "evicted"
+    EXPIRED = "expired"
 
 
 @gql_node_type(

--- a/src/ai/backend/manager/models/alembic/versions/a3b7c9d1e5f2_delete_inactive_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/a3b7c9d1e5f2_delete_inactive_login_sessions.py
@@ -1,0 +1,28 @@
+"""delete inactive login sessions
+
+Revision ID: a3b7c9d1e5f2
+Revises: 17b679c98b50
+Create Date: 2026-04-13 22:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3b7c9d1e5f2"
+down_revision = "17b679c98b50"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # LoginSession rows are now deleted on termination instead of status-updated.
+    # Clean up all historical non-active rows; LoginHistory serves as the audit trail.
+    conn = op.get_bind()
+    conn.execute(sa.text("DELETE FROM login_sessions WHERE status != 'active'"))
+
+
+def downgrade() -> None:
+    # Data-only cleanup: deleted rows cannot be restored.
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/a3b7c9d1e5f2_delete_inactive_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/a3b7c9d1e5f2_delete_inactive_login_sessions.py
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a3b7c9d1e5f2"
-down_revision = "17b679c98b50"
+down_revision = "ecc4b93d7907"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/login_session/enums.py
+++ b/src/ai/backend/manager/models/login_session/enums.py
@@ -17,3 +17,8 @@ class LoginAttemptResult(enum.StrEnum):
     FAILED_PASSWORD_EXPIRED = "failed_password_expired"
     FAILED_REJECTED_BY_HOOK = "failed_rejected_by_hook"
     FAILED_SESSION_ALREADY_EXISTS = "failed_session_already_exists"
+    LOGOUT = "logout"
+    REVOKED_BY_ADMIN = "revoked_by_admin"
+    REVOKED_BY_USER = "revoked_by_user"
+    EVICTED = "evicted"
+    EXPIRED = "expired"

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -636,7 +636,7 @@ class AuthDBSource:
                         {
                             "user_id": user_id,
                             "domain_name": domain_name,
-                            "result": result.value,
+                            "result": result,
                         }
                         for _ in deleted_tokens
                     ],
@@ -729,7 +729,7 @@ class AuthDBSource:
                 sa.insert(lh).values(
                     user_id=row.user_id,
                     domain_name=domain_name,
-                    result=result.value,
+                    result=result,
                 )
             )
             await conn.commit()

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -450,29 +450,37 @@ class AuthDBSource:
             )
 
     @auth_db_source_resilience.apply()
-    async def invalidate_sessions_by_tokens(self, session_tokens: list[str]) -> None:
-        """Invalidate the given active login sessions in bulk.
+    async def delete_sessions_by_tokens(
+        self,
+        session_tokens: list[str],
+        result: LoginAttemptResult,
+    ) -> None:
+        """Delete the given login sessions and record history for each.
 
-        Rows whose status is not ACTIVE are left untouched. This method only
-        invalidates the specified sessions; the caller decides whether to invoke it
-        before or after ``create_login_session`` as appropriate for the surrounding
-        workflow.
+        Uses a CTE to atomically DELETE + INSERT into login_history with a
+        JOIN on users to obtain domain_name.
         """
         if not session_tokens:
             return
-        async with self._db.begin_session() as db_session:
-            query = (
-                sa.update(LoginSessionRow)
-                .where(
-                    LoginSessionRow.session_token.in_(session_tokens)
-                    & (LoginSessionRow.status == LoginSessionStatus.ACTIVE)
-                )
-                .values(
-                    status=LoginSessionStatus.INVALIDATED,
-                    invalidated_at=sa.func.now(),
-                )
+        ls = LoginSessionRow.__table__
+        lh = LoginHistoryRow.__table__
+        async with self._db.connect() as conn:
+            deleted = (
+                sa.delete(ls)
+                .where(ls.c.session_token.in_(session_tokens))
+                .returning(ls.c.user_id)
+                .cte("deleted")
             )
-            await db_session.execute(query)
+            insert_query = lh.insert().from_select(
+                ["user_id", "domain_name", "result"],
+                sa.select(
+                    deleted.c.user_id,
+                    users.c.domain_name,
+                    sa.literal(result.value).label("result"),
+                ).select_from(deleted.join(users, deleted.c.user_id == users.c.uuid)),
+            )
+            await conn.execute(insert_query)
+            await conn.commit()
 
     @auth_db_source_resilience.apply()
     async def create_login_session(
@@ -572,38 +580,69 @@ class AuthDBSource:
             ]
 
     @auth_db_source_resilience.apply()
-    async def invalidate_session_by_token(self, session_token: str) -> None:
-        """Invalidate a single login session by its token."""
-        async with self._db.begin_session() as db_session:
-            query = (
-                sa.update(LoginSessionRow)
-                .where(
-                    (LoginSessionRow.session_token == session_token)
-                    & (LoginSessionRow.status == LoginSessionStatus.ACTIVE)
-                )
-                .values(
-                    status=LoginSessionStatus.INVALIDATED,
-                    invalidated_at=sa.func.now(),
-                )
+    async def delete_session_by_token(
+        self,
+        session_token: str,
+        result: LoginAttemptResult,
+    ) -> None:
+        """Delete a single login session by its token and record history.
+
+        Uses a CTE to atomically DELETE + INSERT into login_history with a
+        JOIN on users to obtain domain_name. No-op if the session is not found.
+        """
+        ls = LoginSessionRow.__table__
+        lh = LoginHistoryRow.__table__
+        async with self._db.connect() as conn:
+            deleted = (
+                sa.delete(ls)
+                .where(ls.c.session_token == session_token)
+                .returning(ls.c.user_id)
+                .cte("deleted")
             )
-            await db_session.execute(query)
+            insert_query = lh.insert().from_select(
+                ["user_id", "domain_name", "result"],
+                sa.select(
+                    deleted.c.user_id,
+                    users.c.domain_name,
+                    sa.literal(result.value).label("result"),
+                ).select_from(deleted.join(users, deleted.c.user_id == users.c.uuid)),
+            )
+            await conn.execute(insert_query)
+            await conn.commit()
 
     @auth_db_source_resilience.apply()
-    async def invalidate_sessions_by_user(self, user_id: UUID) -> None:
-        """Invalidate all active login sessions for a user."""
-        async with self._db.begin_session() as db_session:
-            query = (
-                sa.update(LoginSessionRow)
-                .where(
-                    (LoginSessionRow.user_id == user_id)
-                    & (LoginSessionRow.status == LoginSessionStatus.ACTIVE)
-                )
-                .values(
-                    status=LoginSessionStatus.INVALIDATED,
-                    invalidated_at=sa.func.now(),
-                )
+    async def delete_sessions_by_user(
+        self,
+        user_id: UUID,
+        domain_name: str,
+        result: LoginAttemptResult,
+    ) -> list[str]:
+        """Delete all login sessions for a user, record history, return tokens.
+
+        The caller provides domain_name (available in signout flow).
+        Returns the list of deleted session_tokens for Valkey cleanup.
+        """
+        ls = LoginSessionRow.__table__
+        lh = LoginHistoryRow.__table__
+        async with self._db.connect() as conn:
+            delete_result = await conn.execute(
+                sa.delete(ls).where(ls.c.user_id == user_id).returning(ls.c.session_token)
             )
-            await db_session.execute(query)
+            deleted_tokens = [row.session_token for row in delete_result]
+            if deleted_tokens:
+                await conn.execute(
+                    sa.insert(lh),
+                    [
+                        {
+                            "user_id": user_id,
+                            "domain_name": domain_name,
+                            "result": result.value,
+                        }
+                        for _ in deleted_tokens
+                    ],
+                )
+            await conn.commit()
+            return deleted_tokens
 
     @auth_db_source_resilience.apply()
     async def admin_search_login_sessions(
@@ -654,32 +693,46 @@ class AuthDBSource:
             return row.to_data()
 
     @auth_db_source_resilience.apply()
-    async def revoke_session_by_id(self, session_id: UUID) -> str:
-        """Revoke an active login session by its ID.
+    async def delete_session_by_id(
+        self,
+        session_id: UUID,
+        result: LoginAttemptResult,
+    ) -> str:
+        """Delete a login session by its ID, record history, return session_token.
 
-        Sets status to REVOKED and invalidated_at to current time.
-        Returns the session_token of the revoked session.
-        Raises LoginSessionNotFoundError if no matching active session is found.
+        Uses a CTE to atomically DELETE + INSERT into login_history with a
+        JOIN on users to obtain domain_name.
+        Raises LoginSessionNotFoundError if no session is found.
         """
-        async with self._db.begin_session() as db_session:
-            query = (
-                sa.update(LoginSessionRow)
-                .where(
-                    (LoginSessionRow.id == session_id)
-                    & (LoginSessionRow.status == LoginSessionStatus.ACTIVE)
-                )
-                .values(
-                    status=LoginSessionStatus.REVOKED,
-                    invalidated_at=sa.func.now(),
-                )
-                .returning(LoginSessionRow.session_token)
+        ls = LoginSessionRow.__table__
+        lh = LoginHistoryRow.__table__
+        async with self._db.connect() as conn:
+            # First, delete and get token + user_id
+            delete_result = await conn.execute(
+                sa.delete(ls)
+                .where(ls.c.id == session_id)
+                .returning(ls.c.session_token, ls.c.user_id)
             )
-            result = await db_session.execute(query)
-            session_token = result.scalar()
-            if session_token is None:
+            row = delete_result.first()
+            if row is None:
                 raise LoginSessionNotFoundError(
-                    extra_msg=f"No active login session found with id: {session_id}"
+                    extra_msg=f"No login session found with id: {session_id}"
                 )
+            session_token: str = row.session_token
+            # Get domain_name from users table
+            user_result = await conn.execute(
+                sa.select(users.c.domain_name).where(users.c.uuid == row.user_id)
+            )
+            domain_name = user_result.scalar_one()
+            # Record history
+            await conn.execute(
+                sa.insert(lh).values(
+                    user_id=row.user_id,
+                    domain_name=domain_name,
+                    result=result.value,
+                )
+            )
+            await conn.commit()
             return session_token
 
     # --- Login History ---

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -121,8 +121,10 @@ class AuthRepository:
         )
 
     @auth_repository_resilience.apply()
-    async def invalidate_login_sessions_by_tokens(self, session_tokens: list[str]) -> None:
-        await self._db_source.invalidate_sessions_by_tokens(session_tokens)
+    async def delete_login_sessions_by_tokens(
+        self, session_tokens: list[str], result: LoginAttemptResult
+    ) -> None:
+        await self._db_source.delete_sessions_by_tokens(session_tokens, result)
 
     @auth_repository_resilience.apply()
     async def check_credential_without_migration(
@@ -151,12 +153,16 @@ class AuthRepository:
         return await self._db_source.fetch_active_session_tokens(user_id)
 
     @auth_repository_resilience.apply()
-    async def invalidate_login_session_by_token(self, session_token: str) -> None:
-        await self._db_source.invalidate_session_by_token(session_token)
+    async def delete_login_session_by_token(
+        self, session_token: str, result: LoginAttemptResult
+    ) -> None:
+        await self._db_source.delete_session_by_token(session_token, result)
 
     @auth_repository_resilience.apply()
-    async def invalidate_user_login_sessions(self, user_id: UUID) -> None:
-        await self._db_source.invalidate_sessions_by_user(user_id)
+    async def delete_user_login_sessions(
+        self, user_id: UUID, domain_name: str, result: LoginAttemptResult
+    ) -> list[str]:
+        return await self._db_source.delete_sessions_by_user(user_id, domain_name, result)
 
     @auth_repository_resilience.apply()
     async def admin_search_login_sessions(
@@ -178,9 +184,9 @@ class AuthRepository:
         return await self._db_source.fetch_login_session_by_id(session_id)
 
     @auth_repository_resilience.apply()
-    async def revoke_login_session(self, session_id: UUID) -> str:
-        """Revoke an active login session and return its session_token."""
-        return await self._db_source.revoke_session_by_id(session_id)
+    async def delete_login_session_by_id(self, session_id: UUID, result: LoginAttemptResult) -> str:
+        """Delete a login session, record history, and return its session_token."""
+        return await self._db_source.delete_session_by_id(session_id, result)
 
     @auth_repository_resilience.apply()
     async def record_login_history(

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -275,8 +275,8 @@ class AuthService:
             if await self._valkey_session_client.get_login_session(session_info.session_token):
                 live_sessions.append(session_info)
             else:
-                await self._auth_repository.invalidate_login_session_by_token(
-                    session_info.session_token
+                await self._auth_repository.delete_login_session_by_token(
+                    session_info.session_token, LoginAttemptResult.EXPIRED
                 )
 
         return main_keypair_row, live_sessions
@@ -360,7 +360,9 @@ class AuthService:
         if tokens_to_invalidate:
             for token in tokens_to_invalidate:
                 await self._valkey_session_client.delete_login_session(token)
-            await self._auth_repository.invalidate_login_sessions_by_tokens(tokens_to_invalidate)
+            await self._auth_repository.delete_login_sessions_by_tokens(
+                tokens_to_invalidate, LoginAttemptResult.EVICTED
+            )
 
         session_data = LoginSessionData(
             created=int(time.time()),
@@ -515,14 +517,18 @@ class AuthService:
         )
 
     async def logout(self, action: LogoutAction) -> LogoutActionResult:
-        await self._auth_repository.invalidate_login_session_by_token(action.session_token)
+        await self._auth_repository.delete_login_session_by_token(
+            action.session_token, LoginAttemptResult.LOGOUT
+        )
         await self._valkey_session_client.delete_login_session(action.session_token)
         return LogoutActionResult(success=True)
 
     async def admin_revoke_login_session(
         self, action: AdminRevokeLoginSessionAction
     ) -> RevokeLoginSessionActionResult:
-        session_token = await self._auth_repository.revoke_login_session(action.session_id)
+        session_token = await self._auth_repository.delete_login_session_by_id(
+            action.session_id, LoginAttemptResult.REVOKED_BY_ADMIN
+        )
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
 
@@ -532,7 +538,9 @@ class AuthService:
         session_data = await self._auth_repository.get_login_session_by_id(action.session_id)
         if session_data.user_id != action.user_id:
             raise GenericForbidden("You can only revoke your own login sessions.")
-        session_token = await self._auth_repository.revoke_login_session(action.session_id)
+        session_token = await self._auth_repository.delete_login_session_by_id(
+            action.session_id, LoginAttemptResult.REVOKED_BY_USER
+        )
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
 
@@ -551,11 +559,11 @@ class AuthService:
             email,
             action.password,
         )
-        # Get active session tokens before invalidating, for Valkey cleanup
-        active_sessions = await self._auth_repository.get_active_session_tokens(action.user_id)
-        await self._auth_repository.invalidate_user_login_sessions(action.user_id)
-        for session_info in active_sessions:
-            await self._valkey_session_client.delete_login_session(session_info.session_token)
+        deleted_tokens = await self._auth_repository.delete_user_login_sessions(
+            action.user_id, action.domain_name, LoginAttemptResult.LOGOUT
+        )
+        for token in deleted_tokens:
+            await self._valkey_session_client.delete_login_session(token)
         await self._auth_repository.deactivate_user_and_keypairs(email)
 
         return SignoutActionResult(success=True)

--- a/tests/unit/manager/repositories/auth/test_login_session_force.py
+++ b/tests/unit/manager/repositories/auth/test_login_session_force.py
@@ -299,7 +299,9 @@ class TestLoginSessionForce:
 
         # Step 2: evict existing tokens via the dedicated repository call, then create
         tokens_to_invalidate = [s.session_token for s in cred_result.active_sessions]
-        await auth_db_source.invalidate_sessions_by_tokens(tokens_to_invalidate)
+        await auth_db_source.delete_sessions_by_tokens(
+            tokens_to_invalidate, LoginAttemptResult.EVICTED
+        )
         session_result = await auth_db_source.create_login_session(
             user_id=user_id,
             access_key=access_key,
@@ -363,7 +365,9 @@ class TestLoginSessionForce:
         assert await self._count_active_sessions(db_with_cleanup, sample_user.user_id) == 1
 
         # Logout (invalidate session by token)
-        await auth_db_source.invalidate_session_by_token(result1.session_token)
+        await auth_db_source.delete_session_by_token(
+            result1.session_token, LoginAttemptResult.LOGOUT
+        )
         assert await self._count_active_sessions(db_with_cleanup, sample_user.user_id) == 0
 
         # Re-login without force should succeed

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -14,6 +14,7 @@ from ai.backend.manager.config.unified import AuthConfig, ManagerConfig
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
 from ai.backend.manager.errors.auth import AuthorizationFailed, PasswordExpired
+from ai.backend.manager.models.login_session.enums import LoginAttemptResult
 from ai.backend.manager.models.user import UserRole, UserStatus
 from ai.backend.manager.repositories.auth.db_source.db_source import (
     ActiveSessionInfo,
@@ -430,7 +431,9 @@ async def test_authorize_with_valkey_cross_check_cleans_stale_sessions(
     result = await auth_service.authorize(action)
 
     # Stale session should have been invalidated in DB
-    mock_auth_repository.invalidate_login_session_by_token.assert_awaited_once_with("stale_token")
+    mock_auth_repository.delete_login_session_by_token.assert_awaited_once_with(
+        "stale_token", LoginAttemptResult.EXPIRED
+    )
     assert result.authorization_result is not None
     assert result.authorization_result.session_token == "new_session_token"
 
@@ -497,9 +500,9 @@ async def test_authorize_force_invalidates_existing_sessions(
     result = await auth_service.authorize(action)
 
     # Eviction happens via a dedicated repository call before create_login_session.
-    mock_auth_repository.invalidate_login_sessions_by_tokens.assert_awaited_once_with([
-        "existing_live_token"
-    ])
+    mock_auth_repository.delete_login_sessions_by_tokens.assert_awaited_once_with(
+        ["existing_live_token"], LoginAttemptResult.EVICTED
+    )
     mock_auth_repository.create_login_session.assert_awaited_once()
     create_kwargs = mock_auth_repository.create_login_session.call_args.kwargs
     assert "tokens_to_invalidate" not in create_kwargs
@@ -550,4 +553,4 @@ async def test_create_login_session_does_not_pass_max_concurrent_sessions_to_rep
     call_kwargs = mock_auth_repository.create_login_session.call_args.kwargs
     assert "max_concurrent_sessions" not in call_kwargs
     assert "tokens_to_invalidate" not in call_kwargs
-    mock_auth_repository.invalidate_login_sessions_by_tokens.assert_not_called()
+    mock_auth_repository.delete_login_sessions_by_tokens.assert_not_called()

--- a/tests/unit/manager/services/auth/test_max_concurrent_logins.py
+++ b/tests/unit/manager/services/auth/test_max_concurrent_logins.py
@@ -14,6 +14,7 @@ from ai.backend.manager.config.unified import AuthConfig
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
 from ai.backend.manager.errors.auth import TooManyConcurrentLoginSessions
+from ai.backend.manager.models.login_session.enums import LoginAttemptResult
 from ai.backend.manager.models.user import UserRole, UserStatus
 from ai.backend.manager.repositories.auth.db_source.db_source import (
     ActiveSessionInfo,
@@ -340,9 +341,11 @@ class TestMaxConcurrentLoginsEnforcement:
             auth_config=_make_auth_config(),
         )
 
-        invalidate_mock = mock_auth_repository.invalidate_login_sessions_by_tokens
+        delete_mock = mock_auth_repository.delete_login_sessions_by_tokens
         if case.expected_evicted_tokens is None:
-            invalidate_mock.assert_not_called()
+            delete_mock.assert_not_called()
         else:
-            invalidate_mock.assert_called_once_with(case.expected_evicted_tokens)
+            delete_mock.assert_called_once_with(
+                case.expected_evicted_tokens, LoginAttemptResult.EVICTED
+            )
         assert result.authorization_result is not None


### PR DESCRIPTION
## Summary
- Login session rows are now **deleted** from the DB on termination (logout, revoke, eviction, expiry) instead of status-updated, eliminating persistent `session_token` exposure
- Each termination records a `LoginHistory` entry with new result types (`LOGOUT`, `REVOKED_BY_ADMIN`, `REVOKED_BY_USER`, `EVICTED`, `EXPIRED`) for full audit trail
- Alembic migration cleans up existing non-active session rows; `status`/`invalidated_at` column removal deferred to follow-up PR

## Test plan
- [ ] Login → logout → verify `login_sessions` row deleted + `login_history` has LOGOUT record
- [ ] Admin revoke → verify row deleted + REVOKED_BY_ADMIN history
- [ ] Force login (exceed max_concurrent_logins) → verify evicted sessions deleted + EVICTED history
- [ ] `./bai v2 admin login-history search --result LOGOUT` returns new event types
- [ ] Alembic migration successfully removes non-active rows on existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11013.org.readthedocs.build/en/11013/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11013.org.readthedocs.build/ko/11013/

<!-- readthedocs-preview sorna-ko end -->