### PR TITLE
feat: Distribute bssh-server binary alongside bssh via import workflow

### DIFF
--- a/.github/workflows/import-bssh.yml
+++ b/.github/workflows/import-bssh.yml
@@ -38,19 +38,21 @@ jobs:
               run: |
                   TAG="${{ steps.get-tag.outputs.tag }}"
                   for ARCH in aarch64 x86_64; do
-                    URL="https://github.com/lablup/bssh/releases/download/${TAG}/bssh-linux-${ARCH}-musl.tar.gz"
-                    echo "Downloading from: $URL"
-                    curl -fL -o bssh.tar.gz "$URL"
-                    tar -xzf bssh.tar.gz
-                    if [ -f "bssh" ]; then
-                      mv bssh "bssh.${ARCH}.bin"
-                      chmod +x "bssh.${ARCH}.bin"
-                      echo "Binary extracted and renamed to bssh.${ARCH}.bin"
-                    else
-                      echo "Error: bssh binary not found in the archive for $ARCH"
-                      exit 1
-                    fi
-                    rm -f bssh.tar.gz
+                    for TOOL in bssh bssh-server; do
+                      URL="https://github.com/lablup/bssh/releases/download/${TAG}/${TOOL}-linux-${ARCH}-musl.tar.gz"
+                      echo "Downloading from: $URL"
+                      curl -fL -o tool.tar.gz "$URL"
+                      tar -xzf tool.tar.gz
+                      if [ -f "${TOOL}" ]; then
+                        mv "${TOOL}" "${TOOL}.${ARCH}.bin"
+                        chmod +x "${TOOL}.${ARCH}.bin"
+                        echo "Binary extracted and renamed to ${TOOL}.${ARCH}.bin"
+                      else
+                        echo "Error: ${TOOL} binary not found in the archive for $ARCH"
+                        exit 1
+                      fi
+                      rm -f tool.tar.gz
+                    done
                   done
 
             - name: Move binaries to target location
@@ -59,26 +61,33 @@ jobs:
                   mkdir -p "${TARGET_DIR}"
                   # Move executable binaries
                   for ARCH in aarch64 x86_64; do
-                    mv "bssh.${ARCH}.bin" "${TARGET_DIR}/"
-                    echo "Binary moved to ${TARGET_DIR}/bssh.${ARCH}.bin"
-                    ls -la "${TARGET_DIR}/bssh.${ARCH}.bin"
+                    for TOOL in bssh bssh-server; do
+                      mv "${TOOL}.${ARCH}.bin" "${TARGET_DIR}/"
+                      echo "Binary moved to ${TARGET_DIR}/${TOOL}.${ARCH}.bin"
+                      ls -la "${TARGET_DIR}/${TOOL}.${ARCH}.bin"
+                    done
                   done
-                  # Move manpages
-                  mv bssh.1 "${TARGET_DIR}/"
+                  # Move manpages (only bssh currently ships a manpage)
+                  for MAN in bssh.1 bssh-server.1; do
+                    if [ -f "${MAN}" ]; then
+                      mv "${MAN}" "${TARGET_DIR}/"
+                      echo "Manpage moved to ${TARGET_DIR}/${MAN}"
+                    fi
+                  done
 
             - name: Add news fragment
               run: |
-                  echo "Update bssh binaries to ${{ steps.get-tag.outputs.tag }}" > changes/.deps.md
+                  echo "Update bssh and bssh-server binaries to ${{ steps.get-tag.outputs.tag }}" > changes/.deps.md
 
             - name: Create pull request
               uses: peter-evans/create-pull-request@v7
               with:
                   token: ${{ secrets.OCTODOG }}
-                  commit-message: "chore: Update bssh binaries to ${{ steps.get-tag.outputs.tag }}"
-                  title: "deps: Update bssh binaries to ${{ steps.get-tag.outputs.tag }}"
+                  commit-message: "chore: Update bssh and bssh-server binaries to ${{ steps.get-tag.outputs.tag }}"
+                  title: "deps: Update bssh and bssh-server binaries to ${{ steps.get-tag.outputs.tag }}"
                   author: "Lablup Octodog <mu001@lablup.com>"
                   body: |
-                      This PR updates the bssh binaries (musl variant) for both aarch64 and x86_64 architectures to version ${{ steps.get-tag.outputs.tag }}.
+                      This PR updates the bssh and bssh-server binaries (musl variant) for both aarch64 and x86_64 architectures to version ${{ steps.get-tag.outputs.tag }}.
 
                       Source: https://github.com/lablup/bssh/releases/tag/${{ steps.get-tag.outputs.tag }}
 

