### PR TITLE
fix: support nullify on auto scaling rule update for nullable fields

### DIFF
--- a/changes/11137.fix.md
+++ b/changes/11137.fix.md
@@ -1,0 +1,1 @@
+Allow auto scaling rule updates to clear nullable fields (`min_threshold`, `max_threshold`, `min_replicas`, `max_replicas`, `prometheus_query_preset_id`) by sending an explicit `null`, while keeping omitted fields unchanged.

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -302,6 +302,20 @@ from .pagination import PaginationSpec
 DEFAULT_PAGINATION_LIMIT = 10
 
 
+def _tristate_from_input[T](value: T | Sentinel | None) -> TriState[T]:
+    """Map a DTO-style optional value (Sentinel / None / value) to TriState.
+
+    - ``Sentinel`` → NOP (field was not provided; leave the attribute unchanged)
+    - ``None`` → NULLIFY (field was provided as ``null``; clear the attribute)
+    - otherwise → UPDATE (replace with the given value)
+    """
+    if isinstance(value, Sentinel):
+        return TriState[T].nop()
+    if value is None:
+        return TriState[T].nullify()
+    return TriState[T].update(value)
+
+
 @lru_cache(maxsize=1)
 def _get_deployment_pagination_spec() -> PaginationSpec:
     return PaginationSpec(
@@ -975,16 +989,8 @@ class DeploymentAdapter(BaseAdapter):
                 if input.metric_name is not None
                 else OptionalState.nop()
             ),
-            min_threshold=(
-                OptionalState.update(input.min_threshold)
-                if not isinstance(input.min_threshold, Sentinel) and input.min_threshold is not None
-                else OptionalState.nop()
-            ),
-            max_threshold=(
-                OptionalState.update(input.max_threshold)
-                if not isinstance(input.max_threshold, Sentinel) and input.max_threshold is not None
-                else OptionalState.nop()
-            ),
+            min_threshold=_tristate_from_input(input.min_threshold),
+            max_threshold=_tristate_from_input(input.max_threshold),
             step_size=(
                 OptionalState.update(input.step_size)
                 if input.step_size is not None
@@ -995,22 +1001,9 @@ class DeploymentAdapter(BaseAdapter):
                 if input.time_window is not None
                 else OptionalState.nop()
             ),
