### PR TITLE
fix(BA-5701): handle not_equals and not_in in GQL status/role filter conversion

### DIFF
--- a/changes/11024.fix.md
+++ b/changes/11024.fix.md
@@ -1,0 +1,1 @@
+Fix GQL user adapter to handle `not_equals` and `not_in` operations in status and role filter conversion, which were previously silently ignored.

--- a/src/ai/backend/manager/api/adapters/user.py
+++ b/src/ai/backend/manager/api/adapters/user.py
@@ -1067,6 +1067,18 @@ class UserAdapter(BaseAdapter):
             conditions.append(
                 UserConditions.by_status_in([DataUserStatus(s.value) for s in sf.in_])
             )
+        if sf.not_equals is not None:
+            conditions.append(
+                negate_conditions([
+                    UserConditions.by_status_equals(DataUserStatus(sf.not_equals.value))
+                ])
+            )
+        if sf.not_in is not None:
+            conditions.append(
+                negate_conditions([
+                    UserConditions.by_status_in([DataUserStatus(s.value) for s in sf.not_in])
+                ])
+            )
         return conditions
 
     @staticmethod
@@ -1076,6 +1088,18 @@ class UserAdapter(BaseAdapter):
             conditions.append(UserConditions.by_role_equals(DataUserRole(rf.equals.value)))
         if rf.in_ is not None:
             conditions.append(UserConditions.by_role_in([DataUserRole(r.value) for r in rf.in_]))
+        if rf.not_equals is not None:
+            conditions.append(
+                negate_conditions([
+                    UserConditions.by_role_equals(DataUserRole(rf.not_equals.value))
+                ])
+            )
+        if rf.not_in is not None and len(rf.not_in) > 0:
+            conditions.append(
+                negate_conditions([
+                    UserConditions.by_role_in([DataUserRole(r.value) for r in rf.not_in])
+                ])
+            )
         return conditions
 
     def _convert_domain_nested_filter(


### PR DESCRIPTION
## Summary
- `_convert_status_filter()` and `_convert_role_filter()` in the GQL user adapter only handled `equals` and `in_` operations, silently ignoring `not_equals` and `not_in`
- Applied the same `negate_conditions()` pattern already used by the REST v2 adapter (`_convert_rest_filter`)

## Test plan
- [x] `pants lint` passes
- [x] `pants test tests/unit/manager/api/adapters::` passes
- [ ] GQL query `projectUsersV2(filter: {status: {notEquals: ACTIVE}})` returns only non-ACTIVE users
- [ ] GQL query `projectUsersV2(filter: {role: {notEquals: USER}})` returns only non-USER roles

Resolves BA-5701