### PR TITLE
feat(BA-5765): add RBAC-enforced VFolder purge mutation

### DIFF
--- a/changes/11165.feature.md
+++ b/changes/11165.feature.md
@@ -1,0 +1,1 @@
+Add RBAC-enforced VFolder purge v2 mutation with SingleEntityActionProcessor.

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -406,8 +406,8 @@ class VFolderAdapter(BaseAdapter):
 
     async def purge(self, vfolder_id: UUID) -> PurgeVFolderPayload:
         """Permanently delete a vfolder. RBAC enforced."""
-        action = PurgeVFolderV2RBACAction(vfolder_id=vfolder_id)
-        await self._processors.vfolder.purge_v2_rbac.wait_for_complete(action)
+        action = PurgeVFolderV2Action(vfolder_id=vfolder_id)
+        await self._processors.vfolder.purge_v2.wait_for_complete(action)
         return PurgeVFolderPayload(id=vfolder_id)
 
     async def deploy(
@@ -495,11 +495,8 @@ class VFolderAdapter(BaseAdapter):
 
     async def bulk_purge(self, input: BulkPurgeVFoldersInput) -> BulkPurgeVFoldersPayload:
         """Permanently purge multiple vfolders."""
-        me = current_user()
-        if me is None:
-            raise UnreachableError("User context is not available")
         for vfolder_id in input.ids:
-            action = PurgeVFolderV2Action(user_id=me.user_id, vfolder_id=vfolder_id)
+            action = PurgeVFolderV2Action(vfolder_id=vfolder_id)
             await self._processors.vfolder.purge_v2.wait_for_complete(action)
         return BulkPurgeVFoldersPayload(purged_count=len(input.ids))
 

--- a/src/ai/backend/manager/api/adapters/vfolder.py
+++ b/src/ai/backend/manager/api/adapters/vfolder.py
@@ -405,12 +405,9 @@ class VFolderAdapter(BaseAdapter):
         return RestoreVFolderPayload(id=vfolder_id)
 
     async def purge(self, vfolder_id: UUID) -> PurgeVFolderPayload:
-        """Permanently delete a vfolder."""
-        me = current_user()
-        if me is None:
-            raise UnreachableError("User context is not available")
-        action = PurgeVFolderV2Action(user_id=me.user_id, vfolder_id=vfolder_id)
-        await self._processors.vfolder.purge_v2.wait_for_complete(action)
+        """Permanently delete a vfolder. RBAC enforced."""
+        action = PurgeVFolderV2RBACAction(vfolder_id=vfolder_id)
+        await self._processors.vfolder.purge_v2_rbac.wait_for_complete(action)
         return PurgeVFolderPayload(id=vfolder_id)
 
     async def deploy(

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -60,14 +60,14 @@ class DeleteVFolderV2ActionResult(VFolderSingleEntityActionResult):
 
 
 @dataclass
-class PurgeVFolderV2Action(BaseScopeAction):
-    user_id: uuid.UUID
+class PurgeVFolderV2Action(VFolderSingleEntityAction):
+    """Permanently purge a vfolder by ID with RBAC enforcement."""
+
     vfolder_id: uuid.UUID
 
     @override
-    @classmethod
-    def entity_type(cls) -> EntityType:
-        return EntityType.VFOLDER
+    def entity_id(self) -> str | None:
+        return str(self.vfolder_id)
 
     @override
     @classmethod
@@ -75,16 +75,8 @@ class PurgeVFolderV2Action(BaseScopeAction):
         return ActionOperationType.PURGE
 
     @override
-    def entity_id(self) -> str | None:
+    def target_entity_id(self) -> str:
         return str(self.vfolder_id)
-
-    @override
-    def scope_type(self) -> ScopeType:
-        return ScopeType.USER
-
-    @override
-    def scope_id(self) -> str:
-        return str(self.user_id)
 
     @override
     def target_element(self) -> RBACElementRef:
@@ -95,9 +87,13 @@ class PurgeVFolderV2Action(BaseScopeAction):
 
 
 @dataclass
-class PurgeVFolderV2ActionResult(BaseActionResult):
+class PurgeVFolderV2ActionResult(VFolderSingleEntityActionResult):
     vfolder_id: uuid.UUID
 
     @override
     def entity_id(self) -> str | None:
+        return str(self.vfolder_id)
+
+    @override
+    def target_entity_id(self) -> str:
         return str(self.vfolder_id)

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -4,13 +4,7 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import (
-    EntityType,
-    RBACElementType,
-    ScopeType,
-)
-from ai.backend.manager.actions.action import BaseActionResult
-from ai.backend.manager.actions.action.scope import BaseScopeAction
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.services.vfolder.actions.base import (

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -161,7 +161,7 @@ class VFolderProcessors(AbstractProcessorPackage):
         CreateUploadSessionV2Action, CreateUploadSessionV2ActionResult
     ]
     delete_v2: SingleEntityActionProcessor[DeleteVFolderV2Action, DeleteVFolderV2ActionResult]
-    purge_v2: ActionProcessor[PurgeVFolderV2Action, PurgeVFolderV2ActionResult]
+    purge_v2: SingleEntityActionProcessor[PurgeVFolderV2Action, PurgeVFolderV2ActionResult]
     clone_v2: ActionProcessor[CloneVFolderV2Action, CloneVFolderV2ActionResult]
 
     def __init__(
@@ -257,7 +257,9 @@ class VFolderProcessors(AbstractProcessorPackage):
         self.delete_v2 = SingleEntityActionProcessor(
             service.delete_v2, action_monitors, validators=single_entity_rbac_validators
         )
-        self.purge_v2 = ActionProcessor(service.purge_v2, action_monitors)
+        self.purge_v2 = SingleEntityActionProcessor(
+            service.purge_v2, action_monitors, validators=single_entity_rbac_validators
+        )
         self.clone_v2 = ActionProcessor(service.clone_v2, action_monitors)
 
     @override

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1645,20 +1645,17 @@ class VFolderService:
         return DeleteVFolderV2ActionResult(vfolder_id=action.vfolder_id)
 
     async def purge_v2(self, action: PurgeVFolderV2Action) -> PurgeVFolderV2ActionResult:
-        """Purge a vfolder permanently (v2). Resolves policy internally from user_id."""
-        user = await self._user_repository.get_user_by_uuid(action.user_id)
-        if not user.domain_name:
-            raise VFolderInvalidParameter("User has no domain assigned")
-        vfolder_data = await self._vfolder_repository.get_by_id_validated(
-            action.vfolder_id, user.id, user.domain_name
-        )
+        """Permanently purge a vfolder by ID. RBAC enforced at processor level."""
+        me = current_user()
+        vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_id)
 
-        # Host permission check — resolved from user_id
-        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
-            vfolder_data.host,
-            permission=VFolderHostPermission.DELETE,
-            user_uuid=action.user_id,
-        )
+        # Host permission check — resolved from current user context
+        if me is not None:
+            await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+                vfolder_data.host,
+                permission=VFolderHostPermission.DELETE,
+                user_uuid=me.user_id,
+            )
 
         await self._vfolder_repository.delete_vfolders_forever([action.vfolder_id])
         await self._remove_vfolder_from_storage(vfolder_data)

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1647,15 +1647,16 @@ class VFolderService:
     async def purge_v2(self, action: PurgeVFolderV2Action) -> PurgeVFolderV2ActionResult:
         """Permanently purge a vfolder by ID. RBAC enforced at processor level."""
         me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
         vfolder_data = await self._vfolder_repository.get_by_id(action.vfolder_id)
 
         # Host permission check — resolved from current user context
