### PR TITLE
refactor(BA-5700): Split out `LabelMatcher` support in Prometheus presets

### DIFF
--- a/changes/11025.enhance.md
+++ b/changes/11025.enhance.md
@@ -1,0 +1,1 @@
+Add explicit LabelMatcher to Prometheus query presets to support regex matching operators

--- a/src/ai/backend/common/clients/prometheus/__init__.py
+++ b/src/ai/backend/common/clients/prometheus/__init__.py
@@ -1,9 +1,10 @@
 from .client import PrometheusClient
-from .preset import MetricPreset
+from .preset import LabelMatcher, MetricPreset
 from .querier import ContainerMetricQuerier, MetricQuerier
 from .types import ValueType
 
 __all__ = [
+    "LabelMatcher",
     "PrometheusClient",
     "MetricPreset",
     "MetricQuerier",

--- a/src/ai/backend/common/clients/prometheus/__init__.py
+++ b/src/ai/backend/common/clients/prometheus/__init__.py
@@ -1,10 +1,11 @@
 from .client import PrometheusClient
-from .preset import LabelMatcher, MetricPreset
+from .preset import LabelMatcher, LabelOperator, MetricPreset
 from .querier import ContainerMetricQuerier, MetricQuerier
 from .types import ValueType
 
 __all__ = [
     "LabelMatcher",
+    "LabelOperator",
     "PrometheusClient",
     "MetricPreset",
     "MetricQuerier",

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -1,6 +1,14 @@
 from collections.abc import Mapping, Set
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Self
+
+
+class LabelOperator(StrEnum):
+    EQUAL = "="
+    NOT_EQUAL = "!="
+    REGEX = "=~"
+    NOT_REGEX = "!~"
 
 
 @dataclass(frozen=True)
@@ -8,15 +16,15 @@ class LabelMatcher:
     """PromQL label matcher with an explicit operator."""
 
     value: str
-    operator: str = "="
+    operator: LabelOperator = LabelOperator.EQUAL
 
     @classmethod
     def exact(cls, value: str) -> Self:
-        return cls(value=value, operator="=")
+        return cls(value=value, operator=LabelOperator.EQUAL)
 
     @classmethod
     def regex(cls, value: str) -> Self:
-        return cls(value=value, operator="=~")
+        return cls(value=value, operator=LabelOperator.REGEX)
 
 
 def _escape_label_value(value: str) -> str:

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -2,6 +2,22 @@ from collections.abc import Mapping, Set
 from dataclasses import dataclass, field
 
 
+@dataclass(frozen=True)
+class LabelMatcher:
+    """PromQL label matcher with an explicit operator."""
+
+    value: str
+    operator: str = "="
+
+    @classmethod
+    def exact(cls, value: str) -> "LabelMatcher":
+        return cls(value=value, operator="=")
+
+    @classmethod
+    def regex(cls, value: str) -> "LabelMatcher":
+        return cls(value=value, operator="=~")
+
+
 def _escape_label_value(value: str) -> str:
     # PromQL string literals: escape backslash, double quote, newline, carriage return
     return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
@@ -15,7 +31,7 @@ class MetricPreset:
     template: str
 
     # Query labels (injected into {labels} placeholder)
-    labels: Mapping[str, str] = field(default_factory=dict)
+    labels: Mapping[str, LabelMatcher] = field(default_factory=dict)
 
     # Group by labels (injected into {group_by} placeholder)
     group_by: Set[str] = field(default_factory=frozenset)
@@ -25,7 +41,10 @@ class MetricPreset:
 
     def render(self) -> str:
         """Render the PromQL query with all values injected."""
-        label_str = ",".join(f'{k}="{_escape_label_value(v)}"' for k, v in self.labels.items())
+        label_str = ",".join(
+            f'{key}{value.operator}"{_escape_label_value(value.value)}"'
+            for key, value in self.labels.items()
+        )
         return self.template.format(
             labels=label_str,
             window=self.window,

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping, Set
 from dataclasses import dataclass, field
+from typing import Self
 
 
 @dataclass(frozen=True)
@@ -10,11 +11,11 @@ class LabelMatcher:
     operator: str = "="
 
     @classmethod
-    def exact(cls, value: str) -> "LabelMatcher":
+    def exact(cls, value: str) -> Self:
         return cls(value=value, operator="=")
 
     @classmethod
-    def regex(cls, value: str) -> "LabelMatcher":
+    def regex(cls, value: str) -> Self:
         return cls(value=value, operator="=~")
 
 

--- a/src/ai/backend/common/clients/prometheus/querier.py
+++ b/src/ai/backend/common/clients/prometheus/querier.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from uuid import UUID
 
+from ai.backend.common.clients.prometheus.preset import LabelMatcher
 from ai.backend.common.clients.prometheus.types import ValueType
 
 
@@ -14,7 +15,7 @@ class MetricQuerier(ABC):
     """
 
     @abstractmethod
-    def labels(self) -> Mapping[str, str]:
+    def labels(self) -> Mapping[str, LabelMatcher]:
         """Return the labels to be used in the Prometheus query."""
         ...
 
@@ -34,22 +35,22 @@ class ContainerMetricQuerier(MetricQuerier):
     user_id: UUID | None = None
     project_id: UUID | None = None
 
-    def labels(self) -> Mapping[str, str]:
+    def labels(self) -> Mapping[str, LabelMatcher]:
         """Return the labels for the container metric query."""
-        result: dict[str, str] = {
-            "container_metric_name": self.metric_name,
-            "value_type": self.value_type,
+        result: dict[str, LabelMatcher] = {
+            "container_metric_name": LabelMatcher.exact(self.metric_name),
+            "value_type": LabelMatcher.exact(self.value_type),
         }
         if self.kernel_id is not None:
-            result["kernel_id"] = str(self.kernel_id)
+            result["kernel_id"] = LabelMatcher.exact(str(self.kernel_id))
         if self.session_id is not None:
-            result["session_id"] = str(self.session_id)
+            result["session_id"] = LabelMatcher.exact(str(self.session_id))
         if self.agent_id is not None:
-            result["agent_id"] = self.agent_id
+            result["agent_id"] = LabelMatcher.exact(self.agent_id)
         if self.user_id is not None:
-            result["user_id"] = str(self.user_id)
+            result["user_id"] = LabelMatcher.exact(str(self.user_id))
         if self.project_id is not None:
-            result["project_id"] = str(self.project_id)
+            result["project_id"] = LabelMatcher.exact(str(self.project_id))
         return result
 
     def group_by_labels(self) -> frozenset[str]:

--- a/src/ai/backend/manager/services/prometheus_query_preset/service.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/service.py
@@ -1,7 +1,7 @@
 import logging
 
 from ai.backend.common.clients.prometheus.client import PrometheusClient
-from ai.backend.common.clients.prometheus.preset import MetricPreset
+from ai.backend.common.clients.prometheus.preset import LabelMatcher, MetricPreset
 from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
 from ai.backend.common.exception import PrometheusQueryPresetInvalidLabel
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -90,6 +90,12 @@ class PrometheusQueryPresetService:
                     f"Allowed: {sorted(preset_data.group_labels)}"
                 )
 
+    def _build_filter_label_matchers(
+        self,
+        filter_labels: dict[str, str],
+    ) -> dict[str, LabelMatcher]:
+        return {key: LabelMatcher.exact(value) for key, value in filter_labels.items()}
+
     async def execute_preset(self, action: ExecutePresetAction) -> ExecutePresetActionResult:
         preset_data = await self._repository.get_by_id(action.preset_id)
         self._validate_labels(action.options, preset_data)
@@ -98,7 +104,7 @@ class PrometheusQueryPresetService:
 
         metric_preset = MetricPreset(
             template=preset_data.query_template,
-            labels=action.options.filter_labels,
+            labels=self._build_filter_label_matchers(action.options.filter_labels),
             group_by=set(action.options.group_labels),
             window=time_window,
         )

--- a/src/ai/backend/manager/sokovan/deployment/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/executor.py
@@ -12,7 +12,7 @@ from ai.backend.common.clients.http_client.client_pool import (
     ClientPool,
 )
 from ai.backend.common.clients.prometheus.client import PrometheusClient
-from ai.backend.common.clients.prometheus.preset import MetricPreset
+from ai.backend.common.clients.prometheus.preset import LabelMatcher, MetricPreset
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.data.permission.types import RBACElementType
@@ -762,7 +762,7 @@ class DeploymentExecutor:
         preset_data: PrometheusQueryPresetData = presets[preset_id]
 
         # Auto-inject deployment-specific label for scoping
-        labels: dict[str, str] = {"model_service_name": deployment.metadata.name}
+        labels = {"model_service_name": LabelMatcher.exact(deployment.metadata.name)}
 
         # time_window: preset default → fallback to "5m"
         time_window = preset_data.time_window or "5m"

--- a/tests/unit/common/clients/prometheus/test_client.py
+++ b/tests/unit/common/clients/prometheus/test_client.py
@@ -5,6 +5,7 @@ import aiohttp
 import pytest
 
 from ai.backend.common.clients.prometheus import (
+    LabelMatcher,
     MetricPreset,
     PrometheusClient,
 )
@@ -66,7 +67,10 @@ class TestQueryRange:
     def sample_preset(self) -> MetricPreset:
         return MetricPreset(
             template="sum(my_metric{{{labels}}}) by ({group_by})",
-            labels={"container_metric_name": "mem", "value_type": "current"},
+            labels={
+                "container_metric_name": LabelMatcher.exact("mem"),
+                "value_type": LabelMatcher.exact("current"),
+            },
             group_by=frozenset({"value_type"}),
             window="5m",
         )
@@ -175,7 +179,10 @@ class TestQueryInstant:
     def sample_preset(self) -> MetricPreset:
         return MetricPreset(
             template="sum(my_metric{{{labels}}}) by ({group_by})",
-            labels={"container_metric_name": "mem", "value_type": "current"},
+            labels={
+                "container_metric_name": LabelMatcher.exact("mem"),
+                "value_type": LabelMatcher.exact("current"),
+            },
             group_by=frozenset({"value_type"}),
             window="5m",
         )

--- a/tests/unit/common/clients/prometheus/test_preset.py
+++ b/tests/unit/common/clients/prometheus/test_preset.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 
 import pytest
 
-from ai.backend.common.clients.prometheus import MetricPreset
+from ai.backend.common.clients.prometheus import LabelMatcher, MetricPreset
 
 
 @dataclass
 class RenderTestCase:
     id: str
     template: str
-    labels: dict[str, str]
+    labels: dict[str, LabelMatcher]
     group_by: frozenset[str]
     window: str
     expected: str
@@ -32,7 +32,7 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="multiple_group_by_sorted",
                 template="sum(my_metric{{{labels}}}) by ({group_by})",
-                labels={"job": "test"},
+                labels={"job": LabelMatcher.exact("test")},
                 group_by=frozenset({"value_type", "kernel_id", "session_id"}),
                 window="",
                 expected='sum(my_metric{job="test"}) by (kernel_id,session_id,value_type)',
@@ -52,7 +52,7 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="with_window",
                 template="sum(rate(my_metric{{{labels}}}[{window}])) by ({group_by})",
-                labels={"job": "test"},
+                labels={"job": LabelMatcher.exact("test")},
                 group_by=frozenset({"instance"}),
                 window="5m",
                 expected='sum(rate(my_metric{job="test"}[5m])) by (instance)',
@@ -60,7 +60,7 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="escapes_double_quotes_in_label_value",
                 template="my_metric{{{labels}}}",
-                labels={"key": 'value with "quotes"'},
+                labels={"key": LabelMatcher.exact('value with "quotes"')},
                 group_by=frozenset(),
                 window="",
                 expected='my_metric{key="value with \\"quotes\\""}',
@@ -68,7 +68,7 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="escapes_backslash_in_label_value",
                 template="my_metric{{{labels}}}",
-                labels={"path": "C:\\Users\\test"},
+                labels={"path": LabelMatcher.exact("C:\\Users\\test")},
                 group_by=frozenset(),
                 window="",
                 expected='my_metric{path="C:\\\\Users\\\\test"}',
@@ -76,7 +76,7 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="escapes_newline_in_label_value",
                 template="my_metric{{{labels}}}",
-                labels={"msg": "line1\nline2"},
+                labels={"msg": LabelMatcher.exact("line1\nline2")},
                 group_by=frozenset(),
                 window="",
                 expected='my_metric{msg="line1\\nline2"}',
@@ -84,10 +84,18 @@ class TestMetricPresetRender:
             RenderTestCase(
                 id="escapes_mixed_special_chars",
                 template="my_metric{{{labels}}}",
-                labels={"data": 'path\\to\\"file"\nend'},
+                labels={"data": LabelMatcher.exact('path\\to\\"file"\nend')},
                 group_by=frozenset(),
                 window="",
                 expected='my_metric{data="path\\\\to\\\\\\"file\\"\\nend"}',
+            ),
+            RenderTestCase(
+                id="regex_matcher",
+                template="my_metric{{{labels}}}",
+                labels={"kernel_id": LabelMatcher.regex("kernel-1|kernel-2")},
+                group_by=frozenset(),
+                window="",
+                expected='my_metric{kernel_id=~"kernel-1|kernel-2"}',
             ),
         ],
         ids=lambda c: c.id,

--- a/tests/unit/common/clients/prometheus/test_querier.py
+++ b/tests/unit/common/clients/prometheus/test_querier.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from ai.backend.common.clients.prometheus import ContainerMetricQuerier, ValueType
+from ai.backend.common.clients.prometheus import ContainerMetricQuerier, LabelMatcher, ValueType
 
 
 class TestContainerMetricQuerier:
@@ -15,8 +15,8 @@ class TestContainerMetricQuerier:
         result = querier.labels()
 
         assert result == {
-            "container_metric_name": "cpu_util",
-            "value_type": "current",
+            "container_metric_name": LabelMatcher.exact("cpu_util"),
+            "value_type": LabelMatcher.exact("current"),
         }
 
     async def test_labels_all_fields(self) -> None:
@@ -38,13 +38,13 @@ class TestContainerMetricQuerier:
         result = querier.labels()
 
         assert result == {
-            "container_metric_name": "net_rx",
-            "value_type": "current",
-            "kernel_id": str(kernel_id),
-            "session_id": str(session_id),
-            "agent_id": "agent-001",
-            "user_id": str(user_id),
-            "project_id": str(project_id),
+            "container_metric_name": LabelMatcher.exact("net_rx"),
+            "value_type": LabelMatcher.exact("current"),
+            "kernel_id": LabelMatcher.exact(str(kernel_id)),
+            "session_id": LabelMatcher.exact(str(session_id)),
+            "agent_id": LabelMatcher.exact("agent-001"),
+            "user_id": LabelMatcher.exact(str(user_id)),
+            "project_id": LabelMatcher.exact(str(project_id)),
         }
 
     async def test_group_by_required_only(self) -> None:


### PR DESCRIPTION
resolve #11021 (BA-5700)
## What changed
- split out the Prometheus `LabelMatcher` work onto a dedicated branch from `main`
- make `MetricPreset` and related querier paths use explicit `LabelMatcher` instances for label rendering
- update `LabelMatcher` factory methods to return `Self`

## Why
- separate the reusable Prometheus label-matching refactor from the follow-up live-stat compatibility fixes
- make exact-match vs regex-match intent explicit in query construction
- keep the factory return annotations consistent and clearer

## Impact
- Prometheus preset and querier code now express label operators explicitly

## Validation
- `pants check src/ai/backend/common/clients/prometheus/preset.py src/ai/backend/common/clients/prometheus/querier.py src/ai/backend/manager/services/prometheus_query_preset/service.py tests/unit/common/clients/prometheus/test_preset.py tests/unit/common/clients/prometheus/test_client.py tests/unit/common/clients/prometheus/test_querier.py`
- `pants test tests/unit/common/clients/prometheus/test_preset.py tests/unit/common/clients/prometheus/test_client.py tests/unit/common/clients/prometheus/test_querier.py tests/unit/manager/services/prometheus_query_preset/test_prometheus_query_preset_service.py`
