### PR TITLE
fix: pick up model-definition.yaml edits in legacy modify_endpoint

### DIFF
--- a/changes/11146.fix.md
+++ b/changes/11146.fix.md
@@ -1,0 +1,1 @@
+Make legacy `modify_endpoint` pick up edits to the model vfolder's `model-definition.yaml` by fetching the file directly and comparing it with the current revision's stored definition. Also stop re-using the previous revision's resolved definition as a user override, which was masking on-disk changes.

--- a/src/ai/backend/manager/services/model_serving/services/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/services/model_serving.py
@@ -13,6 +13,7 @@ from yarl import URL
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.bgtask.reporter import ProgressReporter
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.defs.session import SESSION_PRIORITY_DEFAULT
@@ -902,10 +903,21 @@ class ModelServingService:
             self._config_provider.legacy_etcd_config_loader,
         )
 
-        # 2. If revision-level fields changed, create + activate via controller.
+        # 2. Decide whether a new revision is needed.
+        #    Revision-level spec changes always force a new revision. Otherwise
+        #    (short-circuit) compare the vfolder's model-definition.yaml with
+        #    the current revision's stored definition — this catches the case
+        #    where the user edited model-definition.yaml without changing any
+        #    other modify_endpoint argument.
+        needs_new_revision = (
+            spec.has_revision_changes()
+            or await self._model_definition_content_changed(action.endpoint_id, spec)
+        )
+
+        # 3. Create + activate via controller when needed.
         #    This ensures the same pipeline as v2: preset → merge → resolve → RBAC
         #    → deploying_revision guard → DEPLOYING strategy.
-        if spec.has_revision_changes():
+        if needs_new_revision:
             creator = await self._build_revision_creator_from_spec(action.endpoint_id, spec)
             revision = await self._deployment_controller.add_revision(action.endpoint_id, creator)
             await self._deployment_controller.activate_revision(action.endpoint_id, revision.id)
@@ -918,6 +930,37 @@ class ModelServingService:
         return ModifyEndpointActionResult(
             endpoint_id=action.endpoint_id, success=result.success, data=result.data
         )
+
+    async def _model_definition_content_changed(
+        self,
+        endpoint_id: uuid.UUID,
+        spec: EndpointUpdaterSpec,
+    ) -> bool:
+        """Return True if the vfolder's model-definition.yaml differs from the
+        current revision's stored definition.
+
+        Reads the YAML straight from storage and compares with the stored
+        ModelDefinition, avoiding the cost of building a full
+        ``ModelRevisionCreator`` solely for change detection. If the file is
+        missing or unreadable we treat it as "no change" (conservative).
+        """
+        current_rev = await self._deployment_repository.get_current_revision(endpoint_id)
+        vfolder_id = current_rev.model_mount_config.vfolder_id
+        if vfolder_id is None:
+            return False
+        path = (
+            spec.model_definition_path.optional_value()
+            or current_rev.model_mount_config.definition_path
+        )
+        try:
+            raw = await self._deployment_repository.fetch_model_definition(
+                vfolder_id=vfolder_id,
+                model_definition_path=path,
+            )
+        except Exception:
+            return False
+        fresh = ModelDefinition.model_validate(raw)
+        return fresh != current_rev.model_definition
 
     async def _build_revision_creator_from_spec(
         self,
@@ -993,7 +1036,11 @@ class ModelServingService:
                     or current_rev.model_runtime_config.runtime_variant
                 ),
             ),
