### PR TITLE
fix: correct category_id type to UUID and add category GQL support

### DIFF
--- a/changes/11130.fix.md
+++ b/changes/11130.fix.md
@@ -1,0 +1,1 @@
+Correct category_id type to UUID in QueryDefinitionGQL and add GQL query/mutation support for prometheus query preset categories.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2170,6 +2170,35 @@ type CancelImportArtifactPayload
   artifactRevision: ArtifactRevision!
 }
 
+"""Added in 26.3.0. Filter input for querying query preset categories."""
+input CategoryFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by name."""
+  name: StringFilter = null
+}
+
+"""Added in 26.3.0. Specifies ordering for query preset category results."""
+input CategoryOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: CategoryOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""
+Added in 26.3.0. Fields available for ordering query preset category results.
+"""
+enum CategoryOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
 """Added in 24.12.0"""
 type CheckAndTransitStatus
   @join__type(graph: GRAPHENE)
@@ -2875,6 +2904,27 @@ type CreateAutoScalingRulePayload
   rule: AutoScalingRule!
 }
 
+"""Added in 26.3.0. Input for creating a new query preset category."""
+input CreateCategoryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Human-readable category name (must be unique)."""
+  name: String!
+
+  """Optional category description."""
+  description: String = null
+}
+
+"""
+Added in 26.3.0. Payload returned after creating a query preset category.
+"""
+type CreateCategoryPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created category."""
+  category: QueryPresetCategory!
+}
+
 """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
 type CreateContainerRegistry
   @join__type(graph: GRAPHENE)
@@ -3492,7 +3542,7 @@ input CreateQueryDefinitionInput
   rank: Int! = 0
 
   """Category UUID."""
-  categoryId: String = null
+  categoryId: UUID = null
 
   """Prometheus metric name."""
   metricName: String!
@@ -4109,6 +4159,16 @@ type DeleteAutoScalingRulePayload
 {
   """ID of the deleted auto-scaling rule"""
   id: ID!
+}
+
+"""
+Added in 26.3.0. Payload returned after deleting a query preset category.
+"""
+type DeleteCategoryPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Deleted category ID"""
+  id: UUID!
 }
 
 """Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
@@ -9519,7 +9579,7 @@ input ModifyQueryDefinitionInput
   rank: Int
 
   """New category UUID."""
-  categoryId: String
+  categoryId: UUID
 
   """New metric name."""
   metricName: String
@@ -10541,6 +10601,12 @@ type Mutation
 
   """Added in 26.3.0. Delete a query definition (admin only)"""
   adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 26.3.0. Create a new query preset category (admin only)."""
+  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 26.3.0. Delete a query preset category (admin only)."""
+  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a new role (admin only)."""
   adminCreateRole(input: CreateRoleInput!): Role! @join__field(graph: STRAWBERRY)
@@ -13042,6 +13108,16 @@ type Query
   """
   prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
 
+  """
+  Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.
+  """
+  prometheusQueryPresetCategory(id: ID!): QueryPresetCategory @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.2. List query preset categories with filtering and pagination. Available to any authenticated user.
+  """
+  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]! @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role @join__field(graph: STRAWBERRY)
 
@@ -13445,7 +13521,7 @@ type QueryDefinition implements Node
   rank: Int!
 
   """Category UUID."""
-  categoryId: String
+  categoryId: UUID
 
   """Prometheus metric name."""
   metricName: String!
@@ -13464,6 +13540,9 @@ type QueryDefinition implements Node
 
   """Last update timestamp."""
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. Resolved category entity."""
+  category: QueryPresetCategory
 }
 
 """Added in 26.3.0. Paginated connection for query definition records."""
@@ -13577,6 +13656,26 @@ enum QueryDefinitionOrderField
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
   NAME @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.3.0. Prometheus query preset category."""
