### PR TITLE
fix(BA-5702): add RBAC validation to v2 vfolder GET endpoint

### DIFF
--- a/changes/11062.fix.md
+++ b/changes/11062.fix.md
@@ -1,0 +1,1 @@
+Add RBAC validation to v2 vfolder GET endpoint

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -115,6 +115,7 @@ from ai.backend.manager.services.vfolder.actions.file_v2 import (
     MkdirV2Action,
     MoveFileV2Action,
 )
+from ai.backend.manager.services.vfolder.actions.get_v2 import GetVFolderV2Action
 from ai.backend.manager.services.vfolder.actions.search_in_project import (
     SearchVFoldersInProjectAction,
 )
@@ -377,20 +378,11 @@ class VFolderAdapter(BaseAdapter):
         return CreateUploadSessionPayload(token=result.token, url=result.url)
 
     async def get(self, vfolder_id: UUID) -> VFolderNode:
-        """Get a single vfolder by ID."""
-        conditions: list[QueryCondition] = [VFolderConditions.by_id(vfolder_id)]
-        querier = self._build_querier(
-            conditions=conditions,
-            orders=[],
-            pagination_spec=_VFOLDER_PAGINATION_SPEC,
-            limit=1,
+        """Get a single vfolder by ID with RBAC validation."""
+        result = await self._processors.vfolder.get_v2.wait_for_complete(
+            GetVFolderV2Action(vfolder_uuid=vfolder_id)
         )
-        result = await self._processors.vfolder_admin.admin_search_vfolders.wait_for_complete(
-            AdminSearchVFoldersAction(querier=querier)
-        )
-        if not result.data:
-            raise VFolderNotFound()
-        return self._vfolder_data_to_node(result.data[0])
+        return self._vfolder_data_to_node(result.vfolder)
 
     async def delete(self, vfolder_id: UUID) -> DeleteVFolderPayload:
         """Soft-delete a vfolder (move to trash)."""

--- a/src/ai/backend/manager/services/vfolder/actions/get_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/get_v2.py
@@ -1,0 +1,50 @@
+"""V2 get vfolder action — vfolder_uuid only, RBAC validated at processor level."""
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.actions.action.single_entity import BaseSingleEntityActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.vfolder.types import VFolderData
+from ai.backend.manager.services.vfolder.actions.base import VFolderSingleEntityAction
+
+
+@dataclass
+class GetVFolderV2Action(VFolderSingleEntityAction):
+    vfolder_uuid: uuid.UUID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.vfolder_uuid)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.vfolder_uuid)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.VFOLDER,
+            element_id=str(self.vfolder_uuid),
+        )
+
+
+@dataclass
+class GetVFolderV2ActionResult(BaseSingleEntityActionResult):
+    vfolder: VFolderData
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.vfolder.id)
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.vfolder.id)

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -48,6 +48,10 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     GetMyStorageHostPermissionsAction,
     GetMyStorageHostPermissionsActionResult,
 )
