### PR TITLE
feat(BA-5735): add admin API to refresh revisions for active deployments

### DIFF
--- a/changes/11134.feature.md
+++ b/changes/11134.feature.md
@@ -1,0 +1,1 @@
+Add admin API to refresh revisions for all active deployments, rebuilding each revision through `DeploymentController` so preset, deployment-config, and model_definition are re-resolved. Partial success is reported per deployment.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -260,6 +260,16 @@ type AdminGetSSHKeypairPayload
 }
 
 """
+Added in UNRELEASED. Payload for admin bulk revision refresh mutation result.
+"""
+type AdminRefreshDeploymentRevisionsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Per-deployment refresh outcomes (partial success by design)"""
+  results: [RevisionRefreshResult!]!
+}
+
+"""
 Added in 26.4.2. Admin input for registering (overwriting) a user's SSH keypair.
 """
 input AdminRegisterSSHKeypairInput
@@ -10186,6 +10196,11 @@ type Mutation
   addModelRevision(input: AddRevisionInput!, options: AddRevisionOptions = null): AddRevisionPayload! @join__field(graph: STRAWBERRY)
 
   """
+  Added in UNRELEASED. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
+  """
+  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload! @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.2. Create or update the deployment policy for a given deployment (upsert semantics). If the deployment already has a policy, it is replaced entirely with the new configuration
   """
   updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload! @join__field(graph: STRAWBERRY)
@@ -14571,6 +14586,27 @@ type RestoreArtifactsPayload
 {
   """List of restored artifacts."""
   artifacts: [Artifact!]!
+}
+
+"""
+Added in UNRELEASED. Per-deployment result of an admin bulk revision refresh.
+"""
+type RevisionRefreshResult
+  @join__type(graph: STRAWBERRY)
+{
+  """Deployment ID"""
+  deploymentId: UUID!
+
+  """
+  Newly created revision ID; null when the refresh failed for this deployment
+  """
+  newRevisionId: UUID
+
+  """Whether the refresh succeeded for this deployment"""
+  success: Boolean!
+
+  """Error class and message when the refresh failed; null on success"""
+  failureReason: String
 }
 
 """Added in 26.4.2. Payload returned after revoking a login session."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -204,6 +204,14 @@ type AdminGetSSHKeypairPayload {
 }
 
 """
+Added in UNRELEASED. Payload for admin bulk revision refresh mutation result.
+"""
+type AdminRefreshDeploymentRevisionsPayload {
+  """Per-deployment refresh outcomes (partial success by design)"""
+  results: [RevisionRefreshResult!]!
+}
+
+"""
 Added in 26.4.2. Admin input for registering (overwriting) a user's SSH keypair.
 """
 input AdminRegisterSSHKeypairInput {
@@ -6178,6 +6186,11 @@ type Mutation {
   addModelRevision(input: AddRevisionInput!, options: AddRevisionOptions = null): AddRevisionPayload!
 
   """
