### PR TITLE
fix(BA-5757): pass mounts to `add_revision` in admin revision refresh

### DIFF
--- a/changes/11148.fix.md
+++ b/changes/11148.fix.md
@@ -1,0 +1,1 @@
+Fix `./bai admin deployment revision refresh` failing with a `TypeError` on every deployment after the revision-merge pipeline refactor.

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -875,7 +875,16 @@ class DeploymentService:
             try:
                 spec = await self._deployment_repository.get_current_revision_spec(endpoint_id)
                 creator = _build_creator_from_revision_spec(spec)
-                new_revision = await self._deployment_controller.add_revision(endpoint_id, creator)
+                mounts = MountMetadata(
+                    model_vfolder_id=creator.mounts.model_vfolder_id,
+                    model_definition_path=creator.mounts.model_definition_path,
+                    model_mount_destination=creator.mounts.model_mount_destination,
+                )
+                new_revision = await self._deployment_controller.add_revision(
+                    endpoint_id=endpoint_id,
+                    overrides=revision_draft_from_creator(creator),
+                    mounts=mounts,
+                )
                 await self._deployment_controller.activate_revision(endpoint_id, new_revision.id)
                 results.append(
                     RevisionRefreshResult(


### PR DESCRIPTION
## Summary
- `./bai admin deployment revision refresh` was failing for every active deployment with `TypeError: DeploymentController.add_revision() missing 1 required positional argument: 'mounts'`.
- PR #11145 changed `add_revision()` to take an explicit `RevisionDraft` + `MountMetadata`, but `admin_refresh_deployment_revisions` was missed and kept calling it with a `ModelRevisionCreator`.
- Mirror the `add_model_revision` pattern: extract `MountMetadata` from the rebuilt creator and project it onto a `RevisionDraft` via `revision_draft_from_creator()` before calling `add_revision`.

Resolves BA-5757.