### PR TITLE
fix: merge diverged alembic heads (f7d3, 2a53)

### DIFF
--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4683,9 +4683,9 @@ input DeploymentOrderBy
 enum DeploymentOrderField
   @join__type(graph: STRAWBERRY)
 {
+  NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
-  NAME @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 25.19.0. Deployment policy configuration."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3012,9 +3012,9 @@ input DeploymentOrderBy {
 }
 
 enum DeploymentOrderField {
+  NAME
   CREATED_AT
   UPDATED_AT
-  NAME
 }
 
 """Added in 25.19.0. Deployment policy configuration."""

--- a/src/ai/backend/manager/models/alembic/versions/89a57e90f3b4_merge_f7d3_and_2a53.py
+++ b/src/ai/backend/manager/models/alembic/versions/89a57e90f3b4_merge_f7d3_and_2a53.py
@@ -1,0 +1,21 @@
+"""merge f7d3 and 2a53
+
+Revision ID: 89a57e90f3b4
+Revises: f7d3738a3cef, 2a531e0c528e
+Create Date: 2026-04-14
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "89a57e90f3b4"
+down_revision = ("f7d3738a3cef", "2a531e0c528e")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Manager alembic에서 multi head 상태 발생 (`f7d3738a3cef`, `2a531e0c528e`)
- 두 migration이 `b4e7f1a2c3d5`에서 독립적으로 분기
- Merge migration 추가로 single head 복원

## Test plan
- [ ] `alembic heads` 명령으로 single head 확인
- [ ] `alembic upgrade head` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)