### PR TITLE
fix(BA-5707): separate prometheus setup module to prevent import-time ValueClass misfire

### DIFF
--- a/changes/11038.fix.md
+++ b/changes/11038.fix.md
@@ -1,0 +1,1 @@
+Fix Prometheus metrics silently missing on Linux by separating the multiprocess setup module to prevent import-time `ValueClass` misfire.

--- a/src/ai/backend/account_manager/cli/start_server.py
+++ b/src/ai/backend/account_manager/cli/start_server.py
@@ -18,7 +18,7 @@ def main(ctx: click.Context) -> None:
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
 
     setup_prometheus_multiprocess_dir("account-manager")
 

--- a/src/ai/backend/account_manager/server.py
+++ b/src/ai/backend/account_manager/server.py
@@ -36,7 +36,7 @@ from ai.backend.common.metrics.http import (
     build_prometheus_metrics_handler,
 )
 from ai.backend.common.metrics.metric import CommonMetricRegistry
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.types import HostPortPair

--- a/src/ai/backend/agent/cli/start_server.py
+++ b/src/ai/backend/agent/cli/start_server.py
@@ -47,7 +47,7 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
     from ai.backend.logging import LogLevel
 
     setup_prometheus_multiprocess_dir("agent")

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -88,7 +88,7 @@ from ai.backend.common.metrics.http import (
     build_prometheus_metrics_handler,
 )
 from ai.backend.common.metrics.metric import CommonMetricRegistry
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.service_discovery.etcd_discovery.service_discovery import (
     ETCDServiceDiscovery,

--- a/src/ai/backend/appproxy/coordinator/cli/start_server.py
+++ b/src/ai/backend/appproxy/coordinator/cli/start_server.py
@@ -50,7 +50,7 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
     from ai.backend.logging import LogLevel
 
     setup_prometheus_multiprocess_dir("appproxy-coordinator")

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -102,7 +102,7 @@ from ai.backend.common.message_queue.hiredis_queue import HiRedisQueue
 from ai.backend.common.message_queue.queue import AbstractMessageQueue
 from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
 from ai.backend.common.metrics.http import build_api_metric_middleware
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.service_discovery.event_publisher import ServiceDiscoveryEventPublisher
 from ai.backend.common.service_discovery.redis_discovery.service_discovery import (

--- a/src/ai/backend/appproxy/worker/cli/start_server.py
+++ b/src/ai/backend/appproxy/worker/cli/start_server.py
@@ -49,7 +49,7 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
     from ai.backend.logging import LogLevel
 
     setup_prometheus_multiprocess_dir("appproxy-worker")

--- a/src/ai/backend/appproxy/worker/server.py
+++ b/src/ai/backend/appproxy/worker/server.py
@@ -92,7 +92,7 @@ from ai.backend.common.message_queue.hiredis_queue import HiRedisQueue
 from ai.backend.common.message_queue.queue import AbstractMessageQueue
 from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
 from ai.backend.common.metrics.http import build_api_metric_middleware
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.service_discovery.event_publisher import ServiceDiscoveryEventPublisher
 from ai.backend.common.service_discovery.redis_discovery.service_discovery import (

--- a/src/ai/backend/common/metrics/multiprocess.py
+++ b/src/ai/backend/common/metrics/multiprocess.py
@@ -1,95 +1,23 @@
 """
-Prometheus multiprocess mode support.
+Prometheus multiprocess mode metric generation.
 
-In multiprocess environments (e.g., manager with multiple workers via aiotools),
-each worker process has its own prometheus_client registry. Without multiprocess mode,
-Prometheus scraping via a shared port (reuse_port=True) only sees one random worker's
-metrics per scrape, leading to incorrect counter values.
-
-This module provides:
-- setup_prometheus_multiprocess_dir(): Must be called BEFORE any prometheus_client import
-- generate_latest_multiprocess(): Always aggregates metrics across all workers
-- generate_latest_singleprocess(): For single-process components using default registry
-- cleanup_prometheus_multiprocess_dir(): Called on full server shutdown
+For directory setup, see ``multiprocess_setup.py`` — that module is kept
+free of prometheus_client imports so the env var can be set before the
+library determines its ValueClass.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import shutil
-from pathlib import Path
 
 from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.multiprocess import MultiProcessCollector
 from prometheus_client.multiprocess import mark_process_dead as _mark_dead
 
+from ai.backend.common.metrics.multiprocess_setup import get_multiprocess_dir
+
 log = logging.getLogger(__spec__.name)
-
-_multiprocess_dir: Path | None = None
-
-_DEFAULT_BASE_DIR = Path("./run/prometheus")
-
-
-def setup_prometheus_multiprocess_dir(
-    component: str = "manager",
-    base_dir: Path | None = None,
-) -> Path:
-    """
-    Set up the prometheus multiprocess directory and environment variable.
-
-    MUST be called before any prometheus_client import.
-
-    Creates a directory for prometheus multiprocess files and sets
-    the PROMETHEUS_MULTIPROC_DIR environment variable.
-
-    The base directory is resolved in the following priority order:
-    1. ``base_dir`` argument (if provided)
-    2. ``BACKENDAI_PROMETHEUS_DIR`` environment variable (if set)
-    3. Default: ``./run/prometheus/``
-
-    Args:
-        component: Component name for directory naming (e.g., 'manager', 'agent')
-        base_dir: Optional override for the base directory. Takes precedence over
-            the ``BACKENDAI_PROMETHEUS_DIR`` environment variable.
-
-    Returns:
-        Path to the created multiprocess directory
-    """
-    global _multiprocess_dir
-
-    if _multiprocess_dir is not None:
-        return _multiprocess_dir
-
-    if base_dir is not None:
-        resolved_base = base_dir
-    elif env_base := os.environ.get("BACKENDAI_PROMETHEUS_DIR"):
-        resolved_base = Path(env_base)
-    else:
-        resolved_base = _DEFAULT_BASE_DIR
-
-    multiprocess_dir = resolved_base / component
-    try:
-        multiprocess_dir.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        log.error(
-            "Cannot create prometheus multiprocess dir %s — permission denied. "
-            "Ensure the directory is writable by the current user.",
-            multiprocess_dir,
-        )
-        raise
-
-    # Clean stale .db files from previous runs
-    for db_file in multiprocess_dir.glob("*.db"):
-        try:
-            db_file.unlink()
-        except OSError:
-            pass
-
-    os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(multiprocess_dir)
-    _multiprocess_dir = multiprocess_dir
-    log.info("Prometheus multiprocess dir: %s", multiprocess_dir)
-    return multiprocess_dir
 
 
 def generate_latest_multiprocess() -> bytes:
@@ -101,6 +29,7 @@ def generate_latest_multiprocess() -> bytes:
 
     This should be used by multi-worker components (manager, agent, storage, etc.).
     """
+    multiprocess_dir = get_multiprocess_dir()
     try:
         registry = CollectorRegistry()
         MultiProcessCollector(registry)  # type: ignore[no-untyped-call]
@@ -108,21 +37,21 @@ def generate_latest_multiprocess() -> bytes:
     except ValueError:
         # Directory may have been deleted (e.g., by systemd-tmpfiles-clean).
         # Attempt to recreate it and retry once.
-        if _multiprocess_dir is not None:
+        if multiprocess_dir is not None:
             try:
-                _multiprocess_dir.mkdir(parents=True, exist_ok=True)
-                os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(_multiprocess_dir)
+                multiprocess_dir.mkdir(parents=True, exist_ok=True)
+                os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(multiprocess_dir)
                 registry = CollectorRegistry()
                 MultiProcessCollector(registry)  # type: ignore[no-untyped-call]
                 log.warning(
                     "Prometheus multiprocess dir was missing and has been recreated: %s",
-                    _multiprocess_dir,
+                    multiprocess_dir,
                 )
                 return generate_latest(registry)
             except Exception:
                 log.error(
                     "Failed to recover prometheus multiprocess dir: %s",
-                    _multiprocess_dir,
+                    multiprocess_dir,
                     exc_info=True,
                 )
         return b""
@@ -136,23 +65,6 @@ def generate_latest_singleprocess() -> bytes:
     multiprocess aggregation.
     """
     return generate_latest()
-
-
-def cleanup_prometheus_multiprocess_dir() -> None:
-    """
-    Clean up the prometheus multiprocess directory.
-
-    Should be called on full server shutdown (not per-worker).
-    """
-    global _multiprocess_dir
-
-    if _multiprocess_dir is not None and _multiprocess_dir.exists():
-        shutil.rmtree(_multiprocess_dir, ignore_errors=True)
-        log.info("Cleaned up prometheus multiprocess dir: %s", _multiprocess_dir)
-        _multiprocess_dir = None
-
-    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
-        del os.environ["PROMETHEUS_MULTIPROC_DIR"]
 
 
 def mark_process_dead(pid: int) -> None:

--- a/src/ai/backend/common/metrics/multiprocess_setup.py
+++ b/src/ai/backend/common/metrics/multiprocess_setup.py
@@ -1,0 +1,107 @@
+"""
+Prometheus multiprocess directory setup.
+
+This module intentionally does NOT import prometheus_client so that it can
+be safely imported and called before any prometheus_client import.
+
+prometheus_client determines its ValueClass (MutexValue vs MmapedValue) at
+import time by checking the PROMETHEUS_MULTIPROC_DIR environment variable.
+Once fixed, it never re-evaluates — even across fork().  Keeping this module
+free of prometheus_client ensures the env var is set before the library loads.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+log = logging.getLogger(__spec__.name)
+
+_multiprocess_dir: Path | None = None
+
+_DEFAULT_BASE_DIR = Path("./run/prometheus")
+
+
+def setup_prometheus_multiprocess_dir(
+    component: str = "manager",
+    base_dir: Path | None = None,
+) -> Path:
+    """
+    Set up the prometheus multiprocess directory and environment variable.
+
+    MUST be called before any prometheus_client import.
+
+    Creates a directory for prometheus multiprocess files and sets
+    the PROMETHEUS_MULTIPROC_DIR environment variable.
+
+    The base directory is resolved in the following priority order:
+    1. ``base_dir`` argument (if provided)
+    2. ``BACKENDAI_PROMETHEUS_DIR`` environment variable (if set)
+    3. Default: ``./run/prometheus/``
+
+    Args:
+        component: Component name for directory naming (e.g., 'manager', 'agent')
+        base_dir: Optional override for the base directory. Takes precedence over
+            the ``BACKENDAI_PROMETHEUS_DIR`` environment variable.
+
+    Returns:
+        Path to the created multiprocess directory
+    """
+    global _multiprocess_dir
+
+    if _multiprocess_dir is not None:
+        return _multiprocess_dir
+
+    if base_dir is not None:
+        resolved_base = base_dir
+    elif env_base := os.environ.get("BACKENDAI_PROMETHEUS_DIR"):
+        resolved_base = Path(env_base)
+    else:
+        resolved_base = _DEFAULT_BASE_DIR
+
+    multiprocess_dir = resolved_base / component
+    try:
+        multiprocess_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.error(
+            "Cannot create prometheus multiprocess dir %s — permission denied. "
+            "Ensure the directory is writable by the current user.",
+            multiprocess_dir,
+        )
+        raise
+
+    # Clean stale .db files from previous runs
+    for db_file in multiprocess_dir.glob("*.db"):
+        try:
+            db_file.unlink()
+        except OSError:
+            pass
+
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(multiprocess_dir)
+    _multiprocess_dir = multiprocess_dir
+    log.info("Prometheus multiprocess dir: %s", multiprocess_dir)
+    return multiprocess_dir
+
+
+def cleanup_prometheus_multiprocess_dir() -> None:
+    """
+    Clean up the prometheus multiprocess directory.
+
+    Should be called on full server shutdown (not per-worker).
+    """
+    global _multiprocess_dir
+
+    if _multiprocess_dir is not None and _multiprocess_dir.exists():
+        shutil.rmtree(_multiprocess_dir, ignore_errors=True)
+        log.info("Cleaned up prometheus multiprocess dir: %s", _multiprocess_dir)
+        _multiprocess_dir = None
+
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        del os.environ["PROMETHEUS_MULTIPROC_DIR"]
+
+
+def get_multiprocess_dir() -> Path | None:
+    """Return the current multiprocess directory, if configured."""
+    return _multiprocess_dir

--- a/src/ai/backend/manager/cli/start_server.py
+++ b/src/ai/backend/manager/cli/start_server.py
@@ -47,7 +47,7 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
     from ai.backend.logging import LogLevel
 
     # Must be called before importing server module (which triggers prometheus_client import)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -44,7 +44,7 @@ from ai.backend.common.dependencies import DependencyBuilderStack
 from ai.backend.common.json import dump_json_str
 from ai.backend.common.metrics.http import build_prometheus_metrics_handler
 from ai.backend.common.metrics.metric import CommonMetricRegistry
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.utils import env_info
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel

--- a/src/ai/backend/storage/cli/start_server.py
+++ b/src/ai/backend/storage/cli/start_server.py
@@ -50,7 +50,7 @@ def main(
 
     This is a thin wrapper that defers the heavy import of server module.
     """
-    from ai.backend.common.metrics.multiprocess import setup_prometheus_multiprocess_dir
+    from ai.backend.common.metrics.multiprocess_setup import setup_prometheus_multiprocess_dir
     from ai.backend.logging import LogLevel
 
     setup_prometheus_multiprocess_dir("storage")

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -54,7 +54,7 @@ from ai.backend.common.message_queue.hiredis_queue import HiRedisQueue
 from ai.backend.common.message_queue.queue import AbstractMessageQueue
 from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
 from ai.backend.common.metrics.metric import CommonMetricRegistry
-from ai.backend.common.metrics.multiprocess import cleanup_prometheus_multiprocess_dir
+from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.plugin import AbstractPlugin, BasePluginContext

--- a/tests/unit/common/test_prometheus_multiprocess.py
+++ b/tests/unit/common/test_prometheus_multiprocess.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 
 import pytest
 
-import ai.backend.common.metrics.multiprocess as mp_mod
-from ai.backend.common.metrics.multiprocess import (
+import ai.backend.common.metrics.multiprocess_setup as mp_setup_mod
+from ai.backend.common.metrics.multiprocess import generate_latest_multiprocess
+from ai.backend.common.metrics.multiprocess_setup import (
     cleanup_prometheus_multiprocess_dir,
-    generate_latest_multiprocess,
     setup_prometheus_multiprocess_dir,
 )
 
@@ -19,10 +19,10 @@ from ai.backend.common.metrics.multiprocess import (
 @pytest.fixture(autouse=True)
 def _reset_multiprocess_state() -> Iterator[None]:
     """Reset the module-level global state before each test."""
-    original_dir = mp_mod._multiprocess_dir
+    original_dir = mp_setup_mod._multiprocess_dir
     original_env = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
     yield
-    mp_mod._multiprocess_dir = original_dir
+    mp_setup_mod._multiprocess_dir = original_dir
     if original_env is not None:
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = original_env
     elif "PROMETHEUS_MULTIPROC_DIR" in os.environ:
@@ -31,7 +31,7 @@ def _reset_multiprocess_state() -> Iterator[None]:
 
 class TestSetupPrometheusMultiprocDir:
     def test_creates_directory_with_default_base(self, tmp_path: Path) -> None:
-        with patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path):
+        with patch.object(mp_setup_mod, "_DEFAULT_BASE_DIR", tmp_path):
             result = setup_prometheus_multiprocess_dir("manager")
 
         assert result == tmp_path / "manager"
@@ -45,7 +45,7 @@ class TestSetupPrometheusMultiprocDir:
         (prom_dir / "counter_456.db").touch()
         (prom_dir / "keep_this.txt").touch()
 
-        with patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path):
+        with patch.object(mp_setup_mod, "_DEFAULT_BASE_DIR", tmp_path):
             setup_prometheus_multiprocess_dir("manager")
 
         assert not (prom_dir / "gauge_liveall_123.db").exists()
@@ -53,7 +53,7 @@ class TestSetupPrometheusMultiprocDir:
         assert (prom_dir / "keep_this.txt").exists()
 
     def test_idempotent_returns_same_path(self, tmp_path: Path) -> None:
-        with patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path):
+        with patch.object(mp_setup_mod, "_DEFAULT_BASE_DIR", tmp_path):
             first = setup_prometheus_multiprocess_dir("manager")
             second = setup_prometheus_multiprocess_dir("manager")
 
@@ -61,7 +61,7 @@ class TestSetupPrometheusMultiprocDir:
 
     def test_idempotent_ignores_different_component(self, tmp_path: Path) -> None:
         """Once setup, calling again with different component still returns the first path."""
-        with patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path):
+        with patch.object(mp_setup_mod, "_DEFAULT_BASE_DIR", tmp_path):
             first = setup_prometheus_multiprocess_dir("manager")
             second = setup_prometheus_multiprocess_dir("agent")
 
@@ -97,7 +97,7 @@ class TestGenerateLatestMultiprocess:
         prom_dir = tmp_path / "test-component"
         prom_dir.mkdir(parents=True)
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(prom_dir)
-        mp_mod._multiprocess_dir = prom_dir
+        mp_setup_mod._multiprocess_dir = prom_dir
 
         result = generate_latest_multiprocess()
         assert isinstance(result, bytes)
@@ -106,7 +106,7 @@ class TestGenerateLatestMultiprocess:
         prom_dir = tmp_path / "test-component"
         prom_dir.mkdir(parents=True)
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(prom_dir)
-        mp_mod._multiprocess_dir = prom_dir
+        mp_setup_mod._multiprocess_dir = prom_dir
 
         # Simulate systemd-tmpfiles-clean deleting the directory
         prom_dir.rmdir()
@@ -119,7 +119,7 @@ class TestGenerateLatestMultiprocess:
 
     def test_returns_empty_bytes_on_unrecoverable_failure(self) -> None:
         # Set an invalid path that can't be recreated
-        mp_mod._multiprocess_dir = Path("/nonexistent/impossible/path")
+        mp_setup_mod._multiprocess_dir = Path("/nonexistent/impossible/path")
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = "/nonexistent/impossible/path"
 
         result = generate_latest_multiprocess()
@@ -132,16 +132,16 @@ class TestCleanupPrometheusMultiprocDir:
         prom_dir.mkdir(parents=True)
         (prom_dir / "test.db").touch()
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(prom_dir)
-        mp_mod._multiprocess_dir = prom_dir
+        mp_setup_mod._multiprocess_dir = prom_dir
 
         cleanup_prometheus_multiprocess_dir()
 
         assert not prom_dir.exists()
         assert "PROMETHEUS_MULTIPROC_DIR" not in os.environ
-        assert mp_mod._multiprocess_dir is None
+        assert mp_setup_mod._multiprocess_dir is None
 
     def test_noop_when_not_initialized(self) -> None:
-        mp_mod._multiprocess_dir = None
+        mp_setup_mod._multiprocess_dir = None
         if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
             del os.environ["PROMETHEUS_MULTIPROC_DIR"]
 
@@ -151,13 +151,13 @@ class TestCleanupPrometheusMultiprocDir:
 
 class TestDefaultBaseDirUid:
     def test_default_base_dir_is_hardcoded(self) -> None:
-        assert Path("./run/prometheus") == mp_mod._DEFAULT_BASE_DIR
+        assert Path("./run/prometheus") == mp_setup_mod._DEFAULT_BASE_DIR
 
     def test_setup_raises_on_permission_error(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         with (
-            patch.object(mp_mod, "_DEFAULT_BASE_DIR", tmp_path),
+            patch.object(mp_setup_mod, "_DEFAULT_BASE_DIR", tmp_path),
             patch.object(Path, "mkdir", side_effect=PermissionError("mock denied")),
             caplog.at_level(logging.ERROR),
         ):


### PR DESCRIPTION
## Summary
- `prometheus_client` determines `ValueClass` (MutexValue vs MmapedValue) once at import time by checking `PROMETHEUS_MULTIPROC_DIR` env var. The old `multiprocess.py` imported `prometheus_client` at module top level, causing `ValueClass` to be fixed as `MutexValue` before the env var was set.
- On macOS (spawn) workers re-import fresh so the bug was masked; on Linux (fork) workers inherit the wrong `ValueClass`, silently dropping all Prometheus metrics.
- Split `multiprocess_setup.py` (no `prometheus_client` import) from `multiprocess.py` so the env var is always set before the library loads.

## Test plan
- [x] Existing unit tests updated and passing
- [ ] Verify Prometheus metrics appear on Linux multi-worker deployment (manager, agent, account-manager, appproxy)

Resolves BA-5707