### PR TITLE
feat(BA-5742): implement SessionV2GQL.images and expose image on KernelV2GQL

### DIFF
--- a/changes/11111.feature.md
+++ b/changes/11111.feature.md
@@ -1,0 +1,1 @@
+Implement `SessionV2.images` resolver and expose `image` on `KernelV2` in the GraphQL API.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7254,6 +7254,9 @@ type KernelV2 implements Node
   """User and ownership information."""
   userInfo: KernelV2UserInfo!
 
+  """Added in UNRELEASED. Container image identity for this kernel."""
+  imageInfo: KernelV2ImageInfo!
+
   """Network configuration and exposed ports."""
   network: KernelV2NetworkInfo!
 
@@ -7277,6 +7280,9 @@ type KernelV2 implements Node
 
   """Added in 26.2.0. The domain this kernel belongs to."""
   domain: DomainV2
+
+  """Added in UNRELEASED. The container image used by this kernel."""
+  image: ImageV2
 
   """Added in 26.2.0. The resource group this kernel is assigned to."""
   resourceGroup: ResourceGroup
@@ -7340,6 +7346,21 @@ input KernelV2Filter
   AND: [KernelV2Filter!] = null
   OR: [KernelV2Filter!] = null
   NOT: [KernelV2Filter!] = null
