### PR TITLE
refactor(BA-5799): surface silent failures in gather-with-return_exceptions sites

### DIFF
--- a/changes/11221.fix.md
+++ b/changes/11221.fix.md
@@ -1,0 +1,1 @@
+Surface per-task failures in background `asyncio.gather(..., return_exceptions=True)` sites by switching to `aiotools.as_completed_safe()` — image-pull trigger, container enumeration, volume stats observation, kernel log piping, and HuggingFace metadata download now log errors instead of silently discarding them.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1661,47 +1661,50 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         self,
         status_filter: frozenset[ContainerStatus] = ACTIVE_STATUS_SET,
     ) -> Sequence[tuple[KernelId, Container]]:
-        result = []
         fetch_tasks = []
         async with closing_async(Docker()) as docker:
             for container in await docker.containers.list():
 
-                async def _fetch_container_info(container: DockerContainer) -> None:
-                    kernel_id_str: str = "(unknown)"
+                async def _fetch_container_info(
+                    container: DockerContainer,
+                ) -> tuple[KernelId, Container] | None:
                     try:
                         kernel_id = await get_kernel_id_from_container(container)
-                        if kernel_id is None:
-                            return
-                        kernel_id_str = str(kernel_id)
-                        if container["State"]["Status"] in status_filter:
-                            owner_id = AgentId(
-                                container["Config"]["Labels"].get(LabelName.OWNER_AGENT, "")
-                            )
-                            if self.id == owner_id:
-                                await container.show()
-                                result.append(
-                                    (
-                                        kernel_id,
-                                        container_from_docker_container(container),
-                                    ),
-                                )
                     except DockerError as e:
                         if e.status == HTTPStatus.NOT_FOUND:
                             log.warning(e.message)
-                            return
+                            return None
                         raise
-                    except asyncio.CancelledError:
-                        pass
-                    except Exception:
-                        log.exception(
-                            "error while fetching container information (cid:{}, k:{})",
-                            container._id,
-                            kernel_id_str,
-                        )
+                    if kernel_id is None:
+                        return None
+                    if container["State"]["Status"] not in status_filter:
+                        return None
+                    owner_id = AgentId(container["Config"]["Labels"].get(LabelName.OWNER_AGENT, ""))
+                    if self.id != owner_id:
+                        return None
+                    try:
+                        await container.show()
+                    except DockerError as e:
+                        if e.status == HTTPStatus.NOT_FOUND:
+                            log.warning(e.message)
+                            return None
+                        raise
+                    return kernel_id, container_from_docker_container(container)
 
                 fetch_tasks.append(_fetch_container_info(container))
 
