### PR TITLE
fix: correct auto-scaling rule last_triggered_at NULL handling and add NullableDateTimeFilter

### DIFF
--- a/changes/11102.fix.md
+++ b/changes/11102.fix.md
@@ -1,0 +1,1 @@
+Fix auto-scaling rule `last_triggered_at` returning fake timestamps instead of null, and add `NullableDateTimeFilter` for filtering nullable datetime columns

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1678,7 +1678,7 @@ type AutoScalingRule implements Node
   """
   prometheusQueryPresetId: ID
   createdAt: DateTime!
-  lastTriggeredAt: DateTime!
+  lastTriggeredAt: DateTime
 }
 
 """Added in 25.19.0. Connection for auto-scaling rules."""
@@ -1709,7 +1709,7 @@ input AutoScalingRuleFilter
   @join__type(graph: STRAWBERRY)
 {
   createdAt: DateTimeFilter = null
-  lastTriggeredAt: DateTimeFilter = null
+  lastTriggeredAt: NullableDateTimeFilter = null
   AND: [AutoScalingRuleFilter!] = null
   OR: [AutoScalingRuleFilter!] = null
   NOT: [AutoScalingRuleFilter!] = null
@@ -10931,6 +10931,19 @@ input NotificationRuleTypeFilter
 
   """Excludes rules whose type is in this list."""
   notIn: [NotificationRuleType!] = null
+}
+
+"""
+Added in UNRELEASED. Filter for nullable datetime fields with IS NULL / IS NOT NULL support.
+"""
+input NullableDateTimeFilter
+  @join__type(graph: STRAWBERRY)
+{
+  before: DateTime = null
+  after: DateTime = null
+  equals: DateTime = null
+  notEquals: DateTime = null
+  isNull: Boolean = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1152,7 +1152,7 @@ type AutoScalingRule implements Node {
   """
   prometheusQueryPresetId: ID
   createdAt: DateTime!
-  lastTriggeredAt: DateTime!
+  lastTriggeredAt: DateTime
 }
 
 """Added in 25.19.0. Connection for auto-scaling rules."""
