### PR TITLE
fix(BA-5771): include health status values in routestatus enum downgrade

### DIFF
--- a/changes/11182.fix.md
+++ b/changes/11182.fix.md
@@ -1,0 +1,1 @@
+Fix alembic downgrade failure by including missing health status values in routestatus enum recreation

--- a/src/ai/backend/manager/models/alembic/versions/04e150fdefa0_convert_routing_enum_to_varchar.py
+++ b/src/ai/backend/manager/models/alembic/versions/04e150fdefa0_convert_routing_enum_to_varchar.py
@@ -42,11 +42,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Recreate native ENUM types
+    # Recreate native ENUM types — include 'healthy', 'unhealthy', 'degraded'
+    # which were converted to 'running' + health_status by e3111d960208 but
+    # must exist in the enum for that migration's downgrade to cast back.
     op.execute(
         sa.text(
             "CREATE TYPE routestatus AS ENUM "
-            "('provisioning', 'running', 'terminating', 'terminated', 'failed_to_start')"
+            "('provisioning', 'running', 'healthy', 'unhealthy', 'degraded',"
+            " 'terminating', 'terminated', 'failed_to_start')"
         )
     )
     op.execute(sa.text("CREATE TYPE routetrafficstatus AS ENUM ('active', 'inactive')"))
@@ -58,6 +61,9 @@ def downgrade() -> None:
         type_=sa.Enum(
             "provisioning",
             "running",
+            "healthy",
+            "unhealthy",
+            "degraded",
             "terminating",
             "terminated",
             "failed_to_start",

--- a/src/ai/backend/manager/models/alembic/versions/04e150fdefa0_convert_routing_enum_to_varchar.py
+++ b/src/ai/backend/manager/models/alembic/versions/04e150fdefa0_convert_routing_enum_to_varchar.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-05
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "04e150fdefa0"
@@ -54,11 +55,12 @@ def downgrade() -> None:
     )
     op.execute(sa.text("CREATE TYPE routetrafficstatus AS ENUM ('active', 'inactive')"))
 
-    # Convert back: VARCHAR → native ENUM
+    # Convert back: VARCHAR → native ENUM (create_type=False since types are
+    # already created above via raw SQL)
     op.alter_column(
         "routings",
         "status",
-        type_=sa.Enum(
+        type_=postgresql.ENUM(
             "provisioning",
             "running",
             "healthy",
@@ -68,6 +70,7 @@ def downgrade() -> None:
             "terminated",
             "failed_to_start",
             name="routestatus",
+            create_type=False,
         ),
         existing_nullable=False,
         postgresql_using="status::routestatus",
@@ -79,7 +82,7 @@ def downgrade() -> None:
     op.alter_column(
         "routings",
         "traffic_status",
-        type_=sa.Enum("active", "inactive", name="routetrafficstatus"),
+        type_=postgresql.ENUM("active", "inactive", name="routetrafficstatus", create_type=False),
         existing_nullable=False,
         postgresql_using="traffic_status::routetrafficstatus",
     )


### PR DESCRIPTION
## Summary
- `04e150fdefa0` migration's downgrade recreated the `routestatus` enum without `healthy`, `unhealthy`, `degraded` values
- This caused `e3111d960208`'s downgrade to fail with `invalid input value for enum routestatus: "healthy"` when casting running routes back to their original health-based status
- Added the missing enum values to both the `CREATE TYPE` statement and the `sa.Enum()` call

## Test plan
- [ ] Run `alembic downgrade` from head past both migrations without error
- [ ] Verify `routestatus` enum includes all required values after downgrade of `04e150fdefa0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)