+  Added in UNRELEASED. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
+  """
+  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload!
+
+  """
   Added in 26.4.2. Create or update the deployment policy for a given deployment (upsert semantics). If the deployment already has a policy, it is replaced entirely with the new configuration
   """
   updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload!
@@ -9631,6 +9644,25 @@ Added in 25.15.0. Response payload for artifact restoration operations. Contains
 type RestoreArtifactsPayload {
   """List of restored artifacts."""
   artifacts: [Artifact!]!
+}
+
+"""
+Added in UNRELEASED. Per-deployment result of an admin bulk revision refresh.
+"""
+type RevisionRefreshResult {
+  """Deployment ID"""
+  deploymentId: UUID!
+
+  """
+  Newly created revision ID; null when the refresh failed for this deployment
+  """
+  newRevisionId: UUID
+
+  """Whether the refresh succeeded for this deployment"""
+  success: Boolean!
+
+  """Error class and message when the refresh failed; null on success"""
+  failureReason: String
 }
 
 """Added in 26.4.2. Payload returned after revoking a login session."""

--- a/src/ai/backend/client/cli/v2/admin/deployment.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment.py
@@ -121,6 +121,26 @@ def revision() -> None:
     """Admin deployment revision commands."""
 
 
+@revision.command(name="refresh")
+def revision_refresh() -> None:
+    """Rebuild and activate a fresh revision for every active deployment.
+
+    Useful to repair deployments whose current revision has stale or missing
+    model_definition after backing store migrations. Each deployment is
+    processed independently; partial success is reported per deployment.
+    """
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.deployment.admin_refresh_deployment_revisions()
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
 @revision.command(name="search")
 @click.option(
     "--deployment-id",

--- a/src/ai/backend/client/v2/domains_v2/deployment.py
+++ b/src/ai/backend/client/v2/domains_v2/deployment.py
@@ -34,6 +34,7 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
 from ai.backend.common.dto.manager.v2.deployment.response import (
     ActivateRevisionPayload,
     AddRevisionPayload,
+    AdminRefreshDeploymentRevisionsPayload,
     AdminSearchDeploymentsPayload,
     AdminSearchRevisionsPayload,
     BulkDeleteAccessTokensPayload,
@@ -283,6 +284,16 @@ class V2DeploymentClient(BaseDomainClient):
             _PATH + f"/{body.model_deployment_id}/replicas/sync",
             request=body,
             response_model=SyncReplicaPayload,
+        )
+
+    async def admin_refresh_deployment_revisions(
+        self,
+    ) -> AdminRefreshDeploymentRevisionsPayload:
+        """Rebuild and activate a fresh revision for every active deployment (superadmin)."""
+        return await self._client.typed_request(
+            "POST",
+            _PATH + "/admin/refresh-revisions",
+            response_model=AdminRefreshDeploymentRevisionsPayload,
         )
 
     # ------------------------------------------------------------------

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -41,6 +41,7 @@ __all__ = (
     "ActivateDeploymentPayload",
     "ActivateRevisionPayload",
     "AddRevisionPayload",
+    "AdminRefreshDeploymentRevisionsPayload",
     "AdminSearchDeploymentsPayload",
     "AdminSearchRevisionsPayload",
     "AutoScalingRuleNode",
@@ -65,6 +66,7 @@ __all__ = (
     "SearchDeploymentPoliciesPayload",
     "SearchReplicasPayload",
     "SearchRoutesPayload",
+    "RevisionRefreshResultInfo",
     "SyncReplicaPayload",
     "UpdateAutoScalingRulePayload",
     "UpdateDeploymentPayload",
@@ -178,6 +180,29 @@ class AddRevisionPayload(BaseResponseModel):
     """Payload for add revision mutation result."""
 
     revision: RevisionNode = Field(description="Added revision")
+
+
+class RevisionRefreshResultInfo(BaseResponseModel):
+    """Per-deployment result of an admin bulk revision refresh."""
+
+    deployment_id: UUID = Field(description="Deployment ID")
+    new_revision_id: UUID | None = Field(
+        default=None,
+        description="Newly created revision ID; null when the refresh failed for this deployment",
+    )
+    success: bool = Field(description="Whether the refresh succeeded for this deployment")
+    failure_reason: str | None = Field(
+        default=None,
+        description="Error class and message when the refresh failed; null on success",
+    )
+
+
+class AdminRefreshDeploymentRevisionsPayload(BaseResponseModel):
+    """Payload for admin bulk revision refresh mutation result."""
+
+    results: list[RevisionRefreshResultInfo] = Field(
+        description="Per-deployment refresh outcomes (partial success by design)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -60,6 +60,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
     AccessTokenNode,
     ActivateRevisionPayload,
     AddRevisionPayload,
+    AdminRefreshDeploymentRevisionsPayload,
     AdminSearchDeploymentsPayload,
     AdminSearchRevisionsPayload,
     AutoScalingRuleNode,
@@ -78,6 +79,7 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
     GetDeploymentPolicyPayload,
     ReplicaNode,
     RevisionNode,
+    RevisionRefreshResultInfo,
     RouteNode,
     SearchAccessTokensPayload,
     SearchAutoScalingRulesPayload,
@@ -280,6 +282,9 @@ from ai.backend.manager.services.deployment.actions.model_revision.search_revisi
 )
 from ai.backend.manager.services.deployment.actions.model_revision.search_revisions import (
     SearchRevisionsAction,
+)
+from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions import (
+    RefreshDeploymentRevisionsAction,
 )
 from ai.backend.manager.services.deployment.actions.revision_operations import (
     ActivateRevisionAction,
@@ -819,6 +824,27 @@ class DeploymentAdapter(BaseAdapter):
             previous_revision_id=action_result.previous_revision_id,
             activated_revision_id=action_result.activated_revision_id,
             deployment_policy=self._policy_data_to_dto(action_result.deployment_policy),
+        )
+
+    async def admin_refresh_deployment_revisions(
+        self,
+    ) -> AdminRefreshDeploymentRevisionsPayload:
+        """Create and activate a fresh revision for every active deployment."""
+        action_result = (
+            await self._processors.deployment.admin_refresh_deployment_revisions.wait_for_complete(
+                RefreshDeploymentRevisionsAction()
+            )
+        )
+        return AdminRefreshDeploymentRevisionsPayload(
+            results=[
+                RevisionRefreshResultInfo(
+                    deployment_id=r.deployment_id,
+                    new_revision_id=r.new_revision_id,
+                    success=r.success,
+                    failure_reason=r.failure_reason,
+                )
+                for r in action_result.results
+            ]
         )
 
     async def delete(self, input: DeleteDeploymentInput) -> DeleteDeploymentPayload:

--- a/src/ai/backend/manager/api/gql/deployment/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/__init__.py
@@ -20,6 +20,7 @@ from .resolver import (
     admin_create_deployment_revision_preset,
     admin_delete_deployment_revision_preset,
     admin_deployments,
+    admin_refresh_deployment_revisions,
     admin_update_deployment_revision_preset,
     # Access Token
     create_access_token,
@@ -68,6 +69,8 @@ from .types import (
     ActivenessStatus,
     AddRevisionInput,
     AddRevisionPayload,
+    # Admin refresh revisions
+    AdminRefreshDeploymentRevisionsPayload,
     # Auto Scaling
     AutoScalingMetricSource,
     AutoScalingRule,
@@ -136,6 +139,7 @@ from .types import (
     ResourceConfig,
     ResourceConfigInput,
     ResourceGroupInput,
+    RevisionRefreshResult,
     RollingUpdateConfigInputGQL,
     RollingUpdateStrategySpecGQL,
     # Route
@@ -186,6 +190,7 @@ __all__ = [
     "UpdateAutoScalingRuleInput",
     "UpdateAutoScalingRulePayload",
     # Deployment Types
+    "AdminRefreshDeploymentRevisionsPayload",
     "CreateDeploymentInput",
     "CreateDeploymentPayload",
     "DeleteDeploymentInput",
@@ -205,6 +210,7 @@ __all__ = [
     "ModelDeploymentNetworkAccess",
     "ModelDeploymentNetworkAccessInput",
     "ReplicaState",
+    "RevisionRefreshResult",
     "SyncReplicaInput",
     "SyncReplicaPayload",
     "UpdateDeploymentInput",
@@ -282,6 +288,7 @@ __all__ = [
     "deployment",
     "deployment_status_changed",
     "admin_deployments",
+    "admin_refresh_deployment_revisions",
     "my_deployments",
     "project_deployments",
     "sync_replicas",

--- a/src/ai/backend/manager/api/gql/deployment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/__init__.py
@@ -15,6 +15,7 @@ from .auto_scaling import (
 )
 from .deployment import (
     admin_deployments,
+    admin_refresh_deployment_revisions,
     create_model_deployment,
     delete_model_deployment,
     deployment,
@@ -63,6 +64,7 @@ __all__ = [
     "delete_auto_scaling_rule",
     # Deployment
     "admin_deployments",
+    "admin_refresh_deployment_revisions",
     "my_deployments",
     "project_deployments",
     "deployment",

--- a/src/ai/backend/manager/api/gql/deployment/resolver/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/deployment.py
@@ -10,6 +10,7 @@ from strawberry.relay import PageInfo
 
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.dto.manager.v2.deployment.request import AdminSearchDeploymentsInput
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import encode_cursor, resolve_global_id
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -18,6 +19,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_subscription,
 )
 from ai.backend.manager.api.gql.deployment.types.deployment import (
+    AdminRefreshDeploymentRevisionsPayload,
     CreateDeploymentInput,
     CreateDeploymentPayload,
     DeleteDeploymentInput,
@@ -29,6 +31,7 @@ from ai.backend.manager.api.gql.deployment.types.deployment import (
     ModelDeploymentConnection,
     ModelDeploymentEdge,
     ProjectDeploymentScopeGQL,
+    RevisionRefreshResult,
     SyncReplicaInput,
     SyncReplicaPayload,
     UpdateDeploymentInput,
@@ -236,6 +239,34 @@ async def sync_replicas(
 ) -> SyncReplicaPayload:
     payload = await info.context.adapters.deployment.sync_replicas(input.to_pydantic())
     return SyncReplicaPayload(success=payload.success)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Rebuild and activate a fresh revision for every active deployment (superadmin). "
+            "Used to repair deployments whose current revision has stale or missing "
+            "model_definition after backing store migrations."
+        ),
+    )
+)  # type: ignore[misc]
+async def admin_refresh_deployment_revisions(
+    info: Info[StrawberryGQLContext],
+) -> AdminRefreshDeploymentRevisionsPayload:
+    check_admin_only()
+    payload = await info.context.adapters.deployment.admin_refresh_deployment_revisions()
+    return AdminRefreshDeploymentRevisionsPayload(
+        results=[
+            RevisionRefreshResult(
+                deployment_id=r.deployment_id,
+                new_revision_id=r.new_revision_id,
+                success=r.success,
+                failure_reason=r.failure_reason,
+            )
+            for r in payload.results
+        ]
+    )
 
 
 # Subscription resolvers

--- a/src/ai/backend/manager/api/gql/deployment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/__init__.py
@@ -26,6 +26,7 @@ from .auto_scaling import (
     UpdateAutoScalingRulePayload,
 )
 from .deployment import (
+    AdminRefreshDeploymentRevisionsPayload,
     CreateDeploymentInput,
     CreateDeploymentPayload,
     DeleteDeploymentInput,
@@ -46,6 +47,7 @@ from .deployment import (
     ModelDeploymentNetworkAccessInput,
     ProjectDeploymentScopeGQL,
     ReplicaState,
+    RevisionRefreshResult,
     SyncReplicaInput,
     SyncReplicaPayload,
     UpdateDeploymentInput,
@@ -163,6 +165,7 @@ __all__ = [
     "UpdateAutoScalingRuleInput",
     "UpdateAutoScalingRulePayload",
     # Deployment
+    "AdminRefreshDeploymentRevisionsPayload",
     "CreateDeploymentInput",
     "CreateDeploymentPayload",
     "DeleteDeploymentInput",
@@ -183,6 +186,7 @@ __all__ = [
     "ModelDeploymentNetworkAccess",
     "ModelDeploymentNetworkAccessInput",
     "ReplicaState",
+    "RevisionRefreshResult",
     "SyncReplicaInput",
     "SyncReplicaPayload",
     "UpdateDeploymentInput",

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -51,6 +51,9 @@ from ai.backend.common.dto.manager.v2.deployment.request import (
     UpdateDeploymentInput as UpdateDeploymentInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.response import (
+    AdminRefreshDeploymentRevisionsPayload as AdminRefreshDeploymentRevisionsPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment.response import (
     CreateDeploymentPayload as CreateDeploymentPayloadDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.response import (
@@ -61,6 +64,9 @@ from ai.backend.common.dto.manager.v2.deployment.response import (
 )
 from ai.backend.common.dto.manager.v2.deployment.response import (
     DeploymentStatusChangedPayload as DeploymentStatusChangedPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment.response import (
+    RevisionRefreshResultInfo as RevisionRefreshResultInfoDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment.response import (
     SyncReplicaPayload as SyncReplicaPayloadDTO,
@@ -714,3 +720,32 @@ class SyncReplicaPayload:
     """Payload for replica sync mutation result."""
 
     success: strawberry.auto
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-deployment result of an admin bulk revision refresh.",
+    ),
+    model=RevisionRefreshResultInfoDTO,
+)
+class RevisionRefreshResult:
+    """Per-deployment result of an admin bulk revision refresh."""
+
+    deployment_id: strawberry.auto
+    new_revision_id: strawberry.auto
+    success: strawberry.auto
+    failure_reason: strawberry.auto
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for admin bulk revision refresh mutation result.",
+    ),
+    model=AdminRefreshDeploymentRevisionsPayloadDTO,
+)
+class AdminRefreshDeploymentRevisionsPayload:
+    """Payload for admin bulk revision refresh mutation result."""
+
+    results: strawberry.auto

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -64,6 +64,7 @@ from .deployment import (
     admin_create_deployment_revision_preset,
     admin_delete_deployment_revision_preset,
     admin_deployments,
+    admin_refresh_deployment_revisions,
     admin_update_deployment_revision_preset,
     # Access Token
     create_access_token,
@@ -657,6 +658,7 @@ class Mutation:
     delete_model_deployment = delete_model_deployment
     sync_replicas = sync_replicas
     add_model_revision = add_model_revision
+    admin_refresh_deployment_revisions = admin_refresh_deployment_revisions
     update_deployment_policy = update_deployment_policy
     # Notification - Admin APIs
     admin_create_notification_channel = admin_create_notification_channel

--- a/src/ai/backend/manager/api/rest/v2/deployment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/deployment/handler.py
@@ -247,6 +247,11 @@ class V2DeploymentHandler:
         result = await self._adapter.sync_replicas(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
+    async def admin_refresh_deployment_revisions(self) -> APIResponse:
+        """Rebuild and activate a fresh revision for every active deployment."""
+        result = await self._adapter.admin_refresh_deployment_revisions()
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
     # ------------------------------------------------------------------
     # Route operations
     # ------------------------------------------------------------------

--- a/src/ai/backend/manager/api/rest/v2/deployment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/deployment/registry.py
@@ -111,6 +111,12 @@ def register_v2_deployment_routes(
         handler.search_revision_resource_slots,
         middlewares=[auth_required],
     )
+    registry.add(
+        "POST",
+        "/admin/refresh-revisions",
+        handler.admin_refresh_deployment_revisions,
+        middlewares=[superadmin_required],
+    )
 
     # ------------------------------------------------------------------
     # Replica operations

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -966,3 +966,13 @@ class RevisionSearchScope:
     """Scope for searching revisions within a specific deployment."""
 
     deployment_id: UUID
+
+
+@dataclass(frozen=True)
+class RevisionRefreshResult:
+    """Per-deployment result of an admin bulk revision refresh."""
+
+    deployment_id: UUID
+    new_revision_id: UUID | None
+    success: bool
+    failure_reason: str | None

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -59,6 +59,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
     ModelRevisionData,
+    ModelRevisionSpec,
     RevisionSearchResult,
     RouteHealthStatus,
     RouteInfo,
@@ -2471,6 +2472,43 @@ class DeploymentDBSource:
                     f"Deployment revision {current_revision_id} not found"
                 )
             return row.to_data()
+
+    async def get_current_revision_spec(
+        self,
+        endpoint_id: uuid.UUID,
+    ) -> ModelRevisionSpec:
+        """Get the current revision of a deployment as a ModelRevisionSpec.
+
+        Used by operations that need to rebuild a ModelRevisionCreator from
+        an existing revision (e.g. admin revision refresh).
+
+        Raises:
+            DeploymentRevisionNotFound: If the endpoint has no current revision.
+        """
+        async with self._db.begin_readonly_session() as db_sess:
+            endpoint_query = sa.select(EndpointRow.current_revision).where(
+                EndpointRow.id == endpoint_id
+            )
+            result = await db_sess.execute(endpoint_query)
+            current_revision_id = result.scalar_one_or_none()
+            if current_revision_id is None:
+                raise DeploymentRevisionNotFound(f"Endpoint {endpoint_id} has no current revision")
+
+            revision_query = (
+                sa.select(DeploymentRevisionRow)
+                .where(DeploymentRevisionRow.id == current_revision_id)
+                .options(
+                    selectinload(DeploymentRevisionRow.image_row),
+                    selectinload(DeploymentRevisionRow.resource_slot_rows),
+                )
+            )
+            revision_result = await db_sess.execute(revision_query)
+            row = revision_result.scalar_one_or_none()
+            if row is None:
+                raise DeploymentRevisionNotFound(
+                    f"Deployment revision {current_revision_id} not found"
+                )
+            return row.to_model_revision_spec()
 
     async def search_revisions(
         self,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -58,6 +58,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
     ModelRevisionData,
+    ModelRevisionSpec,
     RevisionSearchResult,
     RouteHealthStatus,
     RouteInfo,
@@ -1268,6 +1269,18 @@ class DeploymentRepository:
             DeploymentRevisionNotFound: If the endpoint has no current revision.
         """
         return await self._db_source.get_current_revision(endpoint_id)