-            model_definition=current_rev.model_definition,
+            # Legacy EndpointUpdaterSpec has no user-provided model_definition
+            # override; leaving this as None lets the resolve pipeline pick up
+            # the current vfolder YAML instead of re-merging the previous
+            # revision's already-resolved definition back on top of it.
+            model_definition=None,
         )
 
     async def validate_model_service(

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -526,7 +526,7 @@ class DeploymentController:
         """Generate the final model definition for a revision.
 
         Delegates to ModelDefinitionGeneratorRegistry for the full merge:
-        programmatic generation → user override → storage file override.
+        programmatic generation → vfolder file override → user override.
         """
         context = ModelDefinitionContext(
             mounts=MountMetadata(

--- a/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
+++ b/tests/unit/manager/services/model_serving/actions/test_model_serving_crud_actions.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.events.dispatcher import EventDispatcher
@@ -253,11 +254,30 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
         spec.runtime_variant = OptionalState.nop()
         return spec
 
+    def _mock_current_revision(self) -> MagicMock:
+        """Build a MagicMock shaped like ModelRevisionData for
+        `_build_revision_creator_from_spec`.
+        """
+        mock_current_rev = MagicMock()
+        mock_current_rev.image_id = uuid.uuid4()
+        mock_current_rev.cluster_config.mode = "SINGLE_NODE"
+        mock_current_rev.cluster_config.size = 1
+        mock_current_rev.resource_config.resource_slot = {}
+        mock_current_rev.resource_config.resource_opts = {}
+        mock_current_rev.model_mount_config.vfolder_id = uuid.uuid4()
+        mock_current_rev.model_mount_config.definition_path = "model-definition.yaml"
+        mock_current_rev.model_mount_config.mount_destination = "/models"
+        mock_current_rev.model_runtime_config.environ = None
+        mock_current_rev.model_runtime_config.runtime_variant = "custom"
+        mock_current_rev.model_definition = None
+        return mock_current_rev
+
     async def test_replica_count_change_marks_check_replica(
         self,
         model_serving_processors: ModelServingProcessors,
         mock_modify_endpoint: AsyncMock,
         mock_deployment_controller: MagicMock,
+        mock_deployment_repository: MagicMock,
         endpoint_id: uuid.UUID,
     ) -> None:
         """replica_count change (2->5) returns success=true with CHECK_REPLICA marking."""
@@ -269,6 +289,15 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
         mock_endpoint_data.id = endpoint_id
         mock_modify_endpoint.return_value = MutationResult(
             success=True, message="ok", data=mock_endpoint_data
+        )
+
+        # has_revision_changes=False → modify_endpoint reads current_rev and
+        # fetches the vfolder YAML to compare. Stub the fetch to raise so the
+        # helper treats it as "no change" and falls through to CHECK_REPLICA.
+        mock_current_rev = self._mock_current_revision()
+        mock_deployment_repository.get_current_revision = AsyncMock(return_value=mock_current_rev)
+        mock_deployment_repository.fetch_model_definition = AsyncMock(
+            side_effect=Exception("no file"),
         )
 
         action = ModifyEndpointAction(endpoint_id=endpoint_id, updater=mock_updater)
@@ -334,9 +363,10 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
         model_serving_processors: ModelServingProcessors,
         mock_modify_endpoint: AsyncMock,
         mock_deployment_controller: MagicMock,
+        mock_deployment_repository: MagicMock,
         endpoint_id: uuid.UUID,
     ) -> None:
-        """No replica change returns success without CHECK_REPLICA marking."""
+        """No replica change and unchanged YAML returns success with no side effects."""
         updater_spec = self._make_updater_spec(replicas=None)
         mock_updater = MagicMock()
         mock_updater.spec = updater_spec
@@ -347,10 +377,68 @@ class TestModifyEndpoint(ModelServingCRUDBaseFixtures):
             success=True, message="ok", data=mock_endpoint_data
         )
 
+        mock_current_rev = self._mock_current_revision()
+        mock_deployment_repository.get_current_revision = AsyncMock(return_value=mock_current_rev)
+        mock_deployment_repository.fetch_model_definition = AsyncMock(
+            side_effect=Exception("no file"),
+        )
+        mock_deployment_controller.add_revision = AsyncMock()
+        mock_deployment_controller.activate_revision = AsyncMock()
+
         action = ModifyEndpointAction(endpoint_id=endpoint_id, updater=mock_updater)
         result = await model_serving_processors.modify_endpoint.wait_for_complete(action)
 
         assert result.success is True
+        mock_deployment_controller.mark_lifecycle_needed.assert_not_called()
+        mock_deployment_controller.add_revision.assert_not_called()
+        mock_deployment_controller.activate_revision.assert_not_called()
+
+    async def test_model_definition_yaml_change_triggers_revision(
+        self,
+        model_serving_processors: ModelServingProcessors,
+        mock_modify_endpoint: AsyncMock,
+        mock_deployment_controller: MagicMock,
+        mock_deployment_repository: MagicMock,
+        endpoint_id: uuid.UUID,
+    ) -> None:
+        """Editing model-definition.yaml in the vfolder (with no other argument
+        changes) must create and activate a new revision.
+        """
+        updater_spec = self._make_updater_spec(replicas=None, has_revision_changes=False)
+        mock_updater = MagicMock()
+        mock_updater.spec = updater_spec
+
+        mock_endpoint_data = MagicMock()
+        mock_endpoint_data.id = endpoint_id
+        mock_modify_endpoint.return_value = MutationResult(
+            success=True, message="ok", data=mock_endpoint_data
+        )
+
+        # Stored vs. on-disk definitions differ → helper detects a change and
+        # forces a new revision.
+        mock_current_rev = self._mock_current_revision()
+        mock_current_rev.model_definition = ModelDefinition.model_validate({
+            "models": [{"name": "old", "model_path": "/models/old"}],
+        })
+        mock_deployment_repository.get_current_revision = AsyncMock(return_value=mock_current_rev)
+        mock_deployment_repository.fetch_model_definition = AsyncMock(
+            return_value={"models": [{"name": "new", "model_path": "/models/new"}]},
+        )
+
+        mock_revision = MagicMock()
+        mock_revision.id = uuid.uuid4()
+        mock_deployment_controller.add_revision = AsyncMock(return_value=mock_revision)
+        mock_deployment_controller.activate_revision = AsyncMock()
+
+        action = ModifyEndpointAction(endpoint_id=endpoint_id, updater=mock_updater)
+        result = await model_serving_processors.modify_endpoint.wait_for_complete(action)
+
+        assert result.success is True
+        mock_deployment_repository.fetch_model_definition.assert_awaited_once()
+        mock_deployment_controller.add_revision.assert_awaited_once()
+        mock_deployment_controller.activate_revision.assert_awaited_once_with(
+            endpoint_id, mock_revision.id
+        )
         mock_deployment_controller.mark_lifecycle_needed.assert_not_called()
 
     async def test_non_existent_endpoint_raises(


### PR DESCRIPTION
## Summary
- Legacy `modify_endpoint` (GQL) silently ignored edits to a model vfolder's `model-definition.yaml` when no other argument changed — the resulting spec fields were identical, `has_revision_changes()` returned `False`, and no new revision was created.
- Even when a revision *did* get created, the previous revision's fully-resolved `model_definition` was re-used as a "user override" on the new revision. The resolver merged that stale snapshot back on top of the freshly-read YAML, masking the on-disk edit.

## Changes
- `services/model_serving/services/model_serving.py`
  - `_build_revision_creator_from_spec` now passes `model_definition=None`. The legacy `EndpointUpdaterSpec` has no user-override field, so the resolver reads the current vfolder YAML cleanly instead of re-merging the previous snapshot.
  - `modify_endpoint` fetches the vfolder YAML directly via `DeploymentRepository.fetch_model_definition` and compares it with `current_rev.model_definition`; any difference joins `has_revision_changes()` via a short-circuit `or` to force a new revision + activation. The full `ModelRevisionCreator` is only built when we actually need to create a revision.
- `sokovan/deployment/deployment_controller.py` — no API change; the temporary public wrapper added during iteration was dropped again so `_resolve_model_definition` stays private.
- Tests — updated two existing `TestModifyEndpoint` tests to mock the direct-fetch helper and added `test_model_definition_yaml_change_triggers_revision` covering the YAML-only-edit path.

## Test plan
- [x] `pants fmt / lint / test` on changed files + transitive dependents
- [x] `TestModifyEndpoint::test_replica_count_change_marks_check_replica`
- [x] `TestModifyEndpoint::test_no_replica_change_no_marking`
- [x] `TestModifyEndpoint::test_revision_change_calls_add_and_activate_revision`
- [x] `TestModifyEndpoint::test_model_definition_yaml_change_triggers_revision` (new)
- [ ] E2E: edit `model-definition.yaml` in the model vfolder, call `modify_endpoint` with no other argument changes, confirm a new revision is created and the new content is served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)