-            await asyncio.gather(*fetch_tasks, return_exceptions=True)
+            # Consolidate result collection and per-task exception handling in
+            # one place so each container's outcome is visible at a single
+            # call site.
+            result: list[tuple[KernelId, Container]] = []
+            async for fut in aiotools.as_completed_safe(fetch_tasks):
+                try:
+                    entry = await fut
+                except Exception:
+                    log.exception("error while fetching container information")
+                    continue
+                if entry is not None:
+                    result.append(entry)
         return result
 
     @override

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -1041,37 +1041,34 @@ class KubernetesAgent(
         await kube_config.load_kube_config()
         core_api = kube_client.CoreV1Api()
 
-        result = []
         fetch_tasks = []
         for deployment in (await core_api.list_namespaced_pod("backend-ai")).items:
             # Additional check to filter out real worker pods only?
 
-            async def _fetch_container_info(pod: Any) -> None:
-                kernel_id: KernelId | str | None = "(unknown)"
-                try:
-                    kernel_id = await get_kernel_id_from_deployment(pod)
-                    if kernel_id is None or kernel_id not in self.kernel_registry:
-                        return
-                    # Is it okay to assume that only one container resides per pod?
-                    if pod["status"]["containerStatuses"][0]["stats"].keys()[0] in status_filter:
-                        result.append(
-                            (
-                                kernel_id,
-                                await container_from_pod(pod),
-                            ),
-                        )
-                except asyncio.CancelledError:
-                    pass
-                except Exception:
-                    log.exception(
-                        "error while fetching container information (cid:{}, k:{})",
-                        pod["metadata"]["uid"],
-                        kernel_id,
-                    )
+            async def _fetch_container_info(
+                pod: Any,
+            ) -> tuple[KernelId, Container] | None:
+                kernel_id = await get_kernel_id_from_deployment(pod)
+                if kernel_id is None or kernel_id not in self.kernel_registry:
+                    return None
+                # Is it okay to assume that only one container resides per pod?
+                if pod["status"]["containerStatuses"][0]["stats"].keys()[0] in status_filter:
+                    return kernel_id, await container_from_pod(pod)
+                return None
 
             fetch_tasks.append(_fetch_container_info(deployment))
 
-        await asyncio.gather(*fetch_tasks, return_exceptions=True)
+        # Consolidate result collection and per-task exception handling in one
+        # place so each pod's outcome is visible at a single call site.
+        result: list[tuple[KernelId, Container]] = []
+        async for fut in aiotools.as_completed_safe(fetch_tasks):
+            try:
+                entry = await fut
+            except Exception:
+                log.exception("error while fetching container information")
+                continue
+            if entry is not None:
+                result.append(entry)
         return result
 
     @override

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -28,6 +28,7 @@ from typing import (
 if TYPE_CHECKING:
     from janus import _AsyncQueueProxy
 
+import aiotools
 import janus
 import msgpack
 import zmq
@@ -77,17 +78,28 @@ async def pipe_output(
     console_fd = sys.stdout.fileno() if target == "stdout" else sys.stderr.fileno()
     target_bytes = target.encode("ascii")
     loop = current_loop()
+
+    async def _write(sink: str, awaitable: Awaitable[Any]) -> None:
+        try:
+            await awaitable
+        except Exception:
+            log.exception("Failed to write kernel {} to {}", target, sink)
+
     try:
         while True:
             data = await stream.read(4096)
             if not data:
                 break
-            await asyncio.gather(
-                loop.run_in_executor(None, os.write, console_fd, data),
-                loop.run_in_executor(None, os.write, log_fd, data),
-                outsock.send_multipart([target_bytes, data]),
-                return_exceptions=True,
-            )
+            writes = [
+                _write("console", loop.run_in_executor(None, os.write, console_fd, data)),
+                _write("logfile", loop.run_in_executor(None, os.write, log_fd, data)),
+                _write(
+                    "outsock",
+                    cast(Awaitable[Any], outsock.send_multipart([target_bytes, data])),
+                ),
+            ]
+            async for fut in aiotools.as_completed_safe(writes):
+                await fut
     except asyncio.CancelledError:
         pass
     except Exception:

--- a/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
+++ b/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import defaultdict
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Coroutine
 from dataclasses import dataclass
 from itertools import groupby
 from typing import Any
 from uuid import UUID
 
+import aiotools
 import async_timeout
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -137,14 +138,15 @@ class SessionLauncher:
                         image_config = img_cfg.to_image_config(AutoPullBehavior(auto_pull))
                         agent_image_configs[agent_id][canonical] = image_config
 
-        # Trigger image checking and pulling on each agent
-        async def pull_for_agent(
-            agent_id: AgentId, images: dict[str, ImageConfig]
-        ) -> Mapping[str, str]:
+        # Trigger image checking and pulling on each agent. The coroutine
+        # returns the owning agent_id on success so that the outer loop can
+        # log per-agent results and failures at a single call site.
+        async def pull_for_agent(agent_id: AgentId, images: dict[str, ImageConfig]) -> AgentId:
             async with self._agent_client_pool.acquire(agent_id) as client:
-                return await client.check_and_pull(images)
+                await client.check_and_pull(images)
+            return agent_id
 
-        pull_tasks: list[Awaitable[Mapping[str, str]]] = []
+        pull_tasks: list[Coroutine[Any, Any, AgentId]] = []
         for agent_id, agent_images in agent_image_configs.items():
             pull_tasks.append(pull_for_agent(agent_id, agent_images))
 
@@ -157,7 +159,17 @@ class SessionLauncher:
                     "check_and_pull_images",
                     success_detail="Image pull triggered",
                 ):
-                    await asyncio.gather(*pull_tasks, return_exceptions=True)
+                    succeeded: list[AgentId] = []
+                    async for fut in aiotools.as_completed_safe(pull_tasks):
+                        try:
+                            succeeded.append(await fut)
+                        except Exception:
+                            log.exception("Failed to trigger image pull on an agent")
+                    log.debug(
+                        "Image pull triggered on {}/{} agents",
+                        len(succeeded),
+                        len(pull_tasks),
+                    )
 
     async def start_sessions_for_handler(
         self,

--- a/src/ai/backend/storage/client/huggingface.py
+++ b/src/ai/backend/storage/client/huggingface.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 
 import aiohttp
+import aiotools
 from huggingface_hub import (
     HfApi,
     hf_hub_url,
@@ -456,33 +457,46 @@ class HuggingFaceScanner:
         )
         semaphore = asyncio.Semaphore(max_concurrent)
 
-        async def download_metadata(model_data: ModelData) -> None:
-            """Download metadata (README and file size) for a single model."""
+        async def download_metadata(model_data: ModelData) -> str | None:
+            """Download metadata (README and file size) for a single model.
+
+            Returns the model id on success (for logging) and lets exceptions
+            propagate so the caller can log them centrally alongside result
+            processing.
+            """
             async with semaphore:
-                try:
-                    model_target = ModelTarget(model_id=model_data.id, revision=model_data.revision)
-                    total_size = await self._calculate_model_size(model_target)
-                    readme_content = await self._download_readme(model_target)
+                model_target = ModelTarget(model_id=model_data.id, revision=model_data.revision)
+                total_size = await self._calculate_model_size(model_target)
+                readme_content = await self._download_readme(model_target)
 
-                    # Only add to results if we have README content
-                    if readme_content:
-                        metadata_info = ModelMetadataInfo(
-                            model_id=model_data.id,
-                            revision=model_data.revision,
-                            readme_content=readme_content,
-                            registry_type=ArtifactRegistryType.HUGGINGFACE,
-                            registry_name=registry_name,
-                            size=total_size,
-                        )
-                        await event_producer.anycast_event(
-                            ModelMetadataFetchDoneEvent(model=metadata_info)
-                        )
-                except Exception:
-                    pass
+                # Only emit the event when README content is available.
+                if readme_content:
+                    metadata_info = ModelMetadataInfo(
+                        model_id=model_data.id,
+                        revision=model_data.revision,
+                        readme_content=readme_content,
+                        registry_type=ArtifactRegistryType.HUGGINGFACE,
+                        registry_name=registry_name,
+                        size=total_size,
+                    )
+                    await event_producer.anycast_event(
+                        ModelMetadataFetchDoneEvent(model=metadata_info)
+                    )
+                    return model_data.id
+                return None
 
-        # Download metadata concurrently with semaphore limit
+        # Download metadata concurrently with semaphore limit.
+        # Result handling (emitted count) and exception handling live together
+        # in the iterator to keep the per-model outcome visible at one site.
         tasks = [download_metadata(model) for model in models]
-        await asyncio.gather(*tasks, return_exceptions=True)
+        emitted = 0
+        async for fut in aiotools.as_completed_safe(tasks):
+            try:
+                if await fut is not None:
+                    emitted += 1
+            except Exception:
+                log.exception("Failed to download model metadata")
+        log.info("Finished model metadata processing: {}/{} emitted", emitted, len(models))
 
     async def _download_readme(self, model: ModelTarget) -> str | None:
         """Download README content for a model.

--- a/src/ai/backend/storage/volumes/stats/observer.py
+++ b/src/ai/backend/storage/volumes/stats/observer.py
@@ -6,6 +6,8 @@ import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, override
 
+import aiotools
+
 from ai.backend.common.clients.valkey_client.valkey_volume_stats import ValkeyVolumeStatsClient
 from ai.backend.common.observer.types import AbstractObserver
 from ai.backend.logging import BraceStyleAdapter
@@ -68,8 +70,16 @@ class VolumeStatsObserver(AbstractObserver):
             log.debug("No volumes to observe")
             return
 
+        # `_observe_single` captures its own exceptions, but iterating via
+        # `as_completed_safe` ensures that when the outer observe() is cancelled
+        # (e.g. by the Runner's timeout), in-flight per-volume tasks are
+        # cancelled and awaited cleanly instead of being orphaned.
         tasks = [self._observe_single(volume_name) for volume_name in volumes.keys()]
-        await asyncio.gather(*tasks, return_exceptions=True)
+        async for fut in aiotools.as_completed_safe(tasks):
+            try:
+                await fut
+            except Exception:
+                log.exception("Unexpected error while observing a volume")
 
     @override
     async def cleanup(self) -> None:


### PR DESCRIPTION
## Summary

Replaces `await asyncio.gather(..., return_exceptions=True)` at sites where the return value was being discarded — silently swallowing every per-task failure — with `aiotools.as_completed_safe()` and a tight iterator that logs each failure and, where applicable, collects results at a single call site.

refs BA-5799, resolves #11221.

## What changed

| Site | Before | After |
|---|---|---|
| `manager/sokovan/scheduler/launcher/launcher.py` — per-agent image pull trigger | Failures swallowed; no hint which agent's pull failed | `as_completed_safe` + per-agent exception log; success count at debug |
| `agent/docker/agent.py` — container enumeration | `result.append()` + `try/except` inlined in each per-container task; unclear outcome surface | Per-task coroutine returns `(KernelId, Container) \| None`; outer loop does result.append + exception logging in one place |
| `agent/kubernetes/agent.py` — container enumeration | Same as docker | Same refactor |
| `kernel/base.py` — kernel stdout/stderr piping (console/logfile/outsock) | All three write failures swallowed | `as_completed_safe` + per-sink exception log |
| `storage/volumes/stats/observer.py` — per-volume observation | Bare gather discarded any leaked exceptions | `as_completed_safe` + defensive exception log (per-volume handling stays intrinsic to `_observe_single` where the metric categories live) |
| `storage/client/huggingface.py` — model metadata download | `except: pass` inside the task; outer gather discarded | Exceptions propagate; outer loop logs and counts emitted models |

## Non-goals (followups)

The audit identified other `return_exceptions=True` callsites where the exception check is weak (`isinstance(r, Exception)` instead of `BaseException`) and one dead `except TimeoutError` block. Those are **not** included here — see #11221 for the full list. The pattern-B bugs (`agent/agent.py:clean_kernel_objects`, `kernel/base.py:1188`, `services/user/service.py`, `sokovan/scheduler/coordinator.py:1326`) remain open.

The cleanup-after-cancel callsites (`__aexit__`, `cancel_all`, `aclose`, event-loop shutdown) are **intentionally unchanged** — they are already correct as-is and `as_completed_safe` would not improve them.

## Test plan

- [x] `pants fmt --changed-since=main` (ruff format)
- [x] `pants lint --changed-since=main` (ruff check + visibility)
- [x] `pants check --changed-since=main --changed-dependents=transitive` (mypy, 419 files, 0 issues)
- [ ] Manual smoke test: start an agent, launch a session, verify image-pull failure path logs the agent id (local Docker)
- [ ] Manual smoke test: run storage proxy volume observer with an intentionally failing volume, confirm the failure is logged