### PR TITLE
feat(BA-5737): add RBAC-enforced VFolder create mutations

### DIFF
--- a/changes/11139.feature.md
+++ b/changes/11139.feature.md
@@ -1,0 +1,1 @@
+Add project-scoped `createProjectVFolder` GraphQL mutation with RBAC enforcement via ScopeActionProcessor.

--- a/changes/11139.feature.md
+++ b/changes/11139.feature.md
@@ -1,1 +1,1 @@
-Add project-scoped `createProjectVFolder` GraphQL mutation with RBAC enforcement via ScopeActionProcessor.
+Add project-scoped `createVFolderInProject` GraphQL mutation with RBAC enforcement via ScopeActionProcessor.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3954,6 +3954,9 @@ Added in UNRELEASED. Input for creating a virtual folder within a project.
 input CreateVFolderInProjectInput
   @join__type(graph: STRAWBERRY)
 {
+  """Project UUID that owns the vfolder."""
+  projectId: UUID!
+
   """VFolder name."""
   name: String!
 
@@ -10823,7 +10826,7 @@ type Mutation
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(projectId: UUID!, input: CreateVFolderInProjectInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  createVFolderInProject(input: CreateVFolderInProjectInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload! @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3949,14 +3949,11 @@ type CreateUserV2Payload
 }
 
 """
-Added in UNRELEASED. Input for creating a virtual folder within a project.
+Added in UNRELEASED. Scope-agnostic body for vfolder creation. The owning scope is supplied as a separate mutation argument.
 """
-input CreateVFolderInProjectInput
+input CreateVFolderInScopeInput
   @join__type(graph: STRAWBERRY)
 {
-  """Project UUID that owns the vfolder."""
-  projectId: UUID!
-
   """VFolder name."""
   name: String!
 
@@ -10826,7 +10823,7 @@ type Mutation
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(input: CreateVFolderInProjectInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload! @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10798,6 +10798,11 @@ type Mutation
   """Added in 26.4.2. Create a new virtual folder."""
   createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
+  """
+  Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
+  """
+  createProjectVFolder(projectId: UUID!, input: CreateVFolderV2Input!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload! @join__field(graph: STRAWBERRY)
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3948,7 +3948,9 @@ type CreateUserV2Payload
   user: UserV2!
 }
 
-"""Added in 26.4.2. Input for creating a new virtual folder."""
+"""
+Added in UNRELEASED. Input for creating a virtual folder within a project.
+"""
 input CreateVFolderInProjectInput
   @join__type(graph: STRAWBERRY)
 {
@@ -3968,6 +3970,7 @@ input CreateVFolderInProjectInput
   cloneable: Boolean! = false
 }
 
+"""Added in 26.4.2. Input for creating a new virtual folder."""
 input CreateVFolderV2Input
   @join__type(graph: STRAWBERRY)
 {

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3960,11 +3960,11 @@ input CreateVFolderInProjectInput
   """Storage host for the vfolder."""
   host: String = null
 
-  """Usage mode of the vfolder (general, model, data)."""
-  usageMode: String! = "general"
+  """Usage mode of the vfolder."""
+  usageMode: VFolderUsageMode! = GENERAL
 
-  """Default permission of the vfolder (ro, rw, wd)."""
-  permission: String! = "rw"
+  """Default mount permission of the vfolder."""
+  permission: VFolderMountPermission! = READ_WRITE
 
   """Whether the vfolder is cloneable."""
   cloneable: Boolean! = false

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3949,6 +3949,25 @@ type CreateUserV2Payload
 }
 
 """Added in 26.4.2. Input for creating a new virtual folder."""
+input CreateVFolderInProjectInput
+  @join__type(graph: STRAWBERRY)
+{
+  """VFolder name."""
+  name: String!
+
+  """Storage host for the vfolder."""
+  host: String = null
+
+  """Usage mode of the vfolder (general, model, data)."""
+  usageMode: String! = "general"
+
+  """Default permission of the vfolder (ro, rw, wd)."""
+  permission: String! = "rw"
+
+  """Whether the vfolder is cloneable."""
+  cloneable: Boolean! = false
+}
+
 input CreateVFolderV2Input
   @join__type(graph: STRAWBERRY)
 {
@@ -10801,7 +10820,7 @@ type Mutation
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createProjectVFolder(projectId: UUID!, input: CreateVFolderV2Input!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInProjectInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload! @join__field(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6788,6 +6788,11 @@ type Mutation {
   """Added in 26.4.2. Create a new virtual folder."""
   createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload!
 
+  """
+  Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
+  """
+  createProjectVFolder(projectId: UUID!, input: CreateVFolderV2Input!): CreateVFolderV2Payload!
+
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload!
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2470,6 +2470,23 @@ type CreateVFSStoragePayload {
 }
 
 """Added in 26.4.2. Input for creating a new virtual folder."""
+input CreateVFolderInProjectInput {
+  """VFolder name."""
+  name: String!
+
+  """Storage host for the vfolder."""
+  host: String = null
+
+  """Usage mode of the vfolder (general, model, data)."""
+  usageMode: String! = "general"
+
+  """Default permission of the vfolder (ro, rw, wd)."""
+  permission: String! = "rw"
+
+  """Whether the vfolder is cloneable."""
+  cloneable: Boolean! = false
+}
+
 input CreateVFolderV2Input {
   """VFolder name."""
   name: String!
@@ -6791,7 +6808,7 @@ type Mutation {
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createProjectVFolder(projectId: UUID!, input: CreateVFolderV2Input!): CreateVFolderV2Payload!
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInProjectInput!): CreateVFolderV2Payload!
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2470,12 +2470,9 @@ type CreateVFSStoragePayload {
 }
 
 """
-Added in UNRELEASED. Input for creating a virtual folder within a project.
+Added in UNRELEASED. Scope-agnostic body for vfolder creation. The owning scope is supplied as a separate mutation argument.
 """
-input CreateVFolderInProjectInput {
-  """Project UUID that owns the vfolder."""
-  projectId: UUID!
-
+input CreateVFolderInScopeInput {
   """VFolder name."""
   name: String!
 
@@ -6814,7 +6811,7 @@ type Mutation {
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(input: CreateVFolderInProjectInput!): CreateVFolderV2Payload!
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload!
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2473,6 +2473,9 @@ type CreateVFSStoragePayload {
 Added in UNRELEASED. Input for creating a virtual folder within a project.
 """
 input CreateVFolderInProjectInput {
+  """Project UUID that owns the vfolder."""
+  projectId: UUID!
+
   """VFolder name."""
   name: String!
 
@@ -6811,7 +6814,7 @@ type Mutation {
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(projectId: UUID!, input: CreateVFolderInProjectInput!): CreateVFolderV2Payload!
+  createVFolderInProject(input: CreateVFolderInProjectInput!): CreateVFolderV2Payload!
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
   deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2469,7 +2469,9 @@ type CreateVFSStoragePayload {
   vfsStorage: VFSStorage!
 }
 
-"""Added in 26.4.2. Input for creating a new virtual folder."""
+"""
+Added in UNRELEASED. Input for creating a virtual folder within a project.
+"""
 input CreateVFolderInProjectInput {
   """VFolder name."""
   name: String!
@@ -2487,6 +2489,7 @@ input CreateVFolderInProjectInput {
   cloneable: Boolean! = false
 }
 
+"""Added in 26.4.2. Input for creating a new virtual folder."""
 input CreateVFolderV2Input {
   """VFolder name."""
   name: String!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2479,11 +2479,11 @@ input CreateVFolderInProjectInput {
   """Storage host for the vfolder."""
   host: String = null
 
-  """Usage mode of the vfolder (general, model, data)."""
-  usageMode: String! = "general"
+  """Usage mode of the vfolder."""
+  usageMode: VFolderUsageMode! = GENERAL
 
-  """Default permission of the vfolder (ro, rw, wd)."""
-  permission: String! = "rw"
+  """Default mount permission of the vfolder."""
+  permission: VFolderMountPermission! = READ_WRITE
 
   """Whether the vfolder is cloneable."""
   cloneable: Boolean! = false

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -183,10 +183,10 @@ def project_create(
 ) -> None:
     """Create a vfolder owned by a project."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInProjectInput
     from ai.backend.common.dto.manager.v2.vfolder.types import VFolderUsageMode
 
-    input_dto = CreateVFolderInput(
+    input_dto = CreateVFolderInProjectInput(
         name=name,
         usage_mode=VFolderUsageMode(usage_mode),
         host=host,

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -187,6 +187,7 @@ def project_create(
     from ai.backend.common.dto.manager.v2.vfolder.types import VFolderUsageMode
 
     input_dto = CreateVFolderInProjectInput(
+        project_id=project_id,
         name=name,
         usage_mode=VFolderUsageMode(usage_mode),
         host=host,
@@ -196,7 +197,7 @@ def project_create(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.create_in_project(project_id, input_dto)
+            result = await registry.vfolder.create_in_project(input_dto)
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -163,6 +163,47 @@ def get(vfolder_id: UUID) -> None:
     asyncio.run(_run())
 
 
+@vfolder.command(name="project-create")
+@click.argument("project_id", type=click.UUID)
+@click.option("--name", required=True, help="VFolder name.")
+@click.option(
+    "--usage-mode",
+    default="general",
+    type=click.Choice(["general", "model", "data"], case_sensitive=False),
+    help="Usage mode of the vfolder.",
+)
+@click.option("--host", default=None, type=str, help="Storage host.")
+@click.option("--cloneable", is_flag=True, default=False, help="Allow cloning.")
+def project_create(
+    project_id: UUID,
+    name: str,
+    usage_mode: str,
+    host: str | None,
+    cloneable: bool,
+) -> None:
+    """Create a vfolder owned by a project."""
+
+    from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInput
+    from ai.backend.common.dto.manager.v2.vfolder.types import VFolderUsageMode
+
+    input_dto = CreateVFolderInput(
+        name=name,
+        usage_mode=VFolderUsageMode(usage_mode),
+        host=host,
+        cloneable=cloneable,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.vfolder.create_in_project(project_id, input_dto)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
 @vfolder.command()
 @click.argument("vfolder_id", type=click.UUID)
 def delete(vfolder_id: UUID) -> None:

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -183,11 +183,10 @@ def project_create(
 ) -> None:
     """Create a vfolder owned by a project."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInProjectInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInScopeInput
     from ai.backend.common.dto.manager.v2.vfolder.types import VFolderUsageMode
 
-    input_dto = CreateVFolderInProjectInput(
-        project_id=project_id,
+    input_dto = CreateVFolderInScopeInput(
         name=name,
         usage_mode=VFolderUsageMode(usage_mode),
         host=host,
@@ -197,7 +196,7 @@ def project_create(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.vfolder.create_in_project(input_dto)
+            result = await registry.vfolder.create_in_project(project_id, input_dto)
             print_result(result)
         finally:
             await registry.close()

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -11,8 +11,8 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
-    CreateVFolderInProjectInput,
     CreateVFolderInput,
+    CreateVFolderInScopeInput,
     DeleteFilesInput,
     DeployVFolderInput,
     ListFilesInput,
@@ -81,15 +81,13 @@ class V2VFolderClient(BaseDomainClient):
 
     async def create_in_project(
         self,
-        request: CreateVFolderInProjectInput,
+        project_id: UUID,
+        request: CreateVFolderInScopeInput,
     ) -> CreateVFolderPayload:
-        """Create a vfolder owned by a project.
-
-        The target project is read from ``request.project_id``.
-        """
+        """Create a vfolder owned by ``project_id``."""
         return await self._client.typed_request(
             "POST",
-            f"{_PATH}/projects/{request.project_id}",
+            f"{_PATH}/projects/{project_id}/create",
             request=request,
             response_model=CreateVFolderPayload,
         )

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -81,13 +81,15 @@ class V2VFolderClient(BaseDomainClient):
 
     async def create_in_project(
         self,
-        project_id: UUID,
         request: CreateVFolderInProjectInput,
     ) -> CreateVFolderPayload:
-        """Create a vfolder owned by a project."""
+        """Create a vfolder owned by a project.
+
+        The target project is read from ``request.project_id``.
+        """
         return await self._client.typed_request(
             "POST",
-            f"{_PATH}/projects/{project_id}",
+            f"{_PATH}/projects/{request.project_id}",
             request=request,
             response_model=CreateVFolderPayload,
         )

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -78,6 +78,19 @@ class V2VFolderClient(BaseDomainClient):
             response_model=CreateVFolderPayload,
         )
 
+    async def create_in_project(
+        self,
+        project_id: UUID,
+        request: CreateVFolderInput,
+    ) -> CreateVFolderPayload:
+        """Create a vfolder owned by a project."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/projects/{project_id}",
+            request=request,
+            response_model=CreateVFolderPayload,
+        )
+
     async def create_upload_session(
         self,
         vfolder_id: UUID,

--- a/src/ai/backend/client/v2/domains_v2/vfolder.py
+++ b/src/ai/backend/client/v2/domains_v2/vfolder.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
+    CreateVFolderInProjectInput,
     CreateVFolderInput,
     DeleteFilesInput,
     DeployVFolderInput,
@@ -81,7 +82,7 @@ class V2VFolderClient(BaseDomainClient):
     async def create_in_project(
         self,
         project_id: UUID,
-        request: CreateVFolderInput,
+        request: CreateVFolderInProjectInput,
     ) -> CreateVFolderPayload:
         """Create a vfolder owned by a project."""
         return await self._client.typed_request(

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -30,6 +30,7 @@ __all__ = (
     "CloneVFolderInput",
     "CreateDownloadSessionInput",
     "CreateUploadSessionInput",
+    "CreateVFolderInProjectInput",
     "CreateVFolderInput",
     "DeleteFilesInput",
     "DeleteInvitationInput",
@@ -72,6 +73,35 @@ class CreateVFolderInput(BaseRequestModel):
     )
     cloneable: bool = Field(default=False, description="Whether the vfolder is cloneable")
     unmanaged_path: str | None = Field(default=None, description="Path for unmanaged vfolders")
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def strip_and_validate_name(cls, v: object) -> object:
+        if isinstance(v, str):
+            stripped = v.strip()
+            if not stripped:
+                raise ValueError("name must not be blank or whitespace-only")
+            return stripped
+        return v
+
+
+class CreateVFolderInProjectInput(BaseRequestModel):
+    """Input for creating a virtual folder within a project.
+
+    Unlike ``CreateVFolderInput``, ``project_id`` is supplied as a separate
+    mutation/path argument so this model contains only the payload fields.
+    """
+
+    name: VFolderName = Field(description="VFolder name")
+    host: str | None = Field(default=None, description="Storage host for the vfolder")
+    usage_mode: VFolderUsageMode = Field(
+        default=VFolderUsageMode.GENERAL, description="Usage mode of the vfolder"
+    )
+    permission: VFolderPermissionField = Field(
+        default=VFolderPermissionField.READ_WRITE,
+        description="Default permission of the vfolder",
+    )
+    cloneable: bool = Field(default=False, description="Whether the vfolder is cloneable")
 
     @field_validator("name", mode="before")
     @classmethod

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -88,10 +88,13 @@ class CreateVFolderInput(BaseRequestModel):
 class CreateVFolderInProjectInput(BaseRequestModel):
     """Input for creating a virtual folder within a project.
 
-    Unlike ``CreateVFolderInput``, ``project_id`` is supplied as a separate
-    mutation/path argument so this model contains only the payload fields.
+    The project the vfolder belongs to is identified by ``project_id``. In
+    transport layers where the scope is expressed separately (REST path
+    segment, GraphQL scope argument), that value is injected into this
+    field before the DTO reaches the adapter.
     """
 
+    project_id: UUID = Field(description="Project UUID that owns the vfolder")
     name: VFolderName = Field(description="VFolder name")
     host: str | None = Field(default=None, description="Storage host for the vfolder")
     usage_mode: VFolderUsageMode = Field(

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -30,7 +30,7 @@ __all__ = (
     "CloneVFolderInput",
     "CreateDownloadSessionInput",
     "CreateUploadSessionInput",
-    "CreateVFolderInProjectInput",
+    "CreateVFolderInScopeInput",
     "CreateVFolderInput",
     "DeleteFilesInput",
     "DeleteInvitationInput",
@@ -85,16 +85,16 @@ class CreateVFolderInput(BaseRequestModel):
         return v
 
 
-class CreateVFolderInProjectInput(BaseRequestModel):
-    """Input for creating a virtual folder within a project.
+class CreateVFolderInScopeInput(BaseRequestModel):
+    """Scope-agnostic body for vfolder creation under a specific scope.
 
-    The project the vfolder belongs to is identified by ``project_id``. In
-    transport layers where the scope is expressed separately (REST path
-    segment, GraphQL scope argument), that value is injected into this
-    field before the DTO reaches the adapter.
+    The owning scope (project, user, domain, …) is supplied externally by
+    the transport layer (REST path segment, GraphQL mutation argument)
+    and is NOT part of this body. This keeps the body reusable across
+    scope-specific endpoints without forcing clients to duplicate the
+    scope identifier.
     """
 
-    project_id: UUID = Field(description="Project UUID that owns the vfolder")
     name: VFolderName = Field(description="VFolder name")
     host: str | None = Field(default=None, description="Storage host for the vfolder")
     usage_mode: VFolderUsageMode = Field(

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -15,6 +15,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
+    CreateVFolderInProjectInput,
     CreateVFolderInput,
     DeleteFilesInput,
     DeployVFolderInput,
@@ -369,7 +370,7 @@ class VFolderAdapter(BaseAdapter):
     async def create_in_project(
         self,
         project_id: UUID,
-        input: CreateVFolderInput,
+        input: CreateVFolderInProjectInput,
     ) -> CreateVFolderPayload:
         """Create a vfolder owned by ``project_id``.
 

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -369,10 +369,9 @@ class VFolderAdapter(BaseAdapter):
 
     async def create_in_project(
         self,
-        project_id: UUID,
         input: CreateVFolderInProjectInput,
     ) -> CreateVFolderPayload:
-        """Create a vfolder owned by ``project_id``.
+        """Create a vfolder owned by ``input.project_id``.
 
         Uses ``CreateVFolderInProjectAction`` which is PROJECT-scoped so the
         caller must hold CREATE permission on the project.
@@ -381,7 +380,7 @@ class VFolderAdapter(BaseAdapter):
         if me is None:
             raise UnreachableError("User context is not available")
         action = CreateVFolderInProjectAction(
-            project_id=project_id,
+            project_id=input.project_id,
             user_id=me.user_id,
             domain_name=me.domain_name,
             name=input.name,

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -15,8 +15,8 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
-    CreateVFolderInProjectInput,
     CreateVFolderInput,
+    CreateVFolderInScopeInput,
     DeleteFilesInput,
     DeployVFolderInput,
     ListFilesInput,
@@ -369,9 +369,10 @@ class VFolderAdapter(BaseAdapter):
 
     async def create_in_project(
         self,
-        input: CreateVFolderInProjectInput,
+        project_id: UUID,
+        input: CreateVFolderInScopeInput,
     ) -> CreateVFolderPayload:
-        """Create a vfolder owned by ``input.project_id``.
+        """Create a vfolder owned by the given project.
 
         Uses ``CreateVFolderInProjectAction`` which is PROJECT-scoped so the
         caller must hold CREATE permission on the project.
@@ -380,7 +381,7 @@ class VFolderAdapter(BaseAdapter):
         if me is None:
             raise UnreachableError("User context is not available")
         action = CreateVFolderInProjectAction(
-            project_id=input.project_id,
+            project_id=project_id,
             user_id=me.user_id,
             domain_name=me.domain_name,
             name=input.name,

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -127,6 +127,9 @@ from ai.backend.manager.services.vfolder.actions.search_user_vfolders import (
 from ai.backend.manager.services.vfolder.actions.upload_session_v2 import (
     CreateUploadSessionV2Action,
 )
+from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
+    CreateVFolderInProjectAction,
+)
 from ai.backend.manager.services.vfolder.actions.vfolder_v2 import (
     DeleteVFolderV2Action,
     PurgeVFolderV2Action,
@@ -361,6 +364,32 @@ class VFolderAdapter(BaseAdapter):
             cloneable=input.cloneable,
         )
         result = await self._processors.vfolder.create_vfolder_v2.wait_for_complete(action)
+        return CreateVFolderPayload(vfolder=self._vfolder_data_to_node(result.vfolder))
+
+    async def create_in_project(
+        self,
+        project_id: UUID,
+        input: CreateVFolderInput,
+    ) -> CreateVFolderPayload:
+        """Create a vfolder owned by ``project_id``.
+
+        Uses ``CreateVFolderInProjectAction`` which is PROJECT-scoped so the
+        caller must hold CREATE permission on the project.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        action = CreateVFolderInProjectAction(
+            project_id=project_id,
+            user_id=me.user_id,
+            domain_name=me.domain_name,
+            name=input.name,
+            host=input.host,
+            usage_mode=VFolderUsageMode(input.usage_mode.value),
+            permission=VFolderPermission(input.permission.value),
+            cloneable=input.cloneable,
+        )
+        result = await self._processors.vfolder.create_vfolder_in_project.wait_for_complete(action)
         return CreateVFolderPayload(vfolder=self._vfolder_data_to_node(result.vfolder))
 
     async def create_upload_session(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -415,6 +415,7 @@ from .vfolder_v2 import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
+    create_project_vfolder_v2,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -841,6 +842,7 @@ class Mutation:
     deploy_model_card_v2 = deploy_model_card_v2
     # VFolder V2 mutations
     create_vfolder_v2 = create_vfolder_v2
+    create_project_vfolder_v2 = create_project_vfolder_v2
     delete_vfolder_v2 = delete_vfolder_v2
     purge_vfolder_v2 = purge_vfolder_v2
     restore_vfolder_v2 = restore_vfolder_v2

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -415,7 +415,7 @@ from .vfolder_v2 import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
-    create_project_vfolder_v2,
+    create_vfolder_in_project,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -842,7 +842,7 @@ class Mutation:
     deploy_model_card_v2 = deploy_model_card_v2
     # VFolder V2 mutations
     create_vfolder_v2 = create_vfolder_v2
-    create_project_vfolder_v2 = create_project_vfolder_v2
+    create_vfolder_in_project = create_vfolder_in_project
     delete_vfolder_v2 = delete_vfolder_v2
     purge_vfolder_v2 = purge_vfolder_v2
     restore_vfolder_v2 = restore_vfolder_v2

--- a/src/ai/backend/manager/api/gql/vfolder_v2/__init__.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/__init__.py
@@ -9,6 +9,7 @@ from .resolver import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
+    create_project_vfolder_v2,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -48,6 +49,7 @@ __all__ = [
     # Mutations
     "bulk_delete_vfolders_v2",
     "bulk_purge_vfolders_v2",
+    "create_project_vfolder_v2",
     "create_vfolder_v2",
     "delete_vfolder_v2",
     "deploy_vfolder_v2",

--- a/src/ai/backend/manager/api/gql/vfolder_v2/__init__.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/__init__.py
@@ -9,7 +9,7 @@ from .resolver import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
-    create_project_vfolder_v2,
+    create_vfolder_in_project,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -49,7 +49,7 @@ __all__ = [
     # Mutations
     "bulk_delete_vfolders_v2",
     "bulk_purge_vfolders_v2",
-    "create_project_vfolder_v2",
+    "create_vfolder_in_project",
     "create_vfolder_v2",
     "delete_vfolder_v2",
     "deploy_vfolder_v2",

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/__init__.py
@@ -4,7 +4,7 @@ from .mutation import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
-    create_project_vfolder_v2,
+    create_vfolder_in_project,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -28,7 +28,7 @@ __all__ = [
     # Mutations
     "bulk_delete_vfolders_v2",
     "bulk_purge_vfolders_v2",
-    "create_project_vfolder_v2",
+    "create_vfolder_in_project",
     "create_vfolder_v2",
     "delete_vfolder_v2",
     "deploy_vfolder_v2",

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/__init__.py
@@ -4,6 +4,7 @@ from .mutation import (
     bulk_delete_vfolders_v2,
     bulk_purge_vfolders_v2,
     clone_vfolder_v2,
+    create_project_vfolder_v2,
     create_vfolder_v2,
     delete_vfolder_v2,
     deploy_vfolder_v2,
@@ -27,6 +28,7 @@ __all__ = [
     # Mutations
     "bulk_delete_vfolders_v2",
     "bulk_purge_vfolders_v2",
+    "create_project_vfolder_v2",
     "create_vfolder_v2",
     "delete_vfolder_v2",
     "deploy_vfolder_v2",

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -16,6 +16,7 @@ from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
     BulkPurgeVFoldersPayloadGQL,
     CloneVFolderInputGQL,
     CloneVFolderPayloadGQL,
+    CreateVFolderInProjectInputGQL,
     CreateVFolderInputGQL,
     CreateVFolderPayloadGQL,
     DeleteFilesInputGQL,
@@ -253,12 +254,12 @@ async def bulk_delete_vfolders_v2(
             "Requires project-scoped CREATE permission."
         ),
     ),
-    name="createProjectVFolder",
+    name="createVFolderInProject",
 )  # type: ignore[misc]
-async def create_project_vfolder_v2(
+async def create_vfolder_in_project(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-    input: CreateVFolderInputGQL,
+    input: CreateVFolderInProjectInputGQL,
 ) -> CreateVFolderPayloadGQL:
     """Create a new virtual folder scoped to a project."""
     payload = await info.context.adapters.vfolder.create_in_project(project_id, input.to_pydantic())

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -258,11 +258,10 @@ async def bulk_delete_vfolders_v2(
 )  # type: ignore[misc]
 async def create_vfolder_in_project(
     info: Info[StrawberryGQLContext],
-    project_id: UUID,
     input: CreateVFolderInProjectInputGQL,
 ) -> CreateVFolderPayloadGQL:
     """Create a new virtual folder scoped to a project."""
-    payload = await info.context.adapters.vfolder.create_in_project(project_id, input.to_pydantic())
+    payload = await info.context.adapters.vfolder.create_in_project(input.to_pydantic())
     return CreateVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -247,6 +247,26 @@ async def bulk_delete_vfolders_v2(
 
 @gql_mutation(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Create a virtual folder owned by the specified project. "
+            "Requires project-scoped CREATE permission."
+        ),
+    ),
+    name="createProjectVFolder",
+)  # type: ignore[misc]
+async def create_project_vfolder_v2(
+    info: Info[StrawberryGQLContext],
+    project_id: UUID,
+    input: CreateVFolderInputGQL,
+) -> CreateVFolderPayloadGQL:
+    """Create a new virtual folder scoped to a project."""
+    payload = await info.context.adapters.vfolder.create_in_project(project_id, input.to_pydantic())
+    return CreateVFolderPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
         added_version="26.4.2",
         description="Permanently purge multiple virtual folders.",
     )

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -16,8 +16,8 @@ from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
     BulkPurgeVFoldersPayloadGQL,
     CloneVFolderInputGQL,
     CloneVFolderPayloadGQL,
-    CreateVFolderInProjectInputGQL,
     CreateVFolderInputGQL,
+    CreateVFolderInScopeInputGQL,
     CreateVFolderPayloadGQL,
     DeleteFilesInputGQL,
     DeleteFilesPayloadGQL,
@@ -258,10 +258,11 @@ async def bulk_delete_vfolders_v2(
 )  # type: ignore[misc]
 async def create_vfolder_in_project(
     info: Info[StrawberryGQLContext],
-    input: CreateVFolderInProjectInputGQL,
+    project_id: UUID,
+    input: CreateVFolderInScopeInputGQL,
 ) -> CreateVFolderPayloadGQL:
     """Create a new virtual folder scoped to a project."""
-    payload = await info.context.adapters.vfolder.create_in_project(input.to_pydantic())
+    payload = await info.context.adapters.vfolder.create_in_project(project_id, input.to_pydantic())
     return CreateVFolderPayloadGQL.from_pydantic(payload)
 
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -138,6 +138,7 @@ class CreateVFolderInputGQL(PydanticInputMixin[CreateInputDTO]):
     name="CreateVFolderInProjectInput",
 )
 class CreateVFolderInProjectInputGQL(PydanticInputMixin[CreateInProjectInputDTO]):
+    project_id: UUID = gql_field(description="Project UUID that owns the vfolder.")
     name: str = gql_field(description="VFolder name.")
     host: str | None = gql_field(default=None, description="Storage host for the vfolder.")
     usage_mode: VFolderUsageModeGQL = gql_field(

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -97,6 +97,10 @@ from ai.backend.manager.api.gql.deployment.types.revision_preset import (
     PresetDeploymentStrategyInputGQL,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+from ai.backend.manager.api.gql.vfolder_v2.types.enum import (
+    VFolderMountPermissionGQL,
+    VFolderUsageModeGQL,
+)
 from ai.backend.manager.api.gql.vfolder_v2.types.node import VFolderGQL
 
 # ============================================================
@@ -136,11 +140,12 @@ class CreateVFolderInputGQL(PydanticInputMixin[CreateInputDTO]):
 class CreateVFolderInProjectInputGQL(PydanticInputMixin[CreateInProjectInputDTO]):
     name: str = gql_field(description="VFolder name.")
     host: str | None = gql_field(default=None, description="Storage host for the vfolder.")
-    usage_mode: str = gql_field(
-        default="general", description="Usage mode of the vfolder (general, model, data)."
+    usage_mode: VFolderUsageModeGQL = gql_field(
+        default=VFolderUsageModeGQL.GENERAL, description="Usage mode of the vfolder."
     )
-    permission: str = gql_field(
-        default="rw", description="Default permission of the vfolder (ro, rw, wd)."
+    permission: VFolderMountPermissionGQL = gql_field(
+        default=VFolderMountPermissionGQL.READ_WRITE,
+        description="Default mount permission of the vfolder.",
     )
     cloneable: bool = gql_field(default=False, description="Whether the vfolder is cloneable.")
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -20,6 +20,9 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CreateUploadSessionInput as UploadInputDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.request import (
+    CreateVFolderInProjectInput as CreateInProjectInputDTO,
+)
+from ai.backend.common.dto.manager.v2.vfolder.request import (
     CreateVFolderInput as CreateInputDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.request import (
@@ -113,6 +116,25 @@ class CreateVFolderInputGQL(PydanticInputMixin[CreateInputDTO]):
     project_id: UUID | None = gql_field(
         default=None, description="Project ID for project-owned vfolder."
     )
+    host: str | None = gql_field(default=None, description="Storage host for the vfolder.")
+    usage_mode: str = gql_field(
+        default="general", description="Usage mode of the vfolder (general, model, data)."
+    )
+    permission: str = gql_field(
+        default="rw", description="Default permission of the vfolder (ro, rw, wd)."
+    )
+    cloneable: bool = gql_field(default=False, description="Whether the vfolder is cloneable.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for creating a virtual folder within a project.",
+    ),
+    name="CreateVFolderInProjectInput",
+)
+class CreateVFolderInProjectInputGQL(PydanticInputMixin[CreateInProjectInputDTO]):
+    name: str = gql_field(description="VFolder name.")
     host: str | None = gql_field(default=None, description="Storage host for the vfolder.")
     usage_mode: str = gql_field(
         default="general", description="Usage mode of the vfolder (general, model, data)."

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -20,10 +20,10 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CreateUploadSessionInput as UploadInputDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.request import (
-    CreateVFolderInProjectInput as CreateInProjectInputDTO,
+    CreateVFolderInput as CreateInputDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.request import (
-    CreateVFolderInput as CreateInputDTO,
+    CreateVFolderInScopeInput as CreateInScopeInputDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.request import (
     DeleteFilesInput as DeleteFilesInputDTO,
@@ -133,12 +133,14 @@ class CreateVFolderInputGQL(PydanticInputMixin[CreateInputDTO]):
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="Input for creating a virtual folder within a project.",
+        description=(
+            "Scope-agnostic body for vfolder creation. The owning scope is "
+            "supplied as a separate mutation argument."
+        ),
     ),
-    name="CreateVFolderInProjectInput",
+    name="CreateVFolderInScopeInput",
 )
-class CreateVFolderInProjectInputGQL(PydanticInputMixin[CreateInProjectInputDTO]):
-    project_id: UUID = gql_field(description="Project UUID that owns the vfolder.")
+class CreateVFolderInScopeInputGQL(PydanticInputMixin[CreateInScopeInputDTO]):
     name: str = gql_field(description="VFolder name.")
     host: str | None = gql_field(default=None, description="Storage host for the vfolder.")
     usage_mode: VFolderUsageModeGQL = gql_field(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -112,8 +112,13 @@ class V2VFolderHandler:
         path: PathParam[ProjectIdPathParam],
         body: BodyParam[CreateVFolderInProjectInput],
     ) -> APIResponse:
-        """Create a vfolder owned by a project."""
-        result = await self._adapter.create_in_project(path.parsed.project_id, body.parsed)
+        """Create a vfolder owned by a project.
+
+        The path segment ``{project_id}`` is authoritative; any ``project_id``
+        value in the body is overridden to match the URL.
+        """
+        dto = body.parsed.model_copy(update={"project_id": path.parsed.project_id})
+        result = await self._adapter.create_in_project(dto)
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
 
     async def deploy(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -106,6 +106,15 @@ class V2VFolderHandler:
         result = await self._adapter.restore(path.parsed.vfolder_id)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
+    async def project_create(
+        self,
+        path: PathParam[ProjectIdPathParam],
+        body: BodyParam[CreateVFolderInput],
+    ) -> APIResponse:
+        """Create a vfolder owned by a project."""
+        result = await self._adapter.create_in_project(path.parsed.project_id, body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
+
     async def deploy(
         self,
         path: PathParam[VFolderIdPathParam],

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -12,8 +12,8 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
-    CreateVFolderInProjectInput,
     CreateVFolderInput,
+    CreateVFolderInScopeInput,
     DeleteFilesInput,
     DeployVFolderInput,
     ListFilesInput,
@@ -110,15 +110,10 @@ class V2VFolderHandler:
     async def project_create(
         self,
         path: PathParam[ProjectIdPathParam],
-        body: BodyParam[CreateVFolderInProjectInput],
+        body: BodyParam[CreateVFolderInScopeInput],
     ) -> APIResponse:
-        """Create a vfolder owned by a project.
-
-        The path segment ``{project_id}`` is authoritative; any ``project_id``
-        value in the body is overridden to match the URL.
-        """
-        dto = body.parsed.model_copy(update={"project_id": path.parsed.project_id})
-        result = await self._adapter.create_in_project(dto)
+        """Create a vfolder owned by a project. Scope comes from the URL path."""
+        result = await self._adapter.create_in_project(path.parsed.project_id, body.parsed)
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
 
     async def deploy(

--- a/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/handler.py
@@ -12,6 +12,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
     CloneVFolderInput,
     CreateDownloadSessionInput,
     CreateUploadSessionInput,
+    CreateVFolderInProjectInput,
     CreateVFolderInput,
     DeleteFilesInput,
     DeployVFolderInput,
@@ -109,7 +110,7 @@ class V2VFolderHandler:
     async def project_create(
         self,
         path: PathParam[ProjectIdPathParam],
-        body: BodyParam[CreateVFolderInput],
+        body: BodyParam[CreateVFolderInProjectInput],
     ) -> APIResponse:
         """Create a vfolder owned by a project."""
         result = await self._adapter.create_in_project(path.parsed.project_id, body.parsed)

--- a/src/ai/backend/manager/api/rest/v2/vfolder/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/registry.py
@@ -118,7 +118,7 @@ def register_v2_vfolder_routes(
     )
     registry.add(
         "POST",
-        "/projects/{project_id}",
+        "/projects/{project_id}/create",
         handler.project_create,
         middlewares=[auth_required],
     )

--- a/src/ai/backend/manager/api/rest/v2/vfolder/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/vfolder/registry.py
@@ -118,6 +118,12 @@ def register_v2_vfolder_routes(
     )
     registry.add(
         "POST",
+        "/projects/{project_id}",
+        handler.project_create,
+        middlewares=[auth_required],
+    )
+    registry.add(
+        "POST",
         "/delete",
         handler.bulk_delete,
         middlewares=[auth_required],

--- a/src/ai/backend/manager/data/group/types.py
+++ b/src/ai/backend/manager/data/group/types.py
@@ -76,10 +76,10 @@ class GroupData:
 
 @dataclass(frozen=True)
 class ProjectResourceInfo:
-    group_uuid: uuid.UUID
+    project_id: uuid.UUID
     max_vfolder_count: int
     max_quota_scope_size: int
-    group_type: ProjectType
+    project_type: ProjectType
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/group/types.py
+++ b/src/ai/backend/manager/data/group/types.py
@@ -75,6 +75,14 @@ class GroupData:
 
 
 @dataclass(frozen=True)
+class ProjectResourceInfo:
+    group_uuid: uuid.UUID
+    max_vfolder_count: int
+    max_quota_scope_size: int
+    group_type: ProjectType
+
+
+@dataclass(frozen=True)
 class ProjectMemberRoleSpec:
     """ScopeSystemRoleData implementation for the project-scoped member role."""
 

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -835,10 +835,10 @@ class VfolderRepository:
                 return None
 
             return ProjectResourceInfo(
-                group_uuid=group_row.id,
+                project_id=group_row.id,
                 max_vfolder_count=group_row.resource_policy_row.max_vfolder_count,
                 max_quota_scope_size=group_row.resource_policy_row.max_quota_scope_size,
-                group_type=group_row.type,
+                project_type=group_row.type,
             )
 
     @vfolder_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -23,6 +23,7 @@ from ai.backend.common.types import (
     VFolderID,
 )
 from ai.backend.manager.data.agent.types import AgentStatus
+from ai.backend.manager.data.group.types import ProjectResourceInfo
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.types import (
@@ -60,7 +61,7 @@ from ai.backend.manager.errors.storage import (
 )
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.agent import agents
-from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.group import association_groups_users as agus
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.keypair import KeyPairRow, keypairs
@@ -806,11 +807,8 @@ class VfolderRepository:
     @vfolder_repository_resilience.apply()
     async def get_group_resource_info(
         self, group_id_or_name: str | uuid.UUID, domain_name: str
-    ) -> tuple[uuid.UUID, int, int, ProjectType] | None:
-        """
-        Get group resource information by group ID or name.
-        Returns (group_uuid, max_vfolder_count, max_quota_scope_size, group_type) or None.
-        """
+    ) -> ProjectResourceInfo | None:
+        """Get group resource information by group ID or name."""
 
         async with self._db.begin_readonly_session_read_committed() as session:
             if isinstance(group_id_or_name, str):
@@ -836,11 +834,11 @@ class VfolderRepository:
             if not group_row:
                 return None
 
-            return (
-                group_row.id,
-                group_row.resource_policy_row.max_vfolder_count,
-                group_row.resource_policy_row.max_quota_scope_size,
-                group_row.type,
+            return ProjectResourceInfo(
+                group_uuid=group_row.id,
+                max_vfolder_count=group_row.resource_policy_row.max_vfolder_count,
+                max_quota_scope_size=group_row.resource_policy_row.max_quota_scope_size,
+                group_type=group_row.type,
             )
 
     @vfolder_repository_resilience.apply()

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_in_project.py
@@ -1,0 +1,82 @@
+"""RBAC-enforced v2 VFolder actions.
+
+Create is PROJECT-scoped (entity doesn't exist yet) and uses
+``ScopeActionProcessor`` with ``scope_rbac_validators``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.common.types import VFolderUsageMode
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.vfolder.types import VFolderData
+from ai.backend.manager.models.vfolder import VFolderPermission
+from ai.backend.manager.services.vfolder.actions.base import (
+    VFolderScopeAction,
+    VFolderScopeActionResult,
+)
+
+# ---------------------------------------------------------------------------
+# Create (scope action — entity does not exist yet, requires project_id)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CreateVFolderInProjectAction(VFolderScopeAction):
+    """Create a vfolder owned by a specific project."""
+
+    project_id: uuid.UUID
+    user_id: uuid.UUID
+    domain_name: str
+    name: str
+    host: str | None
+    usage_mode: VFolderUsageMode
+    permission: VFolderPermission
+    cloneable: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.PROJECT
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.project_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.PROJECT,
+            element_id=str(self.project_id),
+        )
+
+
+@dataclass
+class CreateVFolderInProjectActionResult(VFolderScopeActionResult):
+    project_id: uuid.UUID
+    vfolder: VFolderData
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.vfolder.id)
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.PROJECT
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.project_id)

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -92,6 +92,10 @@ from ai.backend.manager.services.vfolder.actions.upload_session_v2 import (
     CreateUploadSessionV2Action,
     CreateUploadSessionV2ActionResult,
 )
+from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
+    CreateVFolderInProjectAction,
+    CreateVFolderInProjectActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.vfolder_v2 import (
     DeleteVFolderV2Action,
     DeleteVFolderV2ActionResult,
@@ -163,6 +167,9 @@ class VFolderProcessors(AbstractProcessorPackage):
     delete_v2: SingleEntityActionProcessor[DeleteVFolderV2Action, DeleteVFolderV2ActionResult]
     purge_v2: SingleEntityActionProcessor[PurgeVFolderV2Action, PurgeVFolderV2ActionResult]
     clone_v2: ActionProcessor[CloneVFolderV2Action, CloneVFolderV2ActionResult]
+    create_vfolder_in_project: ScopeActionProcessor[
+        CreateVFolderInProjectAction, CreateVFolderInProjectActionResult
+    ]
 
     def __init__(
         self,
@@ -261,6 +268,11 @@ class VFolderProcessors(AbstractProcessorPackage):
             service.purge_v2, action_monitors, validators=single_entity_rbac_validators
         )
         self.clone_v2 = ActionProcessor(service.clone_v2, action_monitors)
+        self.create_vfolder_in_project = ScopeActionProcessor(
+            service.create_in_project,
+            action_monitors,
+            validators=scope_rbac_validators,
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -300,4 +312,5 @@ class VFolderProcessors(AbstractProcessorPackage):
             DeleteVFolderV2Action.spec(),
             PurgeVFolderV2Action.spec(),
             CloneVFolderV2Action.spec(),
+            CreateVFolderInProjectAction.spec(),
         ]

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1538,6 +1538,73 @@ class VFolderService:
 
         return await self._vfolder_repository.get_by_id(folder_id)
 
+    async def _resolve_host(self, requested_host: str | None) -> str:
+        """Return the target storage host, falling back to the configured default."""
+        host = requested_host
+        if not host:
+            host = self._config_provider.config.volumes.default_host
+            if not host:
+                raise VFolderInvalidParameter(
+                    "You must specify the vfolder host because the default host is not configured."
+                )
+        return host
+
+    def _check_name_parameter(self, name: str, is_group: bool) -> None:
+        """Dot-prefixed names (except ``.local``) cannot be used for group-owned vfolders."""
+        if name.startswith(".") and name != ".local" and is_group:
+            raise VFolderInvalidParameter("dot-prefixed vfolders cannot be a group folder.")
+
+    async def _resolve_project_info(
+        self, project_id: uuid.UUID, domain_name: str
+    ) -> tuple[uuid.UUID, int, int, ProjectType]:
+        """Fetch ``(group_uuid, max_vfolder_count, max_quota_scope_size, group_type)``."""
+        group_info = await self._vfolder_repository.get_group_resource_info(project_id, domain_name)
+        if not group_info:
+            raise ProjectNotFound(f"Project with {project_id} not found.")
+        return group_info
+
+    async def _check_user_vfolder_quota(self, user_uuid: uuid.UUID, max_count: int) -> None:
+        """Enforce per-user vfolder count quota (no-op when ``max_count <= 0``)."""
+        if max_count <= 0:
+            return
+        current = await self._vfolder_repository.count_vfolders_by_user(user_uuid)
+        if current >= max_count:
+            raise VFolderInvalidParameter("You cannot create more vfolders.")
+
+    async def _check_group_vfolder_quota(self, group_uuid: uuid.UUID, max_count: int) -> None:
+        """Enforce per-group vfolder count quota (no-op when ``max_count <= 0``)."""
+        if max_count <= 0:
+            return
+        current = await self._vfolder_repository.count_vfolders_by_group(group_uuid)
+        if current >= max_count:
+            raise VFolderInvalidParameter("You cannot create more vfolders.")
+
+    def _determine_ownership(
+        self,
+        user_uuid: uuid.UUID,
+        group_uuid: uuid.UUID | None,
+        user_role: UserRole,
+        group_type: ProjectType | None,
+    ) -> tuple[str, QuotaScopeID]:
+        """Decide ``(ownership_type, quota_scope_id)`` for create_v2.
+
+        When ``group_uuid`` is set, gates non-admin users from group ownership
+        (except MODEL_STORE) via the legacy UserRole check.
+        """
+        if group_uuid is not None:
+            self._check_user_role_for_group(user_role, group_type)
+            return "group", QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
+        return "user", QuotaScopeID(QuotaScopeType.USER, user_uuid)
+
+    def _check_model_store_usage_mode(
+        self, group_type: ProjectType | None, usage_mode: VFolderUsageMode
+    ) -> None:
+        """Ensure ``usage_mode`` is MODEL when the project is a MODEL_STORE."""
+        if group_type == ProjectType.MODEL_STORE and usage_mode != VFolderUsageMode.MODEL:
+            raise VFolderInvalidParameter(
+                "Only Model VFolder can be created under the model store project"
+            )
+
     async def create_v2(self, action: CreateVFolderV2Action) -> CreateVFolderV2ActionResult:
         """Create a new vfolder (v2). Resolves policy internally from user_id."""
         user_uuid = action.user_id
@@ -1545,19 +1612,8 @@ class VFolderService:
         project_id = action.project_id
 
         email, user_role = await self._load_user(user_uuid)
-
-        # Resolve host
-        folder_host = action.host
-        if not folder_host:
-            folder_host = self._config_provider.config.volumes.default_host
-            if not folder_host:
-                raise VFolderInvalidParameter(
-                    "You must specify the vfolder host because the default host is not configured."
-                )
-
-        if action.name.startswith(".") and action.name != ".local":
-            if project_id is not None:
-                raise VFolderInvalidParameter("dot-prefixed vfolders cannot be a group folder.")
+        folder_host = await self._resolve_host(action.host)
+        self._check_name_parameter(action.name, is_group=project_id is not None)
 
         group_uuid: uuid.UUID | None = None
         group_type: ProjectType | None = None
@@ -1566,12 +1622,12 @@ class VFolderService:
         container_uid: int | None = None
 
         if project_id is not None:
-            group_info = await self._vfolder_repository.get_group_resource_info(
-                project_id, domain_name
-            )
-            if not group_info:
-                raise ProjectNotFound(f"Project with {project_id} not found.")
-            group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
+            (
+                group_uuid,
+                max_vfolder_count,
+                max_quota_scope_size,
+                group_type,
+            ) = await self._resolve_project_info(project_id, domain_name)
             container_uid = None
         else:
             user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
@@ -1583,22 +1639,11 @@ class VFolderService:
             VFOLDER_GROUP_PERMISSION_MODE if container_uid is not None else None
         )
 
-        # Determine ownership
-        if group_uuid is not None:
-            ownership_type = "group"
-            quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
-            self._check_user_role_for_group(user_role, group_type)
-        else:
-            ownership_type = "user"
-            quota_scope_id = QuotaScopeID(QuotaScopeType.USER, user_uuid)
-
+        ownership_type, quota_scope_id = self._determine_ownership(
+            user_uuid, group_uuid, user_role, group_type
+        )
         allowed_types = await self._check_ownership_allowed(ownership_type)
-
-        if group_type == ProjectType.MODEL_STORE:
-            if action.usage_mode != VFolderUsageMode.MODEL:
-                raise VFolderInvalidParameter(
-                    "Only Model VFolder can be created under the model store project"
-                )
+        self._check_model_store_usage_mode(group_type, action.usage_mode)
 
         # Host permission check — resolved from user_id, not passed resource_policy
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(
@@ -1608,16 +1653,12 @@ class VFolderService:
             group_id=group_uuid,
         )
 
-        # Quota check
-        if max_vfolder_count > 0:
-            if ownership_type == "user":
-                current_count = await self._vfolder_repository.count_vfolders_by_user(user_uuid)
-            else:
-                if group_uuid is None:
-                    raise VFolderInvalidParameter("Group UUID is required for group-owned vfolders")
-                current_count = await self._vfolder_repository.count_vfolders_by_group(group_uuid)
-            if current_count >= max_vfolder_count:
-                raise VFolderInvalidParameter("You cannot create more vfolders.")
+        if ownership_type == "user":
+            await self._check_user_vfolder_quota(user_uuid, max_vfolder_count)
+        else:
+            if group_uuid is None:
+                raise VFolderInvalidParameter("Group UUID is required for group-owned vfolders")
+            await self._check_group_vfolder_quota(group_uuid, max_vfolder_count)
 
         await self._check_name_uniqueness(
             action.name, user_uuid, user_role, domain_name, allowed_types
@@ -1703,34 +1744,19 @@ class VFolderService:
         project_id = action.project_id
 
         email, user_role = await self._load_user(user_uuid)
+        folder_host = await self._resolve_host(action.host)
+        self._check_name_parameter(action.name, is_group=True)
 
-        # Resolve host
-        folder_host = action.host
-        if not folder_host:
-            folder_host = self._config_provider.config.volumes.default_host
-            if not folder_host:
-                raise VFolderInvalidParameter(
-                    "You must specify the vfolder host because the default host is not configured."
-                )
-
-        if action.name.startswith(".") and action.name != ".local":
-            raise VFolderInvalidParameter("dot-prefixed vfolders cannot be a group folder.")
-
-        # Resolve project info
-        group_info = await self._vfolder_repository.get_group_resource_info(project_id, domain_name)
-        if not group_info:
-            raise ProjectNotFound(f"Project with {project_id} not found.")
-        group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
-
+        (
+            group_uuid,
+            max_vfolder_count,
+            max_quota_scope_size,
+            group_type,
+        ) = await self._resolve_project_info(project_id, domain_name)
         quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
 
         allowed_types = await self._check_ownership_allowed("group")
-
-        if group_type == ProjectType.MODEL_STORE:
-            if action.usage_mode != VFolderUsageMode.MODEL:
-                raise VFolderInvalidParameter(
-                    "Only Model VFolder can be created under the model store project"
-                )
+        self._check_model_store_usage_mode(group_type, action.usage_mode)
 
         # Host permission check
         await self._vfolder_repository.ensure_host_permission_allowed_by_user(
@@ -1740,11 +1766,7 @@ class VFolderService:
             group_id=group_uuid,
         )
 
-        # Quota check
-        if max_vfolder_count > 0:
-            current_count = await self._vfolder_repository.count_vfolders_by_group(group_uuid)
-            if current_count >= max_vfolder_count:
-                raise VFolderInvalidParameter("You cannot create more vfolders.")
+        await self._check_group_vfolder_quota(group_uuid, max_vfolder_count)
 
         await self._check_name_uniqueness(
             action.name, user_uuid, user_role, domain_name, allowed_types

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -275,10 +275,10 @@ class VFolderService:
                 )
                 if not group_info:
                     raise ProjectNotFound(f"Project with {group_id_or_name} not found.")
-                group_uuid = group_info.group_uuid
+                group_uuid = group_info.project_id
                 max_vfolder_count = group_info.max_vfolder_count
                 max_quota_scope_size = group_info.max_quota_scope_size
-                group_type = group_info.group_type
+                group_type = group_info.project_type
                 container_uid = None
             case None:
                 user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
@@ -1569,10 +1569,10 @@ class VFolderService:
 
         if project_id is not None:
             project_info = await self._resolve_project_info(project_id, domain_name)
-            group_uuid = project_info.group_uuid
+            group_uuid = project_info.project_id
             max_vfolder_count = project_info.max_vfolder_count
             max_quota_scope_size = project_info.max_quota_scope_size
-            group_type = project_info.group_type
+            group_type = project_info.project_type
             container_uid = None
         else:
             user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
@@ -1703,10 +1703,10 @@ class VFolderService:
         self._check_name_parameter(action.name, is_group=True)
 
         project_info = await self._resolve_project_info(project_id, domain_name)
-        group_uuid = project_info.group_uuid
+        group_uuid = project_info.project_id
         max_vfolder_count = project_info.max_vfolder_count
         max_quota_scope_size = project_info.max_quota_scope_size
-        group_type = project_info.group_type
+        group_type = project_info.project_type
         quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
 
         allowed_types = await self._check_ownership_allowed("group")

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import math
 import uuid
+from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
 from typing import (
     Any,
@@ -1436,17 +1437,114 @@ class VFolderService:
             await _check_vfolder_status(row["status"], action.required_status)
         return GetAccessibleVFolderActionResult(row=row)
 
+    async def _load_user(self, user_uuid: uuid.UUID) -> tuple[str, UserRole]:
+        """Load user and return ``(email, role)``. Raises if the record is incomplete."""
+        user = await self._user_repository.get_user_by_uuid(user_uuid)
+        if user.role is None or user.domain_name is None:
+            raise ObjectNotFound(object_name="User")
+        return user.email, user.role
+
+    def _check_user_role_for_group(
+        self, user_role: UserRole, group_type: ProjectType | None
+    ) -> None:
+        """Legacy gate: non-admin users may only create group vfolders in MODEL_STORE projects."""
+        if (
+            user_role not in (UserRole.SUPERADMIN, UserRole.ADMIN)
+            and group_type != ProjectType.MODEL_STORE
+        ):
+            raise Forbidden("no permission")
+
+    async def _check_ownership_allowed(self, ownership_type: str) -> Sequence[str]:
+        """Ensure the cluster allows this ownership_type. Returns the allowed list."""
+        allowed_vfolder_types = (
+            await self._config_provider.legacy_etcd_config_loader.get_vfolder_types()
+        )
+        if ownership_type not in allowed_vfolder_types:
+            raise VFolderInvalidParameter(
+                f"{ownership_type}-owned vfolder is not allowed in this cluster"
+            )
+        return list(allowed_vfolder_types)
+
+    async def _check_name_uniqueness(
+        self,
+        name: str,
+        user_uuid: uuid.UUID,
+        user_role: UserRole,
+        domain_name: str,
+        allowed_types: Sequence[str],
+    ) -> None:
+        """Raise VFolderAlreadyExists if the user already owns a vfolder with this name."""
+        name_exists = await self._vfolder_repository.check_vfolder_name_exists(
+            name, user_uuid, user_role, domain_name, list(allowed_types)
+        )
+        if name_exists:
+            raise VFolderAlreadyExists(f"VFolder with the given name already exists. ({name})")
+
+    async def _do_create_vfolder(
+        self,
+        *,
+        folder_id: uuid.UUID,
+        name: str,
+        domain_name: str,
+        quota_scope_id: QuotaScopeID,
+        usage_mode: VFolderUsageMode,
+        permission: VFolderPermission,
+        host: str,
+        creator: str,
+        creator_id: uuid.UUID,
+        ownership_type: VFolderOwnershipType,
+        user: uuid.UUID | None,
+        group: uuid.UUID | None,
+        cloneable: bool,
+        max_quota_scope_size: int,
+        vfolder_permission_mode: int | None,
+        create_owner_permission: bool,
+    ) -> VFolderData:
+        """Call storage-proxy, insert the row, and fetch back the created VFolderData."""
+        try:
+            vfid = VFolderID(quota_scope_id, folder_id)
+            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(host, False)
+            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+            await manager_client.create_folder(
+                volume_name, str(vfid), max_quota_scope_size, vfolder_permission_mode
+            )
+        except aiohttp.ClientResponseError as e:
+            raise VFolderCreationFailure from e
+
+        params = VFolderCreateParams(
+            id=folder_id,
+            name=name,
+            domain_name=domain_name,
+            quota_scope_id=str(quota_scope_id),
+            usage_mode=usage_mode,
+            permission=permission,
+            host=host,
+            creator=creator,
+            creator_id=creator_id,
+            ownership_type=ownership_type,
+            user=user,
+            group=group,
+            unmanaged_path=None,
+            cloneable=cloneable,
+            status=VFolderOperationStatus.READY,
+        )
+
+        try:
+            await self._vfolder_repository.create_vfolder_with_permission(
+                params, create_owner_permission=create_owner_permission
+            )
+        except sa_exc.DataError as e:
+            raise VFolderInvalidParameter from e
+
+        return await self._vfolder_repository.get_by_id(folder_id)
+
     async def create_v2(self, action: CreateVFolderV2Action) -> CreateVFolderV2ActionResult:
         """Create a new vfolder (v2). Resolves policy internally from user_id."""
         user_uuid = action.user_id
         domain_name = action.domain_name
         project_id = action.project_id
 
-        # Resolve user info from DB
-        user = await self._user_repository.get_user_by_uuid(user_uuid)
-        if user.role is None or user.domain_name is None:
-            raise ObjectNotFound(object_name="User")
-        user_role = user.role
+        email, user_role = await self._load_user(user_uuid)
 
         # Resolve host
         folder_host = action.host
@@ -1456,10 +1554,6 @@ class VFolderService:
                 raise VFolderInvalidParameter(
                     "You must specify the vfolder host because the default host is not configured."
                 )
-
-        allowed_vfolder_types = (
-            await self._config_provider.legacy_etcd_config_loader.get_vfolder_types()
-        )
 
         if action.name.startswith(".") and action.name != ".local":
             if project_id is not None:
@@ -1493,18 +1587,12 @@ class VFolderService:
         if group_uuid is not None:
             ownership_type = "group"
             quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
-            if (
-                user_role not in (UserRole.SUPERADMIN, UserRole.ADMIN)
-                and group_type != ProjectType.MODEL_STORE
-            ):
-                raise Forbidden("no permission")
+            self._check_user_role_for_group(user_role, group_type)
         else:
             ownership_type = "user"
             quota_scope_id = QuotaScopeID(QuotaScopeType.USER, user_uuid)
-        if ownership_type not in allowed_vfolder_types:
-            raise VFolderInvalidParameter(
-                f"{ownership_type}-owned vfolder is not allowed in this cluster"
-            )
+
+        allowed_types = await self._check_ownership_allowed(ownership_type)
 
         if group_type == ProjectType.MODEL_STORE:
             if action.usage_mode != VFolderUsageMode.MODEL:
@@ -1531,61 +1619,31 @@ class VFolderService:
             if current_count >= max_vfolder_count:
                 raise VFolderInvalidParameter("You cannot create more vfolders.")
 
-        # Name uniqueness check
-        name_exists = await self._vfolder_repository.check_vfolder_name_exists(
-            action.name, user_uuid, user_role, domain_name, list(allowed_vfolder_types)
+        await self._check_name_uniqueness(
+            action.name, user_uuid, user_role, domain_name, allowed_types
         )
-        if name_exists:
-            raise VFolderAlreadyExists(
-                f"VFolder with the given name already exists. ({action.name})"
-            )
-
-        # Create in storage
-        folder_id = uuid.uuid4()
-        try:
-            vfid = VFolderID(quota_scope_id, folder_id)
-            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
-            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
-            await manager_client.create_folder(
-                volume_name, str(vfid), max_quota_scope_size, vfolder_permission_mode
-            )
-        except aiohttp.ClientResponseError as e:
-            raise VFolderCreationFailure from e
 
         mount_permission = action.permission
         if group_type == ProjectType.MODEL_STORE:
             mount_permission = VFolderPermission.READ_ONLY
 
-        # Create in DB
-        params = VFolderCreateParams(
-            id=folder_id,
+        vfolder_data = await self._do_create_vfolder(
+            folder_id=uuid.uuid4(),
             name=action.name,
             domain_name=domain_name,
-            quota_scope_id=str(quota_scope_id),
+            quota_scope_id=quota_scope_id,
             usage_mode=action.usage_mode,
             permission=mount_permission,
             host=folder_host,
-            creator=user.email,
+            creator=email,
             creator_id=user_uuid,
             ownership_type=VFolderOwnershipType(ownership_type),
             user=user_uuid if ownership_type == "user" else None,
             group=group_uuid if ownership_type == "group" else None,
-            unmanaged_path=None,
             cloneable=action.cloneable,
-            status=VFolderOperationStatus.READY,
-        )
-
-        try:
-            create_owner_permission = group_type == ProjectType.MODEL_STORE
-            await self._vfolder_repository.create_vfolder_with_permission(
-                params, create_owner_permission=create_owner_permission
-            )
-        except sa_exc.DataError as e:
-            raise VFolderInvalidParameter from e
-
-        # Fetch created vfolder data for response
-        vfolder_data = await self._vfolder_repository.get_by_id_validated(
-            folder_id, user_uuid, domain_name
+            max_quota_scope_size=max_quota_scope_size,
+            vfolder_permission_mode=vfolder_permission_mode,
+            create_owner_permission=(group_type == ProjectType.MODEL_STORE),
         )
         return CreateVFolderV2ActionResult(vfolder=vfolder_data)
 
@@ -1644,6 +1702,8 @@ class VFolderService:
         domain_name = action.domain_name
         project_id = action.project_id
 
+        email, user_role = await self._load_user(user_uuid)
+
         # Resolve host
         folder_host = action.host
         if not folder_host:
@@ -1663,6 +1723,8 @@ class VFolderService:
         group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
 
         quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
+
+        allowed_types = await self._check_ownership_allowed("group")
 
         if group_type == ProjectType.MODEL_STORE:
             if action.usage_mode != VFolderUsageMode.MODEL:
@@ -1684,49 +1746,32 @@ class VFolderService:
             if current_count >= max_vfolder_count:
                 raise VFolderInvalidParameter("You cannot create more vfolders.")
 
-        # Create in storage
-        folder_id = uuid.uuid4()
+        await self._check_name_uniqueness(
+            action.name, user_uuid, user_role, domain_name, allowed_types
+        )
+
         mount_permission = action.permission
         if group_type == ProjectType.MODEL_STORE:
             mount_permission = VFolderPermission.READ_ONLY
 
-        try:
-            vfid = VFolderID(quota_scope_id, folder_id)
-            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
-            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
-            await manager_client.create_folder(volume_name, str(vfid), max_quota_scope_size, None)
-        except aiohttp.ClientResponseError as e:
-            raise VFolderCreationFailure from e
-
-        # Create in DB
-        params = VFolderCreateParams(
-            id=folder_id,
+        vfolder_data = await self._do_create_vfolder(
+            folder_id=uuid.uuid4(),
             name=action.name,
             domain_name=domain_name,
-            quota_scope_id=str(quota_scope_id),
+            quota_scope_id=quota_scope_id,
             usage_mode=action.usage_mode,
             permission=mount_permission,
             host=folder_host,
-            creator=str(user_uuid),
+            creator=email,
             creator_id=user_uuid,
             ownership_type=VFolderOwnershipType.GROUP,
             user=None,
             group=group_uuid,
-            unmanaged_path=None,
             cloneable=action.cloneable,
-            status=VFolderOperationStatus.READY,
+            max_quota_scope_size=max_quota_scope_size,
+            vfolder_permission_mode=None,
+            create_owner_permission=(group_type == ProjectType.MODEL_STORE),
         )
-
-        try:
-            create_owner_permission = group_type == ProjectType.MODEL_STORE
-            await self._vfolder_repository.create_vfolder_with_permission(
-                params, create_owner_permission=create_owner_permission
-            )
-        except sa_exc.DataError as e:
-            raise VFolderInvalidParameter from e
-
-        # Fetch created vfolder data for response
-        vfolder_data = await self._vfolder_repository.get_by_id(folder_id)
         return CreateVFolderInProjectActionResult(
             project_id=action.project_id,
             vfolder=vfolder_data,

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1480,64 +1480,6 @@ class VFolderService:
         if name_exists:
             raise VFolderAlreadyExists(f"VFolder with the given name already exists. ({name})")
 
-    async def _do_create_vfolder(
-        self,
-        *,
-        folder_id: uuid.UUID,
-        name: str,
-        domain_name: str,
-        quota_scope_id: QuotaScopeID,
-        usage_mode: VFolderUsageMode,
-        permission: VFolderPermission,
-        host: str,
-        creator: str,
-        creator_id: uuid.UUID,
-        ownership_type: VFolderOwnershipType,
-        user: uuid.UUID | None,
-        group: uuid.UUID | None,
-        cloneable: bool,
-        max_quota_scope_size: int,
-        vfolder_permission_mode: int | None,
-        create_owner_permission: bool,
-    ) -> VFolderData:
-        """Call storage-proxy, insert the row, and fetch back the created VFolderData."""
-        try:
-            vfid = VFolderID(quota_scope_id, folder_id)
-            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(host, False)
-            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
-            await manager_client.create_folder(
-                volume_name, str(vfid), max_quota_scope_size, vfolder_permission_mode
-            )
-        except aiohttp.ClientResponseError as e:
-            raise VFolderCreationFailure from e
-
-        params = VFolderCreateParams(
-            id=folder_id,
-            name=name,
-            domain_name=domain_name,
-            quota_scope_id=str(quota_scope_id),
-            usage_mode=usage_mode,
-            permission=permission,
-            host=host,
-            creator=creator,
-            creator_id=creator_id,
-            ownership_type=ownership_type,
-            user=user,
-            group=group,
-            unmanaged_path=None,
-            cloneable=cloneable,
-            status=VFolderOperationStatus.READY,
-        )
-
-        try:
-            await self._vfolder_repository.create_vfolder_with_permission(
-                params, create_owner_permission=create_owner_permission
-            )
-        except sa_exc.DataError as e:
-            raise VFolderInvalidParameter from e
-
-        return await self._vfolder_repository.get_by_id(folder_id)
-
     async def _resolve_host(self, requested_host: str | None) -> str:
         """Return the target storage host, falling back to the configured default."""
         host = requested_host
@@ -1668,11 +1610,19 @@ class VFolderService:
         if group_type == ProjectType.MODEL_STORE:
             mount_permission = VFolderPermission.READ_ONLY
 
-        vfolder_data = await self._do_create_vfolder(
-            folder_id=uuid.uuid4(),
+        folder_id = uuid.uuid4()
+        vfid = VFolderID(quota_scope_id, folder_id)
+        proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
+        manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+        await manager_client.create_folder(
+            volume_name, str(vfid), max_quota_scope_size, vfolder_permission_mode
+        )
+
+        params = VFolderCreateParams(
+            id=folder_id,
             name=action.name,
             domain_name=domain_name,
-            quota_scope_id=quota_scope_id,
+            quota_scope_id=str(quota_scope_id),
             usage_mode=action.usage_mode,
             permission=mount_permission,
             host=folder_host,
@@ -1681,10 +1631,12 @@ class VFolderService:
             ownership_type=VFolderOwnershipType(ownership_type),
             user=user_uuid if ownership_type == "user" else None,
             group=group_uuid if ownership_type == "group" else None,
+            unmanaged_path=None,
             cloneable=action.cloneable,
-            max_quota_scope_size=max_quota_scope_size,
-            vfolder_permission_mode=vfolder_permission_mode,
-            create_owner_permission=(group_type == ProjectType.MODEL_STORE),
+            status=VFolderOperationStatus.READY,
+        )
+        vfolder_data = await self._vfolder_repository.create_vfolder_with_permission(
+            params, create_owner_permission=(group_type == ProjectType.MODEL_STORE)
         )
         return CreateVFolderV2ActionResult(vfolder=vfolder_data)
 
@@ -1776,11 +1728,17 @@ class VFolderService:
         if group_type == ProjectType.MODEL_STORE:
             mount_permission = VFolderPermission.READ_ONLY
 
-        vfolder_data = await self._do_create_vfolder(
-            folder_id=uuid.uuid4(),
+        folder_id = uuid.uuid4()
+        vfid = VFolderID(quota_scope_id, folder_id)
+        proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
+        manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+        await manager_client.create_folder(volume_name, str(vfid), max_quota_scope_size, None)
+
+        params = VFolderCreateParams(
+            id=folder_id,
             name=action.name,
             domain_name=domain_name,
-            quota_scope_id=quota_scope_id,
+            quota_scope_id=str(quota_scope_id),
             usage_mode=action.usage_mode,
             permission=mount_permission,
             host=folder_host,
@@ -1789,10 +1747,12 @@ class VFolderService:
             ownership_type=VFolderOwnershipType.GROUP,
             user=None,
             group=group_uuid,
+            unmanaged_path=None,
             cloneable=action.cloneable,
-            max_quota_scope_size=max_quota_scope_size,
-            vfolder_permission_mode=None,
-            create_owner_permission=(group_type == ProjectType.MODEL_STORE),
+            status=VFolderOperationStatus.READY,
+        )
+        vfolder_data = await self._vfolder_repository.create_vfolder_with_permission(
+            params, create_owner_permission=(group_type == ProjectType.MODEL_STORE)
         )
         return CreateVFolderInProjectActionResult(
             project_id=action.project_id,

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -158,6 +158,10 @@ from ai.backend.manager.services.vfolder.actions.upload_session_v2 import (
     CreateUploadSessionV2Action,
     CreateUploadSessionV2ActionResult,
 )
+from ai.backend.manager.services.vfolder.actions.vfolder_in_project import (
+    CreateVFolderInProjectAction,
+    CreateVFolderInProjectActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.vfolder_v2 import (
     DeleteVFolderV2Action,
     DeleteVFolderV2ActionResult,
@@ -1626,6 +1630,107 @@ class VFolderService:
         """Get a single vfolder by ID (v2). RBAC is enforced at the processor level."""
         vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_uuid)
         return GetVFolderV2ActionResult(vfolder=vfolder_data)
+
+    async def create_in_project(
+        self, action: CreateVFolderInProjectAction
+    ) -> CreateVFolderInProjectActionResult:
+        """Create a vfolder owned by a project.
+
+        RBAC is enforced by the ScopeActionProcessor at the processor level.
+        Unlike ``create_v2`` this method does NOT check ``UserRole`` — project
+        CREATE permission is validated by the scope RBAC validator.
+        """
+        user_uuid = action.user_id
+        domain_name = action.domain_name
+        project_id = action.project_id
+
+        # Resolve host
+        folder_host = action.host
+        if not folder_host:
+            folder_host = self._config_provider.config.volumes.default_host
+            if not folder_host:
+                raise VFolderInvalidParameter(
+                    "You must specify the vfolder host because the default host is not configured."
+                )
+
+        if action.name.startswith(".") and action.name != ".local":
+            raise VFolderInvalidParameter("dot-prefixed vfolders cannot be a group folder.")
+
+        # Resolve project info
+        group_info = await self._vfolder_repository.get_group_resource_info(project_id, domain_name)
+        if not group_info:
+            raise ProjectNotFound(f"Project with {project_id} not found.")
+        group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
+
+        quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
+
+        if group_type == ProjectType.MODEL_STORE:
+            if action.usage_mode != VFolderUsageMode.MODEL:
+                raise VFolderInvalidParameter(
+                    "Only Model VFolder can be created under the model store project"
+                )
+
+        # Host permission check
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            folder_host,
+            permission=VFolderHostPermission.CREATE,
+            user_uuid=user_uuid,
+            group_id=group_uuid,
+        )
+
+        # Quota check
+        if max_vfolder_count > 0:
+            current_count = await self._vfolder_repository.count_vfolders_by_group(group_uuid)
+            if current_count >= max_vfolder_count:
+                raise VFolderInvalidParameter("You cannot create more vfolders.")
+
+        # Create in storage
+        folder_id = uuid.uuid4()
+        mount_permission = action.permission
+        if group_type == ProjectType.MODEL_STORE:
+            mount_permission = VFolderPermission.READ_ONLY
+
+        try:
+            vfid = VFolderID(quota_scope_id, folder_id)
+            proxy_name, volume_name = self._storage_manager.get_proxy_and_volume(folder_host, False)
+            manager_client = self._storage_manager.get_manager_facing_client(proxy_name)
+            await manager_client.create_folder(volume_name, str(vfid), max_quota_scope_size, None)
+        except aiohttp.ClientResponseError as e:
+            raise VFolderCreationFailure from e
+
+        # Create in DB
+        params = VFolderCreateParams(
+            id=folder_id,
+            name=action.name,
+            domain_name=domain_name,
+            quota_scope_id=str(quota_scope_id),
+            usage_mode=action.usage_mode,
+            permission=mount_permission,
+            host=folder_host,
+            creator=str(user_uuid),
+            creator_id=user_uuid,
+            ownership_type=VFolderOwnershipType.GROUP,
+            user=None,
+            group=group_uuid,
+            unmanaged_path=None,
+            cloneable=action.cloneable,
+            status=VFolderOperationStatus.READY,
+        )
+
+        try:
+            create_owner_permission = group_type == ProjectType.MODEL_STORE
+            await self._vfolder_repository.create_vfolder_with_permission(
+                params, create_owner_permission=create_owner_permission
+            )
+        except sa_exc.DataError as e:
+            raise VFolderInvalidParameter from e
+
+        # Fetch created vfolder data for response
+        vfolder_data = await self._vfolder_repository.get_by_id(folder_id)
+        return CreateVFolderInProjectActionResult(
+            project_id=action.project_id,
+            vfolder=vfolder_data,
+        )
 
     async def delete_v2(self, action: DeleteVFolderV2Action) -> DeleteVFolderV2ActionResult:
         """Soft-delete a vfolder by ID. RBAC enforced at processor level."""

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -31,6 +31,7 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.group.types import ProjectResourceInfo
 from ai.backend.manager.data.vfolder.dto import UserIdentity
 from ai.backend.manager.data.vfolder.types import (
     VFolderCreateParams,
@@ -274,7 +275,10 @@ class VFolderService:
                 )
                 if not group_info:
                     raise ProjectNotFound(f"Project with {group_id_or_name} not found.")
-                group_uuid, max_vfolder_count, max_quota_scope_size, group_type = group_info
+                group_uuid = group_info.group_uuid
+                max_vfolder_count = group_info.max_vfolder_count
+                max_quota_scope_size = group_info.max_quota_scope_size
+                group_type = group_info.group_type
                 container_uid = None
             case None:
                 user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
@@ -1498,8 +1502,8 @@ class VFolderService:
 
     async def _resolve_project_info(
         self, project_id: uuid.UUID, domain_name: str
-    ) -> tuple[uuid.UUID, int, int, ProjectType]:
-        """Fetch ``(group_uuid, max_vfolder_count, max_quota_scope_size, group_type)``."""
+    ) -> ProjectResourceInfo:
+        """Fetch project resource info for vfolder creation."""
         group_info = await self._vfolder_repository.get_group_resource_info(project_id, domain_name)
         if not group_info:
             raise ProjectNotFound(f"Project with {project_id} not found.")
@@ -1564,12 +1568,11 @@ class VFolderService:
         container_uid: int | None = None
 
         if project_id is not None:
-            (
-                group_uuid,
-                max_vfolder_count,
-                max_quota_scope_size,
-                group_type,
-            ) = await self._resolve_project_info(project_id, domain_name)
+            project_info = await self._resolve_project_info(project_id, domain_name)
+            group_uuid = project_info.group_uuid
+            max_vfolder_count = project_info.max_vfolder_count
+            max_quota_scope_size = project_info.max_quota_scope_size
+            group_type = project_info.group_type
             container_uid = None
         else:
             user_info = await self._vfolder_repository.get_user_resource_info(user_uuid)
@@ -1699,12 +1702,11 @@ class VFolderService:
         folder_host = await self._resolve_host(action.host)
         self._check_name_parameter(action.name, is_group=True)
 
-        (
-            group_uuid,
-            max_vfolder_count,
-            max_quota_scope_size,
-            group_type,
-        ) = await self._resolve_project_info(project_id, domain_name)
+        project_info = await self._resolve_project_info(project_id, domain_name)
+        group_uuid = project_info.group_uuid
+        max_vfolder_count = project_info.max_vfolder_count
+        max_quota_scope_size = project_info.max_quota_scope_size
+        group_type = project_info.group_type
         quota_scope_id = QuotaScopeID(QuotaScopeType.PROJECT, group_uuid)
 
         allowed_types = await self._check_ownership_allowed("group")

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -11,9 +11,10 @@ import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import sqlalchemy as sa
 import yarl
 
 from ai.backend.client.v2.auth import HMACAuth
@@ -22,7 +23,13 @@ from ai.backend.client.v2.exceptions import PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.dto.manager.field import VFolderPermissionField
 from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInScopeInput
-from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
+from ai.backend.common.types import (
+    QuotaScopeID,
+    QuotaScopeType,
+    VFolderHostPermission,
+    VFolderHostPermissionMap,
+    VFolderUsageMode,
+)
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
@@ -34,11 +41,17 @@ from ai.backend.manager.api.rest.routing import RouteRegistry
 from ai.backend.manager.api.rest.types import RouteDeps
 from ai.backend.manager.api.rest.v2.vfolder.handler import V2VFolderHandler
 from ai.backend.manager.api.rest.v2.vfolder.registry import register_v2_vfolder_routes
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
 from ai.backend.manager.data.vfolder.types import (
     VFolderMountPermission,
     VFolderOperationStatus,
     VFolderOwnershipType,
 )
+from ai.backend.manager.models.group import groups
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -76,13 +89,27 @@ def vfolder_processors(
     database_engine: ExtendedAsyncSAEngine,
     rbac_permission_repo: PermissionControllerRepository,
 ) -> VFolderProcessors:
-    """Override: real scope + single-entity RBAC validators."""
+    """Override: real scope + single-entity RBAC validators.
+
+    Storage-proxy calls (``get_proxy_and_volume`` / ``create_folder``) and
+    the etcd-backed allowed-vfolder-types lookup are stubbed so that
+    service-layer create paths can complete without external dependencies.
+    """
     vfolder_repository = VfolderRepository(database_engine)
     user_repository = UserRepository(database_engine)
+    config_provider = MagicMock()
+    config_provider.legacy_etcd_config_loader.get_vfolder_types = AsyncMock(
+        return_value=["user", "group"]
+    )
+    storage_manager = MagicMock()
+    storage_manager.get_proxy_and_volume.return_value = ("local", "local")
+    manager_client = MagicMock()
+    manager_client.create_folder = AsyncMock(return_value=None)
+    storage_manager.get_manager_facing_client.return_value = manager_client
     service = VFolderService(
-        config_provider=MagicMock(),
+        config_provider=config_provider,
         etcd=MagicMock(),
-        storage_manager=MagicMock(),
+        storage_manager=storage_manager,
         background_task_manager=MagicMock(),
         vfolder_repository=vfolder_repository,
         user_repository=user_repository,
@@ -149,6 +176,88 @@ async def user_v2_registry(
         yield registry
     finally:
         await registry.close()
+
+
+@pytest.fixture()
+async def project_host_permission_fixture(
+    db_engine: SAEngine,
+    group_fixture: uuid.UUID,
+    vfolder_host_permission_fixture: None,
+) -> AsyncIterator[None]:
+    """Grant all VFolderHostPermission flags on the 'local' host to the test project.
+
+    The base ``vfolder_host_permission_fixture`` covers the domain and keypair
+    resource policy, but group-owned creates read from the project row itself.
+    """
+    all_perms: set[VFolderHostPermission] = set(VFolderHostPermission)
+    host_perms = VFolderHostPermissionMap({"local": all_perms})
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            groups.update()
+            .where(groups.c.id == group_fixture)
+            .values(allowed_vfolder_hosts=host_perms)
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            groups.update()
+            .where(groups.c.id == group_fixture)
+            .values(allowed_vfolder_hosts=VFolderHostPermissionMap())
+        )
+
+
+@pytest.fixture()
+async def regular_user_vfolder_create_permission(
+    db_engine: SAEngine,
+    regular_user_fixture: UserFixtureData,
+    group_fixture: uuid.UUID,
+) -> AsyncIterator[None]:
+    """Grant PROJECT-scoped VFOLDER:CREATE permission to the regular user."""
+    role_id = uuid.uuid4()
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values(
+                id=role_id,
+                name=f"test-vfolder-creator-{secrets.token_hex(4)}",
+                status=RoleStatus.ACTIVE,
+            )
+        )
+        await conn.execute(
+            sa.insert(UserRoleRow.__table__).values(
+                user_id=regular_user_fixture.user_uuid,
+                role_id=role_id,
+            )
+        )
+        await conn.execute(
+            sa.insert(PermissionRow.__table__).values(
+                role_id=role_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(group_fixture),
+                entity_type=EntityType.VFOLDER,
+                operation=OperationType.CREATE,
+            )
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+@pytest.fixture()
+async def created_vfolder_cleanup(
+    db_engine: SAEngine,
+) -> AsyncIterator[list[uuid.UUID]]:
+    """Collect vfolder IDs created during a test and delete them on teardown."""
+    ids: list[uuid.UUID] = []
+    yield ids
+    if ids:
+        async with db_engine.begin() as conn:
+            await conn.execute(vfolders.delete().where(vfolders.c.id.in_(ids)))
 
 
 @pytest.fixture()
@@ -242,7 +351,7 @@ class TestPurgeVFolderRBAC:
 
 
 class TestCreateVFolderInProjectRBAC:
-    """POST /v2/vfolders/projects/{project_id} -- ScopeActionProcessor RBAC."""
+    """POST /v2/vfolders/projects/{project_id}/create -- ScopeActionProcessor RBAC."""
 
     async def test_regular_user_denied(
         self,
@@ -260,3 +369,42 @@ class TestCreateVFolderInProjectRBAC:
         )
         with pytest.raises(PermissionDeniedError):
             await user_v2_registry.vfolder.create_in_project(group_fixture, request)
+
+    async def test_superadmin_succeeds(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        group_fixture: uuid.UUID,
+        project_host_permission_fixture: None,
+        created_vfolder_cleanup: list[uuid.UUID],
+    ) -> None:
+        """Superadmin bypasses scope RBAC and can create a project-owned vfolder."""
+        request = CreateVFolderInScopeInput(
+            name=f"rbac-admin-{secrets.token_hex(4)}",
+            host="local",
+            usage_mode=VFolderUsageMode.GENERAL,
+            permission=VFolderPermissionField.READ_WRITE,
+            cloneable=False,
+        )
+        payload = await admin_v2_registry.vfolder.create_in_project(group_fixture, request)
+        created_vfolder_cleanup.append(payload.vfolder.id)
+        assert payload.vfolder.ownership.project_id == group_fixture
+
+    async def test_regular_user_with_permission_succeeds(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        group_fixture: uuid.UUID,
+        project_host_permission_fixture: None,
+        regular_user_vfolder_create_permission: None,
+        created_vfolder_cleanup: list[uuid.UUID],
+    ) -> None:
+        """Regular user granted PROJECT-scoped VFOLDER:CREATE succeeds."""
+        request = CreateVFolderInScopeInput(
+            name=f"rbac-user-{secrets.token_hex(4)}",
+            host="local",
+            usage_mode=VFolderUsageMode.GENERAL,
+            permission=VFolderPermissionField.READ_WRITE,
+            cloneable=False,
+        )
+        payload = await user_v2_registry.vfolder.create_in_project(group_fixture, request)
+        created_vfolder_cleanup.append(payload.vfolder.id)
+        assert payload.vfolder.ownership.project_id == group_fixture

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -20,6 +20,8 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.exceptions import PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.field import VFolderPermissionField
+from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInProjectInput
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
@@ -237,3 +239,24 @@ class TestPurgeVFolderRBAC:
     ) -> None:
         with pytest.raises(PermissionDeniedError):
             await user_v2_registry.vfolder.purge(project_vfolder.id)
+
+
+class TestCreateVFolderInProjectRBAC:
+    """POST /v2/vfolders/projects/{project_id} -- ScopeActionProcessor RBAC."""
+
+    async def test_regular_user_denied(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        group_fixture: uuid.UUID,
+        vfolder_host_permission_fixture: None,
+    ) -> None:
+        """Regular user without project CREATE permission is denied before service runs."""
+        request = CreateVFolderInProjectInput(
+            name=f"rbac-denied-{secrets.token_hex(4)}",
+            host="local",
+            usage_mode=VFolderUsageMode.GENERAL,
+            permission=VFolderPermissionField.READ_WRITE,
+            cloneable=False,
+        )
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.vfolder.create_in_project(group_fixture, request)

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -252,6 +252,7 @@ class TestCreateVFolderInProjectRBAC:
     ) -> None:
         """Regular user without project CREATE permission is denied before service runs."""
         request = CreateVFolderInProjectInput(
+            project_id=group_fixture,
             name=f"rbac-denied-{secrets.token_hex(4)}",
             host="local",
             usage_mode=VFolderUsageMode.GENERAL,
@@ -259,4 +260,4 @@ class TestCreateVFolderInProjectRBAC:
             cloneable=False,
         )
         with pytest.raises(PermissionDeniedError):
-            await user_v2_registry.vfolder.create_in_project(group_fixture, request)
+            await user_v2_registry.vfolder.create_in_project(request)

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -21,7 +21,7 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.exceptions import PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.dto.manager.field import VFolderPermissionField
-from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInProjectInput
+from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInScopeInput
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
@@ -251,8 +251,7 @@ class TestCreateVFolderInProjectRBAC:
         vfolder_host_permission_fixture: None,
     ) -> None:
         """Regular user without project CREATE permission is denied before service runs."""
-        request = CreateVFolderInProjectInput(
-            project_id=group_fixture,
+        request = CreateVFolderInScopeInput(
             name=f"rbac-denied-{secrets.token_hex(4)}",
             host="local",
             usage_mode=VFolderUsageMode.GENERAL,
@@ -260,4 +259,4 @@ class TestCreateVFolderInProjectRBAC:
             cloneable=False,
         )
         with pytest.raises(PermissionDeniedError):
-            await user_v2_registry.vfolder.create_in_project(request)
+            await user_v2_registry.vfolder.create_in_project(group_fixture, request)

--- a/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
@@ -245,10 +245,10 @@ class TestCreateVFolderAction:
     ) -> None:
         mock_vfolder_repository.get_group_resource_info = AsyncMock(
             return_value=ProjectResourceInfo(
-                group_uuid=group_uuid,
+                project_id=group_uuid,
                 max_vfolder_count=10,
                 max_quota_scope_size=0,
-                group_type=ProjectType.GENERAL,
+                project_type=ProjectType.GENERAL,
             )
         )
         mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()
@@ -403,10 +403,10 @@ class TestCreateVFolderAction:
     ) -> None:
         mock_vfolder_repository.get_group_resource_info = AsyncMock(
             return_value=ProjectResourceInfo(
-                group_uuid=group_uuid,
+                project_id=group_uuid,
                 max_vfolder_count=10,
                 max_quota_scope_size=0,
-                group_type=ProjectType.MODEL_STORE,
+                project_type=ProjectType.MODEL_STORE,
             )
         )
         mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()

--- a/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
@@ -17,6 +17,7 @@ from ai.backend.common.types import (
     QuotaScopeType,
     VFolderUsageMode,
 )
+from ai.backend.manager.data.group.types import ProjectResourceInfo
 from ai.backend.manager.data.vfolder.dto import UserIdentity
 from ai.backend.manager.data.vfolder.types import (
     VFolderAccessInfo,
@@ -243,7 +244,12 @@ class TestCreateVFolderAction:
         group_uuid: uuid.UUID,
     ) -> None:
         mock_vfolder_repository.get_group_resource_info = AsyncMock(
-            return_value=(group_uuid, 10, 0, None)
+            return_value=ProjectResourceInfo(
+                group_uuid=group_uuid,
+                max_vfolder_count=10,
+                max_quota_scope_size=0,
+                group_type=ProjectType.GENERAL,
+            )
         )
         mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()
         mock_vfolder_repository.count_vfolders_by_group = AsyncMock(return_value=0)
@@ -396,7 +402,12 @@ class TestCreateVFolderAction:
         group_uuid: uuid.UUID,
     ) -> None:
         mock_vfolder_repository.get_group_resource_info = AsyncMock(
-            return_value=(group_uuid, 10, 0, ProjectType.MODEL_STORE)
+            return_value=ProjectResourceInfo(
+                group_uuid=group_uuid,
+                max_vfolder_count=10,
+                max_quota_scope_size=0,
+                group_type=ProjectType.MODEL_STORE,
+            )
         )
         mock_vfolder_repository.ensure_host_permission_allowed = AsyncMock()
         mock_vfolder_repository.count_vfolders_by_group = AsyncMock(return_value=0)


### PR DESCRIPTION
## Summary
- Add `createProjectVFolderInProject` GraphQL mutations so project admin flows have a consistent project-scoped mutation surface alongside the existing `projectVfolders` query.

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main` — green
- [x] Manual verification with live server after CI green

Resolves BA-5737

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11139.org.readthedocs.build/en/11139/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11139.org.readthedocs.build/ko/11139/

<!-- readthedocs-preview sorna-ko end -->