### PR TITLE
fix(BA-5772): guard allowed_vfolder_hosts against missing resource_policy key

### DIFF
--- a/changes/11185.fix.md
+++ b/changes/11185.fix.md
@@ -1,0 +1,1 @@
+Fix `KeyError: 'allowed_vfolder_hosts'` when the keypair resource policy is missing during vfolder ownership changes.

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -795,8 +795,8 @@ async def get_allowed_vfolder_hosts_by_group(
             result_hosts = allowed_hosts | values
             allowed_hosts = result_hosts
     # Keypair Resource Policy's allowed_vfolder_hosts
-    final_result: VFolderHostPermissionMap = (
-        allowed_hosts | resource_policy["allowed_vfolder_hosts"]
+    final_result: VFolderHostPermissionMap = allowed_hosts | resource_policy.get(
+        "allowed_vfolder_hosts", VFolderHostPermissionMap()
     )
     return final_result
 
@@ -854,8 +854,8 @@ async def get_allowed_vfolder_hosts_by_user(
             result_hosts = allowed_hosts | row.allowed_vfolder_hosts
             allowed_hosts = result_hosts
     # Keypair Resource Policy's allowed_vfolder_hosts
-    final_result: VFolderHostPermissionMap = (
-        allowed_hosts | resource_policy["allowed_vfolder_hosts"]
+    final_result: VFolderHostPermissionMap = allowed_hosts | resource_policy.get(
+        "allowed_vfolder_hosts", VFolderHostPermissionMap()
     )
     return final_result
 


### PR DESCRIPTION
## Summary
- `get_allowed_vfolder_hosts_by_user` / `get_allowed_vfolder_hosts_by_group` indexed `resource_policy["allowed_vfolder_hosts"]` unconditionally and raised `KeyError` when a caller passed an empty mapping.
- The direct trigger is `VFolderRepository.change_vfolder_ownership`, which falls back to `{}` when the new owner's keypair references a resource policy row that no longer exists in `keypair_resource_policies`.
- Replaced the indexing with `.get("allowed_vfolder_hosts", VFolderHostPermissionMap())`, matching the defensive pattern already used by `get_allowed_hosts_for_user`.

## Test plan
- [ ] Manually reproduce: invoke `./bai admin vfolder change-ownership` where the new owner's keypair points at a non-existent resource policy; confirm no `KeyError` and the ownership transfer proceeds (allowed hosts = domain/group union only).
- [ ] Existing vfolder ownership-transfer unit tests continue to pass.

Resolves BA-5772