### PR TITLE
fix(BA-5725): grant admin_page read on project/domain creation

### DIFF
--- a/changes/11074.fix.md
+++ b/changes/11074.fix.md
@@ -1,0 +1,1 @@
+Grant `project_admin_page:read` / `domain_admin_page:read` permissions to the auto-generated admin role when a new project or domain is created.

--- a/src/ai/backend/manager/data/domain/types.py
+++ b/src/ai/backend/manager/data/domain/types.py
@@ -48,10 +48,12 @@ class DomainData:
         return f"domain-{self.name}-admin"
 
     def entity_operations(self) -> Mapping[RBACElementType, Iterable[OperationType]]:
-        return {
+        operations: dict[RBACElementType, Iterable[OperationType]] = {
             entity.to_element(): OperationType.admin_operations()
             for entity in EntityType.admin_accessible_entity_types_in_domain()
         }
+        operations[RBACElementType.DOMAIN_ADMIN_PAGE] = {OperationType.READ}
+        return operations
 
 
 @dataclass

--- a/src/ai/backend/manager/data/group/types.py
+++ b/src/ai/backend/manager/data/group/types.py
@@ -66,10 +66,12 @@ class GroupData:
         return f"project-{str(self.id)[:8]}-admin"
 
     def entity_operations(self) -> Mapping[RBACElementType, Iterable[OperationType]]:
-        return {
+        operations: dict[RBACElementType, Iterable[OperationType]] = {
             entity.to_element(): OperationType.admin_operations()
             for entity in EntityType.admin_accessible_entity_types_in_project()
         }
+        operations[RBACElementType.PROJECT_ADMIN_PAGE] = {OperationType.READ}
+        return operations
 
 
 @dataclass

--- a/tests/unit/manager/data/domain/BUILD
+++ b/tests/unit/manager/data/domain/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/data/domain/test_types.py
+++ b/tests/unit/manager/data/domain/test_types.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.domain.types import DomainData
+from ai.backend.manager.data.permission.types import OperationType
+
+
+def _make_domain_data() -> DomainData:
+    now = datetime.now(tz=UTC)
+    return DomainData(
+        name="default",
+        description=None,
+        is_active=True,
+        created_at=now,
+        modified_at=now,
+        total_resource_slots=ResourceSlot(),
+        allowed_vfolder_hosts=VFolderHostPermissionMap(),
+        allowed_docker_registries=[],
+        dotfiles=b"",
+        integration_name=None,
+    )
+
+
+class TestDomainDataEntityOperations:
+    def test_includes_domain_admin_page_read(self) -> None:
+        operations = _make_domain_data().entity_operations()
+
+        assert RBACElementType.DOMAIN_ADMIN_PAGE in operations
+        assert set(operations[RBACElementType.DOMAIN_ADMIN_PAGE]) == {OperationType.READ}
+
+    def test_admin_resource_entries_unchanged(self) -> None:
+        operations = _make_domain_data().entity_operations()
+
+        assert set(operations[RBACElementType.VFOLDER]) == OperationType.admin_operations()
+        assert set(operations[RBACElementType.USER]) == OperationType.admin_operations()

--- a/tests/unit/manager/data/group/BUILD
+++ b/tests/unit/manager/data/group/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/data/group/test_types.py
+++ b/tests/unit/manager/data/group/test_types.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import uuid
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.group.types import GroupData, ProjectType
+from ai.backend.manager.data.permission.types import OperationType
+
+
+def _make_group_data() -> GroupData:
+    return GroupData(
+        id=uuid.uuid4(),
+        name="test-project",
+        description=None,
+        is_active=True,
+        created_at=None,
+        modified_at=None,
+        integration_name=None,
+        domain_name="default",
+        total_resource_slots=ResourceSlot(),
+        allowed_vfolder_hosts=VFolderHostPermissionMap(),
+        dotfiles=b"",
+        resource_policy="default",
+        type=ProjectType.GENERAL,
+        container_registry=None,
+    )
+
+
+class TestGroupDataEntityOperations:
+    def test_includes_project_admin_page_read(self) -> None:
+        operations = _make_group_data().entity_operations()
+
+        assert RBACElementType.PROJECT_ADMIN_PAGE in operations
+        assert set(operations[RBACElementType.PROJECT_ADMIN_PAGE]) == {OperationType.READ}
+
+    def test_admin_resource_entries_unchanged(self) -> None:
+        operations = _make_group_data().entity_operations()
+
+        # Sanity check: existing admin entries still receive full admin operations.
+        assert set(operations[RBACElementType.VFOLDER]) == OperationType.admin_operations()
+        assert set(operations[RBACElementType.USER]) == OperationType.admin_operations()


### PR DESCRIPTION
## Summary
- Add `PROJECT_ADMIN_PAGE:read` / `DOMAIN_ADMIN_PAGE:read` to `GroupData.entity_operations()` and `DomainData.entity_operations()` so the auto-generated admin role created by `RoleManager.create_system_role` includes them.
- Without this, project/domain admins of any group/domain created after migration `3b6297b1bd75` could not access their admin page (the migration backfilled existing roles only).
- Add unit tests under `tests/unit/manager/data/{group,domain}/` to guard against regressions.

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main`
- [x] `pants check tests/unit/manager/data/group:: tests/unit/manager/data/domain::`
- [x] `pants test tests/unit/manager/data/group:: tests/unit/manager/data/domain::`
- [x] Manual: create a new project/domain, assign a user as admin, verify access to the admin page

Resolves BA-5725