### PR TITLE
feat(BA-5776): implement bulk permission check query

### DIFF
--- a/changes/11189.feature.md
+++ b/changes/11189.feature.md
@@ -1,1 +1,1 @@
-Add batch scope-chain permission check query for validating multiple entities in a single DB round-trip.
+Add bulk scope-chain permission check query for validating multiple entities in a single DB round-trip.

--- a/changes/11189.feature.md
+++ b/changes/11189.feature.md
@@ -1,0 +1,1 @@
+Add batch scope-chain permission check query for validating multiple entities in a single DB round-trip.

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -95,7 +95,7 @@ class ScopeChainPermissionCheckInput:
 
 
 @dataclass(frozen=True)
-class BatchPermissionCheckInput:
+class BulkPermissionCheckInput:
     user_id: uuid.UUID
     target_element_type: RBACElementType
     target_entity_ids: list[str]

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -13,7 +13,7 @@ from .object_permission import (
 )
 from .permission import ScopedPermissionCreateInput
 from .status import RoleStatus
-from .types import EntityType, OperationType, RBACElementRef, RoleSource
+from .types import EntityType, OperationType, RBACElementRef, RBACElementType, RoleSource
 
 
 @dataclass(frozen=True)
@@ -97,9 +97,9 @@ class ScopeChainPermissionCheckInput:
 @dataclass(frozen=True)
 class BatchPermissionCheckInput:
     user_id: uuid.UUID
-    target_element_refs: list[RBACElementRef]
+    target_element_type: RBACElementType
+    target_entity_ids: list[str]
     operation: OperationType
-    permission_entity_type: EntityType | None
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -95,6 +95,14 @@ class ScopeChainPermissionCheckInput:
 
 
 @dataclass(frozen=True)
+class BatchPermissionCheckInput:
+    user_id: uuid.UUID
+    target_element_refs: list[RBACElementRef]
+    operation: OperationType
+    permission_entity_type: EntityType | None
+
+
+@dataclass(frozen=True)
 class UserRoleAssignmentInput:
     """
     Input to create a new user-role association.

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
@@ -441,17 +441,6 @@ class PermissionDBSource:
             result = await db_session.scalars(stmt)
             return list(result.all())
 
-    async def get_entity_mapped_scopes(
-        self, target_object_id: ObjectId
-    ) -> list[AssociationScopesEntitiesRow]:
-        async with self._db.begin_readonly_session_read_committed() as db_session:
-            stmt = sa.select(AssociationScopesEntitiesRow).where(
-                AssociationScopesEntitiesRow.entity_id == target_object_id.entity_id,
-                AssociationScopesEntitiesRow.entity_type == target_object_id.entity_type.value,
-            )
-            result = await db_session.scalars(stmt)
-            return list(result.all())
-
     async def check_scope_permission_exist(
         self,
         user_id: uuid.UUID,
@@ -481,42 +470,6 @@ class PermissionDBSource:
         async with self._db.begin_readonly_session_read_committed() as db_session:
             result = await db_session.scalar(role_query)
             return result or False
-
-    def _make_query_statement_for_object_permission(
-        self,
-        user_id: uuid.UUID,
-        object_ids: Iterable[ObjectId],
-    ) -> sa.sql.Select[Any]:
-        object_id_for_cond = [obj_id.entity_id for obj_id in object_ids]
-        return (
-            sa.select(RoleRow)
-            .select_from(
-                sa.join(RoleRow, UserRoleRow, RoleRow.id == UserRoleRow.role_id)
-                .join(PermissionRow, RoleRow.id == PermissionRow.role_id)
-                .join(
-                    AssociationScopesEntitiesRow,
-                    sa.and_(
-                        PermissionRow.scope_id == AssociationScopesEntitiesRow.scope_id,
-                        PermissionRow.scope_type == AssociationScopesEntitiesRow.scope_type,
-                    ),
-                )
-                .join(ObjectPermissionRow, RoleRow.id == ObjectPermissionRow.role_id)
-            )
-            .where(
-                sa.and_(
-                    RoleRow.status == RoleStatus.ACTIVE,
-                    UserRoleRow.user_id == user_id,
-                    sa.or_(
-                        PermissionRow.scope_type == ScopeType.GLOBAL,
-                        AssociationScopesEntitiesRow.entity_id.in_(object_id_for_cond),
-                        ObjectPermissionRow.entity_id.in_(object_id_for_cond),
-                    ),
-                )
-            )
-            .options(
-                contains_eager(RoleRow.object_permission_rows),
-            )
-        )
 
     def _make_query_statement_for_object_permissions(
         self,
@@ -564,20 +517,6 @@ class PermissionDBSource:
                 contains_eager(RoleRow.object_permission_rows),
             )
         )
-
-    async def check_object_permission_exist(
-        self,
-        user_id: uuid.UUID,
-        object_id: ObjectId,
-        operation: OperationType,
-    ) -> bool:
-        role_query = self._make_query_statement_for_object_permissions(
-            user_id, [object_id], operation
-        )
-        async with self._db.begin_readonly_session_read_committed() as db_session:
-            result = await db_session.scalars(role_query)
-            role_rows = cast(list[RoleRow], result.unique().all())
-            return len(role_rows) > 0
 
     async def check_batch_object_permission_exist(
         self,

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -101,6 +101,15 @@ class CreateRoleInput:
     scope_refs: Sequence[RBACElementRef] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _ScopeChainQueryParams:
+    user_id: uuid.UUID
+    target_element_type: RBACElementType
+    entity_ids: list[str]
+    operation: OperationType
+    permission_entity_type: EntityType | None = None
+
+
 class PermissionDBSource:
     _db: ExtendedAsyncSAEngine
 
@@ -860,197 +869,17 @@ class PermissionDBSource:
 
     @staticmethod
     def _build_scope_chain_cte(
-        target_element_ref: RBACElementRef,
-    ) -> sa.CTE:
-        """Build a recursive CTE that walks the scope chain upward via AUTO edges only.
-
-        Starting from the target entity, traverses association_scopes_entities
-        following only AUTO edges to find all ancestor scopes. REF edges
-        terminate the chain — scopes beyond a REF edge are unreachable.
-
-        Uses UNION (not UNION ALL) to prevent infinite recursion on cycles.
-        """
-        ase = AssociationScopesEntitiesRow.__table__
-        target_entity_type = target_element_ref.element_type.to_entity_type()
-
-        # Base case: direct AUTO scope entries for the target entity.
-        scope_chain_base = sa.select(
-            ase.c.scope_type,
-            ase.c.scope_id,
-        ).where(
-            sa.and_(
-                ase.c.entity_type == target_entity_type,
-                ase.c.entity_id == target_element_ref.element_id,
-                ase.c.relation_type == RelationType.AUTO,
-            )
-        )
-        scope_chain_cte = scope_chain_base.cte("scope_chain", recursive=True)
-
-        # Recursive case: walk parent scopes upward, following AUTO edges only.
-        parent = ase.alias("parent")
-        scope_chain_recursive = (
-            sa.select(
-                parent.c.scope_type,
-                parent.c.scope_id,
-            )
-            .select_from(
-                parent.join(
-                    scope_chain_cte,
-                    sa.and_(
-                        parent.c.entity_type == scope_chain_cte.c.scope_type,
-                        parent.c.entity_id == scope_chain_cte.c.scope_id,
-                    ),
-                )
-            )
-            .where(
-                parent.c.relation_type == RelationType.AUTO,
-            )
-        )
-        return scope_chain_cte.union(scope_chain_recursive)
-
-    def _build_scope_chain_permission_query(
-        self,
-        user_id: uuid.UUID,
-        target_element_ref: RBACElementRef,
-        target_entity_type: EntityType,
-        operation: OperationType,
-    ) -> sa.sql.Select[Any]:
-        """Build a query that checks permissions via CTE scope chain traversal."""
-        permissions = PermissionRow.__table__
-        user_roles = UserRoleRow.__table__
-        roles = RoleRow.__table__
-
-        scope_chain_cte = self._build_scope_chain_cte(target_element_ref)
-        return (
-            sa.select(sa.literal(1))
-            .select_from(
-                scope_chain_cte.join(
-                    permissions,
-                    sa.and_(
-                        permissions.c.scope_type == scope_chain_cte.c.scope_type,
-                        permissions.c.scope_id == scope_chain_cte.c.scope_id,
-                    ),
-                )
-                .join(
-                    roles,
-                    roles.c.id == permissions.c.role_id,
-                )
-                .join(
-                    user_roles,
-                    user_roles.c.role_id == roles.c.id,
-                )
-            )
-            .where(
-                sa.and_(
-                    user_roles.c.user_id == user_id,
-                    roles.c.status == RoleStatus.ACTIVE,
-                    permissions.c.entity_type == target_entity_type,
-                    permissions.c.operation == operation,
-                )
-            )
-            .limit(1)
-        )
-
-    def _build_self_scope_permission_query(
-        self,
-        user_id: uuid.UUID,
-        target_element_ref: RBACElementRef,
-        target_entity_type: EntityType,
-        target_scope_type: ScopeType,
-        operation: OperationType,
-    ) -> sa.sql.Select[Any]:
-        """Build a query that checks permissions scoped to the target entity itself."""
-        permissions = PermissionRow.__table__
-        user_roles = UserRoleRow.__table__
-        roles = RoleRow.__table__
-
-        return (
-            sa.select(sa.literal(1))
-            .select_from(
-                permissions.join(
-                    roles,
-                    roles.c.id == permissions.c.role_id,
-                ).join(
-                    user_roles,
-                    user_roles.c.role_id == roles.c.id,
-                )
-            )
-            .where(
-                sa.and_(
-                    user_roles.c.user_id == user_id,
-                    roles.c.status == RoleStatus.ACTIVE,
-                    permissions.c.scope_type == target_scope_type,
-                    permissions.c.scope_id == target_element_ref.element_id,
-                    permissions.c.entity_type == target_entity_type,
-                    permissions.c.operation == operation,
-                )
-            )
-            .limit(1)
-        )
-
-    async def check_permission_with_scope_chain(
-        self,
-        data: ScopeChainPermissionCheckInput,
-    ) -> bool:
-        """CTE-based permission check that traverses the scope chain.
-
-        Two-layer check:
-        1. Self-scope direct match — permission scoped to the target entity itself.
-        2. Scope chain traversal — walks AUTO edges upward via CTE.
-
-        Args:
-            data: Permission check input containing user_id, target_element_ref,
-                operation, and optional permission_entity_type override.
-                When permission_entity_type is provided, it is used as the
-                entity_type filter for permission matching instead of deriving
-                it from target_element_ref. This enables cross-scope entity type
-                checks (e.g., checking MODEL_DEPLOYMENT:READ permission at
-                PROJECT scope).
-        """
-        target_entity_type = (
-            data.permission_entity_type or data.target_element_ref.element_type.to_entity_type()
-        )
-        target_scope_type = data.target_element_ref.element_type.to_scope_type()
-
-        combined_query = sa.select(
-            sa.or_(
-                sa.exists(
-                    self._build_scope_chain_permission_query(
-                        data.user_id,
-                        data.target_element_ref,
-                        target_entity_type,
-                        data.operation,
-                    )
-                ),
-                sa.exists(
-                    self._build_self_scope_permission_query(
-                        data.user_id,
-                        data.target_element_ref,
-                        target_entity_type,
-                        target_scope_type,
-                        data.operation,
-                    )
-                ),
-            )
-        )
-
-        async with self._db.begin_readonly_session_read_committed() as db_session:
-            result = await db_session.scalar(combined_query)
-            return result or False
-
-    @staticmethod
-    def _build_batch_scope_chain_cte(
         target_entity_type: EntityType,
         entity_ids: list[str],
     ) -> sa.CTE:
-        """Build a recursive CTE that walks the scope chain upward for multiple entities.
+        """Build a recursive CTE that walks the scope chain upward via AUTO edges.
 
-        Like _build_scope_chain_cte but carries entity_id through the recursion
-        so each result row can be traced back to its originating entity.
+        Carries entity_id through the recursion so each result row can be
+        traced back to its originating entity.
         """
         ase = AssociationScopesEntitiesRow.__table__
 
