### PR TITLE
feat: add image_id FK to kernels and image_ids to sessions

### DIFF
--- a/changes/11125.feature.md
+++ b/changes/11125.feature.md
@@ -1,0 +1,1 @@
+Add image_id FK to kernels and image_ids to sessions for UUID-based image references

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7256,6 +7256,11 @@ type KernelV2 implements Node
   """The Globally Unique ID of this object"""
   id: ID!
 
+  """
+  The UUID of the image used by this kernel. Null if the image has been purged.
+  """
+  imageId: ID
+
   """Startup command executed when the kernel starts."""
   startupCommand: String
 
@@ -7279,6 +7284,9 @@ type KernelV2 implements Node
 
   """Added in 26.2.0. The agent running this kernel."""
   agent: AgentV2
+
+  """Added in UNRELEASED. The image used by this kernel."""
+  image: ImageV2
 
   """Added in 26.2.0. The user who owns this kernel."""
   user: UserV2
@@ -15984,6 +15992,11 @@ type SessionV2 implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
+
+  """
+  UUIDs of the images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
+  """
+  imageIds: [ID!]
   domainName: String!
   userId: ID!
   projectId: ID!
@@ -16016,7 +16029,7 @@ type SessionV2 implements Node
   resourceGroup: ResourceGroup
 
   """
-  Added in 26.3.0. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
+  Added in UNRELEASED. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
   """
   images: ImageV2Connection!
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4533,6 +4533,11 @@ type KernelV2 implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
 
+  """
+  The UUID of the image used by this kernel. Null if the image has been purged.
+  """
+  imageId: ID
+
   """Startup command executed when the kernel starts."""
   startupCommand: String
 
