### PR TITLE
fix(BA-5791): stop OTP value leaking into sToken hook parameter

### DIFF
--- a/changes/11204.fix.md
+++ b/changes/11204.fix.md
@@ -1,0 +1,1 @@
+Fix TOTP login failure caused by OTP value leaking into sToken hook parameter, which made the keypair auth plugin reject valid logins

--- a/src/ai/backend/manager/plugin/totp/hook.py
+++ b/src/ai/backend/manager/plugin/totp/hook.py
@@ -77,7 +77,7 @@ class TOTPHook(HookPlugin):
         if not user.totp_key:
             raise Reject("User activated TOTP but TOTP key does not exist")
 
-        otp = params.get("stoken") or params.get("sToken") or params.get("otp")
+        otp = params.get("otp")
         if not otp:
             auth_response = RequireTwoFactorAuthResponse(
                 response_type=AuthResponseType.REQUIRE_TWO_FACTOR_AUTH,

--- a/src/ai/backend/manager/services/auth/actions/authorize.py
+++ b/src/ai/backend/manager/services/auth/actions/authorize.py
@@ -34,15 +34,14 @@ class AuthorizeAction(AuthAction):
 
     @property
     def hook_params(self) -> dict[str, str]:
-        otp_value = self.otp or self.stoken or ""
         return {
             "type": self.type.value,
             "domain": self.domain_name,
             "username": self.email,
             "password": self.password,
-            "stoken": otp_value,
-            "sToken": otp_value,
-            "otp": otp_value,
+            "stoken": self.stoken or "",
+            "sToken": self.stoken or "",
+            "otp": self.otp or "",
         }
 
 


### PR DESCRIPTION
## Summary
- `AuthorizeAction.hook_params` was merging OTP and sToken values into all three hook keys (`stoken`, `sToken`, `otp`), causing the keypair auth plugin on the `AUTHORIZE` hook to reject valid TOTP login attempts with "Invalid auth token"
- Separate `stoken`/`sToken` (keypair redirect only) from `otp` (TOTP only) so each hook plugin receives only its intended parameter
- Remove legacy `stoken`/`sToken` fallback in `TOTPHook.validate_otp` — webui has sent OTP via the `otp` field since 2023

## Test plan
- [x] Login with TOTP-activated user and correct OTP succeeds (no "Invalid auth token")
- [x] Login with incorrect OTP returns TOTP-specific rejection ("Invalid TOTP code provided")
- [x] Keypair redirect login (real sToken, no OTP) still authenticates successfully
- [x] `pants test` passes for affected packages

Resolves BA-5791