### PR TITLE
refactor: make DeploymentController the single authority for revision operations

### DIFF
--- a/changes/11126.enhance.md
+++ b/changes/11126.enhance.md
@@ -1,0 +1,1 @@
+Make DeploymentController the single authority for revision creation and activation, ensuring consistent preset application, RBAC, deployment strategy, and concurrency guards across all API paths (v2 and legacy).

--- a/src/ai/backend/manager/dependencies/agents/composer.py
+++ b/src/ai/backend/manager/dependencies/agents/composer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
 from ai.backend.common.events.dispatcher import EventProducer
@@ -20,6 +21,12 @@ from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    ModelDefinitionGeneratorRegistry,
+)
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    RegistryArgs as ModelDefinitionRegistryArgs,
+)
 from ai.backend.manager.sokovan.deployment.deployment_controller import DeploymentController
 from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
     RevisionGeneratorRegistry,
@@ -28,6 +35,11 @@ from ai.backend.manager.sokovan.deployment.route.route_controller import RouteCo
 from ai.backend.manager.sokovan.scheduling_controller.scheduling_controller import (
     SchedulingController,
 )
+
+if TYPE_CHECKING:
+    from ai.backend.manager.repositories.deployment_revision_preset.repository import (
+        DeploymentRevisionPresetRepository,
+    )
 
 from .agent_client_pool import AgentClientPoolDependency, AgentClientPoolInput
 from .appproxy_client_pool import AppProxyClientPoolDependency
@@ -61,6 +73,7 @@ class AgentsInput:
     network_plugin_ctx: NetworkPluginContext
     scheduler_repository: SchedulerRepository
     deployment_repository: DeploymentRepository
+    deployment_revision_preset_repository: DeploymentRevisionPresetRepository | None
 
 
 @dataclass
@@ -72,6 +85,7 @@ class AgentsResources:
 
     scheduling_controller: SchedulingController
     revision_generator_registry: RevisionGeneratorRegistry
+    model_definition_generator_registry: ModelDefinitionGeneratorRegistry
     deployment_controller: DeploymentController
     route_controller: RouteController
     agent_client_pool: AgentClientPool
@@ -135,6 +149,14 @@ class AgentsComposer(DependencyComposer[AgentsInput, AgentsResources]):
             ),
         )
 
+        # 2.5. Model definition generator registry
+        model_definition_generator_registry = ModelDefinitionGeneratorRegistry(
+            ModelDefinitionRegistryArgs(
+                deployment_repository=setup_input.deployment_repository,
+                enable_model_definition_override=setup_input.config_provider.config.deployment.enable_model_definition_override,
+            )
+        )
+
         # 3. Deployment controller (depends on scheduling controller + revision generator registry)
         deployment_controller = await stack.enter_dependency(
             DeploymentControllerDependency(),
@@ -146,6 +168,8 @@ class AgentsComposer(DependencyComposer[AgentsInput, AgentsResources]):
                 event_producer=setup_input.event_producer,
                 valkey_schedule=valkey_schedule,
                 revision_generator_registry=revision_generator_registry,
+                model_definition_generator_registry=model_definition_generator_registry,
+                deployment_revision_preset_repository=setup_input.deployment_revision_preset_repository,
             ),
         )
 
@@ -197,6 +221,7 @@ class AgentsComposer(DependencyComposer[AgentsInput, AgentsResources]):
         yield AgentsResources(
             scheduling_controller=scheduling_controller,
             revision_generator_registry=revision_generator_registry,
+            model_definition_generator_registry=model_definition_generator_registry,
             deployment_controller=deployment_controller,
             route_controller=route_controller,
             agent_client_pool=agent_client_pool,

--- a/src/ai/backend/manager/dependencies/agents/deployment_controller.py
+++ b/src/ai/backend/manager/dependencies/agents/deployment_controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from ai.backend.common.clients.valkey_client.valkey_schedule.client import ValkeyScheduleClient
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
@@ -10,6 +11,9 @@ from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.storage import StorageSessionManager
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    ModelDefinitionGeneratorRegistry,
+)
 from ai.backend.manager.sokovan.deployment.deployment_controller import (
     DeploymentController,
     DeploymentControllerArgs,
@@ -20,6 +24,11 @@ from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
 from ai.backend.manager.sokovan.scheduling_controller.scheduling_controller import (
     SchedulingController,
 )
+
+if TYPE_CHECKING:
+    from ai.backend.manager.repositories.deployment_revision_preset.repository import (
+        DeploymentRevisionPresetRepository,
+    )
 
 
 @dataclass
@@ -33,6 +42,8 @@ class DeploymentControllerInput:
     event_producer: EventProducer
     valkey_schedule: ValkeyScheduleClient
     revision_generator_registry: RevisionGeneratorRegistry
+    model_definition_generator_registry: ModelDefinitionGeneratorRegistry
+    deployment_revision_preset_repository: DeploymentRevisionPresetRepository | None
 
 
 class DeploymentControllerDependency(
@@ -65,6 +76,8 @@ class DeploymentControllerDependency(
                 event_producer=setup_input.event_producer,
                 valkey_schedule=setup_input.valkey_schedule,
                 revision_generator_registry=setup_input.revision_generator_registry,
+                model_definition_generator_registry=setup_input.model_definition_generator_registry,
+                deployment_revision_preset_repository=setup_input.deployment_revision_preset_repository,
             )
         )
         yield controller

--- a/src/ai/backend/manager/dependencies/composer.py
+++ b/src/ai/backend/manager/dependencies/composer.py
@@ -241,6 +241,7 @@ class ManagerDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
                 network_plugin_ctx=plugins.network_plugin_ctx,
                 scheduler_repository=domain.repositories.scheduler.repository,
                 deployment_repository=domain.repositories.deployment.repository,
+                deployment_revision_preset_repository=domain.repositories.deployment_revision_preset.repository,
             ),
         )
 
@@ -308,6 +309,7 @@ class ManagerDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
                 hook_plugin_ctx=plugins.hook_plugin_ctx,
                 deployment_controller=agents.deployment_controller,
                 revision_generator_registry=agents.revision_generator_registry,
+                model_definition_generator_registry=agents.model_definition_generator_registry,
                 agent_cache=components.agent_cache,
                 notification_center=domain.notification_center,
                 appproxy_client_pool=agents.appproxy_client_pool,

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -60,6 +60,9 @@ from ai.backend.manager.service.container_registry.harbor import (
 from ai.backend.manager.services.processors import Processors, ServiceArgs
 from ai.backend.manager.sokovan.deployment import DeploymentController
 from ai.backend.manager.sokovan.deployment.coordinator import DeploymentCoordinator
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    ModelDefinitionGeneratorRegistry,
+)
 from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
     RevisionGeneratorRegistry,
 )
@@ -120,6 +123,7 @@ class ProcessingInput:
     hook_plugin_ctx: HookPluginContext
     deployment_controller: DeploymentController
     revision_generator_registry: RevisionGeneratorRegistry
+    model_definition_generator_registry: ModelDefinitionGeneratorRegistry
     agent_cache: AgentRPCCache
     notification_center: NotificationCenter
     appproxy_client_pool: AppProxyClientPool
@@ -245,6 +249,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             scheduling_controller=setup_input.scheduling_controller,
             deployment_controller=setup_input.deployment_controller,
             revision_generator_registry=setup_input.revision_generator_registry,
+            model_definition_generator_registry=setup_input.model_definition_generator_registry,
             event_producer=setup_input.event_producer,
             agent_cache=setup_input.agent_cache,
             notification_center=setup_input.notification_center,

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -1,6 +1,7 @@
 """Database source implementation for deployment repository."""
 
 import dataclasses
+import logging
 import uuid
 from collections import Counter, defaultdict
 from collections.abc import AsyncIterator, Mapping, Sequence
@@ -31,6 +32,7 @@ from ai.backend.common.types import (
     KernelId,
     SessionId,
 )