-        # Base case: direct AUTO scope entries for all target entities.
+        # Base case: direct AUTO scope entries for target entities.
         scope_chain_base = sa.select(
             ase.c.entity_id,
             ase.c.scope_type,
@@ -1062,7 +891,7 @@ class PermissionDBSource:
                 ase.c.relation_type == RelationType.AUTO,
             )
         )
-        scope_chain_cte = scope_chain_base.cte("batch_scope_chain", recursive=True)
+        scope_chain_cte = scope_chain_base.cte("scope_chain", recursive=True)
 
         # Recursive case: walk parent scopes upward, carrying entity_id.
         parent = ase.alias("parent")
@@ -1087,30 +916,28 @@ class PermissionDBSource:
         )
         return scope_chain_cte.union(scope_chain_recursive)
 
-    async def check_batch_permission_with_scope_chain(
+    async def _check_permissions_via_scope_chain(
         self,
-        data: BatchPermissionCheckInput,
-    ) -> dict[str, bool]:
-        """Batch CTE-based permission check that traverses the scope chain.
+        params: _ScopeChainQueryParams,
+    ) -> set[str]:
+        """Core scope chain permission check shared by single and batch methods.
 
-        Same two-layer semantics as check_permission_with_scope_chain but for
-        multiple entities of the same RBACElementType in a single query.
-        Returns a mapping from each entity ID to its permission result.
+        Two-layer check:
+        1. Scope chain traversal — walks AUTO edges upward via recursive CTE.
+        2. Self-scope direct match — permission scoped to the target entity itself.
+
+        Returns the set of entity IDs that have the requested permission.
         """
-        if not data.target_entity_ids:
-            return {}
-
-        target_entity_type = data.target_element_type.to_entity_type()
-        target_scope_type = data.target_element_type.to_scope_type()
+        association_entity_type = params.target_element_type.to_entity_type()
+        permission_entity_type = params.permission_entity_type or association_entity_type
+        target_scope_type = params.target_element_type.to_scope_type()
 
         permissions = PermissionRow.__table__
         user_roles = UserRoleRow.__table__
         roles = RoleRow.__table__
 
-        # Layer 1: scope chain traversal — find entity_ids with permission via ancestors.
-        scope_chain_cte = self._build_batch_scope_chain_cte(
-            target_entity_type, data.target_entity_ids
-        )
+        # Layer 1: scope chain traversal.
+        scope_chain_cte = self._build_scope_chain_cte(association_entity_type, params.entity_ids)
         scope_chain_query = (
             sa.select(scope_chain_cte.c.entity_id)
             .select_from(
@@ -1132,15 +959,15 @@ class PermissionDBSource:
             )
             .where(
                 sa.and_(
-                    user_roles.c.user_id == data.user_id,
+                    user_roles.c.user_id == params.user_id,
                     roles.c.status == RoleStatus.ACTIVE,
-                    permissions.c.entity_type == target_entity_type,
-                    permissions.c.operation == data.operation,
+                    permissions.c.entity_type == permission_entity_type,
+                    permissions.c.operation == params.operation,
                 )
             )
         )
 
-        # Layer 2: self-scope direct match — permission scoped to the entity itself.
+        # Layer 2: self-scope direct match.
         self_scope_query = (
             sa.select(permissions.c.scope_id.label("entity_id"))
             .select_from(
@@ -1154,27 +981,59 @@ class PermissionDBSource:
             )
             .where(
                 sa.and_(
-                    user_roles.c.user_id == data.user_id,
+                    user_roles.c.user_id == params.user_id,
                     roles.c.status == RoleStatus.ACTIVE,
                     permissions.c.scope_type == target_scope_type,
-                    permissions.c.scope_id.in_(data.target_entity_ids),
-                    permissions.c.entity_type == target_entity_type,
-                    permissions.c.operation == data.operation,
+                    permissions.c.scope_id.in_(params.entity_ids),
+                    permissions.c.entity_type == permission_entity_type,
+                    permissions.c.operation == params.operation,
                 )
             )
         )
 
         combined_query = sa.union(scope_chain_query, self_scope_query)
 
-        result: dict[str, bool] = dict.fromkeys(data.target_entity_ids, False)
-
+        granted: set[str] = set()
         async with self._db.begin_readonly_session_read_committed() as db_session:
             rows = await db_session.execute(combined_query)
             for row in rows:
-                if row.entity_id in result:
-                    result[row.entity_id] = True
+                granted.add(row.entity_id)
 
-        return result
+        return granted
+
+    async def check_permission_with_scope_chain(
+        self,
+        data: ScopeChainPermissionCheckInput,
+    ) -> bool:
+        """CTE-based permission check for a single entity."""
+        granted = await self._check_permissions_via_scope_chain(
+            _ScopeChainQueryParams(
+                user_id=data.user_id,
+                target_element_type=data.target_element_ref.element_type,
+                entity_ids=[data.target_element_ref.element_id],
+                operation=data.operation,
+                permission_entity_type=data.permission_entity_type,
+            )
+        )
+        return data.target_element_ref.element_id in granted
+
+    async def check_batch_permission_with_scope_chain(
+        self,
+        data: BatchPermissionCheckInput,
+    ) -> dict[str, bool]:
+        """Batch CTE-based permission check for multiple entities."""
+        if not data.target_entity_ids:
+            return {}
+
+        granted = await self._check_permissions_via_scope_chain(
+            _ScopeChainQueryParams(
+                user_id=data.user_id,
+                target_element_type=data.target_element_type,
+                entity_ids=data.target_entity_ids,
+                operation=data.operation,
+            )
+        )
+        return {eid: eid in granted for eid in data.target_entity_ids}
 
     async def bulk_assign_role(
         self, bulk_creator: BulkCreator[UserRoleRow]

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -1090,28 +1090,27 @@ class PermissionDBSource:
     async def check_batch_permission_with_scope_chain(
         self,
         data: BatchPermissionCheckInput,
-    ) -> dict[RBACElementRef, bool]:
+    ) -> dict[str, bool]:
         """Batch CTE-based permission check that traverses the scope chain.
 
         Same two-layer semantics as check_permission_with_scope_chain but for
         multiple entities of the same RBACElementType in a single query.
-        Returns a mapping from each input RBACElementRef to its permission result.
+        Returns a mapping from each entity ID to its permission result.
         """
-        if not data.target_element_refs:
+        if not data.target_entity_ids:
             return {}
 
-        first_ref = data.target_element_refs[0]
-        association_entity_type = first_ref.element_type.to_entity_type()
-        target_entity_type = data.permission_entity_type or association_entity_type
-        target_scope_type = first_ref.element_type.to_scope_type()
-        entity_ids = [ref.element_id for ref in data.target_element_refs]
+        target_entity_type = data.target_element_type.to_entity_type()
+        target_scope_type = data.target_element_type.to_scope_type()
 
         permissions = PermissionRow.__table__
         user_roles = UserRoleRow.__table__
         roles = RoleRow.__table__
 
         # Layer 1: scope chain traversal — find entity_ids with permission via ancestors.
-        scope_chain_cte = self._build_batch_scope_chain_cte(association_entity_type, entity_ids)
+        scope_chain_cte = self._build_batch_scope_chain_cte(
+            target_entity_type, data.target_entity_ids
+        )
         scope_chain_query = (
             sa.select(scope_chain_cte.c.entity_id)
             .select_from(
@@ -1158,7 +1157,7 @@ class PermissionDBSource:
                     user_roles.c.user_id == data.user_id,
                     roles.c.status == RoleStatus.ACTIVE,
                     permissions.c.scope_type == target_scope_type,
-                    permissions.c.scope_id.in_(entity_ids),
+                    permissions.c.scope_id.in_(data.target_entity_ids),
                     permissions.c.entity_type == target_entity_type,
                     permissions.c.operation == data.operation,
                 )
@@ -1167,15 +1166,13 @@ class PermissionDBSource:
 
         combined_query = sa.union(scope_chain_query, self_scope_query)
 
-        result: dict[RBACElementRef, bool] = dict.fromkeys(data.target_element_refs, False)
-        ref_by_id = {ref.element_id: ref for ref in data.target_element_refs}
+        result: dict[str, bool] = dict.fromkeys(data.target_entity_ids, False)
 
         async with self._db.begin_readonly_session_read_committed() as db_session:
             rows = await db_session.execute(combined_query)
             for row in rows:
-                ref = ref_by_id.get(row.entity_id)
-                if ref is not None:
-                    result[ref] = True
+                if row.entity_id in result:
+                    result[row.entity_id] = True
 
         return result
 

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -28,6 +28,7 @@ from ai.backend.manager.data.permission.permission import (
 from ai.backend.manager.data.permission.role import (
     AssignedUserData,
     AssignedUserListResult,
+    BatchPermissionCheckInput,
     BulkRoleRevocationFailure,
     BulkRoleRevocationResultData,
     BulkUserRoleRevocationInput,
@@ -1036,6 +1037,147 @@ class PermissionDBSource:
         async with self._db.begin_readonly_session_read_committed() as db_session:
             result = await db_session.scalar(combined_query)
             return result or False
+
+    @staticmethod
+    def _build_batch_scope_chain_cte(
+        target_entity_type: EntityType,
+        entity_ids: list[str],
+    ) -> sa.CTE:
+        """Build a recursive CTE that walks the scope chain upward for multiple entities.
+
+        Like _build_scope_chain_cte but carries entity_id through the recursion
+        so each result row can be traced back to its originating entity.
+        """
+        ase = AssociationScopesEntitiesRow.__table__
+
+        # Base case: direct AUTO scope entries for all target entities.
+        scope_chain_base = sa.select(
+            ase.c.entity_id,
+            ase.c.scope_type,
+            ase.c.scope_id,
+        ).where(
+            sa.and_(
+                ase.c.entity_type == target_entity_type,
+                ase.c.entity_id.in_(entity_ids),
+                ase.c.relation_type == RelationType.AUTO,
+            )
+        )
+        scope_chain_cte = scope_chain_base.cte("batch_scope_chain", recursive=True)
+
+        # Recursive case: walk parent scopes upward, carrying entity_id.
+        parent = ase.alias("parent")
+        scope_chain_recursive = (
+            sa.select(
+                scope_chain_cte.c.entity_id,
+                parent.c.scope_type,
+                parent.c.scope_id,
+            )
+            .select_from(
+                parent.join(
+                    scope_chain_cte,
+                    sa.and_(
+                        parent.c.entity_type == scope_chain_cte.c.scope_type,
+                        parent.c.entity_id == scope_chain_cte.c.scope_id,
+                    ),
+                )
+            )
+            .where(
+                parent.c.relation_type == RelationType.AUTO,
+            )
+        )
+        return scope_chain_cte.union(scope_chain_recursive)
+
+    async def check_batch_permission_with_scope_chain(
+        self,
+        data: BatchPermissionCheckInput,
+    ) -> dict[RBACElementRef, bool]:
+        """Batch CTE-based permission check that traverses the scope chain.
+
+        Same two-layer semantics as check_permission_with_scope_chain but for
+        multiple entities of the same RBACElementType in a single query.
+        Returns a mapping from each input RBACElementRef to its permission result.
+        """
+        if not data.target_element_refs:
+            return {}
+
+        first_ref = data.target_element_refs[0]
+        association_entity_type = first_ref.element_type.to_entity_type()
+        target_entity_type = data.permission_entity_type or association_entity_type
+        target_scope_type = first_ref.element_type.to_scope_type()
+        entity_ids = [ref.element_id for ref in data.target_element_refs]
+
+        permissions = PermissionRow.__table__
+        user_roles = UserRoleRow.__table__
+        roles = RoleRow.__table__
+
+        # Layer 1: scope chain traversal — find entity_ids with permission via ancestors.
+        scope_chain_cte = self._build_batch_scope_chain_cte(association_entity_type, entity_ids)
+        scope_chain_query = (
+            sa.select(scope_chain_cte.c.entity_id)
+            .select_from(
+                scope_chain_cte.join(
+                    permissions,
+                    sa.and_(
+                        permissions.c.scope_type == scope_chain_cte.c.scope_type,
+                        permissions.c.scope_id == scope_chain_cte.c.scope_id,
+                    ),
+                )
+                .join(
+                    roles,
+                    roles.c.id == permissions.c.role_id,
+                )
+                .join(
+                    user_roles,
+                    user_roles.c.role_id == roles.c.id,
+                )
+            )
+            .where(
+                sa.and_(
+                    user_roles.c.user_id == data.user_id,
+                    roles.c.status == RoleStatus.ACTIVE,
+                    permissions.c.entity_type == target_entity_type,
+                    permissions.c.operation == data.operation,
+                )
+            )
+        )
+
+        # Layer 2: self-scope direct match — permission scoped to the entity itself.
+        self_scope_query = (
+            sa.select(permissions.c.scope_id.label("entity_id"))
+            .select_from(
+                permissions.join(
+                    roles,
+                    roles.c.id == permissions.c.role_id,
+                ).join(
+                    user_roles,
+                    user_roles.c.role_id == roles.c.id,
+                )
+            )
+            .where(
+                sa.and_(
+                    user_roles.c.user_id == data.user_id,
+                    roles.c.status == RoleStatus.ACTIVE,
+                    permissions.c.scope_type == target_scope_type,
+                    permissions.c.scope_id.in_(entity_ids),
+                    permissions.c.entity_type == target_entity_type,
+                    permissions.c.operation == data.operation,
+                )
+            )
+        )
+
+        combined_query = sa.union(scope_chain_query, self_scope_query)
+
+        result: dict[RBACElementRef, bool] = dict.fromkeys(data.target_element_refs, False)
+        ref_by_id = {ref.element_id: ref for ref in data.target_element_refs}
+
+        async with self._db.begin_readonly_session_read_committed() as db_session:
+            rows = await db_session.execute(combined_query)
+            for row in rows:
+                ref = ref_by_id.get(row.entity_id)
+                if ref is not None:
+                    result[ref] = True
+
+        return result
 
     async def bulk_assign_role(
         self, bulk_creator: BulkCreator[UserRoleRow]

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -28,7 +28,7 @@ from ai.backend.manager.data.permission.permission import (
 from ai.backend.manager.data.permission.role import (
     AssignedUserData,
     AssignedUserListResult,
-    BatchPermissionCheckInput,
+    BulkPermissionCheckInput,
     BulkRoleRevocationFailure,
     BulkRoleRevocationResultData,
     BulkUserRoleRevocationInput,
@@ -956,9 +956,9 @@ class PermissionDBSource:
         )
         return data.target_element_ref.element_id in granted
 
-    async def check_batch_permission_with_scope_chain(
+    async def check_bulk_permission_with_scope_chain(
         self,
-        data: BatchPermissionCheckInput,
+        data: BulkPermissionCheckInput,
     ) -> dict[str, bool]:
         """Batch CTE-based permission check for multiple entities."""
         if not data.target_entity_ids:

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.permission.permission import (
 from ai.backend.manager.data.permission.role import (
     AssignedUserListResult,
     BatchEntityPermissionCheckInput,
+    BatchPermissionCheckInput,
     BulkRoleAssignmentFailure,
     BulkRoleAssignmentResultData,
     BulkRoleRevocationResultData,
@@ -36,6 +37,7 @@ from ai.backend.manager.data.permission.role import (
     UserRoleRevocationInput,
 )
 from ai.backend.manager.data.permission.types import (
+    RBACElementRef,
     ScopeListResult,
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -336,3 +338,15 @@ class PermissionControllerRepository:
         scope. REF edges are not traversed.
         """
         return await self._db_source.check_permission_with_scope_chain(data)
+
+    @permission_controller_repository_resilience.apply()
+    async def check_batch_permission_with_scope_chain(
+        self,
+        data: BatchPermissionCheckInput,
+    ) -> dict[RBACElementRef, bool]:
+        """Batch permission check that traverses the scope chain via AUTO edges.
+
+        Same semantics as check_permission_with_scope_chain but for multiple
+        entities of the same RBACElementType in a single query.
+        """
+        return await self._db_source.check_batch_permission_with_scope_chain(data)

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -37,7 +37,6 @@ from ai.backend.manager.data.permission.role import (
     UserRoleRevocationInput,
 )
 from ai.backend.manager.data.permission.types import (
-    RBACElementRef,
     ScopeListResult,
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -343,7 +342,7 @@ class PermissionControllerRepository:
     async def check_batch_permission_with_scope_chain(
         self,
         data: BatchPermissionCheckInput,
-    ) -> dict[RBACElementRef, bool]:
+    ) -> dict[str, bool]:
         """Batch permission check that traverses the scope chain via AUTO edges.
 
         Same semantics as check_permission_with_scope_chain but for multiple

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -19,7 +19,7 @@ from ai.backend.manager.data.permission.permission import (
 from ai.backend.manager.data.permission.role import (
     AssignedUserListResult,
     BatchEntityPermissionCheckInput,
-    BatchPermissionCheckInput,
+    BulkPermissionCheckInput,
     BulkRoleAssignmentFailure,
     BulkRoleAssignmentResultData,
     BulkRoleRevocationResultData,
@@ -339,13 +339,13 @@ class PermissionControllerRepository:
         return await self._db_source.check_permission_with_scope_chain(data)
 
     @permission_controller_repository_resilience.apply()
-    async def check_batch_permission_with_scope_chain(
+    async def check_bulk_permission_with_scope_chain(
         self,
-        data: BatchPermissionCheckInput,
+        data: BulkPermissionCheckInput,
     ) -> dict[str, bool]:
         """Batch permission check that traverses the scope chain via AUTO edges.
 
         Same semantics as check_permission_with_scope_chain but for multiple
         entities of the same RBACElementType in a single query.
         """
-        return await self._db_source.check_batch_permission_with_scope_chain(data)
+        return await self._db_source.check_bulk_permission_with_scope_chain(data)

--- a/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
@@ -20,7 +20,6 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
-    RBACElementRef,
     ScopeType,
 )
 from ai.backend.manager.data.user.types import UserStatus
@@ -414,24 +413,16 @@ class TestCheckBatchPermissionWithScopeChain:
 
     # ── Helpers ──
 
-    def _make_refs(self, fixture: BatchFixture) -> list[RBACElementRef]:
-        return [
-            RBACElementRef(element_type=RBACElementType.VFOLDER, element_id=vid)
-            for vid in fixture.vfolder_ids
-        ]
-
     def _make_input(
         self,
         fixture: BatchFixture,
         operation: OperationType,
-        *,
-        permission_entity_type: EntityType | None = None,
     ) -> BatchPermissionCheckInput:
         return BatchPermissionCheckInput(
             user_id=fixture.user_id,
-            target_element_refs=self._make_refs(fixture),
+            target_element_type=RBACElementType.VFOLDER,
+            target_entity_ids=fixture.vfolder_ids,
             operation=operation,
-            permission_entity_type=permission_entity_type,
         )
 
     # ── Tests ──
@@ -441,14 +432,14 @@ class TestCheckBatchPermissionWithScopeChain:
         db_source: PermissionDBSource,
         user_with_active_role: BatchFixture,
     ) -> None:
-        """Empty target_element_refs returns empty dict."""
+        """Empty target_entity_ids returns empty dict."""
         fixture = user_with_active_role
         result = await db_source.check_batch_permission_with_scope_chain(
             BatchPermissionCheckInput(
                 user_id=fixture.user_id,
-                target_element_refs=[],
+                target_element_type=RBACElementType.VFOLDER,
+                target_entity_ids=[],
                 operation=OperationType.READ,
-                permission_entity_type=None,
             )
         )
         assert result == {}
@@ -522,10 +513,9 @@ class TestCheckBatchPermissionWithScopeChain:
         result = await db_source.check_batch_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
-        refs = self._make_refs(fixture)
-        assert result[refs[0]]  # AUTO
-        assert not result[refs[1]]  # REF
-        assert not result[refs[2]]  # no association
+        assert result[fixture.vfolder_ids[0]]  # AUTO
+        assert not result[fixture.vfolder_ids[1]]  # REF
+        assert not result[fixture.vfolder_ids[2]]  # no association
 
     @pytest.mark.parametrize(
         "permission_setup",
@@ -543,10 +533,9 @@ class TestCheckBatchPermissionWithScopeChain:
         result = await db_source.check_batch_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
-        refs = self._make_refs(fixture)
-        assert result[refs[0]]
-        assert not result[refs[1]]
-        assert not result[refs[2]]
+        assert result[fixture.vfolder_ids[0]]
+        assert not result[fixture.vfolder_ids[1]]
+        assert not result[fixture.vfolder_ids[2]]
 
     @pytest.mark.parametrize(
         "permission_setup",
@@ -588,34 +577,6 @@ class TestCheckBatchPermissionWithScopeChain:
         "permission_setup",
         [
             pytest.param(
-                [PermissionEntry("project", OperationType.READ, EntityType.MODEL_DEPLOYMENT)],
-                id="model-deployment-read",
-            )
-        ],
-        indirect=["permission_setup"],
-    )
-    async def test_cross_scope_entity_type(
-        self,
-        db_source: PermissionDBSource,
-        user_with_active_role: BatchFixture,
-        all_vfolders_in_project_auto: None,
-        permission_setup: None,
-    ) -> None:
-        """permission_entity_type override applies to all entities in batch."""
-        result = await db_source.check_batch_permission_with_scope_chain(
-            self._make_input(
-                user_with_active_role,
-                OperationType.READ,
-                permission_entity_type=EntityType.MODEL_DEPLOYMENT,
-            ),
-        )
-        assert all(result.values())
-        assert len(result) == 3
-
-    @pytest.mark.parametrize(
-        "permission_setup",
-        [
-            pytest.param(
                 [
                     PermissionEntry("project", OperationType.READ),
                     PermissionEntry("vfolder_1", OperationType.READ),
@@ -637,10 +598,9 @@ class TestCheckBatchPermissionWithScopeChain:
         result = await db_source.check_batch_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
-        refs = self._make_refs(fixture)
-        assert result[refs[0]]  # via chain
-        assert result[refs[1]]  # via self-scope
-        assert not result[refs[2]]  # no path
+        assert result[fixture.vfolder_ids[0]]  # via chain
+        assert result[fixture.vfolder_ids[1]]  # via self-scope
+        assert not result[fixture.vfolder_ids[2]]  # no path
 
     @pytest.mark.parametrize(
         "permission_setup",
@@ -659,10 +619,9 @@ class TestCheckBatchPermissionWithScopeChain:
         result = await db_source.check_batch_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
-        refs = self._make_refs(fixture)
-        assert result[refs[0]]  # domain_a -> project_a -> vfolder[0]
-        assert result[refs[1]]  # domain_a -> project_b -> vfolder[1]
-        assert not result[refs[2]]  # domain_b -> project_c -> vfolder[2]
+        assert result[fixture.vfolder_ids[0]]  # domain_a -> project_a -> vfolder[0]
+        assert result[fixture.vfolder_ids[1]]  # domain_a -> project_b -> vfolder[1]
+        assert not result[fixture.vfolder_ids[2]]  # domain_b -> project_c -> vfolder[2]
 
     async def test_other_user_not_affected(
         self,

--- a/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
@@ -1,0 +1,678 @@
+"""
+Tests for PermissionDBSource.check_batch_permission_with_scope_chain().
+Covers batched CTE-based scope chain traversal with per-entity results.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+
+import pytest
+
+from ai.backend.common.data.permission.types import (
+    RBACElementType,
+    RelationType,
+)
+from ai.backend.manager.data.permission.role import BatchPermissionCheckInput
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    OperationType,
+    RBACElementRef,
+    ScopeType,
+)
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.object_permission import ObjectPermissionRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
+    PermissionDBSource,
+)
+from ai.backend.testutils.db import with_tables
+
+
+@dataclass
+class PermissionEntry:
+    """A single permission to create in permission_setup fixture."""
+
+    scope_key: str
+    operation: OperationType
+    entity_type: EntityType = EntityType.VFOLDER
+
+
+@dataclass
+class BatchFixture:
+    """Pre-built fixture data for batch scope chain tests."""
+
+    user_id: uuid.UUID
+    role_id: uuid.UUID
+    domain_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    project_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    vfolder_ids: list[str] = field(default_factory=list)
+    # Extra IDs for multi-project / multi-domain tests
+    domain_b_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    project_b_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    project_c_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def __post_init__(self) -> None:
+        if not self.vfolder_ids:
+            self.vfolder_ids = [str(uuid.uuid4()) for _ in range(3)]
+
+
+class TestCheckBatchPermissionWithScopeChain:
+    """Tests for batched CTE-based scope chain permission traversal."""
+
+    @pytest.fixture
+    async def db_with_rbac_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                PermissionRow,
+                ObjectPermissionRow,
+                AssociationScopesEntitiesRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def db_source(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> PermissionDBSource:
+        return PermissionDBSource(db_with_rbac_tables)
+
+    @pytest.fixture
+    def fixture_ids(self) -> BatchFixture:
+        return BatchFixture(
+            user_id=uuid.uuid4(),
+            role_id=uuid.uuid4(),
+        )
+
+    # ── User + role fixtures ──
+
+    @pytest.fixture
+    async def user_with_active_role(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> BatchFixture:
+        """Create a user with an active role (no permissions yet)."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            policy = UserResourcePolicyRow(
+                name="test-rbac-policy",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=0,
+                max_customized_image_count=0,
+            )
+            db_sess.add(policy)
+            user = UserRow(
+                uuid=fixture_ids.user_id,
+                email="testuser@test.com",
+                resource_policy="test-rbac-policy",
+                status=UserStatus.ACTIVE,
+                need_password_change=False,
+                sudo_session_enabled=False,
+            )
+            db_sess.add(user)
+            await db_sess.flush()
+
+            role = RoleRow(
+                id=fixture_ids.role_id,
+                name="test-role",
+                description="Test role for batch scope chain",
+            )
+            db_sess.add(role)
+            await db_sess.flush()
+
+            user_role = UserRoleRow(
+                user_id=fixture_ids.user_id,
+                role_id=fixture_ids.role_id,
+            )
+            db_sess.add(user_role)
+            await db_sess.flush()
+
+        return fixture_ids
+
+    @pytest.fixture
+    async def user_with_inactive_role(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> BatchFixture:
+        """Create a user with an inactive role."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            policy = UserResourcePolicyRow(
+                name="test-rbac-policy",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=0,
+                max_customized_image_count=0,
+            )
+            db_sess.add(policy)
+            user = UserRow(
+                uuid=fixture_ids.user_id,
+                email="testuser@test.com",
+                resource_policy="test-rbac-policy",
+                status=UserStatus.ACTIVE,
+                need_password_change=False,
+                sudo_session_enabled=False,
+            )
+            db_sess.add(user)
+            await db_sess.flush()
+
+            role = RoleRow(
+                id=fixture_ids.role_id,
+                name="inactive-role",
+                status=RoleStatus.INACTIVE,
+            )
+            db_sess.add(role)
+            await db_sess.flush()
+
+            user_role = UserRoleRow(
+                user_id=fixture_ids.user_id,
+                role_id=fixture_ids.role_id,
+            )
+            db_sess.add(user_role)
+            await db_sess.flush()
+
+        return fixture_ids
+
+    # ── Association fixtures ──
+
+    @pytest.fixture
+    async def all_vfolders_in_project_auto(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """All vfolders belong to the same PROJECT (auto edge)."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            for vfolder_id in fixture_ids.vfolder_ids:
+                db_sess.add(
+                    AssociationScopesEntitiesRow(
+                        scope_type=ScopeType.PROJECT,
+                        scope_id=fixture_ids.project_id,
+                        entity_type=EntityType.VFOLDER,
+                        entity_id=vfolder_id,
+                        relation_type=RelationType.AUTO,
+                    )
+                )
+            await db_sess.flush()
+
+    @pytest.fixture
+    async def project_in_domain_auto(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """PROJECT belongs to DOMAIN (auto edge)."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=fixture_ids.domain_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=fixture_ids.project_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            await db_sess.flush()
+
+    @pytest.fixture
+    async def mixed_vfolder_edges(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """vfolder[0] AUTO, vfolder[1] REF, vfolder[2] no association."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=fixture_ids.vfolder_ids[0],
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=fixture_ids.vfolder_ids[1],
+                    relation_type=RelationType.REF,
+                )
+            )
+            await db_sess.flush()
+
+    @pytest.fixture
+    async def multi_project_two_domains(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """Two domains with separate project chains.
+
+        domain_a ← project_a ← vfolder[0]
+        domain_a ← project_b ← vfolder[1]
+        domain_b ← project_c ← vfolder[2]
+        """
+        f = fixture_ids
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            # domain_a ← project_a ← vfolder[0]
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=f.domain_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=f.project_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=f.project_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=f.vfolder_ids[0],
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            # domain_a ← project_b ← vfolder[1]
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=f.domain_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=f.project_b_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=f.project_b_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=f.vfolder_ids[1],
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            # domain_b ← project_c ← vfolder[2]
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=f.domain_b_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=f.project_c_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=f.project_c_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=f.vfolder_ids[2],
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            await db_sess.flush()
+
+    # ── Permission fixture ──
+
+    @pytest.fixture
+    async def permission_setup(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        scope_map: dict[str, tuple[ScopeType, str]] = {
+            "vfolder_0": (ScopeType.VFOLDER, fixture_ids.vfolder_ids[0]),
+            "vfolder_1": (ScopeType.VFOLDER, fixture_ids.vfolder_ids[1]),
+            "project": (ScopeType.PROJECT, fixture_ids.project_id),
+            "domain": (ScopeType.DOMAIN, fixture_ids.domain_id),
+        }
+        for entry in request.param:
+            scope_type, scope_id = scope_map[entry.scope_key]
+            async with db_with_rbac_tables.begin_session() as db_sess:
+                db_sess.add(
+                    PermissionRow(
+                        role_id=fixture_ids.role_id,
+                        scope_type=scope_type,
+                        scope_id=scope_id,
+                        entity_type=entry.entity_type,
+                        operation=entry.operation,
+                    )
+                )
+                await db_sess.flush()
+
+    # ── Other user fixture ──
+
+    @pytest.fixture
+    async def other_user_with_project_permission(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """Another user with READ permission on the same project."""
+        other_user_id = uuid.uuid4()
+        other_role_id = uuid.uuid4()
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            db_sess.add(
+                UserRow(
+                    uuid=other_user_id,
+                    email="other@test.com",
+                    resource_policy="test-rbac-policy",
+                    status=UserStatus.ACTIVE,
+                    need_password_change=False,
+                    sudo_session_enabled=False,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(RoleRow(id=other_role_id, name="other-role"))
+            await db_sess.flush()
+
+            db_sess.add(UserRoleRow(user_id=other_user_id, role_id=other_role_id))
+            db_sess.add(
+                PermissionRow(
+                    role_id=other_role_id,
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.VFOLDER,
+                    operation=OperationType.READ,
+                )
+            )
+            await db_sess.flush()
+
+    # ── Helpers ──
+
+    def _make_refs(self, fixture: BatchFixture) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(element_type=RBACElementType.VFOLDER, element_id=vid)
+            for vid in fixture.vfolder_ids
+        ]
+
+    def _make_input(
+        self,
+        fixture: BatchFixture,
+        operation: OperationType,
+        *,
+        permission_entity_type: EntityType | None = None,
+    ) -> BatchPermissionCheckInput:
+        return BatchPermissionCheckInput(
+            user_id=fixture.user_id,
+            target_element_refs=self._make_refs(fixture),
+            operation=operation,
+            permission_entity_type=permission_entity_type,
+        )
+
+    # ── Tests ──
+
+    async def test_empty_input_returns_empty(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+    ) -> None:
+        """Empty target_element_refs returns empty dict."""
+        fixture = user_with_active_role
+        result = await db_source.check_batch_permission_with_scope_chain(
+            BatchPermissionCheckInput(
+                user_id=fixture.user_id,
+                target_element_refs=[],
+                operation=OperationType.READ,
+                permission_entity_type=None,
+            )
+        )
+        assert result == {}
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("project", OperationType.READ)], id="project-read")],
+        indirect=["permission_setup"],
+    )
+    async def test_all_granted_via_project_scope(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        permission_setup: None,
+    ) -> None:
+        """All vfolders in same project with READ permission -> all True."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.READ),
+        )
+        assert all(result.values())
+        assert len(result) == 3
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("domain", OperationType.UPDATE)], id="domain-update")],
+        indirect=["permission_setup"],
+    )
+    async def test_all_granted_via_domain_chain(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        project_in_domain_auto: None,
+        permission_setup: None,
+    ) -> None:
+        """Permission at DOMAIN scope propagates through chain to all vfolders."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.UPDATE),
+        )
+        assert all(result.values())
+        assert len(result) == 3
+
+    async def test_no_permission_all_denied(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+    ) -> None:
+        """No permissions -> all False."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.READ),
+        )
+        assert not any(result.values())
+        assert len(result) == 3
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("project", OperationType.READ)], id="project-read")],
+        indirect=["permission_setup"],
+    )
+    async def test_mixed_edges_partial_grant(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        mixed_vfolder_edges: None,
+        permission_setup: None,
+    ) -> None:
+        """AUTO edge -> granted, REF edge -> denied, no edge -> denied."""
+        fixture = user_with_active_role
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(fixture, OperationType.READ),
+        )
+        refs = self._make_refs(fixture)
+        assert result[refs[0]]  # AUTO
+        assert not result[refs[1]]  # REF
+        assert not result[refs[2]]  # no association
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("vfolder_0", OperationType.READ)], id="self-scope-v0")],
+        indirect=["permission_setup"],
+    )
+    async def test_self_scope_grants_individually(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        permission_setup: None,
+    ) -> None:
+        """Self-scope permission on vfolder[0] only; others denied."""
+        fixture = user_with_active_role
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(fixture, OperationType.READ),
+        )
+        refs = self._make_refs(fixture)
+        assert result[refs[0]]
+        assert not result[refs[1]]
+        assert not result[refs[2]]
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("project", OperationType.READ)], id="read-perm")],
+        indirect=["permission_setup"],
+    )
+    async def test_operation_mismatch_all_denied(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        permission_setup: None,
+    ) -> None:
+        """READ permission does not satisfy UPDATE check."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.UPDATE),
+        )
+        assert not any(result.values())
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("project", OperationType.READ)], id="project-read")],
+        indirect=["permission_setup"],
+    )
+    async def test_inactive_role_all_denied(
+        self,
+        db_source: PermissionDBSource,
+        user_with_inactive_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        permission_setup: None,
+    ) -> None:
+        """Inactive role does not grant any permission in batch."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_inactive_role, OperationType.READ),
+        )
+        assert not any(result.values())
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [
+            pytest.param(
+                [PermissionEntry("project", OperationType.READ, EntityType.MODEL_DEPLOYMENT)],
+                id="model-deployment-read",
+            )
+        ],
+        indirect=["permission_setup"],
+    )
+    async def test_cross_scope_entity_type(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        permission_setup: None,
+    ) -> None:
+        """permission_entity_type override applies to all entities in batch."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(
+                user_with_active_role,
+                OperationType.READ,
+                permission_entity_type=EntityType.MODEL_DEPLOYMENT,
+            ),
+        )
+        assert all(result.values())
+        assert len(result) == 3
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [
+            pytest.param(
+                [
+                    PermissionEntry("project", OperationType.READ),
+                    PermissionEntry("vfolder_1", OperationType.READ),
+                ],
+                id="chain-plus-self-scope",
+            )
+        ],
+        indirect=["permission_setup"],
+    )
+    async def test_self_scope_and_chain_combined(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        mixed_vfolder_edges: None,
+        permission_setup: None,
+    ) -> None:
+        """vfolder[0] via chain (AUTO), vfolder[1] via self-scope, vfolder[2] denied."""
+        fixture = user_with_active_role
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(fixture, OperationType.READ),
+        )
+        refs = self._make_refs(fixture)
+        assert result[refs[0]]  # via chain
+        assert result[refs[1]]  # via self-scope
+        assert not result[refs[2]]  # no path
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("domain", OperationType.READ)], id="domain-read")],
+        indirect=["permission_setup"],
+    )
+    async def test_domain_chain_multi_project_with_foreign_vfolder(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        multi_project_two_domains: None,
+        permission_setup: None,
+    ) -> None:
+        """Domain permission grants vfolders in child projects but not in another domain."""
+        fixture = user_with_active_role
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(fixture, OperationType.READ),
+        )
+        refs = self._make_refs(fixture)
+        assert result[refs[0]]  # domain_a -> project_a -> vfolder[0]
+        assert result[refs[1]]  # domain_a -> project_b -> vfolder[1]
+        assert not result[refs[2]]  # domain_b -> project_c -> vfolder[2]
+
+    async def test_other_user_not_affected(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        all_vfolders_in_project_auto: None,
+        other_user_with_project_permission: None,
+    ) -> None:
+        """Permission for another user does not leak into batch results."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.READ),
+        )
+        assert not any(result.values())

