### PR TITLE
fix(BA-5749): remove dead LEFT JOIN inflating admin_roles total_count

### DIFF
--- a/changes/11132.fix.md
+++ b/changes/11132.fix.md
@@ -1,0 +1,1 @@
+Fix inflated `total_count` in the `admin_roles` GraphQL query caused by an unused LEFT JOIN on `ObjectPermissionRow`.

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -593,22 +593,9 @@ class PermissionDBSource:
         self,
         querier: BatchQuerier,
     ) -> RoleListResult:
-        """Searches roles with pagination and filtering.
-
-        Uses LEFT JOIN with ObjectPermissionRow to support
-        entity-based filtering. The JOIN is always performed to
-        simplify the implementation, with distinct() used to prevent duplicates.
-        """
+        """Searches roles with pagination and filtering."""
         async with self._db.begin_readonly_session() as db_sess:
-            # Build query with LEFT JOIN to support entity filtering
-            query = (
-                sa.select(RoleRow)
-                .outerjoin(
-                    ObjectPermissionRow,
-                    RoleRow.id == ObjectPermissionRow.role_id,
-                )
-                .distinct()
-            )
+            query = sa.select(RoleRow)
 
             result = await execute_batch_querier(
                 db_sess,

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.permission.types import EntityType, OperationType
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import UserRoleRow
@@ -27,7 +28,11 @@ from ai.backend.manager.models.resource_policy import (
 )
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
+from ai.backend.manager.repositories.base import (
+    BatchQuerier,
+    CursorForwardPagination,
+    OffsetPagination,
+)
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
 )
@@ -161,3 +166,126 @@ class TestSearchRoles:
         assert role_ids == expected_role_ids, (
             f"Failed to order roles by created_at: got {[r.created_at for r in result.items]}, expected {[r.created_at for r in created_roles]}"
         )
+
+
+class TestSearchRolesTotalCountNotInflated:
+    """Regression tests for BA-5749: total_count must not be inflated by ObjectPermissionRow JOIN."""
+
+    @pytest.fixture
+    async def db_with_rbac_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                PermissionRow,
+                ObjectPermissionRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> PermissionControllerRepository:
+        return PermissionControllerRepository(db_with_rbac_tables)
+
+    @pytest.fixture
+    async def roles_with_object_permissions(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> list[CreatedRole]:
+        """Create 2 roles: one with 3 ObjectPermissionRows, one with 0."""
+        created: list[CreatedRole] = []
+        base_time = datetime(2026, 1, 1, tzinfo=UTC)
+
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            # Role with multiple object permissions
+            role_with_perms = RoleRow(
+                name="role-with-perms",
+                description="Role that has multiple object permissions",
+                created_at=base_time,
+            )
+            db_sess.add(role_with_perms)
+            await db_sess.flush()
+            created.append(
+                CreatedRole(
+                    role_id=role_with_perms.id,
+                    role_name="role-with-perms",
+                    created_at=role_with_perms.created_at,
+                )
+            )
+
+            # Add 3 ObjectPermissionRow entries for this role
+            for op_type in [OperationType.READ, OperationType.UPDATE, OperationType.CREATE]:
+                obj_perm = ObjectPermissionRow(
+                    role_id=role_with_perms.id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=str(uuid.uuid4()),
+                    operation=op_type,
+                )
+                db_sess.add(obj_perm)
+
+            # Role with zero object permissions
+            role_without_perms = RoleRow(
+                name="role-without-perms",
+                description="Role that has no object permissions",
+                created_at=base_time + timedelta(minutes=1),
+            )
+            db_sess.add(role_without_perms)
+            await db_sess.flush()
+            created.append(
+                CreatedRole(
+                    role_id=role_without_perms.id,
+                    role_name="role-without-perms",
+                    created_at=role_without_perms.created_at,
+                )
+            )
+
+        return created
+
+    async def test_total_count_not_inflated_with_offset_pagination(
+        self,
+        repository: PermissionControllerRepository,
+        roles_with_object_permissions: list[CreatedRole],
+    ) -> None:
+        """BA-5749: offset pagination total_count must equal distinct role count, not JOIN-inflated count."""
+        querier = BatchQuerier(
+            conditions=[],
+            orders=[RoleOrders.name(ascending=True)],
+            pagination=OffsetPagination(limit=10, offset=0),
+        )
+
+        result = await repository.search_roles(querier)
+
+        assert len(result.items) == 2
+        assert result.total_count == 2
+
+    async def test_total_count_not_inflated_with_cursor_pagination(
+        self,
+        repository: PermissionControllerRepository,
+        roles_with_object_permissions: list[CreatedRole],
+    ) -> None:
+        """BA-5749: cursor pagination total_count must equal distinct role count, not JOIN-inflated count."""
+        querier = BatchQuerier(
+            conditions=[],
+            orders=[],
+            pagination=CursorForwardPagination(
+                first=10,
+                cursor_order=RoleOrders.created_at(ascending=True),
+            ),
+        )
+
+        result = await repository.search_roles(querier)
+
+        assert len(result.items) == 2
+        assert result.total_count == 2


### PR DESCRIPTION
## Summary
- Remove unused LEFT JOIN on `ObjectPermissionRow` and `.distinct()` from `search_roles()` in `PermissionControllerDbSource`
- The JOIN caused `total_count` to be inflated (K× per role with K object permissions) while `items` remained correct, because both pagination paths in `execute_batch_querier` count pre-DISTINCT rows
- No GQL caller ever filters on `ObjectPermissionRow` — the JOIN was dead code

## Test plan
- [x] Regression tests added: role with 3 ObjectPermission rows returns `total_count=2` (not 4) for both offset and cursor pagination
- [x] Existing `test_search_roles_with_name_filter` passes — filter preservation confirmed
- [x] All 11 test files in `permission_controller/` pass
- [x] `pants fmt fix lint` all pass

Resolves BA-5749