+from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.deployment.creator import DeploymentPolicyConfig
 from ai.backend.manager.data.deployment.scale import (
@@ -172,6 +174,9 @@ class EndpointWithRoutesRawData:
 
     endpoint_row: EndpointRow
     route_rows: list[RoutingRow]
+
+
+log = BraceStyleAdapter(logging.getLogger(__name__))
 
 
 class DeploymentDBSource:
@@ -2559,6 +2564,73 @@ class DeploymentDBSource:
             if row is None:
                 return None, False
             return cast(uuid.UUID | None, row[0]), True
+
+    async def prune_old_revisions(
+        self,
+        endpoint_id: uuid.UUID,
+        revision_history_limit: int,
+    ) -> int:
+        """Delete old revisions exceeding the history limit.
+
+        Preserves:
+        - The revision referenced by ``current_revision``
+        - The revision referenced by ``deploying_revision``
+
+        Revisions are ordered by revision_number descending; the newest
+        ``revision_history_limit`` revisions are kept (plus the two
+        protected revisions above).
+
+        Returns the number of deleted revisions.
+        """
+        async with self._begin_session_read_committed() as db_sess:
+            # Fetch protected revision IDs
+            endpoint_query = sa.select(
+                EndpointRow.current_revision,
+                EndpointRow.deploying_revision,
+            ).where(EndpointRow.id == endpoint_id)
+            ep_result = await db_sess.execute(endpoint_query)
+            ep_row = ep_result.one_or_none()
+            if ep_row is None:
+                return 0
+
+            protected_ids: set[uuid.UUID] = set()
+            if ep_row[0] is not None:
+                protected_ids.add(ep_row[0])
+            if ep_row[1] is not None:
+                protected_ids.add(ep_row[1])
+
+            # Find revisions to keep (newest N by revision_number)
+            keep_query = (
+                sa.select(DeploymentRevisionRow.id)
+                .where(DeploymentRevisionRow.endpoint == endpoint_id)
+                .order_by(DeploymentRevisionRow.revision_number.desc())
+                .limit(revision_history_limit)
+            )
+            keep_result = await db_sess.execute(keep_query)
+            keep_ids = {row[0] for row in keep_result.all()}
+
+            # Union: keep the newest N + the protected revisions
+            keep_ids |= protected_ids
+
+            # Delete everything else
+            delete_query = (
+                sa.delete(DeploymentRevisionRow)
+                .where(
+                    DeploymentRevisionRow.endpoint == endpoint_id,
+                    DeploymentRevisionRow.id.notin_(keep_ids),
+                )
+                .returning(DeploymentRevisionRow.id)
+            )
+            delete_result = await db_sess.execute(delete_query)
+            deleted_count = len(delete_result.all())
+            if deleted_count > 0:
+                log.info(
+                    "Pruned {} old revisions for deployment {} (limit={})",
+                    deleted_count,
+                    endpoint_id,
+                    revision_history_limit,
+                )
+            return deleted_count
 
     # -------------------------------------------------------------------------
     # Auto-Scaling Policy Methods (DeploymentAutoScalingPolicyRow)

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -1317,6 +1317,21 @@ class DeploymentRepository:
         """
         return await self._db_source.set_deploying_revision(endpoint_id, revision_id)
 
+    @deployment_repository_resilience.apply()
+    async def prune_old_revisions(
+        self,
+        endpoint_id: uuid.UUID,
+        revision_history_limit: int,
+    ) -> int:
+        """Delete old revisions that exceed the history limit.
+
+        Preserves current_revision and deploying_revision.
+
+        Returns:
+            Number of revisions deleted.
+        """
+        return await self._db_source.prune_old_revisions(endpoint_id, revision_history_limit)
+
     # ========== Deployment Auto-Scaling Policy Operations ==========
 
     @deployment_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -44,7 +44,6 @@ from ai.backend.manager.data.vfolder.types import VFolderLocation, VFolderOwners
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.resource import DatabaseConnectionUnavailable
 from ai.backend.manager.errors.service import EndpointNotFound
-from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.endpoint import (
     AutoScalingMetricComparator,
     AutoScalingMetricSource,
@@ -58,7 +57,6 @@ from ai.backend.manager.models.group import resolve_group_name_or_id
 from ai.backend.manager.models.image import ImageAlias, ImageIdentifier, ImageRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_policy import keypair_resource_policies
-from ai.backend.manager.models.resource_slot.row import DeploymentRevisionResourceSlotRow
 from ai.backend.manager.models.routing import RouteStatus, RoutingRow
 from ai.backend.manager.models.scaling_group import scaling_groups
 from ai.backend.manager.models.session import KernelLoadingStrategy, SessionRow
@@ -756,16 +754,17 @@ class ModelServingRepository:
             return await ImageRow.resolve(session, identifiers)
 
     @model_serving_repository_resilience.apply()
-    async def modify_endpoint(
+    async def modify_endpoint_fields(
         self,
         action: ModifyEndpointAction,
         agent_registry: AgentRegistry,
         legacy_etcd_config_loader: LegacyEtcdLoader,
-        storage_manager: StorageSessionManager,
     ) -> MutationResult:
-        """
-        Modify an endpoint with all validations and checks.
-        This method handles all database operations for endpoint modification.
+        """Apply endpoint-level changes only (name, resource_group, replicas, open_to_public).
+
+        Revision-level changes (resource_slots, image, environ, etc.) are handled
+        separately by the caller via DeploymentController.add_revision() +
+        activate_revision().
         """
 
         async def _do_mutate() -> MutationResult:
@@ -825,107 +824,6 @@ class ModelServingRepository:
                     endpoint_row.domain,
                     endpoint_row.project,
                 )
