### PR TITLE
fix(BA-5707): defer prometheus_client imports in common/metrics/multiprocess

### DIFF
--- a/changes/11036.fix.md
+++ b/changes/11036.fix.md
@@ -1,0 +1,1 @@
+Fix silent loss of all Prometheus metrics in manager and agent by deferring `prometheus_client` imports in `common/metrics/multiprocess.py` so that `ValueClass` is bound to `MmapedValue` instead of `MutexValue`.

--- a/src/ai/backend/common/metrics/multiprocess.py
+++ b/src/ai/backend/common/metrics/multiprocess.py
@@ -20,9 +20,12 @@ import os
 import shutil
 from pathlib import Path
 
-from prometheus_client import CollectorRegistry, generate_latest
-from prometheus_client.multiprocess import MultiProcessCollector
-from prometheus_client.multiprocess import mark_process_dead as _mark_dead
+# NOTE: prometheus_client MUST NOT be imported at module level. Its
+# `values.ValueClass` is bound at import time based on the current value of
+# ``PROMETHEUS_MULTIPROC_DIR``; importing it before
+# ``setup_prometheus_multiprocess_dir`` has set that env var freezes the
+# registry into single-process mode, which silently drops all metrics written
+# by fork-based worker processes.
 
 log = logging.getLogger(__spec__.name)
 
@@ -101,6 +104,9 @@ def generate_latest_multiprocess() -> bytes:
 
     This should be used by multi-worker components (manager, agent, storage, etc.).
     """
+    from prometheus_client import CollectorRegistry, generate_latest
+    from prometheus_client.multiprocess import MultiProcessCollector
+
     try:
         registry = CollectorRegistry()
         MultiProcessCollector(registry)  # type: ignore[no-untyped-call]
@@ -135,6 +141,8 @@ def generate_latest_singleprocess() -> bytes:
     This should be used by single-process components that do not need
     multiprocess aggregation.
     """
+    from prometheus_client import generate_latest
+
     return generate_latest()
 
 
@@ -164,6 +172,8 @@ def mark_process_dead(pid: int) -> None:
     Args:
         pid: Process ID of the dead worker
     """
+    from prometheus_client.multiprocess import mark_process_dead as _mark_dead
+
     try:
         _mark_dead(pid)  # type: ignore[no-untyped-call]
     except Exception:


### PR DESCRIPTION
## Summary
- Move `prometheus_client` imports in `common/metrics/multiprocess.py` from module top level into the function bodies that use them.
- Without this, importing `setup_prometheus_multiprocess_dir` transitively imports `prometheus_client.values`, which binds `ValueClass` **once** at import time based on the current `PROMETHEUS_MULTIPROC_DIR`. Because every CLI entry point imports the setup helper *before* it sets that env var, `ValueClass` was frozen to `MutexValue` (single-process) in the parent. Fork-based aiotools workers (default for manager/agent) inherited that state and every Gauge write was silently dropped.
- Storage was accidentally safe because `storage/server.py:818` calls `multiprocessing.set_start_method("spawn")`, which makes workers start a fresh Python process that re-imports `prometheus_client` after the env var is already set.

## Jira
[BA-5707](https://lablup.atlassian.net/browse/BA-5707)

## Symptom
- `curl :6003/metrics` (agent) and `curl :18080/metrics` (manager) returned 0 bytes.
- `run/prometheus/{agent,manager}/` contained no `.db` files.
- Prometheus had no `backendai_container_utilization` samples → auto-scaling rules backed by Prometheus metrics never got data → `prometheusQueryPresetResult` GQL always returned `result: []`.

## Verification (local dev, full stack restart)
- `run/prometheus/agent/` and `run/prometheus/manager/` now contain the three `.db` files per worker pid.
- `curl :6003/metrics` → ~40 KB, 12 `backendai_container_utilization` samples.
- `curl :18080/metrics` → ~74 KB, 504 `backendai_*` metric lines.
- Prometheus `backendai_container_utilization` sample count: 10.
- `prometheusQueryPresetResult` GQL returns actual vector result with kernel_id + numeric value.
- `pants fmt | lint | check` all pass.

## Test plan
- [ ] After deploy, `curl :18080/metrics` on manager shows non-empty `backendai_*` metrics.
- [ ] After deploy, `curl :6003/metrics` on agent shows `backendai_container_utilization` while any kernel is running.
- [ ] Prometheus has non-zero samples for `backendai_container_utilization`.
- [ ] `prometheusQueryPresetResult` GQL returns non-empty data when a healthy replica is running.
- [ ] Grafana manager dashboards no longer show "No data".

## Note
Other multi-worker components using the same `setup_prometheus_multiprocess_dir` pattern without `set_start_method("spawn")` (account-manager, appproxy coordinator/worker) were almost certainly affected by the same bug and are fixed by this change. Storage's explicit `set_start_method("spawn")` can stay or be removed later — it is no longer required for multi-process metrics to work after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5707]: https://lablup.atlassian.net/browse/BA-5707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