### PR TITLE
fix(BA-5746): create project member role at runtime and backfill existing projects

### DIFF
--- a/changes/11118.feature.md
+++ b/changes/11118.feature.md
@@ -1,0 +1,1 @@
+Create a SYSTEM-sourced member role alongside the admin role on project creation, and backfill missing member roles for existing projects.

--- a/changes/11118.feature.md
+++ b/changes/11118.feature.md
@@ -1,1 +1,0 @@
-Create a SYSTEM-sourced member role alongside the admin role on project creation, and backfill missing member roles for existing projects.

--- a/changes/11118.fix.md
+++ b/changes/11118.fix.md
@@ -1,0 +1,1 @@
+Fix project creation to also create the member system role and backfill member roles for existing projects that were missing one.

--- a/src/ai/backend/manager/data/group/types.py
+++ b/src/ai/backend/manager/data/group/types.py
@@ -72,6 +72,28 @@ class GroupData:
         }
 
 
+@dataclass(frozen=True)
+class ProjectMemberRoleSpec:
+    """ScopeSystemRoleData implementation for the project-scoped member role."""
+
+    project_id: uuid.UUID
+
+    def scope_id(self) -> ScopeId:
+        return ScopeId(
+            scope_type=ScopeType.PROJECT,
+            scope_id=str(self.project_id),
+        )
+
+    def role_name(self) -> str:
+        return f"project-{str(self.project_id)[:8]}-member"
+
+    def entity_operations(self) -> Mapping[RBACElementType, Iterable[OperationType]]:
+        return {
+            entity.to_element(): OperationType.member_operations()
+            for entity in EntityType.member_accessible_entity_types_in_project()
+        }
+
+
 @dataclass
 class GroupModifier(PartialModifier):
     name: OptionalState[str] = field(default_factory=OptionalState[str].nop)

--- a/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
@@ -1,18 +1,21 @@
-"""backfill project member roles
+"""backfill project member roles and promote legacy custom sources to system
 
-Creates a SYSTEM-sourced member role for every project that does not already
-have one at project scope. This fixes two historical gaps:
+Normalizes the project member role across all projects so that every project
+has exactly one SYSTEM-sourced member role at its scope. This fixes two
+historical gaps:
 
 1. Projects created after migration 430b1631804d had no member role at all,
-   because the runtime create path only creates a project admin role.
+   because the runtime create path only created a project admin role. For
+   these, a new SYSTEM-sourced member role is created together with its
+   scope binding and member permissions.
 2. Projects created before 430b1631804d received a member role from that
-   migration, but with source=CUSTOM. We intentionally leave those untouched
-   here (source normalization is out of scope); presence-based detection skips
-   them as "already has a member role".
+   migration, but with source=CUSTOM. For these, the existing role row is
+   promoted to source=SYSTEM in place; no new role is created and existing
+   permissions / user-role mappings are preserved.
 
 Runtime creation of the member role is introduced alongside this migration in
 GroupDBSource.create(), so new projects created after this migration lands
-will already have both roles and the backfill will be a no-op for them.
+will already have both roles and the migration will be a no-op for them.
 
 Revision ID: e3fb172166dc
 Revises: d8e4f2a1b3c7