+type QueryPresetCategory
+  @join__type(graph: STRAWBERRY)
+{
+  """Category ID"""
+  id: UUID!
+
+  """Human-readable category name"""
+  name: String!
+
+  """Optional category description"""
+  description: String
+
+  """Creation timestamp"""
+  createdAt: DateTime!
+
+  """Last update timestamp"""
+  updatedAt: DateTime!
 }
 
 """Added in 26.3.0. Time range for Prometheus query."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1515,6 +1515,29 @@ type CancelImportArtifactPayload {
   artifactRevision: ArtifactRevision!
 }
 
+"""Added in 26.3.0. Filter input for querying query preset categories."""
+input CategoryFilter {
+  """Filter by name."""
+  name: StringFilter = null
+}
+
+"""Added in 26.3.0. Specifies ordering for query preset category results."""
+input CategoryOrderBy {
+  """The field to order by."""
+  field: CategoryOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""
+Added in 26.3.0. Fields available for ordering query preset category results.
+"""
+enum CategoryOrderField {
+  NAME
+  CREATED_AT
+}
+
 """Added in 26.4.2. Payload containing preset availability check results."""
 type CheckPresetAvailabilityPayloadV2 {
   """Resource presets with availability status."""
@@ -1777,6 +1800,23 @@ input CreateAutoScalingRuleInput {
 type CreateAutoScalingRulePayload {
   """Created auto-scaling rule"""
   rule: AutoScalingRule!
+}
+
+"""Added in 26.3.0. Input for creating a new query preset category."""
+input CreateCategoryInput {
+  """Human-readable category name (must be unique)."""
+  name: String!
+
+  """Optional category description."""
+  description: String = null
+}
+
+"""
+Added in 26.3.0. Payload returned after creating a query preset category.
+"""
+type CreateCategoryPayload {
+  """Created category."""
+  category: QueryPresetCategory!
 }
 
 """Added in 26.4.2. Input for creating a container registry."""
@@ -2137,7 +2177,7 @@ input CreateQueryDefinitionInput {
   rank: Int! = 0
 
   """Category UUID."""
-  categoryId: String = null
+  categoryId: UUID = null
 
   """Prometheus metric name."""
   metricName: String!
@@ -2582,6 +2622,14 @@ input DeleteAutoScalingRuleInput {
 type DeleteAutoScalingRulePayload {
   """ID of the deleted auto-scaling rule"""
   id: ID!
+}
+
+"""
+Added in 26.3.0. Payload returned after deleting a query preset category.
+"""
+type DeleteCategoryPayload {
+  """Deleted category ID"""
+  id: UUID!
 }
 
 """Added in 26.4.2. Payload for container registry deletion."""
@@ -5999,7 +6047,7 @@ input ModifyQueryDefinitionInput {
   rank: Int
 
   """New category UUID."""
-  categoryId: String
+  categoryId: UUID
 
   """New metric name."""
   metricName: String
@@ -6543,6 +6591,12 @@ type Mutation {
 
   """Added in 26.3.0. Delete a query definition (admin only)"""
   adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload!
+
+  """Added in 26.3.0. Create a new query preset category (admin only)."""
+  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload!
+
+  """Added in 26.3.0. Delete a query preset category (admin only)."""
+  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload!
 
   """Added in 26.3.0. Create a new role (admin only)."""
   adminCreateRole(input: CreateRoleInput!): Role!
@@ -8259,6 +8313,16 @@ type Query {
   """
   prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult!
 
+  """
+  Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.
+  """
+  prometheusQueryPresetCategory(id: ID!): QueryPresetCategory
+
+  """
+  Added in 26.4.2. List query preset categories with filtering and pagination. Available to any authenticated user.
+  """
+  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]!
+
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role
 
@@ -8659,7 +8723,7 @@ type QueryDefinition implements Node {
   rank: Int!
 
   """Category UUID."""
-  categoryId: String
+  categoryId: UUID
 
   """Prometheus metric name."""
   metricName: String!
@@ -8678,6 +8742,9 @@ type QueryDefinition implements Node {
 
   """Last update timestamp."""
   updatedAt: DateTime!
+
+  """Added in UNRELEASED. Resolved category entity."""
+  category: QueryPresetCategory
 }
 
 """Added in 26.3.0. Paginated connection for query definition records."""
@@ -8771,6 +8838,24 @@ enum QueryDefinitionOrderField {
   CREATED_AT
   UPDATED_AT
   NAME
+}
+
+"""Added in 26.3.0. Prometheus query preset category."""
+type QueryPresetCategory {
+  """Category ID"""
+  id: UUID!
+
+  """Human-readable category name"""
+  name: String!
+
+  """Optional category description"""
+  description: String
+
+  """Creation timestamp"""
+  createdAt: DateTime!
+
+  """Last update timestamp"""
+  updatedAt: DateTime!
 }
 
 """Added in 26.3.0. Time range for Prometheus query."""

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset_category/response.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset_category/response.py
@@ -17,6 +17,7 @@ __all__ = (
     "DeleteCategoryPayload",
     "GetCategoryPayload",
     "SearchCategoriesPayload",
+    "CreateCategoryGQLPayload",
 )
 
 
@@ -46,6 +47,12 @@ class GetCategoryPayload(BaseResponseModel):
     """Payload for getting a single category."""
 
     item: CategoryNode | None = Field(default=None, description="Category data")
+
+
+class CreateCategoryGQLPayload(BaseResponseModel):
+    """GQL-layer payload returned after creating a category."""
+
+    category: CategoryNode = Field(description="Created category.")
 
 
 class SearchCategoriesPayload(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset_category.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset_category.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
@@ -36,6 +37,7 @@ from ai.backend.manager.models.prometheus_query_preset_category.orders import (
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     Creator,
+    OffsetPagination,
     QueryCondition,
     QueryOrder,
 )
@@ -55,6 +57,19 @@ from .pagination import PaginationSpec
 
 class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
     """Adapter for prometheus query preset category domain operations."""
+
+    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[CategoryNode | None]:
+        if not ids:
+            return []
+        querier = BatchQuerier(
+            pagination=OffsetPagination(limit=len(ids)),
+            conditions=[PrometheusQueryPresetCategoryConditions.by_ids(ids)],
+        )
+        action_result = await self._processors.prometheus_query_preset_category.search_categories.wait_for_complete(
+            SearchCategoriesAction(querier=querier)
+        )
+        category_map = {item.id: self._data_to_dto(item) for item in action_result.items}
+        return [category_map.get(category_id) for category_id in ids]
 
     async def create(self, input: CreateCategoryInput) -> CreateCategoryPayload:
         """Create a new prometheus query preset category."""

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -59,6 +59,9 @@ if TYPE_CHECKING:
     from ai.backend.manager.api.gql.project_v2.types.node import (  # pants: no-infer-dep
         ProjectV2GQL,
     )
+    from ai.backend.manager.api.gql.prometheus_query_preset.types.category import (  # pants: no-infer-dep
+        CategoryGQL,
+    )
     from ai.backend.manager.api.gql.prometheus_query_preset.types.node import (  # pants: no-infer-dep
         QueryDefinitionGQL,
     )
@@ -803,5 +806,21 @@ class DataLoaders:
 
             dtos = await adapter.batch_load_by_ids(ids)
             return [QD.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def category_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, CategoryGQL | None]:
+        adapter = self._adapters.prometheus_query_preset_category
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[CategoryGQL | None]:
+            from ai.backend.manager.api.gql.prometheus_query_preset.types.category import (  # pants: no-infer-dep
+                CategoryGQL as CG,
+            )
+
+            dtos = await adapter.batch_load_by_ids(ids)
+            return [CG.from_pydantic(dto) if dto is not None else None for dto in dtos]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
@@ -2,15 +2,26 @@
 
 from .resolver import (
     admin_create_prometheus_query_preset,
+    admin_create_prometheus_query_preset_category,
     admin_delete_prometheus_query_preset,
+    admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
     prometheus_query_preset,
+    prometheus_query_preset_categories,
+    prometheus_query_preset_category,
     prometheus_query_preset_result,
     prometheus_query_presets,
 )
 from .types import (
+    CategoryFilterGQL,
+    CategoryGQL,
+    CategoryOrderByGQL,
+    CategoryOrderFieldGQL,
+    CreateCategoryInputGQL,
+    CreateCategoryPayloadGQL,
     CreateQueryDefinitionInput,
     CreateQueryDefinitionPayload,
+    DeleteCategoryPayloadGQL,
     DeleteQueryDefinitionPayload,
     ExecuteQueryDefinitionOptionsInput,
     MetricLabelEntryGQL,
@@ -35,10 +46,16 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
+    # Category Queries
+    "prometheus_query_preset_category",
+    "prometheus_query_preset_categories",
     # Mutations
     "admin_create_prometheus_query_preset",
     "admin_modify_prometheus_query_preset",
     "admin_delete_prometheus_query_preset",
+    # Category Mutations
+    "admin_create_prometheus_query_preset_category",
+    "admin_delete_prometheus_query_preset_category",
     # Types
     "QueryDefinitionGQL",
     "QueryDefinitionEdge",
@@ -59,4 +76,12 @@ __all__ = [
     "CreateQueryDefinitionPayload",
     "ModifyQueryDefinitionPayload",
     "DeleteQueryDefinitionPayload",
+    # Category Types
+    "CategoryGQL",
+    "CategoryFilterGQL",
+    "CategoryOrderByGQL",
+    "CategoryOrderFieldGQL",
+    "CreateCategoryInputGQL",
+    "CreateCategoryPayloadGQL",
+    "DeleteCategoryPayloadGQL",
 ]

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
@@ -1,5 +1,13 @@
 """Prometheus query preset GQL resolvers."""
 
+from .category_mutation import (
+    admin_create_prometheus_query_preset_category,
+    admin_delete_prometheus_query_preset_category,
+)
+from .category_query import (
+    prometheus_query_preset_categories,
+    prometheus_query_preset_category,
+)
 from .mutation import (
     admin_create_prometheus_query_preset,
     admin_delete_prometheus_query_preset,
@@ -16,8 +24,14 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
+    # Category Queries
+    "prometheus_query_preset_category",
+    "prometheus_query_preset_categories",
     # Mutations
     "admin_create_prometheus_query_preset",
     "admin_modify_prometheus_query_preset",
     "admin_delete_prometheus_query_preset",
+    # Category Mutations
+    "admin_create_prometheus_query_preset_category",
+    "admin_delete_prometheus_query_preset_category",
 ]

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_mutation.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_mutation.py
@@ -1,0 +1,59 @@
+"""Prometheus query preset category GQL mutation resolvers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import ID, Info
+
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    DeleteCategoryInput as DeleteCategoryInputDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response import (
+    CreateCategoryGQLPayload as CreateCategoryGQLPayloadDTO,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.prometheus_query_preset.types.category import (
+    CreateCategoryInputGQL,
+    CreateCategoryPayloadGQL,
+    DeleteCategoryPayloadGQL,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Create a new query preset category (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_create_prometheus_query_preset_category(
+    info: Info[StrawberryGQLContext],
+    input: CreateCategoryInputGQL,
+) -> CreateCategoryPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.prometheus_query_preset_category.create(
+        input.to_pydantic()
+    )
+    return CreateCategoryPayloadGQL.from_pydantic(CreateCategoryGQLPayloadDTO(category=result.item))
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Delete a query preset category (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_delete_prometheus_query_preset_category(
+    info: Info[StrawberryGQLContext],
+    id: ID,
+) -> DeleteCategoryPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.prometheus_query_preset_category.delete(
+        DeleteCategoryInputDTO(id=UUID(id))
+    )
+    return DeleteCategoryPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_query.py
@@ -1,0 +1,73 @@
+"""Prometheus query preset category GQL query resolvers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import ID, Info
+
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    SearchCategoriesInput,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.prometheus_query_preset.types.category import (
+    CategoryFilterGQL,
+    CategoryGQL,
+    CategoryOrderByGQL,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version="26.4.2",
+        description="Get a single query preset category by ID. Available to any authenticated user.",
+    )
+)  # type: ignore[misc]
+async def prometheus_query_preset_category(
+    info: Info[StrawberryGQLContext],
+    id: ID,
+) -> CategoryGQL | None:
+    payload = await info.context.adapters.prometheus_query_preset_category.get(UUID(id))
+    if payload.item is None:
+        return None
+    return CategoryGQL.from_pydantic(payload.item)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version="26.4.2",
+        description="List query preset categories with filtering and pagination. Available to any authenticated user.",
+    )
+)  # type: ignore[misc]
+async def prometheus_query_preset_categories(
+    info: Info[StrawberryGQLContext],
+    filter: CategoryFilterGQL | None = None,
+    order_by: list[CategoryOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> list[CategoryGQL]:
+    pydantic_filter = filter.to_pydantic() if filter else None
+    pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
+
+    payload = await info.context.adapters.prometheus_query_preset_category.search(
+        SearchCategoriesInput(
+            filter=pydantic_filter,
+            order=pydantic_order,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+
+    return [CategoryGQL.from_pydantic(node) for node in payload.items]

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
@@ -1,5 +1,14 @@
 """Prometheus query preset GQL types."""
 
+from .category import (
+    CategoryFilterGQL,
+    CategoryGQL,
+    CategoryOrderByGQL,
+    CategoryOrderFieldGQL,
+    CreateCategoryInputGQL,
+    CreateCategoryPayloadGQL,
+    DeleteCategoryPayloadGQL,
+)
 from .filters import (
     QueryDefinitionFilter,
     QueryDefinitionOrderBy,
@@ -29,6 +38,14 @@ from .payloads import (
 )
 
 __all__ = [
+    # Category types
+    "CategoryGQL",
+    "CategoryFilterGQL",
+    "CategoryOrderByGQL",
+    "CategoryOrderFieldGQL",
+    "CreateCategoryInputGQL",
+    "CreateCategoryPayloadGQL",
+    "DeleteCategoryPayloadGQL",
     # Node types
     "QueryDefinitionGQL",
     "QueryDefinitionEdge",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/category.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/category.py
@@ -1,0 +1,138 @@
+"""Prometheus query preset category GQL types (output, filter, input, payload)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    CategoryFilter as CategoryFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    CategoryOrder as CategoryOrderDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.request import (
+    CreateCategoryInput as CreateCategoryInputDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response import (
+    CategoryNode,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response import (
+    CreateCategoryGQLPayload as CreateCategoryGQLPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset_category.response import (
+    DeleteCategoryPayload as DeleteCategoryPayloadDTO,
+)
+from ai.backend.manager.api.gql.base import (
+    OrderDirection,
+    StringFilter,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticOutputMixin
+
+# --- Output type ---
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Prometheus query preset category.",
+    ),
+    model=CategoryNode,
+    name="QueryPresetCategory",
+)
+class CategoryGQL(PydanticOutputMixin[CategoryNode]):
+    id: UUID = gql_field(description="Category UUID.")
+    name: str = gql_field(description="Human-readable category name.")
+    description: str | None = gql_field(description="Optional category description.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime = gql_field(description="Last update timestamp.")
+
+
+# --- Filter / Order types ---
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter input for querying query preset categories.",
+        added_version="26.3.0",
+    ),
+    name="CategoryFilter",
+)
+class CategoryFilterGQL(PydanticInputMixin[CategoryFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by name.", default=None)
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Fields available for ordering query preset category results.",
+    ),
+    name="CategoryOrderField",
+)
+class CategoryOrderFieldGQL(StrEnum):
+    NAME = "name"
+    CREATED_AT = "created_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Specifies ordering for query preset category results.",
+        added_version="26.3.0",
+    ),
+    name="CategoryOrderBy",
+)
+class CategoryOrderByGQL(PydanticInputMixin[CategoryOrderDTO]):
+    field: CategoryOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.", default=OrderDirection.DESC
+    )
+
+
+# --- Input types ---
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for creating a new query preset category.",
+        added_version="26.3.0",
+    ),
+    name="CreateCategoryInput",
+)
+class CreateCategoryInputGQL(PydanticInputMixin[CreateCategoryInputDTO]):
+    name: str = gql_field(description="Human-readable category name (must be unique).")
+    description: str | None = gql_field(description="Optional category description.", default=None)
+
+
+# --- Payload types ---
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Payload returned after creating a query preset category.",
+    ),
+    model=CreateCategoryGQLPayloadDTO,
+    name="CreateCategoryPayload",
+)
+class CreateCategoryPayloadGQL(PydanticOutputMixin[CreateCategoryGQLPayloadDTO]):
+    category: CategoryGQL = gql_field(description="Created category.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version="26.3.0",
+        description="Payload returned after deleting a query preset category.",
+    ),
+    model=DeleteCategoryPayloadDTO,
+    name="DeleteCategoryPayload",
+)
+class DeleteCategoryPayloadGQL(PydanticOutputMixin[DeleteCategoryPayloadDTO]):
+    id: UUID = gql_field(description="Deleted category ID.")

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from strawberry import UNSET
 
@@ -54,7 +55,7 @@ class CreateQueryDefinitionInput(PydanticInputMixin[CreateQueryDefinitionInputDT
     name: str = gql_field(description="Human-readable identifier (must be unique).")
     description: str | None = gql_field(description="Human-readable description.", default=None)
     rank: int = gql_field(description="Sort rank.", default=0)
-    category_id: str | None = gql_field(description="Category UUID.", default=None)
+    category_id: UUID | None = gql_field(description="Category UUID.", default=None)
     metric_name: str = gql_field(description="Prometheus metric name.")
     query_template: str = gql_field(
         description="PromQL template with {labels}, {window}, {group_by} placeholders."
@@ -92,7 +93,7 @@ class ModifyQueryDefinitionInput(PydanticInputMixin[ModifyQueryDefinitionInputDT
     name: str | None = gql_field(description="New name.", default=UNSET)
     description: str | None = gql_field(description="New description.", default=UNSET)
     rank: int | None = gql_field(description="New sort rank.", default=UNSET)
-    category_id: str | None = gql_field(description="New category UUID.", default=UNSET)
+    category_id: UUID | None = gql_field(description="New category UUID.", default=UNSET)
     metric_name: str | None = gql_field(description="New metric name.", default=UNSET)
     query_template: str | None = gql_field(description="New PromQL template.", default=UNSET)
     time_window: str | None = gql_field(description="New default time window.", default=UNSET)

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/node.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/node.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.response import (
@@ -16,15 +18,19 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.response import (
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.response import (
     QueryDefinitionNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_connection_type,
     gql_field,
     gql_node_type,
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
+from .category import CategoryGQL
 from .payloads import QueryDefinitionOptionsGQL
 
 
@@ -40,7 +46,7 @@ class QueryDefinitionGQL(PydanticNodeMixin[QueryDefinitionNode]):
     name: str = gql_field(description="Human-readable query definition identifier.")
     description: str | None = gql_field(description="Human-readable description.")
     rank: int = gql_field(description="Sort rank (lower = higher priority).")
-    category_id: str | None = gql_field(description="Category UUID.")
+    category_id: UUID | None = gql_field(description="Category UUID.")
     metric_name: str = gql_field(description="Prometheus metric name.")
     query_template: str = gql_field(description="PromQL template with placeholders.")
     time_window: str | None = gql_field(
@@ -51,6 +57,16 @@ class QueryDefinitionGQL(PydanticNodeMixin[QueryDefinitionNode]):
     )
     created_at: datetime = gql_field(description="Creation timestamp.")
     updated_at: datetime = gql_field(description="Last update timestamp.")
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION, description="Resolved category entity."
+        )
+    )  # type: ignore[misc]
+    async def category(self, info: Info[StrawberryGQLContext]) -> CategoryGQL | None:
+        if self.category_id is None:
+            return None
+        return await info.context.data_loaders.category_loader.load(self.category_id)
 
 
 QueryDefinitionEdge = Edge[QueryDefinitionGQL]

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -245,9 +245,13 @@ from .project_v2 import (
 )
 from .prometheus_query_preset import (
     admin_create_prometheus_query_preset,
+    admin_create_prometheus_query_preset_category,
     admin_delete_prometheus_query_preset,
+    admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
     prometheus_query_preset,
+    prometheus_query_preset_categories,
+    prometheus_query_preset_category,
     prometheus_query_preset_result,
     prometheus_query_presets,
 )
@@ -503,6 +507,9 @@ class Query:
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
     prometheus_query_preset_result = prometheus_query_preset_result
+    # Prometheus Query Preset Category APIs (read available to any authenticated user)
+    prometheus_query_preset_category = prometheus_query_preset_category
+    prometheus_query_preset_categories = prometheus_query_preset_categories
     # RBAC Admin APIs
     admin_role = admin_role
     admin_roles = admin_roles
@@ -774,6 +781,9 @@ class Mutation:
     admin_create_prometheus_query_preset = admin_create_prometheus_query_preset
     admin_modify_prometheus_query_preset = admin_modify_prometheus_query_preset
     admin_delete_prometheus_query_preset = admin_delete_prometheus_query_preset
+    # Prometheus Query Preset Category - Admin APIs
+    admin_create_prometheus_query_preset_category = admin_create_prometheus_query_preset_category
+    admin_delete_prometheus_query_preset_category = admin_delete_prometheus_query_preset_category
     # RBAC Admin APIs
     admin_create_role = admin_create_role
     admin_update_role = admin_update_role

--- a/src/ai/backend/manager/models/prometheus_query_preset_category/conditions.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset_category/conditions.py
@@ -19,7 +19,7 @@ class PrometheusQueryPresetCategoryConditions:
     """QueryCondition factories for prometheus query preset category filtering."""
 
     @staticmethod
-    def by_ids(category_ids: Collection[str]) -> QueryCondition:
+    def by_ids(category_ids: Collection[uuid.UUID]) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
             return PrometheusQueryPresetCategoryRow.id.in_(category_ids)
 


### PR DESCRIPTION
## Summary
- Fix `category_id` field type mismatch in `QueryDefinitionGQL` and input types (`str` → `UUID`) to align with the DTO layer
- Add `category` field resolver on `QueryDefinitionGQL` with data loader for N+1 prevention
- Add full GQL query/mutation support for prometheus query preset categories (previously REST v2 only): `get`, `search`, `admin_create`, `admin_delete`
- Fix `by_ids` condition parameter type from `Collection[str]` to `Collection[uuid.UUID]`

## Test plan
- [ ] Verify `category_id` is exposed as UUID scalar in GQL schema
- [ ] Query `prometheusQueryPresetCategory(id: ...)` returns category data
- [ ] Query `prometheusQueryPresetCategories(filter: ..., orderBy: ...)` returns paginated results
- [ ] Mutation `adminCreatePrometheusQueryPresetCategory` creates a category (admin only)
- [ ] Mutation `adminDeletePrometheusQueryPresetCategory` deletes a category (admin only)
- [ ] `QueryDefinitionGQL.category` field resolves the related category entity via data loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)