### PR TITLE
fix: use StrEnum for AgentStatusInfoGQL.status to fix GQL serialization

### DIFF
--- a/changes/11127.fix.md
+++ b/changes/11127.fix.md
@@ -1,0 +1,1 @@
+Fix GQL serialization error for AgentStatus enum in agentsV2 query.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -591,15 +591,6 @@ type AgentStats
   totalResource: AgentResource!
 }
 
-enum AgentStatus
-  @join__type(graph: STRAWBERRY)
-{
-  ALIVE @join__enumValue(graph: STRAWBERRY)
-  LOST @join__enumValue(graph: STRAWBERRY)
-  RESTARTING @join__enumValue(graph: STRAWBERRY)
-  TERMINATED @join__enumValue(graph: STRAWBERRY)
-}
-
 enum AgentStatusEnum
   @join__type(graph: STRAWBERRY)
 {
@@ -628,7 +619,7 @@ type AgentStatusInfo
   """
   Current operational status of the agent. One of: ALIVE, LOST, TERMINATED, RESTARTING.
   """
-  status: AgentStatus!
+  status: AgentStatusEnum!
 
   """Timestamp when the agent last changed its status."""
   statusChanged: DateTime

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -383,13 +383,6 @@ type AgentStats {
   totalResource: AgentResource!
 }
 
-enum AgentStatus {
-  ALIVE
-  LOST
-  RESTARTING
-  TERMINATED
-}
-
 enum AgentStatusEnum {
   ALIVE
   LOST
@@ -412,7 +405,7 @@ type AgentStatusInfo {
   """
   Current operational status of the agent. One of: ALIVE, LOST, TERMINATED, RESTARTING.
   """
-  status: AgentStatus!
+  status: AgentStatusEnum!
 
   """Timestamp when the agent last changed its status."""
   statusChanged: DateTime

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -40,7 +40,6 @@ from ai.backend.manager.api.gql.decorators import (
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import dedent_strip
-from ai.backend.manager.data.agent.types import AgentStatus
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.gql.kernel.types import (
@@ -167,7 +166,7 @@ class AgentStatsGQL:
     name="AgentStatusInfo",
 )
 class AgentStatusInfoGQL:
-    status: AgentStatus = gql_field(
+    status: AgentStatusEnum = gql_field(
         description="Current operational status of the agent. Indicates whether the agent is ALIVE (active and reachable), LOST (unreachable), TERMINATED (intentionally stopped), or RESTARTING (in recovery process)."
     )
     status_changed: datetime | None = gql_field(


### PR DESCRIPTION
## Summary
- Fix `Enum 'AgentStatus' cannot represent value: 'ALIVE'` error in `agentsV2` GQL query
- `AgentStatusInfoGQL.status` was typed as `AgentStatus` (`enum.Enum` with int values 0,1,2,3), but Strawberry receives string `"ALIVE"` from the DTO layer and cannot serialize it through an int-valued enum
- Switch to `AgentStatusEnum` (`StrEnum` with `ALIVE="ALIVE"`) which is already used in filter types and matches the DTO string values

## Test plan
- [ ] Query `agentsV2` with `statusInfo { status }` and verify ALIVE/LOST/etc. are returned correctly
- [ ] Verify agent status filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)