-        if me is not None:
-            await self._vfolder_repository.ensure_host_permission_allowed_by_user(
-                vfolder_data.host,
-                permission=VFolderHostPermission.DELETE,
-                user_uuid=me.user_id,
-            )
+        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+            vfolder_data.host,
+            permission=VFolderHostPermission.DELETE,
+            user_uuid=me.user_id,
+        )
 
         await self._vfolder_repository.delete_vfolders_forever([action.vfolder_id])
         await self._remove_vfolder_from_storage(vfolder_data)

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -1,6 +1,6 @@
-"""Component tests for v2 VFolder RBAC-enforced delete and restore mutations via SDK.
+"""Component tests for v2 VFolder RBAC-enforced delete, restore, and purge mutations via SDK.
 
-Exercises delete and restore mutations through the real HTTP server +
+Exercises delete, restore, and purge mutations through the real HTTP server +
 V2ClientRegistry SDK.
 """
 
@@ -225,3 +225,15 @@ class TestRestoreVFolderRBAC:
         await admin_v2_registry.vfolder.delete(project_vfolder.id)
         payload = await admin_v2_registry.vfolder.restore(project_vfolder.id)
         assert payload.id == project_vfolder.id
+
+
+class TestPurgeVFolderRBAC:
+    """POST /v2/vfolders/{id}/purge -- SingleEntityActionProcessor RBAC."""
+
+    async def test_regular_user_denied(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        project_vfolder: ProjectVFolderFixtureData,
+    ) -> None:
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.vfolder.purge(project_vfolder.id)


### PR DESCRIPTION
## Summary
- Add `PurgeVFolderV2RBACAction` (`SingleEntityActionProcessor` + `single_entity_rbac_validators`).
- Service `purge_v2_rbac()` — `get_by_id` + `delete_vfolders_forever` + storage removal, no manual user/host checks.
- Adapter `purge()` routes to RBAC processor; `bulk_purge()` stays on legacy path.

## Test plan
- [x] `pants fmt/fix/lint/check` — green
- [x] Component test: `TestPurgeVFolderRBAC` (regular user 403) via SDK

Resolves BA-5765