### PR TITLE
feat(BA-5740): add scope resolver on EntityRefGQL

### DIFF
--- a/changes/11107.feature.md
+++ b/changes/11107.feature.md
@@ -1,0 +1,1 @@
+Add `scope` resolver on `EntityRefGQL` so RBAC role scope connections can resolve the scope target (e.g., project, domain) directly in GraphQL.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -6070,6 +6070,11 @@ type EntityRef implements Node
 
   """The resolved entity object."""
   entity: EntityNode
+
+  """
+  Added in UNRELEASED. The resolved scope object in which the entity is registered.
+  """
+  scope: EntityNode
 }
 
 """An edge in a connection."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3870,6 +3870,11 @@ type EntityRef implements Node {
 
   """The resolved entity object."""
   entity: EntityNode
+
+  """
+  Added in UNRELEASED. The resolved scope object in which the entity is registered.
+  """
+  scope: EntityNode
 }
 
 """An edge in a connection."""

--- a/src/ai/backend/manager/api/gql/rbac/types/entity.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/entity.py
@@ -21,10 +21,12 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
 from ai.backend.common.dto.manager.v2.rbac.response import (
     AssociationScopesEntitiesNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -48,6 +50,43 @@ class EntityOrderField(StrEnum):
 # ==================== Node Types ====================
 
 
+async def _load_rbac_element(
+    info: Info[StrawberryGQLContext],
+    element_type: RBACElementType,
+    element_id: str,
+) -> EntityNode | None:
+    from ai.backend.common.types import ImageID, SessionId
+
+    data_loaders = info.context.data_loaders
+    match element_type:
+        case RBACElementType.USER:
+            return await data_loaders.user_loader.load(uuid.UUID(element_id))
+        case RBACElementType.PROJECT:
+            return await data_loaders.project_loader.load(uuid.UUID(element_id))
+        case RBACElementType.DOMAIN:
+            return await data_loaders.domain_loader.load(element_id)
+        case RBACElementType.ROLE:
+            return await data_loaders.role_loader.load(uuid.UUID(element_id))
+        case RBACElementType.IMAGE:
+            return await data_loaders.image_loader.load(ImageID(uuid.UUID(element_id)))
+        case RBACElementType.MODEL_DEPLOYMENT:
+            return await data_loaders.deployment_loader.load(uuid.UUID(element_id))
+        case RBACElementType.RESOURCE_GROUP:
+            return await data_loaders.resource_group_loader.load(element_id)
+        case RBACElementType.NOTIFICATION_CHANNEL:
+            return await data_loaders.notification_channel_loader.load(uuid.UUID(element_id))
+        case RBACElementType.NOTIFICATION_RULE:
+            return await data_loaders.notification_rule_loader.load(uuid.UUID(element_id))
+        case RBACElementType.ARTIFACT_REVISION:
+            return await data_loaders.artifact_revision_loader.load(uuid.UUID(element_id))
+        case RBACElementType.CONTAINER_REGISTRY:
+            return await data_loaders.container_registry_loader.load(uuid.UUID(element_id))
+        case RBACElementType.SESSION:
+            return await data_loaders.session_loader.load(SessionId(uuid.UUID(element_id)))
+        case _:
+            return None
+
+
 @gql_node_type(
     BackendAIGQLMeta(
         added_version="26.3.0",
@@ -69,47 +108,22 @@ class EntityRefGQL(PydanticNodeMixin[AssociationScopesEntitiesNode]):
         *,
         info: Info[StrawberryGQLContext],
     ) -> EntityNode | None:
-        from ai.backend.common.types import ImageID, SessionId
-
         element_type = RBACElementType(self.entity_type.value)  # type: ignore[attr-defined]
-        data_loaders = info.context.data_loaders
-        match element_type:
-            case RBACElementType.USER:
-                # DataLoader already returns UserV2GQL | None via from_pydantic conversion
-                return await data_loaders.user_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.PROJECT:
-                # DataLoader already returns ProjectV2GQL | None via from_pydantic conversion
-                return await data_loaders.project_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.DOMAIN:
-                return await data_loaders.domain_loader.load(self.entity_id)
-            case RBACElementType.ROLE:
-                # DataLoader already returns RoleGQL | None via from_pydantic conversion
-                return await data_loaders.role_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.IMAGE:
-                # DataLoader already returns ImageV2GQL | None via from_pydantic conversion
-                return await data_loaders.image_loader.load(ImageID(uuid.UUID(self.entity_id)))
-            case RBACElementType.MODEL_DEPLOYMENT:
-                # DataLoader already returns ModelDeployment | None via from_pydantic conversion
-                return await data_loaders.deployment_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.RESOURCE_GROUP:
-                return await data_loaders.resource_group_loader.load(self.entity_id)
-            case RBACElementType.NOTIFICATION_CHANNEL:
-                return await data_loaders.notification_channel_loader.load(
-                    uuid.UUID(self.entity_id)
-                )
-            case RBACElementType.NOTIFICATION_RULE:
-                return await data_loaders.notification_rule_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.ARTIFACT_REVISION:
-                # DataLoader already returns ArtifactRevision | None via from_pydantic
-                return await data_loaders.artifact_revision_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.CONTAINER_REGISTRY:
-                # DataLoader already returns ContainerRegistryGQL | None via from_pydantic
-                return await data_loaders.container_registry_loader.load(uuid.UUID(self.entity_id))
-            case RBACElementType.SESSION:
-                # DataLoader already returns SessionV2GQL | None via from_pydantic conversion
-                return await data_loaders.session_loader.load(SessionId(uuid.UUID(self.entity_id)))
-            case _:
-                return None
+        return await _load_rbac_element(info, element_type, self.entity_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The resolved scope object in which the entity is registered.",
+        )
+    )  # type: ignore[misc]
+    async def scope(
+        self,
+        *,
+        info: Info[StrawberryGQLContext],
+    ) -> EntityNode | None:
+        element_type = RBACElementType(self.scope_type.value)  # type: ignore[attr-defined]
+        return await _load_rbac_element(info, element_type, self.scope_id)
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]


### PR DESCRIPTION
## Summary
- `Role.scopes` returns `EntityRefGQL` rows filtered by `entity_type=ROLE, entity_id=<role_id>`, which meant the scope side (`scope_type`/`scope_id`) had no resolver and clients could read the raw `scope_id` but not fetch the scope target (e.g. the project name).
- Adds a `scope` resolver on `EntityRefGQL` that mirrors the existing `entity` resolver and returns `EntityNode | None`, so queries like `Role.scopes { edges { node { scope { ... on ProjectV2 { basicInfo { name } } } } } }` now work.
- Extracts the shared `RBACElementType` → DataLoader dispatch into a single `_load_rbac_element` helper reused by both `entity` and `scope` resolvers.

## Test plan
- [x] `pants fmt` / `pants fix` / `pants lint` on the diff — all green
- [x] Live GraphQL test against local manager: `adminRole(id: ...) { scopes { edges { node { scope { ... on ProjectV2 { basicInfo { name } } } } } } }` resolves the associated project correctly (verified `project-86975a60-admin` → `ba-5725-test-project`)
- [x] `entity` resolver still returns the role itself (no regression)

Resolves BA-5740