### PR TITLE
fix: populate model_definition in legacy endpoint creation flow

### DIFF
--- a/changes/11112.fix.md
+++ b/changes/11112.fix.md
@@ -1,0 +1,1 @@
+Populate `model_definition` in the legacy endpoint creation flow so that the executor can read health check configuration from the stored revision data, matching the v2 deployment flow behavior.

--- a/src/ai/backend/manager/data/deployment/creator.py
+++ b/src/ai/backend/manager/data/deployment/creator.py
@@ -82,7 +82,6 @@ class DeploymentCreationDraft:
     replica_spec: ReplicaSpec
     network: DeploymentNetworkSpec
     draft_model_revision: ModelRevisionSpecDraft
-    model_definition: ModelDefinition | None = None
 
     # Accessor properties for backward compatibility
     @property

--- a/src/ai/backend/manager/data/deployment/creator.py
+++ b/src/ai/backend/manager/data/deployment/creator.py
@@ -82,6 +82,7 @@ class DeploymentCreationDraft:
     replica_spec: ReplicaSpec
     network: DeploymentNetworkSpec
     draft_model_revision: ModelRevisionSpecDraft
+    model_definition: ModelDefinition | None = None
 
     # Accessor properties for backward compatibility
     @property

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -402,6 +402,7 @@ class ModelRevisionSpecDraft(ConfiguredModel):
     resource_spec: ResourceSpecDraft
     mounts: MountMetadata
     execution: ExecutionSpec
+    model_definition: ModelDefinition | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/deployment/creators/endpoint.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/endpoint.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import yarl
 
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.types import (
     ClusterMode,
     ResourceSlot,
@@ -71,6 +72,9 @@ class LegacyEndpointCreatorSpec(CreatorSpec[EndpointRow]):
     environ: Mapping[str, str] | None
     callback_url: yarl.URL | None
 
+    # Model definition (resolved content from vfolder or auto-generated)
+    model_definition: ModelDefinition | None
+
     policy: DeploymentPolicyCreatorSpec | None
 
     @classmethod
@@ -125,6 +129,8 @@ class LegacyEndpointCreatorSpec(CreatorSpec[EndpointRow]):
             bootstrap_script=creator.model_revision.execution.bootstrap_script,
             environ=creator.model_revision.execution.environ,
             callback_url=creator.model_revision.execution.callback_url,
+            # Model definition
+            model_definition=creator.model_revision.model_definition,
             # Policy
             policy=None,
         )

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -338,6 +338,9 @@ class DeploymentDBSource:
                 model=spec.model,
                 model_mount_destination=spec.model_mount_destination,
                 model_definition_path=spec.model_definition_path,
+                model_definition=spec.model_definition.model_dump(exclude_none=True, by_alias=True)
+                if spec.model_definition
+                else None,
                 resource_group=spec.resource_group,
                 resource_opts=dict(spec.resource_opts) if spec.resource_opts else {},
                 cluster_mode=spec.cluster_mode.value,

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -528,11 +528,10 @@ class DeploymentService:
         """
         log.info("Creating deployment with name: {}", action.draft.name)
         draft_revision = action.draft.draft_model_revision
-        model_definition = await self._resolve_model_definition_from_draft(draft_revision)
-        deployment_info = await self._deployment_controller.create_deployment(
-            action.draft,
-            model_definition=model_definition,
+        action.draft.model_definition = await self._resolve_model_definition_from_draft(
+            draft_revision
         )
+        deployment_info = await self._deployment_controller.create_deployment(action.draft)
         await self._deployment_controller.mark_lifecycle_needed(
             DeploymentLifecycleType.CHECK_PENDING
         )

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -528,7 +528,7 @@ class DeploymentService:
         """
         log.info("Creating deployment with name: {}", action.draft.name)
         draft_revision = action.draft.draft_model_revision
