### PR TITLE
docs: sync README with current accelerators, CLI, and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Backend.AI
 Backend.AI is a streamlined, container-based computing cluster platform
 that hosts popular computing/ML frameworks and diverse programming languages,
 with pluggable heterogeneous accelerator support including CUDA GPU, ROCm GPU,
-Rebellions, FuriosaAI, HyperAccel, Google TPU, Graphcore IPU and other NPUs.
+Rebellions, FuriosaAI, HyperAccel, Intel Gaudi, Tenstorrent, Google TPU,
+Graphcore IPU and other NPUs.
 
 It allocates and isolates the underlying computing resources for multi-tenant
 computation sessions on-demand or in batches with customizable job schedulers with its own orchestrator named "Sokovan".
@@ -308,11 +309,12 @@ Backend.AI supports plugin-based extensibility via Python package entrypoints:
 - [CUDA Mock](src/ai/backend/accelerator/cuda_mock) - Development without actual GPUs
 - [ROCm](src/ai/backend/accelerator/rocm) - AMD GPU support
 - [Furiosa](src/ai/backend/accelerator/furiosa) - Furiosa NPU (Warboy / RNGD) support
+- [Habana](src/ai/backend/accelerator/habana) - Intel Gaudi HPU (Gaudi 2, Gaudi 3) support
 - [Hyperaccel](src/ai/backend/accelerator/hyperaccel) - Hyperaccel LPU support
 - [IPU](src/ai/backend/accelerator/ipu) - Graphcore IPU support
 - [Rebellions](src/ai/backend/accelerator/rebellions) - Rebellions NPU (ATOM, ATOM+, ATOM Max) support
 - [Tenstorrent](src/ai/backend/accelerator/tenstorrent) - Tenstorrent NPU (Wormhole, Blackhole) support