+}
+
+"""
+Added in UNRELEASED. Container image identity for a kernel (canonical name + architecture).
+"""
+type KernelV2ImageInfo
+  @join__type(graph: STRAWBERRY)
+{
+  """Canonical name of the container image used by this kernel."""
+  canonical: String
+
+  """
+  Architecture of the container image used by this kernel (e.g., x86_64, aarch64).
+  """
+  architecture: String
 }
 
 """Added in 26.2.0. Lifecycle and status information for a kernel."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4531,6 +4531,9 @@ type KernelV2 implements Node {
   """User and ownership information."""
   userInfo: KernelV2UserInfo!
 
+  """Added in UNRELEASED. Container image identity for this kernel."""
+  imageInfo: KernelV2ImageInfo!
+
   """Network configuration and exposed ports."""
   network: KernelV2NetworkInfo!
 
@@ -4554,6 +4557,9 @@ type KernelV2 implements Node {
 
   """Added in 26.2.0. The domain this kernel belongs to."""
   domain: DomainV2
+
+  """Added in UNRELEASED. The container image used by this kernel."""
+  image: ImageV2
 
   """Added in 26.2.0. The resource group this kernel is assigned to."""
   resourceGroup: ResourceGroup
@@ -4609,6 +4615,19 @@ input KernelV2Filter {
   AND: [KernelV2Filter!] = null
   OR: [KernelV2Filter!] = null
   NOT: [KernelV2Filter!] = null
+}
+
+"""
+Added in UNRELEASED. Container image identity for a kernel (canonical name + architecture).
+"""
+type KernelV2ImageInfo {
+  """Canonical name of the container image used by this kernel."""
+  canonical: String
+
+  """
+  Architecture of the container image used by this kernel (e.g., x86_64, aarch64).
+  """
+  architecture: String
 }
 
 """Added in 26.2.0. Lifecycle and status information for a kernel."""

--- a/src/ai/backend/common/dto/manager/v2/kernel/response.py
+++ b/src/ai/backend/common/dto/manager/v2/kernel/response.py
@@ -14,6 +14,7 @@ __all__ = (
     "AdminSearchKernelsPayload",
     "KernelClusterInfo",
     "KernelClusterInfoGQLDTO",
+    "KernelImageInfoGQLDTO",
     "KernelLifecycleInfo",
     "KernelLifecycleInfoGQLDTO",
     "KernelNetworkInfoGQLDTO",
@@ -148,6 +149,9 @@ class KernelNode(BaseResponseModel):
         description="Information about the session this kernel belongs to."
     )
     user_info: KernelUserInfoGQLDTO = Field(description="User and ownership information.")
+    image: KernelImageInfoGQLDTO = Field(
+        description="Container image identity (canonical name, architecture)."
+    )
     network: KernelNetworkInfoGQLDTO = Field(description="Network configuration and exposed ports.")
     cluster: KernelClusterInfoGQLDTO = Field(
         description="Cluster configuration for distributed computing."
@@ -228,6 +232,22 @@ class KernelUserInfoGQLDTO(BaseResponseModel):
     domain_name: str | None = Field(default=None, description="The domain this kernel belongs to.")
     group_id: UUID | None = Field(
         default=None, description="The group (project) ID this kernel belongs to."
+    )
+
+
+class KernelImageInfoGQLDTO(BaseResponseModel):
+    """GQL-specific DTO for KernelV2ImageInfoGQL.
+
+    Identifies the container image used by a kernel by its canonical name and architecture.
+    """
+
+    canonical: str | None = Field(
+        default=None,
+        description="Canonical name of the container image used by this kernel.",
+    )
+    architecture: str | None = Field(
+        default=None,
+        description="Architecture of the container image used by this kernel (e.g., x86_64, aarch64).",
     )
 
 

--- a/src/ai/backend/manager/api/adapters/image.py
+++ b/src/ai/backend/manager/api/adapters/image.py
@@ -44,7 +44,12 @@ from ai.backend.common.dto.manager.v2.image.types import (
     OrderDirection,
 )
 from ai.backend.common.types import ImageID
-from ai.backend.manager.data.image.types import ImageAliasData, ImageData, ImageStatus
+from ai.backend.manager.data.image.types import (
+    ImageAliasData,
+    ImageData,
+    ImageIdentifier,
+    ImageStatus,
+)
 from ai.backend.manager.models.image import ImageType
 from ai.backend.manager.models.image.conditions import (
     ImageAliasConditions,
@@ -124,6 +129,32 @@ class ImageAdapter(BaseAdapter):
             ImageID(item.id): self._data_to_dto(item) for item in action_result.data
         }
         return [image_map.get(image_id) for image_id in image_ids]
+
+    async def batch_load_by_identifiers(
+        self,
+        identifiers: Sequence[ImageIdentifier],
+    ) -> list[ImageNode | None]:
+        """Batch load images by ImageIdentifier (canonical + architecture) for DataLoader use.
+
+        Returns ImageNode DTOs in the same order as the input identifiers list.
+        """
+        if not identifiers:
+            return []
+        unique_identifiers = set(identifiers)
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[ImageConditions.by_image_identifiers(unique_identifiers)],
+        )
+        action_result = await self._processors.image.search_images.wait_for_complete(
+            SearchImagesAction(querier=querier)
+        )
+        image_map: dict[ImageIdentifier, ImageNode] = {
+            ImageIdentifier(
+                canonical=str(item.name), architecture=item.architecture
+            ): self._data_to_dto(item)
+            for item in action_result.data
+        }
+        return [image_map.get(identifier) for identifier in identifiers]
 
     async def batch_load_aliases_by_ids(
         self, alias_ids: Sequence[uuid.UUID]

--- a/src/ai/backend/manager/api/adapters/session.py
+++ b/src/ai/backend/manager/api/adapters/session.py
@@ -27,6 +27,7 @@ from ai.backend.common.dto.manager.v2.kernel.request import (
 from ai.backend.common.dto.manager.v2.kernel.response import (
     AdminSearchKernelsPayload,
     KernelClusterInfoGQLDTO,
+    KernelImageInfoGQLDTO,
     KernelLifecycleInfoGQLDTO,
     KernelNetworkInfoGQLDTO,
     KernelNode,
@@ -1021,9 +1022,21 @@ class SessionAdapter(BaseAdapter):
             if info.resource.resource_opts
             else None
         )
+        image_canonical = (
+            info.image.identifier.canonical if info.image.identifier is not None else None
+        )
+        architecture = (
+            info.image.identifier.architecture
+            if info.image.identifier is not None
+            else info.image.architecture
+        )
         return KernelNode(
             id=info.id,
             startup_command=info.runtime.startup_command,
+            image=KernelImageInfoGQLDTO(
+                canonical=image_canonical,
+                architecture=architecture,
+            ),
             session_info=KernelSessionInfoGQLDTO(
                 session_id=UUID(info.session.session_id),
                 creation_id=info.session.creation_id,

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from strawberry.dataloader import DataLoader
 
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
+from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.permission.id import ObjectId
 
 if TYPE_CHECKING:
@@ -410,6 +411,24 @@ class DataLoaders:
             )
 
             dtos = await adapter.batch_load_by_ids(image_ids)
+            return [IG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def image_by_identifier_loader(
+        self,
+    ) -> DataLoader[ImageIdentifier, ImageV2GQL | None]:
+        adapter = self._adapters.image
+
+        async def load_fn(
+            identifiers: list[ImageIdentifier],
+        ) -> list[ImageV2GQL | None]:
+            from ai.backend.manager.api.gql.image.types import (  # pants: no-infer-dep
+                ImageV2GQL as IG,
+            )
+
+            dtos = await adapter.batch_load_by_identifiers(identifiers)
             return [IG.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -15,6 +15,7 @@ from strawberry.relay import Connection, Edge, NodeID
 from ai.backend.common.dto.manager.v2.kernel.request import KernelFilter, KernelOrder
 from ai.backend.common.dto.manager.v2.kernel.response import (
     KernelClusterInfoGQLDTO,
+    KernelImageInfoGQLDTO,
     KernelLifecycleInfoGQLDTO,
     KernelNetworkInfoGQLDTO,
     KernelNode,
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.api.gql.session.types import SessionV2GQL
 
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.agent.types import AgentV2GQL
 from ai.backend.manager.api.gql.common.types import (
     ResourceOptsGQL,
@@ -56,11 +58,13 @@ from ai.backend.manager.api.gql.common.types import (
 )
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
 from ai.backend.manager.api.gql.fair_share.types.common import ResourceSlotGQL
+from ai.backend.manager.api.gql.image.types import ImageV2GQL
 from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
+from ai.backend.manager.data.image.types import ImageIdentifier
 
 
 @gql_enum(
@@ -199,6 +203,23 @@ class KernelV2UserInfoGQL:
 
 @gql_pydantic_type(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Container image identity for a kernel (canonical name + architecture).",
+    ),
+    model=KernelImageInfoGQLDTO,
+    name="KernelV2ImageInfo",
+)
+class KernelV2ImageInfoGQL:
+    canonical: str | None = gql_field(
+        description="Canonical name of the container image used by this kernel."
+    )
+    architecture: str | None = gql_field(
+        description="Architecture of the container image used by this kernel (e.g., x86_64, aarch64)."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
         added_version="26.2.0",
         description="Resource allocation with requested and used slots.",
     ),
@@ -309,6 +330,12 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         description="Information about the session this kernel belongs to."
     )
     user_info: KernelV2UserInfoGQL = gql_field(description="User and ownership information.")
+    image_info: KernelV2ImageInfoGQL = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Container image identity for this kernel.",
+        )
+    )
     network: KernelV2NetworkInfoGQL = gql_field(
         description="Network configuration and exposed ports."
     )
@@ -362,6 +389,21 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         if self.user_info.domain_name is None:
             return None
         return await info.context.data_loaders.domain_loader.load(self.user_info.domain_name)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The container image used by this kernel.",
+        )
+    )  # type: ignore[misc]
+    async def image(self, info: Info[StrawberryGQLContext]) -> ImageV2GQL | None:
+        canonical = self.image_info.canonical
+        architecture = self.image_info.architecture
+        if canonical is None or architecture is None:
+            return None
+        return await info.context.data_loaders.image_by_identifier_loader.load(
+            ImageIdentifier(canonical=canonical, architecture=architecture)
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -72,7 +72,11 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision import EnvironmentVariablesGQL
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
-from ai.backend.manager.api.gql.image.types import ImageV2ConnectionGQL
+from ai.backend.manager.api.gql.image.types import (
+    ImageV2ConnectionGQL,
+    ImageV2EdgeGQL,
+    ImageV2GQL,
+)
 from ai.backend.manager.api.gql.kernel.types import (
     KernelV2ConnectionGQL,
     KernelV2EdgeGQL,
@@ -84,6 +88,7 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.user.types.node import UserV2GQL
+from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.errors.user import UserNotFound
 
 
@@ -368,8 +373,45 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
             description="The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.",
         )
     )  # type: ignore[misc]
-    async def images(self) -> ImageV2ConnectionGQL:
-        raise NotImplementedError
+    async def images(self, info: Info[StrawberryGQLContext]) -> ImageV2ConnectionGQL:
+        session_id = SessionId(UUID(str(self.id)))
+        kernels_payload = await info.context.adapters.session.search_kernels_by_session(
+            session_id, AdminSearchKernelsInput()
+        )
+
+        seen: set[ImageIdentifier] = set()
+        identifiers: list[ImageIdentifier] = []
+        for kernel in kernels_payload.items:
+            canonical = kernel.image.canonical
+            architecture = kernel.image.architecture
+            if canonical is None or architecture is None:
+                continue
+            identifier = ImageIdentifier(canonical=canonical, architecture=architecture)
+            if identifier in seen:
+                continue
+            seen.add(identifier)
+            identifiers.append(identifier)
+
+        images: list[ImageV2GQL] = []
+        if identifiers:
+            loaded = await info.context.data_loaders.image_by_identifier_loader.load_many(
+                identifiers
+            )
+            images = [image for image in loaded if image is not None]
+
+        edges = [
+            ImageV2EdgeGQL(node=image, cursor=encode_cursor(str(image.id))) for image in images
+        ]
+        return ImageV2ConnectionGQL(
+            edges=edges,
+            page_info=strawberry.relay.PageInfo(
+                has_next_page=False,
+                has_previous_page=False,
+                start_cursor=edges[0].cursor if edges else None,
+                end_cursor=edges[-1].cursor if edges else None,
+            ),
+            count=len(images),
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/models/image/conditions.py
+++ b/src/ai/backend/manager/models/image/conditions.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringInMatchSpec, StringMatchSpec
 from ai.backend.common.types import ImageID
-from ai.backend.manager.data.image.types import ImageStatus
+from ai.backend.manager.data.image.types import ImageIdentifier, ImageStatus
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.image import ImageAliasRow, ImageRow
 from ai.backend.manager.repositories.base import QueryCondition
@@ -30,6 +30,17 @@ class ImageConditions:
     def by_canonicals(canonicals: Collection[str]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ImageRow.name.in_(canonicals)
+
+        return inner
+
+    @staticmethod
+    def by_image_identifiers(
+        identifiers: Collection[ImageIdentifier],
+    ) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.tuple_(ImageRow.name, ImageRow.architecture).in_([
+                (identifier.canonical, identifier.architecture) for identifier in identifiers
+            ])
 
         return inner
 

--- a/src/ai/backend/manager/services/session/actions/search_kernel.py
+++ b/src/ai/backend/manager/services/session/actions/search_kernel.py
@@ -17,8 +17,10 @@ from ai.backend.manager.services.session.base import SessionScopeAction
 class SearchKernelsAction(SessionScopeAction):
     """Search kernels within a scope.
 
