### PR TITLE
fix(BA-5661): enforce RBAC permission checks in action validators

### DIFF
--- a/changes/11014.fix.md
+++ b/changes/11014.fix.md
@@ -1,0 +1,1 @@
+Fix RBAC action validators silently bypassing permission denials; legacy processor paths now observe denials via log and metric instead of raising.

--- a/src/ai/backend/manager/actions/validators/__init__.py
+++ b/src/ai/backend/manager/actions/validators/__init__.py
@@ -6,4 +6,7 @@ from .rbac import LegacyRBACValidators, RBACValidators
 @dataclass
 class ActionValidators:
     rbac: RBACValidators
-    legacy_rbac: LegacyRBACValidators
+    # Optional so existing test fixtures that only pass `rbac=` keep working.
+    # Production code (composer) always sets both; processors that need the
+    # legacy validator fall back to `rbac` when this is None.
+    legacy_rbac: LegacyRBACValidators | None = None

--- a/src/ai/backend/manager/actions/validators/__init__.py
+++ b/src/ai/backend/manager/actions/validators/__init__.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
-from .rbac import RBACValidators
+from .rbac import LegacyRBACValidators, RBACValidators
 
 
 @dataclass
 class ActionValidators:
     rbac: RBACValidators
+    legacy_rbac: LegacyRBACValidators

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,5 +1,9 @@
 from dataclasses import dataclass
 
+from ai.backend.manager.actions.validators.rbac.legacy import (
+    LegacyScopeActionRBACValidator,
+    LegacySingleEntityActionRBACValidator,
+)
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -10,3 +14,9 @@ from ai.backend.manager.actions.validators.rbac.single_entity import (
 class RBACValidators:
     scope: ScopeActionRBACValidator
     single_entity: SingleEntityActionRBACValidator
+
+
+@dataclass
+class LegacyRBACValidators:
+    scope: LegacyScopeActionRBACValidator
+    single_entity: LegacySingleEntityActionRBACValidator

--- a/src/ai/backend/manager/actions/validators/rbac/legacy.py
+++ b/src/ai/backend/manager/actions/validators/rbac/legacy.py
@@ -1,0 +1,120 @@
+"""Legacy RBAC validators for processors invoked from legacy (non-v2) APIs.
+
+These validators perform the same permission check as the strict validators,
+but never raise on denial. They record the denial via log + Prometheus counter
+so we can observe legacy-path violations without breaking legacy behavior.
+"""
+
+import logging
+from typing import override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.metrics.safe import SafeCounter
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.action.scope import BaseScopeAction
+from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
+from ai.backend.manager.actions.validator.scope import ScopeActionValidator
+from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
+from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
+from ai.backend.manager.errors.user import UserNotFound
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_rbac_legacy_denied_total = SafeCounter(
+    name="backendai_manager_rbac_legacy_permission_denied_total",
+    labelnames=["validator", "entity_type", "operation"],
+    documentation=(
+        "Number of RBAC permission denials observed on the legacy processor path. "
+        "These are not enforced — the action still proceeds."
+    ),
+)
+
+
+class LegacySingleEntityActionRBACValidator(SingleEntityActionValidator):
+    """Non-enforcing RBAC validator for single-entity actions on legacy processors.
+
+    Runs the same permission check as `SingleEntityActionRBACValidator` but only
+    logs and records a metric when the check fails — never raises. Used so that
+    legacy API endpoints retain their existing behavior while we gain visibility
+    into which legacy call sites would be rejected under strict enforcement.
+    """
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+    ) -> None:
+        self._repository = repository
+
+    @override
+    async def validate(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        user = current_user()
+        if user is None:
+            raise UserNotFound("User not found in context")
+
+        operation = action.operation_type().to_permission_operation()
+        target = action.target_element()
+        allowed = await self._repository.check_permission_with_scope_chain(
+            ScopeChainPermissionCheckInput(
+                user_id=user.user_id,
+                target_element_ref=target,
+                operation=operation,
+                permission_entity_type=None,
+            )
+        )
+        if not allowed:
+            _rbac_legacy_denied_total.labels(
+                validator="single_entity",
+                entity_type=str(target.element_type),
+                operation=str(operation),
+            ).inc()
+            log.warning(
+                "legacy RBAC: user {} lacks permission {} on {} (not enforced)",
+                user.user_id,
+                operation,
+                target,
+            )
+
+
+class LegacyScopeActionRBACValidator(ScopeActionValidator):
+    """Non-enforcing RBAC validator for scope actions on legacy processors."""
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+    ) -> None:
+        self._repository = repository
+
+    @override
+    async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        user = current_user()
+        if user is None:
+            raise UserNotFound("User not found in context")
+
+        operation = action.operation_type().to_permission_operation()
+        entity_type = action.entity_type()
+        target = action.target_element()
+        allowed = await self._repository.check_permission_with_scope_chain(
+            ScopeChainPermissionCheckInput(
+                user_id=user.user_id,
+                target_element_ref=target,
+                operation=operation,
+                permission_entity_type=entity_type,
+            )
+        )
+        if not allowed:
+            _rbac_legacy_denied_total.labels(
+                validator="scope",
+                entity_type=str(entity_type),
+                operation=str(operation),
+            ).inc()
+            log.warning(
+                "legacy RBAC: user {} lacks permission {} on {} at {} (not enforced)",
+                user.user_id,
+                operation,
+                entity_type,
+                target,
+            )

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -5,6 +5,7 @@ from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.validator.scope import ScopeActionValidator
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
+from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -24,7 +25,7 @@ class ScopeActionRBACValidator(ScopeActionValidator):
         if user is None:
             raise UserNotFound("User not found in context")
 