-- [TPU](src/ai/backend/accelerator/tpu) - Google TPU (v2, v3) support
+- [TPU](src/ai/backend/accelerator/tpu) - Google TPU (v2 ~ Ironwood) support
 
 **Monitoring Plugins**
 - [`backendai_monitor_stats_v10`](https://github.com/lablup/backend.ai-monitor-datadog) - Datadog statistics collector

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Start each component in separate terminals:
 
 **Account Manager** (Terminal 5, optional for SSO and unified user profile):
 ```bash
-./backend.ai am start-server --debug
+./backend.ai am start-server
 ```
 
 **App Proxy** (Terminal 6-7, optional for in-container service access):

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Backend.AI supports plugin-based extensibility via Python package entrypoints:
 
 **Accelerator Plugins** (`backendai_accelerator_v21`)
 - [CUDA](src/ai/backend/accelerator/cuda_open) - NVIDIA GPU support
-- [CUDA Mock](src/ai/backend/accelerator/mock) - Development without actual GPUs
+- [Mock](src/ai/backend/accelerator/mock) - Development without actual GPUs
 - [ROCm](src/ai/backend/accelerator/rocm) - AMD GPU support
 - [Furiosa](src/ai/backend/accelerator/furiosa) - Furiosa NPU (Warboy / RNGD) support
 - [Habana](src/ai/backend/accelerator/habana) - Intel Gaudi HPU (Gaudi 2, Gaudi 3) support

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Backend.AI supports plugin-based extensibility via Python package entrypoints:
 - [IPU](src/ai/backend/accelerator/ipu) - Graphcore IPU support
 - [Rebellions](src/ai/backend/accelerator/rebellions) - Rebellions NPU (ATOM, ATOM+, ATOM Max) support
 - [Tenstorrent](src/ai/backend/accelerator/tenstorrent) - Tenstorrent NPU (Wormhole, Blackhole) support
-- [TPU](src/ai/backend/accelerator/tpu) - Google TPU (v2 ~ Ironwood) support
+- [TPU](src/ai/backend/accelerator/tpu) - Google TPU (v2 and newer generations) support
 
 **Monitoring Plugins**
 - [`backendai_monitor_stats_v10`](https://github.com/lablup/backend.ai-monitor-datadog) - Datadog statistics collector

--- a/README.md
+++ b/README.md
@@ -87,15 +87,20 @@ Start each component in separate terminals:
 
 **Storage Proxy** (Terminal 3):
 ```bash
-./py -m ai.backend.storage.server
+./backend.ai storage start-server --debug
 ```
 
 **Web Server** (Terminal 4):
 ```bash
-./py -m ai.backend.web.server
+./backend.ai web start-server --debug
 ```
 
-**App Proxy** (Terminal 5-6, optional for in-container service access):
+**Account Manager** (Terminal 5, optional for SSO and unified user profile):
+```bash
+./backend.ai am start-server --debug
+```
+
+**App Proxy** (Terminal 6-7, optional for in-container service access):
 ```bash
 ./backend.ai app-proxy-coordinator start-server --debug
 ./backend.ai app-proxy-worker start-server --debug
@@ -175,7 +180,7 @@ as a reference implementation of API clients.
   - `account_manager/`: Unified user profile and SSO management
   - `agent/`: Agent as per-node controller
   - `agent/docker/`: Agent's Docker backend
-  - `agent/k8s/`: Agent's Kubernetes backend
+  - `agent/kubernetes/`: Agent's Kubernetes backend
   - `agent/dummy/`: Agent's dummy backend
   - `kernel/`: Agent's kernel runner counterpart
   - `runner/`: Agent's in-kernel prebuilt binaries
@@ -250,6 +255,10 @@ Backend.AI consists of the following core components:
 - Plugin interfaces: `backendai_scheduler_v10`, `backendai_agentselector_v10`, `backendai_hook_v20`, `backendai_webapp_v20`, `backendai_monitor_stats_v10`, `backendai_monitor_error_v10`
 - Legacy repo: https://github.com/lablup/backend.ai-manager
 
+**[Account Manager](src/ai/backend/account_manager/README.md)** - Unified user profile and SSO daemon
+- Manages user accounts including Backend.AI's first-party service
+- Single sign-on across Backend.AI components
+
 **[Agent](src/ai/backend/agent/README.md)** - Kernel lifecycle management on compute nodes
 - Manages Docker containers (kernels) on individual nodes
 - Self-registers to cluster via heartbeats
@@ -306,7 +315,7 @@ Backend.AI supports plugin-based extensibility via Python package entrypoints:
 
 **Accelerator Plugins** (`backendai_accelerator_v21`)
 - [CUDA](src/ai/backend/accelerator/cuda_open) - NVIDIA GPU support
-- [CUDA Mock](src/ai/backend/accelerator/cuda_mock) - Development without actual GPUs
+- [CUDA Mock](src/ai/backend/accelerator/mock) - Development without actual GPUs
 - [ROCm](src/ai/backend/accelerator/rocm) - AMD GPU support
 - [Furiosa](src/ai/backend/accelerator/furiosa) - Furiosa NPU (Warboy / RNGD) support
 - [Habana](src/ai/backend/accelerator/habana) - Intel Gaudi HPU (Gaudi 2, Gaudi 3) support

--- a/changes/11175.doc.md
+++ b/changes/11175.doc.md
@@ -1,0 +1,1 @@
+Sync README with current accelerator plugins (Habana, Tenstorrent, TPU Ironwood), unified `./backend.ai` CLI commands, Account Manager, and directory structure


### PR DESCRIPTION
## Summary

Sync `README.md` with the current state of the repository. README drifted from reality across several sections — this brings them back in line.

### Accelerators
- Add **Intel Gaudi (Habana, Gaudi 2/3)** and **Tenstorrent** to the intro paragraph (the Plugins section already had them or was being updated, so the intro was missing items).
- Add **Habana** entry to the Plugins section pointing to `src/ai/backend/accelerator/habana`.
- Update **Google TPU** coverage from `(v2, v3)` to `(v2 ~ Ironwood)`.
- Fix broken **CUDA Mock** link: `cuda_mock` → `mock` (matches the actual directory name).

### Quick Start
- Replace deprecated `./py -m ai.backend.storage.server` with `./backend.ai storage start-server --debug`.
- Replace deprecated `./py -m ai.backend.web.server` with `./backend.ai web start-server --debug`.
- Add **Account Manager** terminal step (`./backend.ai am start-server --debug`) — optional, for SSO and unified user profile.
- Renumber App Proxy terminals accordingly (5-6 → 6-7).

### Major Components
- Add an **Account Manager** entry under Server-Side Components to match the directory listing and Quick Start.

### Directory Structure
- Fix `agent/k8s/` → `agent/kubernetes/` (actual directory name).

## Verification

- All accelerator subdirectories listed in the Plugins section verified to exist under `src/ai/backend/accelerator/`.
- Unified CLI subcommand entry points (`storage`, `web`, `am`) verified in component `BUILD` files (`backendai_cli_v10` group).
- Link `src/ai/backend/account_manager/README.md` verified to exist.

No source code changes — documentation only.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11175.org.readthedocs.build/en/11175/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11175.org.readthedocs.build/ko/11175/

<!-- readthedocs-preview sorna-ko end -->