### PR TITLE
fix: merge 4 alembic heads into single head

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
+++ b/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
@@ -13,9 +13,9 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade() -> None:
     pass
 
 
-def downgrade():
+def downgrade() -> None:
     pass

--- a/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
+++ b/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
@@ -1,0 +1,21 @@
+"""merge 4 heads
+
+Revision ID: 85743d601993
+Revises: 3f5c20f7bb07, 5e7a3b9c1d2f, cd067180a8b1, e3fb172166dc
+Create Date: 2026-04-16
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "85743d601993"
+down_revision = ("3f5c20f7bb07", "5e7a3b9c1d2f", "cd067180a8b1", "e3fb172166dc")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary
- Manager alembic에 4개의 head가 발생하여 single head로 merge
- Merged heads: `3f5c20f7bb07`, `5e7a3b9c1d2f`, `cd067180a8b1`, `e3fb172166dc`
- Empty merge migration (no schema changes)

## Test plan
- [ ] `alembic heads` 실행 시 single head(`85743d601993`) 확인
- [ ] `alembic upgrade head` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)