### PR TITLE
feat: add GQL node lazy resolver fields and clean up NotImplemented stubs

### DIFF
--- a/changes/11120.enhance.md
+++ b/changes/11120.enhance.md
@@ -1,0 +1,1 @@
+Add lazy resolver fields for FK references across GQL Node types and deprecate legacy Graphene stub resolvers with v2 dataloader-based alternatives.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13132,21 +13132,6 @@ type Query
   rgUserFairShares(scope: ResourceGroupUserScope!, filter: RGUserFairShareFilter = null, orderBy: [UserFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserFairShareConnection @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.2.0. List domain usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgDomainUsageBuckets(scope: ResourceGroupDomainScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection @join__field(graph: STRAWBERRY)
-
-  """
-  Added in 26.2.0. List project usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgProjectUsageBuckets(scope: ResourceGroupProjectScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY)
-
-  """
-  Added in 26.2.0. List user usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgUserUsageBuckets(scope: ResourceGroupUserScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection @join__field(graph: STRAWBERRY)
-
-  """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
   containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1679,6 +1679,11 @@ type AutoScalingRule implements Node
   prometheusQueryPresetId: ID
   createdAt: DateTime!
   lastTriggeredAt: DateTime
+
+  """
+  Added in UNRELEASED. The Prometheus query preset used for metric-based auto-scaling.
+  """
+  queryPreset: QueryDefinition
 }
 
 """Added in 25.19.0. Connection for auto-scaling rules."""
@@ -4626,6 +4631,9 @@ type DeploymentHistory implements Node
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The deployment this history record belongs to."""
+  deployment: ModelDeployment
 }
 
 """Added in 26.3.0. Deployment history connection."""
@@ -4774,6 +4782,9 @@ type DeploymentRevisionPreset implements Node
 
   """Timestamp of the last modification to this deployment preset."""
   updatedAt: DateTime
+
+  """Added in UNRELEASED. The runtime variant this preset is designed for."""
+  runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
@@ -7593,6 +7604,9 @@ type KeyPairGQL implements Node
 
   """UUID of the user who owns this keypair."""
   userId: UUID!
+
+  """Added in UNRELEASED. The user who owns this keypair."""
+  user: UserV2
 }
 
 """An edge in a connection."""
@@ -8084,6 +8098,12 @@ type LoginHistoryV2 implements Node
 
   """Timestamp when the login attempt occurred."""
   createdAt: DateTime!
+
+  """Added in UNRELEASED. The user who attempted to log in."""
+  user: UserV2
+
+  """Added in UNRELEASED. The domain at the time of the login attempt."""
+  domain: DomainV2
 }
 
 """Added in 26.4.2. Connection type for paginated login history results."""
@@ -8192,6 +8212,9 @@ type LoginSessionV2 implements Node
 
   """Timestamp when the session was invalidated."""
   invalidatedAt: DateTime
+
+  """Added in UNRELEASED. The user who owns this login session."""
+  user: UserV2
 }
 
 """Added in 26.4.2. Connection type for paginated login session results."""
@@ -8414,6 +8437,15 @@ type ModelCardV2 implements Node
   """
   vfolder: VFolder
 
+  """Added in UNRELEASED. The domain this model card belongs to."""
+  domain: DomainV2
+
+  """Added in UNRELEASED. The project this model card belongs to."""
+  project: ProjectV2
+
+  """Added in UNRELEASED. The user who created this model card."""
+  creator: UserV2
+
   """
   Deployment revision presets that satisfy this model card's minimum resource requirements. Equivalent to the root `model_card_available_presets` query but scoped to this card.
   """
@@ -8603,8 +8635,18 @@ type ModelDeployment implements Node
   replicaState: ReplicaState!
   createdUserId: ID!
 
+  """
+  Added in UNRELEASED. The current active revision of this deployment, resolved via DataLoader.
+  """
+  currentRevision: ModelRevision
+
   """The created user of this entity."""
-  createdUser: UserNode!
+  createdUser: UserNode! @deprecated(reason: "Use created_user_v2 instead.")
+
+  """
+  Added in UNRELEASED. The user who created this deployment, resolved via DataLoader.
+  """
+  createdUserV2: UserV2
 
   """Added in 25.19.0. Deployment policy configuration."""
   deploymentPolicy: DeploymentPolicy
@@ -8652,10 +8694,20 @@ type ModelDeploymentMetadata
   @join__type(graph: STRAWBERRY)
 {
   """The project of this entity."""
-  project: GroupNode!
+  project: GroupNode! @deprecated(reason: "Use project_v2 instead.")
+
+  """
+  Added in UNRELEASED. The project this deployment belongs to, resolved via DataLoader.
+  """
+  projectV2: ProjectV2
 
   """The domain of this entity."""
-  domain: DomainNode!
+  domain: DomainNode! @deprecated(reason: "Use domain_v2 instead.")
+
+  """
+  Added in UNRELEASED. The domain this deployment belongs to, resolved via DataLoader.
+  """
+  domainV2: DomainV2
   projectId: ID!
   domainName: String!
   name: String!
@@ -8879,7 +8931,12 @@ type ModelReplica implements Node
   """
   The session ID associated with the replica. This can be null right after replica creation.
   """
-  session: ComputeSessionNode!
+  session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
+
+  """
+  Added in UNRELEASED. The compute session running this replica, resolved via DataLoader.
+  """
+  sessionV2: SessionV2
 
   """The revision of this entity."""
   revision: ModelRevision!
@@ -8946,7 +9003,12 @@ type ModelRevision implements Node
   createdAt: DateTime!
 
   """The image of this entity."""
-  image: ImageNode!
+  image: ImageNode! @deprecated(reason: "Use image_v2 instead.")
+
+  """
+  Added in UNRELEASED. The container image used by this revision, resolved via DataLoader.
+  """
+  imageV2: ImageV2
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
@@ -14218,6 +14280,9 @@ type ResourcePresetV2 implements Node
 
   """Resource group name. Null means global preset."""
   resourceGroupName: String
+
+  """Added in UNRELEASED. The resource group this preset belongs to."""
+  resourceGroup: ResourceGroup
 }
 
 """An edge in a connection."""
@@ -14591,6 +14656,9 @@ type RoleAssignment implements Node
 
   """The assigned user."""
   user: UserV2
+
+  """Added in UNRELEASED. The user who granted this role assignment."""
+  grantedByUser: UserV2
 }
 
 """Added in 26.3.0. Role assignment connection."""
@@ -14815,7 +14883,12 @@ type Route implements Node
   """
   The session associated with the route. Can be null if the route is still provisioning.
   """
-  session: ID
+  session: ID @deprecated(reason: "Use session_v2 instead.")
+
+  """
+  Added in UNRELEASED. The compute session associated with this route, resolved via DataLoader.
+  """
+  sessionV2: SessionV2
 
   """The revision associated with the route."""
   revision: ModelRevision
@@ -14888,6 +14961,12 @@ type RouteHistory implements Node
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The route this history record belongs to."""
+  route: Route
+
+  """Added in UNRELEASED. The deployment this history record belongs to."""
+  deployment: ModelDeployment
 }
 
 """Added in 26.3.0. Route history connection."""
