### PR TITLE
fix(BA-5724): make login_client_type_id migration idempotent

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
@@ -32,12 +32,8 @@ def upgrade() -> None:
             ),
         )
 
-    has_fk = any(
-        fk["constrained_columns"] == ["login_client_type_id"]
-        and fk["referred_table"] == "login_client_types"
-        for fk in inspector.get_foreign_keys("login_sessions")
-    )
-    if not has_fk:
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("login_sessions")]
+    if "fk_login_sessions_login_client_type_id" not in fks:
         op.create_foreign_key(
             "fk_login_sessions_login_client_type_id",
             "login_sessions",
@@ -47,11 +43,8 @@ def upgrade() -> None:
             ondelete="SET NULL",
         )
 
-    has_index = any(
-        idx["column_names"] == ["login_client_type_id"]
-        for idx in inspector.get_indexes("login_sessions")
-    )
-    if not has_index:
+    indexes = [idx["name"] for idx in inspector.get_indexes("login_sessions")]
+    if "ix_login_sessions_login_client_type_id" not in indexes:
         op.create_index(
             "ix_login_sessions_login_client_type_id",
             "login_sessions",

--- a/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
@@ -19,27 +19,44 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "login_sessions",
-        sa.Column(
-            "login_client_type_id",
-            postgresql.UUID(as_uuid=True),
-            nullable=True,
-        ),
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("login_sessions")]
+    if "login_client_type_id" not in columns:
+        op.add_column(
+            "login_sessions",
+            sa.Column(
+                "login_client_type_id",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+            ),
+        )
+
+    has_fk = any(
+        fk["constrained_columns"] == ["login_client_type_id"]
+        and fk["referred_table"] == "login_client_types"
+        for fk in inspector.get_foreign_keys("login_sessions")
     )
-    op.create_foreign_key(
-        "fk_login_sessions_login_client_type_id",
-        "login_sessions",
-        "login_client_types",
-        ["login_client_type_id"],
-        ["id"],
-        ondelete="SET NULL",
+    if not has_fk:
+        op.create_foreign_key(
+            "fk_login_sessions_login_client_type_id",
+            "login_sessions",
+            "login_client_types",
+            ["login_client_type_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    has_index = any(
+        idx["column_names"] == ["login_client_type_id"]
+        for idx in inspector.get_indexes("login_sessions")
     )
-    op.create_index(
-        "ix_login_sessions_login_client_type_id",
-        "login_sessions",
-        ["login_client_type_id"],
-    )
+    if not has_index:
+        op.create_index(
+            "ix_login_sessions_login_client_type_id",
+            "login_sessions",
+            ["login_client_type_id"],
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Resolves BA-5724.

## Summary
- Add existence checks (column, FK, index) to migration `c7f2a8e31b04` so it succeeds even when schema objects already exist
- Fixes the `DuplicateColumnError` when running `alembic upgrade head` on a DB that was initialized via `create_all` after the model added `login_client_type_id` but before this migration existed

## Test plan
- [ ] Run `alembic upgrade head` on a DB where `login_client_type_id` column already exists in `login_sessions`
- [ ] Run `alembic upgrade head` on a clean DB without the column
- [ ] Verify downgrade still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)