--- a/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_batch_permission_with_scope_chain.py
@@ -635,3 +635,76 @@ class TestCheckBatchPermissionWithScopeChain:
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert not any(result.values())
+
+    # ── Cycle detection ──
+
+    @pytest.fixture
+    async def scope_chain_with_cycle(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: BatchFixture,
+    ) -> None:
+        """Create a cycle: vfolders -> project -> domain -> project (back-edge)."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            # vfolders -> project (AUTO)
+            for vfolder_id in fixture_ids.vfolder_ids:
+                db_sess.add(
+                    AssociationScopesEntitiesRow(
+                        scope_type=ScopeType.PROJECT,
+                        scope_id=fixture_ids.project_id,
+                        entity_type=EntityType.VFOLDER,
+                        entity_id=vfolder_id,
+                        relation_type=RelationType.AUTO,
+                    )
+                )
+            # project -> domain (AUTO)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=fixture_ids.domain_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=fixture_ids.project_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            # domain -> project (AUTO, creates cycle)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.DOMAIN,
+                    entity_id=fixture_ids.domain_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            await db_sess.flush()
+
+    @pytest.mark.parametrize(
+        "permission_setup",
+        [pytest.param([PermissionEntry("domain", OperationType.READ)], id="domain-read")],
+        indirect=["permission_setup"],
+    )
+    async def test_scope_chain_cycle_terminates_with_permission(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        scope_chain_with_cycle: None,
+        permission_setup: None,
+    ) -> None:
+        """Cyclic scope chain terminates without infinite recursion; permission is found."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.READ),
+        )
+        assert all(result.values())
+
+    async def test_scope_chain_cycle_terminates_without_permission(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: BatchFixture,
+        scope_chain_with_cycle: None,
+    ) -> None:
+        """Cyclic scope chain terminates without infinite recursion; no permission granted."""
+        result = await db_source.check_batch_permission_with_scope_chain(
+            self._make_input(user_with_active_role, OperationType.READ),
+        )
+        assert not any(result.values())