@@ -228,20 +231,60 @@ def _create_member_permissions(
     insert_skip_on_conflict(db_conn, permissions_table, rows)
 
 
+def _promote_legacy_member_roles_to_system(db_conn: Connection) -> None:
+    """Promote legacy project member roles (``role_project_{id8}_member``) that
+    were created with ``source = custom`` by migration ``430b1631804d`` so that
+    every project member role has ``source = system``.
+
+    Only roles whose (a) name matches the legacy member role pattern and
+    (b) are bound in ``association_scopes_entities`` at PROJECT scope are
+    updated, to avoid touching any unrelated custom role. The filter is
+    idempotent: roles that are already ``system`` simply match zero rows.
+    """
+    roles_table = get_roles_table()
+    assoc_table = get_association_scopes_entities_table()
+
+    legacy_scope_subq = (
+        sa.select(sa.literal(1))
+        .select_from(assoc_table)
+        .where(
+            assoc_table.c.scope_type == ScopeType.PROJECT,
+            assoc_table.c.entity_type == "role",
+            sa.cast(assoc_table.c.entity_id, sa.String) == sa.cast(roles_table.c.id, sa.String),
+        )
+        .exists()
+    )
+
+    stmt = (
+        sa.update(roles_table)
+        .where(
+            roles_table.c.name.like("role_project_%_member"),
+            roles_table.c.source == RoleSource.CUSTOM,
+            legacy_scope_subq,
+        )
+        .values(source=RoleSource.SYSTEM)
+    )
+    db_conn.execute(stmt)
+
+
 def upgrade() -> None:
     conn = op.get_bind()
 
+    # 1. Backfill member roles for projects that have none.
     project_rows = _query_projects_missing_member_role(conn)
     project_ids: list[uuid.UUID] = [row.id for row in project_rows]
-    if not project_ids:
-        return
+    if project_ids:
+        project_to_role = _create_member_roles_for_projects(conn, project_ids)
+        _bind_roles_to_project_scopes(conn, project_to_role)
+        _create_member_permissions(conn, project_to_role)
 
-    project_to_role = _create_member_roles_for_projects(conn, project_ids)
-    _bind_roles_to_project_scopes(conn, project_to_role)
-    _create_member_permissions(conn, project_to_role)
+    # 2. Promote legacy CUSTOM member roles to SYSTEM so that all project
+    #    member roles have a consistent source across the database.
+    _promote_legacy_member_roles_to_system(conn)
 
 
 def downgrade() -> None:
     # We cannot safely distinguish backfilled member roles from those that
-    # existed beforehand, so downgrade is intentionally a no-op.
+    # existed beforehand, and the pre-upgrade source of legacy roles is not
+    # recorded anywhere, so downgrade is intentionally a no-op.
     pass

--- a/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
@@ -1,0 +1,247 @@
+"""backfill project member roles
+
+Creates a SYSTEM-sourced member role for every project that does not already
+have one at project scope. This fixes two historical gaps:
+
+1. Projects created after migration 430b1631804d had no member role at all,
+   because the runtime create path only creates a project admin role.
+2. Projects created before 430b1631804d received a member role from that
+   migration, but with source=CUSTOM. We intentionally leave those untouched
+   here (source normalization is out of scope); presence-based detection skips
+   them as "already has a member role".
+
+Runtime creation of the member role is introduced alongside this migration in
+GroupDBSource.create(), so new projects created after this migration lands
+will already have both roles and the backfill will be a no-op for them.
+
+Revision ID: e3fb172166dc
+Revises: d8e4f2a1b3c7
+Create Date: 2026-04-15
+
+"""
+
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection, Row
+
+from ai.backend.manager.models.base import GUID, IDColumn
+from ai.backend.manager.models.rbac_models.migration.enums import (
+    RoleSource,
+    RoleStatus,
+    ScopeType,
+)
+from ai.backend.manager.models.rbac_models.migration.models import (
+    get_association_scopes_entities_table,
+    get_roles_table,
+    mapper_registry,
+)
+from ai.backend.manager.models.rbac_models.migration.utils import (
+    insert_skip_on_conflict,
+    query_role_rows_by_name,
+)
+
+# revision identifiers, used by Alembic.
+revision = "e3fb172166dc"
+down_revision = "d8e4f2a1b3c7"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+
+# Snapshot of MEMBER_ACCESSIBLE_ENTITY_TYPES_IN_PROJECT at the time of writing.
+# Kept inline so that runtime enum changes do not retroactively alter the set
+# of permissions granted by this migration.
+_MEMBER_ACCESSIBLE_ENTITY_TYPES: tuple[str, ...] = (
+    "user",
+    "vfolder",
+    "image",
+    "session",
+    "artifact",
+    "artifact_registry",
+    "app_config",
+    "notification_channel",
+    "notification_rule",
+    "model_deployment",
+    "model_card",
+)
+
+# Snapshot of OperationType.member_operations() — member roles only grant READ.
+_MEMBER_OPERATIONS: tuple[str, ...] = ("read",)
+
+
+def _get_groups_table() -> sa.Table:
+    return sa.Table(
+        "groups",
+        mapper_registry.metadata,
+        IDColumn(),
+        extend_existing=True,
+    )
+
+
+def _get_permissions_table() -> sa.Table:
+    """Local definition matching the current (post-f41bbe0c0f12) schema where
+    ``permission_group_id`` has been replaced by direct ``role_id`` / scope
+    columns on the ``permissions`` table."""
+    return sa.Table(
+        "permissions",
+        mapper_registry.metadata,
+        IDColumn(),
+        sa.Column("role_id", GUID, nullable=False),
+        sa.Column("scope_type", sa.VARCHAR(length=32), nullable=False),
+        sa.Column("scope_id", sa.String(length=64), nullable=False),
+        sa.Column("entity_type", sa.String(32), nullable=False),
+        sa.Column("operation", sa.String(32), nullable=False),
+        extend_existing=True,
+    )
+
+
+def _member_role_name(project_id: uuid.UUID) -> str:
+    """Match ProjectMemberRoleSpec.role_name() used by the runtime create path."""
+    return f"project-{str(project_id)[:8]}-member"
+
+
+def _legacy_member_role_name(project_id: uuid.UUID) -> str:
+    """Name used by the original migration 430b1631804d for member roles."""
+    return f"role_project_{str(project_id)[:8]}_member"
+
+
+def _query_projects_missing_member_role(db_conn: Connection) -> Sequence[Row[Any]]:
+    """Return groups.id for every project that has no member role bound at
+    its project scope, regardless of the role's source or naming convention.
+
+    A project is considered to already have a member role if there exists any
+    role bound in association_scopes_entities at (PROJECT, project_id) whose
+    name matches either the runtime naming convention or the legacy naming
+    convention for that project id.
+    """
+    groups_table = _get_groups_table()
+    roles_table = get_roles_table()
+    assoc_table = get_association_scopes_entities_table()
+
+    runtime_pattern = (
+        "project-" + sa.func.substring(sa.cast(groups_table.c.id, sa.String), 1, 8) + "-member"
+    )
+    legacy_pattern = (
+        "role_project_" + sa.func.substring(sa.cast(groups_table.c.id, sa.String), 1, 8) + "_member"
+    )
+
+    member_exists_subq = (
+        sa.select(sa.literal(1))
+        .select_from(
+            assoc_table.join(
+                roles_table,
+                sa.cast(assoc_table.c.entity_id, sa.String) == sa.cast(roles_table.c.id, sa.String),
+            )
+        )
+        .where(
+            assoc_table.c.scope_type == ScopeType.PROJECT,
+            assoc_table.c.scope_id == sa.cast(groups_table.c.id, sa.String),
+            assoc_table.c.entity_type == "role",
+            sa.or_(
+                roles_table.c.name == runtime_pattern,
+                roles_table.c.name == legacy_pattern,
+            ),
+        )
+    ).exists()
+
+    query = sa.select(groups_table.c.id).where(sa.not_(member_exists_subq))
+    return list(db_conn.execute(query).all())
+
+
+def _create_member_roles_for_projects(
+    db_conn: Connection, project_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, uuid.UUID]:
+    """Create a SYSTEM-sourced member role row per project.
+
+    Returns a mapping {project_id -> role_id}. Uses insert_skip_on_conflict so
+    that a partially-applied previous run cannot produce duplicate rows, and
+    then re-queries by name to resolve the role ids.
+    """
+    if not project_ids:
+        return {}
+
+    roles_table = get_roles_table()
+    role_inputs: list[dict[str, Any]] = []
+    name_to_project: dict[str, uuid.UUID] = {}
+    for project_id in project_ids:
+        name = _member_role_name(project_id)
+        role_inputs.append({
+            "name": name,
+            "source": RoleSource.SYSTEM,
+            "status": RoleStatus.ACTIVE,
+        })
+        name_to_project[name] = project_id
+
+    # The roles table has no unique constraint on name, so insert_skip_on_conflict
+    # would not help here. The outer filter query is what keeps us idempotent.
+    db_conn.execute(sa.insert(roles_table), role_inputs)
+
+    role_rows = query_role_rows_by_name(db_conn, list(name_to_project.keys()))
+    project_to_role: dict[uuid.UUID, uuid.UUID] = {}
+    for row in role_rows:
+        resolved = name_to_project.get(row.name)
+        if resolved is None:
+            continue
+        project_to_role[resolved] = row.id
+    return project_to_role
+
+
+def _bind_roles_to_project_scopes(
+    db_conn: Connection, project_to_role: dict[uuid.UUID, uuid.UUID]
+) -> None:
+    if not project_to_role:
+        return
+    assoc_table = get_association_scopes_entities_table()
+    rows = [
+        {
+            "scope_type": ScopeType.PROJECT,
+            "scope_id": str(project_id),
+            "entity_type": "role",
+            "entity_id": str(role_id),
+        }
+        for project_id, role_id in project_to_role.items()
+    ]
+    insert_skip_on_conflict(db_conn, assoc_table, rows)
+
+
+def _create_member_permissions(
+    db_conn: Connection, project_to_role: dict[uuid.UUID, uuid.UUID]
+) -> None:
+    if not project_to_role:
+        return
+    permissions_table = _get_permissions_table()
+    rows: list[dict[str, Any]] = []
+    for project_id, role_id in project_to_role.items():
+        for entity_type in _MEMBER_ACCESSIBLE_ENTITY_TYPES:
+            for operation in _MEMBER_OPERATIONS:
+                rows.append({
+                    "role_id": role_id,
+                    "scope_type": ScopeType.PROJECT,
+                    "scope_id": str(project_id),
+                    "entity_type": entity_type,
+                    "operation": operation,
+                })
+    insert_skip_on_conflict(db_conn, permissions_table, rows)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    project_rows = _query_projects_missing_member_role(conn)
+    project_ids: list[uuid.UUID] = [row.id for row in project_rows]
+    if not project_ids:
+        return
+
+    project_to_role = _create_member_roles_for_projects(conn, project_ids)
+    _bind_roles_to_project_scopes(conn, project_to_role)
+    _create_member_permissions(conn, project_to_role)
+
+
+def downgrade() -> None:
+    # We cannot safely distinguish backfilled member roles from those that
+    # existed beforehand, so downgrade is intentionally a no-op.
+    pass

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -22,7 +22,12 @@ from ai.backend.common.types import SlotName, VFolderID
 from ai.backend.common.utils import nmget
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.group.types import GroupData, UnassignUserFailure, UnassignUsersResult
+from ai.backend.manager.data.group.types import (
+    GroupData,
+    ProjectMemberRoleSpec,
+    UnassignUserFailure,
+    UnassignUsersResult,
+)
 from ai.backend.manager.data.permission.types import EntityType, RBACElementRef, ScopeType
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.errors.resource import (
@@ -160,8 +165,13 @@ class GroupDBSource:
             result = await execute_rbac_entity_creator(db_session, rbac_creator)
             row: GroupRow = result.row
             data = row.to_data()
-            # Create RBAC role and permissions for the group
+            # Create RBAC roles and permissions for the group.
+            # Each project gets two SYSTEM-sourced roles at its scope: an admin role
+            # (via GroupData) and a member role (read-only access for project members).
             await self._role_manager.create_system_role(db_session, data)
+            await self._role_manager.create_system_role(
+                db_session, ProjectMemberRoleSpec(project_id=data.id)
+            )
 
             return data
 

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import AsyncGenerator
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,7 +23,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
-from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.data.group.types import GroupData, ProjectMemberRoleSpec, ProjectType
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.model_serving.types import EndpointLifecycle
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission as VFolderPermission
@@ -853,6 +854,42 @@ class TestGroupRepository:
             assert scope_assoc.scope_type == ScopeType.DOMAIN
             assert scope_assoc.scope_id == test_domain
             assert scope_assoc.entity_id == str(result.id)
+
+    async def test_create_creates_admin_and_member_system_roles(
+        self,
+        group_repository_with_mock_role_manager: GroupRepository,
+        group_db_source_with_mock_role_manager: GroupDBSource,
+        test_domain: str,
+        default_project_resource_policy: str,
+    ) -> None:
+        """Project creation must request both an admin role (via GroupData) and a
+        member role (via ProjectMemberRoleSpec) from the RoleManager."""
+        creator_spec = GroupCreatorSpec(
+            name="test-roles-group",
+            domain_name=test_domain,
+            description="Test group for role creation",
+            resource_policy=default_project_resource_policy,
+        )
+        creator = Creator(spec=creator_spec)
+
+        result = await group_repository_with_mock_role_manager.create(creator)
+
+        mock_create = cast(
+            AsyncMock, group_db_source_with_mock_role_manager._role_manager.create_system_role
+        )
+        assert mock_create.call_count == 2
+
+        passed_specs = [call.args[1] for call in mock_create.call_args_list]
+        assert any(isinstance(spec, GroupData) and spec.id == result.id for spec in passed_specs)
+        assert any(
+            isinstance(spec, ProjectMemberRoleSpec) and spec.project_id == result.id
+            for spec in passed_specs
+        )
+
+        member_spec = next(spec for spec in passed_specs if isinstance(spec, ProjectMemberRoleSpec))
+        assert member_spec.role_name() == f"project-{str(result.id)[:8]}-member"
+        assert member_spec.scope_id().scope_type == ScopeType.PROJECT
+        assert member_spec.scope_id().scope_id == str(result.id)
 
     # ===========================================
     # Tests for modify_validated method


### PR DESCRIPTION
## Summary
- Project creation only created the admin system role at runtime, so any project created after migration `430b1631804d` had no member role at all and the `modifyGroup` auto-assignment flow (BA-5745) had nothing to map members to.
- Add `ProjectMemberRoleSpec` (a sibling `ScopeSystemRoleData` implementation to `GroupData`) and call `create_system_role` twice from `GroupDBSource.create` so every new project gets two SYSTEM-sourced roles at project scope: the existing admin role and a read-only member role over `member_accessible_entity_types_in_project`.
- Add an idempotent alembic backfill (`e3fb172166dc`) that creates a SYSTEM-sourced member role + scope binding + member permissions for every existing project that has no member role, detecting both the runtime name (`project-{id8}-member`) and the legacy name (`role_project_{id8}_member`). Projects that already have a member role from migration `430b1631804d` are left untouched; promoting their `CUSTOM` source to `SYSTEM` is explicitly out of scope.

## Test plan
- [x] `pants fmt / fix / lint / check` on all touched files
- [x] `pants test tests/unit/manager/repositories/group:: tests/unit/manager/services/group::` (all 6 group test modules pass, including the new `test_create_creates_admin_and_member_system_roles`)
- [x] Manual verification on a live manager: create a new project via `./bai admin project create`, then query `roles` / `association_scopes_entities` / `permissions` and confirm both an admin role and a member role exist at project scope, both with `source = system`
- [x] Manual verification of the migration: `alembic upgrade head` on a database that contains a project with no member role; confirm a SYSTEM-sourced member role gets backfilled and that `alembic upgrade head` is a no-op on the second run (idempotency)

Resolves BA-5746