+from ai.backend.manager.services.vfolder.actions.get_v2 import (
+    GetVFolderV2Action,
+    GetVFolderV2ActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.search_in_project import (
     SearchVFoldersInProjectAction,
     SearchVFoldersInProjectActionResult,
@@ -151,6 +155,7 @@ class VFolderProcessors(AbstractProcessorPackage):
     batch_load_vfolders_by_ids: ActionProcessor[
         BatchLoadVFoldersByIdsAction, BatchLoadVFoldersByIdsActionResult
     ]
+    get_v2: SingleEntityActionProcessor[GetVFolderV2Action, GetVFolderV2ActionResult]
     create_vfolder_v2: ActionProcessor[CreateVFolderV2Action, CreateVFolderV2ActionResult]
     create_upload_session_v2: ActionProcessor[
         CreateUploadSessionV2Action, CreateUploadSessionV2ActionResult
@@ -240,6 +245,9 @@ class VFolderProcessors(AbstractProcessorPackage):
         )
 
         # V2 actions
+        self.get_v2 = SingleEntityActionProcessor(
+            service.get_v2, action_monitors, validators=single_entity_rbac_validators
+        )
         self.create_vfolder_v2 = ActionProcessor(service.create_v2, action_monitors)
         self.create_upload_session_v2 = ActionProcessor(
             service.create_upload_session_v2, action_monitors
@@ -282,6 +290,7 @@ class VFolderProcessors(AbstractProcessorPackage):
             BatchLoadVFoldersByIdsAction.spec(),
             CreateVFolderV2Action.spec(),
             CreateUploadSessionV2Action.spec(),
+            GetVFolderV2Action.spec(),
             DeleteVFolderV2Action.spec(),
             PurgeVFolderV2Action.spec(),
             CloneVFolderV2Action.spec(),

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -111,6 +111,10 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     GetMyStorageHostPermissionsActionResult,
     StorageHostPermissionEntry,
 )
+from ai.backend.manager.services.vfolder.actions.get_v2 import (
+    GetVFolderV2Action,
+    GetVFolderV2ActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.search_in_project import (
     SearchVFoldersInProjectAction,
     SearchVFoldersInProjectActionResult,
@@ -1615,6 +1619,11 @@ class VFolderService:
             token=storage_reply["token"],
             url=str(client_api_url / "upload"),
         )
+
+    async def get_v2(self, action: GetVFolderV2Action) -> GetVFolderV2ActionResult:
+        """Get a single vfolder by ID (v2). RBAC is enforced at the processor level."""
+        vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_uuid)
+        return GetVFolderV2ActionResult(vfolder=vfolder_data)
 
     async def delete_v2(self, action: DeleteVFolderV2Action) -> DeleteVFolderV2ActionResult:
         """Delete (trash) a vfolder (v2). Resolves policy internally from user_id."""

--- a/tests/component/vfolder_v2/BUILD
+++ b/tests/component/vfolder_v2/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -1,0 +1,276 @@
+"""Component test fixtures for v2 VFolder GET endpoint with RBAC validation."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from collections.abc import AsyncIterator, Callable, Coroutine
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.types import (
+    QuotaScopeID,
+    QuotaScopeType,
+    VFolderHostPermission,
+    VFolderHostPermissionMap,
+    VFolderUsageMode,
+)
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.single_entity import (
+    SingleEntityActionRBACValidator,
+)
+from ai.backend.manager.api.adapters.vfolder import VFolderAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.vfolder.handler import V2VFolderHandler
+from ai.backend.manager.api.rest.v2.vfolder.registry import register_v2_vfolder_routes
+from ai.backend.manager.data.vfolder.types import (
+    VFolderMountPermission,
+    VFolderOperationStatus,
+    VFolderOwnershipType,
+)
+from ai.backend.manager.models.domain import domains
+from ai.backend.manager.models.resource_policy import keypair_resource_policies
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.repositories.user.repository import UserRepository
+from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
+from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.vfolder.processors.vfolder import VFolderProcessors
+from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+@dataclass(frozen=True)
+class VFolderFixtureData:
+    id: uuid.UUID
+    name: str
+    host: str
+    domain_name: str
+    quota_scope_id: str
+    usage_mode: VFolderUsageMode
+    permission: VFolderMountPermission
+    ownership_type: VFolderOwnershipType
+    user: str
+    creator: str
+    status: VFolderOperationStatus
+    cloneable: bool
+
+
+VFolderFactory = Callable[..., Coroutine[Any, Any, VFolderFixtureData]]
+
+
+@pytest.fixture()
+def rbac_permission_repo(
+    database_engine: ExtendedAsyncSAEngine,
+) -> PermissionControllerRepository:
+    """Real permission controller repository backed by real DB."""
+    return PermissionControllerRepository(database_engine)
+
+
+@pytest.fixture()
+def vfolder_processors(
+    database_engine: ExtendedAsyncSAEngine,
+    rbac_permission_repo: PermissionControllerRepository,
+) -> VFolderProcessors:
+    """VFolderProcessors with real SingleEntityActionRBACValidator.
+
+    RBAC checks use check_permission_with_scope_chain() against the real DB.
+    Without explicit RBAC permission grants, all access is denied (403).
+    """
+    vfolder_repository = VfolderRepository(database_engine)
+    user_repository = UserRepository(database_engine)
+    service = VFolderService(
+        config_provider=MagicMock(),
+        etcd=MagicMock(),
+        storage_manager=MagicMock(),
+        background_task_manager=MagicMock(),
+        vfolder_repository=vfolder_repository,
+        user_repository=user_repository,
+        valkey_stat_client=MagicMock(),
+    )
+    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo)
+    return VFolderProcessors(
+        service=service,
+        action_monitors=[],
+        validators=ActionValidators(
+            rbac=RBACValidators(
+                scope=AsyncMock(),
+                single_entity=real_single_entity_validator,
+            )
+        ),
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    vfolder_processors: VFolderProcessors,
+) -> list[RouteRegistry]:
+    """Register v2 vfolder routes for testing."""
+    processors = MagicMock(spec=Processors)
+    processors.vfolder = vfolder_processors
+    adapter = VFolderAdapter(processors)
+    handler = V2VFolderHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_vfolder_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as superadmin."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as a regular (non-admin) user."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def vfolder_host_permission_fixture(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    resource_policy_fixture: str,
+) -> AsyncIterator[None]:
+    """Grant all VFolderHostPermission flags for the 'local' host."""
+    all_perms: set[VFolderHostPermission] = set(VFolderHostPermission)
+    host_perms = VFolderHostPermissionMap({"local": all_perms})
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            domains.update()
+            .where(domains.c.name == domain_fixture)
+            .values(allowed_vfolder_hosts=host_perms)
+        )
+        await conn.execute(
+            keypair_resource_policies.update()
+            .where(keypair_resource_policies.c.name == resource_policy_fixture)
+            .values(allowed_vfolder_hosts=host_perms)
+        )
+        await conn.execute(
+            keypair_resource_policies.update()
+            .where(keypair_resource_policies.c.name == "default")
+            .values(allowed_vfolder_hosts=host_perms)
+        )
+    yield
+    empty_perms = VFolderHostPermissionMap()
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            domains.update()
+            .where(domains.c.name == domain_fixture)
+            .values(allowed_vfolder_hosts=empty_perms)
+        )
+        await conn.execute(
+            keypair_resource_policies.update()
+            .where(keypair_resource_policies.c.name == resource_policy_fixture)
+            .values(allowed_vfolder_hosts=empty_perms)
+        )
+
+
+@pytest.fixture()
+async def vfolder_factory(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    admin_user_fixture: UserFixtureData,
+    vfolder_host_permission_fixture: None,
+) -> AsyncIterator[VFolderFactory]:
+    """Factory that inserts vfolder rows directly into DB (bypassing storage-proxy)."""
+    created_ids: list[uuid.UUID] = []
+
+    async def _create(**overrides: Any) -> VFolderFixtureData:
+        unique = secrets.token_hex(4)
+        vfolder_id = uuid.uuid4()
+        user_uuid = admin_user_fixture.user_uuid
+        quota_scope_id = QuotaScopeID(
+            scope_type=QuotaScopeType.USER,
+            scope_id=user_uuid,
+        )
+        defaults: dict[str, Any] = {
+            "id": vfolder_id,
+            "name": f"test-vfolder-{unique}",
+            "host": "local",
+            "domain_name": domain_fixture,
+            "quota_scope_id": str(quota_scope_id),
+            "usage_mode": VFolderUsageMode.GENERAL,
+            "permission": VFolderMountPermission.READ_WRITE,
+            "ownership_type": VFolderOwnershipType.USER,
+            "user": str(user_uuid),
+            "creator": "admin-test@test.local",
+            "status": VFolderOperationStatus.READY,
+            "cloneable": False,
+        }
+        defaults.update(overrides)
+        async with db_engine.begin() as conn:
+            await conn.execute(vfolders.insert().values(**defaults))
+        created_ids.append(defaults["id"])
+        return VFolderFixtureData(**defaults)
+
+    yield _create
+
+    async with db_engine.begin() as conn:
+        for vid in reversed(created_ids):
+            await conn.execute(vfolders.delete().where(vfolders.c.id == vid))
+
+
+@pytest.fixture()
+async def vfolder_owned_by_admin(
+    vfolder_factory: VFolderFactory,
+) -> VFolderFixtureData:
+    """Pre-created vfolder owned by the admin user."""
+    return await vfolder_factory()
+
+
+@pytest.fixture()
+async def vfolder_owned_by_regular_user(
+    vfolder_factory: VFolderFactory,
+    regular_user_fixture: UserFixtureData,
+) -> VFolderFixtureData:
+    """Pre-created vfolder owned by the regular (non-admin) user."""
+    user_uuid = regular_user_fixture.user_uuid
+    return await vfolder_factory(
+        user=str(user_uuid),
+        creator="user-test@test.local",
+        quota_scope_id=str(QuotaScopeID(scope_type=QuotaScopeType.USER, scope_id=user_uuid)),
+    )

--- a/tests/component/vfolder_v2/test_vfolder_get_rbac.py
+++ b/tests/component/vfolder_v2/test_vfolder_get_rbac.py
@@ -1,0 +1,55 @@
+"""Component tests for v2 VFolder GET endpoint RBAC validation.
+
+Tests that the v2 GET /vfolders/{id} endpoint enforces RBAC:
+- Regular users WITHOUT permission are denied (403)
+- Superadmin bypasses RBAC and can access vfolders directly
+- Superadmin querying nonexistent vfolder gets 404 (RBAC bypassed, service returns not found)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.client.v2.exceptions import NotFoundError, PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+
+if TYPE_CHECKING:
+    from .conftest import VFolderFixtureData
+
+
+class TestVFolderGetV2RBAC:
+    """RBAC validation for v2 GET /vfolders/{id}.
+
+    The v2 GET endpoint uses SingleEntityActionProcessor with
+    single_entity_rbac_validators. Superadmin bypasses RBAC;
+    regular users without explicit permission grants are denied.
+    """
+
+    async def test_regular_user_querying_own_vfolder_gets_403(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        vfolder_owned_by_regular_user: VFolderFixtureData,
+    ) -> None:
+        """Regular user without RBAC permission cannot GET their own vfolder."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.vfolder.get(vfolder_owned_by_regular_user.id)
+
+    async def test_superadmin_querying_own_vfolder_bypasses_rbac(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        vfolder_owned_by_admin: VFolderFixtureData,
+    ) -> None:
+        """Superadmin bypasses RBAC and can GET their own vfolder."""
+        result = await admin_v2_registry.vfolder.get(vfolder_owned_by_admin.id)
+        assert result.id == str(vfolder_owned_by_admin.id)
+
+    async def test_superadmin_querying_nonexistent_vfolder_gets_404(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        """Superadmin bypasses RBAC but gets 404 for nonexistent vfolder."""
+        with pytest.raises(NotFoundError):
+            await admin_v2_registry.vfolder.get(uuid.uuid4())

--- a/tests/component/vfolder_v2/test_vfolder_get_rbac.py
+++ b/tests/component/vfolder_v2/test_vfolder_get_rbac.py
@@ -44,7 +44,16 @@ class TestVFolderGetV2RBAC:
     ) -> None:
         """Superadmin bypasses RBAC and can GET their own vfolder."""
         result = await admin_v2_registry.vfolder.get(vfolder_owned_by_admin.id)
-        assert result.id == str(vfolder_owned_by_admin.id)
+        assert result.id == vfolder_owned_by_admin.id
+
+    async def test_superadmin_querying_other_users_vfolder_bypasses_rbac(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        vfolder_owned_by_regular_user: VFolderFixtureData,
+    ) -> None:
+        """Superadmin bypasses RBAC and can GET other users' vfolders."""
+        result = await admin_v2_registry.vfolder.get(vfolder_owned_by_regular_user.id)
+        assert result.id == vfolder_owned_by_regular_user.id
 
     async def test_superadmin_querying_nonexistent_vfolder_gets_404(
         self,


### PR DESCRIPTION
resolve #11026 (BA-5702)

## Summary
- Add RBAC validation to v2 vfolder GET endpoint using `SingleEntityActionProcessor`
- Allow superadmin to bypass RBAC checks in `SingleEntityActionRBACValidator`
- Add component tests verifying RBAC denial for regular users and superadmin bypass

## Test plan
- [x] Regular user without RBAC permission gets 403 on own vfolder
- [x] Superadmin bypasses RBAC and successfully GETs vfolder
- [x] Superadmin gets 404 for nonexistent vfolder (RBAC bypassed, service returns not found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)