--- a/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
@@ -1,6 +1,6 @@
 """
-Tests for PermissionDBSource.check_batch_permission_with_scope_chain().
-Covers batched CTE-based scope chain traversal with per-entity results.
+Tests for PermissionDBSource.check_bulk_permission_with_scope_chain().
+Covers bulk CTE-based scope chain traversal with per-entity results.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from ai.backend.common.data.permission.types import (
     RBACElementType,
     RelationType,
 )
-from ai.backend.manager.data.permission.role import BatchPermissionCheckInput
+from ai.backend.manager.data.permission.role import BulkPermissionCheckInput
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
@@ -72,7 +72,7 @@ class BatchFixture:
             self.vfolder_ids = [str(uuid.uuid4()) for _ in range(3)]
 
 
-class TestCheckBatchPermissionWithScopeChain:
+class TestCheckBulkPermissionWithScopeChain:
     """Tests for batched CTE-based scope chain permission traversal."""
 
     @pytest.fixture
@@ -417,8 +417,8 @@ class TestCheckBatchPermissionWithScopeChain:
         self,
         fixture: BatchFixture,
         operation: OperationType,
-    ) -> BatchPermissionCheckInput:
-        return BatchPermissionCheckInput(
+    ) -> BulkPermissionCheckInput:
+        return BulkPermissionCheckInput(
             user_id=fixture.user_id,
             target_element_type=RBACElementType.VFOLDER,
             target_entity_ids=fixture.vfolder_ids,
@@ -434,8 +434,8 @@ class TestCheckBatchPermissionWithScopeChain:
     ) -> None:
         """Empty target_entity_ids returns empty dict."""
         fixture = user_with_active_role
-        result = await db_source.check_batch_permission_with_scope_chain(
-            BatchPermissionCheckInput(
+        result = await db_source.check_bulk_permission_with_scope_chain(
+            BulkPermissionCheckInput(
                 user_id=fixture.user_id,
                 target_element_type=RBACElementType.VFOLDER,
                 target_entity_ids=[],
@@ -457,7 +457,7 @@ class TestCheckBatchPermissionWithScopeChain:
         permission_setup: None,
     ) -> None:
         """All vfolders in same project with READ permission -> all True."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert all(result.values())