@@ -1177,7 +1177,7 @@ type AutoScalingRuleEdge {
 """Added in 25.19.0. """
 input AutoScalingRuleFilter {
   createdAt: DateTimeFilter = null
-  lastTriggeredAt: DateTimeFilter = null
+  lastTriggeredAt: NullableDateTimeFilter = null
   AND: [AutoScalingRuleFilter!] = null
   OR: [AutoScalingRuleFilter!] = null
   NOT: [AutoScalingRuleFilter!] = null
@@ -6842,6 +6842,17 @@ input NotificationRuleTypeFilter {
 
   """Excludes rules whose type is in this list."""
   notIn: [NotificationRuleType!] = null
+}
+
+"""
+Added in UNRELEASED. Filter for nullable datetime fields with IS NULL / IS NOT NULL support.
+"""
+input NullableDateTimeFilter {
+  before: DateTime = null
+  after: DateTime = null
+  equals: DateTime = null
+  notEquals: DateTime = null
+  isNull: Boolean = null
 }
 
 """

--- a/src/ai/backend/client/cli/v2/deployment/auto_scaling_rule.py
+++ b/src/ai/backend/client/cli/v2/deployment/auto_scaling_rule.py
@@ -106,23 +106,39 @@ def create(
     multiple=True,
     help="Order by field:direction (e.g., created_at:desc).",
 )
+@click.option(
+    "--last-triggered-at-is-null",
+    type=bool,
+    default=None,
+    help="Filter by last_triggered_at null status (true=never triggered, false=triggered at least once).",
+)
 def search(
     deployment_id: uuid.UUID,
     limit: int,
     offset: int,
     order_by: tuple[str, ...],
+    last_triggered_at_is_null: bool | None,
 ) -> None:
     """Search auto-scaling rules for a deployment."""
-    from ai.backend.common.dto.manager.v2.auto_scaling_rule.request import (
+    from ai.backend.common.dto.manager.query import NullableDateTimeFilter
+    from ai.backend.common.dto.manager.v2.deployment.request import (
         AutoScalingRuleFilter,
         AutoScalingRuleOrder,
         SearchAutoScalingRulesInput,
     )
-    from ai.backend.common.dto.manager.v2.auto_scaling_rule.types import (
+    from ai.backend.common.dto.manager.v2.deployment.types import (
         AutoScalingRuleOrderField,
     )
 
-    filter_dto = AutoScalingRuleFilter(model_deployment_id=deployment_id)
+    last_triggered_at_filter = (
+        NullableDateTimeFilter(is_null=last_triggered_at_is_null)
+        if last_triggered_at_is_null is not None
+        else None
+    )
+    filter_dto = AutoScalingRuleFilter(
+        deployment_id=deployment_id,
+        last_triggered_at=last_triggered_at_filter,
+    )
     orders = (
         parse_order_options(order_by, AutoScalingRuleOrderField, AutoScalingRuleOrder)
         if order_by

--- a/src/ai/backend/common/dto/manager/auto_scaling_rule/request.py
+++ b/src/ai/backend/common/dto/manager/auto_scaling_rule/request.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import DateTimeFilter, NullableDateTimeFilter
 from ai.backend.common.types import AutoScalingMetricSource
 
 from .types import (
@@ -70,6 +71,10 @@ class AutoScalingRuleFilter(BaseRequestModel):
     """Filter for auto-scaling rules."""
 
     model_deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
+    created_at: DateTimeFilter | None = Field(default=None, description="Creation datetime filter")
+    last_triggered_at: NullableDateTimeFilter | None = Field(
+        default=None, description="Last triggered datetime filter"
+    )
 
 
 class AutoScalingRuleOrder(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
+++ b/src/ai/backend/common/dto/manager/auto_scaling_rule/response.py
@@ -43,7 +43,7 @@ class AutoScalingRuleDTO(BaseModel):
         default=None, description="Prometheus query preset ID"
     )
     created_at: datetime = Field(description="Creation timestamp")
-    last_triggered_at: datetime = Field(description="Last triggered timestamp")
+    last_triggered_at: datetime | None = Field(default=None, description="Last triggered timestamp")
 
 
 class CreateAutoScalingRuleResponse(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/query.py
+++ b/src/ai/backend/common/dto/manager/query.py
@@ -111,6 +111,34 @@ class DateTimeFilter(BaseRequestModel):
         return None
 
 
+class NullableDateTimeFilter(DateTimeFilter):
+    """Filter for nullable datetime fields.
+
+    Extends DateTimeFilter with is_null support for columns that allow NULL values
+    (e.g., last_triggered_at). Use DateTimeFilter for NOT NULL columns.
+    """
+
+    is_null: bool | None = Field(
+        default=None,
+        description="Filter by null status: true = IS NULL, false = IS NOT NULL",
+    )
+
+    def build_query_condition(
+        self,
+        before_factory: Callable[[datetime], _QC],
+        after_factory: Callable[[datetime], _QC],
+        equals_factory: Callable[[datetime], _QC],
+        is_null_factory: Callable[[], _QC] | None = None,
+        is_not_null_factory: Callable[[], _QC] | None = None,
+    ) -> _QC | None:
+        if self.is_null is not None:
+            if self.is_null and is_null_factory is not None:
+                return is_null_factory()
+            if not self.is_null and is_not_null_factory is not None:
+                return is_not_null_factory()
+        return super().build_query_condition(before_factory, after_factory, equals_factory)
+
+
 class DateTimeRangeFilter(BaseRequestModel):
     """
     Filters records by a datetime range.

--- a/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/response.py
+++ b/src/ai/backend/common/dto/manager/v2/auto_scaling_rule/response.py
@@ -42,7 +42,7 @@ class AutoScalingRuleNode(BaseResponseModel):
         default=None, description="Prometheus query preset ID"
     )
     created_at: datetime = Field(description="Creation timestamp")
-    last_triggered_at: datetime = Field(description="Last triggered timestamp")
+    last_triggered_at: datetime | None = Field(default=None, description="Last triggered timestamp")
 
 
 class CreateAutoScalingRulePayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -20,7 +20,7 @@ from ai.backend.common.data.model_deployment.types import (
     RouteStatus,
     RouteTrafficStatus,
 )
-from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
+from ai.backend.common.dto.manager.query import DateTimeFilter, NullableDateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment.types import (
     AccessTokenOrderField,
@@ -576,7 +576,7 @@ class AutoScalingRuleFilter(BaseRequestModel):
 
     deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
     created_at: DateTimeFilter | None = Field(default=None, description="Creation datetime filter")
-    last_triggered_at: DateTimeFilter | None = Field(
+    last_triggered_at: NullableDateTimeFilter | None = Field(
         default=None, description="Last triggered datetime filter"
     )
     AND: list[AutoScalingRuleFilter] | None = Field(default=None, description="AND conjunction")

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -211,7 +211,7 @@ class AutoScalingRuleNode(BaseResponseModel):
         default=None, description="Prometheus query preset ID"
     )
     created_at: datetime = Field(description="Creation timestamp")
-    last_triggered_at: datetime = Field(description="Last triggered timestamp")
+    last_triggered_at: datetime | None = Field(default=None, description="Last triggered timestamp")
 
 
 class DeploymentPolicyNode(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -1705,6 +1705,8 @@ class DeploymentAdapter(BaseAdapter):
                     before_factory=AutoScalingRuleConditions.by_last_triggered_at_before,
                     after_factory=AutoScalingRuleConditions.by_last_triggered_at_after,
                     equals_factory=AutoScalingRuleConditions.by_last_triggered_at_equals,
+                    is_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_null,
+                    is_not_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_not_null,
                 )
                 if condition is not None:
                     conditions.append(condition)

--- a/src/ai/backend/manager/api/gql/base.py
+++ b/src/ai/backend/manager/api/gql/base.py
@@ -24,8 +24,10 @@ from ai.backend.common.data.filter_specs import (
 from ai.backend.common.dto.manager.query import DateFilter as DateFilterDTO
 from ai.backend.common.dto.manager.query import DateTimeFilter as DateTimeFilterDTO
 from ai.backend.common.dto.manager.query import IntFilter as IntFilterDTO
+from ai.backend.common.dto.manager.query import NullableDateTimeFilter as NullableDateTimeFilterDTO
 from ai.backend.common.dto.manager.query import StringFilter as StringFilterDTO
 from ai.backend.common.dto.manager.query import UUIDFilter as UUIDFilterDTO
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.adapters.cursor import decode_cursor as decode_cursor
 from ai.backend.manager.api.adapters.cursor import encode_cursor as encode_cursor
 from ai.backend.manager.api.gql.decorators import (
@@ -334,6 +336,21 @@ class DateTimeFilter(PydanticInputMixin[DateTimeFilterDTO]):
     after: datetime | None = None
     equals: datetime | None = None
     not_equals: datetime | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter for nullable datetime fields with IS NULL / IS NOT NULL support.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="NullableDateTimeFilter",
+)
+class NullableDateTimeFilter(PydanticInputMixin[NullableDateTimeFilterDTO]):
+    before: datetime | None = None
+    after: datetime | None = None
+    equals: datetime | None = None
+    not_equals: datetime | None = None
+    is_null: bool | None = None
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
@@ -42,7 +42,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     AutoScalingRuleOrderField,
 )
-from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection
+from ai.backend.manager.api.gql.base import DateTimeFilter, NullableDateTimeFilter, OrderDirection
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -75,7 +75,7 @@ class AutoScalingRuleFilter(PydanticInputMixin[AutoScalingRuleFilterDTO]):
     """Filter for auto-scaling rules."""
 
     created_at: DateTimeFilter | None = None
-    last_triggered_at: DateTimeFilter | None = None
+    last_triggered_at: NullableDateTimeFilter | None = None
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None
@@ -124,7 +124,7 @@ class AutoScalingRule(PydanticNodeMixin[AutoScalingRuleNodeDTO]):
     )
 
     created_at: datetime
-    last_triggered_at: datetime
+    last_triggered_at: datetime | None
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def

--- a/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
+++ b/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
@@ -117,6 +117,24 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
             conditions.append(
                 AutoScalingRuleConditions.by_deployment_id(filter.model_deployment_id)
             )
+        if filter.created_at is not None:
+            condition = filter.created_at.build_query_condition(
+                before_factory=AutoScalingRuleConditions.by_created_at_before,
+                after_factory=AutoScalingRuleConditions.by_created_at_after,
+                equals_factory=AutoScalingRuleConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.last_triggered_at is not None:
+            condition = filter.last_triggered_at.build_query_condition(
+                before_factory=AutoScalingRuleConditions.by_last_triggered_at_before,
+                after_factory=AutoScalingRuleConditions.by_last_triggered_at_after,
+                equals_factory=AutoScalingRuleConditions.by_last_triggered_at_equals,
+                is_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_null,
+                is_not_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_not_null,
+            )
+            if condition is not None:
+                conditions.append(condition)
 
         return conditions
 

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -606,7 +606,7 @@ class ModelDeploymentAutoScalingRuleData:
     min_replicas: int | None
     max_replicas: int | None
     created_at: datetime
-    last_triggered_at: datetime
+    last_triggered_at: datetime | None
     prometheus_query_preset_id: UUID | None = None
 
 

--- a/src/ai/backend/manager/data/model_serving/types.py
+++ b/src/ai/backend/manager/data/model_serving/types.py
@@ -121,7 +121,7 @@ class EndpointAutoScalingRuleData:
     min_replicas: int
     max_replicas: int
     created_at: datetime
-    last_triggered_at: datetime
+    last_triggered_at: datetime | None
     endpoint: uuid.UUID
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d8e4f2a1b3c7_make_endpoint_created_at_not_null.py
+++ b/src/ai/backend/manager/models/alembic/versions/d8e4f2a1b3c7_make_endpoint_created_at_not_null.py
@@ -1,7 +1,7 @@
 """make endpoint created_at columns NOT NULL
 
 Revision ID: d8e4f2a1b3c7
-Revises: f7d3738a3cef
+Revises: a3b4c5d6e7f8
 Create Date: 2026-04-15
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "d8e4f2a1b3c7"
-down_revision = "f7d3738a3cef"
+down_revision = "a3b4c5d6e7f8"
 branch_labels = None
 depends_on = None
 

--- a/src/ai/backend/manager/models/alembic/versions/d8e4f2a1b3c7_make_endpoint_created_at_not_null.py
+++ b/src/ai/backend/manager/models/alembic/versions/d8e4f2a1b3c7_make_endpoint_created_at_not_null.py
@@ -1,0 +1,43 @@
+"""make endpoint created_at columns NOT NULL
+
+Revision ID: d8e4f2a1b3c7
+Revises: f7d3738a3cef
+Create Date: 2026-04-15
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d8e4f2a1b3c7"
+down_revision = "f7d3738a3cef"
+branch_labels = None
+depends_on = None
+
+_TABLES = ["endpoints", "endpoint_tokens", "endpoint_auto_scaling_rules"]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in _TABLES:
+        # Backfill any NULLs (should be none due to server_default, but be safe)
+        conn.execute(sa.text(f"UPDATE {table} SET created_at = now() WHERE created_at IS NULL"))
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+            existing_server_default="now()",
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=True,
+            existing_server_default="now()",
+        )

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -550,6 +550,20 @@ class AutoScalingRuleConditions:
         return inner
 
     @staticmethod
+    def by_last_triggered_at_is_null() -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return EndpointAutoScalingRuleRow.last_triggered_at.is_(None)
+
+        return inner
+
+    @staticmethod
+    def by_last_triggered_at_is_not_null() -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return EndpointAutoScalingRuleRow.last_triggered_at.isnot(None)
+
+        return inner
+
+    @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
         """Cursor condition for forward pagination (after cursor).
 

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -1030,7 +1030,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             min_replicas=self.min_replicas or 0,
             max_replicas=self.max_replicas or 0,
             created_at=self.created_at or datetime.now(UTC),
-            last_triggered_at=self.last_triggered_at or datetime.now(UTC),
+            last_triggered_at=self.last_triggered_at,
             endpoint=self.endpoint,
         )
 
@@ -1103,7 +1103,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             min_replicas=self.min_replicas,
             max_replicas=self.max_replicas,
             created_at=self.created_at or datetime.now(UTC),
-            last_triggered_at=self.last_triggered_at or datetime.now(UTC),
+            last_triggered_at=self.last_triggered_at,
             prometheus_query_preset_id=self.prometheus_query_preset_id,
         )
 

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -7,7 +7,7 @@ from collections.abc import (
     Iterable,
     Sequence,
 )
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import (
@@ -231,11 +231,11 @@ class EndpointRow(Base):  # type: ignore[misc]
     retries: Mapped[int] = mapped_column(
         "retries", sa.Integer, nullable=False, default=0, server_default="0"
     )
-    created_at: Mapped[datetime | None] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         "created_at",
         sa.DateTime(timezone=True),
         server_default=sa.text("now()"),
-        nullable=True,
+        nullable=False,
     )
     destroyed_at: Mapped[datetime | None] = mapped_column(
         "destroyed_at",
@@ -702,7 +702,7 @@ class EndpointRow(Base):  # type: ignore[misc]
             ),
             cluster_size=current_rev.cluster_size if current_rev else 1,
             open_to_public=self.open_to_public if self.open_to_public is not None else False,
-            created_at=self.created_at or datetime.now(UTC),
+            created_at=self.created_at,
             destroyed_at=self.destroyed_at,
             retries=self.retries,
             lifecycle_stage=self.lifecycle_stage,
@@ -821,8 +821,8 @@ class EndpointTokenRow(Base):  # type: ignore[misc]
     expires_at: Mapped[datetime | None] = mapped_column(
         "expires_at", sa.DateTime(timezone=True), nullable=True
     )
-    created_at: Mapped[datetime | None] = mapped_column(
-        "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
 
     endpoint_row: Mapped[EndpointRow | None] = relationship(
@@ -914,7 +914,7 @@ class EndpointTokenRow(Base):  # type: ignore[misc]
             domain=self.domain,
             project=self.project,
             session_owner=self.session_owner,
-            created_at=self.created_at or datetime.now(UTC),
+            created_at=self.created_at,
         )
 
 
@@ -949,11 +949,11 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
         nullable=True,
     )
 
-    created_at: Mapped[datetime | None] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         "created_at",
         sa.DateTime(timezone=True),
         server_default=sa.text("now()"),
-        nullable=True,
+        nullable=False,
     )
     last_triggered_at: Mapped[datetime | None] = mapped_column(
         "last_triggered_at",
@@ -1029,7 +1029,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             cooldown_seconds=self.cooldown_seconds,
             min_replicas=self.min_replicas or 0,
             max_replicas=self.max_replicas or 0,
-            created_at=self.created_at or datetime.now(UTC),
+            created_at=self.created_at,
             last_triggered_at=self.last_triggered_at,
             endpoint=self.endpoint,
         )
@@ -1066,7 +1066,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
                 min_replicas=self.min_replicas,
                 max_replicas=self.max_replicas,
             ),
-            created_at=self.created_at or datetime.now(UTC),
+            created_at=self.created_at,
             last_triggered_at=self.last_triggered_at,
         )
 
@@ -1102,7 +1102,7 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
             time_window=self.cooldown_seconds,
             min_replicas=self.min_replicas,
             max_replicas=self.max_replicas,
-            created_at=self.created_at or datetime.now(UTC),
+            created_at=self.created_at,
             last_triggered_at=self.last_triggered_at,
             prometheus_query_preset_id=self.prometheus_query_preset_id,
         )

--- a/tests/unit/manager/repositories/model_serving/conftest.py
+++ b/tests/unit/manager/repositories/model_serving/conftest.py
@@ -459,7 +459,7 @@ def create_full_featured_endpoint(
 
     # Set attributes normally set by database
     endpoint_row.id = EndpointId(uuid.uuid4())
-    endpoint_row.created_at = None
+    endpoint_row.created_at = datetime.now(tz=UTC)
     endpoint_row.destroyed_at = None
     endpoint_row.lifecycle_stage = EndpointLifecycle.CREATED
     endpoint_row.retries = 0


### PR DESCRIPTION
## Summary
- Fix `last_triggered_at` being falsely reported as `datetime.now(UTC)` when the DB value is NULL — now correctly returns `null` across all layers (GQL, REST, CLI)
- Add `NullableDateTimeFilter` (extends `DateTimeFilter` with `is_null: bool`) for filtering nullable datetime columns, available across GQL/REST/SDK/CLI
- Make `created_at` columns on `endpoints`, `endpoint_tokens`, and `endpoint_auto_scaling_rules` NOT NULL via migration (they already had `server_default=now()` so no actual NULLs exist), removing all `or datetime.now(UTC)` fallbacks
- Fix CLI `search` command importing from wrong DTO package (`v2/auto_scaling_rule` → `v2/deployment`)

## Test plan
- [x] GQL: `lastTriggeredAt: { isNull: true/false }` filter verified
- [x] CLI: `--last-triggered-at-is-null true/false` filter verified
- [x] GQL: `lastTriggeredAt` returns `null` (not fake timestamp) for never-triggered rules
- [x] CLI: `last_triggered_at` returns `null` for never-triggered rules
- [x] `pants lint` / `pants check` pass
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11102.org.readthedocs.build/en/11102/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11102.org.readthedocs.build/ko/11102/

<!-- readthedocs-preview sorna-ko end -->