### PR TITLE
fix(BA-5774): skip already-attached networks to avoid duplicate-attach 403

### DIFF
--- a/changes/11209.fix.md
+++ b/changes/11209.fix.md
@@ -1,0 +1,1 @@
+Fix single-node session creation failing with `DockerError 403 "endpoint already exists"` when the accelerator plugin `docker-networks` config includes `bridge`, by skipping networks already attached to the container before calling `network.connect()`.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1325,9 +1325,13 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             # serve both single-node and multi-node without duplicate-attach 403s.
             if additional_network_names:
                 container_info = await container.show()
-                already_attached_networks = set(
-                    container_info.get("NetworkSettings", {}).get("Networks", {}).keys()
-                )
+                networks = container_info.get("NetworkSettings", {}).get("Networks", {}) or {}
+                # `get_docker_networks()` may return either network names or IDs
+                # (see `Resources.get_docker_networks` contract), so collect both
+                # the dict keys (names) and `NetworkID` values to filter against.
+                already_attached_networks = set(networks.keys()) | {
+                    n["NetworkID"] for n in networks.values() if n.get("NetworkID")
+                }
             else:
                 already_attached_networks = set()
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1320,9 +1320,24 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 n = await self.computers[dev_name].instance.get_docker_networks(device_alloc)
                 additional_network_names |= set(n)
 
-            for name in additional_network_names:
+            # Skip networks already attached by Docker (e.g. `bridge` auto-attached
+            # when NetworkMode is unset). A single `docker-networks` config can then
+            # serve both single-node and multi-node without duplicate-attach 403s.
+            container_info = await container.show()
+            already_attached_networks = set(
+                container_info.get("NetworkSettings", {}).get("Networks", {}).keys()
+            )
+
+            for name in additional_network_names - already_attached_networks:
                 network = await docker.networks.get(name)
-                await network.connect({"Container": container._id})
+                try:
+                    await network.connect({"Container": container._id})
+                except DockerError as e:
+                    # Defense against a race between container.show() and connect()
+                    # where Docker may attach the network in between.
+                    if e.status == 403 and "already exists" in str(e.message):
+                        continue
+                    raise
 
             kernel_obj.set_container_id(ContainerId(cid))
             container_network_info: ContainerNetworkInfo | None = None

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1068,9 +1068,12 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         if not requested:
             return
         container_info = await container.show()
-        networks = container_info.get("NetworkSettings", {}).get("Networks", {}) or {}
+        networks = {}
+        if (network_settings := container_info.get("NetworkSettings")) is not None:
+            if (networks_dict := network_settings.get("Networks")) is not None:
+                networks = networks_dict
         already_attached = set(networks.keys()) | {
-            n["NetworkID"] for n in networks.values() if n.get("NetworkID")
+            n["NetworkID"] for n in networks.values() if n is not None and n.get("NetworkID")
         }
         for ref in requested - already_attached:
             network = await docker.networks.get(ref)

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1052,6 +1052,37 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 f"seccomp={json.dumps(seccomp_profile)}"
             ]
 
