### PR TITLE
fix(BA-5724): make login_client_type_id migration idempotent (#11093)

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7f2a8e31b04_add_login_client_type_id_to_login_sessions.py
@@ -19,27 +19,37 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "login_sessions",
-        sa.Column(
-            "login_client_type_id",
-            postgresql.UUID(as_uuid=True),
-            nullable=True,
-        ),
-    )
-    op.create_foreign_key(
-        "fk_login_sessions_login_client_type_id",
-        "login_sessions",
-        "login_client_types",
-        ["login_client_type_id"],
-        ["id"],
-        ondelete="SET NULL",
-    )
-    op.create_index(
-        "ix_login_sessions_login_client_type_id",
-        "login_sessions",
-        ["login_client_type_id"],
-    )
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("login_sessions")]
+    if "login_client_type_id" not in columns:
+        op.add_column(
+            "login_sessions",
+            sa.Column(
+                "login_client_type_id",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+            ),
+        )
+
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("login_sessions")]
+    if "fk_login_sessions_login_client_type_id" not in fks:
+        op.create_foreign_key(
+            "fk_login_sessions_login_client_type_id",
+            "login_sessions",
+            "login_client_types",
+            ["login_client_type_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("login_sessions")]
+    if "ix_login_sessions_login_client_type_id" not in indexes:
+        op.create_index(
+            "ix_login_sessions_login_client_type_id",
+            "login_sessions",
+            ["login_client_type_id"],
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
This is an auto-generated backport PR of #11093 to the 26.4 release.