### PR TITLE
fix(BA-5758): replace broken revision name filter with `revision_number`

### DIFF
--- a/changes/11150.fix.md
+++ b/changes/11150.fix.md
@@ -1,0 +1,1 @@
+Replace the non-existent `name` filter on deployment revisions with a `revision_number` filter and ordering across the DTO, GraphQL, REST, and CLI layers (`./bai deployment revision search --name-contains` is replaced by `--revision-number`).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9110,7 +9110,7 @@ type ModelRevisionEdge
 input ModelRevisionFilter
   @join__type(graph: STRAWBERRY)
 {
-  name: StringFilter = null
+  revisionNumber: IntFilter = null
   deploymentId: ID = null
   AND: [ModelRevisionFilter!] = null
   OR: [ModelRevisionFilter!] = null
@@ -9129,7 +9129,7 @@ input ModelRevisionOrderBy
 enum ModelRevisionOrderField
   @join__type(graph: STRAWBERRY)
 {
-  NAME @join__enumValue(graph: STRAWBERRY)
+  REVISION_NUMBER @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5946,7 +5946,7 @@ type ModelRevisionEdge {
 
 """Added in 25.19.0. """
 input ModelRevisionFilter {
-  name: StringFilter = null
+  revisionNumber: IntFilter = null
   deploymentId: ID = null
   AND: [ModelRevisionFilter!] = null
   OR: [ModelRevisionFilter!] = null
@@ -5961,7 +5961,7 @@ input ModelRevisionOrderBy {
 
 """Added in 25.19.0. Fields available for ordering model revisions."""
 enum ModelRevisionOrderField {
-  NAME
+  REVISION_NUMBER
   CREATED_AT
 }
 

--- a/src/ai/backend/client/cli/v2/admin/deployment.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment.py
@@ -153,20 +153,23 @@ def revision_refresh() -> None:
 @click.option(
     "--order-by",
     multiple=True,
-    help="Order by field:direction (e.g., name:asc, created_at:desc).",
+    help="Order by field:direction (e.g., revision_number:asc, created_at:desc).",
 )
 @click.option(
-    "--name-contains", type=str, default=None, help="Filter revisions by name (contains)."
+    "--revision-number",
+    type=int,
+    default=None,
+    help="Filter revisions by revision number (exact match).",
 )
 def revision_search(
     deployment_id: str | None,
     limit: int | None,
     offset: int | None,
     order_by: tuple[str, ...],
-    name_contains: str | None,
+    revision_number: int | None,
 ) -> None:
     """Search deployment revisions (admin)."""
-    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.query import IntFilter
     from ai.backend.common.dto.manager.v2.deployment.request import (
         AdminSearchRevisionsInput,
         RevisionFilter,
@@ -176,9 +179,11 @@ def revision_search(
 
     # Build filter only if any filter option is provided
     filter_dto: RevisionFilter | None = None
-    if name_contains is not None or deployment_id is not None:
+    if revision_number is not None or deployment_id is not None:
         filter_dto = RevisionFilter(
-            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            revision_number=IntFilter(equals=revision_number)
+            if revision_number is not None
+            else None,
             deployment_id=UUID(deployment_id) if deployment_id is not None else None,
         )
 

--- a/src/ai/backend/client/cli/v2/deployment/revision.py
+++ b/src/ai/backend/client/cli/v2/deployment/revision.py
@@ -97,18 +97,26 @@ def current(deployment_id: str) -> None:
 
 @revision.command()
 @click.argument("deployment_id", type=str)
-@click.option("--name-contains", type=str, default=None, help="Filter by revision name")
+@click.option(
+    "--revision-number", type=int, default=None, help="Filter by revision number (exact match)"
+)
 @click.option("--limit", type=int, default=20, help="Maximum number of results")
 @click.option("--offset", type=int, default=0, help="Offset for pagination")
-def search(deployment_id: str, name_contains: str | None, limit: int, offset: int) -> None:
+def search(deployment_id: str, revision_number: int | None, limit: int, offset: int) -> None:
     """Search revisions for a deployment."""
 
+    from ai.backend.common.dto.manager.query import IntFilter
     from ai.backend.common.dto.manager.v2.deployment.request import (
         AdminSearchRevisionsInput,
+        RevisionFilter,
     )
 
+    filter_dto: RevisionFilter | None = None
+    if revision_number is not None:
+        filter_dto = RevisionFilter(revision_number=IntFilter(equals=revision_number))
+
     body = AdminSearchRevisionsInput(
-        filter=f'name_contains: "{name_contains}"' if name_contains else None,
+        filter=filter_dto,
         limit=limit,
         offset=offset,
     )

--- a/src/ai/backend/common/dto/manager/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/deployment/request.py
@@ -19,7 +19,7 @@ from ai.backend.common.data.model_deployment.types import (
     RouteStatus,
     RouteTrafficStatus,
 )
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import IntFilter, StringFilter
 from ai.backend.common.types import ClusterMode, RuntimeVariant
 
 from .types import DeploymentOrder, RevisionOrder, RouteOrder
@@ -76,7 +76,7 @@ class DeploymentFilter(BaseRequestModel):
 class RevisionFilter(BaseRequestModel):
     """Filter for revisions."""
 
-    name: StringFilter | None = Field(default=None, description="Filter by name")
+    revision_number: IntFilter | None = Field(default=None, description="Filter by revision number")
     deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
 
 

--- a/src/ai/backend/common/dto/manager/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/deployment/types.py
@@ -30,7 +30,7 @@ class DeploymentOrderField(enum.StrEnum):
 class RevisionOrderField(enum.StrEnum):
     """Fields that can be used for ordering revisions."""
 
-    NAME = "name"
+    REVISION_NUMBER = "revision_number"
     CREATED_AT = "created_at"
 
 

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -20,7 +20,12 @@ from ai.backend.common.data.model_deployment.types import (
     RouteStatus,
     RouteTrafficStatus,
 )
-from ai.backend.common.dto.manager.query import DateTimeFilter, NullableDateTimeFilter, StringFilter
+from ai.backend.common.dto.manager.query import (
+    DateTimeFilter,
+    IntFilter,
+    NullableDateTimeFilter,
+    StringFilter,
+)
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment.types import (
     AccessTokenOrderField,
@@ -523,7 +528,7 @@ DeploymentFilter.model_rebuild()
 class RevisionFilter(BaseRequestModel):
     """Filter for deployment revisions."""
 
-    name: StringFilter | None = Field(default=None, description="Name filter")
+    revision_number: IntFilter | None = Field(default=None, description="Filter by revision number")
     deployment_id: UUID | None = Field(default=None, description="Filter by deployment ID")
     AND: list[RevisionFilter] | None = Field(default=None, description="AND conjunction")
     OR: list[RevisionFilter] | None = Field(default=None, description="OR conjunction")

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -87,7 +87,7 @@ class DeploymentOrderField(StrEnum):
 class RevisionOrderField(StrEnum):
     """Fields available for ordering deployment revisions."""
 
-    NAME = "name"
+    REVISION_NUMBER = "revision_number"
     CREATED_AT = "created_at"
 
 

--- a/src/ai/backend/manager/api/adapters/deployment.py
+++ b/src/ai/backend/manager/api/adapters/deployment.py
@@ -1589,14 +1589,10 @@ class DeploymentAdapter(BaseAdapter):
 
     def _convert_revision_filter(self, f: RevisionFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
-        if f.name is not None:
-            condition = self.convert_string_filter(
-                f.name,
-                contains_factory=RevisionConditions.by_name_contains,
-                equals_factory=RevisionConditions.by_name_equals,
-                starts_with_factory=RevisionConditions.by_name_starts_with,
-                ends_with_factory=RevisionConditions.by_name_ends_with,
-                in_factory=RevisionConditions.by_name_in,
+        if f.revision_number is not None:
+            condition = self.convert_int_filter(
+                f.revision_number,
+                RevisionConditions.by_revision_number,
             )
             if condition is not None:
                 conditions.append(condition)
@@ -2048,8 +2044,8 @@ class DeploymentAdapter(BaseAdapter):
         for o in orders:
             ascending = o.direction == OrderDirection.ASC
             match o.field:
-                case RevisionOrderField.NAME:
-                    result.append(RevisionOrders.name(ascending))
+                case RevisionOrderField.REVISION_NUMBER:
+                    result.append(RevisionOrders.revision_number(ascending))
                 case RevisionOrderField.CREATED_AT:
                     result.append(RevisionOrders.created_at(ascending))
         return result

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -104,8 +104,8 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import MountPermission as CommonMountPermission
 from ai.backend.manager.api.gql.base import (
+    IntFilter,
     OrderDirection,
-    StringFilter,
     to_global_id,
 )
 from ai.backend.manager.api.gql.common.types import (
@@ -542,7 +542,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     name="ModelRevisionOrderField",
 )
 class ModelRevisionOrderFieldGQL(StrEnum):
-    NAME = "name"
+    REVISION_NUMBER = "revision_number"
     CREATED_AT = "created_at"
 
 
@@ -552,7 +552,7 @@ class ModelRevisionOrderFieldGQL(StrEnum):
     name="ModelRevisionFilter",
 )
 class ModelRevisionFilter(PydanticInputMixin[RevisionFilterDTO]):
-    name: StringFilter | None = None
+    revision_number: IntFilter | None = None
     deployment_id: ID | None = None
 
     AND: list[Self] | None = None

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -261,15 +261,11 @@ class RevisionAdapter(BaseFilterAdapter):
         """Convert revision filter to list of query conditions."""
         conditions: list[QueryCondition] = []
 
-        # Name filter
-        if filter.name is not None:
-            condition = self.convert_string_filter(
-                filter.name,
-                contains_factory=RevisionConditions.by_name_contains,
-                equals_factory=RevisionConditions.by_name_equals,
-                starts_with_factory=RevisionConditions.by_name_starts_with,
-                ends_with_factory=RevisionConditions.by_name_ends_with,
-                in_factory=RevisionConditions.by_name_in,
+        # Revision number filter
+        if filter.revision_number is not None:
+            condition = self.convert_int_filter(
+                filter.revision_number,
+                RevisionConditions.by_revision_number,
             )
             if condition is not None:
                 conditions.append(condition)
@@ -284,8 +280,8 @@ class RevisionAdapter(BaseFilterAdapter):
         """Convert revision order specification to query order."""
         ascending = order.direction == OrderDirection.ASC
 
-        if order.field == RevisionOrderField.NAME:
-            return RevisionOrders.name(ascending=ascending)
+        if order.field == RevisionOrderField.REVISION_NUMBER:
+            return RevisionOrders.revision_number(ascending=ascending)
         if order.field == RevisionOrderField.CREATED_AT:
             return RevisionOrders.created_at(ascending=ascending)
         raise ValueError(f"Unknown order field: {order.field}")

--- a/src/ai/backend/manager/models/deployment_revision/conditions.py
+++ b/src/ai/backend/manager/models/deployment_revision/conditions.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Collection
-from typing import cast
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringInMatchSpec, StringMatchSpec
+from ai.backend.manager.models.condition_utils import make_int_conditions
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.repositories.base import QueryCondition
 
@@ -30,72 +29,7 @@ class RevisionConditions:
 
         return inner
 
-    @staticmethod
-    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.case_insensitive:
-                condition = sa.func.lower(DeploymentRevisionRow.name) == spec.value.lower()
-            else:
-                condition = DeploymentRevisionRow.name == spec.value
-            if spec.negated:
-                condition = sa.not_(condition)
-            return condition
-
-        return inner
-
-    @staticmethod
-    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.case_insensitive:
-                condition = DeploymentRevisionRow.name.ilike(f"%{spec.value}%")
-            else:
-                condition = DeploymentRevisionRow.name.like(f"%{spec.value}%")
-            if spec.negated:
-                condition = sa.not_(condition)
-            return cast(sa.sql.expression.ColumnElement[bool], condition)
-
-        return inner
-
-    @staticmethod
-    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.case_insensitive:
-                condition = DeploymentRevisionRow.name.ilike(f"{spec.value}%")
-            else:
-                condition = DeploymentRevisionRow.name.like(f"{spec.value}%")
-            if spec.negated:
-                condition = sa.not_(condition)
-            return cast(sa.sql.expression.ColumnElement[bool], condition)
-
-        return inner
-
-    @staticmethod
-    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.case_insensitive:
-                condition = DeploymentRevisionRow.name.ilike(f"%{spec.value}")
-            else:
-                condition = DeploymentRevisionRow.name.like(f"%{spec.value}")
-            if spec.negated:
-                condition = sa.not_(condition)
-            return cast(sa.sql.expression.ColumnElement[bool], condition)
-
-        return inner
-
-    @staticmethod
-    def by_name_in(spec: StringInMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            if spec.case_insensitive:
-                condition = sa.func.lower(DeploymentRevisionRow.name).in_([
-                    v.lower() for v in spec.values
-                ])
-            else:
-                condition = DeploymentRevisionRow.name.in_(spec.values)
-            if spec.negated:
-                condition = sa.not_(condition)
-            return cast(sa.sql.expression.ColumnElement[bool], condition)
-
-        return inner
+    by_revision_number = make_int_conditions(DeploymentRevisionRow.revision_number)
 
     @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:

--- a/src/ai/backend/manager/models/deployment_revision/orders.py
+++ b/src/ai/backend/manager/models/deployment_revision/orders.py
@@ -12,10 +12,10 @@ class RevisionOrders:
     """Query orders for revisions."""
 
     @staticmethod
-    def name(ascending: bool = True) -> QueryOrder:
+    def revision_number(ascending: bool = True) -> QueryOrder:
         if ascending:
-            return cast(QueryOrder, DeploymentRevisionRow.name.asc())
-        return cast(QueryOrder, DeploymentRevisionRow.name.desc())
+            return cast(QueryOrder, DeploymentRevisionRow.revision_number.asc())
+        return cast(QueryOrder, DeploymentRevisionRow.revision_number.desc())
 
     @staticmethod
     def created_at(ascending: bool = True) -> QueryOrder:

--- a/tests/unit/common/dto/manager/v2/deployment/test_types.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_types.py
@@ -99,8 +99,8 @@ class TestDeploymentOrderField:
 class TestRevisionOrderField:
     """Tests for RevisionOrderField enum."""
 
-    def test_name_value(self) -> None:
-        assert RevisionOrderField.NAME.value == "name"
+    def test_revision_number_value(self) -> None:
+        assert RevisionOrderField.REVISION_NUMBER.value == "revision_number"
 
     def test_created_at_value(self) -> None:
         assert RevisionOrderField.CREATED_AT.value == "created_at"


### PR DESCRIPTION
## Summary
- `deployment_revisions` has no `name` column — revisions are identified by `revision_number`, and `revision-{N}` is only a display-side composition in Python. The entire `RevisionFilter.name` / `RevisionOrderField.NAME` path was non-functional end-to-end: pydantic `ValidationError` in the CLI and `AttributeError` on `DeploymentRevisionRow.name` in the repository.
- Drop the dead `name` field/enum value from the DTO (v2 + legacy), GraphQL (`ModelRevisionFilter`, `ModelRevisionOrderFieldGQL`), manager adapter (v2 + REST v1), row-level conditions/orders, and both revision search CLIs. Add a working `revision_number: IntFilter` and `RevisionOrderField.REVISION_NUMBER` equivalent (`make_int_conditions(DeploymentRevisionRow.revision_number)` plus a matching ordering method).
- CLI: `./bai deployment revision search --name-contains <str>` → `--revision-number <int>` (exact match), same for the admin-scoped `./bai admin deployment revision search` variant. The corresponding v2 `RevisionOrderField` enum test is updated to match.

Resolves BA-5758.