@@ -477,7 +477,7 @@ class TestCheckBatchPermissionWithScopeChain:
         permission_setup: None,
     ) -> None:
         """Permission at DOMAIN scope propagates through chain to all vfolders."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.UPDATE),
         )
         assert all(result.values())
@@ -490,7 +490,7 @@ class TestCheckBatchPermissionWithScopeChain:
         all_vfolders_in_project_auto: None,
     ) -> None:
         """No permissions -> all False."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert not any(result.values())
@@ -510,7 +510,7 @@ class TestCheckBatchPermissionWithScopeChain:
     ) -> None:
         """AUTO edge -> granted, REF edge -> denied, no edge -> denied."""
         fixture = user_with_active_role
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
         assert result[fixture.vfolder_ids[0]]  # AUTO
@@ -530,7 +530,7 @@ class TestCheckBatchPermissionWithScopeChain:
     ) -> None:
         """Self-scope permission on vfolder[0] only; others denied."""
         fixture = user_with_active_role
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
         assert result[fixture.vfolder_ids[0]]
@@ -550,7 +550,7 @@ class TestCheckBatchPermissionWithScopeChain:
         permission_setup: None,
     ) -> None:
         """READ permission does not satisfy UPDATE check."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.UPDATE),
         )
         assert not any(result.values())
@@ -568,7 +568,7 @@ class TestCheckBatchPermissionWithScopeChain:
         permission_setup: None,
     ) -> None:
         """Inactive role does not grant any permission in batch."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_inactive_role, OperationType.READ),
         )
         assert not any(result.values())
