### PR TITLE
fix: set Secure flag on session cookie when SSL is enabled

### DIFF
--- a/changes/11035.fix.md
+++ b/changes/11035.fix.md
@@ -1,0 +1,1 @@
+Set Secure flag on session cookie when SSL is enabled.

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -755,6 +755,7 @@ async def redis_ctx(
     redis_storage = RedisStorage(
         valkey_session_client,
         max_age=config.session.max_age,
+        secure=config.service.ssl_enabled,
     )
     setup_session(app, redis_storage)
     try:


### PR DESCRIPTION
## Summary
- Set `Secure` flag on `AIOHTTP_SESSION` cookie based on `config.service.ssl_enabled`
- When SSL is enabled, browsers will only send the session cookie over HTTPS, preventing cookie exposure over plain HTTP
- No impact on local development (HTTP) since `ssl_enabled` defaults to `false`

## Test plan
- [ ] Verify session cookie includes `Secure` flag when `ssl-enabled = true`
- [ ] Verify session cookie works normally when `ssl-enabled = false` (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)