+
+    @deployment_repository_resilience.apply()
+    async def get_current_revision_spec(
+        self,
+        endpoint_id: uuid.UUID,
+    ) -> ModelRevisionSpec:
+        """Get the current revision as a ModelRevisionSpec for revision refresh.
+
+        Raises:
+            DeploymentRevisionNotFound: If the endpoint has no current revision.
+        """
+        return await self._db_source.get_current_revision_spec(endpoint_id)
 
     @deployment_repository_resilience.apply()
     async def search_revisions(

--- a/src/ai/backend/manager/services/deployment/actions/refresh_deployment_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/refresh_deployment_revisions.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.deployment.types import RevisionRefreshResult
+from ai.backend.manager.services.deployment.actions.base import DeploymentBaseAction
+
+
+@dataclass
+class RefreshDeploymentRevisionsAction(DeploymentBaseAction):
+    """Admin-only action to refresh revisions for all active deployments.
+
+    Creates a new revision based on each active deployment's current revision
+    and activates it, allowing DeploymentController to re-resolve preset,
+    deployment-config, and model_definition.
+    """
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class RefreshDeploymentRevisionsActionResult(BaseActionResult):
+    results: list[RevisionRefreshResult] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -98,6 +98,10 @@ from ai.backend.manager.services.deployment.actions.model_revision.search_revisi
     SearchRevisionsAction,
     SearchRevisionsActionResult,
 )