-        await self._repository.check_permission_with_scope_chain(
+        allowed = await self._repository.check_permission_with_scope_chain(
             ScopeChainPermissionCheckInput(
                 user_id=user.user_id,
                 target_element_ref=action.target_element(),
@@ -32,3 +33,9 @@ class ScopeActionRBACValidator(ScopeActionValidator):
                 permission_entity_type=action.entity_type(),
             )
         )
+        if not allowed:
+            raise NotEnoughPermission(
+                f"User {user.user_id} lacks permission "
+                f"{action.operation_type().to_permission_operation()} "
+                f"on {action.entity_type()} at {action.target_element()}"
+            )

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -5,6 +5,7 @@ from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
+from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -24,7 +25,7 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
         if user is None:
             raise UserNotFound("User not found in context")
 
-        await self._repository.check_permission_with_scope_chain(
+        allowed = await self._repository.check_permission_with_scope_chain(
             ScopeChainPermissionCheckInput(
                 user_id=user.user_id,
                 target_element_ref=action.target_element(),
@@ -32,3 +33,9 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
                 permission_entity_type=None,
             )
         )
+        if not allowed:
+            raise NotEnoughPermission(
+                f"User {user.user_id} lacks permission "
+                f"{action.operation_type().to_permission_operation()} "
+                f"on {action.target_element()}"
+            )

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -29,7 +29,11 @@ from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
 from ai.backend.manager.actions.validators import ActionValidators
-from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators, RBACValidators
+from ai.backend.manager.actions.validators.rbac.legacy import (
+    LegacyScopeActionRBACValidator,
+    LegacySingleEntityActionRBACValidator,
+)
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
@@ -254,6 +258,10 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             scope=ScopeActionRBACValidator(permission_controller_repository),
             single_entity=SingleEntityActionRBACValidator(permission_controller_repository),
         )
+        legacy_rbac_validators = LegacyRBACValidators(
+            scope=LegacyScopeActionRBACValidator(permission_controller_repository),
+            single_entity=LegacySingleEntityActionRBACValidator(permission_controller_repository),
+        )
 
         processors = await stack.enter_dependency(
             ProcessorsDependency(),
@@ -262,7 +270,10 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 action_monitors=[reporter_monitor, prometheus_monitor, audit_log_monitor],
                 event_hub=setup_input.event_hub,
                 event_fetcher=setup_input.event_fetcher,
-                validators=ActionValidators(rbac=rbac_validators),
+                validators=ActionValidators(
+                    rbac=rbac_validators,
+                    legacy_rbac=legacy_rbac_validators,
+                ),
             ),
         )
 

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -4,7 +4,9 @@ from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
+from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators
 from ai.backend.manager.services.image.actions.alias_image import (
     AliasImageAction,
     AliasImageActionResult,
@@ -159,9 +161,12 @@ class ImageProcessors(AbstractProcessorPackage):
 
         # Single entity actions — also invoked from gql_legacy, so use the
         # non-enforcing legacy RBAC validator to avoid breaking legacy callers.
-        legacy_single_entity_validator = (
-            validators.legacy_rbac.single_entity
-            if validators.legacy_rbac is not None
+        # Mocked test fixtures do not provide a legacy_rbac, so isinstance
+        # guards against MagicMock attribute access returning a truthy mock.
+        legacy_rbac = validators.legacy_rbac
+        legacy_single_entity_validator: SingleEntityActionValidator = (
+            legacy_rbac.single_entity
+            if isinstance(legacy_rbac, LegacyRBACValidators)
             else validators.rbac.single_entity
         )
         self.forget_image_by_id = SingleEntityActionProcessor(

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -157,12 +157,17 @@ class ImageProcessors(AbstractProcessorPackage):
         self.get_all_images = ActionProcessor(service.get_all_images, action_monitors)
         self.search_images = ActionProcessor(service.search_images, action_monitors)
 
-        # Single entity actions with RBAC validation
+        # Single entity actions — also invoked from gql_legacy, so use the
+        # non-enforcing legacy RBAC validator to avoid breaking legacy callers.
         self.forget_image_by_id = SingleEntityActionProcessor(
-            service.forget_image_by_id, action_monitors, validators=[validators.rbac.single_entity]
+            service.forget_image_by_id,
+            action_monitors,
+            validators=[validators.legacy_rbac.single_entity],
         )
         self.purge_image_by_id = SingleEntityActionProcessor(
-            service.purge_image_by_id, action_monitors, validators=[validators.rbac.single_entity]
+            service.purge_image_by_id,
+            action_monitors,
+            validators=[validators.legacy_rbac.single_entity],
         )
         # Superadmin-only mutations — access is enforced by check_admin_only at the API layer,
         # so per-entity RBAC validation is not required here.

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -159,15 +159,20 @@ class ImageProcessors(AbstractProcessorPackage):
 
         # Single entity actions — also invoked from gql_legacy, so use the
         # non-enforcing legacy RBAC validator to avoid breaking legacy callers.
+        legacy_single_entity_validator = (
+            validators.legacy_rbac.single_entity
+            if validators.legacy_rbac is not None
+            else validators.rbac.single_entity
+        )
         self.forget_image_by_id = SingleEntityActionProcessor(
             service.forget_image_by_id,
             action_monitors,
-            validators=[validators.legacy_rbac.single_entity],
+            validators=[legacy_single_entity_validator],
         )
         self.purge_image_by_id = SingleEntityActionProcessor(
             service.purge_image_by_id,
             action_monitors,
-            validators=[validators.legacy_rbac.single_entity],
+            validators=[legacy_single_entity_validator],
         )
         # Superadmin-only mutations — access is enforced by check_admin_only at the API layer,
         # so per-entity RBAC validation is not required here.

--- a/src/ai/backend/manager/services/model_serving/processors/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/processors/model_serving.py
@@ -119,10 +119,15 @@ class ModelServingProcessors(AbstractProcessorPackage):
             service.delete, action_monitors, validators=[validators.rbac.single_entity]
         )
         # modify_endpoint is invoked only from gql_legacy — non-enforcing validator.
+        legacy_single_entity_validator = (
+            validators.legacy_rbac.single_entity
+            if validators.legacy_rbac is not None
+            else validators.rbac.single_entity
+        )
         self.modify_endpoint = SingleEntityActionProcessor(
             service.modify_endpoint,
             action_monitors,
-            validators=[validators.legacy_rbac.single_entity],
+            validators=[legacy_single_entity_validator],
         )
         self.update_route = SingleEntityActionProcessor(
             service.update_route, action_monitors, validators=[validators.rbac.single_entity]

--- a/src/ai/backend/manager/services/model_serving/processors/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/processors/model_serving.py
@@ -118,8 +118,11 @@ class ModelServingProcessors(AbstractProcessorPackage):
         self.delete_model_service = SingleEntityActionProcessor(
             service.delete, action_monitors, validators=[validators.rbac.single_entity]
         )
+        # modify_endpoint is invoked only from gql_legacy — non-enforcing validator.
         self.modify_endpoint = SingleEntityActionProcessor(
-            service.modify_endpoint, action_monitors, validators=[validators.rbac.single_entity]
+            service.modify_endpoint,
+            action_monitors,
+            validators=[validators.legacy_rbac.single_entity],
         )
         self.update_route = SingleEntityActionProcessor(
             service.update_route, action_monitors, validators=[validators.rbac.single_entity]

--- a/src/ai/backend/manager/services/model_serving/processors/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/processors/model_serving.py
@@ -5,7 +5,9 @@ from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
+from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators
 from ai.backend.manager.services.model_serving.actions.clear_error import (
     ClearErrorAction,
     ClearErrorActionResult,
@@ -119,9 +121,12 @@ class ModelServingProcessors(AbstractProcessorPackage):
             service.delete, action_monitors, validators=[validators.rbac.single_entity]
         )
         # modify_endpoint is invoked only from gql_legacy — non-enforcing validator.
-        legacy_single_entity_validator = (
-            validators.legacy_rbac.single_entity
-            if validators.legacy_rbac is not None
+        # Mocked test fixtures do not provide a legacy_rbac, so isinstance
+        # guards against MagicMock attribute access returning a truthy mock.
+        legacy_rbac = validators.legacy_rbac
+        legacy_single_entity_validator: SingleEntityActionValidator = (
+            legacy_rbac.single_entity
+            if isinstance(legacy_rbac, LegacyRBACValidators)
             else validators.rbac.single_entity
         )
         self.modify_endpoint = SingleEntityActionProcessor(

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -6,7 +6,10 @@ from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
+from ai.backend.manager.actions.validator.scope import ScopeActionValidator
+from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators
 from ai.backend.manager.services.user.actions.admin_month_stats import (
     AdminMonthStatsAction,
     AdminMonthStatsActionResult,
@@ -152,16 +155,17 @@ class UserProcessors(AbstractProcessorPackage):
     ) -> None:
         # Scope actions with RBAC — create_user is also invoked from gql_legacy,
         # so use the non-enforcing legacy validator to avoid breaking callers.
-        legacy_scope_validator = (
-            validators.legacy_rbac.scope
-            if validators.legacy_rbac is not None
-            else validators.rbac.scope
-        )
-        legacy_single_entity_validator = (
-            validators.legacy_rbac.single_entity
-            if validators.legacy_rbac is not None
-            else validators.rbac.single_entity
-        )
+        # Mocked test fixtures do not provide a legacy_rbac, so isinstance
+        # guards against MagicMock attribute access returning a truthy mock.
+        legacy_rbac = validators.legacy_rbac
+        if isinstance(legacy_rbac, LegacyRBACValidators):
+            legacy_scope_validator: ScopeActionValidator = legacy_rbac.scope
+            legacy_single_entity_validator: SingleEntityActionValidator = (
+                legacy_rbac.single_entity
+            )
+        else:
+            legacy_scope_validator = validators.rbac.scope
+            legacy_single_entity_validator = validators.rbac.single_entity
         self.create_user = ScopeActionProcessor(
             user_service.create_user,
             action_monitors,

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -160,9 +160,7 @@ class UserProcessors(AbstractProcessorPackage):
         legacy_rbac = validators.legacy_rbac
         if isinstance(legacy_rbac, LegacyRBACValidators):
             legacy_scope_validator: ScopeActionValidator = legacy_rbac.scope
-            legacy_single_entity_validator: SingleEntityActionValidator = (
-                legacy_rbac.single_entity
-            )
+            legacy_single_entity_validator: SingleEntityActionValidator = legacy_rbac.single_entity
         else:
             legacy_scope_validator = validators.rbac.scope
             legacy_single_entity_validator = validators.rbac.single_entity

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -152,10 +152,20 @@ class UserProcessors(AbstractProcessorPackage):
     ) -> None:
         # Scope actions with RBAC — create_user is also invoked from gql_legacy,
         # so use the non-enforcing legacy validator to avoid breaking callers.
+        legacy_scope_validator = (
+            validators.legacy_rbac.scope
+            if validators.legacy_rbac is not None
+            else validators.rbac.scope
+        )
+        legacy_single_entity_validator = (
+            validators.legacy_rbac.single_entity
+            if validators.legacy_rbac is not None
+            else validators.rbac.single_entity
+        )
         self.create_user = ScopeActionProcessor(
             user_service.create_user,
             action_monitors,
-            validators=[validators.legacy_rbac.scope],
+            validators=[legacy_scope_validator],
         )
         self.search_users_by_domain = ActionProcessor(
             user_service.search_users_by_domain, action_monitors
@@ -176,7 +186,7 @@ class UserProcessors(AbstractProcessorPackage):
         self.modify_user = SingleEntityActionProcessor(
             user_service.modify_user,
             action_monitors,
-            validators=[validators.legacy_rbac.single_entity],
+            validators=[legacy_single_entity_validator],
         )
         self.modify_user_by_id = SingleEntityActionProcessor(
             user_service.modify_user_by_id,
@@ -193,7 +203,7 @@ class UserProcessors(AbstractProcessorPackage):
         self.purge_user = SingleEntityActionProcessor(
             user_service.purge_user,
             action_monitors,
-            validators=[validators.legacy_rbac.single_entity],
+            validators=[legacy_single_entity_validator],
         )
         self.purge_user_by_id = SingleEntityActionProcessor(
             user_service.purge_user_by_id,

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -150,9 +150,12 @@ class UserProcessors(AbstractProcessorPackage):
         action_monitors: list[ActionMonitor],
         validators: ActionValidators,
     ) -> None:
-        # Scope actions with RBAC
+        # Scope actions with RBAC — create_user is also invoked from gql_legacy,
+        # so use the non-enforcing legacy validator to avoid breaking callers.
         self.create_user = ScopeActionProcessor(
-            user_service.create_user, action_monitors, validators=[validators.rbac.scope]
+            user_service.create_user,
+            action_monitors,
+            validators=[validators.legacy_rbac.scope],
         )
         self.search_users_by_domain = ActionProcessor(
             user_service.search_users_by_domain, action_monitors
@@ -169,8 +172,11 @@ class UserProcessors(AbstractProcessorPackage):
         self.get_user = SingleEntityActionProcessor(
             user_service.get_user, action_monitors, validators=[validators.rbac.single_entity]
         )
+        # modify_user is also invoked from gql_legacy — non-enforcing validator.
         self.modify_user = SingleEntityActionProcessor(
-            user_service.modify_user, action_monitors, validators=[validators.rbac.single_entity]
+            user_service.modify_user,
+            action_monitors,
+            validators=[validators.legacy_rbac.single_entity],
         )
         self.modify_user_by_id = SingleEntityActionProcessor(
             user_service.modify_user_by_id,
@@ -183,8 +189,11 @@ class UserProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=[validators.rbac.single_entity],
         )
+        # purge_user is invoked only from gql_legacy — non-enforcing validator.
         self.purge_user = SingleEntityActionProcessor(
-            user_service.purge_user, action_monitors, validators=[validators.rbac.single_entity]
+            user_service.purge_user,
+            action_monitors,
+            validators=[validators.legacy_rbac.single_entity],
         )
         self.purge_user_by_id = SingleEntityActionProcessor(
             user_service.purge_user_by_id,


### PR DESCRIPTION
## Summary
- `SingleEntity`/`ScopeActionRBACValidator` awaited `check_permission_with_scope_chain()` but discarded the `bool` result, silently allowing denied actions through. Now raises `NotEnoughPermission` on denial.
- Added `Legacy{SingleEntity,Scope}ActionRBACValidator` that run the same permission check but only log + increment a Prometheus counter (`backendai_manager_rbac_legacy_permission_denied_total`) on denial, without raising.
- Wired `LegacyRBACValidators` through `ActionValidators` and swapped the validator on processor entries invoked from `gql_legacy` paths (`image.forget_image_by_id`/`purge_image_by_id`, `user.create_user`/`modify_user`/`purge_user`, `model_serving.modify_endpoint`) so legacy behavior is preserved while we gain visibility into would-be denials.

## Test plan
- [x] Unit test: denied single-entity / scope action under strict validator → `NotEnoughPermission` raised
- [x] Unit test: allowed action still passes validation without exception
- [x] Unit test: legacy validators do not raise on denial and record the counter
- [ ] Manual: legacy gql_legacy mutations (create/modify/purge user, forget/purge image, modify endpoint) still succeed for previously-allowed callers

Resolves BA-5661