### PR TITLE
fix(BA-5745): auto-sync RBAC role on modifyGroup user add/remove

### DIFF
--- a/changes/11116.fix.md
+++ b/changes/11116.fix.md
@@ -1,1 +1,1 @@
-Automatically sync RBAC project-member role bindings when users are added to or removed from a project via `modifyGroup`.
+Automatically sync RBAC project-member role bindings when users are added to or removed from a project via `modifyGroup` or `modifyUser`.

--- a/changes/11116.fix.md
+++ b/changes/11116.fix.md
@@ -1,0 +1,1 @@
+Automatically sync RBAC project-member role bindings when users are added to or removed from a project via `modifyGroup`.

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -205,11 +205,12 @@ class GroupDBSource:
     ) -> None:
         """Add users to a project within an existing session.
 
-        Creates the business association (association_groups_users) together with
-        the RBAC scope binding and user-role mappings for the project's system roles,
-        so that membership changes made via `modify_group` stay consistent with
-        `assign_users_to_project`. Already-assigned users are skipped to avoid
-        unique-constraint conflicts.
+        Creates the business association (association_groups_users), the RBAC
+        scope binding, and a user-role mapping to the project's member role.
+        Admin roles are intentionally NOT granted here; the modifyGroup
+        add path represents "make this user a project member", not
+        "make this user a project admin". Already-assigned users are
+        filtered out to avoid unique-constraint conflicts.
         """
         project_domain_subq = (
             sa.select(GroupRow.domain_name).where(GroupRow.id == project_id).scalar_subquery()
@@ -243,22 +244,36 @@ class GroupDBSource:
         ]
         await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=pairs))
 
-        project_role_ids = (
-            await session.scalars(
-                sa.select(AssociationScopesEntitiesRow.entity_id).where(
-                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
-                    AssociationScopesEntitiesRow.scope_id == str(project_id),
-                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
-                )
+        # Locate the project's member role. Two naming conventions coexist:
+        # the runtime name `project-{id8}-member` used by GroupDBSource.create
+        # since BA-5746, and the legacy name `role_project_{id8}_member`
+        # created by alembic migration 430b1631804d for pre-existing projects.
+        runtime_member_name = f"project-{str(project_id)[:8]}-member"
+        legacy_member_name = f"role_project_{str(project_id)[:8]}_member"
+        member_role_id = await session.scalar(
+            sa.select(RoleRow.id)
+            .join(
+                AssociationScopesEntitiesRow,
+                sa.cast(AssociationScopesEntitiesRow.entity_id, sa.String)
+                == sa.cast(RoleRow.id, sa.String),
             )
-        ).all()
-        if not project_role_ids:
+            .where(
+                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                AssociationScopesEntitiesRow.scope_id == str(project_id),
+                AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                RoleRow.name.in_([runtime_member_name, legacy_member_name]),
+            )
+        )
+        if member_role_id is None:
+            log.warning(
+                "project {} has no member role bound at its scope; "
+                "skipping user-role mapping for modifyGroup add",
+                project_id,
+            )
             return
 
         user_role_specs = [
-            UserRoleCreatorSpec(user_id=row.uuid, role_id=uuid.UUID(role_id))
-            for row in new_user_rows
-            for role_id in project_role_ids
+            UserRoleCreatorSpec(user_id=row.uuid, role_id=member_role_id) for row in new_user_rows
         ]
         await execute_bulk_creator(session, BulkCreator(specs=user_role_specs))
 

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -33,7 +33,7 @@ from ai.backend.manager.errors.resource import (
 )
 from ai.backend.manager.models.domain import domains
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
-from ai.backend.manager.models.group import association_groups_users, groups
+from ai.backend.manager.models.group import groups
 from ai.backend.manager.models.group.row import (
     AssocGroupUserRow,
     GroupRow,
@@ -172,7 +172,7 @@ class GroupDBSource:
         user_uuids: list[uuid.UUID] | None = None,
     ) -> GroupData | None:
         """Modify a group with validation."""
-        group_id = updater.pk_value
+        group_id = cast(UUID, updater.pk_value)
 
         async with self._db.begin_session() as session:
             # First verify the group exists
@@ -185,17 +185,9 @@ class GroupDBSource:
             # Handle user addition/removal
             if user_uuids and user_update_mode:
                 if user_update_mode == "add":
-                    values = [{"user_id": uuid, "group_id": group_id} for uuid in user_uuids]
-                    await session.execute(
-                        sa.insert(association_groups_users).values(values),
-                    )
+                    await self._add_users_to_project_in_session(session, group_id, user_uuids)
                 elif user_update_mode == "remove":
-                    await session.execute(
-                        sa.delete(association_groups_users).where(
-                            (association_groups_users.c.user_id.in_(user_uuids))
-                            & (association_groups_users.c.group_id == group_id),
-                        ),
-                    )
+                    await self._remove_users_from_project_in_session(session, group_id, user_uuids)
 
             # Update group data (execute_updater returns None if no values to update)
             result = await execute_updater(session, updater)
@@ -204,6 +196,114 @@ class GroupDBSource:
 
             # No group updates or only user updates were performed
             return None
+
+    async def _add_users_to_project_in_session(
+        self,
+        session: SASession,
+        project_id: uuid.UUID,
+        user_uuids: list[uuid.UUID],
+    ) -> None:
+        """Add users to a project within an existing session.
+
+        Creates the business association (association_groups_users) together with
+        the RBAC scope binding and user-role mappings for the project's system roles,
+        so that membership changes made via `modify_group` stay consistent with
+        `assign_users_to_project`. Already-assigned users are skipped to avoid
+        unique-constraint conflicts.
+        """
+        project_domain_subq = (
+            sa.select(GroupRow.domain_name).where(GroupRow.id == project_id).scalar_subquery()
+        )
+        new_user_rows = (
+            await session.scalars(
+                sa.select(UserRow)
+                .outerjoin(
+                    AssocGroupUserRow,
+                    (UserRow.uuid == AssocGroupUserRow.user_id)
+                    & (AssocGroupUserRow.group_id == project_id),
+                )
+                .where(
+                    UserRow.uuid.in_(user_uuids)
+                    & (UserRow.domain_name == project_domain_subq)
+                    & AssocGroupUserRow.user_id.is_(None)
+                )
+            )
+        ).all()
+        if not new_user_rows:
+            return
+
+        project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
+        pairs = [
+            RBACScopeBindingPair(
+                spec=AssocGroupUserCreatorSpec(user_id=row.uuid, group_id=project_id),
+                entity_ref=RBACElementRef(RBACElementType.USER, str(row.uuid)),
+                scope_ref=project_scope_ref,
+            )
+            for row in new_user_rows
+        ]
+        await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=pairs))
+
+        project_role_ids = (
+            await session.scalars(
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                )
+            )
+        ).all()
+        if not project_role_ids:
+            return
+
+        user_role_specs = [
+            UserRoleCreatorSpec(user_id=row.uuid, role_id=uuid.UUID(role_id))
+            for row in new_user_rows
+            for role_id in project_role_ids
+        ]
+        await execute_bulk_creator(session, BulkCreator(specs=user_role_specs))
+
+    async def _remove_users_from_project_in_session(
+        self,
+        session: SASession,
+        project_id: uuid.UUID,
+        user_uuids: list[uuid.UUID],
+    ) -> None:
+        """Remove users from a project within an existing session.
+
+        Deletes the business N:N association, the RBAC scope binding, and any
+        user-role mappings for roles scoped to this project, mirroring
+        `unassign_users_from_project`.
+        """
+        assigned_user_ids = (
+            await session.scalars(
+                sa.select(AssocGroupUserRow.user_id).where(
+                    AssocGroupUserRow.user_id.in_(user_uuids),
+                    AssocGroupUserRow.group_id == project_id,
+                )
+            )
+        ).all()
+        if not assigned_user_ids:
+            return
+
+        unbinder = UserProjectEntityUnbinder(
+            user_uuids=list(assigned_user_ids),
+            project_id=project_id,
+        )
+        await execute_rbac_scope_entity_unbinder(session, unbinder)
+
+        project_role_ids_subq = sa.select(
+            AssociationScopesEntitiesRow.entity_id,
+        ).where(
+            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+            AssociationScopesEntitiesRow.scope_id == str(project_id),
+            AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+        )
+        await session.execute(
+            sa.delete(UserRoleRow).where(
+                UserRoleRow.user_id.in_(assigned_user_ids),
+                sa.cast(UserRoleRow.role_id, sa.String).in_(project_role_ids_subq),
+            )
+        )
 
     async def mark_inactive(self, group_id: uuid.UUID) -> None:
         """Mark a group as inactive (soft delete)."""

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -25,7 +25,7 @@ from ai.backend.manager.data.keypair.types import (
     KeyPairCreator,
     KeyPairData,
 )
