### PR TITLE
fix(BA-5708): bind aiohttp session identity to manager session_token in token login

### DIFF
--- a/changes/11042.fix.md
+++ b/changes/11042.fix.md
@@ -1,0 +1,1 @@
+Fix orphan `login_sessions` rows after WebUI logout when authenticated via the keypair (sToken) login flow.

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -61,6 +61,7 @@ from ai.backend.common.health_checker.types import ComponentId
 from ai.backend.common.middlewares.exception import general_exception_middleware
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.web.session import (
+    Session,
     extra_config_headers,
     get_session,
     get_time,
@@ -277,6 +278,17 @@ async def update_password_no_auth(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+def _bind_session_to_manager_token(session: Session, session_token: str | None) -> None:
+    # Use Manager's session_token as session identity so the aiohttp session cookie
+    # matches the login_sessions row, allowing logout to delete the correct row.
+    # Bypass set_new_identity() since the session may not be new (e.g., browser has
+    # a cookie from a previous failed attempt).
+    if not session_token:
+        return
+    session._identity = session_token
+    session._new = True
+
+
 async def login_check_handler(request: web.Request) -> web.Response:
     session = await get_session(request)
     stats: WebStats = request.app["stats"]
@@ -435,13 +447,7 @@ async def login_handler(request: web.Request) -> web.Response:
                         "role": token.role,
                         "status": token.status,
                     }
-                    # Use Manager's session_token as session identity
-                    # so Valkey key matches DB session_token.
-                    # Bypass set_new_identity() since session may not be new
-                    # (e.g., browser has a cookie from a previous failed attempt).
-                    if token.session_token:
-                        session._identity = token.session_token
-                        session._new = True
+                    _bind_session_to_manager_token(session, token.session_token)
                     session["authenticated"] = True
                     session["token"] = stored_token  # store full token
                     result["authenticated"] = True
@@ -667,6 +673,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
                 "role": token.role,
                 "status": token.status,
             }
+            _bind_session_to_manager_token(session, token.session_token)
             session["authenticated"] = True
             session["token"] = stored_token  # store full token
             result["authenticated"] = True


### PR DESCRIPTION
## Summary
The sToken/keypair login path (`token_login_handler`) never copied the manager-issued `session_token` into the aiohttp session identity, so the browser cookie held an unrelated random value. On logout the webserver forwarded that random value to the manager, the DELETE matched zero rows, and the `login_sessions` row created during keypair authorize was leaked.

## Test plan
- [x] Log in via the keypair-auth hook plugin (sToken redirect flow) and verify a row is created in `login_sessions`.
- [x] Log out from the WebUI and verify the row is removed.
- [x] Repeat for the regular email/password login to confirm no regression.

Resolves BA-5708

🤖 Generated with [Claude Code](https://claude.com/claude-code)