-
-                # If revision-level fields changed, create a new revision
-                if spec.has_revision_changes():
-                    current_rev = endpoint_row._find_current_revision()
-                    if current_rev is None:
-                        raise InvalidAPIParameters("Endpoint has no current revision")
-
-                    # Re-read model definition from vfolder to pick up file changes
-                    refreshed_model_definition = await self._fetch_model_definition_from_vfolder(
-                        db_session,
-                        storage_manager,
-                        current_rev.model,
-                        spec.model_definition_path.optional_value()
-                        or current_rev.model_definition_path,
-                    )
-
-                    # Resolve image if changed
-                    image_id = current_rev.image
-                    image_ref = spec.image.optional_value()
-                    if image_ref is not None:
-                        image_name = image_ref.name
-                        arch = image_ref.architecture.value()
-                        resolved_image = await ImageRow.resolve(
-                            db_session,
-                            [ImageIdentifier(image_name, arch), ImageAlias(image_name)],
-                        )
-                        image_id = resolved_image.id
-
-                    # Merge resource_slots: spec overrides current revision
-                    merged_slots: ResourceSlot = (
-                        spec.resource_slots.optional_value()
-                        or ResourceSlot({
-                            r.slot_name: r.quantity for r in current_rev.resource_slot_rows
-                        })
-                    )
-
-                    # Merge revision fields: current revision as base, spec overrides
-                    new_revision = DeploymentRevisionRow(
-                        endpoint=endpoint_row.id,
-                        revision_number=0,  # placeholder, will be set atomically below
-                        image=image_id,
-                        model=current_rev.model,
-                        model_mount_destination=current_rev.model_mount_destination,
-                        model_definition_path=(
-                            spec.model_definition_path.optional_value()
-                            if spec.model_definition_path.optional_value() is not None
-                            else current_rev.model_definition_path
-                        ),
-                        model_definition=refreshed_model_definition or current_rev.model_definition,
-                        resource_group=endpoint_row.resource_group,
-                        resource_opts=(
-                            spec.resource_opts.optional_value()
-                            if spec.resource_opts.optional_value() is not None
-                            else current_rev.resource_opts
-                        ),
-                        cluster_mode=(
-                            spec.cluster_mode.value().value
-                            if spec.cluster_mode.optional_value() is not None
-                            else current_rev.cluster_mode
-                        ),
-                        cluster_size=(
-                            spec.cluster_size.optional_value() or current_rev.cluster_size
-                        ),
-                        startup_command=current_rev.startup_command,
-                        bootstrap_script=current_rev.bootstrap_script,
-                        environ=(
-                            spec.environ.optional_value()
-                            if spec.environ.optional_value() is not None
-                            else current_rev.environ
-                        ),
-                        callback_url=current_rev.callback_url,
-                        runtime_variant=(
-                            spec.runtime_variant.optional_value() or current_rev.runtime_variant
-                        ),
-                        extra_mounts=list(current_rev.extra_mounts),
-                    )
-
-                    # Atomically assign next revision number
-                    max_query = sa.select(sa.func.max(DeploymentRevisionRow.revision_number)).where(
-                        DeploymentRevisionRow.endpoint == endpoint_row.id
-                    )
-                    result = await db_session.execute(max_query)
-                    latest = result.scalar()
-                    new_revision.revision_number = (latest or 0) + 1
-
-                    db_session.add(new_revision)
-                    await db_session.flush()
-
-                    # Write normalized resource slot rows
-                    for slot_name, quantity in merged_slots.items():
-                        db_session.add(
-                            DeploymentRevisionResourceSlotRow(
-                                revision_id=new_revision.id,
-                                slot_name=str(slot_name),
-                                quantity=quantity,
-                            )
-                        )
-                    await db_session.flush()
-
-                    # Activate: set as current revision
-                    endpoint_row.current_revision = new_revision.id
 
                 await db_session.commit()
 

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -5,7 +5,6 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
-from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import (
     ActivenessStatus,
@@ -17,21 +16,17 @@ from ai.backend.common.data.model_deployment.types import (
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import UnreachableError
 from ai.backend.common.types import (
-    ClusterMode,
     ResourceSlot,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.deployment.creator import (
     DeploymentPolicyConfig,
-    ModelRevisionCreator,
     NewDeploymentCreator,
 )
 from ai.backend.manager.data.deployment.types import (
     ClusterConfigData,
     DeploymentInfo,
-    DeploymentLifecycleSubStep,
     DeploymentNetworkSpec,
-    ExecutionSpec,
     ExtraVFolderMountData,
     ModelDeploymentAccessTokenData,
     ModelDeploymentData,
@@ -40,21 +35,16 @@ from ai.backend.manager.data.deployment.types import (
     ModelReplicaData,
     ModelRevisionData,
     ModelRuntimeConfigData,
-    MountMetadata,
     ReplicaSpec,
     ReplicaStateData,
     ResourceConfigData,
-    ResourceSpec,
-    RevisionDraft,
     RouteHealthStatus,
     RouteInfo,
     RouteStatus,
     RouteTrafficStatus,
-    merge_revision_drafts,
 )
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
-    PresetValueData,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.service import RoutingNotFound
@@ -63,7 +53,6 @@ from ai.backend.manager.models.deployment_policy import (
     DeploymentPolicyRow,
     RollingUpdateSpec,
 )
-from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.base.upserter import Upserter
@@ -76,7 +65,6 @@ from ai.backend.manager.repositories.deployment.creators import (
     DeploymentNetworkFields,
     DeploymentReplicaFields,
     DeploymentResourceFields,
-    DeploymentRevisionCreatorSpec,
     EndpointTokenCreatorSpec,
     ModelRevisionFields,
 )
@@ -206,13 +194,8 @@ from ai.backend.manager.services.deployment.actions.update_deployment import (
     UpdateDeploymentActionResult,
 )
 from ai.backend.manager.sokovan.deployment import DeploymentController
-from ai.backend.manager.sokovan.deployment.definition_generator.base import ModelDefinitionContext
 from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
     ModelDefinitionGeneratorRegistry,
-)
-from ai.backend.manager.sokovan.deployment.exceptions import (
-    DeploymentAlreadyInProgress,
-    InvalidEndpointState,
 )
 from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
     RevisionGeneratorRegistry,
@@ -641,7 +624,7 @@ class DeploymentService:
         Raises:
             DeploymentPolicyNotFound: If the policy does not exist
         """
-        data = await self._deployment_controller.get_deployment_policy(action.endpoint_id)
+        data = await self._deployment_repository.get_deployment_policy(action.endpoint_id)
         return GetDeploymentPolicyActionResult(data=data)
 
     async def search_deployment_policies(
@@ -671,92 +654,6 @@ class DeploymentService:
         return UpsertDeploymentPolicyActionResult(data=result.data, created=result.created)
 
     # ========== Revision Operations ==========
-
-    async def _apply_preset(
-        self,
-        creator: ModelRevisionCreator,
-    ) -> ModelRevisionCreator:
-        """Apply DeploymentRevisionPreset values to the creator if revision_preset_id is specified.
-
-        Creates a RevisionDraft from the preset, another from the request (creator),
-        and merges them with request taking priority over preset.
-        Returns a new ModelRevisionCreator with merged values.
-        """
-        if not creator.revision_preset_id or not self._deployment_revision_preset_repository:
-            return creator
-
-        preset_data = await self._deployment_revision_preset_repository.get_by_id(
-            creator.revision_preset_id,
-        )
-        preset_slots = await self._deployment_revision_preset_repository.get_resource_slots(
-            creator.revision_preset_id,
-        )
-
-        preset_draft = RevisionDraft(
-            image_id=preset_data.image_id,
-            resource_slots={slot_name: str(quantity) for slot_name, quantity in preset_slots},
-            resource_opts={o.name: o.value for o in preset_data.resource_opts},
-            cluster_mode=ClusterMode(preset_data.cluster_mode)
-            if preset_data.cluster_mode
-            else None,
-            cluster_size=preset_data.cluster_size,
-            startup_command=preset_data.startup_command,
-            bootstrap_script=preset_data.bootstrap_script,
-            environ={e.key: e.value for e in preset_data.environ},
-            model_definition=(
-                ModelDefinition(**preset_data.model_definition)
-                if preset_data.model_definition
-                else None
-            ),
-        )
-
-        request_draft = RevisionDraft(
-            image_id=creator.image_id,
-            resource_slots=(
-                dict(creator.resource_spec.resource_slots)
-                if creator.resource_spec.resource_slots
-                else None
-            ),
-            resource_opts=(
-                dict(creator.resource_spec.resource_opts)
-                if creator.resource_spec.resource_opts
-                else None
-            ),
-            cluster_mode=creator.resource_spec.cluster_mode,
-            cluster_size=creator.resource_spec.cluster_size,
-            startup_command=creator.execution.startup_command,
-            bootstrap_script=creator.execution.bootstrap_script,
-            environ=creator.execution.environ,
-            runtime_variant=creator.execution.runtime_variant,
-            model_definition=creator.model_definition,
-        )
-
-        merged = merge_revision_drafts(preset_draft, request_draft)
-
-        return ModelRevisionCreator(
-            image_id=merged.image_id or creator.image_id,
-            resource_spec=ResourceSpec(
-                cluster_mode=merged.cluster_mode or creator.resource_spec.cluster_mode,
-                cluster_size=merged.cluster_size or creator.resource_spec.cluster_size,
-                resource_slots=merged.resource_slots or creator.resource_spec.resource_slots,
-                resource_opts=merged.resource_opts,
-            ),
-            mounts=creator.mounts,
-            execution=ExecutionSpec(
-                startup_command=merged.startup_command,
-                bootstrap_script=merged.bootstrap_script,
-                environ=merged.environ,
-                runtime_variant=merged.runtime_variant or creator.execution.runtime_variant,
-                callback_url=creator.execution.callback_url,
-                inference_runtime_config=creator.execution.inference_runtime_config,
-            ),
-            model_definition=merged.model_definition,
-            revision_preset_id=creator.revision_preset_id,
-            preset_values=[
-                PresetValueData(preset_id=pv.preset_id, value=pv.value)
-                for pv in preset_data.preset_values
-            ],
-        )
 
     # System defaults used when neither the caller input nor the preset provides a value.
     _DEFAULT_REVISION_HISTORY_LIMIT = 10
@@ -851,146 +748,18 @@ class DeploymentService:
             strategy_spec=strategy_spec,
         )
 
-    async def _merge_deployment_config(
-        self,
-        revision_creator: ModelRevisionCreator,
-    ) -> ModelRevisionCreator:
-        """Merge deployment-config.yaml defaults into the revision creator.
-
-        Loads the deployment config from the model vfolder and merges
-        environ and resource_slots. The creator's values take precedence
-        over deployment config defaults.
-
-        If loading the deployment config fails (e.g. network error, malformed file),
-        the creator is returned as-is since deployment configs are optional defaults.
-        """
-        generator = self._revision_generator_registry.get(
-            revision_creator.execution.runtime_variant
-        )
-        try:
-            deployment_config = await generator.load_deployment_config(
-                vfolder_id=revision_creator.mounts.model_vfolder_id,
-                runtime_variant=revision_creator.execution.runtime_variant,
-            )
-        except Exception:
-            log.warning(
-                "Failed to load deployment config for vfolder {}, proceeding without it",
-                revision_creator.mounts.model_vfolder_id,
-                exc_info=True,
-            )
-            return revision_creator
-        if deployment_config is None:
-            return revision_creator
-
-        merged_environ = revision_creator.execution.environ
-        if deployment_config.environ:
-            merged_environ = {
-                **deployment_config.environ,
-                **(revision_creator.execution.environ or {}),
-            }
-
-        merged_resource_slots = revision_creator.resource_spec.resource_slots
-        if deployment_config.resource_slots:
-            merged_resource_slots = {
-                **deployment_config.resource_slots,
-                **revision_creator.resource_spec.resource_slots,
-            }
-
-        return ModelRevisionCreator(
-            image_id=revision_creator.image_id,
-            resource_spec=revision_creator.resource_spec.model_copy(
-                update={"resource_slots": merged_resource_slots},
-            ),
-            mounts=revision_creator.mounts,
-            execution=revision_creator.execution.model_copy(
-                update={"environ": merged_environ},
-            ),
-            model_definition=revision_creator.model_definition,
-        )
-
-    async def _resolve_model_definition(
-        self,
-        revision_creator: ModelRevisionCreator,
-    ) -> ModelDefinition:
-        """Generate the final model definition for a revision.
-
-        Builds a ModelDefinitionContext from the creator data and delegates to
-        ModelDefinitionGeneratorRegistry, which performs the full merge:
-        programmatic generation → user override → storage file override.
-        """
-        context = ModelDefinitionContext(
-            mounts=MountMetadata(
-                model_vfolder_id=revision_creator.mounts.model_vfolder_id,
-                model_definition_path=revision_creator.mounts.model_definition_path,
-                model_mount_destination=revision_creator.mounts.model_mount_destination,
-            ),
-            execution=revision_creator.execution,
-            model_definition=revision_creator.model_definition,
-        )
-        return await self._model_definition_generator_registry.generate_model_definition(context)
-
     async def add_model_revision(
         self, action: AddModelRevisionAction
     ) -> AddModelRevisionActionResult:
         """Add a new model revision to an existing deployment.
 
-        Resolves the final model definition before creating the revision,
-        so the DB row contains the fully-merged definition from the start.
-        Subsequent PROVISIONING uses the stored value directly.
-
-        Uses an atomic read-then-write operation for revision_number
-        assignment to prevent race conditions from concurrent requests.
-        The revision_number placeholder (0) is replaced atomically
-        inside the repository.
+        Delegates to DeploymentController.add_revision() which owns the full
+        pipeline: preset apply → config merge → model definition resolve →
+        revision create (with RBAC) → history pruning.
         """
-        deployment_id = action.model_deployment_id
-        log.info("Adding model revision to deployment {}", deployment_id)
-
-        endpoint_info = await self._deployment_repository.get_endpoint_info(deployment_id)
-        preset_applied = await self._apply_preset(action.adder)
-        merged_creator = await self._merge_deployment_config(preset_applied)
-        resolved_model_definition = await self._resolve_model_definition(merged_creator)
-
-        spec = DeploymentRevisionCreatorSpec(
-            endpoint_id=deployment_id,
-            image_id=merged_creator.image_id,
-            resource_group=endpoint_info.metadata.resource_group,
-            resource_slots=ResourceSlot(merged_creator.resource_spec.resource_slots),
-            # TODO: None and {} have different semantics (not provided vs empty options). CreatorSpec should accept Optional.
-            resource_opts=merged_creator.resource_spec.resource_opts or {},
-            cluster_mode=merged_creator.resource_spec.cluster_mode.value,
-            cluster_size=merged_creator.resource_spec.cluster_size,
-            model_id=merged_creator.mounts.model_vfolder_id,
-            model_mount_destination=merged_creator.mounts.model_mount_destination,
-            model_definition_path=merged_creator.mounts.model_definition_path,
-            model_definition=resolved_model_definition,
-            startup_command=merged_creator.execution.startup_command,
-            bootstrap_script=merged_creator.execution.bootstrap_script,
-            # TODO: None and {} have different semantics (not provided vs empty environ). CreatorSpec should accept Optional.
-            environ=merged_creator.execution.environ or {},
-            callback_url=str(merged_creator.execution.callback_url)
-            if merged_creator.execution.callback_url
-            else None,
-            runtime_variant=merged_creator.execution.runtime_variant,
-            # TODO: Convert merged_creator.mounts.extra_mounts (list[MountInfo]) to Sequence[VFolderMount] instead of discarding.
-            extra_mounts=(),
-            preset_values=[
-                PresetValueEntry(preset_id=pv.preset_id, value=pv.value)
-                for pv in merged_creator.preset_values
-            ],
+        revision_data = await self._deployment_controller.add_revision(
+            action.model_deployment_id, action.adder
         )
-        creator = RBACEntityCreator(
-            spec=spec,
-            element_type=RBACElementType.DEPLOYMENT_REVISION,
-            scope_ref=RBACElementRef(
-                element_type=RBACElementType.MODEL_DEPLOYMENT,
-                element_id=str(deployment_id),
-            ),
-        )
-        revision_data = await self._deployment_repository.create_revision_with_next_number(
-            creator, deployment_id
-        )
-
         return AddModelRevisionActionResult(revision=revision_data)
 
     async def get_revision_by_id(
@@ -1021,68 +790,18 @@ class DeploymentService:
     ) -> ActivateRevisionActionResult:
         """Activate a specific revision by initiating the deployment strategy.
 
-        Sets deploying_revision and transitions the deployment to DEPLOYING state.
-        The coordinator will execute the configured deployment strategy (rolling update,
-        blue-green, etc.) and swap deploying_revision → current_revision on completion.
-
-        Args:
-            action: Action containing deployment and revision IDs
-
-        Returns:
-            ActivateRevisionActionResult: Result containing the updated deployment
+        Delegates to DeploymentController.activate_revision() which validates
+        state, sets deploying_revision atomically, and triggers the DEPLOYING
+        lifecycle for strategy execution.
         """
-        # 1. Validate revision exists (raises exception if not found)
-        _revision = await self._deployment_repository.get_revision(action.revision_id)
-
-        # 2. Validate deployment state
-        deployment_info = await self._deployment_repository.get_endpoint_info(action.deployment_id)
-        if deployment_info.deploying_revision_id is not None:
-            raise DeploymentAlreadyInProgress(
-                f"Deployment {action.deployment_id} already has deploying_revision "
-                f"{deployment_info.deploying_revision_id} in progress."
-            )
-        if deployment_info.current_revision_id == action.revision_id:
-            raise InvalidEndpointState(
-                f"Revision {action.revision_id} is already the current revision "
-                f"of deployment {action.deployment_id}."
-            )
-
-        # 3. Set deploying_revision and transition to DEPLOYING lifecycle.
-        # The DB WHERE clause includes ``deploying_revision IS NULL`` to guard
-        # against concurrent activations; updated=False means the guard fired.
-        previous_revision_id, updated = await self._deployment_repository.set_deploying_revision(
+        result = await self._deployment_controller.activate_revision(
             action.deployment_id, action.revision_id
         )
-        if not updated:
-            raise DeploymentAlreadyInProgress(
-                f"Deployment {action.deployment_id} already has a deploying revision in progress "
-                f"(concurrent activation detected)."
-            )
-
-        # 4. Trigger DEPLOYING lifecycle to start strategy execution
-        await self._deployment_controller.mark_lifecycle_needed(
-            DeploymentLifecycleType.DEPLOYING,
-            sub_step=DeploymentLifecycleSubStep.DEPLOYING_PROVISIONING,
-        )
-
-        log.info(
-            "Started deploying revision {} for deployment {} (current: {})",
-            action.revision_id,
-            action.deployment_id,
-            previous_revision_id,
-        )
-
-        # 5. Get updated deployment info and policy
-        deployment_info = await self._deployment_repository.get_endpoint_info(action.deployment_id)
-        deployment_policy = await self._deployment_controller.get_deployment_policy(
-            action.deployment_id
-        )
-
         return ActivateRevisionActionResult(
-            deployment=_convert_deployment_info_to_data(deployment_info),
-            previous_revision_id=previous_revision_id,
-            activated_revision_id=action.revision_id,
-            deployment_policy=deployment_policy,
+            deployment=_convert_deployment_info_to_data(result.deployment_info),
+            previous_revision_id=result.previous_revision_id,
+            activated_revision_id=result.activated_revision_id,
+            deployment_policy=result.deployment_policy,
         )
 
     # ========== Route Operations ==========

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -149,12 +149,6 @@ from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
 from ai.backend.manager.services.vfolder.services.vfolder_admin import VFolderAdminService
 from ai.backend.manager.services.vfs_storage.processors import VFSStorageProcessors
 from ai.backend.manager.services.vfs_storage.service import VFSStorageService
-from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
-    ModelDefinitionGeneratorRegistry,
-)
-from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
-    RegistryArgs as ModelDefinitionRegistryArgs,
-)
 
 
 def create_services(args: ServiceArgs) -> Services:
@@ -316,7 +310,7 @@ def create_services(args: ServiceArgs) -> Services:
             config_provider=args.config_provider,
             valkey_live=args.valkey_live,
             repository=repositories.model_serving.repository,
-            deployment_repository=args.deployment_controller._deployment_repository,
+            deployment_repository=repositories.deployment.repository,
             deployment_controller=args.deployment_controller,
             scheduling_controller=args.scheduling_controller,
             revision_generator_registry=args.revision_generator_registry,
@@ -388,14 +382,9 @@ def create_services(args: ServiceArgs) -> Services:
         ),
         deployment=DeploymentService(
             args.deployment_controller,
-            args.deployment_controller._deployment_repository,
+            repositories.deployment.repository,
             args.revision_generator_registry,
-            ModelDefinitionGeneratorRegistry(
-                ModelDefinitionRegistryArgs(
-                    deployment_repository=args.deployment_controller._deployment_repository,
-                    enable_model_definition_override=args.config_provider.config.deployment.enable_model_definition_override,
-                )
-            ),
+            args.model_definition_generator_registry,
             deployment_revision_preset_repository=repositories.deployment_revision_preset.repository,
             runtime_variant_preset_repository=repositories.runtime_variant_preset.repository,
         ),

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -4,7 +4,7 @@ import logging
 import secrets
 import uuid
 from http import HTTPStatus
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from pydantic import HttpUrl
@@ -34,17 +34,20 @@ from ai.backend.common.types import (
     ImageAlias,
     KernelEnqueueingConfig,
     MountPermission,
+    ResourceSlot,
     SessionTypes,
     VFolderID,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.deployment.creator import VFolderMountsCreator
 from ai.backend.manager.data.deployment.types import (
     ExecutionSpec,
     ImageIdentifierDraft,
     ModelRevisionSpec,
     ModelRevisionSpecDraft,
     MountMetadata,
+    ResourceSpec,
     ResourceSpecDraft,
     RouteHealthStatus,
 )
@@ -149,6 +152,9 @@ from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
 from ai.backend.manager.sokovan.deployment.types import DeploymentLifecycleType
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.types import MountOptionModel, UserScope
+
+if TYPE_CHECKING:
+    from ai.backend.manager.data.deployment.creator import ModelRevisionCreator
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
@@ -889,22 +895,108 @@ class ModelServingService:
         return ForceSyncActionResult(success=True)
 
     async def modify_endpoint(self, action: ModifyEndpointAction) -> ModifyEndpointActionResult:
-        result = await self._repository.modify_endpoint(
+        spec = cast(EndpointUpdaterSpec, action.updater.spec)
+
+        # 1. Apply endpoint-level changes (name, resource_group, replicas)
+        #    via the existing repository method (which only writes endpoint columns).
+        result = await self._repository.modify_endpoint_fields(
             action,
             self._agent_registry,
             self._config_provider.legacy_etcd_config_loader,
-            self._storage_manager,
         )
-        spec = cast(EndpointUpdaterSpec, action.updater.spec)
-        if spec.replica_count_modified() or spec.has_revision_changes():
-            # Trigger CHECK_REPLICA for both cases:
-            # - replica count change: reconcile running session count
-            # - revision change: rotate sessions to use the newly activated revision
+
+        # 2. If revision-level fields changed, create + activate via controller.
+        #    This ensures the same pipeline as v2: preset → merge → resolve → RBAC
+        #    → deploying_revision guard → DEPLOYING strategy.
+        if spec.has_revision_changes():
+            creator = await self._build_revision_creator_from_spec(action.endpoint_id, spec)
+            revision = await self._deployment_controller.add_revision(action.endpoint_id, creator)
+            await self._deployment_controller.activate_revision(action.endpoint_id, revision.id)
+        elif spec.replica_count_modified():
+            # Replica-only change: trigger CHECK_REPLICA to reconcile
             await self._deployment_controller.mark_lifecycle_needed(
                 DeploymentLifecycleType.CHECK_REPLICA,
             )
+
         return ModifyEndpointActionResult(
             endpoint_id=action.endpoint_id, success=result.success, data=result.data
+        )
+
+    async def _build_revision_creator_from_spec(
+        self,
+        endpoint_id: uuid.UUID,
+        spec: EndpointUpdaterSpec,
+    ) -> ModelRevisionCreator:
+        """Build a ModelRevisionCreator from EndpointUpdaterSpec and the current revision.
+
+        Reads the current revision as a base and applies spec overrides.
+        Image resolution (name → image_id) is handled here since the legacy
+        spec carries an ImageRef, not an image_id.
+        """
+
+        current_rev = await self._deployment_repository.get_current_revision(endpoint_id)
+
+        # Resolve image_id: use spec override or keep current
+        image_id = current_rev.image_id
+        image_ref = spec.image.optional_value()
+        if image_ref is not None:
+            arch = (
+                image_ref.architecture.value()
+                if image_ref.architecture.optional_value()
+                else "x86_64"
+            )
+            image_id = await self._deployment_repository.get_image_id(
+                ImageIdentifier(image_ref.name, arch)
+            )
+
+        # Merge resource_slots
+        merged_slots = spec.resource_slots.optional_value() or ResourceSlot(
+            current_rev.resource_config.resource_slot
+        )
+
+        return ModelRevisionCreator(
+            image_id=image_id,
+            resource_spec=ResourceSpec(
+                cluster_mode=(
+                    spec.cluster_mode.value()
+                    if spec.cluster_mode.optional_value() is not None
+                    else current_rev.cluster_config.mode
+                ),
+                cluster_size=(
+                    spec.cluster_size.optional_value() or current_rev.cluster_config.size
+                ),
+                resource_slots=dict(merged_slots),
+                resource_opts=(
+                    spec.resource_opts.optional_value()
+                    if spec.resource_opts.optional_value() is not None
+                    else dict(current_rev.resource_config.resource_opts)
+                ),
+            ),
+            mounts=VFolderMountsCreator(
+                model_vfolder_id=current_rev.model_mount_config.vfolder_id or uuid.UUID(int=0),
+                model_definition_path=(
+                    spec.model_definition_path.optional_value()
+                    if spec.model_definition_path.optional_value() is not None
+                    else current_rev.model_mount_config.definition_path
+                ),
+                model_mount_destination=(
+                    current_rev.model_mount_config.mount_destination or "/models"
+                ),
+            ),
+            execution=ExecutionSpec(
+                startup_command=None,
+                bootstrap_script=None,
+                environ=(
+                    spec.environ.optional_value()
+                    if spec.environ.optional_value() is not None
+                    else (current_rev.model_runtime_config.environ or None)
+                ),
+                runtime_variant=(
+                    spec.runtime_variant.optional_value()
+                    or current_rev.model_runtime_config.runtime_variant
+                ),
+            ),
+            model_definition=current_rev.model_definition,
         )
 
     async def validate_model_service(

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -4,7 +4,7 @@ import logging
 import secrets
 import uuid
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import aiohttp
 from pydantic import HttpUrl
@@ -40,7 +40,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.deployment.creator import VFolderMountsCreator
+from ai.backend.manager.data.deployment.creator import ModelRevisionCreator, VFolderMountsCreator
 from ai.backend.manager.data.deployment.types import (
     ExecutionSpec,
     ImageIdentifierDraft,
@@ -152,9 +152,6 @@ from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
 from ai.backend.manager.sokovan.deployment.types import DeploymentLifecycleType
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.types import MountOptionModel, UserScope
-
-if TYPE_CHECKING:
-    from ai.backend.manager.data.deployment.creator import ModelRevisionCreator
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -319,6 +319,9 @@ if TYPE_CHECKING:
         VFSStorageService,  # pants: no-infer-dep
     )
     from ai.backend.manager.sokovan.deployment import DeploymentController  # pants: no-infer-dep
+    from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+        ModelDefinitionGeneratorRegistry,  # pants: no-infer-dep
+    )
     from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
         RevisionGeneratorRegistry,  # pants: no-infer-dep
     )
@@ -350,6 +353,7 @@ class ServiceArgs:
     scheduling_controller: SchedulingController
     deployment_controller: DeploymentController
     revision_generator_registry: RevisionGeneratorRegistry
+    model_definition_generator_registry: ModelDefinitionGeneratorRegistry
     event_producer: EventProducer
     agent_cache: AgentRPCCache
     notification_center: NotificationCenter

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -3,23 +3,34 @@
 import logging
 import uuid
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.types import ClusterMode, ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.deployment.creator import DeploymentCreationDraft
-from ai.backend.manager.data.deployment.scale import AutoScalingRule, AutoScalingRuleCreator
+from ai.backend.manager.data.deployment.creator import (
+    DeploymentCreationDraft,
+    ModelRevisionCreator,
+)
 from ai.backend.manager.data.deployment.types import (
     DeploymentInfo,
     DeploymentLifecycleSubStep,
-    DeploymentPolicyData,
+    ExecutionSpec,
+    ModelRevisionData,
+    MountMetadata,
+    ResourceSpec,
+    RevisionDraft,
     RouteInfo,
-    RouteSearchResult,
     RouteTrafficStatus,
+    merge_revision_drafts,
 )
+from ai.backend.manager.data.deployment_revision_preset.types import PresetValueData
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.routing.conditions import RouteConditions
@@ -29,17 +40,36 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityC
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.deployment import DeploymentRepository
 from ai.backend.manager.repositories.deployment.creators.endpoint import LegacyEndpointCreatorSpec
+from ai.backend.manager.repositories.deployment.creators.revision import (
+    DeploymentRevisionCreatorSpec,
+)
 from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentUpdaterSpec,
     RouteUpdaterSpec,
 )
+from ai.backend.manager.sokovan.deployment.definition_generator.base import ModelDefinitionContext
+from ai.backend.manager.sokovan.deployment.definition_generator.registry import (
+    ModelDefinitionGeneratorRegistry,
+)
+from ai.backend.manager.sokovan.deployment.exceptions import (
+    DeploymentAlreadyInProgress,
+    InvalidEndpointState,
+)
 from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
     RevisionGeneratorRegistry,
 )
-from ai.backend.manager.sokovan.deployment.types import DeploymentLifecycleType
+from ai.backend.manager.sokovan.deployment.types import (
+    ActivateRevisionResult,
+    DeploymentLifecycleType,
+)
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.sokovan.scheduling_controller.types import SessionValidationSpec
 from ai.backend.manager.types import OptionalState
+
+if TYPE_CHECKING:
+    from ai.backend.manager.repositories.deployment_revision_preset.repository import (
+        DeploymentRevisionPresetRepository,
+    )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -55,10 +85,21 @@ class DeploymentControllerArgs:
     event_producer: EventProducer
     valkey_schedule: ValkeyScheduleClient
     revision_generator_registry: RevisionGeneratorRegistry
+    model_definition_generator_registry: ModelDefinitionGeneratorRegistry
+    deployment_revision_preset_repository: "DeploymentRevisionPresetRepository | None"
 
 
 class DeploymentController:
-    """Controller for deployment and model service management."""
+    """Controller for deployment and model service management.
+
+    Owns all state-changing trigger operations for deployments:
+    - create_deployment / update_deployment / destroy_deployment
+    - add_revision / activate_revision
+    - mark_lifecycle_needed
+
+    Services compose these triggers; read-only queries (search/get) go
+    directly from Service to Repository.
+    """
 
     _scheduling_controller: SchedulingController
     _deployment_repository: DeploymentRepository
@@ -67,6 +108,8 @@ class DeploymentController:
     _event_producer: EventProducer
     _valkey_schedule: ValkeyScheduleClient
     _revision_generator_registry: RevisionGeneratorRegistry
+    _model_definition_generator_registry: ModelDefinitionGeneratorRegistry
+    _deployment_revision_preset_repository: "DeploymentRevisionPresetRepository | None"
 
     def __init__(self, args: DeploymentControllerArgs) -> None:
         """Initialize the deployment controller with required services."""
@@ -77,6 +120,8 @@ class DeploymentController:
         self._event_producer = args.event_producer
         self._valkey_schedule = args.valkey_schedule
         self._revision_generator_registry = args.revision_generator_registry
+        self._model_definition_generator_registry = args.model_definition_generator_registry
+        self._deployment_revision_preset_repository = args.deployment_revision_preset_repository
 
     async def create_deployment(
         self,
@@ -175,32 +220,6 @@ class DeploymentController:
         """
         return await self._deployment_repository.destroy_endpoint(endpoint_id)
 
-    async def create_autoscaling_rule(
-        self,
-        endpoint_id: uuid.UUID,
-        creator: AutoScalingRuleCreator,
-    ) -> AutoScalingRule:
-        return await self._deployment_repository.create_autoscaling_rule(
-            endpoint_id,
-            creator,
-        )
-
-    async def list_autoscaling_rules(
-        self,
-        endpoint_id: uuid.UUID,
-    ) -> list[AutoScalingRule]:
-        return await self._deployment_repository.list_autoscaling_rules(
-            endpoint_id,
-        )
-
-    async def delete_autoscaling_rule(
-        self,
-        rule_id: uuid.UUID,
-    ) -> bool:
-        return await self._deployment_repository.delete_autoscaling_rule(
-            rule_id,
-        )
-
     async def mark_lifecycle_needed(
         self,
         lifecycle_type: DeploymentLifecycleType,
@@ -224,56 +243,325 @@ class DeploymentController:
             sub_step_value,
         )
 
-    # ========== Deployment Policy Methods ==========
+    # ========== Revision Trigger Operations ==========
 
-    async def get_deployment_policy(
+    async def add_revision(
         self,
-        endpoint_id: uuid.UUID,
-    ) -> DeploymentPolicyData:
-        """Get the deployment policy for an endpoint.
+        deployment_id: uuid.UUID,
+        creator: ModelRevisionCreator,
+    ) -> ModelRevisionData:
+        """Add a new revision to a deployment.
 
-        Args:
-            endpoint_id: ID of the endpoint
+        Full pipeline: preset apply → config merge → model definition resolve
+        → revision create (with RBAC) → history pruning.
 
-        Returns:
-            DeploymentPolicyData: Policy data
+        This is the single authority for revision creation — all API paths
+        (v2 GQL, legacy GQL) must go through this method.
         """
-        return await self._deployment_repository.get_deployment_policy(endpoint_id)
+        log.info("Adding model revision to deployment {}", deployment_id)
 
-    # Route operations
+        endpoint_info = await self._deployment_repository.get_endpoint_info(deployment_id)
 
-    async def search_routes(
-        self,
-        querier: BatchQuerier,
-    ) -> RouteSearchResult:
-        """Search routes with pagination and filtering.
+        # 1. Apply preset defaults (revision-level)
+        preset_applied = await self._apply_preset(creator)
+        # 2. Merge deployment-config.yaml from vfolder
+        merged_creator = await self._merge_deployment_config(preset_applied)
+        # 3. Resolve final model definition
+        resolved_model_definition = await self._resolve_model_definition(merged_creator)
 
-        Args:
-            querier: BatchQuerier containing conditions, orders, and pagination
-
-        Returns:
-            RouteSearchResult with items, total_count, and pagination info
-        """
-        return await self._deployment_repository.search_routes(querier)
-
-    async def get_route(
-        self,
-        route_id: uuid.UUID,
-    ) -> RouteInfo | None:
-        """Get a single route by its ID.
-
-        Args:
-            route_id: The route ID
-
-        Returns:
-            RouteInfo if found, None otherwise
-        """
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=1),
-            conditions=[RouteConditions.by_ids([route_id])],
+        spec = DeploymentRevisionCreatorSpec(
+            endpoint_id=deployment_id,
+            image_id=merged_creator.image_id,
+            resource_group=endpoint_info.metadata.resource_group,
+            resource_slots=ResourceSlot(merged_creator.resource_spec.resource_slots),
+            resource_opts=merged_creator.resource_spec.resource_opts or {},
+            cluster_mode=merged_creator.resource_spec.cluster_mode.value,
+            cluster_size=merged_creator.resource_spec.cluster_size,
+            model_id=merged_creator.mounts.model_vfolder_id,
+            model_mount_destination=merged_creator.mounts.model_mount_destination,
+            model_definition_path=merged_creator.mounts.model_definition_path,
+            model_definition=resolved_model_definition,
+            startup_command=merged_creator.execution.startup_command,
+            bootstrap_script=merged_creator.execution.bootstrap_script,
+            environ=merged_creator.execution.environ or {},
+            callback_url=str(merged_creator.execution.callback_url)
+            if merged_creator.execution.callback_url
+            else None,
+            runtime_variant=merged_creator.execution.runtime_variant,
+            extra_mounts=(),
+            preset_values=[
+                PresetValueEntry(preset_id=pv.preset_id, value=pv.value)
+                for pv in merged_creator.preset_values
+            ],
         )
-        result = await self._deployment_repository.search_routes(querier)
-        return result.items[0] if result.items else None
+        rbac_creator = RBACEntityCreator(
+            spec=spec,
+            element_type=RBACElementType.DEPLOYMENT_REVISION,
+            scope_ref=RBACElementRef(
+                element_type=RBACElementType.MODEL_DEPLOYMENT,
+                element_id=str(deployment_id),
+            ),
+        )
+        revision_data = await self._deployment_repository.create_revision_with_next_number(
+            rbac_creator, deployment_id
+        )
+
+        # Prune old revisions beyond history limit
+        await self._prune_revision_history(
+            deployment_id, endpoint_info.metadata.revision_history_limit
+        )
+
+        return revision_data
+
+    async def activate_revision(
+        self,
+        deployment_id: uuid.UUID,
+        revision_id: uuid.UUID,
+    ) -> ActivateRevisionResult:
+        """Activate a specific revision by initiating the deployment strategy.
+
+        Sets deploying_revision and transitions the deployment to DEPLOYING state.
+        The coordinator will execute the configured deployment strategy (rolling
+        update, blue-green, etc.) and swap deploying_revision → current_revision
+        on completion.
+
+        Raises:
+            DeploymentAlreadyInProgress: If another revision is currently deploying.
+            InvalidEndpointState: If the revision is already current.
+        """
+        # 1. Validate revision exists
+        _revision = await self._deployment_repository.get_revision(revision_id)
+
+        # 2. Validate deployment state
+        deployment_info = await self._deployment_repository.get_endpoint_info(deployment_id)
+        if deployment_info.deploying_revision_id is not None:
+            raise DeploymentAlreadyInProgress(
+                f"Deployment {deployment_id} already has deploying_revision "
+                f"{deployment_info.deploying_revision_id} in progress."
+            )
+        if deployment_info.current_revision_id == revision_id:
+            raise InvalidEndpointState(
+                f"Revision {revision_id} is already the current revision "
+                f"of deployment {deployment_id}."
+            )
+
+        # 3. Set deploying_revision atomically (WHERE deploying_revision IS NULL)
+        previous_revision_id, updated = await self._deployment_repository.set_deploying_revision(
+            deployment_id, revision_id
+        )
+        if not updated:
+            raise DeploymentAlreadyInProgress(
+                f"Deployment {deployment_id} already has a deploying revision in progress "
+                f"(concurrent activation detected)."
+            )
+
+        # 4. Trigger DEPLOYING lifecycle
+        await self.mark_lifecycle_needed(
+            DeploymentLifecycleType.DEPLOYING,
+            sub_step=DeploymentLifecycleSubStep.DEPLOYING_PROVISIONING,
+        )
+
+        log.info(
+            "Started deploying revision {} for deployment {} (current: {})",
+            revision_id,
+            deployment_id,
+            previous_revision_id,
+        )
+
+        # 5. Return result with updated info and policy
+        deployment_info = await self._deployment_repository.get_endpoint_info(deployment_id)
+        deployment_policy = await self._deployment_repository.get_deployment_policy(deployment_id)
+
+        return ActivateRevisionResult(
+            deployment_info=deployment_info,
+            previous_revision_id=previous_revision_id,
+            activated_revision_id=revision_id,
+            deployment_policy=deployment_policy,
+        )
+
+    # ========== Revision Private Helpers ==========
+
+    async def _apply_preset(
+        self,
+        creator: ModelRevisionCreator,
+    ) -> ModelRevisionCreator:
+        """Apply DeploymentRevisionPreset values to the creator if revision_preset_id is set.
+
+        Creates a RevisionDraft from the preset, another from the request,
+        and merges them with request values taking priority.
+        """
+        if not creator.revision_preset_id or not self._deployment_revision_preset_repository:
+            return creator
+
+        preset_data = await self._deployment_revision_preset_repository.get_by_id(
+            creator.revision_preset_id,
+        )
+        preset_slots = await self._deployment_revision_preset_repository.get_resource_slots(
+            creator.revision_preset_id,
+        )
+
+        preset_draft = RevisionDraft(
+            image_id=preset_data.image_id,
+            resource_slots={slot_name: str(quantity) for slot_name, quantity in preset_slots},
+            resource_opts={o.name: o.value for o in preset_data.resource_opts},
+            cluster_mode=ClusterMode(preset_data.cluster_mode)
+            if preset_data.cluster_mode
+            else None,
+            cluster_size=preset_data.cluster_size,
+            startup_command=preset_data.startup_command,
+            bootstrap_script=preset_data.bootstrap_script,
+            environ={e.key: e.value for e in preset_data.environ},
+            model_definition=(
+                ModelDefinition(**preset_data.model_definition)
+                if preset_data.model_definition
+                else None
+            ),
+        )
+
+        request_draft = RevisionDraft(
+            image_id=creator.image_id,
+            resource_slots=(
+                dict(creator.resource_spec.resource_slots)
+                if creator.resource_spec.resource_slots
+                else None
+            ),
+            resource_opts=(
+                dict(creator.resource_spec.resource_opts)
+                if creator.resource_spec.resource_opts
+                else None
+            ),
+            cluster_mode=creator.resource_spec.cluster_mode,
+            cluster_size=creator.resource_spec.cluster_size,
+            startup_command=creator.execution.startup_command,
+            bootstrap_script=creator.execution.bootstrap_script,
+            environ=creator.execution.environ,
+            runtime_variant=creator.execution.runtime_variant,
+            model_definition=creator.model_definition,
+        )
+
+        merged = merge_revision_drafts(preset_draft, request_draft)
+
+        return ModelRevisionCreator(
+            image_id=merged.image_id or creator.image_id,
+            resource_spec=ResourceSpec(
+                cluster_mode=merged.cluster_mode or creator.resource_spec.cluster_mode,
+                cluster_size=merged.cluster_size or creator.resource_spec.cluster_size,
+                resource_slots=merged.resource_slots or creator.resource_spec.resource_slots,
+                resource_opts=merged.resource_opts,
+            ),
+            mounts=creator.mounts,
+            execution=ExecutionSpec(
+                startup_command=merged.startup_command,
+                bootstrap_script=merged.bootstrap_script,
+                environ=merged.environ,
+                runtime_variant=merged.runtime_variant or creator.execution.runtime_variant,
+                callback_url=creator.execution.callback_url,
+                inference_runtime_config=creator.execution.inference_runtime_config,
+            ),
+            model_definition=merged.model_definition,
+            revision_preset_id=creator.revision_preset_id,
+            preset_values=[
+                PresetValueData(preset_id=pv.preset_id, value=pv.value)
+                for pv in preset_data.preset_values
+            ],
+        )
+
+    async def _merge_deployment_config(
+        self,
+        revision_creator: ModelRevisionCreator,
+    ) -> ModelRevisionCreator:
+        """Merge deployment-config.yaml defaults from the model vfolder.
+
+        The creator's values take precedence over deployment config defaults.
+        If loading the config fails, the creator is returned as-is (configs are optional).
+        """
+        generator = self._revision_generator_registry.get(
+            revision_creator.execution.runtime_variant
+        )
+        try:
+            deployment_config = await generator.load_deployment_config(
+                vfolder_id=revision_creator.mounts.model_vfolder_id,
+                runtime_variant=revision_creator.execution.runtime_variant,
+            )
+        except Exception:
+            log.warning(
+                "Failed to load deployment config for vfolder {}, proceeding without it",
+                revision_creator.mounts.model_vfolder_id,
+                exc_info=True,
+            )
+            return revision_creator
+        if deployment_config is None:
+            return revision_creator
+
+        merged_environ = revision_creator.execution.environ
+        if deployment_config.environ:
+            merged_environ = {
+                **deployment_config.environ,
+                **(revision_creator.execution.environ or {}),
+            }
+
+        merged_resource_slots = revision_creator.resource_spec.resource_slots
+        if deployment_config.resource_slots:
+            merged_resource_slots = {
+                **deployment_config.resource_slots,
+                **revision_creator.resource_spec.resource_slots,
+            }
+
+        return ModelRevisionCreator(
+            image_id=revision_creator.image_id,
+            resource_spec=revision_creator.resource_spec.model_copy(
+                update={"resource_slots": merged_resource_slots},
+            ),
+            mounts=revision_creator.mounts,
+            execution=revision_creator.execution.model_copy(
+                update={"environ": merged_environ},
+            ),
+            model_definition=revision_creator.model_definition,
+        )
+
+    async def _resolve_model_definition(
+        self,
+        revision_creator: ModelRevisionCreator,
+    ) -> ModelDefinition:
+        """Generate the final model definition for a revision.
+
+        Delegates to ModelDefinitionGeneratorRegistry for the full merge:
+        programmatic generation → user override → storage file override.
+        """
+        context = ModelDefinitionContext(
+            mounts=MountMetadata(
+                model_vfolder_id=revision_creator.mounts.model_vfolder_id,
+                model_definition_path=revision_creator.mounts.model_definition_path,
+                model_mount_destination=revision_creator.mounts.model_mount_destination,
+            ),
+            execution=revision_creator.execution,
+            model_definition=revision_creator.model_definition,
+        )
+        return await self._model_definition_generator_registry.generate_model_definition(context)
+
+    async def _prune_revision_history(
+        self,
+        deployment_id: uuid.UUID,
+        revision_history_limit: int | None,
+    ) -> None:
+        """Delete old revisions that exceed the history limit.
+
+        Preserves current_revision and deploying_revision.
+        """
+        if revision_history_limit is None or revision_history_limit <= 0:
+            return
+        try:
+            await self._deployment_repository.prune_old_revisions(
+                deployment_id, revision_history_limit
+            )
+        except Exception:
+            log.warning(
+                "Failed to prune revision history for deployment {}, skipping",
+                deployment_id,
+                exc_info=True,
+            )
+
+    # ========== Route State Operations ==========
 
     async def update_route_traffic_status(
         self,

--- a/src/ai/backend/manager/sokovan/deployment/types.py
+++ b/src/ai/backend/manager/sokovan/deployment/types.py
@@ -14,7 +14,11 @@ from ai.backend.manager.data.deployment.types import (
 )
 
 if TYPE_CHECKING:
-    from ai.backend.manager.data.deployment.types import DeploymentInfoWithRoutes, RouteInfo
+    from ai.backend.manager.data.deployment.types import (
+        DeploymentInfoWithRoutes,
+        DeploymentPolicyData,
+        RouteInfo,
+    )
 
 
 class DeploymentLifecycleType(StrEnum):
@@ -46,6 +50,19 @@ class DeploymentExecutionResult:
     successes: list[DeploymentWithHistory] = field(default_factory=list)
     failures: list[DeploymentExecutionError] = field(default_factory=list)
     skipped: list[DeploymentWithHistory] = field(default_factory=list)
+
+
+@dataclass
+class ActivateRevisionResult:
+    """Result of activating a deployment revision.
+
+    Returned by DeploymentController.activate_revision().
+    """
+
+    deployment_info: DeploymentInfo
+    previous_revision_id: UUID | None
+    activated_revision_id: UUID
+    deployment_policy: DeploymentPolicyData
 
 
 @dataclass

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -117,6 +117,8 @@ def deployment_processors(
     revision_generator_registry = RevisionGeneratorRegistry(
         RevisionGeneratorRegistryArgs(deployment_repository=repo)
     )
+    model_definition_generator_registry = AsyncMock()
+    model_definition_generator_registry.generate_model_definition.return_value = ModelDefinition()
     deployment_controller = DeploymentController(
         DeploymentControllerArgs(
             scheduling_controller=scheduling_controller,
@@ -126,10 +128,10 @@ def deployment_processors(
             event_producer=event_producer,
             valkey_schedule=valkey_clients.schedule,
             revision_generator_registry=revision_generator_registry,
+            model_definition_generator_registry=model_definition_generator_registry,
+            deployment_revision_preset_repository=None,
         )
     )
-    model_definition_generator_registry = AsyncMock()
-    model_definition_generator_registry.generate_model_definition.return_value = ModelDefinition()
     service = DeploymentService(
         deployment_controller,
         repo,

--- a/tests/unit/manager/dependencies/agents/test_deployment_controller.py
+++ b/tests/unit/manager/dependencies/agents/test_deployment_controller.py
@@ -30,6 +30,8 @@ class TestDeploymentControllerDependency:
             event_producer=MagicMock(),
             valkey_schedule=MagicMock(),
             revision_generator_registry=MagicMock(),
+            model_definition_generator_registry=MagicMock(),
+            deployment_revision_preset_repository=None,
         )
 
         dependency = DeploymentControllerDependency()

--- a/tests/unit/manager/dependencies/processing/test_composer.py
+++ b/tests/unit/manager/dependencies/processing/test_composer.py
@@ -54,6 +54,7 @@ def _make_processing_input() -> ProcessingInput:
         hook_plugin_ctx=MagicMock(),
         deployment_controller=MagicMock(),
         revision_generator_registry=MagicMock(),
+        model_definition_generator_registry=MagicMock(),
         agent_cache=MagicMock(),
         notification_center=MagicMock(),
         appproxy_client_pool=MagicMock(),

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -335,15 +335,15 @@ class TestModifyEndpointModelDefinitionRefresh:
     # Tests
     # =========================================================================
 
-    async def test_new_revision_uses_refreshed_model_definition(
+    async def test_modify_endpoint_fields_does_not_create_revision(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
         repository: ModelServingRepository,
         endpoint_and_revision: tuple[uuid.UUID, uuid.UUID],
         user_context: UserData,
     ) -> None:
-        """The new revision created by modify_endpoint must carry the model
-        definition re-read from the vfolder, not the old revision's copy."""
+        """modify_endpoint_fields only applies endpoint-level changes;
+        revision creation is now handled by DeploymentController.add_revision."""
 
         endpoint_id, _ = endpoint_and_revision
         spec = EndpointUpdaterSpec(environ=TriState.update({"NEW_VAR": "1"}))
@@ -354,27 +354,20 @@ class TestModifyEndpointModelDefinitionRefresh:
 
         with (
             with_user(user_context),
-            patch.object(
-                repository,
-                "_fetch_model_definition_from_vfolder",
-                new_callable=AsyncMock,
-                return_value=NEW_MODEL_DEF,
-            ),
             patch(
                 "ai.backend.manager.repositories.model_serving.repository.ModelServiceHelper",
                 check_scaling_group=AsyncMock(),
             ),
         ):
-            result = await repository.modify_endpoint(
+            result = await repository.modify_endpoint_fields(
                 action,
                 agent_registry=MagicMock(),
                 legacy_etcd_config_loader=MagicMock(),
-                storage_manager=MagicMock(),
             )
 
         assert result.success is True
 
-        # Verify the new revision in DB has the refreshed model_definition
+        # Verify no new revision was created — revision count stays at 1
         async with db_with_cleanup.begin_readonly_session() as sess:
             rows = (
                 (
@@ -388,9 +381,5 @@ class TestModifyEndpointModelDefinitionRefresh:
                 .all()
             )
 
-        assert len(rows) == 2
+        assert len(rows) == 1
         assert rows[0].model_definition == OLD_MODEL_DEF
-        assert rows[1].model_definition == NEW_MODEL_DEF, (
-            "New revision must use model_definition freshly read from vfolder, "
-            f"got {rows[1].model_definition!r}"
-        )

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -7,7 +7,6 @@ Tests verify service layer business logic using mocked repositories.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -30,7 +29,6 @@ from ai.backend.manager.data.deployment.creator import (
 )
 from ai.backend.manager.data.deployment.types import (
     ClusterConfigData,
-    DeploymentConfig,
     DeploymentInfo,
     DeploymentMetadata,
     DeploymentNetworkSpec,
@@ -458,225 +456,23 @@ class ModelRevisionFixtures(DeploymentServiceBaseFixtures):
 
 
 class TestAddModelRevision(ModelRevisionFixtures):
-    """Tests for DeploymentService.add_model_revision"""
+    """Tests for DeploymentService.add_model_revision — now delegates to controller."""
 
-    async def test_add_model_revision_first_revision(
+    async def test_add_model_revision_delegates_to_controller(
         self,
         processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
+        mock_deployment_controller: MagicMock,
         deployment_id: uuid.UUID,
-        endpoint_info: DeploymentInfo,
         revision_creator: ModelRevisionCreator,
         revision_data: ModelRevisionData,
     ) -> None:
-        """Adding the first revision should delegate to create_revision_with_next_number."""
+        """add_model_revision should delegate to controller.add_revision."""
+        mock_deployment_controller.add_revision = AsyncMock(return_value=revision_data)
+
         action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
         result = await processors.add_model_revision.wait_for_complete(action)
 
         assert result.revision == revision_data
-        mock_deployment_repository.get_endpoint_info.assert_called_once_with(deployment_id)
-        mock_deployment_repository.create_revision_with_next_number.assert_called_once()
-
-        call_args = mock_deployment_repository.create_revision_with_next_number.call_args
-        creator_arg = call_args[0][0]
-        endpoint_id_arg = call_args[0][1]
-        spec = creator_arg.spec
-        assert endpoint_id_arg == deployment_id
-        assert spec.image_id == revision_creator.image_id
-        assert spec.resource_group == endpoint_info.metadata.resource_group
-        assert spec.model_id == revision_creator.mounts.model_vfolder_id
-        assert spec.runtime_variant == RuntimeVariant("vllm")
-
-    async def test_add_model_revision_maps_resource_fields(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator: ModelRevisionCreator,
-    ) -> None:
-        """All fields from ModelRevisionCreator should be mapped to the spec correctly."""
-        action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
-        await processors.add_model_revision.wait_for_complete(action)
-
-        creator_arg = mock_deployment_repository.create_revision_with_next_number.call_args[0][0]
-        spec = creator_arg.spec
-        assert spec.resource_slots == ResourceSlot(revision_creator.resource_spec.resource_slots)
-        assert spec.resource_opts == revision_creator.resource_spec.resource_opts
-        assert spec.cluster_mode == revision_creator.resource_spec.cluster_mode.value
-        assert spec.cluster_size == revision_creator.resource_spec.cluster_size
-        assert spec.model_mount_destination == revision_creator.mounts.model_mount_destination
-        assert spec.model_definition_path == revision_creator.mounts.model_definition_path
-        assert spec.model_definition == revision_creator.model_definition
-        assert spec.startup_command == revision_creator.execution.startup_command
-        assert spec.bootstrap_script == revision_creator.execution.bootstrap_script
-        assert spec.environ == revision_creator.execution.environ
-        assert spec.callback_url is None
-        assert spec.extra_mounts == ()
-
-    async def test_add_model_revision_with_none_environ(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator_with_none_environ: ModelRevisionCreator,
-    ) -> None:
-        """None environ and resource_opts should be converted to empty dict."""
-        action = AddModelRevisionAction(
-            model_deployment_id=deployment_id, adder=revision_creator_with_none_environ
+        mock_deployment_controller.add_revision.assert_awaited_once_with(
+            deployment_id, revision_creator
         )
-        await processors.add_model_revision.wait_for_complete(action)
-
-        creator_arg = mock_deployment_repository.create_revision_with_next_number.call_args[0][0]
-        spec = creator_arg.spec
-        assert spec.environ == {}
-        assert spec.resource_opts == {}
-
-    @pytest.fixture
-    def sample_model_definition(self) -> ModelDefinition:
-        return ModelDefinition.model_validate({
-            "models": [
-                {
-                    "name": "test-model",
-                    "model-path": "/models",
-                    "service": {"start-command": "serve", "port": 8000},
-                }
-            ]
-        })
-
-    @pytest.fixture
-    def revision_creator_with_model_definition(
-        self,
-        image_id: uuid.UUID,
-        model_vfolder_id: uuid.UUID,
-        sample_model_definition: ModelDefinition,
-    ) -> ModelRevisionCreator:
-        return ModelRevisionCreator(
-            image_id=image_id,
-            resource_spec=ResourceSpec(
-                cluster_mode=ClusterMode.SINGLE_NODE,
-                cluster_size=1,
-                resource_slots={"cpu": "4"},
-            ),
-            mounts=VFolderMountsCreator(model_vfolder_id=model_vfolder_id),
-            execution=ExecutionSpec(runtime_variant=RuntimeVariant("vllm")),
-            model_definition=sample_model_definition,
-        )
-
-    async def test_add_model_revision_stores_resolved_model_definition(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        mock_model_definition_generator_registry: AsyncMock,
-        deployment_id: uuid.UUID,
-        revision_creator_with_model_definition: ModelRevisionCreator,
-        sample_model_definition: ModelDefinition,
-    ) -> None:
-        """Resolved model_definition (from generator registry) should be stored in the DB spec."""
-        mock_model_definition_generator_registry.generate_model_definition.return_value = (
-            sample_model_definition
-        )
-
-        action = AddModelRevisionAction(
-            model_deployment_id=deployment_id, adder=revision_creator_with_model_definition
-        )
-        await processors.add_model_revision.wait_for_complete(action)
-
-        spec = mock_deployment_repository.create_revision_with_next_number.call_args[0][0].spec
-        assert spec.model_definition is not None
-        assert spec.model_definition == sample_model_definition
-
-
-class TestDeploymentConfigMerge(ModelRevisionFixtures):
-    """Tests for deployment config merging in revision creation."""
-
-    @pytest.fixture
-    def setup_mock_deployment_config(
-        self, mock_revision_generator_registry: MagicMock
-    ) -> Callable[[DeploymentConfig], None]:
-        """Factory fixture to inject a deployment config into the mock generator registry."""
-
-        def _setup(deployment_config: DeploymentConfig) -> None:
-            mock_generator = MagicMock()
-            mock_generator.load_deployment_config = AsyncMock(return_value=deployment_config)
-            mock_revision_generator_registry.get.return_value = mock_generator
-
-        return _setup
-
-    async def test_merge_environ_from_deployment_config(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator: ModelRevisionCreator,
-        setup_mock_deployment_config: Callable[[DeploymentConfig], None],
-    ) -> None:
-        """Deployment config environ should be merged with creator environ as base."""
-        setup_mock_deployment_config(
-            DeploymentConfig(
-                environ={"SERVICE_VAR": "from_def", "CUDA_VISIBLE_DEVICES": "1"},
-            )
-        )
-
-        action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
-        await processors.add_model_revision.wait_for_complete(action)
-
-        spec = mock_deployment_repository.create_revision_with_next_number.call_args[0][0].spec
-        # Creator value overrides deployment config for overlapping keys
-        assert spec.environ["CUDA_VISIBLE_DEVICES"] == "0"
-        # Deployment config provides new keys
-        assert spec.environ["SERVICE_VAR"] == "from_def"
-
-    async def test_merge_resource_slots_from_deployment_config(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator: ModelRevisionCreator,
-        setup_mock_deployment_config: Callable[[DeploymentConfig], None],
-    ) -> None:
-        """Deployment config resource_slots should be merged with creator slots as base."""
-        setup_mock_deployment_config(
-            DeploymentConfig(
-                resource_slots={"cpu": "2", "mem": "4g", "cuda.shares": "1.0"},
-            )
-        )
-
-        action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
-        await processors.add_model_revision.wait_for_complete(action)
-
-        spec = mock_deployment_repository.create_revision_with_next_number.call_args[0][0].spec
-        expected = ResourceSlot({"cpu": "4", "mem": "8g", "cuda.shares": "1.0"})
-        assert spec.resource_slots == expected
-
-    async def test_no_deployment_config_uses_creator_values_as_is(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator: ModelRevisionCreator,
-    ) -> None:
-        """When no deployment config exists, creator values are used unchanged."""
-        action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
-        await processors.add_model_revision.wait_for_complete(action)
-
-        spec = mock_deployment_repository.create_revision_with_next_number.call_args[0][0].spec
-        assert spec.environ == revision_creator.execution.environ
-        assert spec.resource_slots == ResourceSlot(revision_creator.resource_spec.resource_slots)
-
-    async def test_deployment_config_with_empty_fields_no_effect(
-        self,
-        processors: DeploymentProcessors,
-        mock_deployment_repository: MagicMock,
-        deployment_id: uuid.UUID,
-        revision_creator: ModelRevisionCreator,
-        setup_mock_deployment_config: Callable[[DeploymentConfig], None],
-    ) -> None:
-        """Deployment config with None environ/resource_slots should not affect creator."""
-        setup_mock_deployment_config(DeploymentConfig(environ=None, resource_slots=None))
-
-        action = AddModelRevisionAction(model_deployment_id=deployment_id, adder=revision_creator)
-        await processors.add_model_revision.wait_for_complete(action)
-
-        spec = mock_deployment_repository.create_revision_with_next_number.call_args[0][0].spec
-        assert spec.environ == revision_creator.execution.environ
-        assert spec.resource_slots == ResourceSlot(revision_creator.resource_spec.resource_slots)

--- a/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
+++ b/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
@@ -52,7 +52,7 @@ from ai.backend.manager.sokovan.deployment.revision_generator.registry import (
 )
 from ai.backend.manager.sokovan.deployment.types import DeploymentLifecycleType
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
-from ai.backend.manager.types import OptionalState
+from ai.backend.manager.types import OptionalState, TriState
 
 
 class ModelServingCRUDBaseFixtures:
@@ -225,7 +225,7 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             AsyncMock,
             mocker.patch.object(
                 mock_repositories.repository,
-                "modify_endpoint",
+                "modify_endpoint_fields",
                 new_callable=AsyncMock,
             ),
         )
@@ -241,6 +241,16 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             spec.replicas = OptionalState[int].nop()
             spec.replica_count_modified.return_value = False
         spec.has_revision_changes.return_value = has_revision_changes
+        # Set default nop values for revision-level fields used by
+        # _build_revision_creator_from_spec
+        spec.image = TriState.nop()
+        spec.resource_slots = OptionalState.nop()
+        spec.resource_opts = TriState.nop()
+        spec.cluster_mode = OptionalState.nop()
+        spec.cluster_size = OptionalState.nop()
+        spec.model_definition_path = TriState.nop()
+        spec.environ = TriState.nop()
+        spec.runtime_variant = OptionalState.nop()
         return spec
 
     async def test_replica_count_change_marks_check_replica(
@@ -270,14 +280,15 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             DeploymentLifecycleType.CHECK_REPLICA
         )
 
-    async def test_revision_change_marks_check_replica(
+    async def test_revision_change_calls_add_and_activate_revision(
         self,
         model_serving_processors: ModelServingProcessors,
         mock_modify_endpoint: AsyncMock,
         mock_deployment_controller: MagicMock,
+        mock_deployment_repository: MagicMock,
         endpoint_id: uuid.UUID,
     ) -> None:
-        """Revision-level field change triggers CHECK_REPLICA to auto-activate the new revision."""
+        """Revision-level field change delegates to controller.add_revision + activate_revision."""
         updater_spec = self._make_updater_spec(replicas=None, has_revision_changes=True)
         mock_updater = MagicMock()
         mock_updater.spec = updater_spec
@@ -288,13 +299,34 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             success=True, message="ok", data=mock_endpoint_data
         )
 
+        # Mock current revision data for _build_revision_creator_from_spec
+        mock_current_rev = MagicMock()
+        mock_current_rev.image_id = uuid.uuid4()
+        mock_current_rev.cluster_config.mode = "SINGLE_NODE"
+        mock_current_rev.cluster_config.size = 1
+        mock_current_rev.resource_config.resource_slot = {}
+        mock_current_rev.resource_config.resource_opts = {}
+        mock_current_rev.model_mount_config.vfolder_id = uuid.uuid4()
+        mock_current_rev.model_mount_config.definition_path = "model-definition.yaml"
+        mock_current_rev.model_mount_config.mount_destination = "/models"
+        mock_current_rev.model_runtime_config.environ = None
+        mock_current_rev.model_runtime_config.runtime_variant = "custom"
+        mock_current_rev.model_definition = None
+        mock_deployment_repository.get_current_revision = AsyncMock(return_value=mock_current_rev)
+
+        # Mock revision returned by add_revision
+        mock_revision = MagicMock()
+        mock_revision.id = uuid.uuid4()
+        mock_deployment_controller.add_revision = AsyncMock(return_value=mock_revision)
+        mock_deployment_controller.activate_revision = AsyncMock()
+
         action = ModifyEndpointAction(endpoint_id=endpoint_id, updater=mock_updater)
         result = await model_serving_processors.modify_endpoint.wait_for_complete(action)
 
         assert result.success is True
-        assert result.data == mock_endpoint_data
-        mock_deployment_controller.mark_lifecycle_needed.assert_awaited_once_with(
-            DeploymentLifecycleType.CHECK_REPLICA
+        mock_deployment_controller.add_revision.assert_awaited_once()
+        mock_deployment_controller.activate_revision.assert_awaited_once_with(
+            endpoint_id, mock_revision.id
         )
 
     async def test_no_replica_change_no_marking(


### PR DESCRIPTION
## Summary
- Move revision creation (`add_revision`) and activation (`activate_revision`) logic from `DeploymentService` into `DeploymentController`, making it the single authority for all state-changing deployment operations — analogous to how `SchedulingController` owns `enqueue_session` and `mark_sessions_for_termination`
- Refactor legacy `ModifyEndpoint` mutation to use `controller.add_revision()` + `controller.activate_revision()` instead of inline revision creation in `ModelServingRepository`, ensuring consistent preset application, RBAC, deployment strategy, and `deploying_revision IS NULL` concurrency guard across all API paths
- Implement revision history pruning (previously TODO) that deletes old revisions exceeding `revision_history_limit` while preserving `current_revision` and `deploying_revision`

## Test plan
- [x] `pants fmt/fix/lint` — all pass
- [x] `pants check` — no new type errors
- [x] Legacy `modify_endpoint` with revision-level change (environ) — new revision created, activated via DEPLOYING strategy
- [x] Legacy `modify_endpoint` with endpoint-level change (name) — no new revision created
- [x] v2 `admin deployment search` / `revision search` — working correctly
- [ ] CI check/test pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)