@@ -4556,6 +4561,9 @@ type KernelV2 implements Node {
 
   """Added in 26.2.0. The agent running this kernel."""
   agent: AgentV2
+
+  """Added in UNRELEASED. The image used by this kernel."""
+  image: ImageV2
 
   """Added in 26.2.0. The user who owns this kernel."""
   user: UserV2
@@ -10599,6 +10607,11 @@ enum SessionTypes {
 type SessionV2 implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
+
+  """
+  UUIDs of the images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
+  """
+  imageIds: [ID!]
   domainName: String!
   userId: ID!
   projectId: ID!
@@ -10631,7 +10644,7 @@ type SessionV2 implements Node {
   resourceGroup: ResourceGroup
 
   """
-  Added in 26.3.0. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
+  Added in UNRELEASED. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
   """
   images: ImageV2Connection!
 

--- a/src/ai/backend/common/dto/manager/v2/kernel/response.py
+++ b/src/ai/backend/common/dto/manager/v2/kernel/response.py
@@ -141,6 +141,10 @@ class KernelNode(BaseResponseModel):
     """Node model representing a kernel (compute container) entity."""
 
     id: UUID = Field(description="Kernel ID.")
+    image_id: UUID | None = Field(
+        default=None,
+        description="The UUID of the image used by this kernel. Null if the image has been purged.",
+    )
     startup_command: str | None = Field(
         default=None, description="Startup command executed when the kernel starts."
     )

--- a/src/ai/backend/common/dto/manager/v2/session/response.py
+++ b/src/ai/backend/common/dto/manager/v2/session/response.py
@@ -152,6 +152,13 @@ class SessionNode(BaseResponseModel):
     """Node model representing a session entity with nested info sub-models."""
 
     id: UUID = Field(description="Session ID.")
+    image_ids: list[UUID] | None = Field(
+        default=None,
+        description=(
+            "UUIDs of the images used by this session. "
+            "Multiple images are possible in multi-kernel (cluster) sessions."
+        ),
+    )
     domain_name: str = Field(description="Domain name the session belongs to.")
     user_id: UUID = Field(description="UUID of the user who owns this session.")
     project_id: UUID = Field(description="Group (project) ID the session belongs to.")

--- a/src/ai/backend/manager/api/adapters/session.py
+++ b/src/ai/backend/manager/api/adapters/session.py
@@ -952,6 +952,7 @@ class SessionAdapter(BaseAdapter):
         )
         return SessionNode(
             id=data.id,
+            image_ids=data.image_ids,
             domain_name=data.domain_name,
             user_id=data.user_uuid,
             project_id=data.group_id,
@@ -1023,6 +1024,7 @@ class SessionAdapter(BaseAdapter):
         )
         return KernelNode(
             id=info.id,
+            image_id=info.image.image_id,
             startup_command=info.runtime.startup_command,
             session_info=KernelSessionInfoGQLDTO(
                 session_id=UUID(info.session.session_id),

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.api.gql.session.types import SessionV2GQL
 
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.common.types import ImageID
 from ai.backend.manager.api.gql.agent.types import AgentV2GQL
 from ai.backend.manager.api.gql.common.types import (
     ResourceOptsGQL,
@@ -56,6 +58,7 @@ from ai.backend.manager.api.gql.common.types import (
 )
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
 from ai.backend.manager.api.gql.fair_share.types.common import ResourceSlotGQL
+from ai.backend.manager.api.gql.image.types import ImageV2GQL
 from ai.backend.manager.api.gql.project_v2.types.node import ProjectV2GQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.resource_group.types import ResourceGroupGQL
@@ -298,6 +301,9 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
     """Kernel type representing a compute container."""
 
     id: NodeID[str]
+    image_id: strawberry.ID | None = gql_field(
+        description="The UUID of the image used by this kernel. Null if the image has been purged.",
+    )
 
     # Inlined fields (from single-element types)
     startup_command: str | None = gql_field(
@@ -332,6 +338,20 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         if agent_data is None:
             return None
         return agent_data
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The image used by this kernel.",
+        )
+    )  # type: ignore[misc]
+    async def image(
+        self,
+        info: Info[StrawberryGQLContext],
+    ) -> ImageV2GQL | None:
+        if self.image_id is None:
+            return None
+        return await info.context.data_loaders.image_loader.load(ImageID(UUID(str(self.image_id))))
 
     @gql_added_field(
         BackendAIGQLMeta(added_version="26.2.0", description="The user who owns this kernel.")

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -51,7 +51,8 @@ from ai.backend.common.dto.manager.v2.session.types import (
     ProjectSessionScope,
     SessionStatusFilter,
 )
-from ai.backend.common.types import SessionId
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.common.types import ImageID, SessionId
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter, encode_cursor
 from ai.backend.manager.api.gql.common.types import (
     ClusterModeGQL,
@@ -306,6 +307,14 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
 
     id: NodeID[str]
 
+    # Image IDs for this session (used by images resolver)
+    image_ids: list[strawberry.ID] | None = gql_field(
+        description=(
+            "UUIDs of the images used by this session. "
+            "Multiple images are possible in multi-kernel (cluster) sessions."
+        ),
+    )
+
     # Fields used as keys for dynamic resolvers
     domain_name: str
     user_id: ID
@@ -364,12 +373,39 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
 
     @gql_added_field(
         BackendAIGQLMeta(
-            added_version="26.3.0",
+            added_version=NEXT_RELEASE_VERSION,
             description="The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.",
         )
     )  # type: ignore[misc]
-    async def images(self) -> ImageV2ConnectionGQL:
-        raise NotImplementedError
+    async def images(self, info: Info[StrawberryGQLContext]) -> ImageV2ConnectionGQL:
+        from ai.backend.manager.api.gql.image.types import ImageV2EdgeGQL
+
+        if not self.image_ids:
+            return ImageV2ConnectionGQL(
+                edges=[],
+                page_info=strawberry.relay.PageInfo(
+                    has_next_page=False,
+                    has_previous_page=False,
+                    start_cursor=None,
+                    end_cursor=None,
+                ),
+                count=0,
+            )
+
+        unique_ids = list(dict.fromkeys(ImageID(UUID(str(iid))) for iid in self.image_ids))
+        results = await info.context.data_loaders.image_loader.load_many(unique_ids)
+        nodes = [img for img in results if img is not None]
+        edges = [ImageV2EdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+        return ImageV2ConnectionGQL(
+            edges=edges,
+            page_info=strawberry.relay.PageInfo(
+                has_next_page=False,
+                has_previous_page=False,
+                start_cursor=edges[0].cursor if edges else None,
+                end_cursor=edges[-1].cursor if edges else None,
+            ),
+            count=len(nodes),
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/data/kernel/types.py
+++ b/src/ai/backend/manager/data/kernel/types.py
@@ -231,6 +231,7 @@ class ResourceInfo:
 
 @dataclass
 class ImageInfo:
+    image_id: UUID | None
     identifier: ImageIdentifier | None
     registry: str | None
     tag: str | None

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -168,6 +168,7 @@ class SessionData:
     access_key: AccessKey | None
     agent_ids: list[str] | None
     images: list[str] | None
+    image_ids: list[UUID] | None
     tag: str | None
     vfolder_mounts: list[VFolderMountData] | None
     environ: dict[str, Any] | None

--- a/src/ai/backend/manager/event_dispatcher/handlers/image.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/image.py
@@ -1,6 +1,10 @@
 import logging
 from datetime import UTC, datetime
+from uuid import UUID
 
+import sqlalchemy as sa
+
+from ai.backend.common.docker import ImageRef
 from ai.backend.common.events.event_types.image.anycast import (
     ImagePullFailedEvent,
     ImagePullFinishedEvent,
@@ -10,6 +14,7 @@ from ai.backend.common.types import (
     AgentId,
 )
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.utils import (
     ExtendedAsyncSAEngine,
 )
@@ -30,6 +35,27 @@ class ImageEventHandler:
         self._db = db
         self._schedule_coordinator = schedule_coordinator
 
+    async def _resolve_image_id(
+        self,
+        image: str,
+        image_ref: ImageRef | None,
+    ) -> UUID | None:
+        """Resolve a canonical image string to an image UUID.
+
+        This is the conversion point at the agent boundary where string-based
+        image references from agent events are translated to UUID-based references
+        used internally by the manager.
+        """
+        canonical = image_ref.canonical if image_ref else image
+        architecture = image_ref.architecture if image_ref else None
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(ImageRow.id).where(ImageRow.name == canonical)
+            if architecture:
+                query = query.where(ImageRow.architecture == architecture)
+            query = query.limit(1)
+            result = await db_sess.execute(query)
+            return result.scalar_one_or_none()
+
     async def handle_image_pull_started(
         self,
         _context: None,
@@ -39,8 +65,12 @@ class ImageEventHandler:
         dt = datetime.fromtimestamp(ev.timestamp, tz=UTC)
         log.debug("handle_image_pull_started: ag:{} img:{}, start_dt:{}", ev.agent_id, ev.image, dt)
 
+        image_id = await self._resolve_image_id(ev.image, ev.image_ref)
         await self._schedule_coordinator.update_kernels_to_pulling_for_image(
-            ev.agent_id, ev.image, ev.image_ref.canonical if ev.image_ref else None
+            ev.agent_id,
+            ev.image,
+            ev.image_ref.canonical if ev.image_ref else None,
+            image_id=image_id,
         )
 
     async def handle_image_pull_finished(
@@ -49,8 +79,12 @@ class ImageEventHandler:
         dt = datetime.fromtimestamp(ev.timestamp, tz=UTC)
         log.debug("handle_image_pull_finished: ag:{} img:{}, end_dt:{}", ev.agent_id, ev.image, dt)
 
+        image_id = await self._resolve_image_id(ev.image, ev.image_ref)
         await self._schedule_coordinator.update_kernels_to_prepared_for_image(
-            ev.agent_id, ev.image, ev.image_ref.canonical if ev.image_ref else None
+            ev.agent_id,
+            ev.image,
+            ev.image_ref.canonical if ev.image_ref else None,
+            image_id=image_id,
         )
 
     async def handle_image_pull_failed(
@@ -61,6 +95,11 @@ class ImageEventHandler:
     ) -> None:
         log.warning("handle_image_pull_failed: ag:{} img:{}, msg:{}", ev.agent_id, ev.image, ev.msg)
 
+        image_id = await self._resolve_image_id(ev.image, ev.image_ref)
         await self._schedule_coordinator.cancel_kernels_for_failed_image(
-            ev.agent_id, ev.image, ev.msg, ev.image_ref.canonical if ev.image_ref else None
+            ev.agent_id,
+            ev.image,
+            ev.msg,
+            ev.image_ref.canonical if ev.image_ref else None,
+            image_id=image_id,
         )

--- a/src/ai/backend/manager/models/alembic/versions/cd067180a8b1_add_image_id_to_kernels_and_sessions.py
+++ b/src/ai/backend/manager/models/alembic/versions/cd067180a8b1_add_image_id_to_kernels_and_sessions.py
@@ -1,0 +1,99 @@
+"""add image_id to kernels and image_ids to sessions
+
+Revision ID: cd067180a8b1
+Revises: d8e4f2a1b3c7
+Create Date: 2026-04-16
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "cd067180a8b1"
+down_revision = "d8e4f2a1b3c7"
+# Part of: 26.3.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # --- kernels.image_id ---
+    columns = [c["name"] for c in inspector.get_columns("kernels")]
+    if "image_id" not in columns:
+        op.add_column(
+            "kernels",
+            sa.Column(
+                "image_id",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+            ),
+        )
+
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("kernels")]
+    if "fk_kernels_image_id" not in fks:
+        op.create_foreign_key(
+            "fk_kernels_image_id",
+            "kernels",
+            "images",
+            ["image_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("kernels")]
+    if "ix_kernels_image_id" not in indexes:
+        op.create_index(
+            "ix_kernels_image_id",
+            "kernels",
+            ["image_id"],
+        )
+
+    # Backfill kernels.image_id from images table
+    op.execute(
+        sa.text(
+            "UPDATE kernels SET image_id = images.id"
+            " FROM images"
+            " WHERE kernels.image = images.name"
+            "   AND kernels.architecture = images.architecture"
+            "   AND kernels.image_id IS NULL"
+        )
+    )
+
+    # --- sessions.image_ids ---
+    session_columns = [c["name"] for c in inspector.get_columns("sessions")]
+    if "image_ids" not in session_columns:
+        op.add_column(
+            "sessions",
+            sa.Column(
+                "image_ids",
+                postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+                nullable=True,
+            ),
+        )
+
+    # Backfill sessions.image_ids from kernels
+    op.execute(
+        sa.text(
+            "UPDATE sessions SET image_ids = subq.ids"
+            " FROM ("
+            "   SELECT session_id, array_agg(DISTINCT image_id) AS ids"
+            "   FROM kernels"
+            "   WHERE image_id IS NOT NULL"
+            "   GROUP BY session_id"
+            " ) subq"
+            " WHERE sessions.id = subq.session_id"
+            "   AND sessions.image_ids IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sessions", "image_ids")
+    op.drop_index("ix_kernels_image_id", table_name="kernels")
+    op.drop_constraint("fk_kernels_image_id", "kernels", type_="foreignkey")
+    op.drop_column("kernels", "image_id")

--- a/src/ai/backend/manager/models/kernel/row.py
+++ b/src/ai/backend/manager/models/kernel/row.py
@@ -354,15 +354,6 @@ def _get_user_row_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     return UserRow.uuid == foreign(KernelRow.user_uuid)
 
 
-def _get_image_row_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.image import ImageRow
-
-    return sa.and_(
-        KernelRow.image == ImageRow.name,
-        KernelRow.architecture == ImageRow.architecture,
-    )
-
-
 class KernelRow(Base):  # type: ignore[misc]
     __tablename__ = "kernels"
 
@@ -443,8 +434,15 @@ class KernelRow(Base):  # type: ignore[misc]
         "access_key", sa.String(length=20), nullable=True
     )
     # `image` is a string representing canonical name which shaped "<REGISTRY>/<PROJECT>/<IMAGE_NAME>:<TAG>".
+    # Kept as historical audit data; active reference is `image_id`.
     image: Mapped[str | None] = mapped_column("image", sa.String(length=512), nullable=True)
-    # ForeignKeyIDColumn("image_id", "images.id")
+    image_id: Mapped[uuid.UUID | None] = mapped_column(
+        "image_id",
+        GUID,
+        sa.ForeignKey("images.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     architecture: Mapped[str | None] = mapped_column(
         "architecture", sa.String(length=32), default="x86_64", nullable=True
     )
@@ -646,8 +644,7 @@ class KernelRow(Base):  # type: ignore[misc]
     session: Mapped[SessionRow] = relationship("SessionRow", back_populates="kernels")
     image_row: Mapped[ImageRow | None] = relationship(
         "ImageRow",
-        foreign_keys="KernelRow.image",
-        primaryjoin=_get_image_row_join_condition,
+        foreign_keys="KernelRow.image_id",
     )
     agent_row: Mapped[AgentRow | None] = relationship("AgentRow", back_populates="kernels")
     group_row: Mapped[GroupRow] = relationship("GroupRow", back_populates="kernels")
@@ -948,6 +945,7 @@ class KernelRow(Base):  # type: ignore[misc]
             user_uuid=info.user_permission.user_uuid,
             access_key=info.user_permission.access_key,
             image=info.image.identifier.canonical if info.image.identifier else None,
+            image_id=info.image.image_id,
             architecture=info.image.identifier.architecture if info.image.identifier else None,
             registry=info.image.registry,
             tag=info.image.tag,
@@ -1011,6 +1009,7 @@ class KernelRow(Base):  # type: ignore[misc]
                 gids=self.gids,
             ),
             image=ImageInfo(
+                image_id=self.image_id,
                 identifier=ImageIdentifier(
                     canonical=self.image,
                     architecture=self.architecture or "",

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -740,8 +740,10 @@ class SessionRow(Base):  # type: ignore[misc]
         foreign_keys=[access_key],
     )
 
-    # `image` column is identical to kernels `image` column.
+    # `images` stores canonical image name strings for historical audit.
     images: Mapped[list[str] | None] = mapped_column("images", sa.ARRAY(sa.String), nullable=True)
+    # `image_ids` stores active references to ImageRow; SET NULL cascades from kernels.
+    image_ids: Mapped[list[UUID] | None] = mapped_column("image_ids", sa.ARRAY(GUID), nullable=True)
     tag: Mapped[str | None] = mapped_column("tag", sa.String(length=64), nullable=True)
 
     # Resource occupation
@@ -926,6 +928,7 @@ class SessionRow(Base):  # type: ignore[misc]
             user_uuid=session_data.user_uuid,
             access_key=session_data.access_key,
             images=session_data.images,
+            image_ids=session_data.image_ids,
             tag=session_data.tag,
             occupying_slots=session_data.occupying_slots,
             requested_slots=session_data.requested_slots,
@@ -971,6 +974,7 @@ class SessionRow(Base):  # type: ignore[misc]
             user_uuid=self.user_uuid,
             access_key=AccessKey(self.access_key) if self.access_key else None,
             images=self.images,
+            image_ids=self.image_ids,
             tag=self.tag,
             occupying_slots=self.occupying_slots,
             requested_slots=self.requested_slots,

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1322,6 +1322,7 @@ class ScheduleDBSource:
                 batch_timeout=session_data.batch_timeout,
                 callback_url=session_data.callback_url,
                 images=session_data.images,
+                image_ids=session_data.image_ids,
                 network_type=session_data.network_type,
                 network_id=session_data.network_id,
                 designated_agent_ids=session_data.designated_agent_list,
@@ -1352,6 +1353,7 @@ class ScheduleDBSource:
                     user_uuid=kernel.user_uuid,
                     access_key=kernel.access_key,
                     image=kernel.image,
+                    image_id=kernel.image_id,
                     architecture=kernel.architecture,
                     registry=kernel.registry,
                     tag=kernel.tag,
@@ -1612,6 +1614,7 @@ class ScheduleDBSource:
             image_row = await ImageRow.resolve(db_sess, [image_ref])
             if image_row:
                 image_infos[image_ref.canonical] = ImageInfo(
+                    id=image_row.id,
                     canonical=image_row.name,  # 'name' is the canonical reference in ImageRow
                     architecture=image_row.architecture,
                     registry=image_row.registry,
@@ -2597,7 +2600,11 @@ class ScheduleDBSource:
             return cast(CursorResult[Any], result).rowcount
 
     async def update_kernels_to_pulling_for_image(
-        self, agent_id: AgentId, image: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> int:
         """
         Update kernel status from PREPARING to PULLING for the specified image on an agent.
@@ -2605,12 +2612,18 @@ class ScheduleDBSource:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference (canonical format)
+        :param image_id: Optional image UUID; when provided, matches by image_id instead of name
         :return: Number of kernels updated
         """
         async with self._begin_session_read_committed() as db_sess:
             now = await self._get_db_now_in_session(db_sess)
-            # Use image_ref if provided (canonical format), otherwise use image
-            image_to_match = image_ref if image_ref else image
+            # Prefer image_id (UUID) for matching when available
+            if image_id is not None:
+                image_condition = KernelRow.image_id == image_id
+            else:
+                # Use image_ref if provided (canonical format), otherwise use image
+                image_to_match = image_ref if image_ref else image
+                image_condition = KernelRow.image == image_to_match
             # Find kernels on this agent with this image in SCHEDULED or PREPARING state.
             # SCHEDULED is included because image pulling can start before kernel
             # transitions to PREPARING (which happens in create_kernel RPC).
@@ -2619,7 +2632,7 @@ class ScheduleDBSource:
                 .where(
                     sa.and_(
                         KernelRow.agent == agent_id,
-                        KernelRow.image == image_to_match,
+                        image_condition,
                         KernelRow.status.in_([
                             KernelStatus.SCHEDULED,
                             KernelStatus.PREPARING,
@@ -2639,7 +2652,11 @@ class ScheduleDBSource:
             return cast(CursorResult[Any], result).rowcount
 
     async def update_kernels_to_prepared_for_image(
-        self, agent_id: AgentId, image: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> int:
         """
         Update kernel status to PREPARED for the specified image on an agent.
@@ -2648,12 +2665,18 @@ class ScheduleDBSource:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference (canonical format)
+        :param image_id: Optional image UUID; when provided, matches by image_id instead of name
         :return: Number of kernels updated
         """
         async with self._begin_session_read_committed() as db_sess:
             now = await self._get_db_now_in_session(db_sess)
-            # Use image_ref if provided (canonical format), otherwise use image
-            image_to_match = image_ref if image_ref else image
+            # Prefer image_id (UUID) for matching when available
+            if image_id is not None:
+                image_condition = KernelRow.image_id == image_id
+            else:
+                # Use image_ref if provided (canonical format), otherwise use image
+                image_to_match = image_ref if image_ref else image
+                image_condition = KernelRow.image == image_to_match
             # Find kernels on this agent with this image in SCHEDULED, PULLING or PREPARING state
             # and update them to PREPARED.
             # SCHEDULED is included because when image already exists, ImagePullFinishedEvent
@@ -2663,7 +2686,7 @@ class ScheduleDBSource:
                 .where(
                     sa.and_(
                         KernelRow.agent == agent_id,
-                        KernelRow.image == image_to_match,
+                        image_condition,
                         KernelRow.status.in_([
                             KernelStatus.SCHEDULED,
                             KernelStatus.PULLING,
@@ -2684,7 +2707,12 @@ class ScheduleDBSource:
             return cast(CursorResult[Any], result).rowcount
 
     async def cancel_kernels_for_failed_image(
-        self, agent_id: AgentId, image: str, error_msg: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        error_msg: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> set[SessionId]:
         """Cancel SCHEDULED/PULLING/PREPARING kernels of a failed-to-pull
         image on an agent and free their ``resource_allocations`` rows in
@@ -2692,7 +2720,12 @@ class ScheduleDBSource:
         """
         async with self._begin_session_read_committed() as db_sess:
             now = await self._get_db_now_in_session(db_sess)
-            image_to_match = image_ref if image_ref else image
+            # Prefer image_id (UUID) for matching when available
+            if image_id is not None:
+                image_condition = KernelRow.image_id == image_id
+            else:
+                image_to_match = image_ref if image_ref else image
+                image_condition = KernelRow.image == image_to_match
             # SCHEDULED is included because image pull failure can occur
             # before the kernel transitions to PREPARING.
             stmt = (
@@ -2700,7 +2733,7 @@ class ScheduleDBSource:
                 .where(
                     sa.and_(
                         KernelRow.agent == agent_id,
-                        KernelRow.image == image_to_match,
+                        image_condition,
                         KernelRow.status.in_([
                             KernelStatus.SCHEDULED,
                             KernelStatus.PULLING,
@@ -2814,7 +2847,7 @@ class ScheduleDBSource:
 
     async def _resolve_image_configs(
         self, db_sess: SASession, unique_images: set[ImageIdentifier]
-    ) -> dict[str, ImageConfigData]:
+    ) -> dict[UUID, ImageConfigData]:
         """
         Resolve image configurations for the given unique images.
 
@@ -2822,7 +2855,7 @@ class ScheduleDBSource:
 
         :param db_sess: Database session to use
         :param unique_images: Set of ImageIdentifier objects to resolve
-        :return: Dictionary mapping image names to ImageConfigData
+        :return: Dictionary mapping image UUIDs to ImageConfigData
         """
         if not unique_images:
             return {}
@@ -2838,13 +2871,14 @@ class ScheduleDBSource:
         image_rows = result.scalars().all()
 
         # Convert to ImageConfigData
-        image_configs: dict[str, ImageConfigData] = {}
+        image_configs: dict[UUID, ImageConfigData] = {}
         for image_row in image_rows:
             try:
                 img_ref = image_row.image_ref
                 registry_row = image_row.registry_row
 
                 image_config = ImageConfigData(
+                    id=image_row.id,
                     canonical=img_ref.canonical,
                     architecture=image_row.architecture,
                     project=image_row.project,
@@ -2856,8 +2890,8 @@ class ScheduleDBSource:
                     registry_username=registry_row.username,
                     registry_password=registry_row.password,
                 )
-                # Use the canonical name as key (which is what KernelRow.image contains)
-                image_configs[image_row.name] = image_config
+                # Use the image UUID as key for reliable matching
+                image_configs[image_row.id] = image_config
             except Exception as e:
                 log.error(f"Failed to process image {image_row.name}: {e}")
                 continue
@@ -2885,6 +2919,7 @@ class ScheduleDBSource:
                         KernelRow.agent_addr,
                         KernelRow.scaling_group,
                         KernelRow.image,
+                        KernelRow.image_id,
                         KernelRow.architecture,
                         KernelRow.status,
                         KernelRow.status_changed,
@@ -2906,6 +2941,7 @@ class ScheduleDBSource:
                     agent_addr=kernel.agent_addr,
                     scaling_group=kernel.scaling_group or "",
                     image=kernel.image or "",
+                    image_id=kernel.image_id,
                     architecture=kernel.architecture or "",
                     status=kernel.status,
                     status_changed=kernel.status_changed.timestamp()
@@ -2941,6 +2977,7 @@ class ScheduleDBSource:
                         KernelRow.agent_addr,
                         KernelRow.scaling_group,
                         KernelRow.image,
+                        KernelRow.image_id,
                         KernelRow.architecture,
                     )
                 ),
@@ -3060,6 +3097,7 @@ class ScheduleDBSource:
                 KernelRow.agent_addr,
                 KernelRow.scaling_group,
                 KernelRow.image,
+                KernelRow.image_id,
                 KernelRow.architecture,
                 KernelRow.cluster_role,
                 KernelRow.cluster_idx,
@@ -3114,6 +3152,7 @@ class ScheduleDBSource:
                     agent_addr=row.agent_addr,
                     scaling_group=row.scaling_group,
                     image=row.image,
+                    image_id=row.image_id,
                     architecture=row.architecture,
                     status=row.kernel_status,
                     status_changed=row.status_changed.timestamp() if row.status_changed else None,
@@ -3162,6 +3201,7 @@ class ScheduleDBSource:
                 KernelRow.agent_addr,
                 KernelRow.scaling_group,
                 KernelRow.image,
+                KernelRow.image_id,
                 KernelRow.architecture,
                 KernelRow.cluster_role,
                 KernelRow.cluster_idx,
@@ -3220,6 +3260,7 @@ class ScheduleDBSource:
                     "agent_addr": row.agent_addr,
                     "scaling_group": row.scaling_group,
                     "image": row.image,
+                    "image_id": row.image_id,
                     "architecture": row.architecture,
                     "kernel_status": row.kernel_status,
                     "status_changed": row.status_changed,
@@ -3269,6 +3310,7 @@ class ScheduleDBSource:
                     agent_addr=k["agent_addr"],
                     scaling_group=k["scaling_group"],
                     image=k["image"],
+                    image_id=k["image_id"],
                     architecture=k["architecture"],
                     status=k["kernel_status"],
                     status_changed=k["status_changed"].timestamp() if k["status_changed"] else None,
@@ -4037,6 +4079,7 @@ class ScheduleDBSource:
                 KernelRow.agent_addr,
                 KernelRow.scaling_group,
                 KernelRow.image,
+                KernelRow.image_id,
                 KernelRow.architecture,
                 KernelRow.cluster_role,
                 KernelRow.cluster_idx,
@@ -4086,6 +4129,7 @@ class ScheduleDBSource:
                     agent_addr=row.agent_addr,
                     scaling_group=row.scaling_group,
                     image=row.image,
+                    image_id=row.image_id,
                     architecture=row.architecture,
                     status=row.kernel_status,
                     status_changed=row.status_changed.timestamp() if row.status_changed else None,
@@ -4166,6 +4210,7 @@ class ScheduleDBSource:
                 KernelRow.agent_addr,
                 KernelRow.scaling_group,
                 KernelRow.image,
+                KernelRow.image_id,
                 KernelRow.architecture,
                 KernelRow.cluster_role,
                 KernelRow.cluster_idx,
@@ -4219,6 +4264,7 @@ class ScheduleDBSource:
                     "agent_addr": row.agent_addr,
                     "scaling_group": row.scaling_group,
                     "image": row.image,
+                    "image_id": row.image_id,
                     "architecture": row.architecture,
                     "kernel_status": row.kernel_status,
                     "status_changed": row.status_changed,
@@ -4268,6 +4314,7 @@ class ScheduleDBSource:
                     agent_addr=k["agent_addr"],
                     scaling_group=k["scaling_group"],
                     image=k["image"],
+                    image_id=k["image_id"],
                     architecture=k["architecture"],
                     status=k["kernel_status"],
                     status_changed=k["status_changed"].timestamp() if k["status_changed"] else None,
@@ -4382,6 +4429,7 @@ class ScheduleDBSource:
                     KernelRow.agent_addr,
                     KernelRow.scaling_group,
                     KernelRow.image,
+                    KernelRow.image_id,
                     KernelRow.architecture,
                     KernelRow.cluster_role,
                     KernelRow.cluster_idx,
@@ -4419,6 +4467,7 @@ class ScheduleDBSource:
                     agent_addr=row.agent_addr,
                     scaling_group=row.scaling_group,
                     image=row.image,
+                    image_id=row.image_id,
                     architecture=row.architecture,
                     status=row.status,
                     status_changed=(row.status_changed.timestamp() if row.status_changed else None),
@@ -4538,6 +4587,7 @@ class ScheduleDBSource:
                     KernelRow.agent_addr,
                     KernelRow.scaling_group,
                     KernelRow.image,
+                    KernelRow.image_id,
                     KernelRow.architecture,
                     KernelRow.cluster_role,
                     KernelRow.cluster_idx,
@@ -4575,6 +4625,7 @@ class ScheduleDBSource:
                     agent_addr=row.agent_addr,
                     scaling_group=row.scaling_group,
                     image=row.image,
+                    image_id=row.image_id,
                     architecture=row.architecture,
                     status=row.status,
                     status_changed=(row.status_changed.timestamp() if row.status_changed else None),

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -406,7 +406,11 @@ class SchedulerRepository:
 
     @scheduler_repository_resilience.apply()
     async def update_kernels_to_pulling_for_image(
-        self, agent_id: AgentId, image: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> int:
         """
         Update kernel status from PREPARING to PULLING for the specified image on an agent.
@@ -414,13 +418,20 @@ class SchedulerRepository:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID; when provided, matches by image_id instead of name
         :return: Number of kernels updated
         """
-        return await self._db_source.update_kernels_to_pulling_for_image(agent_id, image, image_ref)
+        return await self._db_source.update_kernels_to_pulling_for_image(
+            agent_id, image, image_ref, image_id
+        )
 
     @scheduler_repository_resilience.apply()
     async def update_kernels_to_prepared_for_image(
-        self, agent_id: AgentId, image: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> int:
         """
         Update kernel status to PREPARED for the specified image on an agent.
@@ -429,15 +440,21 @@ class SchedulerRepository:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID; when provided, matches by image_id instead of name
         :return: Number of kernels updated
         """
         return await self._db_source.update_kernels_to_prepared_for_image(
-            agent_id, image, image_ref
+            agent_id, image, image_ref, image_id
         )
 
     @scheduler_repository_resilience.apply()
     async def cancel_kernels_for_failed_image(
-        self, agent_id: AgentId, image: str, error_msg: str, image_ref: str | None = None
+        self,
+        agent_id: AgentId,
+        image: str,
+        error_msg: str,
+        image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> set[SessionId]:
         """
         Cancel kernels for an image that failed to be available on an agent.
@@ -447,10 +464,11 @@ class SchedulerRepository:
         :param image: The image name that failed
         :param error_msg: The error message to include in status
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID; when provided, matches by image_id instead of name
         :return: Set of affected session IDs
         """
         affected_session_ids = await self._db_source.cancel_kernels_for_failed_image(
-            agent_id, image, error_msg, image_ref
+            agent_id, image, error_msg, image_ref, image_id
         )
 
         # Check if any sessions need to be cancelled

--- a/src/ai/backend/manager/repositories/scheduler/types/search.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from ai.backend.manager.sokovan.data import (
     ImageConfigData,
@@ -30,7 +31,7 @@ class SessionWithKernelsSearchResult:
     """Result of searching sessions with kernel data and image configs."""
 
     sessions: list[SessionDataForPull]
-    image_configs: dict[str, ImageConfigData] = field(default_factory=dict)
+    image_configs: dict[UUID, ImageConfigData] = field(default_factory=dict)
     total_count: int = 0
     has_next_page: bool = False
     has_previous_page: bool = False
@@ -41,7 +42,7 @@ class SessionWithKernelsAndUserSearchResult:
     """Result of searching sessions with kernel data, user info, and image configs."""
 
     sessions: list[SessionDataForStart]
-    image_configs: dict[str, ImageConfigData] = field(default_factory=dict)
+    image_configs: dict[UUID, ImageConfigData] = field(default_factory=dict)
     total_count: int = 0
     has_next_page: bool = False
     has_previous_page: bool = False

--- a/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
+++ b/src/ai/backend/manager/repositories/scheduler/types/session_creation.py
@@ -224,7 +224,8 @@ class KernelEnqueueData:
     group_id: UUID
     user_uuid: UUID
     access_key: AccessKey
-    image: str  # Canonical image name
+    image: str  # Canonical image name (historical audit)
+    image_id: UUID | None  # Active reference to ImageRow
     architecture: str
     registry: str
     tag: str | None
@@ -289,6 +290,7 @@ class SessionEnqueueData:
     batch_timeout: int | None  # seconds
     callback_url: yarl.URL | None
     images: list[str]
+    image_ids: list[UUID]
     designated_agent_list: list[str] | None
     network_type: NetworkType | None = None
     network_id: str | None = None
@@ -318,6 +320,7 @@ class ScalingGroupNetworkInfo:
 class ImageInfo:
     """Resolved image information."""
 
+    id: UUID
     canonical: str
     architecture: str
     registry: str

--- a/src/ai/backend/manager/sokovan/data/image.py
+++ b/src/ai/backend/manager/sokovan/data/image.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 from ai.backend.common.types import AutoPullBehavior, ImageConfig
 
@@ -19,6 +20,7 @@ class ImageIdentifier:
 class ImageConfigData:
     """Image configuration data resolved from database."""
 
+    id: UUID
     canonical: str
     architecture: str
     project: str | None

--- a/src/ai/backend/manager/sokovan/data/lifecycle.py
+++ b/src/ai/backend/manager/sokovan/data/lifecycle.py
@@ -37,6 +37,7 @@ class KernelBindingData:
     agent_addr: str | None
     scaling_group: str
     image: str
+    image_id: UUID | None
     architecture: str
     status: KernelStatus | None = None
     status_changed: float | None = None
@@ -111,7 +112,7 @@ class SessionsForPullWithImages:
     """Sessions for image pulling with their image configurations."""
 
     sessions: list[SessionDataForPull]
-    image_configs: dict[str, ImageConfigData]
+    image_configs: dict[UUID, ImageConfigData]
 
 
 @dataclass
@@ -119,7 +120,7 @@ class SessionsForStartWithImages:
     """Sessions for starting with their image configurations."""
 
     sessions: list[SessionDataForStart]
-    image_configs: dict[str, ImageConfigData]
+    image_configs: dict[UUID, ImageConfigData]
 
 
 @dataclass
@@ -127,7 +128,7 @@ class ScheduledSessionsWithImages:
     """Scheduled sessions with their image configurations."""
 
     sessions: list[ScheduledSessionData]
-    image_configs: dict[str, ImageConfigData]
+    image_configs: dict[UUID, ImageConfigData]
 
 
 @dataclass
@@ -139,6 +140,7 @@ class KernelStartData:
     agent_addr: str
     scaling_group: str
     image: str
+    image_id: UUID | None
     architecture: str
     cluster_role: str
     cluster_idx: int
@@ -174,7 +176,7 @@ class PreparedSessionsWithImages:
     """Prepared sessions with their image configurations."""
 
     sessions: list[PreparedSessionData]
-    image_configs: dict[str, ImageConfigData]
+    image_configs: dict[UUID, ImageConfigData]
 
 
 @dataclass

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -5,6 +5,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Final
+from uuid import UUID
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.events.dispatcher import EventProducer
@@ -1583,10 +1584,11 @@ class ScheduleCoordinator:
         agent_id: AgentId,
         image: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> None:
         """Update kernel status from PREPARING to PULLING for the specified image on an agent."""
         await self._kernel_state_engine.update_kernels_to_pulling_for_image(
-            agent_id, image, image_ref
+            agent_id, image, image_ref, image_id=image_id
         )
 
     async def update_kernels_to_prepared_for_image(
@@ -1594,10 +1596,11 @@ class ScheduleCoordinator:
         agent_id: AgentId,
         image: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> None:
         """Update kernel status to PREPARED for the specified image on an agent."""
         result = await self._kernel_state_engine.update_kernels_to_prepared_for_image(
-            agent_id, image, image_ref
+            agent_id, image, image_ref, image_id=image_id
         )
         if result > 0:
             log.info(
@@ -1617,10 +1620,11 @@ class ScheduleCoordinator:
         image: str,
         error_msg: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> None:
         """Cancel kernels for an image that failed to be available on an agent."""
         await self._kernel_state_engine.cancel_kernels_for_failed_image(
-            agent_id, image, error_msg, image_ref
+            agent_id, image, error_msg, image_ref, image_id=image_id
         )
         # No need to request scheduling for cancelled kernels
 

--- a/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
+++ b/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
@@ -6,6 +6,7 @@ All database operations go through the repository pattern.
 """
 
 import logging
+from uuid import UUID
 
 from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -154,6 +155,7 @@ class KernelStateEngine:
         agent_id: AgentId,
         image: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> None:
         """
         Update kernel status from PREPARING to PULLING for the specified image on an agent.
@@ -161,20 +163,25 @@ class KernelStateEngine:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID for precise matching
         """
         log.debug(
-            "Updating kernels to PULLING for agent:{} image:{}",
+            "Updating kernels to PULLING for agent:{} image:{} image_id:{}",
             agent_id,
             image,
+            image_id,
         )
 
-        await self._repository.update_kernels_to_pulling_for_image(agent_id, image, image_ref)
+        await self._repository.update_kernels_to_pulling_for_image(
+            agent_id, image, image_ref, image_id=image_id
+        )
 
     async def update_kernels_to_prepared_for_image(
         self,
         agent_id: AgentId,
         image: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> int:
         """
         Update kernel status to PREPARED for the specified image on an agent.
@@ -183,10 +190,11 @@ class KernelStateEngine:
         :param agent_id: The agent ID where kernels should be updated
         :param image: The image name to match kernels
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID for precise matching
         :return: The number of kernels updated to PREPARED state
         """
         return await self._repository.update_kernels_to_prepared_for_image(
-            agent_id, image, image_ref
+            agent_id, image, image_ref, image_id=image_id
         )
 
     async def cancel_kernels_for_failed_image(
@@ -195,6 +203,7 @@ class KernelStateEngine:
         image: str,
         error_msg: str,
         image_ref: str | None = None,
+        image_id: UUID | None = None,
     ) -> None:
         """
         Cancel kernels for an image that failed to be available on an agent.
@@ -203,16 +212,18 @@ class KernelStateEngine:
         :param image: The image name that failed
         :param error_msg: The error message to include in status
         :param image_ref: Optional image reference
+        :param image_id: Optional image UUID for precise matching
         """
         log.warning(
-            "Cancelling kernels for failed image on agent:{} image:{}, msg:{}",
+            "Cancelling kernels for failed image on agent:{} image:{} image_id:{}, msg:{}",
             agent_id,
             image,
+            image_id,
             error_msg,
         )
 
         await self._repository.cancel_kernels_for_failed_image(
-            agent_id, image, error_msg, image_ref
+            agent_id, image, error_msg, image_ref, image_id=image_id
         )
 
     async def reset_kernels_to_pending_for_sessions(

--- a/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
+++ b/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
 from itertools import groupby
 from typing import Any
+from uuid import UUID
 
 import async_timeout
 from cryptography.hazmat.backends import default_backend
@@ -89,7 +90,7 @@ class SessionLauncher:
     async def trigger_image_pulling(
         self,
         sessions: list[SessionDataForPull],
-        image_configs: dict[str, ImageConfigData],
+        image_configs: dict[UUID, ImageConfigData],
     ) -> None:
         """
         Trigger image checking and pulling on agents for the given sessions.
@@ -99,14 +100,14 @@ class SessionLauncher:
         after coordinator queries sessions.
 
         :param sessions: List of sessions with kernels
-        :param image_configs: Image configurations indexed by image name
+        :param image_configs: Image configurations indexed by image ID
         """
         await self._trigger_image_pulling_for_sessions(sessions, image_configs)
 
     async def _trigger_image_pulling_for_sessions(
         self,
         sessions: list[SessionDataForPull],
-        image_configs: dict[str, ImageConfigData],
+        image_configs: dict[UUID, ImageConfigData],
     ) -> None:
         """
         Trigger image checking and pulling on agents for the given sessions.
@@ -114,7 +115,7 @@ class SessionLauncher:
         Internal implementation method.
 
         :param sessions: List of sessions with kernels
-        :param image_configs: Image configurations indexed by image name
+        :param image_configs: Image configurations indexed by image ID
         """
         auto_pull = self._config_provider.config.docker.image.auto_pull.value
 
@@ -125,9 +126,9 @@ class SessionLauncher:
         for session in sessions:
             for kernel in session.kernels:
                 agent_id = kernel.agent_id
-                if agent_id:
+                if agent_id and kernel.image_id is not None:
                     # Image config must exist since we queried based on kernels
-                    img_cfg = image_configs[kernel.image]
+                    img_cfg = image_configs[kernel.image_id]
 
                     # Convert ImageConfigData to ImageConfig format
                     # Use canonical as key for agent_image_configs to avoid duplicates
@@ -161,7 +162,7 @@ class SessionLauncher:
     async def start_sessions_for_handler(
         self,
         sessions: list[SessionDataForStart],
-        image_configs: dict[str, ImageConfigData],
+        image_configs: dict[UUID, ImageConfigData],
     ) -> None:
         """
         Start sessions on agents for the given sessions.
@@ -173,7 +174,7 @@ class SessionLauncher:
         Note: Status transition is handled by the Coordinator, not here.
 
         :param sessions: List of sessions with full data for starting
-        :param image_configs: Image configurations indexed by image name
+        :param image_configs: Image configurations indexed by image ID
         """
         with RecorderContext[SessionId].shared_phase(
             "trigger_kernel_creation",
@@ -188,13 +189,13 @@ class SessionLauncher:
     async def _start_sessions_concurrently(
         self,
         sessions: list[SessionDataForStart],
-        image_configs: dict[str, ImageConfigData],
+        image_configs: dict[UUID, ImageConfigData],
     ) -> None:
         """
         Start multiple sessions concurrently with individual timeouts.
 
         :param sessions: List of sessions to start
-        :param image_configs: Image configurations for the sessions
+        :param image_configs: Image configurations indexed by image ID
         """
 
         async def start_with_timeout(session: SessionDataForStart) -> None:
@@ -216,13 +217,13 @@ class SessionLauncher:
     async def _start_single_session(
         self,
         session: SessionDataForStart,
-        image_configs: dict[str, ImageConfigData],
+        image_configs: dict[UUID, ImageConfigData],
     ) -> None:
         """
         Start a single session by creating kernels on agents.
 
         :param session: Session data to start
-        :param image_configs: Image configurations for the session
+        :param image_configs: Image configurations indexed by image ID
         """
         log_fmt = "start-session(s:{}, type:{}, name:{}, ak:{}, cluster_mode:{}): "
         log_args = (
@@ -292,10 +293,10 @@ class SessionLauncher:
             ssh_keypair = await self._create_cluster_ssh_keypair()
 
             # Convert ImageConfigData to ImageConfig format for agents
-            image_configs_by_canonical: dict[str, ImageConfig] = {}
-            for image_key, img_cfg in image_configs.items():
-                image_config = img_cfg.to_image_config(AutoPullBehavior.DIGEST)
-                image_configs_by_canonical[image_key] = image_config
+            # Build a mapping from image ID to agent-compatible ImageConfig
+            image_configs_by_id: dict[UUID, ImageConfig] = {}
+            for img_id, img_cfg in image_configs.items():
+                image_configs_by_id[img_id] = img_cfg.to_image_config(AutoPullBehavior.DIGEST)
 
             # Create kernels on each agent
             async def create_kernels_on_agent(
@@ -311,18 +312,20 @@ class SessionLauncher:
                     kernel_id_str = str(k.kernel_id)
                     image_str = k.image
 
-                    # Use resolved image config or fallback
-                    if image_str not in image_configs_by_canonical:
-                        # This should not happen - all images should be resolved by precondition check
+                    # Use resolved image config by image_id
+                    if k.image_id is None or k.image_id not in image_configs_by_id:
                         log.error(
-                            "Image {} not found in resolved configs - this indicates precondition check failed",
+                            "Image ID {} (canonical: {}) not found in resolved configs"
+                            " - this indicates precondition check failed",
+                            k.image_id,
                             image_str,
                         )
                         raise ValueError(
-                            f"Image {image_str} not found in database - session start failed"
+                            f"Image {image_str} (id={k.image_id}) not found in database"
+                            " - session start failed"
                         )
 
-                    kernel_image_config = image_configs_by_canonical[image_str]
+                    kernel_image_config = image_configs_by_id[k.image_id]
 
                     # Use cluster configuration from kernel data
                     cluster_role = k.cluster_role

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/preparer.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/preparer.py
@@ -116,6 +116,7 @@ class SessionPreparer:
 
         # Collect images from kernels
         session_images = self._collect_session_images(kernel_data_list)
+        session_image_ids = self._collect_session_image_ids(kernel_data_list)
 
         # Use pre-calculated session total
         total_requested = calculated_resources.session_requested_slots
@@ -148,6 +149,7 @@ class SessionPreparer:
             batch_timeout=(int(spec.batch_timeout.total_seconds()) if spec.batch_timeout else None),
             callback_url=spec.callback_url,
             images=session_images,
+            image_ids=session_image_ids,
             network_type=network_type,
             network_id=network_id,
             bootstrap_script=bootstrap_script,
@@ -257,6 +259,7 @@ class SessionPreparer:
                 user_uuid=spec.user_scope.user_uuid,
                 access_key=spec.access_key,
                 image=image_info.canonical if image_info else self.DEFAULT_IMAGE_NAME,
+                image_id=image_info.id if image_info else None,
                 architecture=image_info.architecture if image_info else self.DEFAULT_ARCHITECTURE,
                 registry=image_info.registry if image_info else self.DEFAULT_REGISTRY,
                 tag=spec.session_tag,
@@ -321,3 +324,21 @@ class SessionPreparer:
                     session_images.append(kernel.image)
 
         return session_images
+
+    def _collect_session_image_ids(
+        self,
+        kernel_data_list: list[KernelEnqueueData],
+    ) -> list[uuid.UUID]:
+        """Collect unique image IDs from kernels, with main kernel first."""
+        session_image_ids: list[uuid.UUID] = []
+        seen: set[uuid.UUID] = set()
+
+        for kernel in kernel_data_list:
+            if kernel.image_id is not None and kernel.image_id not in seen:
+                seen.add(kernel.image_id)
+                if kernel.cluster_role == DEFAULT_ROLE:
+                    session_image_ids.insert(0, kernel.image_id)
+                else:
+                    session_image_ids.append(kernel.image_id)
+
+        return session_image_ids

--- a/tests/unit/manager/api/adapters/test_session_adapter.py
+++ b/tests/unit/manager/api/adapters/test_session_adapter.py
@@ -54,6 +54,7 @@ def _create_session_data(
         target_sgroup_names=None,
         agent_ids=None,
         images=None,
+        image_ids=None,
         tag=None,
         terminated_at=None,
         starts_at=None,

--- a/tests/unit/manager/api/compute_sessions/test_handler.py
+++ b/tests/unit/manager/api/compute_sessions/test_handler.py
@@ -83,6 +83,7 @@ def create_session_data(
         access_key=None,
         agent_ids=["agent-001"],
         images=images or ["cr.backend.ai/stable/python:3.11"],
+        image_ids=None,
         tag=None,
         vfolder_mounts=None,
         environ=None,
@@ -132,6 +133,7 @@ def create_kernel_info(
             gids=None,
         ),
         image=ImageInfo(
+            image_id=None,
             identifier=None,
             registry=None,
             tag=None,

--- a/tests/unit/manager/models/resource_slot/conftest.py
+++ b/tests/unit/manager/models/resource_slot/conftest.py
@@ -9,9 +9,11 @@ import pytest
 from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
@@ -52,6 +54,8 @@ async def database_with_resource_slot_tables(
             KeyPairRow,
             GroupRow,
             AgentRow,
+            ContainerRegistryRow,
+            ImageRow,
             SessionRow,
             KernelRow,
             # Resource slot tables

--- a/tests/unit/manager/repositories/domain/test_domain_purgers.py
+++ b/tests/unit/manager/repositories/domain/test_domain_purgers.py
@@ -16,9 +16,11 @@ from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow, ProjectType
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import (
@@ -61,6 +63,8 @@ class TestDomainPurgersIntegration:
                 GroupRow,
                 SessionRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 KernelRow,
             ],
         ):

--- a/tests/unit/manager/repositories/group/test_group_purgers.py
+++ b/tests/unit/manager/repositories/group/test_group_purgers.py
@@ -18,11 +18,12 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 
 # Import Row classes to ensure SQLAlchemy mapper initialization
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
 from ai.backend.manager.models.group import GroupRow, ProjectType
 from ai.backend.manager.models.hasher.types import PasswordInfo
-from ai.backend.manager.models.image import ImageRow  # noqa: F401
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import (
@@ -70,6 +71,8 @@ class TestGroupPurgersIntegration:
                 GroupRow,
                 SessionRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 KernelRow,
                 VFolderRow,
                 EndpointRow,

--- a/tests/unit/manager/repositories/resource_slot/test_db_source.py
+++ b/tests/unit/manager/repositories/resource_slot/test_db_source.py
@@ -18,8 +18,10 @@ from ai.backend.manager.errors.resource_slot import (
     ResourceSlotTypeNotFound,
 )
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
 from ai.backend.manager.models.resource_slot import (
@@ -214,6 +216,8 @@ class TestResourceAllocations:
                 ScalingGroupRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -257,6 +261,8 @@ class TestAggregation:
                 ScalingGroupRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -588,6 +594,8 @@ class TestComputeActualAgentResourceUsage:
                 ScalingGroupRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/scaling_group/test_resource_info.py
+++ b/tests/unit/manager/repositories/scaling_group/test_resource_info.py
@@ -16,9 +16,11 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
@@ -125,6 +127,8 @@ class TestResourceInfo:
                 GroupRow,
                 SessionRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 KernelRow,
                 ResourceSlotTypeRow,
                 AgentResourceRow,

--- a/tests/unit/manager/repositories/scheduler/test_cancellation_resource_freeing.py
+++ b/tests/unit/manager/repositories/scheduler/test_cancellation_resource_freeing.py
@@ -30,8 +30,10 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import (
@@ -69,6 +71,8 @@ _BASE_TABLES = [
     AssociationScopesEntitiesRow,
     EntityFieldRow,
     AgentRow,
+    ContainerRegistryRow,
+    ImageRow,
     SessionRow,
     KernelRow,
     ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/scheduler/test_resource_allocation.py
+++ b/tests/unit/manager/repositories/scheduler/test_resource_allocation.py
@@ -33,8 +33,10 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.resource_slot import AgentResourceCapacityExceeded
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import (
@@ -104,6 +106,8 @@ class TestUpdateKernelStatusRunningResourceAllocation:
                 AssociationScopesEntitiesRow,
                 EntityFieldRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/scheduler/test_resource_deallocation.py
+++ b/tests/unit/manager/repositories/scheduler/test_resource_deallocation.py
@@ -34,8 +34,10 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import (
@@ -85,6 +87,8 @@ class TestForceTerminateResourceDeallocation:
                 AssociationScopesEntitiesRow,
                 EntityFieldRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -630,6 +634,8 @@ class TestBulkTerminateResourceDeallocation:
                 AssociationScopesEntitiesRow,
                 EntityFieldRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -1060,6 +1066,8 @@ class TestNegativeValueGuard:
                 AssociationScopesEntitiesRow,
                 EntityFieldRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/scheduler/test_scheduling_history_recording.py
+++ b/tests/unit/manager/repositories/scheduler/test_scheduling_history_recording.py
@@ -31,8 +31,10 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SchedulingResult, SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import (
@@ -87,6 +89,8 @@ class TestEnqueueSessionSchedulingHistory:
                 AssociationScopesEntitiesRow,
                 EntityFieldRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -337,6 +341,7 @@ class TestEnqueueSessionSchedulingHistory:
             batch_timeout=None,
             callback_url=None,
             images=["python:3.8"],
+            image_ids=[],
             designated_agent_list=None,
             kernels=[
                 KernelEnqueueData(
@@ -357,6 +362,7 @@ class TestEnqueueSessionSchedulingHistory:
                     user_uuid=test_user_uuid,
                     access_key=test_access_key,
                     image="python:3.8",
+                    image_id=None,
                     architecture="x86_64",
                     registry="docker.io",
                     tag=None,
@@ -425,6 +431,8 @@ class TestMarkTerminatingSchedulingHistory:
                 KeyPairRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -29,9 +29,11 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.agent.row import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow, ProjectType
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow, KernelStatus
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import (
@@ -80,6 +82,8 @@ class TestSessionRepository:
                 UserRow,
                 GroupRow,
                 KeyPairRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -417,6 +421,8 @@ class TestBatchPopulateSessionOccupiedSlots:
                 UserRow,
                 GroupRow,
                 KeyPairRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -738,6 +744,8 @@ class TestGetTemplateInfoById:
                 GroupRow,
                 session_templates,
                 KeyPairRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/session/test_session_search_in_project.py
+++ b/tests/unit/manager/repositories/session/test_session_search_in_project.py
@@ -25,8 +25,10 @@ from ai.backend.common.types import (
 from ai.backend.manager.data.group.types import ProjectType
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.agent.row import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow, KernelStatus
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import (
@@ -65,6 +67,8 @@ class TestSessionSearchInProject:
                 UserRow,
                 GroupRow,
                 KeyPairRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,

--- a/tests/unit/manager/repositories/template/test_template_repository.py
+++ b/tests/unit/manager/repositories/template/test_template_repository.py
@@ -14,9 +14,11 @@ from ai.backend.common.types import DefaultForUnspecified, ResourceSlot, VFolder
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import (
@@ -67,6 +69,8 @@ class TestTemplateRepository:
                 KeyPairRow,
                 GroupRow,
                 AssocGroupUserRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 session_templates,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -223,6 +223,7 @@ def _make_session_data(
         user_uuid=user_id,
         access_key=access_key,
         images=["cr.backend.ai/stable/python:latest"],
+        image_ids=None,
         tag=None,
         occupying_slots=ResourceSlot({"cpu": 1, "mem": 1024}),
         requested_slots=ResourceSlot({"cpu": 1, "mem": 1024}),

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -248,6 +248,7 @@ def sample_session_data(
         user_uuid=sample_user_id,
         access_key=sample_access_key,
         images=["cr.backend.ai/stable/python:latest"],
+        image_ids=None,
         tag=None,
         occupying_slots=ResourceSlot({"cpu": 1, "mem": 1024}),
         requested_slots=ResourceSlot({"cpu": 1, "mem": 1024}),
@@ -352,6 +353,7 @@ class TestMatchSessions:
                 user_uuid=sample_user_id,
                 access_key=sample_access_key,
                 images=["python:latest"],
+                image_ids=None,
                 tag=None,
                 occupying_slots=ResourceSlot({}),
                 requested_slots=ResourceSlot({}),
@@ -1721,6 +1723,7 @@ class TestSearchKernels:
                 gids=[1000],
             ),
             image=ImageInfo(
+                image_id=None,
                 identifier=None,
                 registry="cr.backend.ai",
                 tag="latest",

--- a/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
@@ -169,6 +169,7 @@ def _create_session(
                 gids=None,
             ),
             image=ImageInfo(
+                image_id=None,
                 identifier=None,
                 registry="docker.io",
                 tag="latest",
@@ -270,6 +271,7 @@ def _create_kernel(
             gids=None,
         ),
         image=ImageInfo(
+            image_id=None,
             identifier=None,
             registry="docker.io",
             tag="latest",
@@ -572,6 +574,7 @@ def sessions_for_pull_factory() -> Callable[..., SessionsForPullWithImages]:
                         agent_addr=k.resource.agent_addr,
                         scaling_group=s.session_info.resource.scaling_group_name or "default",
                         image="test-image:latest",
+                        image_id=None,
                         architecture=k.image.architecture or "x86_64",
                     )
                     for k in s.kernel_infos
@@ -579,10 +582,12 @@ def sessions_for_pull_factory() -> Callable[..., SessionsForPullWithImages]:
             )
             for s in sessions
         ]
+        _image_id = uuid4()
         return SessionsForPullWithImages(
             sessions=sessions_for_pull,
             image_configs={
-                "test-image:latest": ImageConfigData(
+                _image_id: ImageConfigData(
+                    id=_image_id,
                     canonical="test-image:latest",
                     architecture="x86_64",
                     project=None,
@@ -620,6 +625,7 @@ def sessions_for_start_factory() -> Callable[..., SessionsForStartWithImages]:
                         agent_addr=k.resource.agent_addr,
                         scaling_group=s.session_info.resource.scaling_group_name or "default",
                         image="test-image:latest",
+                        image_id=None,
                         architecture=k.image.architecture or "x86_64",
                     )
                     for k in s.kernel_infos
@@ -631,10 +637,12 @@ def sessions_for_start_factory() -> Callable[..., SessionsForStartWithImages]:
             )
             for s in sessions
         ]
+        _image_id = uuid4()
         return SessionsForStartWithImages(
             sessions=sessions_for_start,
             image_configs={
-                "test-image:latest": ImageConfigData(
+                _image_id: ImageConfigData(
+                    id=_image_id,
                     canonical="test-image:latest",
                     architecture="x86_64",
                     project=None,

--- a/tests/unit/manager/sokovan/scheduler/launcher/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/launcher/conftest.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -31,6 +31,11 @@ from ai.backend.manager.sokovan.scheduler.launcher.launcher import (
     SessionLauncher,
     SessionLauncherArgs,
 )
+
+# Shared image IDs for linking kernel <-> image config in tests
+_DEFAULT_IMAGE_ID = UUID("00000000-0000-0000-0000-000000000001")
+_IMAGE_ID_1 = UUID("00000000-0000-0000-0000-000000000002")
+_IMAGE_ID_2 = UUID("00000000-0000-0000-0000-000000000003")
 
 # =============================================================================
 # Mock Dependencies
@@ -124,6 +129,7 @@ def _create_kernel_binding_data(
     kernel_id: KernelId | None = None,
     agent_id: AgentId | None = None,
     image: str = "cr.backend.ai/stable/python:3.9-ubuntu20.04",
+    image_id: UUID | None = _DEFAULT_IMAGE_ID,
     cluster_role: str = "main",
     cluster_idx: int = 0,
 ) -> KernelBindingData:
@@ -133,6 +139,7 @@ def _create_kernel_binding_data(
         agent_id=agent_id or AgentId("agent-1"),
         agent_addr="tcp://agent-1:6001",
         image=image,
+        image_id=image_id,
         architecture="x86_64",
         cluster_role=cluster_role,
         cluster_idx=cluster_idx,
@@ -197,8 +204,8 @@ def session_for_pull_multiple_kernels_same_agent() -> SessionDataForPull:
     agent_id = AgentId("agent-1")
     return _create_session_for_pull(
         kernels=[
-            _create_kernel_binding_data(agent_id=agent_id, image="image-1"),
-            _create_kernel_binding_data(agent_id=agent_id, image="image-2"),
+            _create_kernel_binding_data(agent_id=agent_id, image="image-1", image_id=_IMAGE_ID_1),
+            _create_kernel_binding_data(agent_id=agent_id, image="image-2", image_id=_IMAGE_ID_2),
         ]
     )
 
@@ -310,9 +317,11 @@ def session_for_start_kernel_no_agent() -> SessionDataForStart:
 
 def _create_image_config_data(
     canonical: str = "cr.backend.ai/stable/python:3.9-ubuntu20.04",
+    image_id: UUID = _DEFAULT_IMAGE_ID,
 ) -> ImageConfigData:
     """Create ImageConfigData for tests."""
     return ImageConfigData(
+        id=image_id,
         canonical=canonical,
         architecture="x86_64",
         project="stable",
@@ -327,17 +336,20 @@ def _create_image_config_data(
 
 
 @pytest.fixture
-def image_config_default() -> dict[str, ImageConfigData]:
+def image_config_default() -> dict[UUID, ImageConfigData]:
     """Default image configuration."""
+    config = _create_image_config_data()
     return {
-        "cr.backend.ai/stable/python:3.9-ubuntu20.04": _create_image_config_data(),
+        config.id: config,
     }
 
 
 @pytest.fixture
-def image_configs_multiple() -> dict[str, ImageConfigData]:
+def image_configs_multiple() -> dict[UUID, ImageConfigData]:
     """Multiple image configurations."""
+    config1 = _create_image_config_data(canonical="image-1", image_id=_IMAGE_ID_1)
+    config2 = _create_image_config_data(canonical="image-2", image_id=_IMAGE_ID_2)
     return {
-        "image-1": _create_image_config_data(canonical="image-1"),
-        "image-2": _create_image_config_data(canonical="image-2"),
+        config1.id: config1,
+        config2.id: config2,
     }

--- a/tests/unit/manager/sokovan/scheduler/launcher/test_launcher.py
+++ b/tests/unit/manager/sokovan/scheduler/launcher/test_launcher.py
@@ -11,6 +11,7 @@ Test Scenarios:
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
 
 import pytest
 
@@ -38,7 +39,7 @@ class TestSessionLauncherImagePulling:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         sessions_for_pull_multiple: list[SessionDataForPull],
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-001: Image pulling triggered for all agents.
 
@@ -63,7 +64,7 @@ class TestSessionLauncherImagePulling:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         session_for_pull_duplicate_images: SessionDataForPull,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-002: Duplicate images are deduplicated per agent.
 
@@ -89,7 +90,7 @@ class TestSessionLauncherImagePulling:
         self,
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-003: Empty session list does nothing.
 
@@ -109,7 +110,7 @@ class TestSessionLauncherImagePulling:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         sessions_for_pull_multiple: list[SessionDataForPull],
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-004: Agent pulling failure doesn't block other agents.
 
@@ -157,7 +158,7 @@ class TestSessionLauncherKernelCreation:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         session_for_start_single_kernel: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-005: Single kernel session started successfully.
 
@@ -186,7 +187,7 @@ class TestSessionLauncherKernelCreation:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         session_for_start_multi_kernel: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-006: Multi-kernel cluster session started.
 
@@ -215,7 +216,7 @@ class TestSessionLauncherKernelCreation:
         launcher: SessionLauncher,
         mock_repository: AsyncMock,
         session_for_start_no_kernels: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-007: Session without kernels updates error info.
 
@@ -239,7 +240,7 @@ class TestSessionLauncherKernelCreation:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         session_for_start_single_kernel: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-008: Multiple sessions started concurrently.
 
@@ -277,7 +278,7 @@ class TestSessionLauncherNetworkSetup:
         mock_agent_client_pool: MagicMock,
         mock_repository: AsyncMock,
         session_for_start_multi_kernel: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-009: Volatile network for single-node multi-kernel session.
 
@@ -301,7 +302,7 @@ class TestSessionLauncherNetworkSetup:
         launcher: SessionLauncher,
         mock_network_plugin_ctx: MagicMock,
         session_for_start_multi_node: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-010: Volatile network for multi-node uses overlay.
 
@@ -325,7 +326,7 @@ class TestSessionLauncherNetworkSetup:
         launcher: SessionLauncher,
         mock_agent_client_pool: MagicMock,
         session_for_start_host_network: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-011: Host network creates SSH port mapping.
 
@@ -350,7 +351,7 @@ class TestSessionLauncherNetworkSetup:
         launcher: SessionLauncher,
         mock_repository: AsyncMock,
         session_for_start_single_kernel: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-012: Network ID is persisted after setup.
 
@@ -374,7 +375,7 @@ class TestSessionLauncherNetworkSetup:
         mock_network_plugin_ctx: MagicMock,
         mock_repository: AsyncMock,
         session_for_start_multi_node: SessionDataForStart,
-        image_config_default: dict[str, ImageConfigData],
+        image_config_default: dict[UUID, ImageConfigData],
     ) -> None:
         """SC-LA-013: Missing network plugin reports error.
 

--- a/tests/unit/manager/sokovan/scheduler/terminator/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/terminator/conftest.py
@@ -222,6 +222,7 @@ def _create_kernel_info(
             gids=None,
         ),
         image=ImageInfo(
+            image_id=None,
             identifier=None,
             registry="docker.io",
             tag="latest",

--- a/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/test_integration.py
@@ -146,6 +146,7 @@ class TestSingleKernelSession:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -241,6 +242,7 @@ class TestSingleKernelSession:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -333,6 +335,7 @@ class TestMultiContainerSession:
             ],
             image_infos={
                 "tensorflow:2.0": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="tensorflow:2.0",
                     architecture="x86_64",
                     registry="docker.io",
@@ -430,6 +433,7 @@ class TestMultiContainerSession:
             ],
             image_infos={
                 "nginx:latest": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="nginx:latest",
                     architecture="x86_64",
                     registry="docker.io",
@@ -440,6 +444,7 @@ class TestMultiContainerSession:
                     },
                 ),
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -450,6 +455,7 @@ class TestMultiContainerSession:
                     },
                 ),
                 "redis:6": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="redis:6",
                     architecture="x86_64",
                     registry="docker.io",
@@ -538,6 +544,7 @@ class TestEdgeCases:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -600,6 +607,7 @@ class TestEdgeCases:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -631,6 +639,7 @@ class TestEdgeCases:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -708,6 +717,7 @@ class TestEdgeCases:
             ],
             image_infos={
                 "python:3.9": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="python:3.9",
                     architecture="x86_64",
                     registry="docker.io",
@@ -776,6 +786,7 @@ class TestMultiClusterScenarios:
             ],
             image_infos={
                 "pytorch:2.0": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="pytorch:2.0",
                     architecture="x86_64",
                     registry="docker.io",
@@ -891,6 +902,7 @@ class TestMultiClusterScenarios:
             ],
             image_infos={
                 "spark:master": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="spark:master",
                     architecture="x86_64",
                     registry="docker.io",
@@ -903,6 +915,7 @@ class TestMultiClusterScenarios:
                     },
                 ),
                 "spark:worker": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="spark:worker",
                     architecture="x86_64",
                     registry="docker.io",
@@ -915,6 +928,7 @@ class TestMultiClusterScenarios:
                     },
                 ),
                 "jupyter:notebook": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="jupyter:notebook",
                     architecture="x86_64",
                     registry="docker.io",
@@ -1000,6 +1014,7 @@ class TestMultiClusterScenarios:
             ],
             image_infos={
                 "llm:server": ImageInfo(
+                    id=uuid.uuid4(),
                     canonical="llm:server",
                     architecture="x86_64",
                     registry="docker.io",

--- a/tests/unit/manager/sokovan/scheduling_controller/validators/test_rules.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/validators/test_rules.py
@@ -53,6 +53,7 @@ def basic_context() -> SessionCreationContext:
         ],
         image_infos={
             "test-image": ImageInfo(
+                id=uuid.uuid4(),
                 canonical="test-image",
                 architecture="x86_64",
                 registry="localhost",

--- a/tests/unit/manager/test_reconcile_agent_resources.py
+++ b/tests/unit/manager/test_reconcile_agent_resources.py
@@ -21,8 +21,10 @@ from ai.backend.common.types import ResourceSlot, SlotName
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
 from ai.backend.manager.models.resource_slot import (
@@ -69,6 +71,8 @@ class TestReconcileAgentResources:
                 ScalingGroupRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,
@@ -463,6 +467,8 @@ class TestOrphanedAllocationCleanup:
                 ScalingGroupRow,
                 GroupRow,
                 AgentRow,
+                ContainerRegistryRow,
+                ImageRow,
                 SessionRow,
                 KernelRow,
                 ResourceSlotTypeRow,


### PR DESCRIPTION
## Summary
- Add `image_id` UUID FK column to `kernels` table (nullable, `SET NULL` on delete) and `image_ids` UUID array to `sessions` table, replacing string-based image references throughout the manager
- Convert all internal manager flows (scheduling, image pulling, state transitions, config resolution, launcher) to operate on `image_id` instead of canonical name strings; agent boundary stays string-based with conversion at event handler
- Implement `SessionV2GQL.images` connection resolver and `KernelV2GQL.image` node resolver; expose `image_ids`/`image_id` in DTO, REST, and CLI responses

## Test plan
- [ ] Apply alembic migration and verify backfill populates `kernels.image_id` from `(image, architecture)` → `images.id`
- [ ] Create session via `./bai` CLI and verify PENDING → RUNNING lifecycle with `image_id` populated
- [ ] Verify `session get` response includes `image_ids` and `kernel search` response includes `image_id`
- [ ] Verify GQL `SessionV2.images` returns ImageV2 connection and `KernelV2.image` returns ImageV2 node
- [ ] Purge an image and verify `kernel.image_id` becomes NULL while `kernel.image` string is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11125.org.readthedocs.build/en/11125/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11125.org.readthedocs.build/ko/11125/

<!-- readthedocs-preview sorna-ko end -->