-        action.draft.model_definition = await self._resolve_model_definition_from_draft(
+        draft_revision.model_definition = await self._resolve_model_definition_from_draft(
             draft_revision
         )
         deployment_info = await self._deployment_controller.create_deployment(action.draft)

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -39,6 +39,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelMountConfigData,
     ModelReplicaData,
     ModelRevisionData,
+    ModelRevisionSpecDraft,
     ModelRuntimeConfigData,
     MountMetadata,
     ReplicaSpec,
@@ -526,7 +527,12 @@ class DeploymentService:
             CreateLegacyDeploymentActionResult: Result containing the created deployment info
         """
         log.info("Creating deployment with name: {}", action.draft.name)
-        deployment_info = await self._deployment_controller.create_deployment(action.draft)
+        draft_revision = action.draft.draft_model_revision
+        model_definition = await self._resolve_model_definition_from_draft(draft_revision)
+        deployment_info = await self._deployment_controller.create_deployment(
+            action.draft,
+            model_definition=model_definition,
+        )
         await self._deployment_controller.mark_lifecycle_needed(
             DeploymentLifecycleType.CHECK_PENDING
         )
@@ -926,6 +932,22 @@ class DeploymentService:
             ),
             execution=revision_creator.execution,
             model_definition=revision_creator.model_definition,
+        )
+        return await self._model_definition_generator_registry.generate_model_definition(context)
+
+    async def _resolve_model_definition_from_draft(
+        self,
+        draft_revision: ModelRevisionSpecDraft,
+    ) -> ModelDefinition:
+        """Generate the final model definition from a legacy draft revision.
+
+        Same as _resolve_model_definition but works with ModelRevisionSpecDraft
+        (used by the legacy create_endpoint_legacy flow).
+        """
+        context = ModelDefinitionContext(
+            mounts=draft_revision.mounts,
+            execution=draft_revision.execution,
+            model_definition=None,
         )
         return await self._model_definition_generator_registry.generate_model_definition(context)
 

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -108,9 +108,9 @@ class DeploymentController:
             vfolder_id=draft.draft_model_revision.mounts.model_vfolder_id,
             default_architecture=default_architecture,
         )
-        if draft.model_definition is not None:
+        if draft.draft_model_revision.model_definition is not None:
             model_revision = model_revision.model_copy(
-                update={"model_definition": draft.model_definition}
+                update={"model_definition": draft.draft_model_revision.model_definition}
             )
         await self._scheduling_controller.validate_session_spec(
             SessionValidationSpec.from_revision(model_revision=model_revision)

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -5,6 +5,7 @@ import uuid
 from dataclasses import dataclass
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -81,12 +82,15 @@ class DeploymentController:
     async def create_deployment(
         self,
         draft: DeploymentCreationDraft,
+        model_definition: ModelDefinition | None = None,
     ) -> DeploymentInfo:
         """
         Create a new deployment based on the provided specification.
 
         Args:
             draft: Deployment creation specification
+            model_definition: Pre-resolved model definition content.
+                If provided, stored in the revision row for use by the executor.
 
         Returns:
             DeploymentInfo: Information about the created deployment
@@ -108,6 +112,10 @@ class DeploymentController:
             vfolder_id=draft.draft_model_revision.mounts.model_vfolder_id,
             default_architecture=default_architecture,
         )