@@ -595,7 +595,7 @@ class TestCheckBatchPermissionWithScopeChain:
     ) -> None:
         """vfolder[0] via chain (AUTO), vfolder[1] via self-scope, vfolder[2] denied."""
         fixture = user_with_active_role
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
         assert result[fixture.vfolder_ids[0]]  # via chain
@@ -616,7 +616,7 @@ class TestCheckBatchPermissionWithScopeChain:
     ) -> None:
         """Domain permission grants vfolders in child projects but not in another domain."""
         fixture = user_with_active_role
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(fixture, OperationType.READ),
         )
         assert result[fixture.vfolder_ids[0]]  # domain_a -> project_a -> vfolder[0]
@@ -631,7 +631,7 @@ class TestCheckBatchPermissionWithScopeChain:
         other_user_with_project_permission: None,
     ) -> None:
         """Permission for another user does not leak into batch results."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert not any(result.values())
@@ -692,7 +692,7 @@ class TestCheckBatchPermissionWithScopeChain:
         permission_setup: None,
     ) -> None:
         """Cyclic scope chain terminates without infinite recursion; permission is found."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert all(result.values())
@@ -704,7 +704,7 @@ class TestCheckBatchPermissionWithScopeChain:
         scope_chain_with_cycle: None,
     ) -> None:
         """Cyclic scope chain terminates without infinite recursion; no permission granted."""
