### PR TITLE
fix(BA-5720): handle null DeviceRequests in CUDA container measures

### DIFF
--- a/changes/11070.fix.md
+++ b/changes/11070.fix.md
@@ -1,0 +1,1 @@
+Handle null `HostConfig.DeviceRequests` from Docker API in CUDA container measures to prevent `TypeError`.

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -294,7 +294,7 @@ class CUDAPlugin(AbstractComputePlugin):
                             continue
                         nvidia_device_reqs = [
                             x
-                            for x in container_info.get("HostConfig", {}).get("DeviceRequests", [])
+                            for x in container_info.get("HostConfig", {}).get("DeviceRequests") or []
                             if x["Driver"] == "nvidia"
                         ]
                         if not nvidia_device_reqs:

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -294,7 +294,8 @@ class CUDAPlugin(AbstractComputePlugin):
                             continue
                         nvidia_device_reqs = [
                             x
-                            for x in container_info.get("HostConfig", {}).get("DeviceRequests") or []
+                            for x in container_info.get("HostConfig", {}).get("DeviceRequests")
+                            or []
                             if x["Driver"] == "nvidia"
                         ]
                         if not nvidia_device_reqs:


### PR DESCRIPTION
resolve #11065 (BA-5720)

## Summary
- Docker API can return `null` for `HostConfig.DeviceRequests` (key exists but value is `None`)
- `.get("DeviceRequests", [])` only provides a default when the key is **missing**, not when the value is `None` → `TypeError: 'NoneType' object is not iterable`
- Fix: `.get("DeviceRequests") or []` to handle both missing key and `None` value

## Test plan
- [ ] Verify no error when `DeviceRequests` is `None`
- [ ] Verify existing behavior when `DeviceRequests` is a normal list

🤖 Generated with [Claude Code](https://claude.com/claude-code)