### PR TITLE
fix: add missing server_default to images.last_used_at

### DIFF
--- a/changes/11031.fix.md
+++ b/changes/11031.fix.md
@@ -1,0 +1,1 @@
+Add missing `server_default` to `images.last_used_at` column so that new image rows without an explicit `last_used_at` value no longer violate the NOT NULL constraint.

--- a/src/ai/backend/manager/models/alembic/versions/f7d3738a3cef_add_server_default_to_images_last_used_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/f7d3738a3cef_add_server_default_to_images_last_used_at.py
@@ -1,0 +1,43 @@
+"""add server_default to images.last_used_at
+
+Revision ID: f7d3738a3cef
+Revises: c7f2a8e31b04
+Create Date: 2026-04-14
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7d3738a3cef"
+down_revision = "c7f2a8e31b04"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = inspector.get_columns("images")
+    for col in columns:
+        if col["name"] == "last_used_at":
+            if col.get("default") is not None:
+                return
+            break
+    else:
+        return
+
+    op.alter_column(
+        "images",
+        "last_used_at",
+        server_default=sa.func.now(),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "images",
+        "last_used_at",
+        server_default=None,
+    )


### PR DESCRIPTION
## Summary
- `images.last_used_at` 컬럼의 ORM 모델에는 `server_default=sa.func.now()`가 정의되어 있지만, 원본 마이그레이션(`cf3290640ea8`)에서 `server_default` 설정이 누락됨
- `last_used_at`을 명시하지 않고 INSERT 시 NOT NULL 제약 위반 발생 가능
- 멱등성 보장: inspector로 기존 default 존재 여부를 확인하여 이미 설정된 경우 스킵

## Test plan
- [ ] `alembic upgrade head` 성공 확인
- [ ] `alembic downgrade -1` 후 재적용 확인
- [ ] `server_default`가 이미 설정된 DB에서 재실행 시 에러 없이 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)