### PR TITLE
fix: use running_at for route health initial_delay calculation

### DIFF
--- a/changes/11029.fix.md
+++ b/changes/11029.fix.md
@@ -1,0 +1,1 @@
+Fix route health initial_delay calculation to use running_at instead of route creation time, preventing premature session termination for custom runtime variants with long model loading times.

--- a/dev
+++ b/dev
@@ -149,14 +149,32 @@ cmd_restart() {
 
 cmd_log() {
   local svc=$1
+  local follow=${2:-}
   local winname
   winname=$(_tmux_window_name "$svc")
   local win
   win=$(tmux list-windows -t "$TMUX_SESSION" -F "#{window_name}" 2>/dev/null | grep "^${winname}$" | head -1) || true
-  if [ -n "$win" ]; then
-    tmux capture-pane -t "$TMUX_SESSION:$win" -p -S -50
-  else
+  if [ -z "$win" ]; then
     echo "$(_color red "No tmux window found for $svc")"
+    return 1
+  fi
+  if [ "$follow" = "-f" ]; then
+    local last_hash=""
+    trap 'exit 0' INT
+    while true; do
+      local output
+      output=$(tmux capture-pane -t "$TMUX_SESSION:$win" -p -S -50 2>/dev/null)
+      local cur_hash
+      cur_hash=$(echo "$output" | md5sum | cut -d' ' -f1)
+      if [ "$cur_hash" != "$last_hash" ]; then
+        clear
+        echo "$output"
+        last_hash=$cur_hash
+      fi
+      sleep 1
+    done
+  else
+    tmux capture-pane -t "$TMUX_SESSION:$win" -p -S -50
   fi
 }
 
@@ -170,7 +188,7 @@ Commands:
   start   <service|all>     Start a service
   stop    <service|all>     Stop a service
   restart <service|all>     Restart a service
-  log     <service>         Show recent log output
+  log     <service> [-f]    Show recent log output (-f to follow)
 
 Services:
   mgr, agent, storage, web, proxy-coordinator, proxy-worker, all
@@ -207,9 +225,9 @@ case "$1" in
     "cmd_$1" "$2"
     ;;
   log)
