### PR TITLE
fix: correct alembic merge migration to only declare actual heads

### DIFF
--- a/changes/11131.fix.md
+++ b/changes/11131.fix.md
@@ -1,0 +1,1 @@
+Fix alembic merge migration declaring non-head ancestors as parents, which caused `alembic upgrade head` to fail.

--- a/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
+++ b/src/ai/backend/manager/models/alembic/versions/85743d601993_merge_4_heads.py
@@ -1,14 +1,14 @@
-"""merge 4 heads
+"""merge 2 heads
 
 Revision ID: 85743d601993
-Revises: 3f5c20f7bb07, 5e7a3b9c1d2f, cd067180a8b1, e3fb172166dc
+Revises: cd067180a8b1, e3fb172166dc
 Create Date: 2026-04-16
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "85743d601993"
-down_revision = ("3f5c20f7bb07", "5e7a3b9c1d2f", "cd067180a8b1", "e3fb172166dc")
+down_revision = ("cd067180a8b1", "e3fb172166dc")
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Migration `85743d601993_merge_4_heads.py` incorrectly listed 4 parents in `down_revision`, but only 2 (`cd067180a8b1`, `e3fb172166dc`) are actual heads — the other 2 (`3f5c20f7bb07`, `5e7a3b9c1d2f`) are already-applied backport ancestors in the main chain.
- This caused `alembic upgrade head` to fail with `KeyError: '3f5c20f7bb07'` when Alembic tried to remove phantom heads from the version table.
- Reduced `down_revision` to the 2 actual heads and updated the docstring accordingly.

## Test plan
- [x] `alembic heads` returns single head `85743d601993`
- [x] `alembic upgrade head` applies `e3fb172166dc`, `cd067180a8b1`, and the merge successfully
- [x] `alembic current` shows `85743d601993 (head)` after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)