-    RBAC validation checks if the user has READ permission in USER scope.
-    Scope is always USER scope with user_id.
+    RBAC validation checks if the user has SESSION READ permission reachable from
+    the user's scope chain (project / domain). The scope chain CTE walks
+    upward from the USER element to find parent scopes where session-level
+    roles are bound.
     """
 
     querier: BatchQuerier
@@ -27,7 +29,7 @@ class SearchKernelsAction(SessionScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.SESSION_KERNEL
+        return EntityType.SESSION
 
     @override
     def entity_id(self) -> str | None:


### PR DESCRIPTION
## Summary
- Expose container image identity on `KernelV2GQL` via a new `KernelV2ImageInfoGQL` sub-info (canonical + architecture) and an `image` resolver returning `ImageV2GQL`
- Implement `SessionV2GQL.images` by fetching kernels and aggregating their unique `ImageIdentifier`s through a new `image_by_identifier_loader` DataLoader
- Add `ImageConditions.by_image_identifiers` + `ImageAdapter.batch_load_by_identifiers` to look up images by `(canonical, architecture)` (the kernels table has no `image_id` FK)

## Test plan
- [ ] `./bai admin session get <id>` with a GraphQL query for `session { images { edges { node { name architecture } } } }` returns the correct set for single-node and multi-node (cluster) sessions
- [ ] GraphQL query `kernel { image { name architecture } image_info { canonical architecture } }` returns the resolved image for each kernel
- [ ] No N+1: verify DB query count stays bounded when selecting many kernels/sessions with their images
- [ ] Regular and admin scopes both work

Resolves BA-5742

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11111.org.readthedocs.build/en/11111/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11111.org.readthedocs.build/ko/11111/

<!-- readthedocs-preview sorna-ko end -->