### PR TITLE
fix(BA-5766): accept aware datetimes or Unix timestamps in CLI execute

### DIFF
--- a/changes/11163.fix.md
+++ b/changes/11163.fix.md
@@ -1,0 +1,1 @@
+Fix Prometheus range query 502 error by using Unix timestamps instead of naive datetime isoformat

--- a/changes/11163.fix.md
+++ b/changes/11163.fix.md
@@ -1,1 +1,1 @@
-Fix Prometheus range query 502 error by using Unix timestamps instead of naive datetime isoformat
+Fix Prometheus range query 502 errors by accepting timezone-aware datetimes or Unix timestamps in CLI execute inputs

--- a/src/ai/backend/client/cli/v2/prometheus_query_preset/commands.py
+++ b/src/ai/backend/client/cli/v2/prometheus_query_preset/commands.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 import click
@@ -27,6 +27,51 @@ from ai.backend.client.cli.v2.helpers import (
     parse_order_options,
     print_result,
 )
+
+_DATETIME_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S%z",
+)
+
+
+class PrometheusTimestampParamType(click.ParamType):
+    """Parse timezone-aware ISO8601 values or Unix timestamps for Prometheus."""
+
+    name = "prometheus-timestamp"
+
+    def __init__(self) -> None:
+        self._datetime_parser = click.DateTime(formats=_DATETIME_FORMATS)
+
+    def convert(
+        self,
+        value: object,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> datetime:
+        if isinstance(value, datetime):
+            return value
+
+        if isinstance(value, str):
+            try:
+                return datetime.fromtimestamp(float(value), tz=UTC)
+            except ValueError:
+                pass
+
+        try:
+            parsed = self._datetime_parser.convert(value, param, ctx)
+        except click.BadParameter:
+            self.fail(
+                "must be a timezone-aware ISO8601 datetime "
+                "(for example: 2026-04-16T23:00:00+09:00 or 2026-04-16T14:00:00Z) "
+                "or a Unix timestamp (for example: 1713372000)",
+                param,
+                ctx,
+            )
+
+        return cast("datetime", parsed)
+
+
+prometheus_timestamp = PrometheusTimestampParamType()
 
 
 @click.group(name="prometheus-query-definition")
@@ -138,8 +183,18 @@ def _parse_label_filters(labels: tuple[str, ...]) -> list[MetricLabelEntry]:
 
 @prometheus_query_preset.command()
 @click.argument("preset_id", type=click.UUID)
-@click.option("--start", type=click.DateTime(), default=None, help="Start time (ISO8601).")
-@click.option("--end", type=click.DateTime(), default=None, help="End time (ISO8601).")
+@click.option(
+    "--start",
+    type=prometheus_timestamp,
+    default=None,
+    help="Start time (timezone-aware ISO8601 or Unix timestamp).",
+)
+@click.option(
+    "--end",
+    type=prometheus_timestamp,
+    default=None,
+    help="End time (timezone-aware ISO8601 or Unix timestamp).",
+)
 @click.option("--step", type=str, default=None, help="Step duration (e.g. 60s).")
 @click.option(
     "--label",

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -5,7 +5,7 @@ Request DTOs for prometheus_query_preset DTO v2.
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import Field, field_validator
@@ -45,13 +45,6 @@ class QueryTimeRangeInputDTO(BaseRequestModel):
     start: datetime = Field(description="Start of the time range.")
     end: datetime = Field(description="End of the time range.")
     step: str = Field(description="Query resolution step (e.g., '60s').")
-
-    @field_validator("start", "end")
-    @classmethod
-    def ensure_timezone_aware(cls, v: datetime) -> datetime:
-        if v.tzinfo is None:
-            return v.replace(tzinfo=UTC)
-        return v
 
 
 class CreateQueryDefinitionOptionsInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -5,7 +5,7 @@ Request DTOs for prometheus_query_preset DTO v2.
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from pydantic import Field, field_validator
@@ -45,6 +45,13 @@ class QueryTimeRangeInputDTO(BaseRequestModel):
     start: datetime = Field(description="Start of the time range.")
     end: datetime = Field(description="End of the time range.")
     step: str = Field(description="Query resolution step (e.g., '60s').")
+
+    @field_validator("start", "end")
+    @classmethod
+    def ensure_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=UTC)
+        return v
 
 
 class CreateQueryDefinitionOptionsInput(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
@@ -176,8 +176,8 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
         )
         qtr = (
             QueryTimeRange(
-                start=time_range.start.isoformat(),
-                end=time_range.end.isoformat(),
+                start=str(time_range.start.timestamp()),
+                end=str(time_range.end.timestamp()),
                 step=time_range.step,
             )
             if time_range is not None

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset.py
@@ -176,8 +176,8 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
         )
         qtr = (
             QueryTimeRange(
-                start=str(time_range.start.timestamp()),
-                end=str(time_range.end.timestamp()),
+                start=time_range.start.isoformat(),
+                end=time_range.end.isoformat(),
                 step=time_range.step,
             )
             if time_range is not None

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -207,7 +207,7 @@ def prometheus_container() -> Iterator[tuple[str, HostPortPairModel]]:
         DockerContainer("prom/prometheus:v2.53.0")
         .with_name(f"test--prometheus-slot-{get_parallel_slot()}-{random_id}")
         .with_exposed_ports(9090)
-        .with_kwargs(tmpfs={"/prometheus": ""})
+        .with_kwargs(tmpfs={"/prometheus": "rw,uid=65534,gid=65534"})
         .with_command(
             "--config.file=/etc/prometheus/prometheus.yml "
             "--storage.tsdb.path=/prometheus "

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -26,6 +26,7 @@ RedisContainerFixture = tuple[str, HostPortPairModel]
 EtcdContainerFixture = tuple[str, HostPortPairModel]
 PostgresContainerFixture = tuple[str, HostPortPairModel]
 MinioContainerFixture = tuple[str, HostPortPairModel]
+PrometheusContainerFixture = tuple[str, HostPortPairModel]
 
 log = logging.getLogger(__spec__.name)
 
@@ -193,5 +194,38 @@ def minio_container() -> Iterator[tuple[str, HostPortPairModel]]:
         time.sleep(0.2)
 
         yield container.get_container_host_ip(), HostPortPairModel(host="127.0.0.1", port=api_port)
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="session", autouse=False)
+def prometheus_container() -> Iterator[tuple[str, HostPortPairModel]]:
+    # Spawn a single-node Prometheus container for a testing session.
+    random_id = secrets.token_hex(8)
+
+    container = (
+        DockerContainer("prom/prometheus:v2.53.0")
+        .with_name(f"test--prometheus-slot-{get_parallel_slot()}-{random_id}")
+        .with_exposed_ports(9090)
+        .with_kwargs(tmpfs={"/prometheus": ""})
+        .with_command(
+            "--config.file=/etc/prometheus/prometheus.yml "
+            "--storage.tsdb.path=/prometheus "
+            "--storage.tsdb.retention.time=1h"
+        )
+    )
+
+    log.info("spawning prometheus container (parallel slot: %d)", get_parallel_slot())
+    container.start()
+    published_port = int(container.get_exposed_port(9090))
+
+    try:
+        wait_for_logs(container, "Server is ready to receive web requests.")
+        time.sleep(0.5)
+
+        yield (
+            container.get_container_host_ip(),
+            HostPortPairModel(host="127.0.0.1", port=published_port),
+        )
     finally:
         container.stop()

--- a/tests/component/common/clients/prometheus/BUILD
+++ b/tests/component/common/clients/prometheus/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/component/common/clients/prometheus/test_client_integration.py
+++ b/tests/component/common/clients/prometheus/test_client_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import pytest
@@ -24,7 +24,7 @@ async def prometheus_client(
     hostport = prometheus_container[1]
     pool = ClientPool(tcp_client_session_factory)
     client = PrometheusClient(
-        endpoint=f"http://{hostport.host}:{hostport.port}/api/v1",
+        endpoint=f"http://{hostport.host}:{hostport.port}/api/v1/",
         client_pool=pool,
     )
     try:
@@ -79,19 +79,19 @@ class TestQueryRangeTimestampFormats:
         with pytest.raises(FailedToGetMetric, match="cannot parse"):
             await prometheus_client.query_range(up_metric_preset, time_range)
 
-    async def test_naive_datetime_as_unix_timestamp_succeeds(
+    async def test_timezone_aware_datetime_isoformat_succeeds(
         self,
         prometheus_client: PrometheusClient,
         up_metric_preset: MetricPreset,
     ) -> None:
-        """Fix verification: converting naive datetime via .timestamp() produces
-        a valid Unix timestamp that Prometheus accepts."""
-        now = datetime.now(tz=UTC)
-        one_minute_ago = datetime.fromtimestamp(now.timestamp() - 60, tz=UTC)
+        """Timezone-aware RFC3339 datetimes should be accepted by Prometheus."""
+        kst = timezone(timedelta(hours=9))
+        end = datetime.now(tz=kst)
+        start = end - timedelta(minutes=1)
 
         time_range = QueryTimeRange(
-            start=str(one_minute_ago.timestamp()),
-            end=str(now.timestamp()),
+            start=start.isoformat(),
+            end=end.isoformat(),
             step="15s",
         )
 

--- a/tests/unit/client/cli/test_prometheus_query_preset_commands.py
+++ b/tests/unit/client/cli/test_prometheus_query_preset_commands.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import click
+import pytest
+
+from ai.backend.client.cli.v2.prometheus_query_preset.commands import prometheus_timestamp
+
+
+class TestPrometheusTimestampParamType:
+    """Tests for Prometheus CLI timestamp parsing."""
+
+    def test_parse_timezone_aware_iso8601(self) -> None:
+        parsed = prometheus_timestamp.convert("2026-04-16T23:00:00+09:00", None, None)
+
+        assert parsed == datetime(2026, 4, 16, 23, 0, 0, tzinfo=timezone(timedelta(hours=9)))
+
+    def test_parse_utc_z_suffix(self) -> None:
+        parsed = prometheus_timestamp.convert("2026-04-16T14:00:00Z", None, None)
+
+        assert parsed == datetime(2026, 4, 16, 14, 0, 0, tzinfo=UTC)
+
+    def test_parse_unix_timestamp(self) -> None:
+        parsed = prometheus_timestamp.convert("1713372000", None, None)
+
+        assert parsed == datetime.fromtimestamp(1713372000, tz=UTC)
+
+    def test_reject_naive_datetime(self) -> None:
+        with pytest.raises(click.BadParameter, match="timezone-aware ISO8601 datetime"):
+            prometheus_timestamp.convert("2026-04-16T23:00:00", None, None)

--- a/tests/unit/common/clients/prometheus/test_client_integration.py
+++ b/tests/unit/common/clients/prometheus/test_client_integration.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.common.clients.http_client.client_pool import ClientPool, tcp_client_session_factory
+from ai.backend.common.clients.prometheus import LabelMatcher, MetricPreset, PrometheusClient
+from ai.backend.common.dto.clients.prometheus import PrometheusResponse, QueryTimeRange
+from ai.backend.common.exception import FailedToGetMetric
+
+if TYPE_CHECKING:
+    from ai.backend.testutils.bootstrap import PrometheusContainerFixture
+
+from ai.backend.testutils.bootstrap import prometheus_container  # noqa: F401
+
+
+@pytest.fixture
+async def prometheus_client(
+    prometheus_container: PrometheusContainerFixture,  # noqa: F811
+) -> AsyncIterator[PrometheusClient]:
+    hostport = prometheus_container[1]
+    pool = ClientPool(tcp_client_session_factory)
+    client = PrometheusClient(
+        endpoint=f"http://{hostport.host}:{hostport.port}/api/v1",
+        client_pool=pool,
+    )
+    try:
+        yield client
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+def up_metric_preset() -> MetricPreset:
+    return MetricPreset(
+        template="up{{{labels}}}",
+        labels={"job": LabelMatcher.exact("prometheus")},
+        group_by=frozenset(),
+    )
+
+
+class TestQueryRangeTimestampFormats:
+    """Regression tests for BA-5766: Prometheus rejects naive datetime isoformat."""
+
+    async def test_unix_timestamp_succeeds(
+        self,
+        prometheus_client: PrometheusClient,
+        up_metric_preset: MetricPreset,
+    ) -> None:
+        now = datetime.now(tz=UTC)
+        time_range = QueryTimeRange(
+            start=str(now.timestamp() - 60),
+            end=str(now.timestamp()),
+            step="15s",
+        )
+
+        result = await prometheus_client.query_range(up_metric_preset, time_range)
+
+        assert isinstance(result, PrometheusResponse)
+        assert result.status == "success"
+        assert result.data.result_type == "matrix"
+
+    async def test_naive_datetime_isoformat_rejected(
+        self,
+        prometheus_client: PrometheusClient,
+        up_metric_preset: MetricPreset,
+    ) -> None:
+        """Regression: naive datetime.isoformat() produces a string without timezone
+        suffix (e.g., '2026-04-16T23:00:00') that Prometheus cannot parse."""
+        time_range = QueryTimeRange(
+            start="2026-04-16T23:00:00",
+            end="2026-04-16T23:15:00",
+            step="60s",
+        )
+
+        with pytest.raises(FailedToGetMetric, match="cannot parse"):
+            await prometheus_client.query_range(up_metric_preset, time_range)
+
+    async def test_naive_datetime_as_unix_timestamp_succeeds(
+        self,
+        prometheus_client: PrometheusClient,
+        up_metric_preset: MetricPreset,
+    ) -> None:
+        """Fix verification: converting naive datetime via .timestamp() produces
+        a valid Unix timestamp that Prometheus accepts."""
+        now = datetime.now(tz=UTC)
+        one_minute_ago = datetime.fromtimestamp(now.timestamp() - 60, tz=UTC)
+
+        time_range = QueryTimeRange(
+            start=str(one_minute_ago.timestamp()),
+            end=str(now.timestamp()),
+            step="15s",
+        )
+
+        result = await prometheus_client.query_range(up_metric_preset, time_range)
+
+        assert isinstance(result, PrometheusResponse)
+        assert result.status == "success"
+        assert result.data.result_type == "matrix"

--- a/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -19,6 +20,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     ModifyQueryDefinitionOptionsInput,
     QueryDefinitionFilter,
     QueryDefinitionOrder,
+    QueryTimeRangeInputDTO,
     SearchQueryDefinitionsInput,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import (
@@ -407,3 +409,48 @@ class TestExecuteQueryDefinitionInput:
         json_str = inp.model_dump_json()
         restored = ExecuteQueryDefinitionInput.model_validate_json(json_str)
         assert restored.time_window == "1h"
+
+
+class TestQueryTimeRangeInputDTO:
+    """Tests for QueryTimeRangeInputDTO model, including BA-5766 regression."""
+
+    @staticmethod
+    def _make_naive(iso: str) -> datetime:
+        """Create a naive datetime from an ISO string (bypasses DTZ001 lint rule)."""
+        return datetime.fromisoformat(iso).replace(tzinfo=None)
+
+    def test_naive_datetime_gets_utc_timezone(self) -> None:
+        """Regression BA-5766: naive datetime must be normalized to UTC."""
+        naive_start = self._make_naive("2026-04-16T23:00:00")
+        naive_end = self._make_naive("2026-04-16T23:15:00")
+        dto = QueryTimeRangeInputDTO(start=naive_start, end=naive_end, step="60s")
+
+        assert dto.start.tzinfo == UTC
+        assert dto.end.tzinfo == UTC
+        assert dto.start.year == 2026
+        assert dto.start.hour == 23
+
+    def test_aware_datetime_preserved(self) -> None:
+        kst = timezone(offset=__import__("datetime").timedelta(hours=9))
+        aware_start = datetime(2026, 4, 17, 8, 0, 0, tzinfo=kst)
+        aware_end = datetime(2026, 4, 17, 8, 15, 0, tzinfo=kst)
+        dto = QueryTimeRangeInputDTO(start=aware_start, end=aware_end, step="60s")
+
+        assert dto.start.tzinfo == kst
+        assert dto.end.tzinfo == kst
+
+    def test_utc_datetime_preserved(self) -> None:
+        utc_start = datetime(2026, 4, 16, 23, 0, 0, tzinfo=UTC)
+        utc_end = datetime(2026, 4, 16, 23, 15, 0, tzinfo=UTC)
+        dto = QueryTimeRangeInputDTO(start=utc_start, end=utc_end, step="15s")
+
+        assert dto.start.tzinfo == UTC
+        assert dto.end.tzinfo == UTC
+
+    def test_timestamp_from_normalized_naive_is_utc_based(self) -> None:
+        """After normalization, .timestamp() must produce UTC-based epoch."""
+        naive_dt = self._make_naive("2026-04-16T23:00:00")
+        dto = QueryTimeRangeInputDTO(start=naive_dt, end=naive_dt, step="60s")
+
+        expected_utc = datetime(2026, 4, 16, 23, 0, 0, tzinfo=UTC)
+        assert dto.start.timestamp() == expected_utc.timestamp()

--- a/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -20,7 +19,6 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     ModifyQueryDefinitionOptionsInput,
     QueryDefinitionFilter,
     QueryDefinitionOrder,
-    QueryTimeRangeInputDTO,
     SearchQueryDefinitionsInput,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import (
@@ -409,48 +407,3 @@ class TestExecuteQueryDefinitionInput:
         json_str = inp.model_dump_json()
         restored = ExecuteQueryDefinitionInput.model_validate_json(json_str)
         assert restored.time_window == "1h"
-
-
-class TestQueryTimeRangeInputDTO:
-    """Tests for QueryTimeRangeInputDTO model, including BA-5766 regression."""
-
-    @staticmethod
-    def _make_naive(iso: str) -> datetime:
-        """Create a naive datetime from an ISO string (bypasses DTZ001 lint rule)."""
-        return datetime.fromisoformat(iso).replace(tzinfo=None)
-
-    def test_naive_datetime_gets_utc_timezone(self) -> None:
-        """Regression BA-5766: naive datetime must be normalized to UTC."""
-        naive_start = self._make_naive("2026-04-16T23:00:00")
-        naive_end = self._make_naive("2026-04-16T23:15:00")
-        dto = QueryTimeRangeInputDTO(start=naive_start, end=naive_end, step="60s")
-
-        assert dto.start.tzinfo == UTC
-        assert dto.end.tzinfo == UTC
-        assert dto.start.year == 2026
-        assert dto.start.hour == 23
-
-    def test_aware_datetime_preserved(self) -> None:
-        kst = timezone(offset=__import__("datetime").timedelta(hours=9))
-        aware_start = datetime(2026, 4, 17, 8, 0, 0, tzinfo=kst)
-        aware_end = datetime(2026, 4, 17, 8, 15, 0, tzinfo=kst)
-        dto = QueryTimeRangeInputDTO(start=aware_start, end=aware_end, step="60s")
-
-        assert dto.start.tzinfo == kst
-        assert dto.end.tzinfo == kst
-
-    def test_utc_datetime_preserved(self) -> None:
-        utc_start = datetime(2026, 4, 16, 23, 0, 0, tzinfo=UTC)
-        utc_end = datetime(2026, 4, 16, 23, 15, 0, tzinfo=UTC)
-        dto = QueryTimeRangeInputDTO(start=utc_start, end=utc_end, step="15s")
-
-        assert dto.start.tzinfo == UTC
-        assert dto.end.tzinfo == UTC
-
-    def test_timestamp_from_normalized_naive_is_utc_based(self) -> None:
-        """After normalization, .timestamp() must produce UTC-based epoch."""
-        naive_dt = self._make_naive("2026-04-16T23:00:00")
-        dto = QueryTimeRangeInputDTO(start=naive_dt, end=naive_dt, step="60s")
-
-        expected_utc = datetime(2026, 4, 16, 23, 0, 0, tzinfo=UTC)
-        assert dto.start.timestamp() == expected_utc.timestamp()


### PR DESCRIPTION
resolve #11162 BA-5766

## Summary
- extend `./bai prometheus-query-definition execute` so `--start` / `--end` accept either timezone-aware ISO8601 datetimes or Unix timestamps
- keep the manager-side request DTO behavior aligned with `main` instead of adding extra timestamp normalization there
- restore RFC3339-style `isoformat()` serialization in the adapter and keep regression coverage in the Prometheus component test
- add a focused CLI unit test for the new timestamp parser

## Why
- Click's default `DateTime()` parser did not accept timezone-aware inputs such as `2026-04-16T23:00:00+09:00`
- Prometheus rejects naive datetime strings like `2026-04-16T23:00:00` for range queries
- allowing explicit timezone-aware datetimes and Unix timestamps in the CLI fixes the user-facing failure without broadening DTO semantics

## Test plan
- [x] `pants lint --only=ruff-check src/ai/backend/client/cli/v2/prometheus_query_preset/commands.py src/ai/backend/manager/api/adapters/prometheus_query_preset.py src/ai/backend/testutils/bootstrap.py tests/unit/client/cli/test_prometheus_query_preset_commands.py tests/component/common/clients/prometheus/test_client_integration.py`
- [x] `pants check src/ai/backend/client/cli/v2/prometheus_query_preset/commands.py tests/unit/client/cli/test_prometheus_query_preset_commands.py`
- [x] `pants test tests/unit/client/cli/test_prometheus_query_preset_commands.py tests/component/common/clients/prometheus/test_client_integration.py`
- [ ] `./bai prometheus-query-definition execute <id> --start '2026-04-16T23:00:00+09:00' --end '2026-04-16T23:15:00+09:00' --step 60s`
- [ ] `./bai prometheus-query-definition execute <id> --start 1713372000 --end 1713372900 --step 60s`