-    [ $# -lt 2 ] && { echo "$(_color red "Usage: ./dev log <service>")"; exit 1; }
+    [ $# -lt 2 ] && { echo "$(_color red "Usage: ./dev log <service> [-f]")"; exit 1; }
     _validate_service "$2"
-    cmd_log "$2"
+    cmd_log "$2" "${3:-}"
     ;;
   *) echo "$(_color red "Unknown command: $1")"; usage; exit 1 ;;
 esac

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -95,10 +95,13 @@ class RouteHealthRecord:
 
     route_id: str
     created_at: int  # Unix timestamp when route was created
-    initial_delay_until: int  # Unix timestamp = created_at + initial_delay
+    initial_delay_until: int  # Unix timestamp = running_at + initial_delay
     health_path: str  # extracted from model_definition
     inference_port: int  # extracted from kernel
     replica_host: str  # extracted from kernel
+
+    # Timestamp when route entered RUNNING state (set by coordinator)
+    running_at: int | None = None
 
     # Agent check results
     agent_healthy: bool = False
@@ -128,7 +131,7 @@ class RouteHealthRecord:
 
     def to_valkey_hash(self) -> Mapping[str, str]:
         """Serialize to Valkey hash fields."""
-        return {
+        data: dict[str, str] = {
             "route_id": self.route_id,
             "created_at": str(self.created_at),
             "initial_delay_until": str(self.initial_delay_until),
@@ -140,6 +143,9 @@ class RouteHealthRecord:
             "manager_healthy": "1" if self.manager_healthy else "0",
             "manager_last_check": str(self.manager_last_check),
         }
+        if self.running_at is not None:
+            data["running_at"] = str(self.running_at)
+        return data
 
     @classmethod
     def from_valkey_hash(cls, data: Mapping[str, str]) -> RouteHealthRecord:
@@ -151,6 +157,7 @@ class RouteHealthRecord:
             health_path=data["health_path"],
             inference_port=int(data["inference_port"]),
             replica_host=data["replica_host"],
+            running_at=int(raw) if (raw := data.get("running_at")) and raw != "0" else None,
             agent_healthy=data.get("agent_healthy", "0") == "1",
             agent_last_check=int(data.get("agent_last_check", "0")),
             manager_healthy=data.get("manager_healthy", "0") == "1",
@@ -667,6 +674,21 @@ class ValkeyScheduleClient:
         batch.expire(key, ROUTE_HEALTH_TTL_SEC)
         async with self._client.client() as conn:
             await conn.exec(batch, raise_on_error=True)
+
+    @valkey_schedule_resilience.apply()
+    async def mark_route_running_at(self, route_id: str) -> None:
+        """
+        Record the RUNNING transition timestamp for a route.
+        Called when a route transitions to RUNNING status.
+        Uses Redis time for consistency with health check comparisons.
+
+        :param route_id: The route ID that entered RUNNING state
+        """
+        key = self._get_route_health_key(route_id)
+        current_time = str(await self._get_redis_time())
+        async with self._client.client() as conn:
+            await conn.hset(key, {"running_at": current_time})
+            await conn.expire(key, ROUTE_HEALTH_TTL_SEC)
 
     @valkey_schedule_resilience.apply()
     async def refresh_route_health_ttl(self, route_id: str) -> None:

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -850,6 +850,8 @@ class ValkeyScheduleClient:
             return None
 
         data = {k.decode(): v.decode() for k, v in result.items()}
+        if "route_id" not in data:
+            return None
         return RouteHealthRecord.from_valkey_hash(data)
 
     @valkey_schedule_resilience.apply()
@@ -888,6 +890,10 @@ class ValkeyScheduleClient:
                 continue
 
             data = {k.decode(): v.decode() for k, v in raw.items()}
+            if "route_id" not in data:
+                # Partial hash (e.g., only running_at set by mark_route_running_at)
+                records[route_id] = None
+                continue
             records[route_id] = RouteHealthRecord.from_valkey_hash(data)
 
         return records

--- a/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_schedule/client.py
@@ -691,6 +691,37 @@ class ValkeyScheduleClient:
             await conn.expire(key, ROUTE_HEALTH_TTL_SEC)
 
     @valkey_schedule_resilience.apply()
+    async def get_route_running_at_batch(self, route_ids: Sequence[str]) -> dict[str, int | None]:
+        """
+        Batch read running_at field from route health hashes.
+        Works even on partial hashes (before full RouteHealthRecord is initialized).
+
+        :param route_ids: Route IDs to look up
+        :return: Mapping of route_id to running_at timestamp (None if not set)
+        """
+        if not route_ids:
+            return {}
+
+        batch = Batch(is_atomic=False)
+        for route_id in route_ids:
+            key = self._get_route_health_key(route_id)
+            batch.hget(key, "running_at")
+
+        async with self._client.client() as conn:
+            results = await conn.exec(batch, raise_on_error=False)
+        if results is None:
+            return dict.fromkeys(route_ids)
+
+        running_at_map: dict[str, int | None] = {}
+        for i, route_id in enumerate(route_ids):
+            raw = results[i] if len(results) > i else None
+            if raw and raw != b"0":
+                running_at_map[route_id] = int(raw)
+            else:
+                running_at_map[route_id] = None
+        return running_at_map
+
+    @valkey_schedule_resilience.apply()
     async def refresh_route_health_ttl(self, route_id: str) -> None:
         """
         Refresh TTL for a route health record without changing any data.

--- a/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/coordinator.py
@@ -370,6 +370,15 @@ class RouteCoordinator:
                 batch_updaters, BulkCreator(specs=all_history_specs)
             )
 
+        # Record running_at in Valkey for routes that just transitioned to RUNNING
+        if (
+            transitions.success is not None
+            and transitions.success.status == RouteStatus.RUNNING
+            and result.successes
+        ):
+            for route in result.successes:
+                await self._valkey_schedule.mark_route_running_at(str(route.route_id))
+
     async def process_if_needed(self, lifecycle_type: RouteLifecycleType) -> None:
         """
         Process route lifecycle operation if needed (based on internal state).

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -230,6 +230,12 @@ class RouteExecutor:
         health_configs = await self._deployment_repo.fetch_health_check_configs_by_revision_ids(
             revision_ids
         )
+        redis_time = await self._valkey_schedule.get_redis_time()
+
+        # Read existing running_at values that were set when routes transitioned to RUNNING
+        route_id_strs = [str(r.route_id) for r in routes]
+        existing_records = await self._valkey_schedule.get_route_health_records_batch(route_id_strs)
+
         records: list[RouteHealthRecord] = []
         for route in routes:
             host, port = replica_info[route.route_id]
@@ -238,16 +244,22 @@ class RouteExecutor:
             health_path = health_config.path if health_config else "/"
             initial_delay = health_config.initial_delay if health_config else 60.0
             created_at = int(route.created_at.timestamp())
-            initial_delay_until = created_at + int(initial_delay)
+
+            # Use running_at from Valkey (set at RUNNING transition), fallback to redis_time
+            route_id_str = str(route.route_id)
+            existing = existing_records.get(route_id_str)
+            running_at = existing.running_at if existing and existing.running_at else redis_time
+            initial_delay_until = running_at + int(initial_delay)
 
             records.append(
                 RouteHealthRecord(
-                    route_id=str(route.route_id),
+                    route_id=route_id_str,
                     created_at=created_at,
                     initial_delay_until=initial_delay_until,
                     health_path=health_path,
                     inference_port=port,
                     replica_host=host,
+                    running_at=running_at,
                 )
             )
 

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -261,8 +261,10 @@ class RouteExecutor:
         redis_time = await self._valkey_schedule.get_redis_time()
 
         # Read existing running_at values that were set when routes transitioned to RUNNING
-        route_id_strs = [str(r.route_id) for r in routes]
-        existing_records = await self._valkey_schedule.get_route_health_records_batch(route_id_strs)
+        # These may be in partial hashes (only running_at field), so read raw field directly
+        running_at_map = await self._valkey_schedule.get_route_running_at_batch([
+            str(r.route_id) for r in routes
+        ])
 
         records: list[RouteHealthRecord] = []
         for route in routes:
@@ -275,8 +277,7 @@ class RouteExecutor:
 
             # Use running_at from Valkey (set at RUNNING transition), fallback to redis_time
             route_id_str = str(route.route_id)
-            existing = existing_records.get(route_id_str)
-            running_at = existing.running_at if existing and existing.running_at else redis_time
+            running_at = running_at_map.get(route_id_str) or redis_time
             initial_delay_until = running_at + int(initial_delay)
 
             records.append(

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -193,6 +193,11 @@ class RouteExecutor:
                 with RouteRecorderContext.shared_step("fetch_kernel_connection_info"):
                     await self._populate_replica_info(routes_missing_replica)
 
+        # Phase 4: Ensure RouteHealthRecords exist in Valkey for routes with replica info
+        routes_with_replica = [r for r in successes if r.replica_host and r.replica_port]
+        if routes_with_replica:
+            await self._ensure_health_records(routes_with_replica)
+
         return RouteExecutionResult(
             successes=successes,
             errors=errors,
@@ -219,6 +224,29 @@ class RouteExecutor:
 
         if populated_routes:
             await self._initialize_health_records(populated_routes, updates)
+
+    async def _ensure_health_records(self, routes: Sequence[RouteData]) -> None:
+        """Ensure RouteHealthRecords exist in Valkey for routes that already have replica info.
+
+        Routes may already have replica_host/port in DB (set by a previous cycle or legacy code)
+        but lack a RouteHealthRecord in Valkey. This method checks and initializes missing records.
+        """
+        route_id_strs = [str(r.route_id) for r in routes]
+        existing = await self._valkey_schedule.get_route_health_records_batch(route_id_strs)
+        missing = [r for r in routes if existing.get(str(r.route_id)) is None]
+        if not missing:
+            return
+        log.warning(
+            "RouteHealthRecord missing in Valkey for {} routes, re-initializing: {}",
+            len(missing),
+            [str(r.route_id)[:8] for r in missing],
+        )
+        replica_info = {
+            r.route_id: (r.replica_host, r.replica_port)
+            for r in missing
+            if r.replica_host and r.replica_port
+        }
+        await self._initialize_health_records(missing, replica_info)
 
     async def _initialize_health_records(
         self,

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/observer/health_check.py
@@ -73,6 +73,11 @@ class RouteHealthObserver(RouteObserver):
                 targets.append((route_id_str, record))
 
         if not targets:
+            if checkable:
+                log.warning(
+                    "Health observer: {} checkable routes but 0 have records in Valkey",
+                    len(checkable),
+                )
             return RouteObservationResult(observed_count=0)
 
         # Perform HTTP health checks in parallel

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -69,17 +69,8 @@ class TestInitializeHealthRecordsInitialDelay:
         route = _make_route(created_at_ts=1000)
         route_id_str = str(route.route_id)
 
-        existing_record = RouteHealthRecord(
-            route_id=route_id_str,
-            created_at=1000,
-            initial_delay_until=0,
-            health_path="/health",
-            inference_port=8000,
-            replica_host="10.0.0.1",
-            running_at=5000,
-        )
-        mock_valkey_schedule.get_route_health_records_batch.return_value = {
-            route_id_str: existing_record,
+        mock_valkey_schedule.get_route_running_at_batch.return_value = {
+            route_id_str: 5000,
         }
         mock_valkey_schedule.get_redis_time.return_value = 5100
         mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
@@ -111,7 +102,7 @@ class TestInitializeHealthRecordsInitialDelay:
         """
         route = _make_route(created_at_ts=1000)
 
-        mock_valkey_schedule.get_route_health_records_batch.return_value = {}
+        mock_valkey_schedule.get_route_running_at_batch.return_value = {}
         mock_valkey_schedule.get_redis_time.return_value = 6000
         mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
             route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
@@ -145,17 +136,8 @@ class TestInitializeHealthRecordsInitialDelay:
         route = _make_route(created_at_ts=1000)
         route_id_str = str(route.route_id)
 
-        existing_record = RouteHealthRecord(
-            route_id=route_id_str,
-            created_at=1000,
-            initial_delay_until=0,
-            health_path="/health",
-            inference_port=8000,
-            replica_host="10.0.0.1",
-            running_at=5000,
-        )
-        mock_valkey_schedule.get_route_health_records_batch.return_value = {
-            route_id_str: existing_record,
+        mock_valkey_schedule.get_route_running_at_batch.return_value = {
+            route_id_str: 5000,
         }
         mock_valkey_schedule.get_redis_time.return_value = 1800
         mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_initial_delay.py
@@ -1,0 +1,414 @@
+"""Tests for initial_delay calculation based on running_at.
+
+Test scenarios:
+- ID-001: running_at is set → initial_delay_until based on running_at
+- ID-002: running_at is None → fallback to redis_time
+- ID-003: created_at has expired but running_at has not → still within initial_delay
+- ID-004: running_at has also expired → initial_delay over
+- ID-005: observer ignores failure within initial_delay (running_at based)
+- ID-006: observer writes failure after initial_delay expires (running_at based)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from dateutil.tz import tzutc
+
+from ai.backend.common.clients.valkey_client.valkey_schedule import RouteHealthRecord
+from ai.backend.common.config import ModelHealthCheck
+from ai.backend.common.types import SessionId
+from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
+from ai.backend.manager.repositories.deployment.types import RouteData
+from ai.backend.manager.sokovan.deployment.route.executor import RouteExecutor
+from ai.backend.manager.sokovan.deployment.route.handlers.observer.health_check import (
+    RouteHealthObserver,
+)
+
+
+def _make_route(
+    created_at_ts: int = 1000,
+    session_id: SessionId | None = None,
+) -> RouteData:
+    return RouteData(
+        route_id=uuid4(),
+        endpoint_id=uuid4(),
+        session_id=session_id or SessionId(uuid4()),
+        status=RouteStatus.RUNNING,
+        health_status=RouteHealthStatus.NOT_CHECKED,
+        traffic_ratio=1.0,
+        created_at=datetime.fromtimestamp(created_at_ts, tz=tzutc()),
+        revision_id=uuid4(),
+        replica_host="10.0.0.1",
+        replica_port=8000,
+    )
+
+
+# =============================================================================
+# _initialize_health_records: initial_delay_until calculation
+# =============================================================================
+
+
+class TestInitializeHealthRecordsInitialDelay:
+    """Tests for initial_delay_until calculation in _initialize_health_records."""
+
+    async def test_running_at_present_uses_running_at(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """ID-001: When running_at exists in Valkey, initial_delay_until is based on running_at.
+
+        Given: Route with running_at=5000 in Valkey, initial_delay=720
+        When: _initialize_health_records
+        Then: initial_delay_until = 5000 + 720 = 5720
+        """
+        route = _make_route(created_at_ts=1000)
+        route_id_str = str(route.route_id)
+
+        existing_record = RouteHealthRecord(
+            route_id=route_id_str,
+            created_at=1000,
+            initial_delay_until=0,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            route_id_str: existing_record,
+        }
+        mock_valkey_schedule.get_redis_time.return_value = 5100
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
+        }
+
+        await route_executor._initialize_health_records(
+            [route],
+            {route.route_id: ("10.0.0.1", 8000)},
+        )
+
+        call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
+        records: list[RouteHealthRecord] = call_args[0][0]
+        assert len(records) == 1
+        assert records[0].running_at == 5000
+        assert records[0].initial_delay_until == 5000 + 720
+
+    async def test_running_at_none_falls_back_to_redis_time(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """ID-002: When running_at is None, fallback to current redis_time.
+
+        Given: No existing record in Valkey (running_at not set), redis_time=6000
+        When: _initialize_health_records
+        Then: initial_delay_until = 6000 + 720 = 6720, running_at = 6000
+        """
+        route = _make_route(created_at_ts=1000)
+
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {}
+        mock_valkey_schedule.get_redis_time.return_value = 6000
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
+        }
+
+        await route_executor._initialize_health_records(
+            [route],
+            {route.route_id: ("10.0.0.1", 8000)},
+        )
+
+        call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
+        records: list[RouteHealthRecord] = call_args[0][0]
+        assert len(records) == 1
+        assert records[0].running_at == 6000
+        assert records[0].initial_delay_until == 6000 + 720
+
+    async def test_created_at_expired_but_running_at_not_expired(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        mock_valkey_schedule: AsyncMock,
+    ) -> None:
+        """ID-003: created_at-based delay would have expired, but running_at-based has not.
+
+        Given: created_at=1000, running_at=5000, initial_delay=720, current_time=1800
+               created_at + 720 = 1720 < 1800 (expired if created_at based)
+               running_at + 720 = 5720 > 1800 (NOT expired with running_at based)
+        When: _initialize_health_records
+        Then: initial_delay_until = 5720 (based on running_at, not created_at)
+        """
+        route = _make_route(created_at_ts=1000)
+        route_id_str = str(route.route_id)
+
+        existing_record = RouteHealthRecord(
+            route_id=route_id_str,
+            created_at=1000,
+            initial_delay_until=0,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        mock_valkey_schedule.get_route_health_records_batch.return_value = {
+            route_id_str: existing_record,
+        }
+        mock_valkey_schedule.get_redis_time.return_value = 1800
+        mock_deployment_repo.fetch_health_check_configs_by_revision_ids.return_value = {
+            route.revision_id: ModelHealthCheck(path="/health", initial_delay=720.0),
+        }
+
+        await route_executor._initialize_health_records(
+            [route],
+            {route.route_id: ("10.0.0.1", 8000)},
+        )
+
+        call_args = mock_valkey_schedule.initialize_route_health_records_batch.call_args
+        records: list[RouteHealthRecord] = call_args[0][0]
+        assert records[0].initial_delay_until == 5720
+        assert records[0].created_at == 1000
+
+
+# =============================================================================
+# RouteHealthObserver: within_initial_delay based on running_at
+# =============================================================================
+
+
+class TestObserverInitialDelay:
+    """Tests for observer's initial_delay behavior with running_at-based records."""
+
+    async def test_observer_ignores_failure_within_initial_delay(self) -> None:
+        """ID-005: Observer does not write failure during initial_delay period.
+
+        Given: running_at=5000, initial_delay=720 → initial_delay_until=5720
+               current redis_time=5500 (within initial_delay)
+               health check fails
+        When: Observer runs
+        Then: update_route_manager_health NOT called for failure
+        """
+        mock_deployment_repo = AsyncMock()
+        mock_valkey = AsyncMock()
+
+        route = _make_route(created_at_ts=1000)
+        route_id_str = str(route.route_id)
+        route_data = MagicMock()
+        route_data.route_id = route.route_id
+        route_data.replica_host = "10.0.0.1"
+        route_data.replica_port = 8000
+
+        record = RouteHealthRecord(
+            route_id=route_id_str,
+            created_at=1000,
+            initial_delay_until=5720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
+        mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
+
+        observer = RouteHealthObserver(
+            deployment_repository=mock_deployment_repo,
+            valkey_schedule=mock_valkey,
+        )
+        # Patch HTTP check to always fail
+        observer._http_health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await observer.observe([route_data])
+
+        # refresh_route_health_ttl should be called (always)
+        mock_valkey.refresh_route_health_ttl.assert_awaited_once_with(route_id_str)
+        # update_route_manager_health should NOT be called (failure ignored during initial_delay)
+        mock_valkey.update_route_manager_health.assert_not_awaited()
+
+    async def test_observer_writes_failure_after_initial_delay(self) -> None:
+        """ID-006: Observer writes failure after initial_delay expires.
+
+        Given: running_at=5000, initial_delay=720 → initial_delay_until=5720
+               current redis_time=5800 (past initial_delay)
+               health check fails
+        When: Observer runs
+        Then: update_route_manager_health called with False
+        """
+        mock_deployment_repo = AsyncMock()
+        mock_valkey = AsyncMock()
+
+        route = _make_route(created_at_ts=1000)
+        route_id_str = str(route.route_id)
+        route_data = MagicMock()
+        route_data.route_id = route.route_id
+        route_data.replica_host = "10.0.0.1"
+        route_data.replica_port = 8000
+
+        record = RouteHealthRecord(
+            route_id=route_id_str,
+            created_at=1000,
+            initial_delay_until=5720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
+        mock_valkey.get_redis_time.return_value = 5800  # Past initial_delay
+
+        observer = RouteHealthObserver(
+            deployment_repository=mock_deployment_repo,
+            valkey_schedule=mock_valkey,
+        )
+        observer._http_health_check = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await observer.observe([route_data])
+
+        mock_valkey.update_route_manager_health.assert_awaited_once_with(route_id_str, False)
+
+    async def test_observer_writes_success_within_initial_delay(self) -> None:
+        """ID-007: Observer writes success even during initial_delay.
+
+        Given: Within initial_delay, health check succeeds
+        When: Observer runs
+        Then: update_route_manager_health called with True
+        """
+        mock_deployment_repo = AsyncMock()
+        mock_valkey = AsyncMock()
+
+        route = _make_route(created_at_ts=1000)
+        route_id_str = str(route.route_id)
+        route_data = MagicMock()
+        route_data.route_id = route.route_id
+        route_data.replica_host = "10.0.0.1"
+        route_data.replica_port = 8000
+
+        record = RouteHealthRecord(
+            route_id=route_id_str,
+            created_at=1000,
+            initial_delay_until=5720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        mock_valkey.get_route_health_records_batch.return_value = {route_id_str: record}
+        mock_valkey.get_redis_time.return_value = 5500  # Within initial_delay
+
+        observer = RouteHealthObserver(
+            deployment_repository=mock_deployment_repo,
+            valkey_schedule=mock_valkey,
+        )
+        observer._http_health_check = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await observer.observe([route_data])
+
+        mock_valkey.update_route_manager_health.assert_awaited_once_with(route_id_str, True)
+
+
+# =============================================================================
+# RouteHealthRecord serialization: running_at
+# =============================================================================
+
+
+class TestRouteHealthRecordRunningAt:
+    """Tests for RouteHealthRecord running_at serialization."""
+
+    def test_running_at_none_not_in_hash(self) -> None:
+        """running_at=None should not appear in serialized hash."""
+        record = RouteHealthRecord(
+            route_id="r1",
+            created_at=1000,
+            initial_delay_until=1720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=None,
+        )
+        h = record.to_valkey_hash()
+        assert "running_at" not in h
+
+    def test_running_at_present_in_hash(self) -> None:
+        """running_at with value should appear in serialized hash."""
+        record = RouteHealthRecord(
+            route_id="r1",
+            created_at=1000,
+            initial_delay_until=5720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        h = record.to_valkey_hash()
+        assert h["running_at"] == "5000"
+
+    def test_from_hash_missing_running_at_is_none(self) -> None:
+        """Deserializing hash without running_at field yields None."""
+        data = {
+            "route_id": "r1",
+            "created_at": "1000",
+            "initial_delay_until": "1720",
+            "health_path": "/health",
+            "inference_port": "8000",
+            "replica_host": "10.0.0.1",
+        }
+        record = RouteHealthRecord.from_valkey_hash(data)
+        assert record.running_at is None
+
+    def test_from_hash_zero_running_at_is_none(self) -> None:
+        """Deserializing hash with running_at=0 yields None (backward compat)."""
+        data = {
+            "route_id": "r1",
+            "created_at": "1000",
+            "initial_delay_until": "1720",
+            "health_path": "/health",
+            "inference_port": "8000",
+            "replica_host": "10.0.0.1",
+            "running_at": "0",
+        }
+        record = RouteHealthRecord.from_valkey_hash(data)
+        assert record.running_at is None
+
+    def test_from_hash_valid_running_at(self) -> None:
+        """Deserializing hash with valid running_at yields int."""
+        data = {
+            "route_id": "r1",
+            "created_at": "1000",
+            "initial_delay_until": "5720",
+            "health_path": "/health",
+            "inference_port": "8000",
+            "replica_host": "10.0.0.1",
+            "running_at": "5000",
+        }
+        record = RouteHealthRecord.from_valkey_hash(data)
+        assert record.running_at == 5000
+
+    def test_roundtrip_with_running_at(self) -> None:
+        """Serialize → deserialize preserves running_at."""
+        original = RouteHealthRecord(
+            route_id="r1",
+            created_at=1000,
+            initial_delay_until=5720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=5000,
+        )
+        restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
+        assert restored.running_at == 5000
+        assert restored.initial_delay_until == 5720
+
+    def test_roundtrip_without_running_at(self) -> None:
+        """Serialize → deserialize preserves running_at=None."""
+        original = RouteHealthRecord(
+            route_id="r1",
+            created_at=1000,
+            initial_delay_until=1720,
+            health_path="/health",
+            inference_port=8000,
+            replica_host="10.0.0.1",
+            running_at=None,
+        )
+        restored = RouteHealthRecord.from_valkey_hash(original.to_valkey_hash())
+        assert restored.running_at is None


### PR DESCRIPTION
## Summary
- Route health `initial_delay_until` was calculated from `route.created_at` (DB INSERT time), causing provisioning time to consume the initial_delay window. Custom runtime variants with long model loading (e.g., 720s) could have their sessions terminated prematurely.
- `RouteHealthRecord` now stores `running_at` (set when route transitions to RUNNING via coordinator), and uses it as the base for `initial_delay_until` calculation. Falls back to redis_time when not set.
- Added `_ensure_health_records` to `check_running_routes`: routes with `replica_host` already in DB but missing Valkey records are detected and re-initialized each cycle.
- Partial Valkey hashes (only `running_at` field, before full record init) are handled gracefully in deserialization.

## Changes
1. `RouteHealthRecord`: add `running_at: int | None` field with serialize/deserialize
2. `ValkeyScheduleClient`: add `mark_route_running_at()` and `get_route_running_at_batch()` methods
3. `RouteCoordinator`: call `mark_route_running_at` on RUNNING transition
4. `RouteExecutor`: add `_ensure_health_records()`, use `running_at` for `initial_delay_until`
5. Partial hash guard in `get_route_health_record(s)_batch`
6. `./dev log -f` for streaming log output

## Test plan
- [x] Unit tests for `running_at` present/absent/fallback scenarios
- [x] Unit tests for observer initial_delay behavior
- [x] Unit tests for RouteHealthRecord serialization roundtrip
- [x] E2E: custom runtime variant with 13min initial_delay, mock server ready at 12m50s
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)