### PR TITLE
fix: expose max_concurrent_logins on Graphene UserResourcePolicy

### DIFF
--- a/changes/11075.fix.md
+++ b/changes/11075.fix.md
@@ -1,0 +1,1 @@
+Expose `max_concurrent_logins` on the legacy Graphene `UserResourcePolicy` type and its create/modify input types so clients still on the Graphene endpoint can query and update the field.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1370,6 +1370,11 @@ type UserResourcePolicy {
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 type ProjectResourcePolicy {
@@ -3153,6 +3158,11 @@ input CreateUserResourcePolicyInput {
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 type ModifyUserResourcePolicy {
@@ -3180,6 +3190,11 @@ input ModifyUserResourcePolicyInput {
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 type DeleteUserResourcePolicy {

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3739,6 +3739,11 @@ input CreateUserResourcePolicyInput
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 """Added in 26.4.0. Input for creating a user resource policy."""
@@ -9442,6 +9447,11 @@ input ModifyUserResourcePolicyInput
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 """Added in 26.4.0. Input for moving a file inside a virtual folder."""
@@ -17846,6 +17856,11 @@ type UserResourcePolicy
   Added in 24.03.0. Maximum available number of customized images one can publish to.
   """
   max_customized_image_count: Int
+
+  """
+  Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited.
+  """
+  max_concurrent_logins: Int
 }
 
 """

--- a/src/ai/backend/manager/api/gql_legacy/resource_policy.py
+++ b/src/ai/backend/manager/api/gql_legacy/resource_policy.py
@@ -515,6 +515,9 @@ class UserResourcePolicy(graphene.ObjectType):  # type: ignore[misc]
     max_customized_image_count = graphene.Int(
         description="Added in 24.03.0. Maximum available number of customized images one can publish to."
     )
+    max_concurrent_logins = graphene.Int(
+        description="Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited."
+    )
 
     @classmethod
     def from_row(
@@ -532,6 +535,7 @@ class UserResourcePolicy(graphene.ObjectType):  # type: ignore[misc]
             max_quota_scope_size=row.max_quota_scope_size,
             max_session_count_per_model_session=row.max_session_count_per_model_session,
             max_customized_image_count=row.max_customized_image_count,
+            max_concurrent_logins=row.max_concurrent_logins,
         )
 
     @classmethod
@@ -601,10 +605,16 @@ class CreateUserResourcePolicyInput(graphene.InputObjectType):  # type: ignore[m
     max_customized_image_count = graphene.Int(
         description="Added in 24.03.0. Maximum available number of customized images one can publish to."
     )
+    max_concurrent_logins = graphene.Int(
+        description="Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited."
+    )
 
     def to_creator(self, name: str) -> Creator[UserResourcePolicyRow]:
         def value_or_default(value: Any, default: int) -> int:
             return value if value is not Undefined and value is not None else default
+
+        def optional_int(value: Any) -> int | None:
+            return None if value is Undefined else value
 
         CreatorSpec = _get_user_resource_policy_creator_spec()
         return Creator(
@@ -616,6 +626,7 @@ class CreateUserResourcePolicyInput(graphene.InputObjectType):  # type: ignore[m
                     self.max_session_count_per_model_session, 0
                 ),
                 max_customized_image_count=value_or_default(self.max_customized_image_count, 3),
+                max_concurrent_logins=optional_int(self.max_concurrent_logins),
             )
         )
 
@@ -633,6 +644,9 @@ class ModifyUserResourcePolicyInput(graphene.InputObjectType):  # type: ignore[m
     max_customized_image_count = graphene.Int(
         description="Added in 24.03.0. Maximum available number of customized images one can publish to."
     )
+    max_concurrent_logins = graphene.Int(
+        description="Added in 26.4.0. Maximum number of concurrent authenticated login sessions per user. Null means unlimited."
+    )
 
     def to_updater(self, name: str) -> Updater[UserResourcePolicyRow]:
         UpdaterSpec = _get_user_resource_policy_updater_spec()
@@ -646,6 +660,7 @@ class ModifyUserResourcePolicyInput(graphene.InputObjectType):  # type: ignore[m
                 max_customized_image_count=OptionalState[int].from_graphql(
                     self.max_customized_image_count
                 ),
+                max_concurrent_logins=TriState[int].from_graphql(self.max_concurrent_logins),
             ),
             pk_value=name,
         )


### PR DESCRIPTION
Mistake PR in testing...

## Summary

- Adds the `max_concurrent_logins` field to the legacy Graphene `UserResourcePolicy` type, along with create/modify input types and their spec mappings
- Closes the gap left by #10838, which introduced `max_concurrent_logins` in the DB model, repository specs, and Strawberry v2 (`UserResourcePolicyV2GQL`) but did not update the Graphene schema still used by the Control Panel

## Problem

Control Panel's User Resource Policy page (feature/1581) queries `max_concurrent_logins` on `UserResourcePolicy`. When a manager >= 26.4.0 is connected, the client's `@since(version: "26.4.0")` gating no longer strips the field, so the query is forwarded to Graphene and fails with:

```
Cannot query field 'max_concurrent_logins' on type 'UserResourcePolicy'
```

See lablup/control-panel#1581 for the downstream impact and #1580 for the hotfix-revert the field was blocked on.

## Changes

`src/ai/backend/manager/api/gql_legacy/resource_policy.py`:

1. **`UserResourcePolicy` ObjectType** — declare `max_concurrent_logins = graphene.Int(...)` and pass `row.max_concurrent_logins` through `from_row()`.
2. **`CreateUserResourcePolicyInput`** — declare the field and pass it to `UserResourcePolicyCreatorSpec` via an `optional_int` helper so `Undefined` maps to `None` (the spec's default, meaning unlimited). The existing `value_or_default` coerces to `int` and would drop the `None` semantics, so it could not be reused here.
3. **`ModifyUserResourcePolicyInput`** — declare the field and pass it to `UserResourcePolicyUpdaterSpec` via `TriState[int].from_graphql(...)`, matching the spec's `TriState[int]` field type (distinct from the other fields which use `OptionalState`) so explicit null-clearing is supported.

All mappings downstream (`UserResourcePolicyCreatorSpec`, `UserResourcePolicyUpdaterSpec`, `UserResourcePolicyRow`, Alembic `689f66507280`) already support the field.

## Test plan

- [ ] `uv run ruff check src/ai/backend/manager/api/gql_legacy/resource_policy.py` passes
- [ ] Start a 26.4.x manager with this patch; confirm `query { user_resource_policies { max_concurrent_logins } }` returns the column value
- [ ] Create a user resource policy via Graphene mutation with `max_concurrent_logins: 5` and verify it persists
- [ ] Modify a user resource policy to set `max_concurrent_logins: null` and verify the column is cleared (TriState semantics)
- [ ] Against this manager, open Control Panel (#1581 branch) → User Resource Policy → verify no "Cannot query field" error and the column/form field display correctly

## Related

- Control Panel: lablup/control-panel#1581
- Original feature: #10838