+        if model_definition is not None:
+            model_revision = model_revision.model_copy(
+                update={"model_definition": model_definition}
+            )
         await self._scheduling_controller.validate_session_spec(
             SessionValidationSpec.from_revision(model_revision=model_revision)
         )

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -5,7 +5,6 @@ import uuid
 from dataclasses import dataclass
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
-from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -82,15 +81,12 @@ class DeploymentController:
     async def create_deployment(
         self,
         draft: DeploymentCreationDraft,
-        model_definition: ModelDefinition | None = None,
     ) -> DeploymentInfo:
         """
         Create a new deployment based on the provided specification.
 
         Args:
             draft: Deployment creation specification
-            model_definition: Pre-resolved model definition content.
-                If provided, stored in the revision row for use by the executor.
 
         Returns:
             DeploymentInfo: Information about the created deployment
@@ -112,9 +108,9 @@ class DeploymentController:
             vfolder_id=draft.draft_model_revision.mounts.model_vfolder_id,
             default_architecture=default_architecture,
         )
-        if model_definition is not None:
+        if draft.model_definition is not None:
             model_revision = model_revision.model_copy(
-                update={"model_definition": model_definition}
+                update={"model_definition": draft.model_definition}
             )
         await self._scheduling_controller.validate_session_spec(
             SessionValidationSpec.from_revision(model_revision=model_revision)

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -3666,6 +3666,7 @@ class TestDeploymentRepositoryDuplicateName:
             bootstrap_script=None,
             environ=None,
             callback_url=None,
+            model_definition=None,
             policy=None,
         )
         return RBACEntityCreator(

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import (
     ActivenessStatus,
@@ -26,6 +27,7 @@ from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACVali
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
 )
+from ai.backend.manager.data.deployment.creator import DeploymentCreationDraft
 from ai.backend.manager.data.deployment.types import (
     AccessTokenSearchResult,
     ClusterConfigData,
@@ -33,12 +35,17 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentMetadata,
     DeploymentNetworkSpec,
     DeploymentState,
+    ExecutionSpec,
+    ImageIdentifierDraft,
     ModelDeploymentAccessTokenData,
     ModelMountConfigData,
     ModelRevisionData,
+    ModelRevisionSpecDraft,
     ModelRuntimeConfigData,
+    MountMetadata,
     ReplicaSpec,
     ResourceConfigData,
+    ResourceSpecDraft,
     RouteHealthStatus,
     RouteInfo,
     RouteSearchResult,
@@ -93,17 +100,24 @@ class DeploymentCRUDBaseFixtures:
         return MagicMock(spec=RevisionGeneratorRegistry)
 
     @pytest.fixture
+    def mock_model_definition_generator_registry(self) -> AsyncMock:
+        registry = AsyncMock()
+        registry.generate_model_definition.return_value = ModelDefinition()
+        return registry
+
+    @pytest.fixture
     def deployment_service(
         self,
         mock_deployment_controller: MagicMock,
         mock_deployment_repository: MagicMock,
         mock_revision_generator_registry: MagicMock,
+        mock_model_definition_generator_registry: AsyncMock,
     ) -> DeploymentService:
         return DeploymentService(
             deployment_controller=mock_deployment_controller,
             deployment_repository=mock_deployment_repository,
             revision_generator_registry=mock_revision_generator_registry,
-            model_definition_generator_registry=MagicMock(),
+            model_definition_generator_registry=mock_model_definition_generator_registry,
         )
 
     @pytest.fixture
@@ -201,6 +215,64 @@ class TestCreateLegacyDeployment(DeploymentCRUDBaseFixtures):
         mock_deployment_controller.mark_lifecycle_needed.assert_called_once_with(
             DeploymentLifecycleType.CHECK_PENDING
         )
+
+    async def test_model_definition_resolved_and_set_on_draft(
+        self,
+        deployment_service: DeploymentService,
+        mock_deployment_controller: MagicMock,
+        mock_model_definition_generator_registry: AsyncMock,
+        endpoint_info: DeploymentInfo,
+    ) -> None:
+        """model_definition is resolved from vfolder and set on the draft before controller call."""
+        expected_definition = ModelDefinition.model_validate({
+            "models": [
+                {
+                    "name": "test-model",
+                    "model-path": "/models",
+                    "service": {"start-command": "serve", "port": 8000},
+                }
+            ]
+        })
+        mock_model_definition_generator_registry.generate_model_definition.return_value = (
+            expected_definition
+        )
+        mock_deployment_controller.create_deployment = AsyncMock(return_value=endpoint_info)
+        mock_deployment_controller.mark_lifecycle_needed = AsyncMock()
+
+        vfolder_id = uuid.uuid4()
+        draft = DeploymentCreationDraft(
+            metadata=endpoint_info.metadata,
+            replica_spec=ReplicaSpec(replica_count=1),
+            network=DeploymentNetworkSpec(open_to_public=False),
+            draft_model_revision=ModelRevisionSpecDraft(
+                image_identifier=ImageIdentifierDraft(
+                    canonical="test:latest", architecture="x86_64"
+                ),
+                resource_spec=ResourceSpecDraft(
+                    cluster_mode=ClusterMode.SINGLE_NODE,
+                    cluster_size=1,
+                    resource_slots={"cpu": "1", "mem": "1g"},
+                ),
+                mounts=MountMetadata(
+                    model_vfolder_id=vfolder_id,
+                    model_definition_path="model-definition.yaml",
+                    model_mount_destination="/models",
+                ),
+                execution=ExecutionSpec(
+                    runtime_variant=RuntimeVariant("custom"),
+                    startup_command=None,
+                ),
+            ),
+        )
+        assert draft.model_definition is None
+
+        action = CreateLegacyDeploymentAction(draft=draft)
+        await deployment_service.create_legacy_deployment(action)
+
+        # model_definition should be resolved and set on the draft
+        assert draft.model_definition == expected_definition
+        mock_model_definition_generator_registry.generate_model_definition.assert_called_once()
+        mock_deployment_controller.create_deployment.assert_called_once_with(draft)
 
     async def test_non_existent_domain_raises(
         self,

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -264,13 +264,13 @@ class TestCreateLegacyDeployment(DeploymentCRUDBaseFixtures):
                 ),
             ),
         )
-        assert draft.model_definition is None
+        assert draft.draft_model_revision.model_definition is None
 
         action = CreateLegacyDeploymentAction(draft=draft)
         await deployment_service.create_legacy_deployment(action)
 
-        # model_definition should be resolved and set on the draft
-        assert draft.model_definition == expected_definition
+        # model_definition should be resolved and set on the draft revision
+        assert draft.draft_model_revision.model_definition == expected_definition
         mock_model_definition_generator_registry.generate_model_definition.assert_called_once()
         mock_deployment_controller.create_deployment.assert_called_once_with(draft)
 


### PR DESCRIPTION
## Summary
- Legacy `create_endpoint_legacy` path was not resolving and storing `model_definition` content in `DeploymentRevisionRow.model_definition` JSONB column
- Unlike the v2 `add_model_revision` flow which calls `_resolve_model_definition()`, the legacy flow left this column as NULL
- This caused the executor (`executor.py`) to miss health check configuration for legacy-created deployments since it reads from `target_revision.model_definition`

## Changes
- `DeploymentService.create_legacy_deployment()`: resolve model_definition via `ModelDefinitionGeneratorRegistry` before calling controller
- `DeploymentController.create_deployment()`: accept optional `model_definition` and set on revision spec
- `LegacyEndpointCreatorSpec`: add `model_definition` field, propagate from `ModelRevisionSpec`
- `db_source.create_endpoint_legacy()`: store `model_definition` in `DeploymentRevisionRow`

## Test plan
- [x] `pants lint/check` pass
- [x] `tests/unit/manager/repositories/deployment/test_deployment_repository.py` — 53 passed
- [x] `tests/unit/manager/services/deployment/test_deployment_service.py` — passed
- [x] `tests/unit/manager/sokovan/deployment/` — all passed
- [x] `tests/unit/manager/sokovan/deployment/definition_generator/` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)