+    async def _attach_additional_networks(
+        self,
+        docker: Docker,
+        container: DockerContainer,
+        requested_networks: Iterable[str],
+    ) -> None:
+        """
+        Connect the container to each requested network, skipping any that
+        Docker has already attached (e.g. `bridge` auto-attached when
+        `NetworkMode` is unset). `requested_networks` may contain network
+        names or IDs per the `Resources.get_docker_networks` contract.
+        """
+        requested = set(requested_networks)
+        if not requested:
+            return
+        container_info = await container.show()
+        networks = container_info.get("NetworkSettings", {}).get("Networks", {}) or {}
+        already_attached = set(networks.keys()) | {
+            n["NetworkID"] for n in networks.values() if n.get("NetworkID")
+        }
+        for ref in requested - already_attached:
+            network = await docker.networks.get(ref)
+            try:
+                await network.connect({"Container": container._id})
+            except DockerError as e:
+                # Defense against a race between container.show() and connect()
+                # where Docker may attach the network in between.
+                if e.status == HTTPStatus.FORBIDDEN and "already exists" in str(e.message):
+                    continue
+                raise
+
     @override
     async def start_container(
         self,
@@ -1320,31 +1351,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 n = await self.computers[dev_name].instance.get_docker_networks(device_alloc)
                 additional_network_names |= set(n)
 
-            # Skip networks already attached by Docker (e.g. `bridge` auto-attached
-            # when NetworkMode is unset). A single `docker-networks` config can then
-            # serve both single-node and multi-node without duplicate-attach 403s.
-            if additional_network_names:
-                container_info = await container.show()
-                networks = container_info.get("NetworkSettings", {}).get("Networks", {}) or {}
-                # `get_docker_networks()` may return either network names or IDs
-                # (see `Resources.get_docker_networks` contract), so collect both
-                # the dict keys (names) and `NetworkID` values to filter against.
-                already_attached_networks = set(networks.keys()) | {
-                    n["NetworkID"] for n in networks.values() if n.get("NetworkID")
-                }
-            else:
-                already_attached_networks = set()
-
-            for name in additional_network_names - already_attached_networks:
-                network = await docker.networks.get(name)
-                try:
-                    await network.connect({"Container": container._id})
-                except DockerError as e:
-                    # Defense against a race between container.show() and connect()
-                    # where Docker may attach the network in between.
-                    if e.status == HTTPStatus.FORBIDDEN and "already exists" in str(e.message):
-                        continue
-                    raise
+            await self._attach_additional_networks(docker, container, additional_network_names)
 
             kernel_obj.set_container_id(ContainerId(cid))
             container_network_info: ContainerNetworkInfo | None = None

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1323,10 +1323,13 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             # Skip networks already attached by Docker (e.g. `bridge` auto-attached
             # when NetworkMode is unset). A single `docker-networks` config can then
             # serve both single-node and multi-node without duplicate-attach 403s.
-            container_info = await container.show()
-            already_attached_networks = set(
-                container_info.get("NetworkSettings", {}).get("Networks", {}).keys()
-            )
+            if additional_network_names:
+                container_info = await container.show()
+                already_attached_networks = set(
+                    container_info.get("NetworkSettings", {}).get("Networks", {}).keys()
+                )
+            else:
+                already_attached_networks = set()
 
             for name in additional_network_names - already_attached_networks:
                 network = await docker.networks.get(name)
@@ -1335,7 +1338,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 except DockerError as e:
                     # Defense against a race between container.show() and connect()
                     # where Docker may attach the network in between.
-                    if e.status == 403 and "already exists" in str(e.message):
+                    if e.status == HTTPStatus.FORBIDDEN and "already exists" in str(e.message):
                         continue
                     raise
 

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -14,11 +14,11 @@ from aiodocker.exceptions import DockerError
 from ai.backend.agent.docker.agent import DockerKernelCreationContext
 
 
-def _make_container_show_response(networks: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _make_container_show_response(networks: dict[str, dict[str, Any] | None]) -> dict[str, Any]:
     return {"NetworkSettings": {"Networks": networks}}
 
 
-def _make_container_mock(networks: dict[str, dict[str, Any]]) -> MagicMock:
+def _make_container_mock(networks: dict[str, dict[str, Any] | None]) -> MagicMock:
     container = MagicMock()
     container._id = "container-id"
     container.show = AsyncMock(return_value=_make_container_show_response(networks))
@@ -142,6 +142,24 @@ class TestAttachAdditionalNetworks:
 
         with pytest.raises(DockerError):
             await context._attach_additional_networks(docker, container, {"bridge"})
+
+    async def test_tolerates_none_network_entry_in_container_show(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        """container.show() may return None for a network entry value."""
+        container = _make_container_mock(
+            networks={"bridge": None},
+        )
+        connect_mock = AsyncMock()
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        await context._attach_additional_networks(docker, container, {"macvlan-roce-0"})
+
+        docker.networks.get.assert_awaited_once_with("macvlan-roce-0")
+        connect_mock.assert_awaited_once()
 
     async def test_reraises_403_when_message_does_not_match(
         self,

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -1,0 +1,162 @@
+"""
+Unit tests for `DockerKernelCreationContext` helpers.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiodocker.exceptions import DockerError
+
+from ai.backend.agent.docker.agent import DockerKernelCreationContext
+
+
+def _make_container_show_response(networks: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    return {"NetworkSettings": {"Networks": networks}}
+
+
+def _make_container_mock(networks: dict[str, dict[str, Any]]) -> MagicMock:
+    container = MagicMock()
+    container._id = "container-id"
+    container.show = AsyncMock(return_value=_make_container_show_response(networks))
+    return container
+
+
+def _make_docker_mock(network_get: AsyncMock | None = None) -> MagicMock:
+    docker = MagicMock()
+    docker.networks = MagicMock()
+    docker.networks.get = network_get if network_get is not None else AsyncMock()
+    return docker
+
+
+@pytest.fixture
+def context() -> DockerKernelCreationContext:
+    # `_attach_additional_networks` does not access any instance state, so we can
+    # bypass __init__ and exercise the method on a bare instance.
+    return DockerKernelCreationContext.__new__(DockerKernelCreationContext)
+
+
+class TestAttachAdditionalNetworks:
+    async def test_no_requested_networks_skips_inspect(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(networks={})
+        docker = _make_docker_mock()
+
+        await context._attach_additional_networks(docker, container, set())
+
+        container.show.assert_not_called()
+        docker.networks.get.assert_not_called()
+
+    async def test_skips_network_already_attached_by_name(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(
+            networks={"bridge": {"NetworkID": "bridge-id", "EndpointID": "ep-1"}},
+        )
+        connect_mock = AsyncMock()
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        await context._attach_additional_networks(docker, container, {"bridge"})
+
+        container.show.assert_awaited_once()
+        docker.networks.get.assert_not_called()
+        connect_mock.assert_not_called()
+
+    async def test_skips_network_already_attached_by_id(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(
+            networks={"bridge": {"NetworkID": "net-abc"}},
+        )
+        connect_mock = AsyncMock()
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        await context._attach_additional_networks(docker, container, {"net-abc"})
+
+        docker.networks.get.assert_not_called()
+        connect_mock.assert_not_called()
+
+    async def test_attaches_only_unattached_networks(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(
+            networks={"bridge": {"NetworkID": "bridge-id"}},
+        )
+        connect_mock = AsyncMock()
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        await context._attach_additional_networks(docker, container, {"bridge", "macvlan-roce-0"})
+
+        docker.networks.get.assert_awaited_once_with("macvlan-roce-0")
+        connect_mock.assert_awaited_once_with({"Container": "container-id"})
+
+    async def test_swallows_403_already_exists_race(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        # The container.show() snapshot says nothing is attached, but Docker
+        # races us and reports the endpoint already exists during connect().
+        container = _make_container_mock(networks={})
+        connect_mock = AsyncMock(
+            side_effect=DockerError(
+                HTTPStatus.FORBIDDEN,
+                {"message": "endpoint with name kernel.x already exists in network bridge"},
+            )
+        )
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        await context._attach_additional_networks(docker, container, {"bridge"})
+
+        connect_mock.assert_awaited_once()
+
+    async def test_reraises_other_docker_errors(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(networks={})
+        connect_mock = AsyncMock(
+            side_effect=DockerError(
+                HTTPStatus.NOT_FOUND,
+                {"message": "network not found"},
+            )
+        )
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        with pytest.raises(DockerError):
+            await context._attach_additional_networks(docker, container, {"bridge"})
+
+    async def test_reraises_403_when_message_does_not_match(
+        self,
+        context: DockerKernelCreationContext,
+    ) -> None:
+        container = _make_container_mock(networks={})
+        connect_mock = AsyncMock(
+            side_effect=DockerError(
+                HTTPStatus.FORBIDDEN,
+                {"message": "permission denied"},
+            )
+        )
+        network = MagicMock()
+        network.connect = connect_mock
+        docker = _make_docker_mock(network_get=AsyncMock(return_value=network))
+
+        with pytest.raises(DockerError):
+            await context._attach_additional_networks(docker, container, {"bridge"})


### PR DESCRIPTION
## Summary

- Before calling `network.connect()` for each entry in `docker-networks`, inspect the container and skip networks Docker has already attached (e.g. `bridge` auto-attached when `NetworkMode` is unset).
- Keep a narrow `DockerError` catch for `403 "already exists"` around `connect()` as a defense against a `container.show()` ↔ `connect()` race.
- Lets a single accelerator plugin `docker-networks` config (e.g. `["bridge", "macvlan-roce-0", "macvlan-roce-1"]`) serve both single-node and multi-node sessions.

Resolves **BA-5774**.

### Background

When an accelerator plugin config (e.g. `cuda.toml`) lists `bridge` in `docker-networks`, **single-node** session creation failed every time with:

```
DockerError(403, 'endpoint with name kernel.<img>.<kid> already exists in network bridge')
```

Root cause: after container start, the agent iterated the `docker-networks` list and called `network.connect()` for each entry **without checking whether the container was already attached**. Docker auto-attaches `bridge` when `NetworkMode` is unset (single-node), so the explicit `connect()` duplicated the attach.

Removing `bridge` from the list fixed single-node but broke multi-node sessions, where `bridge` is needed for control-plane connectivity because overlay is used as the primary `NetworkMode`. A single config could not cover both modes — this patch fixes that.

## Test plan

- [ ] Single-node session creation succeeds with `docker-networks = ["bridge", "macvlan-roce-0", "macvlan-roce-1"]` (no more 403)
- [ ] Multi-node (overlay) session creation still attaches `bridge` successfully for control-plane connectivity
- [ ] Session with `docker-networks` containing only non-auto-attached networks still connects correctly
- [x] Unit/integration tests: `pants test ::` on `src/ai/backend/agent/docker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)