--- a/changes/11136.feature.md
+++ b/changes/11136.feature.md
@@ -1,0 +1,1 @@
+Extend the bssh import workflow to also download and commit the `bssh-server` binary, and mount it into session containers at `/opt/kernel/bssh-server` so that it can be evaluated as an alternative SSH server next to the default dropbear.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -641,6 +641,12 @@ class AbstractKernelCreationContext[KernelObjectType: AbstractKernel](aobject):
         mount_static_binary("all-smi.1", "/usr/local/share/man/man1/all-smi.1", skip_missing=True)
         mount_static_binary(f"bssh.{arch}.bin", "/usr/local/bin/bssh")
         mount_static_binary("bssh.1", "/usr/local/share/man/man1/bssh.1", skip_missing=True)
+        mount_static_binary(
+            f"bssh-server.{arch}.bin", "/opt/kernel/bssh-server", skip_missing=True
+        )
+        mount_static_binary(
+            "bssh-server.1", "/usr/local/share/man/man1/bssh-server.1", skip_missing=True
+        )
 
         jail_path: Path | None
         if self.local_config.container.sandbox_type == ContainerSandboxType.JAIL:

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -641,9 +641,7 @@ class AbstractKernelCreationContext[KernelObjectType: AbstractKernel](aobject):
         mount_static_binary("all-smi.1", "/usr/local/share/man/man1/all-smi.1", skip_missing=True)
         mount_static_binary(f"bssh.{arch}.bin", "/usr/local/bin/bssh")
         mount_static_binary("bssh.1", "/usr/local/share/man/man1/bssh.1", skip_missing=True)
-        mount_static_binary(
-            f"bssh-server.{arch}.bin", "/opt/kernel/bssh-server", skip_missing=True
-        )
+        mount_static_binary(f"bssh-server.{arch}.bin", "/opt/kernel/bssh-server", skip_missing=True)
         mount_static_binary(
             "bssh-server.1", "/usr/local/share/man/man1/bssh-server.1", skip_missing=True
         )


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/import-bssh.yml` so that the automated bssh import workflow also downloads and commits `bssh-server-linux-{aarch64,x86_64}-musl` binaries whenever a new bssh release is cut. The existing bssh client flow is preserved; a single loop now handles both tools.
- Update `src/ai/backend/agent/agent.py` so the agent mounts `bssh-server.{arch}.bin` into session containers at `/opt/kernel/bssh-server` (and the manpage at `/usr/local/share/man/man1/`) with `skip_missing=True`, so that the binary becomes accessible inside sessions once the import workflow imports it without breaking existing agents that don't have it yet.

## Rationale

The `bssh` upstream project released v2.0.x with a new `bssh-server` — a Rust-based SSH server for containers supporting SFTP/SCP, PTY/shell, password/pubkey auth, and audit logging. We want to make it available in session containers alongside the existing dropbear-based SSH server **for stability and performance evaluation** before any decision to replace dropbear is made.

As documented in recent upload-performance measurements (`dogbowl`, 2026-04-16), dropbear is a single-threaded SSH server that caps SFTP throughput at ~75 MB/s (CPU-bound on 1 core), while OpenSSH on the same container setup reaches ~95 MB/s. `bssh-server` built with `russh` is expected to close this gap while keeping the lightweight image footprint. Landing the binary first lets us benchmark it empirically before touching krunner's `intrinsic.py`.

## Test plan

- [ ] Verify the `import-bssh` workflow run (manual dispatch) downloads both `bssh` and `bssh-server` archives for `aarch64` and `x86_64`, extracts the binaries, and creates a PR with `bssh.{arch}.bin`, `bssh-server.{arch}.bin` under `src/ai/backend/runner/`.
- [ ] After the imported binaries land, confirm a new session container has `/opt/kernel/bssh-server` (via `docker exec ... ls -la /opt/kernel/`).
- [ ] Confirm dropbear still starts as the default SSH server for session containers (no behavioral regression).

## Follow-ups (not in this PR)

- Wire `bssh-server` into `src/ai/backend/kernel/intrinsic.py` as an alternative (flag-driven) SSH server, once it has been manually validated.
- Decide on a migration plan from dropbear to `bssh-server` or OpenSSH depending on empirical measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)