-            min_replicas=(
-                OptionalState.update(input.min_replicas)
-                if not isinstance(input.min_replicas, Sentinel) and input.min_replicas is not None
-                else OptionalState.nop()
-            ),
-            max_replicas=(
-                OptionalState.update(input.max_replicas)
-                if not isinstance(input.max_replicas, Sentinel) and input.max_replicas is not None
-                else OptionalState.nop()
-            ),
-            prometheus_query_preset_id=(
-                OptionalState.update(input.prometheus_query_preset_id)
-                if not isinstance(input.prometheus_query_preset_id, Sentinel)
-                and input.prometheus_query_preset_id is not None
-                else OptionalState.nop()
-            ),
+            min_replicas=_tristate_from_input(input.min_replicas),
+            max_replicas=_tristate_from_input(input.max_replicas),
+            prometheus_query_preset_id=_tristate_from_input(input.prometheus_query_preset_id),
         )
         action_result = (
             await self._processors.deployment.update_auto_scaling_rule.wait_for_complete(

--- a/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
+++ b/src/ai/backend/manager/api/rest/auto_scaling_rule/adapter.py
@@ -30,7 +30,7 @@ from ai.backend.manager.repositories.base import (
     QueryCondition,
     QueryOrder,
 )
-from ai.backend.manager.types import OptionalState
+from ai.backend.manager.types import OptionalState, TriState
 
 __all__ = ("AutoScalingRuleAdapter",)
 
@@ -59,35 +59,42 @@ class AutoScalingRuleAdapter(BaseFilterAdapter):
     def build_modifier(
         self, request: UpdateAutoScalingRuleRequest
     ) -> ModelDeploymentAutoScalingRuleModifier:
-        """Convert update request to modifier."""
+        """Convert update request to modifier.
+
+        REST v1 requests do not carry the Sentinel/None/value tri-state that
+        the v2 DTO exposes; ``None`` here always means "no change". The
+        nullable fields still use ``TriState`` on the modifier side to match
+        the shared dataclass signature, but NULLIFY is never emitted from
+        this path.
+        """
         metric_source = OptionalState[AutoScalingMetricSource].nop()
         metric_name = OptionalState[str].nop()
-        min_threshold: OptionalState[Decimal] = OptionalState.nop()
-        max_threshold: OptionalState[Decimal] = OptionalState.nop()
+        min_threshold: TriState[Decimal] = TriState.nop()
+        max_threshold: TriState[Decimal] = TriState.nop()
         step_size = OptionalState[int].nop()
         time_window = OptionalState[int].nop()
-        min_replicas = OptionalState[int].nop()
-        max_replicas = OptionalState[int].nop()
-        prometheus_query_preset_id = OptionalState[UUID].nop()
+        min_replicas: TriState[int] = TriState.nop()
+        max_replicas: TriState[int] = TriState.nop()
+        prometheus_query_preset_id: TriState[UUID] = TriState.nop()
 
         if request.metric_source is not None:
             metric_source = OptionalState.update(request.metric_source)
         if request.metric_name is not None:
             metric_name = OptionalState.update(request.metric_name)
         if request.min_threshold is not None:
-            min_threshold = OptionalState.update(request.min_threshold)
+            min_threshold = TriState.update(request.min_threshold)
         if request.max_threshold is not None:
-            max_threshold = OptionalState.update(request.max_threshold)
+            max_threshold = TriState.update(request.max_threshold)
         if request.step_size is not None:
             step_size = OptionalState.update(request.step_size)
         if request.time_window is not None:
             time_window = OptionalState.update(request.time_window)
         if request.min_replicas is not None:
-            min_replicas = OptionalState.update(request.min_replicas)
+            min_replicas = TriState.update(request.min_replicas)
         if request.max_replicas is not None:
-            max_replicas = OptionalState.update(request.max_replicas)
+            max_replicas = TriState.update(request.max_replicas)
         if request.prometheus_query_preset_id is not None:
-            prometheus_query_preset_id = OptionalState.update(request.prometheus_query_preset_id)
+            prometheus_query_preset_id = TriState.update(request.prometheus_query_preset_id)
 
         return ModelDeploymentAutoScalingRuleModifier(
             metric_source=metric_source,

--- a/src/ai/backend/manager/data/deployment/scale_modifier.py
+++ b/src/ai/backend/manager/data/deployment/scale_modifier.py
@@ -66,13 +66,13 @@ class ModelDeploymentAutoScalingRuleModifier(PartialModifier):
         default_factory=OptionalState[AutoScalingMetricSource].nop
     )
     metric_name: OptionalState[str] = field(default_factory=OptionalState[str].nop)
-    min_threshold: OptionalState[Decimal] = field(default_factory=OptionalState[Decimal].nop)
-    max_threshold: OptionalState[Decimal] = field(default_factory=OptionalState[Decimal].nop)
+    min_threshold: TriState[Decimal] = field(default_factory=TriState[Decimal].nop)
+    max_threshold: TriState[Decimal] = field(default_factory=TriState[Decimal].nop)
     step_size: OptionalState[int] = field(default_factory=OptionalState[int].nop)
     time_window: OptionalState[int] = field(default_factory=OptionalState[int].nop)
-    min_replicas: OptionalState[int] = field(default_factory=OptionalState[int].nop)
-    max_replicas: OptionalState[int] = field(default_factory=OptionalState[int].nop)
-    prometheus_query_preset_id: OptionalState[UUID] = field(default_factory=OptionalState[UUID].nop)
+    min_replicas: TriState[int] = field(default_factory=TriState[int].nop)
+    max_replicas: TriState[int] = field(default_factory=TriState[int].nop)
+    prometheus_query_preset_id: TriState[UUID] = field(default_factory=TriState[UUID].nop)
 
     @override
     def fields_to_update(self) -> dict[str, Any]:
@@ -82,7 +82,7 @@ class ModelDeploymentAutoScalingRuleModifier(PartialModifier):
         self.min_threshold.update_dict(to_update, "min_threshold")
         self.max_threshold.update_dict(to_update, "max_threshold")
         self.step_size.update_dict(to_update, "step_size")
-        self.time_window.update_dict(to_update, "time_window")
+        self.time_window.update_dict(to_update, "cooldown_seconds")
         self.min_replicas.update_dict(to_update, "min_replicas")
         self.max_replicas.update_dict(to_update, "max_replicas")
         self.prometheus_query_preset_id.update_dict(to_update, "prometheus_query_preset_id")

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -1112,30 +1112,14 @@ class EndpointAutoScalingRuleRow(Base):  # type: ignore[misc]
     ) -> None:
         """Apply ModelDeploymentAutoScalingRuleModifier to update fields.
 
-        Uses OptionalState pattern where optional_value() returns the value to update
-        or None if no update should be performed.
+        Uses fields_to_update() which honours both OptionalState (NOP/UPDATE)
+        and TriState (NOP/UPDATE/NULLIFY). Dict keys match DB column names so
+        each entry can be applied directly via setattr, preserving NULLIFY
+        semantics for nullable columns (min/max_threshold, min/max_replicas,
+        prometheus_query_preset_id).
         """
-        if (metric_source := modifier.metric_source.optional_value()) is not None:
-            self.metric_source = metric_source
-        if (metric_name := modifier.metric_name.optional_value()) is not None:
-            self.metric_name = metric_name
-        if (step_size := modifier.step_size.optional_value()) is not None:
-            self.step_size = step_size
-        if (time_window := modifier.time_window.optional_value()) is not None:
-            self.cooldown_seconds = time_window
-        if (min_replicas := modifier.min_replicas.optional_value()) is not None:
-            self.min_replicas = min_replicas
-        if (max_replicas := modifier.max_replicas.optional_value()) is not None:
-            self.max_replicas = max_replicas
-
-        if (max_threshold := modifier.max_threshold.optional_value()) is not None:
-            self.max_threshold = max_threshold
-        if (min_threshold := modifier.min_threshold.optional_value()) is not None:
-            self.min_threshold = min_threshold
-        if (
-            prometheus_query_preset_id := modifier.prometheus_query_preset_id.optional_value()
-        ) is not None:
-            self.prometheus_query_preset_id = prometheus_query_preset_id
+        for column_name, value in modifier.fields_to_update().items():
+            setattr(self, column_name, value)
 
 
 class ModelServiceHelper:

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from uuid import uuid4
 
+from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.config import ModelConfig, ModelDefinition, ModelServiceConfig
 from ai.backend.common.types import ClusterMode, ResourceSlot, RuntimeVariant
-from ai.backend.manager.api.adapters.deployment import DeploymentAdapter
+from ai.backend.manager.api.adapters.deployment import (
+    DeploymentAdapter,
+    _tristate_from_input,
+)
 from ai.backend.manager.data.deployment.types import (
     ClusterConfigData,
     ModelMountConfigData,
@@ -15,6 +20,7 @@ from ai.backend.manager.data.deployment.types import (
     ModelRuntimeConfigData,
     ResourceConfigData,
 )
+from ai.backend.manager.types import TriState
 
 
 class TestRevisionDataToDTO:
@@ -63,3 +69,31 @@ class TestRevisionDataToDTO:
         assert dto.model_definition.models[0].name == "demo-model"
         assert dto.model_definition.models[0].service is not None
         assert dto.model_definition.models[0].service.port == 8000
+
+
+class TestTriStateFromInput:
+    """Tests for _tristate_from_input(): Sentinel/None/value → NOP/NULLIFY/UPDATE."""
+
+    def test_sentinel_yields_nop(self) -> None:
+        result: TriState[Decimal] = _tristate_from_input(SENTINEL)
+        assert result.is_nop()
+
+    def test_none_yields_nullify(self) -> None:
+        result: TriState[Decimal] = _tristate_from_input(None)
+        assert result.is_nullify()
+
+    def test_decimal_value_yields_update(self) -> None:
+        result = _tristate_from_input(Decimal("0.5"))
+        assert result.is_update()
+        assert result.value() == Decimal("0.5")
+
+    def test_uuid_value_yields_update(self) -> None:
+        preset_id = uuid4()
+        result = _tristate_from_input(preset_id)
+        assert result.is_update()
+        assert result.value() == preset_id
+
+    def test_int_value_yields_update(self) -> None:
+        result = _tristate_from_input(3)
+        assert result.is_update()
+        assert result.value() == 3

--- a/tests/unit/manager/data/deployment/BUILD
+++ b/tests/unit/manager/data/deployment/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/data/deployment/test_scale_modifier.py
+++ b/tests/unit/manager/data/deployment/test_scale_modifier.py
@@ -1,0 +1,117 @@
+"""Unit tests for ModelDeploymentAutoScalingRuleModifier.
+
+These tests cover the update-path 3-state semantics for the auto scaling rule:
+
+- ``SENTINEL``/``NOP``  → field is omitted from the update dict
+- ``NULLIFY``            → nullable field is cleared to ``None`` in the dict
+- ``UPDATE(v)``          → field is assigned ``v`` in the dict
+
+Only the nullable DB columns (``min_threshold``, ``max_threshold``,
+``min_replicas``, ``max_replicas``, ``prometheus_query_preset_id``) use
+``TriState`` and therefore support NULLIFY. The non-nullable columns keep the
+narrower ``OptionalState`` (NOP/UPDATE) semantics.
+
+``apply_model_deployment_modifier`` is a trivial ``for k, v: setattr(self, k, v)``
+over this dict, so validating ``fields_to_update()`` fully covers the behaviour
+observable at the Row level.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from ai.backend.common.types import AutoScalingMetricSource
+from ai.backend.manager.data.deployment.scale_modifier import (
+    ModelDeploymentAutoScalingRuleModifier,
+)
+from ai.backend.manager.types import OptionalState, TriState
+
+
+class TestModifierFieldsToUpdate:
+    """fields_to_update() should honour NOP / UPDATE / NULLIFY per state."""
+
+    def test_empty_modifier_produces_empty_dict(self) -> None:
+        modifier = ModelDeploymentAutoScalingRuleModifier()
+        assert modifier.fields_to_update() == {}
+
+    def test_update_values_populate_dict(self) -> None:
+        preset_id = uuid4()
+        modifier = ModelDeploymentAutoScalingRuleModifier(
+            metric_source=OptionalState.update(AutoScalingMetricSource.KERNEL),
+            metric_name=OptionalState.update("cpu_util"),
+            min_threshold=TriState.update(Decimal("10")),
+            max_threshold=TriState.update(Decimal("90")),
+            step_size=OptionalState.update(2),
+            time_window=OptionalState.update(600),
+            min_replicas=TriState.update(1),
+            max_replicas=TriState.update(10),
+            prometheus_query_preset_id=TriState.update(preset_id),
+        )
+        assert modifier.fields_to_update() == {
+            "metric_source": AutoScalingMetricSource.KERNEL,
+            "metric_name": "cpu_util",
+            "min_threshold": Decimal("10"),
+            "max_threshold": Decimal("90"),
+            "step_size": 2,
+            "cooldown_seconds": 600,
+            "min_replicas": 1,
+            "max_replicas": 10,
+            "prometheus_query_preset_id": preset_id,
+        }
+
+    def test_nullify_produces_none_entries(self) -> None:
+        modifier = ModelDeploymentAutoScalingRuleModifier(
+            min_threshold=TriState[Decimal].nullify(),
+            max_threshold=TriState[Decimal].nullify(),
+            min_replicas=TriState[int].nullify(),
+            max_replicas=TriState[int].nullify(),
+            prometheus_query_preset_id=TriState.nullify(),
+        )
+        assert modifier.fields_to_update() == {
+            "min_threshold": None,
+            "max_threshold": None,
+            "min_replicas": None,
+            "max_replicas": None,
+            "prometheus_query_preset_id": None,
+        }
+
+    def test_time_window_maps_to_cooldown_seconds_column(self) -> None:
+        modifier = ModelDeploymentAutoScalingRuleModifier(
+            time_window=OptionalState.update(42),
+        )
+        assert modifier.fields_to_update() == {"cooldown_seconds": 42}
+
+
+class TestNullifyIsolation:
+    """NULLIFY on nullable fields must not affect the non-nullable fields."""
+
+    def test_nullify_on_nullable_fields_alone(self) -> None:
+        modifier = ModelDeploymentAutoScalingRuleModifier(
+            min_threshold=TriState[Decimal].nullify(),
+            prometheus_query_preset_id=TriState.nullify(),
+        )
+        update = modifier.fields_to_update()
+
+        assert update == {"min_threshold": None, "prometheus_query_preset_id": None}
+        assert "metric_source" not in update
+        assert "metric_name" not in update
+        assert "step_size" not in update
+        assert "cooldown_seconds" not in update
+
+    def test_mixed_update_and_nullify(self) -> None:
+        modifier = ModelDeploymentAutoScalingRuleModifier(
+            metric_name=OptionalState.update("gpu_util"),
+            min_threshold=TriState.update(Decimal("20")),
+            max_threshold=TriState[Decimal].nullify(),
+            min_replicas=TriState.update(2),
+            max_replicas=TriState[int].nullify(),
+        )
+
+        assert modifier.fields_to_update() == {
+            "metric_name": "gpu_util",
+            "min_threshold": Decimal("20"),
+            "max_threshold": None,
+            "min_replicas": 2,
+            "max_replicas": None,
+        }


### PR DESCRIPTION
## Summary

- DB-nullable fields on `EndpointAutoScalingRule` (`min_threshold`, `max_threshold`, `min_replicas`, `max_replicas`, `prometheus_query_preset_id`) could not be cleared via the GraphQL/REST v2 update mutation. Explicit `null` collapsed to a no-op because the modifier used `OptionalState` (NOP/UPDATE only) for these columns.
- Promote those five fields to `TriState` in `ModelDeploymentAutoScalingRuleModifier`, route DTO inputs through a new `_tristate_from_input` helper (`Sentinel → nop`, `None → nullify`, value → update), and simplify `apply_model_deployment_modifier` to iterate `fields_to_update()` + `setattr` so NULLIFY reaches the row. `time_window` now maps to the `cooldown_seconds` column.
- GQL inputs and DTOs stay as-is — they already declare the 3-state semantics; only the adapter/modifier/row path needed to honour them.

## Test plan

- [x] Unit: `tests/unit/manager/data/deployment/test_scale_modifier.py` — 3-state dict emission + NULLIFY isolation
- [x] Unit: `tests/unit/manager/api/adapters/test_deployment_adapter.py` — `_tristate_from_input` mapping
- [x] Regression: existing auto scaling rule service/action tests still pass
- [x] E2E (GraphQL, live server): against an existing rule
  - UPDATE (`minThreshold: "0.25"`, `maxReplicas: 6`) → values applied, rest unchanged
  - NULLIFY (`minThreshold: null`, `maxReplicas: null`) → both persisted as `null`
  - SENTINEL (only `metricName` provided) → other fields untouched, nullified values stay `null`
  - Restore to original values succeeds