### PR TITLE
fix(BA-5706): use attribute access on user Row in TOTP hook

### DIFF
--- a/changes/11064.fix.md
+++ b/changes/11064.fix.md
@@ -1,0 +1,1 @@
+Fix `TypeError` in TOTP hook during stoken login by using attribute access on the user Row object.

--- a/src/ai/backend/manager/plugin/totp/hook.py
+++ b/src/ai/backend/manager/plugin/totp/hook.py
@@ -59,9 +59,9 @@ class TOTPHook(HookPlugin):
     async def validate_otp(
         self, request: web.Request, params: Any, user: Any, keypair: Any
     ) -> web.Response | None:
-        if not user["totp_activated"]:
+        if not user.totp_activated:
             if self._plugin_config.forced:
-                token = self._token_parser.serialize(str(user["uuid"]))
+                token = self._token_parser.serialize(str(user.uuid))
                 auth_data = RequireTwoFactorRegistrationResponse(
                     response_type=AuthResponseType.REQUIRE_TWO_FACTOR_REGISTRATION,
                     token=token,
@@ -74,7 +74,7 @@ class TOTPHook(HookPlugin):
                 )
             log.info("TOTP.VALIDATE_OTP(TOTP not forced, user TOTP not activated)")
             return None
-        if not user["totp_key"]:
+        if not user.totp_key:
             raise Reject("User activated TOTP but TOTP key does not exist")
 
         otp = params.get("stoken") or params.get("sToken") or params.get("otp")
@@ -89,7 +89,7 @@ class TOTPHook(HookPlugin):
                 },
             )
 
-        totp = pyotp.TOTP(user["totp_key"])
+        totp = pyotp.TOTP(user.totp_key)
         if not totp.verify(otp):
             raise Reject("Invalid TOTP code provided")
         log.info("TOTP.VALIDATE_OTP(TOTP validated successfully)")


### PR DESCRIPTION
## Summary
- stoken login via the keypair auth plugin failed with `TypeError('tuple indices must be integers or slices, not str')` because `TOTPHook.validate_otp()` used dict-style access (`user["..."]`) on a SQLAlchemy `Row`, which only supports integer indexing in SA 2.0+.
- Switch to attribute access (`user.totp_activated`, `user.uuid`, `user.totp_key`) which works for both `Row` and `RowMapping`, restoring stoken login when TOTP is active.

## Test plan
- [ ] stoken login with TOTP-activated user succeeds without TypeError
- [ ] stoken login with TOTP not activated also works correctly
- [ ] normal password login path remains unaffected
- [ ] `pants test` passes for affected packages

Resolves BA-5706