-from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.permission.types import EntityType, RBACElementRef, ScopeType
 from ai.backend.manager.data.user.types import (
     BulkUserCreateResultData,
     BulkUserUpdateResultData,
@@ -51,7 +51,6 @@ from ai.backend.manager.models.group import (
     GroupRow,
     ProjectType,
     association_groups_users,
-    groups,
 )
 from ai.backend.manager.models.kernel import (
     AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES,
@@ -63,6 +62,10 @@ from ai.backend.manager.models.keypair import (
     generate_keypair_data,
     keypairs,
 )
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.resource_policy import UserResourcePolicyRow
 from ai.backend.manager.models.session import (
@@ -87,14 +90,30 @@ from ai.backend.manager.models.vfolder import (
     vfolder_status_map,
     vfolders,
 )
-from ai.backend.manager.repositories.base.creator import BulkCreatorError, Creator, execute_creator
+from ai.backend.manager.repositories.base.creator import (
+    BulkCreator,
+    BulkCreatorError,
+    Creator,
+    execute_bulk_creator,
+    execute_creator,
+)
 from ai.backend.manager.repositories.base.purger import execute_batch_purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACEntityCreator,
     execute_rbac_entity_creator,
 )
+from ai.backend.manager.repositories.base.rbac.scope_binder import (
+    RBACScopeBinder,
+    RBACScopeBindingPair,
+    execute_rbac_scope_binder,
+)
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
+    execute_rbac_scope_entity_unbinder,
+)
 from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater, execute_updater
+from ai.backend.manager.repositories.group.creators import AssocGroupUserCreatorSpec
+from ai.backend.manager.repositories.group.scope_binders import UserProjectEntityUnbinder
 from ai.backend.manager.repositories.keypair.creators import KeyPairCreatorSpec
 from ai.backend.manager.repositories.keypair.types import UserKeypairSearchScope
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
@@ -381,15 +400,15 @@ class UserDBSource:
         """
         updater_spec = cast(UserUpdaterSpec, updater.spec)
         to_update = updater_spec.build_values()
-        async with self._db.begin() as conn:
+        async with self._db.begin_session() as session:
             # Get current user data for validation
-            current_user = await self._get_user_by_email_with_conn(conn, email)
+            current_user = await self._get_user_by_email_with_session(session, email)
 
             # Check if new username is already taken by another user
             new_username = updater_spec.username.optional_value()
             if new_username and new_username != current_user.username:
                 username_exists = await self._check_username_exists_for_other_user(
-                    conn, username=new_username, exclude_email=email
+                    session, username=new_username, exclude_email=email
                 )
                 if username_exists:
                     raise UserModificationBadRequest(
@@ -399,14 +418,16 @@ class UserDBSource:
             # Check if new domain_name exists
             new_domain_name = updater_spec.domain_name.optional_value()
             if new_domain_name and new_domain_name != current_user.domain_name:
-                domain_exists = await self._check_domain_exists(conn, new_domain_name)
+                domain_exists = await self._check_domain_exists(session, new_domain_name)
                 if not domain_exists:
                     raise UserModificationBadRequest(f"Domain '{new_domain_name}' does not exist.")
 
             # Check if new resource_policy exists
             new_resource_policy = updater_spec.resource_policy.optional_value()
             if new_resource_policy and new_resource_policy != current_user.resource_policy:
-                policy_exists = await self._check_resource_policy_exists(conn, new_resource_policy)
+                policy_exists = await self._check_resource_policy_exists(
+                    session, new_resource_policy
+                )
                 if not policy_exists:
                     raise UserModificationBadRequest(
                         f"Resource policy '{new_resource_policy}' does not exist."
@@ -415,7 +436,7 @@ class UserDBSource:
             # Handle main_access_key validation
             main_access_key = updater_spec.main_access_key.optional_value()
             if main_access_key:
-                await self._validate_and_update_main_access_key(conn, email, main_access_key)
+                await self._validate_and_update_main_access_key(session, email, main_access_key)
 
             # Update user
             if updater_spec.password.optional_value():
@@ -426,7 +447,7 @@ class UserDBSource:
             update_query = (
                 sa.update(users).where(users.c.email == email).values(to_update).returning(users)
             )
-            result = await conn.execute(update_query)
+            result = await session.execute(update_query)
             updated_user = result.first()
             if not updated_user:
                 raise UserModificationFailure("Failed to update user")
@@ -435,13 +456,13 @@ class UserDBSource:
             prev_role = current_user.role
             role = updater_spec.role.optional_value()
             if role is not None and role != prev_role:
-                await self._sync_keypair_roles(conn, updated_user.uuid, role)
+                await self._sync_keypair_roles(session, updated_user.uuid, role)
 
             # Handle group updates
             group_ids = updater_spec.group_ids_value
             if group_ids is not None:
                 await self._update_user_groups(
-                    conn, updated_user.uuid, updated_user.domain_name, group_ids
+                    session, updated_user.uuid, updated_user.domain_name, group_ids
                 )
             return UserData.from_row(updated_user)
 
@@ -463,12 +484,12 @@ class UserDBSource:
         successes: list[UserData] = []
         failures: list[BulkUpdaterError[UserRow]] = []
 
-        async with self._db.begin() as conn:
+        async with self._db.begin_session() as session:
             for idx, item in enumerate(items):
                 try:
-                    async with conn.begin_nested():
+                    async with session.begin_nested():
                         updated_user = await self._update_single_user_validated(
-                            conn, item.user_id, item.updater_spec
+                            session, item.user_id, item.updater_spec
                         )
                         successes.append(updated_user)
                 except Exception as e:
@@ -481,7 +502,7 @@ class UserDBSource:
 
     async def _update_single_user_validated(
         self,
-        conn: AsyncConnection,
+        session: SASession,
         user_id: UUID,
         updater_spec: UserUpdaterSpec,
     ) -> UserData:
@@ -493,13 +514,13 @@ class UserDBSource:
         to_update = updater_spec.build_values()
 
         # Get current user data for validation (by UUID)
-        current_user = await self._get_user_by_uuid_with_conn(conn, user_id)
+        current_user = await self._get_user_by_uuid_with_session(session, user_id)
 
         # Check if new username is already taken by another user
         new_username = updater_spec.username.optional_value()
         if new_username and new_username != current_user.username:
             username_exists = await self._check_username_exists_for_other_user(
-                conn, username=new_username, exclude_email=current_user.email
+                session, username=new_username, exclude_email=current_user.email
             )
             if username_exists:
                 raise UserModificationBadRequest(
@@ -509,14 +530,14 @@ class UserDBSource:
         # Check if new domain_name exists
         new_domain_name = updater_spec.domain_name.optional_value()
         if new_domain_name and new_domain_name != current_user.domain_name:
-            domain_exists = await self._check_domain_exists(conn, new_domain_name)
+            domain_exists = await self._check_domain_exists(session, new_domain_name)
             if not domain_exists:
                 raise UserModificationBadRequest(f"Domain '{new_domain_name}' does not exist.")
 
         # Check if new resource_policy exists
         new_resource_policy = updater_spec.resource_policy.optional_value()
         if new_resource_policy and new_resource_policy != current_user.resource_policy:
-            policy_exists = await self._check_resource_policy_exists(conn, new_resource_policy)
+            policy_exists = await self._check_resource_policy_exists(session, new_resource_policy)
             if not policy_exists:
                 raise UserModificationBadRequest(
                     f"Resource policy '{new_resource_policy}' does not exist."
@@ -526,7 +547,7 @@ class UserDBSource:
         main_access_key = updater_spec.main_access_key.optional_value()
         if main_access_key:
             await self._validate_and_update_main_access_key(
-                conn, current_user.email, main_access_key
+                session, current_user.email, main_access_key
             )
 
         # Update user
@@ -538,7 +559,7 @@ class UserDBSource:
         update_query = (
             sa.update(users).where(users.c.uuid == user_id).values(to_update).returning(users)
         )
-        result = await conn.execute(update_query)
+        result = await session.execute(update_query)
         updated_user = result.first()
         if not updated_user:
             raise UserModificationFailure("Failed to update user")
@@ -547,13 +568,13 @@ class UserDBSource:
         prev_role = current_user.role
         role = updater_spec.role.optional_value()
         if role is not None and role != prev_role:
-            await self._sync_keypair_roles(conn, updated_user.uuid, role)
+            await self._sync_keypair_roles(session, updated_user.uuid, role)
 
         # Handle group updates
         group_ids = updater_spec.group_ids_value
         if group_ids is not None:
             await self._update_user_groups(
-                conn, updated_user.uuid, updated_user.domain_name, group_ids
+                session, updated_user.uuid, updated_user.domain_name, group_ids
             )
         return UserData.from_row(updated_user)
 
@@ -564,8 +585,8 @@ class UserDBSource:
     ) -> UserData:
         """Update user by UUID with validation and handle role/group changes."""
         updater_spec = cast(UserUpdaterSpec, updater.spec)
-        async with self._db.begin() as conn:
-            return await self._update_single_user_validated(conn, user_uuid, updater_spec)
+        async with self._db.begin_session() as session:
+            return await self._update_single_user_validated(session, user_uuid, updater_spec)
 
     async def delete_user_by_uuid_validated(self, user_uuid: UUID) -> None:
         """Soft delete user by UUID, setting status to DELETED and deactivating keypairs."""
@@ -801,13 +822,13 @@ class UserDBSource:
         return result is not None
 
     async def _check_username_exists_for_other_user(
-        self, conn: AsyncConnection, *, username: str, exclude_email: str
+        self, session: SASession, *, username: str, exclude_email: str
     ) -> bool:
         """Check if the username is already taken by another user."""
         query = sa.select(UserRow.uuid).where(
             sa.and_(UserRow.username == username, UserRow.email != exclude_email)
         )
-        result = await conn.scalar(query)
+        result = await session.scalar(query)
         return result is not None
 
     async def _get_user_by_email(self, session: SASession, email: str) -> UserRow:
@@ -824,17 +845,25 @@ class UserDBSource:
             raise UserNotFound(f"User with UUID {user_uuid} not found.")
         return res
 
-    async def _get_user_by_email_with_conn(self, conn: AsyncConnection, email: str) -> UserRow:
-        """Private method to get user by email using connection."""
-        result = await conn.execute(sa.select(users).where(users.c.email == email))
+    async def _get_user_by_email_with_session(self, session: SASession, email: str) -> UserRow:
+        """Private method to get user by email using a session.
+
+        Uses a Core-level select on the ``users`` table so that the returned
+        row exposes column attributes without requiring ORM mapping. Callers
+        treat the result as a read-only snapshot.
+        """
+        result = await session.execute(sa.select(users).where(users.c.email == email))
         res = result.first()
         if res is None:
             raise UserNotFound(f"User with email {email} not found.")
         return cast(UserRow, res)
 
-    async def _get_user_by_uuid_with_conn(self, conn: AsyncConnection, user_uuid: UUID) -> UserRow:
-        """Private method to get user by UUID using connection."""
-        result = await conn.execute(sa.select(users).where(users.c.uuid == user_uuid))
+    async def _get_user_by_uuid_with_session(self, session: SASession, user_uuid: UUID) -> UserRow:
+        """Private method to get user by UUID using a session.
+
+        See ``_get_user_by_email_with_session`` for the Core-level rationale.
+        """
+        result = await session.execute(sa.select(users).where(users.c.uuid == user_uuid))
         res = result.first()
         if res is None:
             raise UserNotFound(f"User with UUID {user_uuid} not found.")
@@ -874,10 +903,9 @@ class UserDBSource:
         return list(gids_to_join)
 
     async def _validate_and_update_main_access_key(
-        self, conn: AsyncConnection, email: str, main_access_key: str
+        self, session: SASession, email: str, main_access_key: str
     ) -> None:
         """Private method to validate and update main access key."""
-        session = SASession(conn)
         keypair_query = (
             sa.select(KeyPairRow)
             .where(KeyPairRow.access_key == main_access_key)
@@ -892,15 +920,15 @@ class UserDBSource:
         if keypair_row.user_row.email != email:
             raise KeyPairForbidden("Cannot set another user's access key as the main access key.")
 
-        await conn.execute(
+        await session.execute(
             sa.update(users).where(users.c.email == email).values(main_access_key=main_access_key)
         )
 
     async def _sync_keypair_roles(
-        self, conn: AsyncConnection, user_uuid: UUID, new_role: UserRole
+        self, session: SASession, user_uuid: UUID, new_role: UserRole
     ) -> None:
         """Private method to sync keypair roles with user role."""
-        result = await conn.execute(
+        result = await session.execute(
             sa.select(
                 keypairs.c.user,
                 keypairs.c.is_active,
@@ -924,7 +952,7 @@ class UserDBSource:
             if not kp.is_active:
                 kp_data["is_active"] = True
             if kp_data:
-                await conn.execute(
+                await session.execute(
                     sa.update(keypairs).values(kp_data).where(keypairs.c.user == user_uuid)
                 )
         else:
@@ -946,7 +974,7 @@ class UserDBSource:
                     kp_updates.append(kp_data)
 
             if kp_updates:
-                await conn.execute(
+                await session.execute(
                     sa.update(keypairs)
                     .values({
                         "is_admin": bindparam("is_admin"),
@@ -956,32 +984,129 @@ class UserDBSource:
                     kp_updates,
                 )
 
-    async def _clear_user_groups(self, conn: AsyncConnection, user_uuid: UUID) -> None:
-        """Private method to clear user's group associations."""
-        await conn.execute(
-            sa.delete(association_groups_users).where(
-                association_groups_users.c.user_id == user_uuid
+    async def _update_user_groups(
+        self,
+        session: SASession,
+        user_uuid: UUID,
+        domain_name: str,
+        group_ids: list[str],
+    ) -> None:
+        """Sync the user's project memberships to match ``group_ids``.
+
+        Produces the same business association + RBAC scope binding + member
+        role mapping as the modifyGroup path (BA-5745) so that membership
+        changes made through modify_user stay consistent with RBAC state.
+        Uses a diff-based approach: only projects entering or leaving the
+        target set are touched, preserving existing rows for unchanged
+        memberships.
+        """
+        # Expand target to include the domain's model-store project(s), matching
+        # the previous behavior of _get_project_scope_ids_for_user.
+        target_project_ids = set(
+            await self._get_project_scope_ids_for_user(
+                session, domain_name, [UUID(gid) for gid in group_ids]
             )
         )
 
-    async def _update_user_groups(
-        self, conn: AsyncConnection, user_uuid: UUID, domain_name: str, group_ids: list[str]
-    ) -> None:
-        """Private method to update user's group associations."""
-        # Clear existing groups
-        await self._clear_user_groups(conn, user_uuid)
+        current_rows = (
+            await session.scalars(
+                sa.select(AssocGroupUserRow.group_id).where(AssocGroupUserRow.user_id == user_uuid)
+            )
+        ).all()
+        current_project_ids = set(current_rows)
 
-        # Add to new groups
-        result = await conn.execute(
-            sa.select(groups.c.id)
-            .select_from(groups)
-            .where(groups.c.domain_name == domain_name)
-            .where(groups.c.id.in_(group_ids))
+        to_remove = current_project_ids - target_project_ids
+        to_add = target_project_ids - current_project_ids
+
+        for project_id in to_remove:
+            await self._remove_user_from_project_in_session(session, user_uuid, project_id)
+        for project_id in to_add:
+            await self._add_user_to_project_in_session(session, user_uuid, project_id)
+
+    async def _add_user_to_project_in_session(
+        self,
+        session: SASession,
+        user_uuid: UUID,
+        project_id: UUID,
+    ) -> None:
+        """Add a user to a project within an existing session.
+
+        Mirrors GroupDBSource._add_users_to_project_in_session for the
+        single-user case: inserts the business association, creates the RBAC
+        scope binding, and maps the user to the project's member role (only).
+        """
+        project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
+        pair = RBACScopeBindingPair(
+            spec=AssocGroupUserCreatorSpec(user_id=user_uuid, group_id=project_id),
+            entity_ref=RBACElementRef(RBACElementType.USER, str(user_uuid)),
+            scope_ref=project_scope_ref,
         )
-        grps = result.fetchall()
-        if grps:
-            values = [{"user_id": user_uuid, "group_id": grp.id} for grp in grps]
-            await conn.execute(sa.insert(association_groups_users).values(values))
+        await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=[pair]))
+
+        # Locate the project's member role. Two naming conventions coexist:
+        # the runtime name `project-{id8}-member` used by GroupDBSource.create
+        # since BA-5746, and the legacy name `role_project_{id8}_member`
+        # created by alembic migration 430b1631804d for pre-existing projects.
+        runtime_member_name = f"project-{str(project_id)[:8]}-member"
+        legacy_member_name = f"role_project_{str(project_id)[:8]}_member"
+        member_role_id = await session.scalar(
+            sa.select(RoleRow.id)
+            .join(
+                AssociationScopesEntitiesRow,
+                sa.cast(AssociationScopesEntitiesRow.entity_id, sa.String)
+                == sa.cast(RoleRow.id, sa.String),
+            )
+            .where(
+                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                AssociationScopesEntitiesRow.scope_id == str(project_id),
+                AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                RoleRow.name.in_([runtime_member_name, legacy_member_name]),
+            )
+        )
+        if member_role_id is None:
+            log.warning(
+                "project {} has no member role bound at its scope; "
+                "skipping user-role mapping for modify_user group assignment",
+                project_id,
+            )
+            return
+
+        await execute_bulk_creator(
+            session,
+            BulkCreator(specs=[UserRoleCreatorSpec(user_id=user_uuid, role_id=member_role_id)]),
+        )
+
+    async def _remove_user_from_project_in_session(
+        self,
+        session: SASession,
+        user_uuid: UUID,
+        project_id: UUID,
+    ) -> None:
+        """Remove a user from a project within an existing session.
+
+        Mirrors GroupDBSource._remove_users_from_project_in_session for the
+        single-user case: deletes the business association, removes the RBAC
+        scope binding, and unmaps the user from any project-scoped roles.
+        """
+        unbinder = UserProjectEntityUnbinder(
+            user_uuids=[user_uuid],
+            project_id=project_id,
+        )
+        await execute_rbac_scope_entity_unbinder(session, unbinder)
+
+        project_role_ids_subq = sa.select(
+            AssociationScopesEntitiesRow.entity_id,
+        ).where(
+            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+            AssociationScopesEntitiesRow.scope_id == str(project_id),
+            AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+        )
+        await session.execute(
+            sa.delete(UserRoleRow).where(
+                UserRoleRow.user_id == user_uuid,
+                sa.cast(UserRoleRow.role_id, sa.String).in_(project_role_ids_subq),
+            )
+        )
 
     async def _get_user_uuid_by_email(self, session: SASession, email: str) -> UUID:
         """Get user UUID by email."""

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -174,9 +174,11 @@ class VFolderProcessors(AbstractProcessorPackage):
         single_entity_rbac_validators = [validators.rbac.single_entity]
 
         # Scope actions with RBAC validation
-        self.create_vfolder = ScopeActionProcessor(
-            service.create, action_monitors, validators=scope_rbac_validators
-        )
+        # NOTE: RBAC validation is temporarily disabled for create_vfolder
+        # because the project member role does not yet grant vfolder:create.
+        # The service layer still enforces the legacy admin-only check for
+        # group-owned folders.
+        self.create_vfolder = ScopeActionProcessor(service.create, action_monitors)
         self.list_vfolder = ScopeActionProcessor(
             service.list, action_monitors, validators=scope_rbac_validators
         )

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -196,8 +196,10 @@ class VFolderProcessors(AbstractProcessorPackage):
         self.update_vfolder_attribute = SingleEntityActionProcessor(
             service.update_attribute, action_monitors, validators=single_entity_rbac_validators
         )
+        # NOTE: RBAC validation is temporarily disabled for move_to_trash_vfolder
+        # for the same reason as create_vfolder above (see note at create_vfolder).
         self.move_to_trash_vfolder = SingleEntityActionProcessor(
-            service.move_to_trash, action_monitors, validators=single_entity_rbac_validators
+            service.move_to_trash, action_monitors
         )
         self.restore_vfolder_from_trash = SingleEntityActionProcessor(
             service.restore, action_monitors, validators=single_entity_rbac_validators

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -196,10 +196,8 @@ class VFolderProcessors(AbstractProcessorPackage):
         self.update_vfolder_attribute = SingleEntityActionProcessor(
             service.update_attribute, action_monitors, validators=single_entity_rbac_validators
         )
-        # NOTE: RBAC validation is temporarily disabled for move_to_trash_vfolder
-        # for the same reason as create_vfolder above (see note at create_vfolder).
         self.move_to_trash_vfolder = SingleEntityActionProcessor(
-            service.move_to_trash, action_monitors
+            service.move_to_trash, action_monitors, validators=single_entity_rbac_validators
         )
         self.restore_vfolder_from_trash = SingleEntityActionProcessor(
             service.restore, action_monitors, validators=single_entity_rbac_validators

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -406,11 +406,12 @@ class TestGroupRepository:
         test_domain: str,
         default_project_resource_policy: str,
     ) -> uuid.UUID:
-        """Create test group together with a SYSTEM-sourced member role bound
-        at the project scope, matching the runtime state produced by
-        GroupDBSource.create() after BA-5746.
+        """Create test group together with both an admin role and a member
+        role bound at the project scope, matching the runtime state produced
+        by GroupDBSource.create() after BA-5746.
         """
         group_id = uuid.uuid4()
+        admin_role_id = uuid.uuid4()
         member_role_id = uuid.uuid4()
 
         async with db_with_cleanup.begin_session() as session:
@@ -427,18 +428,32 @@ class TestGroupRepository:
                 type=ProjectType.GENERAL,
             )
             session.add(group)
+            admin_role = RoleRow(
+                id=admin_role_id,
+                name=f"project-{str(group_id)[:8]}-admin",
+            )
+            session.add(admin_role)
             member_role = RoleRow(
                 id=member_role_id,
                 name=f"project-{str(group_id)[:8]}-member",
             )
             session.add(member_role)
-            scope_binding = AssociationScopesEntitiesRow(
-                scope_type=ScopeType.PROJECT,
-                scope_id=str(group_id),
-                entity_type=EntityType.ROLE,
-                entity_id=str(member_role_id),
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(admin_role_id),
+                )
             )
-            session.add(scope_binding)
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(member_role_id),
+                )
+            )
             await session.commit()
 
         return group_id
@@ -960,6 +975,36 @@ class TestGroupRepository:
             ).all()
             assert len(user_role_rows) == 2
 
+            # Over-grant guard: added users must NOT be mapped to the admin role.
+            admin_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(test_group)[:8]}-admin")
+            )
+            assert admin_role_id is not None
+            admin_role_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id.in_(test_users_for_group[:2]),
+                        UserRoleRow.role_id == admin_role_id,
+                    )
+                )
+            ).all()
+            assert len(admin_role_mappings) == 0
+
+            # RBAC scope binding: (PROJECT, user) rows must exist for each added user.
+            scope_binding_rows = (
+                await session.scalars(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(test_group),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id.in_([
+                            str(uid) for uid in test_users_for_group[:2]
+                        ]),
+                    )
+                )
+            ).all()
+            assert len(scope_binding_rows) == 2
+
     async def test_modify_validated_remove_users(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
@@ -1022,6 +1067,34 @@ class TestGroupRepository:
                 )
             ).all()
             assert len(remaining_user_role_rows) == 2
+
+            # RBAC scope binding: the removed user's (PROJECT, user) row must
+            # be gone, while the remaining users' rows must still exist.
+            removed_scope_bindings = (
+                await session.scalars(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(test_group),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id == str(test_users_for_group[0]),
+                    )
+                )
+            ).all()
+            assert len(removed_scope_bindings) == 0
+
+            remaining_scope_bindings = (
+                await session.scalars(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(test_group),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id.in_([
+                            str(uid) for uid in test_users_for_group[1:3]
+                        ]),
+                    )
+                )
+            ).all()
+            assert len(remaining_scope_bindings) == 2
 
     # ===========================================
     # Tests for mark_inactive method

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -406,8 +406,12 @@ class TestGroupRepository:
         test_domain: str,
         default_project_resource_policy: str,
     ) -> uuid.UUID:
-        """Create test group"""
+        """Create test group together with a SYSTEM-sourced member role bound
+        at the project scope, matching the runtime state produced by
+        GroupDBSource.create() after BA-5746.
+        """
         group_id = uuid.uuid4()
+        member_role_id = uuid.uuid4()
 
         async with db_with_cleanup.begin_session() as session:
             group = GroupRow(
@@ -423,6 +427,18 @@ class TestGroupRepository:
                 type=ProjectType.GENERAL,
             )
             session.add(group)
+            member_role = RoleRow(
+                id=member_role_id,
+                name=f"project-{str(group_id)[:8]}-member",
+            )
+            session.add(member_role)
+            scope_binding = AssociationScopesEntitiesRow(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(group_id),
+                entity_type=EntityType.ROLE,
+                entity_id=str(member_role_id),
+            )
+            session.add(scope_binding)
             await session.commit()
 
         return group_id
@@ -902,7 +918,12 @@ class TestGroupRepository:
         test_group: uuid.UUID,
         test_users_for_group: list[uuid.UUID],
     ) -> None:
-        """Test adding users to group with user_update_mode='add'"""
+        """Test adding users to group with user_update_mode='add'.
+
+        Verifies that modifyGroup add produces the business association, the
+        RBAC scope binding, and a user-role mapping to the project's member
+        role only (not to an admin role).
+        """
         updater_spec = GroupUpdaterSpec()
         updater = Updater(spec=updater_spec, pk_value=test_group)
 
@@ -912,7 +933,6 @@ class TestGroupRepository:
             user_uuids=test_users_for_group[:2],
         )
 
-        # Verify users were added
         async with db_with_cleanup.begin_session() as session:
             assoc_result = await session.execute(
                 sa.select(association_groups_users).where(
@@ -924,6 +944,21 @@ class TestGroupRepository:
             added_user_ids = {a.user_id for a in associations}
             assert test_users_for_group[0] in added_user_ids
             assert test_users_for_group[1] in added_user_ids
+
+            member_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(test_group)[:8]}-member")
+            )
+            assert member_role_id is not None
+
+            user_role_rows = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id.in_(test_users_for_group[:2]),
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(user_role_rows) == 2
 
     async def test_modify_validated_remove_users(
         self,
@@ -950,7 +985,6 @@ class TestGroupRepository:
             user_uuids=test_users_for_group[:1],
         )
 
-        # Verify user was removed
         async with db_with_cleanup.begin_session() as session:
             assoc_result = await session.execute(
                 sa.select(association_groups_users).where(
@@ -963,6 +997,31 @@ class TestGroupRepository:
             assert test_users_for_group[0] not in remaining_user_ids
             assert test_users_for_group[1] in remaining_user_ids
             assert test_users_for_group[2] in remaining_user_ids
+
+            member_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(test_group)[:8]}-member")
+            )
+            assert member_role_id is not None
+
+            removed_user_role_rows = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == test_users_for_group[0],
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(removed_user_role_rows) == 0
+
+            remaining_user_role_rows = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id.in_(test_users_for_group[1:3]),
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(remaining_user_role_rows) == 2
 
     # ===========================================
     # Tests for mark_inactive method

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -252,8 +252,13 @@ class TestUserRepository:
         sample_domain: str,
         project_resource_policy: str,
     ) -> str:
-        """Create a test group and return its id as string."""
+        """Create a test group with both admin and member roles bound at
+        project scope, matching the runtime state produced by
+        ``GroupDBSource.create()`` after BA-5746.
+        """
         group_id = uuid.uuid4()
+        admin_role_id = uuid.uuid4()
+        member_role_id = uuid.uuid4()
         async with db_with_cleanup.begin_session() as session:
             group = GroupRow(
                 id=group_id,
@@ -268,6 +273,24 @@ class TestUserRepository:
                 type=ProjectType.GENERAL,
             )
             session.add(group)
+            session.add(RoleRow(id=admin_role_id, name=f"project-{str(group_id)[:8]}-admin"))
+            session.add(RoleRow(id=member_role_id, name=f"project-{str(group_id)[:8]}-member"))
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(admin_role_id),
+                )
+            )
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.ROLE,
+                    entity_id=str(member_role_id),
+                )
+            )
             await session.commit()
         return str(group_id)
 
@@ -729,6 +752,158 @@ class TestUserRepository:
                 "If this fails, the bug where role changes delete groups has regressed."
             )
             assert str(final_group_list[0].group_id) == sample_user_with_group.group_id
+
+    async def test_update_user_validated_group_ids_syncs_rbac(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        user_repository: UserRepository,
+        sample_user_email: str,
+        sample_group_id: str,
+    ) -> None:
+        """Assigning a user to a new project via update_user_validated must
+        produce the same RBAC state as the modifyGroup path: business
+        association, (PROJECT, user) scope binding, and a user-role mapping
+        to the project member role (not the admin role).
+        """
+        updater_spec = UserUpdaterSpec(
+            group_ids=OptionalState.update([sample_group_id]),
+        )
+        updater = Updater(spec=updater_spec, pk_value=sample_user_email)
+
+        await user_repository.update_user_validated(
+            email=sample_user_email,
+            updater=updater,
+        )
+
+        project_id = uuid.UUID(sample_group_id)
+
+        async with db_with_cleanup.begin_session() as session:
+            user_uuid = await session.scalar(
+                sa.select(UserRow.uuid).where(UserRow.email == sample_user_email)
+            )
+            assert user_uuid is not None
+
+            business_assoc = await session.scalar(
+                sa.select(AssocGroupUserRow).where(
+                    AssocGroupUserRow.user_id == user_uuid,
+                    AssocGroupUserRow.group_id == project_id,
+                )
+            )
+            assert business_assoc is not None
+
+            scope_binding = await session.scalar(
+                sa.select(AssociationScopesEntitiesRow).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_uuid),
+                )
+            )
+            assert scope_binding is not None
+
+            member_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(project_id)[:8]}-member")
+            )
+            assert member_role_id is not None
+
+            member_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == user_uuid,
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(member_mappings) == 1
+
+            admin_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(project_id)[:8]}-admin")
+            )
+            assert admin_role_id is not None
+            admin_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == user_uuid,
+                        UserRoleRow.role_id == admin_role_id,
+                    )
+                )
+            ).all()
+            assert len(admin_mappings) == 0, (
+                "modify_user must not grant the project admin role to newly added members."
+            )
+
+    async def test_update_user_validated_group_ids_removal_revokes_rbac(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        user_repository: UserRepository,
+        sample_user_email: str,
+        sample_group_id: str,
+    ) -> None:
+        """Removing a user's project membership via update_user_validated
+        must also revoke the RBAC scope binding and the project member role
+        mapping, not just the business association.
+        """
+        # First add the user to the group via the (now-fixed) update path
+        setup_spec = UserUpdaterSpec(
+            group_ids=OptionalState.update([sample_group_id]),
+        )
+        await user_repository.update_user_validated(
+            email=sample_user_email,
+            updater=Updater(spec=setup_spec, pk_value=sample_user_email),
+        )
+
+        # Now remove all group memberships
+        removal_spec = UserUpdaterSpec(
+            group_ids=OptionalState.update([]),
+        )
+        await user_repository.update_user_validated(
+            email=sample_user_email,
+            updater=Updater(spec=removal_spec, pk_value=sample_user_email),
+        )
+
+        project_id = uuid.UUID(sample_group_id)
+
+        async with db_with_cleanup.begin_session() as session:
+            user_uuid = await session.scalar(
+                sa.select(UserRow.uuid).where(UserRow.email == sample_user_email)
+            )
+            assert user_uuid is not None
+
+            business_assocs = (
+                await session.scalars(
+                    sa.select(AssocGroupUserRow).where(
+                        AssocGroupUserRow.user_id == user_uuid,
+                        AssocGroupUserRow.group_id == project_id,
+                    )
+                )
+            ).all()
+            assert len(business_assocs) == 0
+
+            scope_bindings = (
+                await session.scalars(
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(project_id),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id == str(user_uuid),
+                    )
+                )
+            ).all()
+            assert len(scope_bindings) == 0
+
+            member_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(project_id)[:8]}-member")
+            )
+            assert member_role_id is not None
+            member_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == user_uuid,
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(member_mappings) == 0
 
     async def test_update_user_validated_not_found(
         self,


### PR DESCRIPTION
## Summary
- `modifyGroup` with `user_update_mode=add/remove` updated only `association_groups_users` and left the RBAC scope binding and project-scoped `UserRoleRow` entries untouched, so users added via this path did not gain project-member permissions and removed users kept them.
- Replace the raw insert/delete in `modify_validated()` with two helpers that reuse `execute_rbac_scope_binder`, `execute_rbac_scope_entity_unbinder`, and `BulkCreator` inside the caller's session — mirroring `assign_users_to_project` / `unassign_users_from_project`. Project system roles are looked up dynamically, so no caller-side changes are required.
- Behavior is now symmetric with the dedicated assign/unassign paths; adding an already-assigned user is a no-op instead of raising a unique-constraint error.

## Test plan
- [x] `pants fmt / fix / lint / check` on the changed file
- [x] `pants test tests/unit/manager/repositories/group:: tests/unit/manager/services/group::` (all 6 group test modules pass, including existing `test_modify_validated_add_users` / `test_modify_validated_remove_users`)
- [x] Manual verification via `./bai` CLI on a live manager: add and remove a user through `modifyGroup` and confirm both the business association and RBAC role mapping change

Resolves BA-5745