### PR TITLE
feat(BA-5682): backfill project-user scopes from association_groups_users

### DIFF
--- a/changes/11080.feature.md
+++ b/changes/11080.feature.md
@@ -1,0 +1,1 @@
+Backfill project-user memberships from `association_groups_users` into `association_scopes_entities` as `project ─ref→ user` relations for RBAC.

--- a/src/ai/backend/manager/models/alembic/versions/c8d4e5f6a7b9_backfill_project_user_scopes_from_association_groups_users.py
+++ b/src/ai/backend/manager/models/alembic/versions/c8d4e5f6a7b9_backfill_project_user_scopes_from_association_groups_users.py
@@ -1,0 +1,50 @@
+"""backfill project-user scopes from association_groups_users
+
+Copies every (user_id, group_id) row in ``association_groups_users`` into
+``association_scopes_entities`` as a project-scope user membership with
+``relation_type='ref'`` (per BEP-1048: Project ─ref─► User).
+
+The statement is a single ``INSERT ... SELECT ... ON CONFLICT DO NOTHING``
+keyed on the ``uq_scope_id_entity_id`` unique constraint, so it is
+idempotent and naturally deduplicates the source rows. Inactive users or
+groups are migrated as-is: the legacy table never filtered on ``is_active``,
+and RBAC lookups against the new table must return the same membership set
+that the legacy table does.
+
+Revision ID: c8d4e5f6a7b9
+Revises: a3b4c5d6e7f8
+Create Date: 2026-04-14
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8d4e5f6a7b9"
+down_revision = "a3b4c5d6e7f8"
+# Part of: 26.3.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        INSERT INTO association_scopes_entities
+            (scope_type, scope_id, entity_type, entity_id, relation_type)
+        SELECT
+            'project',
+            group_id::text,
+            'user',
+            user_id::text,
+            'ref'
+        FROM association_groups_users
+        ON CONFLICT ON CONSTRAINT uq_scope_id_entity_id DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    # No-op: association_scopes_entities rows may also be produced by the
+    # auto-sync path once it lands, so we cannot distinguish backfilled rows
+    # from live ones at downgrade time. Dropping the table column or the
+    # entire feature is handled by its own schema migration.
+    pass


### PR DESCRIPTION
## Summary
- Add Alembic migration `c8d4e5f6a7b9` that copies every `(user_id, group_id)` row from `association_groups_users` into `association_scopes_entities` as a project-scope user membership with `relation_type='ref'`, per BEP-1048 (Project ─ref→ User).
- Single `INSERT ... SELECT ... ON CONFLICT ON CONSTRAINT uq_scope_id_entity_id DO NOTHING`, so the migration is idempotent and naturally deduplicates. Rows are migrated regardless of `is_active` to match legacy lookup semantics.
- `downgrade()` is a no-op: once the auto-sync path lands, backfilled rows cannot be distinguished from live ones, so the schema is torn down by its own future migration rather than here.

## Test plan
- [ ] `alembic upgrade head` on a DB populated with `association_groups_users` rows; verify matching `(project, group_id, user, user_id, ref)` rows appear in `association_scopes_entities`.
- [ ] Re-run `alembic upgrade head` and confirm no duplicate rows / no errors (idempotency).
- [ ] Verify inactive users/groups are migrated as-is.
- [ ] RBAC project membership lookups return the same set as the legacy table.

Resolves BA-5682