-        result = await db_source.check_batch_permission_with_scope_chain(
+        result = await db_source.check_bulk_permission_with_scope_chain(
             self._make_input(user_with_active_role, OperationType.READ),
         )
         assert not any(result.values())

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -1330,3 +1330,87 @@ class TestCheckPermissionWithScopeChain:
             )
         )
         assert result is expected
+
+    # ── Cycle detection ──
+
+    @pytest.fixture
+    async def scope_chain_with_cycle(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: ScopeChainFixture,
+    ) -> None:
+        """Create a cycle: vfolder -> project -> domain -> project (back-edge)."""
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            # vfolder -> project (AUTO)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.VFOLDER,
+                    entity_id=fixture_ids.vfolder_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            # project -> domain (AUTO)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.DOMAIN,
+                    scope_id=fixture_ids.domain_id,
+                    entity_type=EntityType.PROJECT,
+                    entity_id=fixture_ids.project_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            # domain -> project (AUTO, creates cycle)
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=fixture_ids.project_id,
+                    entity_type=EntityType.DOMAIN,
+                    entity_id=fixture_ids.domain_id,
+                    relation_type=RelationType.AUTO,
+                )
+            )
+            await db_sess.flush()
+
+    @pytest.mark.parametrize(
+        ("permission_setup", "check_op", "expected"),
+        [
+            pytest.param(
+                [PermissionEntry("domain", OperationType.READ)],
+                OperationType.READ,
+                True,
+                id="cycle-with-permission",
+            ),
+            pytest.param(
+                [],
+                OperationType.READ,
+                False,
+                id="cycle-without-permission",
+            ),
+        ],
+        indirect=["permission_setup"],
+    )
+    async def test_scope_chain_cycle_terminates(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: ScopeChainFixture,
+        scope_chain_with_cycle: None,
+        permission_setup: None,
+        check_op: OperationType,
+        expected: bool,
+    ) -> None:
+        """Cyclic scope chain terminates without infinite recursion (UNION deduplicates)."""
+        fixture = user_with_active_role
+        result = await db_source.check_permission_with_scope_chain(
+            ScopeChainPermissionCheckInput(
+                user_id=fixture.user_id,
+                target_element_ref=RBACElementRef(
+                    element_type=RBACElementType.VFOLDER,
+                    element_id=fixture.vfolder_id,
+                ),
+                operation=check_op,
+                permission_entity_type=None,
+            )
+        )
+        assert result is expected


### PR DESCRIPTION
## Summary
- Add `BatchPermissionCheckInput` data type and `check_batch_permission_with_scope_chain()` that validates multiple entities of the same `RBACElementType` in a single DB query
- Uses a recursive CTE carrying `entity_id` through scope chain traversal, preserving the same two-layer semantics (scope chain + self-scope) as the single-entity version
- Exposed via `PermissionControllerRepository` with the standard resilience decorator

## Test plan
- [x] Empty input returns empty dict
- [x] All granted via project scope (shared AUTO edges)
- [x] All granted via domain chain (2-level traversal)
- [x] No permission → all denied
- [x] Mixed edges partial grant (AUTO/REF/none)
- [x] Self-scope grants individually
- [x] Operation mismatch → all denied
- [x] Inactive role → all denied
- [x] Cross-scope entity type override
- [x] Self-scope + chain combined
- [x] Multi-project two-domain isolation
- [x] Other user permission isolation

Resolves BA-5776