+from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions import (
+    RefreshDeploymentRevisionsAction,
+    RefreshDeploymentRevisionsActionResult,
+)
 from ai.backend.manager.services.deployment.actions.revision_operations import (
     ActivateRevisionAction,
     ActivateRevisionActionResult,
@@ -172,6 +176,9 @@ class DeploymentProcessors(AbstractProcessorPackage):
         SearchRevisionResourceSlotsAction, SearchRevisionResourceSlotsActionResult
     ]
     activate_revision: ActionProcessor[ActivateRevisionAction, ActivateRevisionActionResult]
+    admin_refresh_deployment_revisions: ActionProcessor[
+        RefreshDeploymentRevisionsAction, RefreshDeploymentRevisionsActionResult
+    ]
 
     # Route operations
     sync_replicas: ActionProcessor[SyncReplicaAction, SyncReplicaActionResult]
@@ -254,6 +261,9 @@ class DeploymentProcessors(AbstractProcessorPackage):
             service.search_revision_resource_slots, action_monitors
         )
         self.activate_revision = ActionProcessor(service.activate_revision, action_monitors)
+        self.admin_refresh_deployment_revisions = ActionProcessor(
+            service.admin_refresh_deployment_revisions, action_monitors
+        )
 
         # Route operations
         self.sync_replicas = ActionProcessor(service.sync_replicas, action_monitors)
