### PR TITLE
fix: consider route health_status when resolving endpoint status

### DIFF
--- a/changes/11033.fix.md
+++ b/changes/11033.fix.md
@@ -1,0 +1,1 @@
+Fix endpoint status to reflect route health check results instead of only lifecycle status

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1836,6 +1836,8 @@ type Routing implements Item {
   endpoint: String
   session: UUID
   status: String
+
+  """Added in 26.4.1."""
   health_status: String
   traffic_ratio: Float
   created_at: DateTime

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1836,6 +1836,7 @@ type Routing implements Item {
   endpoint: String
   session: UUID
   status: String
+  health_status: String
   traffic_ratio: Float
   created_at: DateTime
   error_data: JSONString

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14933,6 +14933,8 @@ type Routing implements Item
   endpoint: String
   session: UUID
   status: String
+
+  """Added in 26.4.1."""
   health_status: String
   traffic_ratio: Float
   created_at: DateTime

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14933,6 +14933,7 @@ type Routing implements Item
   endpoint: String
   session: UUID
   status: String
+  health_status: String
   traffic_ratio: Float
   created_at: DateTime
   error_data: JSONString

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -32,7 +32,7 @@ from ai.backend.common.types import (
     RuleId,
     RuntimeVariant,
 )
-from ai.backend.manager.data.deployment.types import RouteStatus
+from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
 from ai.backend.manager.data.model_serving.creator import EndpointAutoScalingRuleCreator
 from ai.backend.manager.data.model_serving.modifier import (
     ExtraMount,
@@ -872,17 +872,11 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
             case _:
                 if not self.routings:
                     return EndpointStatus.DEGRADED
-                active_route_status_names = {s.name for s in RouteStatus.active_route_statuses()}
-                active_routings = [
-                    r for r in self.routings if r.status in active_route_status_names
-                ]
-                healthy_count = sum(
-                    1 for r in active_routings if r.status == RouteStatus.RUNNING.name
-                )
-                if healthy_count == 0:
-                    return EndpointStatus.UNHEALTHY
-                if healthy_count == len(active_routings):
+                health_statuses = {r.health_status for r in self.routings}
+                if RouteHealthStatus.HEALTHY.name in health_statuses:
                     return EndpointStatus.HEALTHY
+                if RouteHealthStatus.UNHEALTHY.name in health_statuses:
+                    return EndpointStatus.UNHEALTHY
                 return EndpointStatus.DEGRADED
 
     async def resolve_model_vfolder(self, info: graphene.ResolveInfo) -> VirtualFolderNode:

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -872,10 +872,14 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
             case _:
                 if not self.routings:
                     return EndpointStatus.DEGRADED
-                health_statuses = {r.health_status for r in self.routings}
-                if RouteHealthStatus.HEALTHY.name in health_statuses:
+                active_status_names = {s.name for s in RouteStatus.active_route_statuses()}
+                active_routings = [r for r in self.routings if r.status in active_status_names]
+                if not active_routings:
+                    return EndpointStatus.UNHEALTHY
+                health_statuses = {r.health_status for r in active_routings}
+                if health_statuses == {RouteHealthStatus.HEALTHY.name}:
                     return EndpointStatus.HEALTHY
-                if RouteHealthStatus.UNHEALTHY.name in health_statuses:
+                if health_statuses == {RouteHealthStatus.UNHEALTHY.name}:
                     return EndpointStatus.UNHEALTHY
                 return EndpointStatus.DEGRADED
 

--- a/src/ai/backend/manager/api/gql_legacy/routing.py
+++ b/src/ai/backend/manager/api/gql_legacy/routing.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.exc import NoResultFound
 
+from ai.backend.common.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.data.deployment.types import RouteStatus
 from ai.backend.manager.errors.service import RoutingNotFound
 from ai.backend.manager.models.routing import RoutingRow
@@ -31,7 +32,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
     endpoint = graphene.String()
     session = graphene.UUID()
     status = graphene.String()
-    health_status = graphene.String()
+    health_status = graphene.String(description=f"Added in {NEXT_RELEASE_VERSION}.")
     traffic_ratio = graphene.Float()
     created_at = GQLDateTime()
     error = InferenceSessionError()

--- a/src/ai/backend/manager/api/gql_legacy/routing.py
+++ b/src/ai/backend/manager/api/gql_legacy/routing.py
@@ -31,6 +31,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
     endpoint = graphene.String()
     session = graphene.UUID()
     status = graphene.String()
+    health_status = graphene.String()
     traffic_ratio = graphene.Float()
     created_at = GQLDateTime()
     error = InferenceSessionError()
@@ -49,6 +50,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
             endpoint=dto.endpoint,
             session=dto.session,
             status=dto.status.name,
+            health_status=dto.health_status.name,
             traffic_ratio=dto.traffic_ratio,
             created_at=dto.created_at,
             error_data=dto.error_data,
@@ -66,6 +68,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
             endpoint=(endpoint or row.endpoint_row).url,
             session=row.session,
             status=row.status.name,
+            health_status=row.health_status.name,
             traffic_ratio=row.traffic_ratio,
             created_at=row.created_at,
             error_data=row.error_data,

--- a/tests/unit/manager/api/endpoint/test_types.py
+++ b/tests/unit/manager/api/endpoint/test_types.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, EndpointStatus
 from ai.backend.manager.api.gql_legacy.endpoint import Endpoint
-from ai.backend.manager.data.deployment.types import RouteStatus
+from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
 
 
 class TestEndpointType:
@@ -21,6 +21,7 @@ class TestEndpointType:
 
         unhealthy_route = Mock()
         unhealthy_route.status = RouteStatus.FAILED_TO_START.name
+        unhealthy_route.health_status = RouteHealthStatus.UNHEALTHY.name
         mock_endpoint.routings = [unhealthy_route, unhealthy_route]
 
         result = await Endpoint.resolve_status(mock_endpoint, info=Mock())
@@ -36,8 +37,10 @@ class TestEndpointType:
 
         healthy_route = Mock()
         healthy_route.status = RouteStatus.RUNNING.name
+        healthy_route.health_status = RouteHealthStatus.HEALTHY.name
         provisioning_route = Mock()
         provisioning_route.status = RouteStatus.PROVISIONING.name
+        provisioning_route.health_status = RouteHealthStatus.NOT_CHECKED.name
 
         mock_endpoint.routings = [healthy_route, provisioning_route]
 
@@ -57,8 +60,10 @@ class TestEndpointType:
 
         healthy_route = Mock()
         healthy_route.status = RouteStatus.RUNNING.name
+        healthy_route.health_status = RouteHealthStatus.HEALTHY.name
         provisioning_route = Mock()
         provisioning_route.status = RouteStatus.PROVISIONING.name
+        provisioning_route.health_status = RouteHealthStatus.NOT_CHECKED.name
 
         mock_endpoint.routings = [healthy_route, provisioning_route]
 
@@ -76,6 +81,7 @@ class TestEndpointType:
 
         terminated_route = Mock()
         terminated_route.status = RouteStatus.TERMINATED.name
+        terminated_route.health_status = RouteHealthStatus.UNHEALTHY.name
 
         mock_endpoint.routings = [terminated_route, terminated_route]
 
@@ -96,8 +102,10 @@ class TestEndpointType:
 
         healthy_route = Mock()
         healthy_route.status = RouteStatus.RUNNING.name
+        healthy_route.health_status = RouteHealthStatus.HEALTHY.name
         terminated_route = Mock()
         terminated_route.status = RouteStatus.TERMINATED.name
+        terminated_route.health_status = RouteHealthStatus.UNHEALTHY.name
 
         mock_endpoint.routings = [healthy_route, healthy_route, terminated_route]
 

--- a/tests/unit/manager/api/gql_legacy/test_endpoint_resolve_status.py
+++ b/tests/unit/manager/api/gql_legacy/test_endpoint_resolve_status.py
@@ -6,7 +6,7 @@ import pytest
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, EndpointStatus
 from ai.backend.manager.api.gql_legacy.endpoint import Endpoint
-from ai.backend.manager.data.deployment.types import RouteStatus
+from ai.backend.manager.data.deployment.types import RouteHealthStatus, RouteStatus
 
 
 class TestEndpointResolveStatus:
@@ -33,6 +33,7 @@ class TestEndpointResolveStatus:
     async def test_all_inactive_routings_returns_unhealthy(self, info: MagicMock) -> None:
         routing = MagicMock()
         routing.status = RouteStatus.TERMINATED.name
+        routing.health_status = RouteHealthStatus.UNHEALTHY.name
         ep = Endpoint()
         ep.lifecycle_stage = EndpointLifecycle.READY.name
         ep.routings = [routing]


### PR DESCRIPTION
## Summary
- Endpoint status was determined solely by route lifecycle status (`RUNNING`), ignoring `health_status`
- A route could be `RUNNING` + `DEGRADED` but the endpoint would report `HEALTHY`
- Now endpoint status is derived from route `health_status`: HEALTHY if any route is healthy, UNHEALTHY if none healthy but unhealthy exists, DEGRADED otherwise
- Also exposed `health_status` field on the legacy `Routing` GraphQL type

## Test plan
- [ ] Deploy endpoint with 1 route, verify endpoint status matches route health_status
- [ ] Verify DEGRADED route → endpoint DEGRADED (not HEALTHY)
- [ ] Verify mixed HEALTHY + DEGRADED routes → endpoint HEALTHY
- [ ] Verify all UNHEALTHY routes → endpoint UNHEALTHY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11033.org.readthedocs.build/en/11033/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11033.org.readthedocs.build/ko/11033/

<!-- readthedocs-preview sorna-ko end -->