### PR TITLE
fix(BA-5754): add RBAC validation to v2 session GET endpoint

### DIFF
--- a/changes/11143.fix.md
+++ b/changes/11143.fix.md
@@ -1,0 +1,1 @@
+Add RBAC validation to v2 session GET endpoint using SingleEntityActionProcessor

--- a/src/ai/backend/manager/api/adapters/session.py
+++ b/src/ai/backend/manager/api/adapters/session.py
@@ -315,7 +315,7 @@ class SessionAdapter(BaseAdapter):
     # Get single session
     # -------------------------------------------------------------------------
 
-    async def get(self, session_id: UUID) -> SessionNode:
+    async def get(self, session_id: SessionId) -> SessionNode:
         """Get a single session by ID with RBAC validation."""
         action_result = await self._processors.session.get_session.wait_for_complete(
             GetSessionAction(session_id=session_id)
@@ -912,7 +912,7 @@ class SessionAdapter(BaseAdapter):
             result = await self._processors.session.rename_session.wait_for_complete(action)
             return UpdateSessionPayload(session=self._session_data_to_node(result.session_data))
         # If no fields to update, just return the current session
-        session_node = await self.get(session_id)
+        session_node = await self.get(SessionId(session_id))
         return UpdateSessionPayload(session=session_node)
 
     # -------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/session.py
+++ b/src/ai/backend/manager/api/adapters/session.py
@@ -78,7 +78,6 @@ from ai.backend.common.types import (
 from ai.backend.manager.api.adapters.pagination import PaginationSpec
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, KernelStatusInMatchSpec
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
-from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.models.kernel.conditions import KernelConditions
 from ai.backend.manager.models.kernel.orders import (
     DEFAULT_BACKWARD_ORDER as KERNEL_DEFAULT_BACKWARD_ORDER,
@@ -128,6 +127,7 @@ from ai.backend.manager.services.session.actions.enqueue_session import (
 from ai.backend.manager.services.session.actions.get_container_logs import (
     GetContainerLogsAction,
 )
+from ai.backend.manager.services.session.actions.get_session import GetSessionAction
 from ai.backend.manager.services.session.actions.rename_session import RenameSessionAction
 from ai.backend.manager.services.session.actions.search import SearchSessionsAction
 from ai.backend.manager.services.session.actions.search_in_project import (
@@ -316,18 +316,11 @@ class SessionAdapter(BaseAdapter):
     # -------------------------------------------------------------------------
 
     async def get(self, session_id: UUID) -> SessionNode:
-        """Get a single session by ID."""
-        conditions = [SessionConditions.by_ids([SessionId(session_id)])]
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=conditions,
+        """Get a single session by ID with RBAC validation."""
+        action_result = await self._processors.session.get_session.wait_for_complete(
+            GetSessionAction(session_id=session_id)
         )
-        action_result = await self._processors.session.search_sessions.wait_for_complete(
-            SearchSessionsAction(querier=querier, user_id=self._require_user_id())
-        )
-        if not action_result.data:
-            raise SessionNotFound(f"Session not found: {session_id}")
-        return self._session_data_to_node(action_result.data[0])
+        return self._session_data_to_node(action_result.session_data)
 
     # -------------------------------------------------------------------------
     # Batch load (DataLoader)

--- a/src/ai/backend/manager/api/rest/v2/session/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/session/handler.py
@@ -111,7 +111,7 @@ class V2SessionHandler:
         path: PathParam[SessionIdPathParamDTO],
     ) -> APIResponse:
         """Get a single session by ID."""
-        result = await self._adapter.get(path.parsed.session_id)
+        result = await self._adapter.get(SessionId(path.parsed.session_id))
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def my_search(

--- a/src/ai/backend/manager/services/session/actions/get_session.py
+++ b/src/ai/backend/manager/services/session/actions/get_session.py
@@ -1,8 +1,8 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.session.types import SessionData
@@ -14,7 +14,7 @@ from ai.backend.manager.services.session.base import (
 
 @dataclass
 class GetSessionAction(SessionSingleEntityAction):
-    session_id: uuid.UUID
+    session_id: SessionId
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/get_session.py
+++ b/src/ai/backend/manager/services/session/actions/get_session.py
@@ -1,0 +1,39 @@
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.session.types import SessionData
+from ai.backend.manager.services.session.base import (
+    SessionSingleEntityAction,
+    SessionSingleEntityActionResult,
+)
+
+
+@dataclass
+class GetSessionAction(SessionSingleEntityAction):
+    session_id: uuid.UUID
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.session_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.SESSION, str(self.session_id))
+
+
+@dataclass
+class GetSessionActionResult(SessionSingleEntityActionResult):
+    session_data: SessionData
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.session_data.id)

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -74,6 +74,10 @@ from ai.backend.manager.services.session.actions.get_direct_access_info import (
     GetDirectAccessInfoAction,
     GetDirectAccessInfoActionResult,
 )
+from ai.backend.manager.services.session.actions.get_session import (
+    GetSessionAction,
+    GetSessionActionResult,
+)
 from ai.backend.manager.services.session.actions.get_session_info import (
     GetSessionInfoAction,
     GetSessionInfoActionResult,
@@ -187,6 +191,7 @@ class SessionProcessors(AbstractProcessorPackage):
         TerminateSessionsInProjectAction, TerminateSessionsInProjectActionResult
     ]
     upload_files: ActionProcessor[UploadFilesAction, UploadFilesActionResult]
+    get_session: SingleEntityActionProcessor[GetSessionAction, GetSessionActionResult]
     modify_session: SingleEntityActionProcessor[ModifySessionAction, ModifySessionActionResult]
     check_and_transit_status: ActionProcessor[
         CheckAndTransitStatusAction, CheckAndTransitStatusActionResult
@@ -281,6 +286,11 @@ class SessionProcessors(AbstractProcessorPackage):
 
         # Single entity actions with RBAC validation
         rbac_single_entity_validators = [single_entity_validator]
+        self.get_session = SingleEntityActionProcessor(
+            service.get_session,
+            action_monitors,
+            validators=rbac_single_entity_validators,
+        )
         self.modify_session = SingleEntityActionProcessor(
             service.modify_session,
             action_monitors,
@@ -321,6 +331,7 @@ class SessionProcessors(AbstractProcessorPackage):
             TerminateSessionsAction.spec(),
             TerminateSessionsInProjectAction.spec(),
             UploadFilesAction.spec(),
+            GetSessionAction.spec(),
             ModifySessionAction.spec(),
             CheckAndTransitStatusAction.spec(),
         ]

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -147,6 +147,10 @@ from ai.backend.manager.services.session.actions.get_direct_access_info import (
     GetDirectAccessInfoAction,
     GetDirectAccessInfoActionResult,
 )
+from ai.backend.manager.services.session.actions.get_session import (
+    GetSessionAction,
+    GetSessionActionResult,
+)
 from ai.backend.manager.services.session.actions.get_session_info import (
     GetSessionInfoAction,
     GetSessionInfoActionResult,
@@ -1469,6 +1473,13 @@ class SessionService:
                 ts.create_task(self._agent_registry.upload_file(session, file_name, data))
 
         return UploadFilesActionResult(result=None, session_data=session.to_dataclass())
+
+    async def get_session(self, action: GetSessionAction) -> GetSessionActionResult:
+        """Get a single session by ID with RBAC validation."""
+        session_data = await self._session_repository.get_session_data_by_id(
+            SessionId(action.session_id),
+        )
+        return GetSessionActionResult(session_data=session_data)
 
     async def modify_session(self, action: ModifySessionAction) -> ModifySessionActionResult:
         session_id = action.session_id

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1477,7 +1477,7 @@ class SessionService:
     async def get_session(self, action: GetSessionAction) -> GetSessionActionResult:
         """Get a single session by ID with RBAC validation."""
         session_data = await self._session_repository.get_session_data_by_id(
-            SessionId(action.session_id),
+            action.session_id,
         )
         return GetSessionActionResult(session_data=session_data)
 

--- a/tests/component/session_v2/BUILD
+++ b/tests/component/session_v2/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -1,0 +1,436 @@
+"""Component test fixtures for v2 Session GET endpoint with RBAC validation."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import sqlalchemy as sa
+import yarl
+from dateutil.tz import tzutc
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    OperationType,
+    RelationType,
+    RoleStatus,
+    ScopeType,
+)
+from ai.backend.common.plugin.monitor import ErrorPluginContext
+from ai.backend.common.types import ResourceSlot, SessionId, SessionTypes
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.single_entity import (
+    SingleEntityActionRBACValidator,
+)
+from ai.backend.manager.api.adapters.session import SessionAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.session.handler import V2SessionHandler
+from ai.backend.manager.api.rest.v2.session.registry import register_v2_session_routes
+from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.models.kernel import kernels
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.repositories.session.repository import SessionRepository
+from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.session.processors import SessionProcessors
+from ai.backend.manager.services.session.service import SessionService, SessionServiceArgs
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+@dataclass
+class SessionSeedData:
+    session_id: SessionId
+    session_name: str
+    kernel_id: uuid.UUID
+    access_key: str
+    domain_name: str
+    user_uuid: uuid.UUID | None = None
+
+
+@pytest.fixture()
+def rbac_permission_repo(
+    database_engine: ExtendedAsyncSAEngine,
+) -> PermissionControllerRepository:
+    """Real permission controller repository backed by real DB."""
+    return PermissionControllerRepository(database_engine)
+
+
+@pytest.fixture()
+def session_repository(
+    database_engine: ExtendedAsyncSAEngine,
+) -> SessionRepository:
+    return SessionRepository(database_engine)
+
+
+@pytest.fixture()
+async def session_processors(
+    session_repository: SessionRepository,
+    background_task_manager: BackgroundTaskManager,
+    error_monitor: ErrorPluginContext,
+    rbac_permission_repo: PermissionControllerRepository,
+) -> SessionProcessors:
+    """SessionProcessors with real SingleEntityActionRBACValidator.
+
+    RBAC checks use check_permission_with_scope_chain() against the real DB.
+    """
+    args = SessionServiceArgs(
+        agent_registry=AsyncMock(),
+        event_fetcher=AsyncMock(),
+        background_task_manager=background_task_manager,
+        event_hub=AsyncMock(),
+        error_monitor=error_monitor,
+        idle_checker_host=AsyncMock(),
+        session_repository=session_repository,
+        scheduling_controller=AsyncMock(),
+        appproxy_client_pool=AsyncMock(),
+        user_repository=AsyncMock(),
+    )
+    service = SessionService(args)
+    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo)
+    return SessionProcessors(
+        service=service,
+        action_monitors=[],
+        validators=ActionValidators(
+            rbac=RBACValidators(
+                scope=AsyncMock(),
+                single_entity=real_single_entity_validator,
+            )
+        ),
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    session_processors: SessionProcessors,
+) -> list[RouteRegistry]:
+    """Register v2 session routes for testing."""
+    processors = MagicMock(spec=Processors)
+    processors.session = session_processors
+    adapter = SessionAdapter(processors)
+    handler = V2SessionHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_session_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as superadmin."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2 client registry authenticated as a regular (non-admin) user."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+# ---------------------------------------------------------------------------
+# RBAC setup: user system role with owner permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def user_system_role(
+    db_engine: SAEngine,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[uuid.UUID]:
+    """Create a system role with owner permissions for the regular user.
+
+    Replicates what the RoleManager does at user creation time:
+    RoleRow + UserRoleRow + PermissionRows for owner-accessible entity types.
+    """
+    role_id = uuid.uuid4()
+    user_uuid = regular_user_fixture.user_uuid
+
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values(
+                id=role_id,
+                name=f"user-{str(user_uuid)[:8]}",
+                status=RoleStatus.ACTIVE,
+            )
+        )
+        await conn.execute(
+            sa.insert(UserRoleRow.__table__).values(
+                user_id=user_uuid,
+                role_id=role_id,
+            )
+        )
+        # Scope the role to the user
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.USER,
+                scope_id=str(user_uuid),
+                entity_type=EntityType.ROLE,
+                entity_id=str(role_id),
+                relation_type=RelationType.AUTO,
+            )
+        )
+        # Grant owner permissions for all owner-accessible entity types in user scope
+        for entity_type in EntityType.owner_accessible_entity_types_in_user():
+            for operation in OperationType.owner_operations():
+                await conn.execute(
+                    sa.insert(PermissionRow.__table__).values(
+                        role_id=role_id,
+                        scope_type=ScopeType.USER,
+                        scope_id=str(user_uuid),
+                        entity_type=entity_type,
+                        operation=operation,
+                    )
+                )
+        # USER entity type permissions (excluding CREATE)
+        for operation in OperationType.owner_operations():
+            if operation == OperationType.CREATE:
+                continue
+            await conn.execute(
+                sa.insert(PermissionRow.__table__).values(
+                    role_id=role_id,
+                    scope_type=ScopeType.USER,
+                    scope_id=str(user_uuid),
+                    entity_type=EntityType.USER,
+                    operation=operation,
+                )
+            )
+
+    yield role_id
+
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                (AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.ROLE)
+                & (AssociationScopesEntitiesRow.__table__.c.entity_id == str(role_id))
+            )
+        )
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+# ---------------------------------------------------------------------------
+# Session seeding with RBAC scope association
+# ---------------------------------------------------------------------------
+
+
+async def _seed_session(
+    db_engine: SAEngine,
+    *,
+    domain_name: str,
+    group_id: uuid.UUID,
+    user_uuid: uuid.UUID,
+    access_key: str,
+    scaling_group: str,
+    status: SessionStatus = SessionStatus.RUNNING,
+) -> SessionSeedData:
+    """Insert a session + kernel row with RBAC scope association.
+
+    Replicates what the scheduler does at session creation:
+    SessionRow + kernel + AssociationScopesEntitiesRow (session → user scope, session → project scope).
+    """
+    unique = secrets.token_hex(4)
+    session_id = SessionId(uuid.uuid4())
+    session_name = f"test-session-{unique}"
+    kernel_id = uuid.uuid4()
+    now = datetime.now(tzutc())
+
+    status_history: dict[str, Any] = {
+        SessionStatus.PENDING.name: now.isoformat(),
+        status.name: now.isoformat(),
+    }
+
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(SessionRow.__table__).values(
+                id=session_id,
+                creation_id=f"cid-{unique}",
+                name=session_name,
+                session_type=SessionTypes.INTERACTIVE,
+                cluster_size=1,
+                cluster_mode="single-node",
+                domain_name=domain_name,
+                group_id=group_id,
+                user_uuid=user_uuid,
+                access_key=access_key,
+                scaling_group_name=scaling_group,
+                status=status,
+                status_info="",
+                status_history=status_history,
+                occupying_slots=ResourceSlot(),
+                requested_slots=ResourceSlot(),
+                created_at=now,
+            )
+        )
+        await conn.execute(
+            sa.insert(kernels).values(
+                id=kernel_id,
+                session_id=session_id,
+                session_creation_id=f"cid-{unique}",
+                session_name=session_name,
+                session_type=SessionTypes.INTERACTIVE,
+                cluster_role="main",
+                cluster_idx=0,
+                cluster_hostname="main0",
+                cluster_mode="single-node",
+                cluster_size=1,
+                domain_name=domain_name,
+                group_id=group_id,
+                user_uuid=user_uuid,
+                access_key=access_key,
+                scaling_group=scaling_group,
+                status=KernelStatus.RUNNING,
+                status_info="",
+                occupied_slots=ResourceSlot(),
+                requested_slots=ResourceSlot(),
+                repl_in_port=0,
+                repl_out_port=0,
+                stdin_port=0,
+                stdout_port=0,
+                created_at=now,
+            )
+        )
+        # RBAC scope association: session → user scope (AUTO)
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.USER,
+                scope_id=str(user_uuid),
+                entity_type=EntityType.SESSION,
+                entity_id=str(session_id),
+                relation_type=RelationType.AUTO,
+            )
+        )
+        # RBAC scope association: session → project scope (AUTO)
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(group_id),
+                entity_type=EntityType.SESSION,
+                entity_id=str(session_id),
+                relation_type=RelationType.AUTO,
+            )
+        )
+
+    return SessionSeedData(
+        session_id=session_id,
+        session_name=session_name,
+        kernel_id=kernel_id,
+        access_key=access_key,
+        domain_name=domain_name,
+        user_uuid=user_uuid,
+    )
+
+
+async def _cleanup_session(db_engine: SAEngine, session_id: SessionId) -> None:
+    """Remove session, kernel, and RBAC association rows."""
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                (AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.SESSION)
+                & (AssociationScopesEntitiesRow.__table__.c.entity_id == str(session_id))
+            )
+        )
+        await conn.execute(kernels.delete().where(kernels.c.session_id == session_id))
+        await conn.execute(
+            SessionRow.__table__.delete().where(SessionRow.__table__.c.id == session_id)
+        )
+
+
+@pytest.fixture()
+async def admin_session_seed(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    group_fixture: uuid.UUID,
+    admin_user_fixture: UserFixtureData,
+    scaling_group_fixture: str,
+) -> AsyncIterator[SessionSeedData]:
+    """Seed a RUNNING session owned by the admin user."""
+    seed = await _seed_session(
+        db_engine,
+        domain_name=domain_fixture,
+        group_id=group_fixture,
+        user_uuid=admin_user_fixture.user_uuid,
+        access_key=admin_user_fixture.keypair.access_key,
+        scaling_group=scaling_group_fixture,
+    )
+    yield seed
+    await _cleanup_session(db_engine, seed.session_id)
+
+
+@pytest.fixture()
+async def user_session_seed(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    group_fixture: uuid.UUID,
+    regular_user_fixture: UserFixtureData,
+    scaling_group_fixture: str,
+    user_system_role: uuid.UUID,
+) -> AsyncIterator[SessionSeedData]:
+    """Seed a RUNNING session owned by the regular user.
+
+    Depends on user_system_role to ensure the user has RBAC permissions.
+    """
+    seed = await _seed_session(
+        db_engine,
+        domain_name=domain_fixture,
+        group_id=group_fixture,
+        user_uuid=regular_user_fixture.user_uuid,
+        access_key=regular_user_fixture.keypair.access_key,
+        scaling_group=scaling_group_fixture,
+    )
+    yield seed
+    await _cleanup_session(db_engine, seed.session_id)

--- a/tests/component/session_v2/test_session_get_rbac.py
+++ b/tests/component/session_v2/test_session_get_rbac.py
@@ -1,0 +1,75 @@
+"""Component tests for v2 Session GET endpoint RBAC validation.
+
+Tests that the v2 GET /sessions/{id} endpoint enforces RBAC:
+- Regular users can GET their own session (owner permission via scope chain)
+- Regular users WITHOUT permission are denied on other users' sessions (403)
+- Superadmin bypasses RBAC and can access any session
+- Superadmin querying nonexistent session gets 404
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.client.v2.exceptions import NotFoundError, PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+
+if TYPE_CHECKING:
+    from .conftest import SessionSeedData
+
+
+class TestSessionGetV2RBAC:
+    """RBAC validation for v2 GET /sessions/{id}.
+
+    The v2 GET endpoint uses SingleEntityActionProcessor with
+    single_entity_rbac_validators. Superadmin bypasses RBAC;
+    regular users can access their own sessions via owner permission
+    but are denied on other users' sessions.
+    """
+
+    async def test_regular_user_querying_own_session_succeeds(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        user_session_seed: SessionSeedData,
+    ) -> None:
+        """Regular user with owner permission can GET their own session."""
+        result = await user_v2_registry.session.get(user_session_seed.session_id)
+        assert result.id == user_session_seed.session_id
+
+    async def test_regular_user_querying_other_users_session_gets_403(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        admin_session_seed: SessionSeedData,
+    ) -> None:
+        """Regular user cannot GET another user's session."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.session.get(admin_session_seed.session_id)
+
+    async def test_superadmin_querying_own_session_bypasses_rbac(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_session_seed: SessionSeedData,
+    ) -> None:
+        """Superadmin bypasses RBAC and can GET their own session."""
+        result = await admin_v2_registry.session.get(admin_session_seed.session_id)
+        assert result.id == admin_session_seed.session_id
+
+    async def test_superadmin_querying_other_users_session_bypasses_rbac(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_session_seed: SessionSeedData,
+    ) -> None:
+        """Superadmin bypasses RBAC and can GET other users' sessions."""
+        result = await admin_v2_registry.session.get(user_session_seed.session_id)
+        assert result.id == user_session_seed.session_id
+
+    async def test_superadmin_querying_nonexistent_session_gets_404(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        """Superadmin bypasses RBAC but gets 404 for nonexistent session."""
+        with pytest.raises(NotFoundError):
+            await admin_v2_registry.session.get(uuid.uuid4())


### PR DESCRIPTION
resolve #11140 (BA-5754)

## Summary
- Add `SingleEntityActionProcessor` with RBAC validation to the v2 `GET /sessions/{id}` endpoint via `GetSessionAction`
- Add component tests verifying RBAC enforcement: owner access succeeds, non-owner denied (403), superadmin bypass, nonexistent session (404)

## Test plan
- [x] `pants lint tests/component/session_v2::` passes
- [x] `pants check tests/component/session_v2::` passes
- [x] `pants test tests/component/session_v2::` passes (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)