### PR TITLE
fix(BA-5705): import OrderField enums from DTO layer in GQL deployment types

### DIFF
--- a/changes/11037.fix.md
+++ b/changes/11037.fix.md
@@ -1,0 +1,1 @@
+Fix Pydantic validation error when using `orderBy` in deployment-related GraphQL queries (`autoScalingRules`, `deployments`, `replicas`, `accessTokens`)

--- a/src/ai/backend/manager/api/gql/deployment/types/access_token.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/access_token.py
@@ -31,6 +31,9 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     DeleteAccessTokenPayload as DeleteAccessTokenPayloadDTO,
 )
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    AccessTokenOrderField,
+)
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -43,9 +46,6 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
-from ai.backend.manager.data.deployment.types import (
-    AccessTokenOrderField,
-)
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
@@ -39,6 +39,9 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     UpdateAutoScalingRulePayload as UpdateAutoScalingRulePayloadDTO,
 )
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    AutoScalingRuleOrderField,
+)
 from ai.backend.common.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection
 from ai.backend.manager.api.gql.decorators import (
@@ -54,9 +57,6 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
-from ai.backend.manager.data.deployment.types import (
-    AutoScalingRuleOrderField,
-)
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -71,6 +71,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     DeploymentMetadataInfoDTO,
     DeploymentNetworkAccessInfoDTO,
+    DeploymentOrderField,
     DeploymentStrategyInfoDTO,
     ReplicaStateInfo,
 )
@@ -140,7 +141,6 @@ from ai.backend.manager.api.gql_legacy.user import UserNode
 from ai.backend.manager.data.deployment.types import (
     AccessTokenSearchScope,
     AutoScalingRuleSearchScope,
-    DeploymentOrderField,
     ReplicaSearchScope,
     RevisionSearchScope,
 )

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -31,6 +31,9 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     ReplicaStatusChangedPayload as ReplicaStatusChangedPayloadDTO,
 )
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    ReplicaOrderField,
+)
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     to_global_id,
@@ -50,7 +53,6 @@ from ai.backend.manager.api.gql.session_federation import Session
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql_legacy.session import ComputeSessionNode
 from ai.backend.manager.data.deployment.types import (
-    ReplicaOrderField,
     RouteStatus,
     RouteTrafficStatus,
 )


### PR DESCRIPTION
## Summary
- GQL `OrderBy` input types for deployment entities (`AutoScalingRule`, `Deployment`, `Replica`, `AccessToken`) were importing `OrderField` enums from the data layer (`manager.data.deployment.types`) where values are UPPER_CASE (e.g., `CREATED_AT = "CREATED_AT"`)
- `PydanticInputMixin.to_pydantic()` converts to DTO enums which expect snake_case values (`CREATED_AT = "created_at"`), causing Pydantic validation errors when `orderBy` is used in GraphQL queries
- Fixed by importing `OrderField` enums from the DTO layer (`common.dto.manager.v2.deployment.types`) which has matching values

## Test plan
- [x] `pants lint --changed-since=origin/main` passes
- [x] `pants check --changed-since=HEAD~1` passes (no new errors)
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=transitive` passes
- [ ] Verify `autoScalingRules(orderBy: { field: CREATED_AT, order: ASC })` query works without Pydantic error

Resolves BA-5705