@@ -15829,6 +15908,9 @@ type SessionSchedulingHistory implements Node
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The session this history record belongs to."""
+  session: SessionV2
 }
 
 """Added in 26.3.0. Session scheduling history connection."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8349,21 +8349,6 @@ type Query {
   rgUserFairShares(scope: ResourceGroupUserScope!, filter: RGUserFairShareFilter = null, orderBy: [UserFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserFairShareConnection
 
   """
-  Added in 26.2.0. List domain usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgDomainUsageBuckets(scope: ResourceGroupDomainScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection
-
-  """
-  Added in 26.2.0. List project usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgProjectUsageBuckets(scope: ResourceGroupProjectScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection
-
-  """
-  Added in 26.2.0. List user usage buckets within resource group scope. This API is not yet implemented.
-  """
-  rgUserUsageBuckets(scope: ResourceGroupUserScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection
-
-  """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
   containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1153,6 +1153,11 @@ type AutoScalingRule implements Node {
   prometheusQueryPresetId: ID
   createdAt: DateTime!
   lastTriggeredAt: DateTime
+
+  """
+  Added in UNRELEASED. The Prometheus query preset used for metric-based auto-scaling.
+  """
+  queryPreset: QueryDefinition
 }
 
 """Added in 25.19.0. Connection for auto-scaling rules."""
@@ -2969,6 +2974,9 @@ type DeploymentHistory implements Node {
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The deployment this history record belongs to."""
+  deployment: ModelDeployment
 }
 
 """Added in 26.3.0. Deployment history connection."""
@@ -3097,6 +3105,9 @@ type DeploymentRevisionPreset implements Node {
 
   """Timestamp of the last modification to this deployment preset."""
   updatedAt: DateTime
+
+  """Added in UNRELEASED. The runtime variant this preset is designed for."""
+  runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
@@ -4793,6 +4804,9 @@ type KeyPairGQL implements Node {
 
   """UUID of the user who owns this keypair."""
   userId: UUID!
+
+  """Added in UNRELEASED. The user who owns this keypair."""
+  user: UserV2
 }
 
 """An edge in a connection."""
@@ -5110,6 +5124,12 @@ type LoginHistoryV2 implements Node {
 
   """Timestamp when the login attempt occurred."""
   createdAt: DateTime!
+
+  """Added in UNRELEASED. The user who attempted to log in."""
+  user: UserV2
+
+  """Added in UNRELEASED. The domain at the time of the login attempt."""
+  domain: DomainV2
 }
 
 """Added in 26.4.2. Connection type for paginated login history results."""
@@ -5201,6 +5221,9 @@ type LoginSessionV2 implements Node {
 
   """Timestamp when the session was invalidated."""
   invalidatedAt: DateTime
+
+  """Added in UNRELEASED. The user who owns this login session."""
+  user: UserV2
 }
 
 """Added in 26.4.2. Connection type for paginated login session results."""
@@ -5328,6 +5351,15 @@ type ModelCardV2 implements Node {
   The VFolder that stores this model card's files. Resolved through a DataLoader so that listing many model cards does not trigger N+1 fetches.
   """
   vfolder: VFolder
+
+  """Added in UNRELEASED. The domain this model card belongs to."""
+  domain: DomainV2
+
+  """Added in UNRELEASED. The project this model card belongs to."""
+  project: ProjectV2
+
+  """Added in UNRELEASED. The user who created this model card."""
+  creator: UserV2
 
   """
   Deployment revision presets that satisfy this model card's minimum resource requirements. Equivalent to the root `model_card_available_presets` query but scoped to this card.
@@ -5491,8 +5523,18 @@ type ModelDeployment implements Node {
   replicaState: ReplicaState!
   createdUserId: ID!
 
+  """
+  Added in UNRELEASED. The current active revision of this deployment, resolved via DataLoader.
+  """
+  currentRevision: ModelRevision
+
   """The created user of this entity."""
-  createdUser: UserNode!
+  createdUser: UserNode! @deprecated(reason: "Use created_user_v2 instead.")
+
+  """
+  Added in UNRELEASED. The user who created this deployment, resolved via DataLoader.
+  """
+  createdUserV2: UserV2
 
   """Added in 25.19.0. Deployment policy configuration."""
   deploymentPolicy: DeploymentPolicy
@@ -5534,10 +5576,20 @@ Added in 25.19.0. Contains metadata information for a model deployment including
 """
 type ModelDeploymentMetadata {
   """The project of this entity."""
-  project: GroupNode!
+  project: GroupNode! @deprecated(reason: "Use project_v2 instead.")
+
+  """
+  Added in UNRELEASED. The project this deployment belongs to, resolved via DataLoader.
+  """
+  projectV2: ProjectV2
 
   """The domain of this entity."""
-  domain: DomainNode!
+  domain: DomainNode! @deprecated(reason: "Use domain_v2 instead.")
+
+  """
+  Added in UNRELEASED. The domain this deployment belongs to, resolved via DataLoader.
+  """
+  domainV2: DomainV2
   projectId: ID!
   domainName: String!
   name: String!
@@ -5740,7 +5792,12 @@ type ModelReplica implements Node {
   """
   The session ID associated with the replica. This can be null right after replica creation.
   """
-  session: ComputeSessionNode!
+  session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
+
+  """
+  Added in UNRELEASED. The compute session running this replica, resolved via DataLoader.
+  """
+  sessionV2: SessionV2
 
   """The revision of this entity."""
   revision: ModelRevision!
@@ -5800,7 +5857,12 @@ type ModelRevision implements Node {
   createdAt: DateTime!
 
   """The image of this entity."""
-  image: ImageNode!
+  image: ImageNode! @deprecated(reason: "Use image_v2 instead.")
+
+  """
+  Added in UNRELEASED. The container image used by this revision, resolved via DataLoader.
+  """
+  imageV2: ImageV2
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
@@ -9321,6 +9383,9 @@ type ResourcePresetV2 implements Node {
 
   """Resource group name. Null means global preset."""
   resourceGroupName: String
+
+  """Added in UNRELEASED. The resource group this preset belongs to."""
+  resourceGroup: ResourceGroup
 }
 
 """An edge in a connection."""
@@ -9565,6 +9630,9 @@ type RoleAssignment implements Node {
 
   """The assigned user."""
   user: UserV2
+
+  """Added in UNRELEASED. The user who granted this role assignment."""
+  grantedByUser: UserV2
 }
 
 """Added in 26.3.0. Role assignment connection."""
@@ -9754,7 +9822,12 @@ type Route implements Node {
   """
   The session associated with the route. Can be null if the route is still provisioning.
   """
-  session: ID
+  session: ID @deprecated(reason: "Use session_v2 instead.")
+
+  """
+  Added in UNRELEASED. The compute session associated with this route, resolved via DataLoader.
+  """
+  sessionV2: SessionV2
 
   """The revision associated with the route."""
   revision: ModelRevision
@@ -9816,6 +9889,12 @@ type RouteHistory implements Node {
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The route this history record belongs to."""
+  route: Route
+
+  """Added in UNRELEASED. The deployment this history record belongs to."""
+  deployment: ModelDeployment
 }
 
 """Added in 26.3.0. Route history connection."""
@@ -10461,6 +10540,9 @@ type SessionSchedulingHistory implements Node {
   attempts: Int!
   createdAt: DateTime!
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. The session this history record belongs to."""
+  session: SessionV2
 }
 
 """Added in 26.3.0. Session scheduling history connection."""

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -27,19 +27,25 @@ from ai.backend.common.dto.manager.v2.auto_scaling_rule.request import (
     UpdateAutoScalingRuleInput,
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
+    AccessTokenFilter,
     ActivateRevisionInput,
     AddRevisionGQLInputDTO,
     AddRevisionOptions,
     AdminSearchDeploymentsInput,
     AdminSearchRevisionsInput,
+    AutoScalingRuleFilter,
     BulkDeleteAccessTokensInput,
     CreateAccessTokenInput,
     CreateDeploymentInput,
     DeleteAccessTokenInput,
     DeleteDeploymentInput,
+    DeploymentFilter,
     DeploymentOrder,
+    ReplicaFilter,
     ReplicaOrder,
+    RevisionFilter,
     RevisionOrder,
+    RouteFilter,
     RouteOrder,
     SearchAccessTokensInput,
     SearchAutoScalingRulesInput,
@@ -202,6 +208,7 @@ from ai.backend.manager.repositories.base import (
     QueryOrder,
     Updater,
     combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentMetadataUpdaterSpec,
@@ -1467,66 +1474,85 @@ class DeploymentAdapter(BaseAdapter):
     # Querier builders
     # ------------------------------------------------------------------
 
+    def _convert_deployment_filter(self, f: DeploymentFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.name is not None:
+            condition = self.convert_string_filter(
+                f.name,
+                contains_factory=DeploymentConditions.by_name_contains,
+                equals_factory=DeploymentConditions.by_name_equals,
+                starts_with_factory=DeploymentConditions.by_name_starts_with,
+                ends_with_factory=DeploymentConditions.by_name_ends_with,
+                in_factory=DeploymentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.status is not None:
+            if f.status.equals is not None:
+                lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.equals))
+                if lifecycles:
+                    conditions.append(DeploymentConditions.by_status_in(lifecycles))
+            if f.status.in_ is not None:
+                lifecycles = _statuses_to_lifecycles([
+                    ModelDeploymentStatus(s) for s in f.status.in_
+                ])
+                if lifecycles:
+                    conditions.append(DeploymentConditions.by_status_in(lifecycles))
+            if f.status.not_equals is not None:
+                lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.not_equals))
+                if lifecycles:
+                    conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
+            if f.status.not_in is not None:
+                lifecycles = _statuses_to_lifecycles([
+                    ModelDeploymentStatus(s) for s in f.status.not_in
+                ])
+                if lifecycles:
+                    conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
+        if f.open_to_public is not None:
+            conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
+        if f.tags is not None:
+            condition = self.convert_string_filter(
+                f.tags,
+                contains_factory=DeploymentConditions.by_tag_contains,
+                equals_factory=DeploymentConditions.by_tag_equals,
+                starts_with_factory=DeploymentConditions.by_tag_starts_with,
+                ends_with_factory=DeploymentConditions.by_tag_ends_with,
+                in_factory=DeploymentConditions.by_tag_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.endpoint_url is not None:
+            condition = self.convert_string_filter(
+                f.endpoint_url,
+                contains_factory=DeploymentConditions.by_url_contains,
+                equals_factory=DeploymentConditions.by_url_equals,
+                starts_with_factory=DeploymentConditions.by_url_starts_with,
+                ends_with_factory=DeploymentConditions.by_url_ends_with,
+                in_factory=DeploymentConditions.by_url_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_deployment_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_deployment_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_deployment_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_deployment_querier(self, input: AdminSearchDeploymentsInput) -> BatchQuerier:
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.status is not None:
-                if f.status.equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.in_ is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.in_
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.not_equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.not_equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-                if f.status.not_in is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.not_in
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
-            if f.tags is not None:
-                condition = self.convert_string_filter(
-                    f.tags,
-                    contains_factory=DeploymentConditions.by_tag_contains,
-                    equals_factory=DeploymentConditions.by_tag_equals,
-                    starts_with_factory=DeploymentConditions.by_tag_starts_with,
-                    ends_with_factory=DeploymentConditions.by_tag_ends_with,
-                    in_factory=DeploymentConditions.by_tag_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.endpoint_url is not None:
-                condition = self.convert_string_filter(
-                    f.endpoint_url,
-                    contains_factory=DeploymentConditions.by_url_contains,
-                    equals_factory=DeploymentConditions.by_url_equals,
-                    starts_with_factory=DeploymentConditions.by_url_starts_with,
-                    ends_with_factory=DeploymentConditions.by_url_ends_with,
-                    in_factory=DeploymentConditions.by_url_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -1542,6 +1568,36 @@ class DeploymentAdapter(BaseAdapter):
             offset=input.offset,
         )
 
+    def _convert_revision_filter(self, f: RevisionFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.name is not None:
+            condition = self.convert_string_filter(
+                f.name,
+                contains_factory=RevisionConditions.by_name_contains,
+                equals_factory=RevisionConditions.by_name_equals,
+                starts_with_factory=RevisionConditions.by_name_starts_with,
+                ends_with_factory=RevisionConditions.by_name_ends_with,
+                in_factory=RevisionConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_revision_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_revision_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_revision_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_revision_querier(
         self,
         input: AdminSearchRevisionsInput,
@@ -1554,17 +1610,7 @@ class DeploymentAdapter(BaseAdapter):
             f = input.filter
             if scope is None and f.deployment_id is not None:
                 conditions.append(RevisionConditions.by_deployment_id(f.deployment_id))
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=RevisionConditions.by_name_contains,
-                    equals_factory=RevisionConditions.by_name_equals,
-                    starts_with_factory=RevisionConditions.by_name_starts_with,
-                    ends_with_factory=RevisionConditions.by_name_ends_with,
-                    in_factory=RevisionConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_revision_filter(f))
         orders: list[QueryOrder] = self._convert_revision_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
@@ -1578,6 +1624,41 @@ class DeploymentAdapter(BaseAdapter):
             offset=input.offset,
         )
 
+    def _convert_route_filter(self, f: RouteFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.status is not None:
+            conditions.append(
+                RouteConditions.by_statuses([ManagerRouteStatus(s.value) for s in f.status])
+            )
+        if f.health_status is not None:
+            conditions.append(
+                RouteConditions.by_health_statuses([
+                    ManagerRouteHealthStatus(s.value) for s in f.health_status
+                ])
+            )
+        if f.traffic_status is not None:
+            conditions.append(
+                RouteConditions.by_traffic_statuses([
+                    ManagerRouteTrafficStatus(s.value) for s in f.traffic_status
+                ])
+            )
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_route_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_route_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_route_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_route_querier(
         self,
         input: SearchRoutesInput,
@@ -1590,22 +1671,7 @@ class DeploymentAdapter(BaseAdapter):
             f = input.filter
             if scope is None and f.deployment_id is not None:
                 conditions.append(RouteConditions.by_endpoint_id(f.deployment_id))
-            if f.status is not None:
-                conditions.append(
-                    RouteConditions.by_statuses([ManagerRouteStatus(s.value) for s in f.status])
-                )
-            if f.health_status is not None:
-                conditions.append(
-                    RouteConditions.by_health_statuses([
-                        ManagerRouteHealthStatus(s.value) for s in f.health_status
-                    ])
-                )
-            if f.traffic_status is not None:
-                conditions.append(
-                    RouteConditions.by_traffic_statuses([
-                        ManagerRouteTrafficStatus(s.value) for s in f.traffic_status
-                    ])
-                )
+            conditions.extend(self._convert_route_filter(f))
         orders: list[QueryOrder] = self._convert_route_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
@@ -1619,6 +1685,52 @@ class DeploymentAdapter(BaseAdapter):
             offset=input.offset,
         )
 
+    def _convert_access_token_filter(self, f: AccessTokenFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.token is not None:
+            condition = self.convert_string_filter(
+                f.token,
+                contains_factory=AccessTokenConditions.by_token_contains,
+                equals_factory=AccessTokenConditions.by_token_equals,
+                starts_with_factory=AccessTokenConditions.by_token_starts_with,
+                ends_with_factory=AccessTokenConditions.by_token_ends_with,
+                in_factory=AccessTokenConditions.by_token_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.expires_at is not None:
+            condition = f.expires_at.build_query_condition(
+                before_factory=AccessTokenConditions.by_expires_at_before,
+                after_factory=AccessTokenConditions.by_expires_at_after,
+                equals_factory=AccessTokenConditions.by_expires_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.created_at is not None:
+            condition = f.created_at.build_query_condition(
+                before_factory=AccessTokenConditions.by_created_at_before,
+                after_factory=AccessTokenConditions.by_created_at_after,
+                equals_factory=AccessTokenConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_access_token_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_access_token_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_access_token_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_access_token_querier(
         self,
         input: SearchAccessTokensInput,
@@ -1630,34 +1742,7 @@ class DeploymentAdapter(BaseAdapter):
         elif input.filter and input.filter.deployment_id is not None:
             conditions.append(AccessTokenConditions.by_endpoint_id(input.filter.deployment_id))
         if input.filter:
-            f = input.filter
-            if f.token is not None:
-                condition = self.convert_string_filter(
-                    f.token,
-                    contains_factory=AccessTokenConditions.by_token_contains,
-                    equals_factory=AccessTokenConditions.by_token_equals,
-                    starts_with_factory=AccessTokenConditions.by_token_starts_with,
-                    ends_with_factory=AccessTokenConditions.by_token_ends_with,
-                    in_factory=AccessTokenConditions.by_token_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.expires_at is not None:
-                condition = f.expires_at.build_query_condition(
-                    before_factory=AccessTokenConditions.by_expires_at_before,
-                    after_factory=AccessTokenConditions.by_expires_at_after,
-                    equals_factory=AccessTokenConditions.by_expires_at_equals,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.created_at is not None:
-                condition = f.created_at.build_query_condition(
-                    before_factory=AccessTokenConditions.by_created_at_before,
-                    after_factory=AccessTokenConditions.by_created_at_after,
-                    equals_factory=AccessTokenConditions.by_created_at_equals,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_access_token_filter(input.filter))
         orders: list[QueryOrder] = (
             [
                 AccessTokenOrders.created_at(ascending=o.direction == OrderDirection.ASC)
@@ -1678,6 +1763,43 @@ class DeploymentAdapter(BaseAdapter):
             offset=input.offset,
         )
 
+    def _convert_auto_scaling_rule_filter(self, f: AutoScalingRuleFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.created_at is not None:
+            condition = f.created_at.build_query_condition(
+                before_factory=AutoScalingRuleConditions.by_created_at_before,
+                after_factory=AutoScalingRuleConditions.by_created_at_after,
+                equals_factory=AutoScalingRuleConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.last_triggered_at is not None:
+            condition = f.last_triggered_at.build_query_condition(
+                before_factory=AutoScalingRuleConditions.by_last_triggered_at_before,
+                after_factory=AutoScalingRuleConditions.by_last_triggered_at_after,
+                equals_factory=AutoScalingRuleConditions.by_last_triggered_at_equals,
+                is_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_null,
+                is_not_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_not_null,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_auto_scaling_rule_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_auto_scaling_rule_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_auto_scaling_rule_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_auto_scaling_rule_querier(
         self,
         input: SearchAutoScalingRulesInput,
@@ -1691,25 +1813,7 @@ class DeploymentAdapter(BaseAdapter):
                 AutoScalingRuleConditions.by_deployment_id(input.filter.deployment_id)
             )
         if input.filter:
-            f = input.filter
-            if f.created_at is not None:
-                condition = f.created_at.build_query_condition(
-                    before_factory=AutoScalingRuleConditions.by_created_at_before,
-                    after_factory=AutoScalingRuleConditions.by_created_at_after,
-                    equals_factory=AutoScalingRuleConditions.by_created_at_equals,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.last_triggered_at is not None:
-                condition = f.last_triggered_at.build_query_condition(
-                    before_factory=AutoScalingRuleConditions.by_last_triggered_at_before,
-                    after_factory=AutoScalingRuleConditions.by_last_triggered_at_after,
-                    equals_factory=AutoScalingRuleConditions.by_last_triggered_at_equals,
-                    is_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_null,
-                    is_not_null_factory=AutoScalingRuleConditions.by_last_triggered_at_is_not_null,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_auto_scaling_rule_filter(input.filter))
         orders: list[QueryOrder] = (
             [
                 AutoScalingRuleOrders.created_at(ascending=o.direction == OrderDirection.ASC)
@@ -1744,6 +1848,71 @@ class DeploymentAdapter(BaseAdapter):
             offset=input.offset,
         )
 
+    def _convert_replica_filter(self, f: ReplicaFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.status is not None:
+            st = f.status
+            if st.equals is not None:
+                conditions.append(
+                    RouteConditions.by_status_equals(ManagerRouteStatus(st.equals.value))
+                )
+            if st.in_ is not None:
+                conditions.append(
+                    RouteConditions.by_statuses([ManagerRouteStatus(s.value) for s in st.in_])
+                )
+            if st.not_equals is not None:
+                conditions.append(
+                    RouteConditions.by_status_not_equals(ManagerRouteStatus(st.not_equals.value))
+                )
+            if st.not_in is not None:
+                conditions.append(
+                    RouteConditions.by_status_not_in([
+                        ManagerRouteStatus(s.value) for s in st.not_in
+                    ])
+                )
+        if f.traffic_status is not None:
+            ts = f.traffic_status
+            if ts.equals is not None:
+                conditions.append(
+                    RouteConditions.by_traffic_status_equals(
+                        ManagerRouteTrafficStatus(ts.equals.value)
+                    )
+                )
+            if ts.in_ is not None:
+                conditions.append(
+                    RouteConditions.by_traffic_statuses([
+                        ManagerRouteTrafficStatus(s.value) for s in ts.in_
+                    ])
+                )
+            if ts.not_equals is not None:
+                conditions.append(
+                    RouteConditions.by_traffic_status_not_equals(
+                        ManagerRouteTrafficStatus(ts.not_equals.value)
+                    )
+                )
+            if ts.not_in is not None:
+                conditions.append(
+                    RouteConditions.by_traffic_status_not_in([
+                        ManagerRouteTrafficStatus(s.value) for s in ts.not_in
+                    ])
+                )
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_replica_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_replica_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_replica_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
     def _build_replica_querier(
         self,
         input: SearchReplicasInput,
@@ -1756,54 +1925,7 @@ class DeploymentAdapter(BaseAdapter):
             f = input.filter
             if scope is None and f.deployment_id is not None:
                 conditions.append(RouteConditions.by_endpoint_id(f.deployment_id))
-            if f.status is not None:
-                st = f.status
-                if st.equals is not None:
-                    conditions.append(
-                        RouteConditions.by_status_equals(ManagerRouteStatus(st.equals.value))
-                    )
-                if st.in_ is not None:
-                    conditions.append(
-                        RouteConditions.by_statuses([ManagerRouteStatus(s.value) for s in st.in_])
-                    )
-                if st.not_equals is not None:
-                    conditions.append(
-                        RouteConditions.by_status_not_equals(
-                            ManagerRouteStatus(st.not_equals.value)
-                        )
-                    )
-                if st.not_in is not None:
-                    conditions.append(
-                        RouteConditions.by_status_not_in([
-                            ManagerRouteStatus(s.value) for s in st.not_in
-                        ])
-                    )
-            if f.traffic_status is not None:
-                ts = f.traffic_status
-                if ts.equals is not None:
-                    conditions.append(
-                        RouteConditions.by_traffic_status_equals(
-                            ManagerRouteTrafficStatus(ts.equals.value)
-                        )
-                    )
-                if ts.in_ is not None:
-                    conditions.append(
-                        RouteConditions.by_traffic_statuses([
-                            ManagerRouteTrafficStatus(s.value) for s in ts.in_
-                        ])
-                    )
-                if ts.not_equals is not None:
-                    conditions.append(
-                        RouteConditions.by_traffic_status_not_equals(
-                            ManagerRouteTrafficStatus(ts.not_equals.value)
-                        )
-                    )
-                if ts.not_in is not None:
-                    conditions.append(
-                        RouteConditions.by_traffic_status_not_in([
-                            ManagerRouteTrafficStatus(s.value) for s in ts.not_in
-                        ])
-                    )
+            conditions.extend(self._convert_replica_filter(f))
         orders: list[QueryOrder] = self._convert_replica_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
@@ -1875,6 +1997,12 @@ class DeploymentAdapter(BaseAdapter):
                 or_conds.extend(self._convert_allocated_slot_filter(sub, conditions_cls))
             if or_conds:
                 conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_allocated_slot_filter(sub, conditions_cls))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     # ------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
 from ai.backend.common.api_handlers import Sentinel
@@ -46,6 +47,7 @@ from ai.backend.manager.models.prometheus_query_preset.orders import PrometheusQ
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    OffsetPagination,
     QueryCondition,
     QueryOrder,
     Updater,
@@ -72,6 +74,21 @@ from .pagination import PaginationSpec
 
 class PrometheusQueryPresetAdapter(BaseAdapter):
     """Adapter for prometheus query preset domain operations."""
+
+    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[QueryDefinitionNode | None]:
+        if not ids:
+            return []
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=len(ids)),
+            conditions=[PrometheusQueryPresetConditions.by_ids(ids)],
+        )
+        action_result = (
+            await self._processors.prometheus_query_preset.search_presets.wait_for_complete(
+                SearchPresetsAction(querier=querier)
+            )
+        )
+        preset_map = {item.id: self._data_to_dto(item) for item in action_result.items}
+        return [preset_map.get(preset_id) for preset_id in ids]
 
     async def create(self, input: CreateQueryDefinitionInput) -> CreateQueryDefinitionPayload:
         """Create a new prometheus query definition."""

--- a/src/ai/backend/manager/api/adapters/runtime_variant.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.runtime_variant.request import (
@@ -25,7 +26,13 @@ from ai.backend.manager.errors.resource import RuntimeVariantNotFound
 from ai.backend.manager.models.runtime_variant.conditions import RuntimeVariantConditions
 from ai.backend.manager.models.runtime_variant.orders import RuntimeVariantOrders
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder, combine_conditions_or
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    OffsetPagination,
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.runtime_variant.creators import RuntimeVariantCreatorSpec
@@ -50,6 +57,19 @@ def _runtime_variant_pagination_spec() -> PaginationSpec:
 
 
 class RuntimeVariantAdapter(BaseAdapter):
+    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[RuntimeVariantNode | None]:
+        if not ids:
+            return []
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=len(ids)),
+            conditions=[RuntimeVariantConditions.by_ids(ids)],
+        )
+        result = await self._processors.runtime_variant.search.wait_for_complete(
+            SearchRuntimeVariantsAction(querier=querier)
+        )
+        variant_map = {item.id: self._data_to_node(item) for item in result.items}
+        return [variant_map.get(variant_id) for variant_id in ids]
+
     async def search(
         self,
         input: SearchRuntimeVariantsInput,

--- a/src/ai/backend/manager/api/adapters/runtime_variant.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant.py
@@ -32,6 +32,7 @@ from ai.backend.manager.repositories.base import (
     QueryCondition,
     QueryOrder,
     combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
@@ -187,6 +188,12 @@ class RuntimeVariantAdapter(BaseAdapter):
                 or_conds.extend(self._convert_filter(sub))
             if or_conds:
                 conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     def _convert_orders(self, orders: list[RuntimeVariantOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/adapters/runtime_variant_preset.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant_preset.py
@@ -39,7 +39,12 @@ from ai.backend.manager.models.runtime_variant_preset.conditions import (
 )
 from ai.backend.manager.models.runtime_variant_preset.orders import RuntimeVariantPresetOrders
 from ai.backend.manager.models.runtime_variant_preset.row import RuntimeVariantPresetRow
-from ai.backend.manager.repositories.base import QueryCondition, QueryOrder, combine_conditions_or
+from ai.backend.manager.repositories.base import (
+    QueryCondition,
+    QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
+)
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.runtime_variant_preset.creators import (
@@ -264,6 +269,12 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
                 or_conds.extend(self._convert_filter(sub))
             if or_conds:
                 conditions.append(combine_conditions_or(or_conds))
+        if filter_.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter_.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     def _convert_orders(self, orders: list[RuntimeVariantPresetOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/adapters/service_catalog.py
+++ b/src/ai/backend/manager/api/adapters/service_catalog.py
@@ -30,6 +30,8 @@ from ai.backend.manager.repositories.base import (
     OffsetPagination,
     QueryCondition,
     QueryOrder,
+    combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.services.service_catalog.actions.search import (
     SearchServiceCatalogsAction,
@@ -87,6 +89,21 @@ class ServiceCatalogAdapter(BaseAdapter):
                 conditions.append(condition)
         if filter.status is not None:
             conditions.extend(self._convert_status_filter(filter.status))
+        if filter.AND:
+            for sub in filter.AND:
+                conditions.extend(self._convert_filter(sub))
+        if filter.OR:
+            or_conds: list[QueryCondition] = []
+            for sub in filter.OR:
+                or_conds.extend(self._convert_filter(sub))
+            if or_conds:
+                conditions.append(combine_conditions_or(or_conds))
+        if filter.NOT:
+            not_conds: list[QueryCondition] = []
+            for sub in filter.NOT:
+                not_conds.extend(self._convert_filter(sub))
+            if not_conds:
+                conditions.append(negate_conditions(not_conds))
         return conditions
 
     def _convert_string_filter(self, sf: StringFilter) -> QueryCondition | None:

--- a/src/ai/backend/manager/api/adapters/user.py
+++ b/src/ai/backend/manager/api/adapters/user.py
@@ -1281,6 +1281,37 @@ class UserAdapter(BaseAdapter):
                     ])
                 )
 
+        if filter_req.created_at is not None:
+            condition = filter_req.created_at.build_query_condition(
+                before_factory=UserConditions.by_created_at_before,
+                after_factory=UserConditions.by_created_at_after,
+                equals_factory=UserConditions.by_created_at_equals,
+            )
+            if condition is not None:
+                conditions.append(condition)
+
+        if filter_req.domain is not None:
+            conditions.extend(self._convert_domain_nested_filter(filter_req.domain))
+
+        if filter_req.project is not None:
+            conditions.extend(self._convert_project_nested_filter(filter_req.project))
+
+        if filter_req.AND:
+            for sub_filter in filter_req.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+        if filter_req.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in filter_req.OR:
+                or_sub_conditions.extend(self._convert_filter(sub_filter))
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+        if filter_req.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in filter_req.NOT:
+                not_sub_conditions.extend(self._convert_filter(sub_filter))
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
+
         return conditions
 
     def _convert_orders(self, orders: list[UserOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -59,6 +59,9 @@ if TYPE_CHECKING:
     from ai.backend.manager.api.gql.project_v2.types.node import (  # pants: no-infer-dep
         ProjectV2GQL,
     )
+    from ai.backend.manager.api.gql.prometheus_query_preset.types.node import (  # pants: no-infer-dep
+        QueryDefinitionGQL,
+    )
     from ai.backend.manager.api.gql.rbac.types.entity import EntityRefGQL  # pants: no-infer-dep
     from ai.backend.manager.api.gql.rbac.types.permission import (  # pants: no-infer-dep
         PermissionGQL,
@@ -72,6 +75,9 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.api.gql.resource_group.types import (  # pants: no-infer-dep
         ResourceGroupGQL,
+    )
+    from ai.backend.manager.api.gql.runtime_variant.types import (  # pants: no-infer-dep
+        RuntimeVariantGQL,
     )
     from ai.backend.manager.api.gql.scheduling_history.types import (  # pants: no-infer-dep
         DeploymentHistory,
@@ -765,5 +771,37 @@ class DataLoaders:
             return [
                 [RAG.from_pydantic(dto) for dto in role_assignments] for role_assignments in dtos
             ]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def runtime_variant_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, RuntimeVariantGQL | None]:
+        adapter = self._adapters.runtime_variant
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[RuntimeVariantGQL | None]:
+            from ai.backend.manager.api.gql.runtime_variant.types import (  # pants: no-infer-dep
+                RuntimeVariantGQL as RV,
+            )
+
+            dtos = await adapter.batch_load_by_ids(ids)
+            return [RV.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def query_definition_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, QueryDefinitionGQL | None]:
+        adapter = self._adapters.prometheus_query_preset
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[QueryDefinitionGQL | None]:
+            from ai.backend.manager.api.gql.prometheus_query_preset.types.node import (  # pants: no-infer-dep
+                QueryDefinitionGQL as QD,
+            )
+
+            dtos = await adapter.batch_load_by_ids(ids)
+            return [QD.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/auto_scaling.py
@@ -6,9 +6,10 @@ from collections.abc import Iterable
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 from uuid import UUID
 
+import strawberry
 from strawberry import ID, UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID
 
@@ -42,6 +43,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     AutoScalingRuleOrderField,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, NullableDateTimeFilter, OrderDirection
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -56,6 +58,9 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.prometheus_query_preset.types.node import QueryDefinitionGQL
 
 
 @gql_enum(
@@ -125,6 +130,28 @@ class AutoScalingRule(PydanticNodeMixin[AutoScalingRuleNodeDTO]):
 
     created_at: datetime
     last_triggered_at: datetime | None
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The Prometheus query preset used for metric-based auto-scaling.",
+        )
+    )  # type: ignore[misc]
+    async def query_preset(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            QueryDefinitionGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.prometheus_query_preset.types.node"),
+        ]
+        | None
+    ):
+        if self.prometheus_query_preset_id is None:
+            return None
+        return await info.context.data_loaders.query_definition_loader.load(
+            UUID(str(self.prometheus_query_preset_id))
+        )
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 from uuid import UUID
 
 import strawberry
@@ -78,6 +78,7 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ProjectDeploymentScope as ProjectDeploymentScopeDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     StringFilter,
@@ -145,6 +146,11 @@ from ai.backend.manager.data.deployment.types import (
     RevisionSearchScope,
 )
 
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+    from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
+
 DeploymentStatusGQL: type[ModelDeploymentStatus] = gql_enum(
     BackendAIGQLMeta(
         added_version="25.19.0",
@@ -193,19 +199,59 @@ class ModelDeploymentMetadata:
     created_at: datetime
     updated_at: datetime
 
-    @gql_field(description="The project of this entity.")  # type: ignore[misc]
+    @gql_field(
+        description="The project of this entity.",
+        deprecation_reason="Use project_v2 instead.",
+    )  # type: ignore[misc]
     async def project(self, info: Info[StrawberryGQLContext]) -> Project:
         project_global_id = to_global_id(
             GroupNode, UUID(str(self.project_id)), is_target_graphene_object=True
         )
         return Project(id=ID(project_global_id))
 
-    @gql_field(description="The domain of this entity.")  # type: ignore[misc]
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The project this deployment belongs to, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def project_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            ProjectV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.project_loader.load(UUID(str(self.project_id)))
+
+    @gql_field(
+        description="The domain of this entity.",
+        deprecation_reason="Use domain_v2 instead.",
+    )  # type: ignore[misc]
     async def domain(self, info: Info[StrawberryGQLContext]) -> Domain:
         domain_global_id = to_global_id(
             DomainNode, self.domain_name, is_target_graphene_object=True
         )
         return Domain(id=ID(domain_global_id))
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The domain this deployment belongs to, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def domain_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.domain_loader.load(self.domain_name)
 
 
 @gql_pydantic_type(
@@ -237,12 +283,45 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
     replica_state: ReplicaState
     created_user_id: ID
 
-    @gql_field(description="The created user of this entity.")  # type: ignore[misc]
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The current active revision of this deployment, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def current_revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision | None:
+        if self.current_revision_id is None:
+            return None
+        return await info.context.data_loaders.revision_loader.load(
+            UUID(str(self.current_revision_id))
+        )
+
+    @gql_field(
+        description="The created user of this entity.",
+        deprecation_reason="Use created_user_v2 instead.",
+    )  # type: ignore[misc]
     async def created_user(self, info: Info[StrawberryGQLContext]) -> User:
         user_global_id = to_global_id(
             UserNode, UUID(str(self.created_user_id)), is_target_graphene_object=True
         )
         return User(id=strawberry.ID(user_global_id))
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who created this deployment, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def created_user_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(UUID(str(self.created_user_id)))
 
     @gql_added_field(
         BackendAIGQLMeta(added_version="25.19.0", description="Deployment policy configuration.")

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast
 from uuid import UUID
 
+import strawberry
 from strawberry import ID, Info
 from strawberry.relay import Connection, Edge, NodeID
 
@@ -34,6 +35,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ReplicaOrderField,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     to_global_id,
@@ -41,6 +43,7 @@ from ai.backend.manager.api.gql.base import (
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -58,6 +61,9 @@ from ai.backend.manager.data.deployment.types import (
 )
 
 from .revision import ModelRevision
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.session.types import SessionV2GQL
 
 # ========== Enums ==========
 
@@ -188,7 +194,8 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
     created_at: datetime = gql_field(description="Timestamp when the replica was created.")
 
     @gql_field(
-        description="The session ID associated with the replica. This can be null right after replica creation."
+        description="The session ID associated with the replica. This can be null right after replica creation.",
+        deprecation_reason="Use session_v2 instead.",
     )  # type: ignore[misc]
     async def session(self, info: Info[StrawberryGQLContext]) -> Session:
         session_global_id = to_global_id(
@@ -196,11 +203,34 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
         )
         return Session(id=ID(session_global_id))
 
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The compute session running this replica, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def session_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            SessionV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.session.types"),
+        ]
+        | None
+    ):
+        from ai.backend.common.types import SessionId
+
+        return await info.context.data_loaders.session_loader.load(
+            SessionId(UUID(str(self.session_id)))
+        )
+
     @gql_field(description="The revision of this entity.")  # type: ignore[misc]
     async def revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision:
-        """Resolve revision by ID."""
-        node = await info.context.adapters.deployment.get_revision(UUID(str(self.revision_id)))
-        return ModelRevision.from_pydantic(node)
+        """Resolve revision by ID using DataLoader."""
+        result = await info.context.data_loaders.revision_loader.load(UUID(str(self.revision_id)))
+        if result is None:
+            raise ValueError(f"Revision not found: {self.revision_id}")
+        return result
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def

--- a/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
@@ -31,6 +31,7 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.errors.api import UnsupportedOperation
 
 
 @gql_node_type(
@@ -55,8 +56,9 @@ class AllocatedResourceSlotNodeGQL(PydanticNodeMixin[AllocatedResourceSlotNodeDT
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[Self | None]:
-        raise NotImplementedError(
-            "AllocatedResourceSlotNodeGQL is not a root-level entity and does not support resolve_nodes."
+        raise UnsupportedOperation(
+            "AllocatedResourceSlotNodeGQL does not support root-level node resolution. "
+            "Access resource slots through the parent revision or preset."
         )
 
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -101,6 +101,7 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
     PreStartActionInfoDTO,
     ResourceConfigInfoDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import MountPermission as CommonMountPermission
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
@@ -142,6 +143,8 @@ from .resource_slot import (
 )
 
 if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.image.types import ImageV2GQL
+
     from .deployment import ModelDeployment
     from .policy import DeploymentPolicyGQL
 
@@ -439,12 +442,34 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     )
     created_at: datetime = gql_field(description="Timestamp when the revision was created.")
 
-    @gql_field(description="The image of this entity.")  # type: ignore[misc]
+    @gql_field(
+        description="The image of this entity.",
+        deprecation_reason="Use image_v2 instead.",
+    )  # type: ignore[misc]
     async def image(self, info: Info[StrawberryGQLContext]) -> Image:
         image_global_id = to_global_id(
             ImageNode, UUID(str(self.image_id)), is_target_graphene_object=True
         )
         return Image(id=ID(image_global_id))
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The container image used by this revision, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def image_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            ImageV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.image.types"),
+        ]
+        | None
+    ):
+        from ai.backend.common.types import ImageID
+
+        return await info.context.data_loaders.image_loader.load(ImageID(UUID(str(self.image_id))))
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
+import strawberry
 from strawberry import UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID, PageInfo
 from strawberry.scalars import JSON
@@ -56,6 +58,7 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     UpdateDeploymentRevisionPresetPayload as UpdatePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.common.types import ResourceOptsEntryGQL as ResourceOptsEntryInfoGQL
 from ai.backend.manager.api.gql.decorators import (
@@ -88,6 +91,9 @@ from ai.backend.manager.api.gql.deployment.types.revision import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.runtime_variant.types import RuntimeVariantGQL
 
 
 @gql_enum(
@@ -270,6 +276,24 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
     updated_at: datetime | None = gql_field(
         description="Timestamp of the last modification to this deployment preset."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The runtime variant this preset is designed for.",
+        )
+    )  # type: ignore[misc]
+    async def runtime_variant(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            RuntimeVariantGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.runtime_variant.types"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.runtime_variant_loader.load(self.runtime_variant_id)
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/deployment/types/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/route.py
@@ -29,6 +29,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     UpdateRouteTrafficStatusPayload as UpdateRouteTrafficStatusPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.adapter import PaginationSpec
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
@@ -37,6 +38,7 @@ from ai.backend.manager.api.gql.base import (
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -64,6 +66,7 @@ from ai.backend.manager.models.routing.row import RoutingRow
 if TYPE_CHECKING:
     from ai.backend.manager.api.gql.deployment.types.deployment import ModelDeployment
     from ai.backend.manager.api.gql.deployment.types.revision import ModelRevision
+    from ai.backend.manager.api.gql.session.types import SessionV2GQL
 
 
 RouteStatusGQL: type[RouteStatusEnum] = gql_enum(
@@ -128,7 +131,8 @@ class Route(PydanticNodeMixin[RouteNodeDTO]):
         return deployment_data
 
     @gql_field(
-        description="The session associated with the route. Can be null if the route is still provisioning."
+        description="The session associated with the route. Can be null if the route is still provisioning.",
+        deprecation_reason="Use session_v2 instead.",
     )  # type: ignore[misc]
     async def session(self, info: Info[StrawberryGQLContext]) -> ID | None:
         """Return session global ID if available."""
@@ -138,6 +142,29 @@ class Route(PydanticNodeMixin[RouteNodeDTO]):
             ComputeSessionNode, UUID(str(self.session_id)), is_target_graphene_object=True
         )
         return ID(session_global_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The compute session associated with this route, resolved via DataLoader.",
+        )
+    )  # type: ignore[misc]
+    async def session_v2(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            SessionV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.session.types"),
+        ]
+        | None
+    ):
+        if self.session_id is None:
+            return None
+        from ai.backend.common.types import SessionId
+
+        return await info.context.data_loaders.session_loader.load(
+            SessionId(UUID(str(self.session_id)))
+        )
 
     @gql_field(description="The revision associated with the route.")  # type: ignore[misc]
     async def revision(

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -383,6 +383,7 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
     )  # type: ignore[misc]
     async def session(
         self,
+        info: Info[StrawberryGQLContext],
     ) -> (
         Annotated[
             SessionV2GQL,
@@ -390,7 +391,11 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         ]
         | None
     ):
-        raise NotImplementedError
+        from ai.backend.common.types import SessionId
+
+        return await info.context.data_loaders.session_loader.load(
+            SessionId(self.session_info.session_id)
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/keypair/types/node.py
+++ b/src/ai/backend/manager/api/gql/keypair/types/node.py
@@ -3,19 +3,27 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.keypair.response import KeypairNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_field,
     gql_node_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
 
 @gql_node_type(
@@ -52,6 +60,24 @@ class KeyPairGQL(PydanticNodeMixin[KeypairNode]):
         description="The SSH public key associated with this keypair."
     )
     user_id: UUID = gql_field(description="UUID of the user who owns this keypair.")
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who owns this keypair.",
+        )
+    )  # type: ignore[misc]
+    async def user(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(self.user_id)
 
 
 KeyPairEdge = Edge[KeyPairGQL]

--- a/src/ai/backend/manager/api/gql/login_history/types/node.py
+++ b/src/ai/backend/manager/api/gql/login_history/types/node.py
@@ -4,20 +4,29 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.login_history.response import LoginHistoryNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
     gql_node_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
 
 @gql_enum(
@@ -54,6 +63,42 @@ class LoginHistoryV2GQL(PydanticNodeMixin[LoginHistoryNode]):
     result: LoginAttemptResultGQL = gql_field(description="Result of the login attempt.")
     fail_reason: str | None = gql_field(description="Detailed reason for the login failure.")
     created_at: datetime = gql_field(description="Timestamp when the login attempt occurred.")
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who attempted to log in.",
+        )
+    )  # type: ignore[misc]
+    async def user(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(self.user_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The domain at the time of the login attempt.",
+        )
+    )  # type: ignore[misc]
+    async def domain(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.domain_loader.load(self.domain_name)
 
 
 LoginHistoryV2EdgeGQL = Edge[LoginHistoryV2GQL]

--- a/src/ai/backend/manager/api/gql/login_session/types/node.py
+++ b/src/ai/backend/manager/api/gql/login_session/types/node.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.login_session.response import LoginSessionNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
     gql_node_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
 
 @gql_enum(
@@ -50,6 +58,24 @@ class LoginSessionV2GQL(PydanticNodeMixin[LoginSessionNode]):
     invalidated_at: datetime | None = gql_field(
         description="Timestamp when the session was invalidated."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who owns this login session.",
+        )
+    )  # type: ignore[misc]
+    async def user(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(self.user_id)
 
 
 LoginSessionV2EdgeGQL = Edge[LoginSessionV2GQL]

--- a/src/ai/backend/manager/api/gql/model_card/types.py
+++ b/src/ai/backend/manager/api/gql/model_card/types.py
@@ -69,10 +69,12 @@ from ai.backend.common.dto.manager.v2.model_card.types import (
 from ai.backend.common.dto.manager.v2.model_card.types import (
     ProjectModelCardScope as ProjectModelCardScopeDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -91,6 +93,9 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, Pydant
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+    from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
     from ai.backend.manager.api.gql.vfolder_v2.types.node import VFolderGQL
 
 
@@ -226,6 +231,60 @@ class ModelCardGQL(PydanticNodeMixin[NodeDTO]):
         | None
     ):
         return await info.context.data_loaders.vfolder_loader.load(self.vfolder_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The domain this model card belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def domain(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.domain_loader.load(self.domain_name)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The project this model card belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def project(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ProjectV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.project_loader.load(self.project_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who created this model card.",
+        )
+    )  # type: ignore[misc]
+    async def creator(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.user_loader.load(self.creator_id)
 
     @gql_field(  # type: ignore[misc]
         description="Deployment revision presets that satisfy this model card's minimum resource requirements. Equivalent to the root `model_card_available_presets` query but scoped to this card."

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -88,6 +88,7 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     RoleStatusFilter as RoleStatusFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -427,6 +428,26 @@ class RoleAssignmentGQL(PydanticNodeMixin[RoleAssignmentNode]):
     ):
         # DataLoader already returns UserV2GQL | None via from_pydantic conversion
         return await info.context.data_loaders.user_loader.load(self.user_id)
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The user who granted this role assignment.",
+        )
+    )  # type: ignore[misc]
+    async def granted_by_user(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        if self.granted_by is None:
+            return None
+        return await info.context.data_loaders.user_loader.load(self.granted_by)
 
 
 # ==================== Filter Types ====================

--- a/src/ai/backend/manager/api/gql/resource_preset/types.py
+++ b/src/ai/backend/manager/api/gql/resource_preset/types.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.resource_preset.request import (
@@ -32,6 +34,7 @@ from ai.backend.common.dto.manager.v2.resource_preset.response import (
 from ai.backend.common.dto.manager.v2.resource_preset.response import (
     UpdateResourcePresetPayload as UpdateResourcePresetPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.common_types import (
     BinarySizeInfoGQL,
@@ -42,6 +45,7 @@ from ai.backend.manager.api.gql.common_types import (
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -50,6 +54,10 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
 
 __all__ = (
     "CreateResourcePresetInputGQL",
@@ -99,6 +107,26 @@ class ResourcePresetGQL(PydanticNodeMixin[ResourcePresetNode]):
     resource_group_name: str | None = gql_field(
         description="Resource group name. Null means global preset."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The resource group this preset belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def resource_group(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ResourceGroupGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.resource_group.types"),
+        ]
+        | None
+    ):
+        if self.resource_group_name is None:
+            return None
+        return await info.context.data_loaders.resource_group_loader.load(self.resource_group_name)
 
 
 # Filter and OrderBy types

--- a/src/ai/backend/manager/api/gql/resource_usage/__init__.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/__init__.py
@@ -8,9 +8,6 @@ from .resolver import (
     admin_user_usage_buckets,
     domain_usage_buckets,
     project_usage_buckets,
-    rg_domain_usage_buckets,
-    rg_project_usage_buckets,
-    rg_user_usage_buckets,
     user_usage_buckets,
 )
 from .types import (
@@ -38,10 +35,6 @@ __all__ = (
     "admin_domain_usage_buckets",
     "admin_project_usage_buckets",
     "admin_user_usage_buckets",
-    # Resource Group Scoped Resolvers
-    "rg_domain_usage_buckets",
-    "rg_project_usage_buckets",
-    "rg_user_usage_buckets",
     # Legacy Resolvers (deprecated)
     "domain_usage_buckets",
     "project_usage_buckets",

--- a/src/ai/backend/manager/api/gql/resource_usage/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/resolver/__init__.py
@@ -3,16 +3,13 @@
 from .domain_usage import (
     admin_domain_usage_buckets,
     domain_usage_buckets,
-    rg_domain_usage_buckets,
 )
 from .project_usage import (
     admin_project_usage_buckets,
     project_usage_buckets,
-    rg_project_usage_buckets,
 )
 from .user_usage import (
     admin_user_usage_buckets,
-    rg_user_usage_buckets,
     user_usage_buckets,
 )
 
@@ -21,10 +18,6 @@ __all__ = [
     "admin_domain_usage_buckets",
     "admin_project_usage_buckets",
     "admin_user_usage_buckets",
-    # Resource Group Scoped APIs
-    "rg_domain_usage_buckets",
-    "rg_project_usage_buckets",
-    "rg_user_usage_buckets",
     # Legacy APIs (deprecated)
     "domain_usage_buckets",
     "project_usage_buckets",

--- a/src/ai/backend/manager/api/gql/resource_usage/resolver/domain_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/resolver/domain_usage.py
@@ -19,7 +19,7 @@ from ai.backend.manager.api.gql.resource_usage.types import (
     DomainUsageBucketGQL,
     DomainUsageBucketOrderBy,
 )
-from ai.backend.manager.api.gql.types import ResourceGroupDomainScope, StrawberryGQLContext
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
 
 # Admin APIs
@@ -64,31 +64,6 @@ async def admin_domain_usage_buckets(
         ),
         count=payload.total_count,
     )
-
-
-# Resource Group Scoped APIs
-
-
-@gql_root_field(
-    BackendAIGQLMeta(
-        added_version="26.2.0",
-        description="List domain usage buckets within resource group scope. This API is not yet implemented.",
-    )
-)  # type: ignore[misc]
-async def rg_domain_usage_buckets(
-    info: Info[StrawberryGQLContext],
-    scope: ResourceGroupDomainScope,
-    filter: DomainUsageBucketFilter | None = None,
-    order_by: list[DomainUsageBucketOrderBy] | None = None,
-    before: str | None = None,
-    after: str | None = None,
-    first: int | None = None,
-    last: int | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
-) -> DomainUsageBucketConnection | None:
-    """Search domain usage buckets within resource group scope."""
-    raise NotImplementedError("rg_domain_usage_buckets is not yet implemented")
 
 
 # Legacy APIs (deprecated)

--- a/src/ai/backend/manager/api/gql/resource_usage/resolver/project_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/resolver/project_usage.py
@@ -19,7 +19,7 @@ from ai.backend.manager.api.gql.resource_usage.types import (
     ProjectUsageBucketGQL,
     ProjectUsageBucketOrderBy,
 )
-from ai.backend.manager.api.gql.types import ResourceGroupProjectScope, StrawberryGQLContext
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
 
 # Admin APIs
@@ -66,31 +66,6 @@ async def admin_project_usage_buckets(
         ),
         count=payload.total_count,
     )
-
-
-# Resource Group Scoped APIs
-
-
-@gql_root_field(
-    BackendAIGQLMeta(
-        added_version="26.2.0",
-        description="List project usage buckets within resource group scope. This API is not yet implemented.",
-    )
-)  # type: ignore[misc]
-async def rg_project_usage_buckets(
-    info: Info[StrawberryGQLContext],
-    scope: ResourceGroupProjectScope,
-    filter: ProjectUsageBucketFilter | None = None,
-    order_by: list[ProjectUsageBucketOrderBy] | None = None,
-    before: str | None = None,
-    after: str | None = None,
-    first: int | None = None,
-    last: int | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
-) -> ProjectUsageBucketConnection | None:
-    """Search project usage buckets within resource group scope."""
-    raise NotImplementedError("rg_project_usage_buckets is not yet implemented")
 
 
 # Legacy APIs (deprecated)

--- a/src/ai/backend/manager/api/gql/resource_usage/resolver/user_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/resolver/user_usage.py
@@ -19,7 +19,7 @@ from ai.backend.manager.api.gql.resource_usage.types import (
     UserUsageBucketGQL,
     UserUsageBucketOrderBy,
 )
-from ai.backend.manager.api.gql.types import ResourceGroupUserScope, StrawberryGQLContext
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
 
 # Admin APIs
@@ -67,28 +67,6 @@ async def admin_user_usage_buckets(
 
 
 # Resource Group Scoped APIs
-
-
-@gql_root_field(
-    BackendAIGQLMeta(
-        added_version="26.2.0",
-        description="List user usage buckets within resource group scope. This API is not yet implemented.",
-    )
-)  # type: ignore[misc]
-async def rg_user_usage_buckets(
-    info: Info[StrawberryGQLContext],
-    scope: ResourceGroupUserScope,
-    filter: UserUsageBucketFilter | None = None,
-    order_by: list[UserUsageBucketOrderBy] | None = None,
-    before: str | None = None,
-    after: str | None = None,
-    first: int | None = None,
-    last: int | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
-) -> UserUsageBucketConnection | None:
-    """Search user usage buckets within resource group scope."""
-    raise NotImplementedError("rg_user_usage_buckets is not yet implemented")
 
 
 # Legacy APIs (deprecated)

--- a/src/ai/backend/manager/api/gql/scheduling_history/types.py
+++ b/src/ai/backend/manager/api/gql/scheduling_history/types.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
-from typing import Self, cast
+from typing import TYPE_CHECKING, Annotated, Self, cast
 from uuid import UUID
 
+import strawberry
 from strawberry import ID, Info
 from strawberry.relay import NodeID
 
@@ -43,6 +44,7 @@ from ai.backend.common.dto.manager.v2.scheduling_history.types import (
     SessionHistoryScopeDTO,
     SubStepResultInfo,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     OrderDirection,
@@ -51,6 +53,7 @@ from ai.backend.manager.api.gql.base import (
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_node_type,
@@ -63,6 +66,11 @@ from ai.backend.manager.api.gql.pydantic_compat import (
     PydanticOutputMixin,
 )
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.deployment.types.deployment import ModelDeployment
+    from ai.backend.manager.api.gql.deployment.types.route import Route
+    from ai.backend.manager.api.gql.session.types import SessionV2GQL
 
 __all__ = (
     # Enums
@@ -180,6 +188,28 @@ class SessionSchedulingHistory(PydanticNodeMixin[SessionHistoryNode]):
     created_at: datetime
     updated_at: datetime
 
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The session this history record belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def session(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            SessionV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.session.types"),
+        ]
+        | None
+    ):
+        from ai.backend.common.types import SessionId
+
+        return await info.context.data_loaders.session_loader.load(
+            SessionId(UUID(str(self.session_id)))
+        )
+
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def
         cls,
@@ -209,6 +239,24 @@ class DeploymentHistory(PydanticNodeMixin[DeploymentHistoryNode]):
     attempts: int
     created_at: datetime
     updated_at: datetime
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The deployment this history record belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def deployment(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ModelDeployment,
+            strawberry.lazy("ai.backend.manager.api.gql.deployment.types.deployment"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.deployment_loader.load(UUID(str(self.deployment_id)))
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def
@@ -241,6 +289,42 @@ class RouteHistory(PydanticNodeMixin[RouteHistoryNode]):
     attempts: int
     created_at: datetime
     updated_at: datetime
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The route this history record belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def route(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            Route,
+            strawberry.lazy("ai.backend.manager.api.gql.deployment.types.route"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.route_loader.load(UUID(str(self.route_id)))
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The deployment this history record belongs to.",
+        )
+    )  # type: ignore[misc]
+    async def deployment(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> (
+        Annotated[
+            ModelDeployment,
+            strawberry.lazy("ai.backend.manager.api.gql.deployment.types.deployment"),
+        ]
+        | None
+    ):
+        return await info.context.data_loaders.deployment_loader.load(UUID(str(self.deployment_id)))
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -341,9 +341,6 @@ from .resource_usage import (
     admin_user_usage_buckets,
     domain_usage_buckets,
     project_usage_buckets,
-    rg_domain_usage_buckets,
-    rg_project_usage_buckets,
-    rg_user_usage_buckets,
     user_usage_buckets,
 )
 from .runtime_variant import (
@@ -537,9 +534,6 @@ class Query:
     rg_project_fair_shares = rg_project_fair_shares
     rg_user_fair_share = rg_user_fair_share
     rg_user_fair_shares = rg_user_fair_shares
-    rg_domain_usage_buckets = rg_domain_usage_buckets
-    rg_project_usage_buckets = rg_project_usage_buckets
-    rg_user_usage_buckets = rg_user_usage_buckets
     # Container Registry Scoped APIs
     container_registry_images_v2 = container_registry_images_v2
     # Image Scoped APIs

--- a/src/ai/backend/manager/api/gql/user/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/user/resolver/mutation.py
@@ -81,8 +81,7 @@ async def admin_create_user_v2(
     Returns:
         CreateUserPayloadGQL with the created user.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     check_admin_only()
     ctx = info.context
@@ -176,8 +175,7 @@ async def admin_update_user_v2(
     Returns:
         UpdateUserPayloadGQL with the updated user.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     check_admin_only()
     ctx = info.context
@@ -333,8 +331,7 @@ async def update_user_v2(
     Returns:
         UpdateUserPayloadGQL with the updated user.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     ctx = info.context
     me = current_user()
@@ -366,8 +363,7 @@ async def admin_delete_user_v2(
     Returns:
         DeleteUserPayloadGQL indicating success.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     check_admin_only()
     ctx = info.context
@@ -394,8 +390,7 @@ async def admin_delete_users_v2(
     Returns:
         DeleteUsersPayloadGQL with count of deleted users.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     check_admin_only()
     ctx = info.context
@@ -427,8 +422,7 @@ async def admin_purge_user_v2(
     Returns:
         PurgeUserPayloadGQL indicating success.
 
-    Raises:
-        NotImplementedError: This mutation is not yet implemented.
+
     """
     check_admin_only()
     ctx = info.context

--- a/src/ai/backend/manager/errors/api.py
+++ b/src/ai/backend/manager/errors/api.py
@@ -15,6 +15,18 @@ from ai.backend.common.exception import (
 )
 
 
+class UnsupportedOperation(BackendAIError):
+    error_type = "https://api.backend.ai/probs/unsupported-operation"
+    error_title = "This operation is not supported."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.API,
+            operation=ErrorOperation.GENERIC,
+            error_detail=ErrorDetail.NOT_IMPLEMENTED,
+        )
+
+
 class NotImplementedAPI(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/not-implemented"
     error_title = "This API is not implemented."

--- a/src/ai/backend/manager/models/runtime_variant/conditions.py
+++ b/src/ai/backend/manager/models/runtime_variant/conditions.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import uuid
+from collections.abc import Collection
+
 import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
@@ -68,6 +71,13 @@ class RuntimeVariantConditions:
         return inner
 
     by_name_in = staticmethod(make_string_in_factory(RuntimeVariantRow.name))
+
+    @staticmethod
+    def by_ids(ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            return RuntimeVariantRow.id.in_(ids)
+
+        return inner
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:


### PR DESCRIPTION
## Summary
- Add 14 lazy resolver fields for FK references across GQL Node types using existing dataloaders (domain, project, user, session, deployment, route, resource_group, etc.)
- Register 2 new dataloaders (RuntimeVariant, PrometheusQueryPreset) with batch_load_by_ids in adapters
- Deprecate 6 legacy Graphene stub resolvers and add `_v2` alternatives with dataloader-based resolution (created_user_v2, project_v2, domain_v2, image_v2, session_v2)
- Switch ModelReplica.revision from direct adapter call to dataloader (N+1 prevention)
- Implement KernelV2GQL.session resolver (was NotImplementedError)
- Remove 3 unimplemented rg_*_usage_buckets stub resolvers from schema
- Clean up misleading NotImplementedError docstrings in user mutations
- Replace NotImplementedError with UnsupportedOperation (BackendAIError) in AllocatedResourceSlotNodeGQL

## Test plan
- [x] `pants fmt/fix/lint` pass on all changed files
- [x] `pants check` pass (no new type errors)
- [x] Server restart + supergraph regeneration
- [x] GQL queries verified via `./bai gql --v2` for all new/modified resolver fields
- [x] Deprecated fields verified with `@deprecated` directive in schema
- [x] Removed rg_*_usage_buckets confirmed absent from schema introspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11120.org.readthedocs.build/en/11120/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11120.org.readthedocs.build/ko/11120/

<!-- readthedocs-preview sorna-ko end -->