@@ -313,6 +323,7 @@ class DeploymentProcessors(AbstractProcessorPackage):
             SearchRevisionsAction.spec(),
             SearchRevisionResourceSlotsAction.spec(),
             ActivateRevisionAction.spec(),
+            RefreshDeploymentRevisionsAction.spec(),
             # Route operations
             SyncReplicaAction.spec(),
             SearchRoutesAction.spec(),

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -21,7 +21,9 @@ from ai.backend.common.types import (
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.deployment.creator import (
     DeploymentPolicyConfig,
+    ModelRevisionCreator,
     NewDeploymentCreator,
+    VFolderMountsCreator,
 )
 from ai.backend.manager.data.deployment.types import (
     ClusterConfigData,
@@ -34,10 +36,12 @@ from ai.backend.manager.data.deployment.types import (
     ModelMountConfigData,
     ModelReplicaData,
     ModelRevisionData,
+    ModelRevisionSpec,
     ModelRuntimeConfigData,
     ReplicaSpec,
     ReplicaStateData,
     ResourceConfigData,
+    RevisionRefreshResult,
     RouteHealthStatus,
     RouteInfo,
     RouteStatus,
@@ -45,6 +49,7 @@ from ai.backend.manager.data.deployment.types import (
 )
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
+    PresetValueData,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.service import RoutingNotFound
@@ -162,6 +167,10 @@ from ai.backend.manager.services.deployment.actions.model_revision.search_revisi
 from ai.backend.manager.services.deployment.actions.model_revision.search_revisions import (
     SearchRevisionsAction,
     SearchRevisionsActionResult,
+)
+from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions import (
+    RefreshDeploymentRevisionsAction,
+    RefreshDeploymentRevisionsActionResult,
 )
 from ai.backend.manager.services.deployment.actions.revision_operations import (
     ActivateRevisionAction,
@@ -345,6 +354,33 @@ def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
         activeness_status=_resolve_activeness(route.traffic_status, readiness, liveness),
         detail=route.error_data,
         created_at=route.created_at,
+    )
+
+
+def _build_creator_from_revision_spec(spec: ModelRevisionSpec) -> ModelRevisionCreator:
+    """Rebuild a ``ModelRevisionCreator`` from an existing revision's spec.
+
+    ``model_definition`` is reset to ``None`` so ``DeploymentController.add_revision``
+    re-resolves it from the vfolder. ``revision_preset_id`` is left ``None`` since
+    it is not persisted on the revision row; the materialized ``preset_values``
+    carry forward the preset effect without requiring re-application.
+    ``extra_mounts`` is left empty because ``add_revision`` does not propagate
+    this field to the new revision spec (see ``DeploymentController.add_revision``).
+    """
+    return ModelRevisionCreator(
+        image_id=spec.image_id,
+        resource_spec=spec.resource_spec,
+        mounts=VFolderMountsCreator(
+            model_vfolder_id=spec.mounts.model_vfolder_id,
+            model_definition_path=spec.mounts.model_definition_path,
+            model_mount_destination=spec.mounts.model_mount_destination,
+        ),
+        execution=spec.execution,
+        model_definition=None,
+        revision_preset_id=None,
+        preset_values=[
+            PresetValueData(preset_id=pv.preset_id, value=pv.value) for pv in spec.preset_values
+        ],
     )
 
 
@@ -803,6 +839,63 @@ class DeploymentService:
             activated_revision_id=result.activated_revision_id,
             deployment_policy=result.deployment_policy,
         )
+
+    async def admin_refresh_deployment_revisions(
+        self, action: RefreshDeploymentRevisionsAction
+    ) -> RefreshDeploymentRevisionsActionResult:
+        """Refresh revisions for all active deployments.
+
+        For each active deployment, rebuilds a ``ModelRevisionCreator`` from the
+        current revision and delegates to ``DeploymentController.add_revision``
+        (which re-resolves preset / deployment-config / model_definition) and
+        ``activate_revision``. Each deployment is processed independently so a
+        single failure does not abort the rest (partial success by design).
+        """
+        # Bulk scan + independent per-deployment orchestration: multiple repo
+        # and controller calls are required by design to preserve partial
+        # success semantics. Each inner call owns its own transaction boundary.
+        endpoint_ids = await self._deployment_repository.list_active_endpoint_ids()
+        results: list[RevisionRefreshResult] = []
+        succeeded = 0
+        failed = 0
+        for endpoint_id in endpoint_ids:
+            try:
+                spec = await self._deployment_repository.get_current_revision_spec(endpoint_id)
+                creator = _build_creator_from_revision_spec(spec)
+                new_revision = await self._deployment_controller.add_revision(endpoint_id, creator)
+                await self._deployment_controller.activate_revision(endpoint_id, new_revision.id)
+                results.append(
+                    RevisionRefreshResult(
+                        deployment_id=endpoint_id,
+                        new_revision_id=new_revision.id,
+                        success=True,
+                        failure_reason=None,
+                    )
+                )
+                succeeded += 1
+            except Exception as exc:
+                log.warning(
+                    "admin_refresh_deployment_revisions failed for deployment {}: {}: {}",
+                    endpoint_id,
+                    type(exc).__name__,
+                    exc,
+                )
+                results.append(
+                    RevisionRefreshResult(
+                        deployment_id=endpoint_id,
+                        new_revision_id=None,
+                        success=False,
+                        failure_reason=f"{type(exc).__name__}: {exc}",
+                    )
+                )
+                failed += 1
+        log.info(
+            "admin_refresh_deployment_revisions summary: total={} succeeded={} failed={}",
+            len(endpoint_ids),
+            succeeded,
+            failed,
+        )
+        return RefreshDeploymentRevisionsActionResult(results=results)
 
     # ========== Route Operations ==========
 


### PR DESCRIPTION
## Summary

- Added a parameterless superadmin endpoint that rebuilds and activates a fresh revision for every deployment in `EndpointLifecycle.active_states()`. The operation reuses `DeploymentController.add_revision` + `activate_revision`, so preset / deployment-config / model_definition are re-resolved. It's primarily meant to repair deployments whose current revision has stale or missing `model_definition` after backing-store migrations, but generalizes to any case where a fresh re-resolve is needed.
- Each deployment is processed independently — one failure (e.g. endpoint with no current revision) does not abort the rest. Per-deployment outcomes (`success`, `new_revision_id`, `failure_reason`) are returned so operators can triage failures.
- Exposed through REST (`POST /v2/deployments/admin/refresh-revisions`), GraphQL (`mutation admin_refresh_deployment_revisions`), Client SDK, and CLI (`./bai admin deployment revision refresh`).

## Test plan

- [x] `pants fmt`, `pants fix`, `pants lint` pass
- [x] `pants test --changed-since=HEAD --changed-dependents=transitive` passes
- [x] `pants check --changed-since=HEAD` introduces no new errors beyond existing `services/processors.py` import-stub warnings
- [x] E2E: verified on local dev stack with `./bai admin deployment revision refresh`; response contains both success (new revision UUID) and failure entries (deployments with null `current_revision_id` are reported, not aborting)
- [ ] Reviewer to confirm: per-deployment transaction isolation works as expected when one deployment errors mid-run
- [ ] Reviewer to confirm: `admin_refresh_deployment_revisions` mutation appears in `docs/manager/graphql-reference` schema dump once CI regenerates

🤖 Generated with [Claude Code](https://claude.com/claude-code)