### PR TITLE
fix(agent): Scope aiodocker client in DockerKernel.commit() via closing_async

### DIFF
--- a/changes/11228.fix.md
+++ b/changes/11228.fix.md
@@ -1,0 +1,1 @@
+Fix a leaked aiodocker session in `DockerKernel.commit()` by scoping the client via `closing_async`.

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -221,8 +221,7 @@ class DockerKernel(AbstractKernel):
         try:
             async with FileLock(path=lock_path, timeout=0.1, remove_when_unlock=True):
                 log.info("Container (k: {}) is being committed", kernel_id)
-                docker = Docker()
-                try:
+                async with closing_async(Docker()) as docker:
                     # There is a known issue at certain versions of Docker Engine
                     # which prevents container from being committed when request config body is empty
                     # https://github.com/moby/moby/issues/45543
@@ -289,8 +288,6 @@ class DockerKernel(AbstractKernel):
                                         await write_task
                         finally:
                             await docker.images.delete(image_id)
-                finally:
-                    await docker.close()
         except TimeoutError:
             log.warning("Session is already being committed.")
 


### PR DESCRIPTION
## Summary
- Wrap the bare `Docker()` in `DockerKernel.commit()` with `closing_async(...)` so the `aiohttp.ClientSession` is always closed.
- Matches the pattern already used by sibling methods (`get_logs`, `download_file`, `download_single`).

## Why not the broader shared-client refactor?
The original scope of #11227 threaded a shared `Docker` client into `DockerKernel` and its recovery path. After review, the ongoing invariant-maintenance cost (pickle exclusion, `attach_docker()` ordering on recovery, constructor plumbing) outweighed the latency gains on these rarely-called methods. The only real bug — a leaked session in `commit()` — is fixed here in isolation. See the prior discussion on this PR for the full tradeoff analysis.

## Test plan
- [ ] `pants check src/ai/backend/agent/docker::` passes
- [ ] Commit a kernel and verify no aiohttp-session leak warnings on agent shutdown.

Closes #11227
Refs #11216
