### PR TITLE
fix: increase health check initial_delay default from 5min to 30min

### DIFF
--- a/changes/11108.fix.md
+++ b/changes/11108.fix.md
@@ -1,0 +1,1 @@
+Increase default health check initial delay from 5 minutes to 30 minutes for all runtime variant generators to prevent premature failures during large model loading.

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/huggingface_tgi.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/huggingface_tgi.py
@@ -24,7 +24,7 @@ class HuggingFaceTGIModelDefinitionGenerator(ModelDefinitionGenerator):
         if runtime_profile.health_check_endpoint:
             health_check = ModelHealthCheck(
                 path=runtime_profile.health_check_endpoint,
-                initial_delay=300.0,
+                initial_delay=1800.0,
             )
 
         model = ModelConfig(

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/modular_max.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/modular_max.py
@@ -26,7 +26,7 @@ class ModularMAXModelDefinitionGenerator(ModelDefinitionGenerator):
                 path=runtime_profile.health_check_endpoint,
                 interval=10.0,
                 max_retries=10,
-                initial_delay=300.0,
+                initial_delay=1800.0,
             )
 
         model = ModelConfig(

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/nim.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/nim.py
@@ -26,7 +26,7 @@ class NIMModelDefinitionGenerator(ModelDefinitionGenerator):
                 path=runtime_profile.health_check_endpoint,
                 interval=10.0,
                 max_retries=10,
-                initial_delay=300.0,
+                initial_delay=1800.0,
             )
 
         model = ModelConfig(

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/sglang.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/sglang.py
@@ -26,7 +26,7 @@ class SGLangModelDefinitionGenerator(ModelDefinitionGenerator):
                 path=runtime_profile.health_check_endpoint,
                 interval=10.0,
                 max_retries=10,
-                initial_delay=300.0,
+                initial_delay=1800.0,
             )
 
         model = ModelConfig(

--- a/src/ai/backend/manager/sokovan/deployment/definition_generator/vllm.py
+++ b/src/ai/backend/manager/sokovan/deployment/definition_generator/vllm.py
@@ -26,7 +26,7 @@ class VLLMModelDefinitionGenerator(ModelDefinitionGenerator):
                 path=runtime_profile.health_check_endpoint,
                 interval=10.0,
                 max_retries=10,
-                initial_delay=300.0,
+                initial_delay=1800.0,
             )
 
         model = ModelConfig(


### PR DESCRIPTION
## Summary
- All runtime variant definition generators (vLLM, NIM, HuggingFace TGI, SGLang, Modular MAX) had `initial_delay=300.0` (5 minutes) hardcoded for health checks
- Large model loading can take well over 5 minutes, causing premature health check failures
- Increase default to `1800.0` (30 minutes) to accommodate large model deployments
- This value can still be overridden via deployment revision preset or user-provided `model_definition`

## Test plan
- [ ] Deploy a model service and verify health check does not fail prematurely during model loading
- [ ] Verify `initial_delay` can still be overridden via revision preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)