### PR TITLE
fix(BA-5730): apply deployment status filter and add notIn/notEquals operators

### DIFF
--- a/changes/11085.fix.md
+++ b/changes/11085.fix.md
@@ -1,0 +1,1 @@
+Apply `status` filter in deployment search (previously ignored) and expand `DeploymentStatusFilter` with `notEquals` / `notIn` operators.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4880,6 +4880,8 @@ input DeploymentStatusFilter
   """The in  field."""
   in: [DeploymentStatus!] = null
   equals: DeploymentStatus = null
+  notEquals: DeploymentStatus = null
+  notIn: [DeploymentStatus!] = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3183,6 +3183,8 @@ input DeploymentStatusFilter {
   """The in  field."""
   in: [DeploymentStatus!] = null
   equals: DeploymentStatus = null
+  notEquals: DeploymentStatus = null
+  notIn: [DeploymentStatus!] = null
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -450,6 +450,8 @@ class DeploymentStatusFilter(BaseRequestModel):
 
     equals: str | None = Field(default=None, description="Exact status match")
     in_: list[str] | None = Field(default=None, alias="in", description="Status is in list")
+    not_equals: str | None = Field(default=None, description="Excludes exact status match")
+    not_in: list[str] | None = Field(default=None, description="Status is not in list")
 
 
 class RouteStatusFilter(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -16,6 +16,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import (
     DeploymentStrategy,
+    ModelDeploymentStatus,
     RouteHealthStatus,
     RouteStatus,
     RouteTrafficStatus,
@@ -448,10 +449,16 @@ class AddRevisionInput(BaseRequestModel):
 class DeploymentStatusFilter(BaseRequestModel):
     """Filter for deployment status."""
 
-    equals: str | None = Field(default=None, description="Exact status match")
-    in_: list[str] | None = Field(default=None, alias="in", description="Status is in list")
-    not_equals: str | None = Field(default=None, description="Excludes exact status match")
-    not_in: list[str] | None = Field(default=None, description="Status is not in list")
+    equals: ModelDeploymentStatus | None = Field(default=None, description="Exact status match")
+    in_: list[ModelDeploymentStatus] | None = Field(
+        default=None, alias="in", description="Status is in list"
+    )
+    not_equals: ModelDeploymentStatus | None = Field(
+        default=None, description="Excludes exact status match"
+    )
+    not_in: list[ModelDeploymentStatus] | None = Field(
+        default=None, description="Status is not in list"
+    )
 
 
 class RouteStatusFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -202,6 +202,7 @@ from ai.backend.manager.repositories.base import (
     QueryOrder,
     Updater,
     combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentMetadataUpdaterSpec,
@@ -1367,6 +1368,43 @@ class DeploymentAdapter(BaseAdapter):
                         ModelDeploymentStatus(v) for v in s.not_in
                     ])
                 )
+        if f.tags is not None:
+            condition = self.convert_string_filter(
+                f.tags,
+                contains_factory=DeploymentConditions.by_tag_contains,
+                equals_factory=DeploymentConditions.by_tag_equals,
+                starts_with_factory=DeploymentConditions.by_tag_starts_with,
+                ends_with_factory=DeploymentConditions.by_tag_ends_with,
+                in_factory=DeploymentConditions.by_tag_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.endpoint_url is not None:
+            condition = self.convert_string_filter(
+                f.endpoint_url,
+                contains_factory=DeploymentConditions.by_url_contains,
+                equals_factory=DeploymentConditions.by_url_equals,
+                starts_with_factory=DeploymentConditions.by_url_starts_with,
+                ends_with_factory=DeploymentConditions.by_url_ends_with,
+                in_factory=DeploymentConditions.by_url_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._collect_deployment_filter_conditions(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._collect_deployment_filter_conditions(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._collect_deployment_filter_conditions(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
         return conditions
 
     def _build_deployment_querier(self, input: AdminSearchDeploymentsInput) -> BatchQuerier:

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -14,7 +14,6 @@ from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.model_deployment.types import (
     DeploymentStrategy,
-    ModelDeploymentStatus,
     RouteHealthStatus,
     RouteStatus,
     RouteTrafficStatus,
@@ -38,6 +37,7 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     DeleteDeploymentInput,
     DeploymentFilter,
     DeploymentOrder,
+    DeploymentStatusFilter,
     ReplicaOrder,
     RevisionOrder,
     RouteOrder,
@@ -521,7 +521,7 @@ class DeploymentAdapter(BaseAdapter):
             raise RuntimeError("No authenticated user in context")
         conditions: list[QueryCondition] = []
         if input.filter:
-            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -559,7 +559,7 @@ class DeploymentAdapter(BaseAdapter):
         """Search deployments within a specific project."""
         conditions: list[QueryCondition] = []
         if input.filter:
-            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -1333,7 +1333,7 @@ class DeploymentAdapter(BaseAdapter):
     # Querier builders
     # ------------------------------------------------------------------
 
-    def _collect_deployment_filter_conditions(self, f: DeploymentFilter) -> list[QueryCondition]:
+    def _convert_deployment_filter(self, f: DeploymentFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if f.name is not None:
             condition = self.convert_string_filter(
@@ -1349,25 +1349,7 @@ class DeploymentAdapter(BaseAdapter):
         if f.open_to_public is not None:
             conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
         if f.status is not None:
-            s = f.status
-            if s.equals is not None:
-                conditions.append(
-                    DeploymentConditions.by_status_equals(ModelDeploymentStatus(s.equals))
-                )
-            if s.in_ is not None:
-                conditions.append(
-                    DeploymentConditions.by_status_in([ModelDeploymentStatus(v) for v in s.in_])
-                )
-            if s.not_equals is not None:
-                conditions.append(
-                    DeploymentConditions.by_status_not_equals(ModelDeploymentStatus(s.not_equals))
-                )
-            if s.not_in is not None:
-                conditions.append(
-                    DeploymentConditions.by_status_not_in([
-                        ModelDeploymentStatus(v) for v in s.not_in
-                    ])
-                )
+            self._apply_deployment_status_filter(f.status, conditions)
         if f.tags is not None:
             condition = self.convert_string_filter(
                 f.tags,
@@ -1391,26 +1373,39 @@ class DeploymentAdapter(BaseAdapter):
             if condition is not None:
                 conditions.append(condition)
         if f.AND:
-            for sub in f.AND:
-                conditions.extend(self._collect_deployment_filter_conditions(sub))
+            for sub_filter in f.AND:
+                conditions.extend(self._convert_deployment_filter(sub_filter))
         if f.OR:
             or_conditions: list[QueryCondition] = []
-            for sub in f.OR:
-                or_conditions.extend(self._collect_deployment_filter_conditions(sub))
+            for sub_filter in f.OR:
+                or_conditions.extend(self._convert_deployment_filter(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if f.NOT:
             not_conditions: list[QueryCondition] = []
-            for sub in f.NOT:
-                not_conditions.extend(self._collect_deployment_filter_conditions(sub))
+            for sub_filter in f.NOT:
+                not_conditions.extend(self._convert_deployment_filter(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
+    @staticmethod
+    def _apply_deployment_status_filter(
+        s: DeploymentStatusFilter, conditions: list[QueryCondition]
+    ) -> None:
+        if s.equals is not None:
+            conditions.append(DeploymentConditions.by_status_in([s.equals]))
+        elif s.in_ is not None:
+            conditions.append(DeploymentConditions.by_status_in(list(s.in_)))
+        elif s.not_equals is not None:
+            conditions.append(DeploymentConditions.by_status_not_in([s.not_equals]))
+        elif s.not_in is not None:
+            conditions.append(DeploymentConditions.by_status_not_in(list(s.not_in)))
+
     def _build_deployment_querier(self, input: AdminSearchDeploymentsInput) -> BatchQuerier:
         conditions: list[QueryCondition] = []
         if input.filter:
-            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -14,6 +14,7 @@ from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.model_deployment.types import (
     DeploymentStrategy,
+    ModelDeploymentStatus,
     RouteHealthStatus,
     RouteStatus,
     RouteTrafficStatus,
@@ -35,6 +36,7 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     CreateDeploymentInput,
     DeleteAccessTokenInput,
     DeleteDeploymentInput,
+    DeploymentFilter,
     DeploymentOrder,
     ReplicaOrder,
     RevisionOrder,
@@ -518,20 +520,7 @@ class DeploymentAdapter(BaseAdapter):
             raise RuntimeError("No authenticated user in context")
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
+            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -569,20 +558,7 @@ class DeploymentAdapter(BaseAdapter):
         """Search deployments within a specific project."""
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
+            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -1356,23 +1332,47 @@ class DeploymentAdapter(BaseAdapter):
     # Querier builders
     # ------------------------------------------------------------------
 
+    def _collect_deployment_filter_conditions(self, f: DeploymentFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.name is not None:
+            condition = self.convert_string_filter(
+                f.name,
+                contains_factory=DeploymentConditions.by_name_contains,
+                equals_factory=DeploymentConditions.by_name_equals,
+                starts_with_factory=DeploymentConditions.by_name_starts_with,
+                ends_with_factory=DeploymentConditions.by_name_ends_with,
+                in_factory=DeploymentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.open_to_public is not None:
+            conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
+        if f.status is not None:
+            s = f.status
+            if s.equals is not None:
+                conditions.append(
+                    DeploymentConditions.by_status_equals(ModelDeploymentStatus(s.equals))
+                )
+            if s.in_ is not None:
+                conditions.append(
+                    DeploymentConditions.by_status_in([ModelDeploymentStatus(v) for v in s.in_])
+                )
+            if s.not_equals is not None:
+                conditions.append(
+                    DeploymentConditions.by_status_not_equals(ModelDeploymentStatus(s.not_equals))
+                )
+            if s.not_in is not None:
+                conditions.append(
+                    DeploymentConditions.by_status_not_in([
+                        ModelDeploymentStatus(v) for v in s.not_in
+                    ])
+                )
+        return conditions
+
     def _build_deployment_querier(self, input: AdminSearchDeploymentsInput) -> BatchQuerier:
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
+            conditions.extend(self._collect_deployment_filter_conditions(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -447,6 +447,8 @@ class DeploymentStatusFilter(PydanticInputMixin[DeploymentStatusFilterDTO]):
         description="The in  field.", name="in", default=None
     )
     equals: DeploymentStatusGQL | None = None
+    not_equals: DeploymentStatusGQL | None = None
+    not_in: list[DeploymentStatusGQL] | None = None
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -84,6 +84,8 @@ class DeploymentConditions:
 
     by_name_in = staticmethod(make_string_in_factory(EndpointRow.name))
     by_domain_name_in = staticmethod(make_string_in_factory(EndpointRow.domain))
+    by_tag_in = staticmethod(make_string_in_factory(EndpointRow.tag))
+    by_url_in = staticmethod(make_string_in_factory(EndpointRow.url))
 
     @staticmethod
     def by_project_id(project_id: uuid.UUID) -> QueryCondition:
@@ -145,30 +147,66 @@ class DeploymentConditions:
         return inner
 
     @staticmethod
-    def by_status_equals(status: ModelDeploymentStatus) -> QueryCondition:
+    def _status_to_lifecycles(status: ModelDeploymentStatus) -> list[EndpointLifecycle]:
+        """Reverse of _map_lifecycle_to_status: expand a public status into the
+        set of DB lifecycle_stage values that can produce it."""
+        match status:
+            case ModelDeploymentStatus.PENDING:
+                return [EndpointLifecycle.PENDING]
+            case ModelDeploymentStatus.READY:
+                return [EndpointLifecycle.READY, EndpointLifecycle.CREATED]
+            case ModelDeploymentStatus.SCALING:
+                return [EndpointLifecycle.SCALING]
+            case ModelDeploymentStatus.DEPLOYING:
+                return [EndpointLifecycle.DEPLOYING]
+            case ModelDeploymentStatus.DESTROYING | ModelDeploymentStatus.STOPPING:
+                return [EndpointLifecycle.DESTROYING]
+            case ModelDeploymentStatus.DESTROYED | ModelDeploymentStatus.STOPPED:
+                return [EndpointLifecycle.DESTROYED]
+        return []
+
+    @classmethod
+    def _expand_statuses(
+        cls, statuses: Collection[ModelDeploymentStatus]
+    ) -> list[EndpointLifecycle]:
+        expanded: list[EndpointLifecycle] = []
+        for s in statuses:
+            expanded.extend(cls._status_to_lifecycles(s))
+        return expanded
+
+    @classmethod
+    def by_status_equals(cls, status: ModelDeploymentStatus) -> QueryCondition:
+        lifecycles = cls._status_to_lifecycles(status)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage == status
+            return EndpointRow.lifecycle_stage.in_(lifecycles)
 
         return inner
 
-    @staticmethod
-    def by_status_in(statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
+    @classmethod
+    def by_status_in(cls, statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
+        lifecycles = cls._expand_statuses(statuses)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage.in_(statuses)
+            return EndpointRow.lifecycle_stage.in_(lifecycles)
 
         return inner
 
-    @staticmethod
-    def by_status_not_equals(status: ModelDeploymentStatus) -> QueryCondition:
+    @classmethod
+    def by_status_not_equals(cls, status: ModelDeploymentStatus) -> QueryCondition:
+        lifecycles = cls._status_to_lifecycles(status)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage != status
+            return EndpointRow.lifecycle_stage.notin_(lifecycles)
 
         return inner
 
-    @staticmethod
-    def by_status_not_in(statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
+    @classmethod
+    def by_status_not_in(cls, statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
+        lifecycles = cls._expand_statuses(statuses)
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage.notin_(statuses)
+            return EndpointRow.lifecycle_stage.notin_(lifecycles)
 
         return inner
 

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -159,6 +159,20 @@ class DeploymentConditions:
         return inner
 
     @staticmethod
+    def by_status_not_equals(status: ModelDeploymentStatus) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return EndpointRow.lifecycle_stage != status
+
+        return inner
+
+    @staticmethod
+    def by_status_not_in(statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return EndpointRow.lifecycle_stage.notin_(statuses)
+
+        return inner
+
+    @staticmethod
     def by_lifecycle_stages(statuses: Collection[EndpointLifecycle]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return EndpointRow.lifecycle_stage.in_(statuses)

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -175,29 +175,11 @@ class DeploymentConditions:
         return expanded
 
     @classmethod
-    def by_status_equals(cls, status: ModelDeploymentStatus) -> QueryCondition:
-        lifecycles = cls._status_to_lifecycles(status)
-
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage.in_(lifecycles)
-
-        return inner
-
-    @classmethod
     def by_status_in(cls, statuses: Collection[ModelDeploymentStatus]) -> QueryCondition:
         lifecycles = cls._expand_statuses(statuses)
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return EndpointRow.lifecycle_stage.in_(lifecycles)
-
-        return inner
-
-    @classmethod
-    def by_status_not_equals(cls, status: ModelDeploymentStatus) -> QueryCondition:
-        lifecycles = cls._status_to_lifecycles(status)
-
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return EndpointRow.lifecycle_stage.notin_(lifecycles)
 
         return inner
 


### PR DESCRIPTION
## Summary
- Deployment search silently dropped `filter.status` in `_build_deployment_querier`, `my_search`, and `project_search`, so clients could pass a status filter but no filtering occurred.
- Added `not_equals` and `not_in` to `DeploymentStatusFilter` DTO and GQL input to mirror the sibling `RouteStatusFilter` operator set.
- Added `DeploymentConditions.by_status_not_equals` / `by_status_not_in` helpers and consolidated name/open_to_public/status filter handling into a shared `_collect_deployment_filter_conditions` used by all three search paths.

Resolves BA-5730.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11085.org.readthedocs.build/en/11085/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11085.org.readthedocs.build/ko/11085/

<!-- readthedocs-preview sorna-ko end -->