### PR TITLE
feat(BA-5798): implement role invitation REST API, GraphQL, SDK, CLI, and component tests

### DIFF
--- a/changes/11239.feature.md
+++ b/changes/11239.feature.md
@@ -1,0 +1,1 @@
+Add role invitation REST API, SDK client, CLI commands, and component tests with RBAC scope/single-entity validators

--- a/changes/11239.feature.md
+++ b/changes/11239.feature.md
@@ -1,1 +1,1 @@
-Add role invitation REST API, SDK client, CLI commands, and component tests with RBAC scope/single-entity validators
+Add role invitation REST API, GraphQL API, SDK client, CLI commands, and component tests with RBAC scope/single-entity validators

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3689,6 +3689,22 @@ input CreateRoleInput
   scopes: [ScopeInput!] = null
 }
 
+"""Added in UNRELEASED. Input for creating role invitations."""
+input CreateRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  roleId: UUID!
+  emails: [String!]!
+}
+
+"""Added in UNRELEASED. Payload for role invitation creation."""
+type CreateRoleInvitationPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Always true for a successful request"""
+  ok: Boolean!
+}
+
 """Added in 26.4.2. Input for creating a runtime variant."""
 input CreateRuntimeVariantInput
   @join__type(graph: STRAWBERRY)
@@ -10961,6 +10977,18 @@ type Mutation
   """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
   adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload! @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Create role invitations by email."""
+  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Accept a pending role invitation."""
+  acceptRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Reject a pending role invitation."""
+  rejectRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
+  adminCancelRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
   adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
@@ -13516,6 +13544,14 @@ type Query
   """
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. List the current user's role invitations."""
+  myRoleInvitations(limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. List invitations for a specific role (admin only).
+  """
+  adminRoleInvitations(roleId: UUID!, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
 
@@ -15288,6 +15324,66 @@ input RoleFilter
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
+}
+
+"""Added in UNRELEASED. A role invitation."""
+type RoleInvitation implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Inviter user ID."""
+  inviterUserId: UUID
+
+  """Invitee user ID."""
+  inviteeUserId: UUID!
+
+  """Role ID."""
+  roleId: UUID!
+
+  """Invitation state."""
+  state: RoleInvitationState!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Role invitation connection."""
+type RoleInvitationConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RoleInvitationEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RoleInvitationEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RoleInvitation!
+}
+
+"""Added in UNRELEASED. Role invitation state."""
+enum RoleInvitationState
+  @join__type(graph: STRAWBERRY)
+{
+  PENDING @join__enumValue(graph: STRAWBERRY)
+  ACCEPTED @join__enumValue(graph: STRAWBERRY)
+  REJECTED @join__enumValue(graph: STRAWBERRY)
+  CANCELED @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13548,9 +13548,14 @@ type Query
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. List invitations for a specific role (admin only).
+  Added in UNRELEASED. List invitations for a specific role (RBAC scope-validated).
   """
-  adminRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. List all role invitations across the system (superadmin only).
+  """
+  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
@@ -15432,6 +15437,7 @@ input RoleInvitationFilter
   @join__type(graph: STRAWBERRY)
 {
   state: RoleInvitationStateFilter = null
+  roleId: UUIDFilter = null
   role: RoleInvitationRoleNestedFilter = null
   inviter: RoleInvitationUserNestedFilter = null
   invitee: RoleInvitationUserNestedFilter = null

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -10981,13 +10981,13 @@ type Mutation
   createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Accept a pending role invitation."""
-  acceptRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Reject a pending role invitation."""
-  rejectRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
-  adminCancelRoleInvitation(invitationId: UUID!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
   adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
@@ -13545,12 +13545,12 @@ type Query
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List invitations for a specific role (admin only).
   """
-  adminRoleInvitations(roleId: UUID!, orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  adminRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
@@ -15377,7 +15377,7 @@ type RoleInvitationEdge
 }
 
 """Added in UNRELEASED. Order by specification for role invitations."""
-input RoleInvitationOrderByGQL
+input RoleInvitationOrderBy
   @join__type(graph: STRAWBERRY)
 {
   field: RoleInvitationOrderField!
@@ -15401,6 +15401,64 @@ enum RoleInvitationState
   ACCEPTED @join__enumValue(graph: STRAWBERRY)
   REJECTED @join__enumValue(graph: STRAWBERRY)
   CANCELED @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in UNRELEASED. Filter for role invitation state."""
+input RoleInvitationStateFilter
+  @join__type(graph: STRAWBERRY)
+{
+  equals: RoleInvitationState = null
+  in: [RoleInvitationState!] = null
+  notEquals: RoleInvitationState = null
+  notIn: [RoleInvitationState!] = null
+}
+
+"""Added in UNRELEASED. Nested filter for the role associated with an invitation."""
+input RoleInvitationRoleNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  name: StringFilter = null
+}
+
+"""Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation."""
+input RoleInvitationUserNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  email: StringFilter = null
+}
+
+"""Added in UNRELEASED. Filter for role invitations."""
+input RoleInvitationFilter
+  @join__type(graph: STRAWBERRY)
+{
+  state: RoleInvitationStateFilter = null
+  role: RoleInvitationRoleNestedFilter = null
+  inviter: RoleInvitationUserNestedFilter = null
+  invitee: RoleInvitationUserNestedFilter = null
+  AND: [RoleInvitationFilter!] = null
+  OR: [RoleInvitationFilter!] = null
+  NOT: [RoleInvitationFilter!] = null
+}
+
+"""Added in UNRELEASED. Input for accepting a role invitation."""
+input AcceptRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
+}
+
+"""Added in UNRELEASED. Input for rejecting a role invitation."""
+input RejectRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
+}
+
+"""Added in UNRELEASED. Input for canceling a role invitation."""
+input CancelRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -23,6 +23,13 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+"""Added in UNRELEASED. Input for accepting a role invitation."""
+input AcceptRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
+}
+
 """Added in 25.16.0. An access token for model deployment."""
 type AccessToken implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
@@ -2169,6 +2176,13 @@ type CancelImportArtifactPayload
 {
   """Artifact revision with cancelled import."""
   artifactRevision: ArtifactRevision!
+}
+
+"""Added in UNRELEASED. Input for canceling a role invitation."""
+input CancelRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
 }
 
 """Added in 26.3.0. Filter input for querying query preset categories."""
@@ -13548,17 +13562,15 @@ type Query
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. List invitations for a specific role (RBAC scope-validated).
-  """
-  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
-
-  """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """
   adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. List invitations for a specific role."""
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. List valid RBAC scope-entity type combinations."""
   rbacScopeEntityCombinations: [ScopeEntityCombination!]! @join__field(graph: STRAWBERRY)
@@ -14190,6 +14202,13 @@ type RejectArtifactPayload
 {
   """Rejected artifact revision."""
   artifactRevision: ArtifactRevision!
+}
+
+"""Added in UNRELEASED. Input for rejecting a role invitation."""
+input RejectRoleInvitationInput
+  @join__type(graph: STRAWBERRY)
+{
+  invitationId: UUID!
 }
 
 """
@@ -15356,6 +15375,19 @@ type RoleInvitation implements Node
 
   """Last update timestamp."""
   updatedAt: DateTime
+
+  """The user who sent this invitation. Null for system-issued invitations."""
+  inviter: UserV2
+
+  """
+  The user who received this invitation. Null if the user no longer exists.
+  """
+  invitee: UserV2
+
+  """
+  The role this invitation grants on acceptance. Null if the role no longer exists.
+  """
+  role: Role
 }
 
 """Added in UNRELEASED. Role invitation connection."""
@@ -15381,6 +15413,20 @@ type RoleInvitationEdge
   node: RoleInvitation!
 }
 
+"""Added in UNRELEASED. Filter for role invitations."""
+input RoleInvitationFilter
+  @join__type(graph: STRAWBERRY)
+{
+  state: RoleInvitationStateFilter = null
+  roleId: UUIDFilter = null
+  role: RoleInvitationRoleNestedFilter = null
+  inviter: RoleInvitationUserNestedFilter = null
+  invitee: RoleInvitationUserNestedFilter = null
+  AND: [RoleInvitationFilter!] = null
+  OR: [RoleInvitationFilter!] = null
+  NOT: [RoleInvitationFilter!] = null
+}
+
 """Added in UNRELEASED. Order by specification for role invitations."""
 input RoleInvitationOrderBy
   @join__type(graph: STRAWBERRY)
@@ -15398,6 +15444,15 @@ enum RoleInvitationOrderField
   STATE @join__enumValue(graph: STRAWBERRY)
 }
 
+"""
+Added in UNRELEASED. Nested filter for the role associated with an invitation.
+"""
+input RoleInvitationRoleNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  name: StringFilter = null
+}
+
 """Added in UNRELEASED. Role invitation state."""
 enum RoleInvitationState
   @join__type(graph: STRAWBERRY)
@@ -15413,58 +15468,24 @@ input RoleInvitationStateFilter
   @join__type(graph: STRAWBERRY)
 {
   equals: RoleInvitationState = null
+
+  """Match any of the provided states."""
   in: [RoleInvitationState!] = null
+
+  """Exclude exact state match."""
   notEquals: RoleInvitationState = null
+
+  """Exclude any of the provided states."""
   notIn: [RoleInvitationState!] = null
 }
 
-"""Added in UNRELEASED. Nested filter for the role associated with an invitation."""
-input RoleInvitationRoleNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
-  name: StringFilter = null
-}
-
-"""Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation."""
+"""
+Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation.
+"""
 input RoleInvitationUserNestedFilter
   @join__type(graph: STRAWBERRY)
 {
   email: StringFilter = null
-}
-
-"""Added in UNRELEASED. Filter for role invitations."""
-input RoleInvitationFilter
-  @join__type(graph: STRAWBERRY)
-{
-  state: RoleInvitationStateFilter = null
-  roleId: UUIDFilter = null
-  role: RoleInvitationRoleNestedFilter = null
-  inviter: RoleInvitationUserNestedFilter = null
-  invitee: RoleInvitationUserNestedFilter = null
-  AND: [RoleInvitationFilter!] = null
-  OR: [RoleInvitationFilter!] = null
-  NOT: [RoleInvitationFilter!] = null
-}
-
-"""Added in UNRELEASED. Input for accepting a role invitation."""
-input AcceptRoleInvitationInput
-  @join__type(graph: STRAWBERRY)
-{
-  invitationId: UUID!
-}
-
-"""Added in UNRELEASED. Input for rejecting a role invitation."""
-input RejectRoleInvitationInput
-  @join__type(graph: STRAWBERRY)
-{
-  invitationId: UUID!
-}
-
-"""Added in UNRELEASED. Input for canceling a role invitation."""
-input CancelRoleInvitationInput
-  @join__type(graph: STRAWBERRY)
-{
-  invitationId: UUID!
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13545,12 +13545,12 @@ type Query
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  myRoleInvitations(orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List invitations for a specific role (admin only).
   """
-  adminRoleInvitations(roleId: UUID!, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  adminRoleInvitations(roleId: UUID!, orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
@@ -15374,6 +15374,23 @@ type RoleInvitationEdge
 
   """The item at the end of the edge"""
   node: RoleInvitation!
+}
+
+"""Added in UNRELEASED. Order by specification for role invitations."""
+input RoleInvitationOrderByGQL
+  @join__type(graph: STRAWBERRY)
+{
+  field: RoleInvitationOrderField!
+  direction: OrderDirection! = DESC
+}
+
+"""Added in UNRELEASED. Role invitation ordering field."""
+enum RoleInvitationOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+  STATE @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in UNRELEASED. Role invitation state."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3701,8 +3701,8 @@ input CreateRoleInvitationInput
 type CreateRoleInvitationPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Always true for a successful request"""
-  ok: Boolean!
+  """List of created role invitations."""
+  items: [RoleInvitation!]!
 }
 
 """Added in 26.4.2. Input for creating a runtime variant."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8710,12 +8710,12 @@ type Query {
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  myRoleInvitations(orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """
   Added in UNRELEASED. List invitations for a specific role (admin only).
   """
-  adminRoleInvitations(roleId: UUID!, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  adminRoleInvitations(roleId: UUID!, orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
@@ -10257,6 +10257,19 @@ type RoleInvitationEdge {
 
   """The item at the end of the edge"""
   node: RoleInvitation!
+}
+
+"""Added in UNRELEASED. Order by specification for role invitations."""
+input RoleInvitationOrderByGQL {
+  field: RoleInvitationOrderField!
+  direction: OrderDirection! = DESC
+}
+
+"""Added in UNRELEASED. Role invitation ordering field."""
+enum RoleInvitationOrderField {
+  CREATED_AT
+  UPDATED_AT
+  STATE
 }
 
 """Added in UNRELEASED. Role invitation state."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2286,6 +2286,18 @@ input CreateRoleInput {
   scopes: [ScopeInput!] = null
 }
 
+"""Added in UNRELEASED. Input for creating role invitations."""
+input CreateRoleInvitationInput {
+  roleId: UUID!
+  emails: [String!]!
+}
+
+"""Added in UNRELEASED. Payload for role invitation creation."""
+type CreateRoleInvitationPayload {
+  """Always true for a successful request"""
+  ok: Boolean!
+}
+
 """Added in 26.4.2. Input for creating a runtime variant."""
 input CreateRuntimeVariantInput {
   """
@@ -6915,6 +6927,18 @@ type Mutation {
   """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
   adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload!
 
+  """Added in UNRELEASED. Create role invitations by email."""
+  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload!
+
+  """Added in UNRELEASED. Accept a pending role invitation."""
+  acceptRoleInvitation(invitationId: UUID!): RoleInvitation!
+
+  """Added in UNRELEASED. Reject a pending role invitation."""
+  rejectRoleInvitation(invitationId: UUID!): RoleInvitation!
+
+  """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
+  adminCancelRoleInvitation(invitationId: UUID!): RoleInvitation!
+
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
   adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL!
 
@@ -8685,6 +8709,14 @@ type Query {
   """
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
 
+  """Added in UNRELEASED. List the current user's role invitations."""
+  myRoleInvitations(limit: Int = null, offset: Int = null): RoleInvitationConnection!
+
+  """
+  Added in UNRELEASED. List invitations for a specific role (admin only).
+  """
+  adminRoleInvitations(roleId: UUID!, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
 
@@ -10182,6 +10214,57 @@ input RoleFilter {
   AND: [RoleFilter!] = null
   OR: [RoleFilter!] = null
   NOT: [RoleFilter!] = null
+}
+
+"""Added in UNRELEASED. A role invitation."""
+type RoleInvitation implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Inviter user ID."""
+  inviterUserId: UUID
+
+  """Invitee user ID."""
+  inviteeUserId: UUID!
+
+  """Role ID."""
+  roleId: UUID!
+
+  """Invitation state."""
+  state: RoleInvitationState!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Role invitation connection."""
+type RoleInvitationConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RoleInvitationEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RoleInvitationEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RoleInvitation!
+}
+
+"""Added in UNRELEASED. Role invitation state."""
+enum RoleInvitationState {
+  PENDING
+  ACCEPTED
+  REJECTED
+  CANCELED
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8713,9 +8713,14 @@ type Query {
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """
-  Added in UNRELEASED. List invitations for a specific role (admin only).
+  Added in UNRELEASED. List invitations for a specific role (RBAC scope-validated).
   """
-  adminRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+
+  """
+  Added in UNRELEASED. List all role invitations across the system (superadmin only).
+  """
+  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
@@ -10301,6 +10306,7 @@ input RoleInvitationUserNestedFilter {
 """Added in UNRELEASED. Filter for role invitations."""
 input RoleInvitationFilter {
   state: RoleInvitationStateFilter = null
+  roleId: UUIDFilter = null
   role: RoleInvitationRoleNestedFilter = null
   inviter: RoleInvitationUserNestedFilter = null
   invitee: RoleInvitationUserNestedFilter = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6,6 +6,11 @@ schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@externa
   subscription: Subscription
 }
 
+"""Added in UNRELEASED. Input for accepting a role invitation."""
+input AcceptRoleInvitationInput {
+  invitationId: UUID!
+}
+
 """Added in 25.16.0. An access token for model deployment."""
 type AccessToken implements Node {
   """The Globally Unique ID of this object"""
@@ -1514,6 +1519,11 @@ Added in 25.14.0. Response payload for canceling artifact import operations. Con
 type CancelImportArtifactPayload {
   """Artifact revision with cancelled import."""
   artifactRevision: ArtifactRevision!
+}
+
+"""Added in UNRELEASED. Input for canceling a role invitation."""
+input CancelRoleInvitationInput {
+  invitationId: UUID!
 }
 
 """Added in 26.3.0. Filter input for querying query preset categories."""
@@ -8713,17 +8723,15 @@ type Query {
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """
-  Added in UNRELEASED. List invitations for a specific role (RBAC scope-validated).
-  """
-  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
-
-  """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """
   adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
+
+  """Added in UNRELEASED. List invitations for a specific role."""
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """Added in 26.3.0. List valid RBAC scope-entity type combinations."""
   rbacScopeEntityCombinations: [ScopeEntityCombination!]!
@@ -9370,6 +9378,11 @@ Added in 25.14.0. Response payload for artifact revision rejection operations. C
 type RejectArtifactPayload {
   """Rejected artifact revision."""
   artifactRevision: ArtifactRevision!
+}
+
+"""Added in UNRELEASED. Input for rejecting a role invitation."""
+input RejectRoleInvitationInput {
+  invitationId: UUID!
 }
 
 """
@@ -10243,6 +10256,19 @@ type RoleInvitation implements Node {
 
   """Last update timestamp."""
   updatedAt: DateTime
+
+  """The user who sent this invitation. Null for system-issued invitations."""
+  inviter: UserV2
+
+  """
+  The user who received this invitation. Null if the user no longer exists.
+  """
+  invitee: UserV2
+
+  """
+  The role this invitation grants on acceptance. Null if the role no longer exists.
+  """
+  role: Role
 }
 
 """Added in UNRELEASED. Role invitation connection."""
@@ -10264,6 +10290,18 @@ type RoleInvitationEdge {
   node: RoleInvitation!
 }
 
+"""Added in UNRELEASED. Filter for role invitations."""
+input RoleInvitationFilter {
+  state: RoleInvitationStateFilter = null
+  roleId: UUIDFilter = null
+  role: RoleInvitationRoleNestedFilter = null
+  inviter: RoleInvitationUserNestedFilter = null
+  invitee: RoleInvitationUserNestedFilter = null
+  AND: [RoleInvitationFilter!] = null
+  OR: [RoleInvitationFilter!] = null
+  NOT: [RoleInvitationFilter!] = null
+}
+
 """Added in UNRELEASED. Order by specification for role invitations."""
 input RoleInvitationOrderBy {
   field: RoleInvitationOrderField!
@@ -10277,6 +10315,13 @@ enum RoleInvitationOrderField {
   STATE
 }
 
+"""
+Added in UNRELEASED. Nested filter for the role associated with an invitation.
+"""
+input RoleInvitationRoleNestedFilter {
+  name: StringFilter = null
+}
+
 """Added in UNRELEASED. Role invitation state."""
 enum RoleInvitationState {
   PENDING
@@ -10288,46 +10333,22 @@ enum RoleInvitationState {
 """Added in UNRELEASED. Filter for role invitation state."""
 input RoleInvitationStateFilter {
   equals: RoleInvitationState = null
+
+  """Match any of the provided states."""
   in: [RoleInvitationState!] = null
+
+  """Exclude exact state match."""
   notEquals: RoleInvitationState = null
+
+  """Exclude any of the provided states."""
   notIn: [RoleInvitationState!] = null
 }
 
-"""Added in UNRELEASED. Nested filter for the role associated with an invitation."""
-input RoleInvitationRoleNestedFilter {
-  name: StringFilter = null
-}
-
-"""Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation."""
+"""
+Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation.
+"""
 input RoleInvitationUserNestedFilter {
   email: StringFilter = null
-}
-
-"""Added in UNRELEASED. Filter for role invitations."""
-input RoleInvitationFilter {
-  state: RoleInvitationStateFilter = null
-  roleId: UUIDFilter = null
-  role: RoleInvitationRoleNestedFilter = null
-  inviter: RoleInvitationUserNestedFilter = null
-  invitee: RoleInvitationUserNestedFilter = null
-  AND: [RoleInvitationFilter!] = null
-  OR: [RoleInvitationFilter!] = null
-  NOT: [RoleInvitationFilter!] = null
-}
-
-"""Added in UNRELEASED. Input for accepting a role invitation."""
-input AcceptRoleInvitationInput {
-  invitationId: UUID!
-}
-
-"""Added in UNRELEASED. Input for rejecting a role invitation."""
-input RejectRoleInvitationInput {
-  invitationId: UUID!
-}
-
-"""Added in UNRELEASED. Input for canceling a role invitation."""
-input CancelRoleInvitationInput {
-  invitationId: UUID!
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2294,8 +2294,8 @@ input CreateRoleInvitationInput {
 
 """Added in UNRELEASED. Payload for role invitation creation."""
 type CreateRoleInvitationPayload {
-  """Always true for a successful request"""
-  ok: Boolean!
+  """List of created role invitations."""
+  items: [RoleInvitation!]!
 }
 
 """Added in 26.4.2. Input for creating a runtime variant."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6931,13 +6931,13 @@ type Mutation {
   createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload!
 
   """Added in UNRELEASED. Accept a pending role invitation."""
-  acceptRoleInvitation(invitationId: UUID!): RoleInvitation!
+  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation!
 
   """Added in UNRELEASED. Reject a pending role invitation."""
-  rejectRoleInvitation(invitationId: UUID!): RoleInvitation!
+  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation!
 
   """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
-  adminCancelRoleInvitation(invitationId: UUID!): RoleInvitation!
+  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation!
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
   adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL!
@@ -8710,12 +8710,12 @@ type Query {
   myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """
   Added in UNRELEASED. List invitations for a specific role (admin only).
   """
-  adminRoleInvitations(roleId: UUID!, orderBy: [RoleInvitationOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  adminRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
   """Added in 26.4.2. List roles registered in a project scope."""
   projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
@@ -10260,7 +10260,7 @@ type RoleInvitationEdge {
 }
 
 """Added in UNRELEASED. Order by specification for role invitations."""
-input RoleInvitationOrderByGQL {
+input RoleInvitationOrderBy {
   field: RoleInvitationOrderField!
   direction: OrderDirection! = DESC
 }
@@ -10278,6 +10278,50 @@ enum RoleInvitationState {
   ACCEPTED
   REJECTED
   CANCELED
+}
+
+"""Added in UNRELEASED. Filter for role invitation state."""
+input RoleInvitationStateFilter {
+  equals: RoleInvitationState = null
+  in: [RoleInvitationState!] = null
+  notEquals: RoleInvitationState = null
+  notIn: [RoleInvitationState!] = null
+}
+
+"""Added in UNRELEASED. Nested filter for the role associated with an invitation."""
+input RoleInvitationRoleNestedFilter {
+  name: StringFilter = null
+}
+
+"""Added in UNRELEASED. Nested filter for a user (inviter or invitee) of an invitation."""
+input RoleInvitationUserNestedFilter {
+  email: StringFilter = null
+}
+
+"""Added in UNRELEASED. Filter for role invitations."""
+input RoleInvitationFilter {
+  state: RoleInvitationStateFilter = null
+  role: RoleInvitationRoleNestedFilter = null
+  inviter: RoleInvitationUserNestedFilter = null
+  invitee: RoleInvitationUserNestedFilter = null
+  AND: [RoleInvitationFilter!] = null
+  OR: [RoleInvitationFilter!] = null
+  NOT: [RoleInvitationFilter!] = null
+}
+
+"""Added in UNRELEASED. Input for accepting a role invitation."""
+input AcceptRoleInvitationInput {
+  invitationId: UUID!
+}
+
+"""Added in UNRELEASED. Input for rejecting a role invitation."""
+input RejectRoleInvitationInput {
+  invitationId: UUID!
+}
+
+"""Added in UNRELEASED. Input for canceling a role invitation."""
+input CancelRoleInvitationInput {
+  invitationId: UUID!
 }
 
 """Added in 26.3.0. Order by specification for roles"""

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -195,3 +195,11 @@ def model_card() -> None:
 )
 def scheduling_handler() -> None:
     """Admin scheduling handler commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.invitation:invitation",
+)
+def invitation() -> None:
+    """Admin role invitation commands."""

--- a/src/ai/backend/client/cli/v2/admin/invitation.py
+++ b/src/ai/backend/client/cli/v2/admin/invitation.py
@@ -1,0 +1,54 @@
+"""Admin CLI commands for the v2 role invitation resource."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group()
+def invitation() -> None:
+    """Admin role invitation commands."""
+
+
+@invitation.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, state:asc).",
+)
+def search(limit: int | None, offset: int | None, order_by: tuple[str, ...]) -> None:
+    """Search all role invitations across the system (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        RoleInvitationOrderBy,
+        RoleInvitationOrderField,
+        SearchRoleInvitationsInput,
+    )
+
+    orders = (
+        parse_order_options(order_by, RoleInvitationOrderField, RoleInvitationOrderBy)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.admin_search(
+                SearchRoleInvitationsInput(order=orders, limit=limit, offset=offset),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -156,27 +156,6 @@ def parse_order_options(
     return orders
 
 
-def parse_order_options_raw(
-    order_by: tuple[str, ...],
-    order_class: type,
-) -> list[Any]:
-    """Parse ``--order-by field:direction`` options without an enum for the field name."""
-    from ai.backend.common.dto.manager.v2.common import OrderDirection
-
-    orders: list[Any] = []
-    for spec in order_by:
-        parts = spec.split(":", 1)
-        field_name = parts[0]
-        direction_str = parts[1].upper() if len(parts) > 1 else "ASC"
-        orders.append(
-            order_class(
-                field=field_name,
-                direction=OrderDirection(direction_str),
-            )
-        )
-    return orders
-
-
 def print_result(data: Any) -> None:
     """Print a Pydantic model or dict as formatted JSON."""
     if hasattr(data, "model_dump"):

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -156,6 +156,27 @@ def parse_order_options(
     return orders
 
 
+def parse_order_options_raw(
+    order_by: tuple[str, ...],
+    order_class: type,
+) -> list[Any]:
+    """Parse ``--order-by field:direction`` options without an enum for the field name."""
+    from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+    orders: list[Any] = []
+    for spec in order_by:
+        parts = spec.split(":", 1)
+        field_name = parts[0]
+        direction_str = parts[1].upper() if len(parts) > 1 else "ASC"
+        orders.append(
+            order_class(
+                field=field_name,
+                direction=OrderDirection(direction_str),
+            )
+        )
+    return orders
+
+
 def print_result(data: Any) -> None:
     """Print a Pydantic model or dict as formatted JSON."""
     if hasattr(data, "model_dump"):

--- a/src/ai/backend/client/cli/v2/rbac/commands.py
+++ b/src/ai/backend/client/cli/v2/rbac/commands.py
@@ -10,6 +10,7 @@ import click
 
 from .assignment import assignment
 from .entity import entity
+from .invitation import invitation
 from .permission import permission
 from .role import role
 
@@ -24,3 +25,4 @@ rbac.add_command(role)
 rbac.add_command(permission)
 rbac.add_command(assignment)
 rbac.add_command(entity)
+rbac.add_command(invitation)

--- a/src/ai/backend/client/cli/v2/rbac/invitation.py
+++ b/src/ai/backend/client/cli/v2/rbac/invitation.py
@@ -1,0 +1,143 @@
+"""CLI commands for RBAC role invitation management."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    print_result,
+)
+
+
+@click.group()
+def invitation() -> None:
+    """Role invitation commands."""
+
+
+@invitation.command()
+@click.option("--role-id", type=click.UUID, required=True, help="Role ID to invite for.")
+@click.option(
+    "--email",
+    multiple=True,
+    required=True,
+    help="Invitee email address (repeatable).",
+)
+def create(role_id: UUID, email: tuple[str, ...]) -> None:
+    """Create role invitations by email."""
+    from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        CreateRoleInvitationInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role_id,
+                    emails=list(email),
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@invitation.command()
+@click.argument("invitation_id", type=click.UUID)
+def accept(invitation_id: UUID) -> None:
+    """Accept a pending invitation."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.accept(invitation_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@invitation.command()
+@click.argument("invitation_id", type=click.UUID)
+def reject(invitation_id: UUID) -> None:
+    """Reject a pending invitation."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.reject(invitation_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@invitation.command()
+@click.argument("invitation_id", type=click.UUID)
+def cancel(invitation_id: UUID) -> None:
+    """Cancel a pending invitation."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.cancel(invitation_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@invitation.command(name="my-search")
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+def my_search(limit: int | None, offset: int | None) -> None:
+    """Search your own invitations."""
+    from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        SearchRoleInvitationsInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.my_search(
+                SearchRoleInvitationsInput(limit=limit, offset=offset),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@invitation.command(name="role-search")
+@click.argument("role_id", type=click.UUID)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+def role_search(role_id: UUID, limit: int | None, offset: int | None) -> None:
+    """Search invitations for a specific role (admin view)."""
+    from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        SearchRoleInvitationsInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.role_search(
+                role_id,
+                SearchRoleInvitationsInput(limit=limit, offset=offset),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/rbac/invitation.py
+++ b/src/ai/backend/client/cli/v2/rbac/invitation.py
@@ -162,7 +162,7 @@ def role_search(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.role_invitation.role_search(
+            result = await registry.role_invitation.search_by_role(
                 role_id,
                 SearchRoleInvitationsInput(order=orders, limit=limit, offset=offset),
             )

--- a/src/ai/backend/client/cli/v2/rbac/invitation.py
+++ b/src/ai/backend/client/cli/v2/rbac/invitation.py
@@ -107,13 +107,18 @@ def cancel(invitation_id: UUID) -> None:
 )
 def my_search(limit: int | None, offset: int | None, order_by: tuple[str, ...]) -> None:
     """Search your own invitations."""
-    from ai.backend.client.cli.v2.helpers import parse_order_options_raw
+    from ai.backend.client.cli.v2.helpers import parse_order_options
     from ai.backend.common.dto.manager.v2.role_invitation.request import (
         RoleInvitationOrderBy,
+        RoleInvitationOrderField,
         SearchRoleInvitationsInput,
     )
 
-    orders = parse_order_options_raw(order_by, RoleInvitationOrderBy) if order_by else None
+    orders = (
+        parse_order_options(order_by, RoleInvitationOrderField, RoleInvitationOrderBy)
+        if order_by
+        else None
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
@@ -141,13 +146,18 @@ def role_search(
     role_id: UUID, limit: int | None, offset: int | None, order_by: tuple[str, ...]
 ) -> None:
     """Search invitations for a specific role (admin view)."""
-    from ai.backend.client.cli.v2.helpers import parse_order_options_raw
+    from ai.backend.client.cli.v2.helpers import parse_order_options
     from ai.backend.common.dto.manager.v2.role_invitation.request import (
         RoleInvitationOrderBy,
+        RoleInvitationOrderField,
         SearchRoleInvitationsInput,
     )
 
-    orders = parse_order_options_raw(order_by, RoleInvitationOrderBy) if order_by else None
+    orders = (
+        parse_order_options(order_by, RoleInvitationOrderField, RoleInvitationOrderBy)
+        if order_by
+        else None
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())

--- a/src/ai/backend/client/cli/v2/rbac/invitation.py
+++ b/src/ai/backend/client/cli/v2/rbac/invitation.py
@@ -100,17 +100,26 @@ def cancel(invitation_id: UUID) -> None:
 @invitation.command(name="my-search")
 @click.option("--limit", type=int, default=None, help="Maximum items to return.")
 @click.option("--offset", type=int, default=None, help="Number of items to skip.")
-def my_search(limit: int | None, offset: int | None) -> None:
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, state:asc).",
+)
+def my_search(limit: int | None, offset: int | None, order_by: tuple[str, ...]) -> None:
     """Search your own invitations."""
+    from ai.backend.client.cli.v2.helpers import parse_order_options_raw
     from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        RoleInvitationOrderBy,
         SearchRoleInvitationsInput,
     )
+
+    orders = parse_order_options_raw(order_by, RoleInvitationOrderBy) if order_by else None
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             result = await registry.role_invitation.my_search(
-                SearchRoleInvitationsInput(limit=limit, offset=offset),
+                SearchRoleInvitationsInput(order=orders, limit=limit, offset=offset),
             )
             print_result(result)
         finally:
@@ -123,18 +132,29 @@ def my_search(limit: int | None, offset: int | None) -> None:
 @click.argument("role_id", type=click.UUID)
 @click.option("--limit", type=int, default=None, help="Maximum items to return.")
 @click.option("--offset", type=int, default=None, help="Number of items to skip.")
-def role_search(role_id: UUID, limit: int | None, offset: int | None) -> None:
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, state:asc).",
+)
+def role_search(
+    role_id: UUID, limit: int | None, offset: int | None, order_by: tuple[str, ...]
+) -> None:
     """Search invitations for a specific role (admin view)."""
+    from ai.backend.client.cli.v2.helpers import parse_order_options_raw
     from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        RoleInvitationOrderBy,
         SearchRoleInvitationsInput,
     )
+
+    orders = parse_order_options_raw(order_by, RoleInvitationOrderBy) if order_by else None
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             result = await registry.role_invitation.role_search(
                 role_id,
-                SearchRoleInvitationsInput(limit=limit, offset=offset),
+                SearchRoleInvitationsInput(order=orders, limit=limit, offset=offset),
             )
             print_result(result)
         finally:

--- a/src/ai/backend/client/v2/domains_v2/role_invitation.py
+++ b/src/ai/backend/client/v2/domains_v2/role_invitation.py
@@ -1,0 +1,83 @@
+"""V2 SDK client for role invitations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput,
+    SearchRoleInvitationsInput,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    CreateRoleInvitationPayload,
+    RoleInvitationNode,
+    SearchRoleInvitationsPayload,
+)
+
+_PATH = "/v2/role-invitations"
+
+
+class V2RoleInvitationClient(BaseDomainClient):
+    """SDK client for ``/v2/role-invitations`` endpoints."""
+
+    async def create(
+        self,
+        request: CreateRoleInvitationInput,
+    ) -> CreateRoleInvitationPayload:
+        """Create role invitations by email."""
+        return await self._client.typed_request(
+            "POST",
+            _PATH,
+            request=request,
+            response_model=CreateRoleInvitationPayload,
+        )
+
+    async def accept(self, invitation_id: UUID) -> RoleInvitationNode:
+        """Accept a pending invitation."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/{invitation_id}/accept",
+            response_model=RoleInvitationNode,
+        )
+
+    async def reject(self, invitation_id: UUID) -> RoleInvitationNode:
+        """Reject a pending invitation."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/{invitation_id}/reject",
+            response_model=RoleInvitationNode,
+        )
+
+    async def cancel(self, invitation_id: UUID) -> RoleInvitationNode:
+        """Cancel a pending invitation."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{invitation_id}",
+            response_model=RoleInvitationNode,
+        )
+
+    async def my_search(
+        self,
+        request: SearchRoleInvitationsInput,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations addressed to the current user."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/search",
+            request=request,
+            response_model=SearchRoleInvitationsPayload,
+        )
+
+    async def role_search(
+        self,
+        role_id: UUID,
+        request: SearchRoleInvitationsInput,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations for a specific role."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/roles/{role_id}/search",
+            request=request,
+            response_model=SearchRoleInvitationsPayload,
+        )

--- a/src/ai/backend/client/v2/domains_v2/role_invitation.py
+++ b/src/ai/backend/client/v2/domains_v2/role_invitation.py
@@ -81,3 +81,15 @@ class V2RoleInvitationClient(BaseDomainClient):
             request=request,
             response_model=SearchRoleInvitationsPayload,
         )
+
+    async def admin_search(
+        self,
+        request: SearchRoleInvitationsInput,
+    ) -> SearchRoleInvitationsPayload:
+        """Search all invitations across the system (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchRoleInvitationsPayload,
+        )

--- a/src/ai/backend/client/v2/domains_v2/role_invitation.py
+++ b/src/ai/backend/client/v2/domains_v2/role_invitation.py
@@ -69,7 +69,7 @@ class V2RoleInvitationClient(BaseDomainClient):
             response_model=SearchRoleInvitationsPayload,
         )
 
-    async def role_search(
+    async def search_by_role(
         self,
         role_id: UUID,
         request: SearchRoleInvitationsInput,

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from .domains_v2.resource_preset import V2ResourcePresetClient
     from .domains_v2.resource_slot import V2ResourceSlotClient
     from .domains_v2.resource_usage import V2ResourceUsageClient
+    from .domains_v2.role_invitation import V2RoleInvitationClient
     from .domains_v2.runtime_variant import V2RuntimeVariantClient
     from .domains_v2.runtime_variant_preset import V2RuntimeVariantPresetClient
     from .domains_v2.scheduling_handler import V2SchedulingHandlerClient
@@ -207,6 +208,12 @@ class V2ClientRegistry:
         from .domains_v2.project import V2ProjectClient
 
         return V2ProjectClient(self._client)
+
+    @cached_property
+    def role_invitation(self) -> V2RoleInvitationClient:
+        from .domains_v2.role_invitation import V2RoleInvitationClient
+
+        return V2RoleInvitationClient(self._client)
 
     @cached_property
     def prometheus_query_preset(self) -> V2PrometheusQueryPresetClient:

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -340,6 +340,7 @@ class ScopeType(enum.StrEnum):
     ARTIFACT_REVISION = "artifact_revision"
     AGENT = "agent"
     ROLE = "role"
+    ROLE_ASSIGNMENT = "role:assignment"
     NOTIFICATION_CHANNEL = "notification_channel"
     KEYPAIR = "keypair"
 

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/__init__.py
@@ -1,0 +1,28 @@
+"""
+Role invitation DTOs v2 for Manager API.
+"""
+
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput,
+    SearchRoleInvitationsInput,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    CreateRoleInvitationPayload,
+    RoleInvitationNode,
+    SearchRoleInvitationsPayload,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.types import (
+    RoleInvitationStateDTO,
+)
+
+__all__ = (
+    # Types
+    "RoleInvitationStateDTO",
+    # Input models (request)
+    "CreateRoleInvitationInput",
+    "SearchRoleInvitationsInput",
+    # Node and Payload models (response)
+    "CreateRoleInvitationPayload",
+    "RoleInvitationNode",
+    "SearchRoleInvitationsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/__init__.py
@@ -3,7 +3,10 @@ Role invitation DTOs v2 for Manager API.
 """
 
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    AcceptRoleInvitationInput,
+    CancelRoleInvitationInput,
     CreateRoleInvitationInput,
+    RejectRoleInvitationInput,
     SearchRoleInvitationsInput,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
@@ -19,7 +22,10 @@ __all__ = (
     # Types
     "RoleInvitationStateDTO",
     # Input models (request)
+    "AcceptRoleInvitationInput",
+    "CancelRoleInvitationInput",
     "CreateRoleInvitationInput",
+    "RejectRoleInvitationInput",
     "SearchRoleInvitationsInput",
     # Node and Payload models (response)
     "CreateRoleInvitationPayload",

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
@@ -12,6 +12,7 @@ from pydantic import Field
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 
 
 class CreateRoleInvitationInput(BaseRequestModel):
@@ -22,6 +23,24 @@ class CreateRoleInvitationInput(BaseRequestModel):
         min_length=1,
         description="Invitee email addresses",
     )
+
+
+class AcceptRoleInvitationInput(BaseRequestModel):
+    """Input for accepting a role invitation."""
+
+    invitation_id: UUID = Field(description="Invitation ID to accept")
+
+
+class RejectRoleInvitationInput(BaseRequestModel):
+    """Input for rejecting a role invitation."""
+
+    invitation_id: UUID = Field(description="Invitation ID to reject")
+
+
+class CancelRoleInvitationInput(BaseRequestModel):
+    """Input for canceling a role invitation."""
+
+    invitation_id: UUID = Field(description="Invitation ID to cancel")
 
 
 class RoleInvitationOrderField(StrEnum):
@@ -39,12 +58,23 @@ class RoleInvitationOrderBy(BaseRequestModel):
 
 
 class RoleInvitationStateFilter(BaseRequestModel):
-    """Filter for invitation state with equality and membership operators."""
+    """Filter for invitation state with equality and membership operators.
 
-    equals: str | None = None
-    in_: list[str] | None = Field(default=None, alias="in")
-    not_equals: str | None = None
-    not_in: list[str] | None = None
+    Follows the Strawberry GQL EnumFilter pattern.
+    """
+
+    equals: RoleInvitationStateDTO | None = Field(
+        default=None, description="Exact match for invitation state."
+    )
+    in_: list[RoleInvitationStateDTO] | None = Field(
+        default=None, alias="in", description="Match any of the provided states."
+    )
+    not_equals: RoleInvitationStateDTO | None = Field(
+        default=None, description="Exclude exact state match."
+    )
+    not_in: list[RoleInvitationStateDTO] | None = Field(
+        default=None, description="Exclude any of the provided states."
+    )
 
 
 class RoleNestedFilter(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 
 class CreateRoleInvitationInput(BaseRequestModel):
@@ -21,8 +22,20 @@ class CreateRoleInvitationInput(BaseRequestModel):
     )
 
 
+class RoleInvitationOrderBy(BaseRequestModel):
+    """Order by specification for role invitations."""
+
+    field: str
+    direction: OrderDirection = OrderDirection.DESC
+
+
 class SearchRoleInvitationsInput(BaseRequestModel):
     """Pagination search input for role invitations."""
 
+    order: list[RoleInvitationOrderBy] | None = None
+    first: int | None = None
+    after: str | None = None
+    last: int | None = None
+    before: str | None = None
     limit: int | None = None
     offset: int | None = None

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
@@ -1,0 +1,28 @@
+"""
+Request DTOs for role invitation v2.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+
+
+class CreateRoleInvitationInput(BaseRequestModel):
+    """Input for creating role invitations."""
+
+    role_id: UUID = Field(description="Role ID to invite for")
+    emails: list[str] = Field(
+        min_length=1,
+        description="Invitee email addresses",
+    )
+
+
+class SearchRoleInvitationsInput(BaseRequestModel):
+    """Pagination search input for role invitations."""
+
+    limit: int | None = None
+    offset: int | None = None

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
@@ -4,11 +4,13 @@ Request DTOs for role invitation v2.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from uuid import UUID
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 
@@ -22,16 +24,66 @@ class CreateRoleInvitationInput(BaseRequestModel):
     )
 
 
+class RoleInvitationOrderField(StrEnum):
+    """Orderable fields for role invitations."""
+
+    CREATED_AT = "created_at"
+    STATE = "state"
+
+
 class RoleInvitationOrderBy(BaseRequestModel):
     """Order by specification for role invitations."""
 
-    field: str
+    field: RoleInvitationOrderField
     direction: OrderDirection = OrderDirection.DESC
+
+
+class RoleInvitationStateFilter(BaseRequestModel):
+    """Filter for invitation state with equality and membership operators."""
+
+    equals: str | None = None
+    in_: list[str] | None = Field(default=None, alias="in")
+    not_equals: str | None = None
+    not_in: list[str] | None = None
+
+
+class RoleNestedFilter(BaseRequestModel):
+    """Nested filter for the role associated with an invitation."""
+
+    name: StringFilter | None = None
+
+
+RoleNestedFilter.model_rebuild()
+
+
+class UserNestedFilter(BaseRequestModel):
+    """Nested filter for a user (inviter or invitee) of an invitation."""
+
+    email: StringFilter | None = None
+
+
+UserNestedFilter.model_rebuild()
+
+
+class RoleInvitationFilter(BaseRequestModel):
+    """Filter for role invitations."""
+
+    state: RoleInvitationStateFilter | None = None
+    role: RoleNestedFilter | None = None
+    inviter: UserNestedFilter | None = None
+    invitee: UserNestedFilter | None = None
+    AND: list[RoleInvitationFilter] | None = None
+    OR: list[RoleInvitationFilter] | None = None
+    NOT: list[RoleInvitationFilter] | None = None
+
+
+RoleInvitationFilter.model_rebuild()
 
 
 class SearchRoleInvitationsInput(BaseRequestModel):
     """Pagination search input for role invitations."""
 
+    filter: RoleInvitationFilter | None = None
     order: list[RoleInvitationOrderBy] | None = None
     first: int | None = None
     after: str | None = None

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/request.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 
@@ -99,6 +99,7 @@ class RoleInvitationFilter(BaseRequestModel):
     """Filter for role invitations."""
 
     state: RoleInvitationStateFilter | None = None
+    role_id: UUIDFilter | None = None
     role: RoleNestedFilter | None = None
     inviter: UserNestedFilter | None = None
     invitee: UserNestedFilter | None = None

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
@@ -1,0 +1,51 @@
+"""
+Response DTOs for role invitation v2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+
+from .types import RoleInvitationStateDTO
+
+__all__ = (
+    "CreateRoleInvitationPayload",
+    "RoleInvitationNode",
+    "SearchRoleInvitationsPayload",
+)
+
+
+class RoleInvitationNode(BaseResponseModel):
+    """Node model representing a role invitation."""
+
+    id: UUID = Field(description="Invitation ID")
+    inviter_user_id: UUID | None = Field(default=None, description="Inviter user ID")
+    invitee_user_id: UUID = Field(description="Invitee user ID")
+    role_id: UUID = Field(description="Role ID")
+    state: RoleInvitationStateDTO = Field(description="Invitation state")
+    created_at: datetime = Field(description="Creation timestamp")
+    updated_at: datetime | None = Field(default=None, description="Last update timestamp")
+
+
+class CreateRoleInvitationPayload(BaseResponseModel):
+    """Payload for role invitation creation.
+
+    The response is deliberately opaque: no distinction between
+    'user found' and 'user not found / not eligible'.
+    """
+
+    ok: bool = Field(default=True, description="Always true for a successful request")
+
+
+class SearchRoleInvitationsPayload(BaseResponseModel):
+    """Paginated result for role invitation search."""
+
+    items: list[RoleInvitationNode] = Field(description="List of invitation nodes.")
+    total_count: int = Field(description="Total number of invitations matching the filter.")
+    has_next_page: bool = Field(description="Whether there is a next page.")
+    has_previous_page: bool = Field(description="Whether there is a previous page.")

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
@@ -35,9 +35,7 @@ class RoleInvitationNode(BaseResponseModel):
 class CreateRoleInvitationPayload(BaseResponseModel):
     """Payload for role invitation creation."""
 
-    items: list[RoleInvitationNode] = Field(
-        description="List of created role invitations."
-    )
+    items: list[RoleInvitationNode] = Field(description="List of created role invitations.")
 
 
 class SearchRoleInvitationsPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/response.py
@@ -33,13 +33,11 @@ class RoleInvitationNode(BaseResponseModel):
 
 
 class CreateRoleInvitationPayload(BaseResponseModel):
-    """Payload for role invitation creation.
+    """Payload for role invitation creation."""
 
-    The response is deliberately opaque: no distinction between
-    'user found' and 'user not found / not eligible'.
-    """
-
-    ok: bool = Field(default=True, description="Always true for a successful request")
+    items: list[RoleInvitationNode] = Field(
+        description="List of created role invitations."
+    )
 
 
 class SearchRoleInvitationsPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/role_invitation/types.py
+++ b/src/ai/backend/common/dto/manager/v2/role_invitation/types.py
@@ -1,0 +1,16 @@
+"""
+Types for role invitation DTOs v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RoleInvitationStateDTO(StrEnum):
+    """Role invitation state."""
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    CANCELED = "canceled"

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -165,7 +165,7 @@ from ai.backend.manager.data.permission.role import (
 from ai.backend.manager.data.permission.status import RoleStatus as InternalRoleStatus
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.permission.types import RoleSource as InternalRoleSource
-from ai.backend.manager.data.role_invitation.types import RoleInvitationData
+from ai.backend.manager.data.role_invitation.types import RoleInvitationData, RoleInvitationState
 from ai.backend.manager.models.rbac.exceptions import InvalidScope
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
@@ -1654,13 +1654,19 @@ class RBACAdapter(BaseAdapter):
         f: RoleInvitationStateFilterDTO,
     ) -> QueryCondition | None:
         if f.equals is not None:
-            return RoleInvitationConditions.by_state_equals(f.equals)
+            return RoleInvitationConditions.by_state_equals(RoleInvitationState(f.equals.value))
         if f.in_ is not None:
-            return RoleInvitationConditions.by_state_in(f.in_)
+            return RoleInvitationConditions.by_state_in([
+                RoleInvitationState(s.value) for s in f.in_
+            ])
         if f.not_equals is not None:
-            return RoleInvitationConditions.by_state_not_equals(f.not_equals)
+            return RoleInvitationConditions.by_state_not_equals(
+                RoleInvitationState(f.not_equals.value)
+            )
         if f.not_in is not None:
-            return RoleInvitationConditions.by_state_not_in(f.not_in)
+            return RoleInvitationConditions.by_state_not_in([
+                RoleInvitationState(s.value) for s in f.not_in
+            ])
         return None
 
     def _convert_invitation_role_nested_filter(

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -1558,11 +1558,13 @@ class RBACAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.permission_controller.create_role_invitation.wait_for_complete(
-            CreateInvitationServiceAction(
-                role_id=input.role_id,
-                invitee_emails=input.emails,
-                inviter_user_id=me.user_id,
+        result = (
+            await self._processors.permission_controller.create_role_invitation.wait_for_complete(
+                CreateInvitationServiceAction(
+                    role_id=input.role_id,
+                    invitee_emails=input.emails,
+                    inviter_user_id=me.user_id,
+                )
             )
         )
         return CreateRoleInvitationPayload(

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -116,10 +116,22 @@ from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationFilter as RoleInvitationFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
     RoleInvitationOrderBy as RoleInvitationOrderByDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationStateFilter as RoleInvitationStateFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleNestedFilter as InvitationRoleNestedFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
     SearchRoleInvitationsInput as SearchRoleInvitationsInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    UserNestedFilter as InvitationUserNestedFilterDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
     CreateRoleInvitationPayload,
@@ -1607,6 +1619,89 @@ class RBACAdapter(BaseAdapter):
                 result.append(RoleInvitationOrders.state(ascending))
         return result
 
+    def _convert_invitation_filter(self, f: RoleInvitationFilterDTO) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.state is not None:
+            cond = self._convert_invitation_state_filter(f.state)
+            if cond is not None:
+                conditions.append(cond)
+        if f.role is not None:
+            conditions.extend(self._convert_invitation_role_nested_filter(f.role))
+        if f.inviter is not None:
+            conditions.extend(self._convert_invitation_user_nested_filter(f.inviter, "inviter"))
+        if f.invitee is not None:
+            conditions.extend(self._convert_invitation_user_nested_filter(f.invitee, "invitee"))
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_invitation_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_invitation_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_invitation_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
+    @staticmethod
+    def _convert_invitation_state_filter(
+        f: RoleInvitationStateFilterDTO,
+    ) -> QueryCondition | None:
+        if f.equals is not None:
+            return RoleInvitationConditions.by_state_equals(f.equals)
+        if f.in_ is not None:
+            return RoleInvitationConditions.by_state_in(f.in_)
+        if f.not_equals is not None:
+            return RoleInvitationConditions.by_state_not_equals(f.not_equals)
+        if f.not_in is not None:
+            return RoleInvitationConditions.by_state_not_in(f.not_in)
+        return None
+
+    def _convert_invitation_role_nested_filter(
+        self, f: InvitationRoleNestedFilterDTO
+    ) -> list[QueryCondition]:
+        role_conditions: list[QueryCondition] = []
+        if f.name is not None:
+            cond = self.convert_string_filter(
+                f.name,
+                contains_factory=RoleInvitationConditions.role_name_contains,
+                equals_factory=RoleInvitationConditions.role_name_equals,
+                starts_with_factory=RoleInvitationConditions.role_name_starts_with,
+                ends_with_factory=RoleInvitationConditions.role_name_ends_with,
+                in_factory=RoleInvitationConditions.role_name_in,
+            )
+            if cond is not None:
+                role_conditions.append(cond)
+        if role_conditions:
+            return [RoleInvitationConditions.exists_role_with_conditions(role_conditions)]
+        return []
+
+    def _convert_invitation_user_nested_filter(
+        self, f: InvitationUserNestedFilterDTO, relation: str
+    ) -> list[QueryCondition]:
+        user_conditions: list[QueryCondition] = []
+        if f.email is not None:
+            cond = self.convert_string_filter(
+                f.email,
+                contains_factory=RoleInvitationConditions._user_email_contains,
+                equals_factory=RoleInvitationConditions._user_email_equals,
+                starts_with_factory=RoleInvitationConditions._user_email_starts_with,
+                ends_with_factory=RoleInvitationConditions._user_email_ends_with,
+                in_factory=RoleInvitationConditions._user_email_in,
+            )
+            if cond is not None:
+                user_conditions.append(cond)
+        if not user_conditions:
+            return []
+        if relation == "inviter":
+            return [RoleInvitationConditions.exists_inviter_with_conditions(user_conditions)]
+        return [RoleInvitationConditions.exists_invitee_with_conditions(user_conditions)]
+
     async def my_search_role_invitations(
         self,
         input: SearchRoleInvitationsInputDTO,
@@ -1615,9 +1710,10 @@ class RBACAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
+        conditions = self._convert_invitation_filter(input.filter) if input.filter else []
         orders = self._convert_invitation_orders(input.order) if input.order else []
         querier = self._build_querier(
-            conditions=[],
+            conditions=conditions,
             orders=orders,
             pagination_spec=_invitation_pagination_spec(),
             first=input.first,
@@ -1649,9 +1745,10 @@ class RBACAdapter(BaseAdapter):
         input: SearchRoleInvitationsInputDTO,
     ) -> SearchRoleInvitationsPayload:
         """Search invitations for a specific role (admin/project-admin view)."""
+        conditions = self._convert_invitation_filter(input.filter) if input.filter else []
         orders = self._convert_invitation_orders(input.order) if input.order else []
         querier = self._build_querier(
-            conditions=[],
+            conditions=conditions,
             orders=orders,
             pagination_spec=_invitation_pagination_spec(),
             first=input.first,

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -1554,21 +1554,20 @@ class RBACAdapter(BaseAdapter):
         self,
         input: CreateRoleInvitationInputDTO,
     ) -> CreateRoleInvitationPayload:
-        """Create role invitations by email.
-
-        The response is deliberately opaque to prevent user enumeration.
-        """
+        """Create role invitations by email."""
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        await self._processors.permission_controller.create_role_invitation.wait_for_complete(
+        result = await self._processors.permission_controller.create_role_invitation.wait_for_complete(
             CreateInvitationServiceAction(
                 role_id=input.role_id,
                 invitee_emails=input.emails,
                 inviter_user_id=me.user_id,
             )
         )
-        return CreateRoleInvitationPayload()
+        return CreateRoleInvitationPayload(
+            items=[self._invitation_data_to_node(d) for d in result.created],
+        )
 
     async def accept_role_invitation(
         self,

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -255,6 +255,11 @@ from ai.backend.manager.services.permission_contoller.actions.search_role_invita
     AcceptRoleInvitationAction as AcceptInvitationServiceAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    AdminSearchRoleInvitationsAction,
+    SearchMyRoleInvitationsAction,
+    SearchRoleInvitationsByRoleAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
     CancelRoleInvitationAction as CancelInvitationServiceAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
@@ -262,10 +267,6 @@ from ai.backend.manager.services.permission_contoller.actions.search_role_invita
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
     RejectRoleInvitationAction as RejectInvitationServiceAction,
-)
-from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
-    SearchMyRoleInvitationsAction,
-    SearchRoleInvitationsByRoleAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_roles import (
     SearchRolesAction,
@@ -1626,6 +1627,14 @@ class RBACAdapter(BaseAdapter):
             cond = self._convert_invitation_state_filter(f.state)
             if cond is not None:
                 conditions.append(cond)
+        if f.role_id is not None:
+            cond = self.convert_uuid_filter(
+                f.role_id,
+                equals_factory=RoleInvitationConditions.by_role_id_filter_equals,
+                in_factory=RoleInvitationConditions.by_role_id_filter_in,
+            )
+            if cond is not None:
+                conditions.append(cond)
         if f.role is not None:
             conditions.extend(self._convert_invitation_role_nested_filter(f.role))
         if f.inviter is not None:
@@ -1772,6 +1781,35 @@ class RBACAdapter(BaseAdapter):
                 querier=querier,
                 scope=RoleInvitationSearchScope(role_id=role_id),
             )
+        )
+        raw = action_result.result
+        return SearchRoleInvitationsPayload(
+            items=[self._invitation_data_to_node(item) for item in raw.items],
+            total_count=raw.total_count,
+            has_next_page=raw.has_next_page,
+            has_previous_page=raw.has_previous_page,
+        )
+
+    async def admin_search_role_invitations(
+        self,
+        input: SearchRoleInvitationsInputDTO,
+    ) -> SearchRoleInvitationsPayload:
+        """Search all invitations across the system (superadmin only)."""
+        conditions = self._convert_invitation_filter(input.filter) if input.filter else []
+        orders = self._convert_invitation_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_invitation_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        action_result = await self._processors.permission_controller.admin_search_role_invitations.wait_for_complete(
+            AdminSearchRoleInvitationsAction(querier=querier)
         )
         raw = action_result.result
         return SearchRoleInvitationsPayload(

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -116,6 +116,9 @@ from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationOrderBy as RoleInvitationOrderByDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
     SearchRoleInvitationsInput as SearchRoleInvitationsInputDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
@@ -171,6 +174,11 @@ from ai.backend.manager.models.rbac_models.orders import (
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
+from ai.backend.manager.models.role_invitation.conditions import (
+    RoleInvitationConditions,
+    RoleInvitationOrders,
+)
+from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
     BulkCreator,
@@ -309,6 +317,17 @@ def _entity_pagination_spec() -> PaginationSpec:
         forward_condition_factory=EntityScopeConditions.by_cursor_forward,
         backward_condition_factory=EntityScopeConditions.by_cursor_backward,
         tiebreaker_order=AssociationScopesEntitiesRow.id.asc(),
+    )
+
+
+@lru_cache(maxsize=1)
+def _invitation_pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=RoleInvitationOrders.created_at(ascending=False),
+        backward_order=RoleInvitationOrders.created_at(ascending=True),
+        forward_condition_factory=RoleInvitationConditions.by_cursor_forward,
+        backward_condition_factory=RoleInvitationConditions.by_cursor_backward,
+        tiebreaker_order=RoleInvitationRow.id.asc(),
     )
 
 
@@ -1575,6 +1594,19 @@ class RBACAdapter(BaseAdapter):
         )
         return self._invitation_data_to_node(result.data)
 
+    @staticmethod
+    def _convert_invitation_orders(orders: list[RoleInvitationOrderByDTO]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for o in orders:
+            ascending = o.direction == OrderDirectionV2.ASC
+            if o.field == "created_at":
+                result.append(RoleInvitationOrders.created_at(ascending))
+            elif o.field == "updated_at":
+                result.append(RoleInvitationOrders.updated_at(ascending))
+            elif o.field == "state":
+                result.append(RoleInvitationOrders.state(ascending))
+        return result
+
     async def my_search_role_invitations(
         self,
         input: SearchRoleInvitationsInputDTO,
@@ -1583,11 +1615,18 @@ class RBACAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        querier = BatchQuerier(
-            pagination=OffsetPagination(
-                limit=input.limit or 20,
-                offset=input.offset or 0,
-            ),
+        orders = self._convert_invitation_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=[],
+            orders=orders,
+            pagination_spec=_invitation_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+            base_conditions=[RoleInvitationConditions.by_invitee(me.user_id)],
         )
         action_result = await self._processors.permission_controller.search_my_role_invitations.wait_for_complete(
             SearchMyRoleInvitationsAction(
@@ -1610,11 +1649,18 @@ class RBACAdapter(BaseAdapter):
         input: SearchRoleInvitationsInputDTO,
     ) -> SearchRoleInvitationsPayload:
         """Search invitations for a specific role (admin/project-admin view)."""
-        querier = BatchQuerier(
-            pagination=OffsetPagination(
-                limit=input.limit or 20,
-                offset=input.offset or 0,
-            ),
+        orders = self._convert_invitation_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=[],
+            orders=orders,
+            pagination_spec=_invitation_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+            base_conditions=[RoleInvitationConditions.by_role(role_id)],
         )
         action_result = await self._processors.permission_controller.search_role_invitations_by_role.wait_for_complete(
             SearchRoleInvitationsByRoleAction(

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -112,6 +112,18 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     OrderDirection as OrderDirectionV2,
 )
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    SearchRoleInvitationsInput as SearchRoleInvitationsInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    CreateRoleInvitationPayload,
+    RoleInvitationNode,
+    SearchRoleInvitationsPayload,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import build_operation_description
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
@@ -138,6 +150,7 @@ from ai.backend.manager.data.permission.role import (
 from ai.backend.manager.data.permission.status import RoleStatus as InternalRoleStatus
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.permission.types import RoleSource as InternalRoleSource
+from ai.backend.manager.data.role_invitation.types import RoleInvitationData
 from ai.backend.manager.models.rbac.exceptions import InvalidScope
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
@@ -181,6 +194,10 @@ from ai.backend.manager.repositories.permission_controller.updaters import (
     PermissionUpdaterSpec,
     RoleUpdaterSpec,
 )
+from ai.backend.manager.repositories.role_invitation.types import (
+    InviteeSearchScope,
+    RoleInvitationSearchScope,
+)
 from ai.backend.manager.services.permission_contoller.actions.assign_role import AssignRoleAction
 from ai.backend.manager.services.permission_contoller.actions.bulk_assign_role import (
     BulkAssignRoleAction,
@@ -213,6 +230,22 @@ from ai.backend.manager.services.permission_contoller.actions.search_entities im
 from ai.backend.manager.services.permission_contoller.actions.search_permissions import (
     SearchPermissionsAction,
     SearchPermissionsActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    AcceptRoleInvitationAction as AcceptInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CancelRoleInvitationAction as CancelInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CreateRoleInvitationAction as CreateInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    RejectRoleInvitationAction as RejectInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    SearchMyRoleInvitationsAction,
+    SearchRoleInvitationsByRoleAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_roles import (
     SearchRolesAction,
@@ -1468,4 +1501,132 @@ class RBACAdapter(BaseAdapter):
             updated_at=data.updated_at,
             deleted_at=data.deleted_at,
             description=data.description,
+        )
+
+    # ------------------------------------------------------------------ role invitations
+
+    @staticmethod
+    def _invitation_data_to_node(
+        data: RoleInvitationData,
+    ) -> RoleInvitationNode:
+        return RoleInvitationNode(
+            id=data.id,
+            inviter_user_id=data.inviter_user_id,
+            invitee_user_id=data.invitee_user_id,
+            role_id=data.role_id,
+            state=RoleInvitationStateDTO(data.state.value),
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    async def create_role_invitation(
+        self,
+        input: CreateRoleInvitationInputDTO,
+    ) -> CreateRoleInvitationPayload:
+        """Create role invitations by email.
+
+        The response is deliberately opaque to prevent user enumeration.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        await self._processors.permission_controller.create_role_invitation.wait_for_complete(
+            CreateInvitationServiceAction(
+                role_id=input.role_id,
+                invitee_emails=input.emails,
+                inviter_user_id=me.user_id,
+            )
+        )
+        return CreateRoleInvitationPayload()
+
+    async def accept_role_invitation(
+        self,
+        invitation_id: UUID,
+    ) -> RoleInvitationNode:
+        """Accept a PENDING invitation."""
+        result = (
+            await self._processors.permission_controller.accept_role_invitation.wait_for_complete(
+                AcceptInvitationServiceAction(invitation_id=invitation_id)
+            )
+        )
+        return self._invitation_data_to_node(result.data)
+
+    async def reject_role_invitation(
+        self,
+        invitation_id: UUID,
+    ) -> RoleInvitationNode:
+        """Reject a PENDING invitation."""
+        result = (
+            await self._processors.permission_controller.reject_role_invitation.wait_for_complete(
+                RejectInvitationServiceAction(invitation_id=invitation_id)
+            )
+        )
+        return self._invitation_data_to_node(result.data)
+
+    async def cancel_role_invitation(
+        self,
+        invitation_id: UUID,
+    ) -> RoleInvitationNode:
+        """Cancel a PENDING invitation."""
+        result = (
+            await self._processors.permission_controller.cancel_role_invitation.wait_for_complete(
+                CancelInvitationServiceAction(invitation_id=invitation_id)
+            )
+        )
+        return self._invitation_data_to_node(result.data)
+
+    async def my_search_role_invitations(
+        self,
+        input: SearchRoleInvitationsInputDTO,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations for the current authenticated user."""
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        querier = BatchQuerier(
+            pagination=OffsetPagination(
+                limit=input.limit or 20,
+                offset=input.offset or 0,
+            ),
+        )
+        action_result = await self._processors.permission_controller.search_my_role_invitations.wait_for_complete(
+            SearchMyRoleInvitationsAction(
+                user_id=me.user_id,
+                querier=querier,
+                scope=InviteeSearchScope(invitee_user_id=me.user_id),
+            )
+        )
+        raw = action_result.result
+        return SearchRoleInvitationsPayload(
+            items=[self._invitation_data_to_node(item) for item in raw.items],
+            total_count=raw.total_count,
+            has_next_page=raw.has_next_page,
+            has_previous_page=raw.has_previous_page,
+        )
+
+    async def role_search_invitations(
+        self,
+        role_id: UUID,
+        input: SearchRoleInvitationsInputDTO,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations for a specific role (admin/project-admin view)."""
+        querier = BatchQuerier(
+            pagination=OffsetPagination(
+                limit=input.limit or 20,
+                offset=input.offset or 0,
+            ),
+        )
+        action_result = await self._processors.permission_controller.search_role_invitations_by_role.wait_for_complete(
+            SearchRoleInvitationsByRoleAction(
+                role_id=role_id,
+                querier=querier,
+                scope=RoleInvitationSearchScope(role_id=role_id),
+            )
+        )
+        raw = action_result.result
+        return SearchRoleInvitationsPayload(
+            items=[self._invitation_data_to_node(item) for item in raw.items],
+            total_count=raw.total_count,
+            has_next_page=raw.has_next_page,
+            has_previous_page=raw.has_previous_page,
         )

--- a/src/ai/backend/manager/api/gql/rbac/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/__init__.py
@@ -28,6 +28,7 @@ from .resolver import (
     rbac_permission_matrix,
     rbac_scope_entity_combinations,
     reject_role_invitation,
+    role_scoped_role_invitations,
 )
 from .types import (
     AssignRoleInput,
@@ -142,6 +143,7 @@ __all__ = (
     "admin_bulk_revoke_role",
     # Role invitation resolvers
     "my_role_invitations",
+    "role_scoped_role_invitations",
     "admin_role_invitations",
     "create_role_invitation",
     "accept_role_invitation",

--- a/src/ai/backend/manager/api/gql/rbac/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/__init__.py
@@ -37,7 +37,7 @@ from .types import (
     BulkRevokeRolePayloadGQL,
     CreatePermissionInput,
     CreateRoleInput,
-    CreateRoleInvitationInput,
+    CreateRoleInvitationInputGQL,
     CreateRoleInvitationPayload,
     EntityActionInfoGQL,
     EntityConnection,
@@ -110,7 +110,7 @@ __all__ = (
     # Role invitation types
     "RoleInvitationGQL",
     "RoleInvitationConnection",
-    "CreateRoleInvitationInput",
+    "CreateRoleInvitationInputGQL",
     "CreateRoleInvitationPayload",
     # Connections
     "RoleConnection",

--- a/src/ai/backend/manager/api/gql/rbac/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from .resolver import (
+    accept_role_invitation,
     admin_assign_role,
     admin_bulk_assign_role,
     admin_bulk_revoke_role,
+    admin_cancel_role_invitation,
     admin_create_permission,
     admin_create_role,
     admin_delete_permission,
@@ -14,14 +16,18 @@ from .resolver import (
     admin_revoke_role,
     admin_role,
     admin_role_assignments,
+    admin_role_invitations,
     admin_roles,
     admin_update_permission,
     admin_update_role,
+    create_role_invitation,
+    my_role_invitations,
     my_roles,
     project_roles,
     rbac_entity_operation_combinations,
     rbac_permission_matrix,
     rbac_scope_entity_combinations,
+    reject_role_invitation,
 )
 from .types import (
     AssignRoleInput,
@@ -31,6 +37,8 @@ from .types import (
     BulkRevokeRolePayloadGQL,
     CreatePermissionInput,
     CreateRoleInput,
+    CreateRoleInvitationInput,
+    CreateRoleInvitationPayload,
     EntityActionInfoGQL,
     EntityConnection,
     EntityFilter,
@@ -51,6 +59,8 @@ from .types import (
     RoleConnection,
     RoleFilter,
     RoleGQL,
+    RoleInvitationConnection,
+    RoleInvitationGQL,
     RoleOrderBy,
     RoleSourceGQL,
     RoleStatusGQL,
@@ -97,6 +107,11 @@ __all__ = (
     # Payloads
     "BulkAssignRolePayloadGQL",
     "BulkRevokeRolePayloadGQL",
+    # Role invitation types
+    "RoleInvitationGQL",
+    "RoleInvitationConnection",
+    "CreateRoleInvitationInput",
+    "CreateRoleInvitationPayload",
     # Connections
     "RoleConnection",
     "PermissionConnection",
@@ -125,4 +140,11 @@ __all__ = (
     "admin_revoke_role",
     "admin_bulk_assign_role",
     "admin_bulk_revoke_role",
+    # Role invitation resolvers
+    "my_role_invitations",
+    "admin_role_invitations",
+    "create_role_invitation",
+    "accept_role_invitation",
+    "reject_role_invitation",
+    "admin_cancel_role_invitation",
 )

--- a/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
@@ -32,6 +32,7 @@ from .role_invitation import (
     create_role_invitation,
     my_role_invitations,
     reject_role_invitation,
+    role_scoped_role_invitations,
 )
 
 __all__ = [
@@ -63,6 +64,7 @@ __all__ = [
     "admin_bulk_revoke_role",
     # Role invitation queries
     "my_role_invitations",
+    "role_scoped_role_invitations",
     "admin_role_invitations",
     # Role invitation mutations
     "create_role_invitation",

--- a/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
@@ -25,6 +25,14 @@ from .role import (
     my_roles,
     project_roles,
 )
+from .role_invitation import (
+    accept_role_invitation,
+    admin_cancel_role_invitation,
+    admin_role_invitations,
+    create_role_invitation,
+    my_role_invitations,
+    reject_role_invitation,
+)
 
 __all__ = [
     # Permission queries
@@ -53,4 +61,12 @@ __all__ = [
     "admin_revoke_role",
     "admin_bulk_assign_role",
     "admin_bulk_revoke_role",
+    # Role invitation queries
+    "my_role_invitations",
+    "admin_role_invitations",
+    # Role invitation mutations
+    "create_role_invitation",
+    "accept_role_invitation",
+    "reject_role_invitation",
+    "admin_cancel_role_invitation",
 ]

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -190,7 +190,7 @@ async def admin_role_invitations(
         added_version=NEXT_RELEASE_VERSION,
         description="Create role invitations by email.",
     )
-)  # type: ignore[misc]
+)
 async def create_role_invitation(
     info: Info[StrawberryGQLContext],
     input: CreateRoleInvitationInputGQL,
@@ -204,7 +204,7 @@ async def create_role_invitation(
         added_version=NEXT_RELEASE_VERSION,
         description="Accept a pending role invitation.",
     )
-)  # type: ignore[misc]
+)
 async def accept_role_invitation(
     info: Info[StrawberryGQLContext],
     input: AcceptRoleInvitationInputGQL,
@@ -219,7 +219,7 @@ async def accept_role_invitation(
         added_version=NEXT_RELEASE_VERSION,
         description="Reject a pending role invitation.",
     )
-)  # type: ignore[misc]
+)
 async def reject_role_invitation(
     info: Info[StrawberryGQLContext],
     input: RejectRoleInvitationInputGQL,
@@ -234,7 +234,7 @@ async def reject_role_invitation(
         added_version=NEXT_RELEASE_VERSION,
         description="Cancel a pending role invitation (admin only).",
     )
-)  # type: ignore[misc]
+)
 async def admin_cancel_role_invitation(
     info: Info[StrawberryGQLContext],
     input: CancelRoleInvitationInputGQL,

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -86,10 +86,10 @@ async def my_role_invitations(
 @gql_root_field(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="List invitations for a specific role (admin only).",
+        description="List invitations for a specific role.",
     )
 )  # type: ignore[misc]
-async def admin_role_invitations(
+async def role_scoped_role_invitations(
     info: Info[StrawberryGQLContext],
     role_id: UUID,
     filter: RoleInvitationFilterGQL | None = None,
@@ -101,9 +101,57 @@ async def admin_role_invitations(
     limit: int | None = None,
     offset: int | None = None,
 ) -> RoleInvitationConnection:
-    check_admin_only()
     result = await info.context.adapters.rbac.role_search_invitations(
         role_id,
+        SearchRoleInvitationsInput(
+            filter=filter.to_pydantic() if filter is not None else None,
+            order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    edges = [
+        RoleInvitationEdge(
+            node=RoleInvitationGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return RoleInvitationConnection(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="List all role invitations across the system (superadmin only).",
+    )
+)  # type: ignore[misc]
+async def admin_role_invitations(
+    info: Info[StrawberryGQLContext],
+    filter: RoleInvitationFilterGQL | None = None,
+    order_by: list[RoleInvitationOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> RoleInvitationConnection:
+    check_admin_only()
+    result = await info.context.adapters.rbac.admin_search_role_invitations(
         SearchRoleInvitationsInput(
             filter=filter.to_pydantic() if filter is not None else None,
             order=[o.to_pydantic() for o in order_by] if order_by is not None else None,

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -1,0 +1,159 @@
+"""GraphQL resolvers for role invitation management."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    SearchRoleInvitationsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.rbac.types.role_invitation import (
+    CreateRoleInvitationInput,
+    CreateRoleInvitationPayload,
+    RoleInvitationConnection,
+    RoleInvitationEdge,
+    RoleInvitationGQL,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+# ==================== Query Resolvers ====================
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="List the current user's role invitations.",
+    )
+)  # type: ignore[misc]
+async def my_role_invitations(
+    info: Info[StrawberryGQLContext],
+    limit: int | None = None,
+    offset: int | None = None,
+) -> RoleInvitationConnection:
+    result = await info.context.adapters.rbac.my_search_role_invitations(
+        SearchRoleInvitationsInput(limit=limit, offset=offset),
+    )
+    edges = [
+        RoleInvitationEdge(
+            node=RoleInvitationGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return RoleInvitationConnection(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="List invitations for a specific role (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_role_invitations(
+    info: Info[StrawberryGQLContext],
+    role_id: UUID,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> RoleInvitationConnection:
+    check_admin_only()
+    result = await info.context.adapters.rbac.role_search_invitations(
+        role_id,
+        SearchRoleInvitationsInput(limit=limit, offset=offset),
+    )
+    edges = [
+        RoleInvitationEdge(
+            node=RoleInvitationGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return RoleInvitationConnection(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )
+
+
+# ==================== Mutation Resolvers ====================
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Create role invitations by email.",
+    )
+)  # type: ignore[misc]
+async def create_role_invitation(
+    info: Info[StrawberryGQLContext],
+    input: CreateRoleInvitationInput,
+) -> CreateRoleInvitationPayload:
+    result = await info.context.adapters.rbac.create_role_invitation(input.to_pydantic())
+    return CreateRoleInvitationPayload.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Accept a pending role invitation.",
+    )
+)  # type: ignore[misc]
+async def accept_role_invitation(
+    info: Info[StrawberryGQLContext],
+    invitation_id: UUID,
+) -> RoleInvitationGQL:
+    result = await info.context.adapters.rbac.accept_role_invitation(invitation_id)
+    return RoleInvitationGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Reject a pending role invitation.",
+    )
+)  # type: ignore[misc]
+async def reject_role_invitation(
+    info: Info[StrawberryGQLContext],
+    invitation_id: UUID,
+) -> RoleInvitationGQL:
+    result = await info.context.adapters.rbac.reject_role_invitation(invitation_id)
+    return RoleInvitationGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cancel a pending role invitation (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_cancel_role_invitation(
+    info: Info[StrawberryGQLContext],
+    invitation_id: UUID,
+) -> RoleInvitationGQL:
+    check_admin_only()
+    result = await info.context.adapters.rbac.cancel_role_invitation(invitation_id)
+    return RoleInvitationGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -23,6 +23,7 @@ from ai.backend.manager.api.gql.rbac.types.role_invitation import (
     RoleInvitationConnection,
     RoleInvitationEdge,
     RoleInvitationGQL,
+    RoleInvitationOrderByGQL,
 )
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
@@ -38,11 +39,24 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 )  # type: ignore[misc]
 async def my_role_invitations(
     info: Info[StrawberryGQLContext],
+    order_by: list[RoleInvitationOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
 ) -> RoleInvitationConnection:
     result = await info.context.adapters.rbac.my_search_role_invitations(
-        SearchRoleInvitationsInput(limit=limit, offset=offset),
+        SearchRoleInvitationsInput(
+            order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
     )
     edges = [
         RoleInvitationEdge(
@@ -72,13 +86,26 @@ async def my_role_invitations(
 async def admin_role_invitations(
     info: Info[StrawberryGQLContext],
     role_id: UUID,
+    order_by: list[RoleInvitationOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
 ) -> RoleInvitationConnection:
     check_admin_only()
     result = await info.context.adapters.rbac.role_search_invitations(
         role_id,
-        SearchRoleInvitationsInput(limit=limit, offset=offset),
+        SearchRoleInvitationsInput(
+            order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
     )
     edges = [
         RoleInvitationEdge(

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -18,10 +18,14 @@ from ai.backend.manager.api.gql.decorators import (
     gql_root_field,
 )
 from ai.backend.manager.api.gql.rbac.types.role_invitation import (
-    CreateRoleInvitationInput,
+    AcceptRoleInvitationInputGQL,
+    CancelRoleInvitationInputGQL,
+    CreateRoleInvitationInputGQL,
     CreateRoleInvitationPayload,
+    RejectRoleInvitationInputGQL,
     RoleInvitationConnection,
     RoleInvitationEdge,
+    RoleInvitationFilterGQL,
     RoleInvitationGQL,
     RoleInvitationOrderByGQL,
 )
@@ -39,6 +43,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 )  # type: ignore[misc]
 async def my_role_invitations(
     info: Info[StrawberryGQLContext],
+    filter: RoleInvitationFilterGQL | None = None,
     order_by: list[RoleInvitationOrderByGQL] | None = None,
     before: str | None = None,
     after: str | None = None,
@@ -49,6 +54,7 @@ async def my_role_invitations(
 ) -> RoleInvitationConnection:
     result = await info.context.adapters.rbac.my_search_role_invitations(
         SearchRoleInvitationsInput(
+            filter=filter.to_pydantic() if filter is not None else None,
             order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
             first=first,
             after=after,
@@ -86,6 +92,7 @@ async def my_role_invitations(
 async def admin_role_invitations(
     info: Info[StrawberryGQLContext],
     role_id: UUID,
+    filter: RoleInvitationFilterGQL | None = None,
     order_by: list[RoleInvitationOrderByGQL] | None = None,
     before: str | None = None,
     after: str | None = None,
@@ -98,6 +105,7 @@ async def admin_role_invitations(
     result = await info.context.adapters.rbac.role_search_invitations(
         role_id,
         SearchRoleInvitationsInput(
+            filter=filter.to_pydantic() if filter is not None else None,
             order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
             first=first,
             after=after,
@@ -137,7 +145,7 @@ async def admin_role_invitations(
 )  # type: ignore[misc]
 async def create_role_invitation(
     info: Info[StrawberryGQLContext],
-    input: CreateRoleInvitationInput,
+    input: CreateRoleInvitationInputGQL,
 ) -> CreateRoleInvitationPayload:
     result = await info.context.adapters.rbac.create_role_invitation(input.to_pydantic())
     return CreateRoleInvitationPayload.from_pydantic(result)
@@ -151,9 +159,10 @@ async def create_role_invitation(
 )  # type: ignore[misc]
 async def accept_role_invitation(
     info: Info[StrawberryGQLContext],
-    invitation_id: UUID,
+    input: AcceptRoleInvitationInputGQL,
 ) -> RoleInvitationGQL:
-    result = await info.context.adapters.rbac.accept_role_invitation(invitation_id)
+    dto = input.to_pydantic()
+    result = await info.context.adapters.rbac.accept_role_invitation(dto.invitation_id)
     return RoleInvitationGQL.from_pydantic(result)
 
 
@@ -165,9 +174,10 @@ async def accept_role_invitation(
 )  # type: ignore[misc]
 async def reject_role_invitation(
     info: Info[StrawberryGQLContext],
-    invitation_id: UUID,
+    input: RejectRoleInvitationInputGQL,
 ) -> RoleInvitationGQL:
-    result = await info.context.adapters.rbac.reject_role_invitation(invitation_id)
+    dto = input.to_pydantic()
+    result = await info.context.adapters.rbac.reject_role_invitation(dto.invitation_id)
     return RoleInvitationGQL.from_pydantic(result)
 
 
@@ -179,8 +189,9 @@ async def reject_role_invitation(
 )  # type: ignore[misc]
 async def admin_cancel_role_invitation(
     info: Info[StrawberryGQLContext],
-    invitation_id: UUID,
+    input: CancelRoleInvitationInputGQL,
 ) -> RoleInvitationGQL:
     check_admin_only()
-    result = await info.context.adapters.rbac.cancel_role_invitation(invitation_id)
+    dto = input.to_pydantic()
+    result = await info.context.adapters.rbac.cancel_role_invitation(dto.invitation_id)
     return RoleInvitationGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/rbac/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/__init__.py
@@ -61,6 +61,14 @@ from .role import (
     RoleStatusGQL,
     UpdateRoleInput,
 )
+from .role_invitation import (
+    CreateRoleInvitationInput,
+    CreateRoleInvitationPayload,
+    RoleInvitationConnection,
+    RoleInvitationEdge,
+    RoleInvitationGQL,
+    RoleInvitationStateGQL,
+)
 from .scope import RBACElementTypeGQL, ScopeInputGQL
 
 __all__ = [
@@ -126,6 +134,13 @@ __all__ = [
     "EntityNode",
     "EntityEdge",
     "EntityConnection",
+    # Role invitation types
+    "RoleInvitationStateGQL",
+    "RoleInvitationGQL",
+    "RoleInvitationConnection",
+    "RoleInvitationEdge",
+    "CreateRoleInvitationInput",
+    "CreateRoleInvitationPayload",
     # Scope types
     "ScopeInputGQL",
     # Scope-entity combination

--- a/src/ai/backend/manager/api/gql/rbac/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/__init__.py
@@ -67,6 +67,8 @@ from .role_invitation import (
     RoleInvitationConnection,
     RoleInvitationEdge,
     RoleInvitationGQL,
+    RoleInvitationOrderByGQL,
+    RoleInvitationOrderField,
     RoleInvitationStateGQL,
 )
 from .scope import RBACElementTypeGQL, ScopeInputGQL
@@ -139,6 +141,8 @@ __all__ = [
     "RoleInvitationGQL",
     "RoleInvitationConnection",
     "RoleInvitationEdge",
+    "RoleInvitationOrderField",
+    "RoleInvitationOrderByGQL",
     "CreateRoleInvitationInput",
     "CreateRoleInvitationPayload",
     # Scope types

--- a/src/ai/backend/manager/api/gql/rbac/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/__init__.py
@@ -62,14 +62,21 @@ from .role import (
     UpdateRoleInput,
 )
 from .role_invitation import (
-    CreateRoleInvitationInput,
+    AcceptRoleInvitationInputGQL,
+    CancelRoleInvitationInputGQL,
+    CreateRoleInvitationInputGQL,
     CreateRoleInvitationPayload,
+    RejectRoleInvitationInputGQL,
     RoleInvitationConnection,
     RoleInvitationEdge,
+    RoleInvitationFilterGQL,
     RoleInvitationGQL,
     RoleInvitationOrderByGQL,
-    RoleInvitationOrderField,
+    RoleInvitationOrderFieldGQL,
+    RoleInvitationRoleNestedFilterGQL,
+    RoleInvitationStateFilterGQL,
     RoleInvitationStateGQL,
+    RoleInvitationUserNestedFilterGQL,
 )
 from .scope import RBACElementTypeGQL, ScopeInputGQL
 
@@ -141,9 +148,16 @@ __all__ = [
     "RoleInvitationGQL",
     "RoleInvitationConnection",
     "RoleInvitationEdge",
-    "RoleInvitationOrderField",
+    "RoleInvitationOrderFieldGQL",
     "RoleInvitationOrderByGQL",
-    "CreateRoleInvitationInput",
+    "RoleInvitationFilterGQL",
+    "RoleInvitationStateFilterGQL",
+    "RoleInvitationRoleNestedFilterGQL",
+    "RoleInvitationUserNestedFilterGQL",
+    "CreateRoleInvitationInputGQL",
+    "AcceptRoleInvitationInputGQL",
+    "RejectRoleInvitationInputGQL",
+    "CancelRoleInvitationInputGQL",
     "CreateRoleInvitationPayload",
     # Scope types
     "ScopeInputGQL",

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -1,0 +1,112 @@
+"""GQL types for role invitations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    CreateRoleInvitationPayload as CreateRoleInvitationPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    RoleInvitationNode as RoleInvitationNodeDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_enum,
+    gql_field,
+    gql_node_type,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import (
+    PydanticInputMixin,
+    PydanticNodeMixin,
+    PydanticOutputMixin,
+)
+
+RoleInvitationStateGQL: type[RoleInvitationStateDTO] = gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Role invitation state.",
+    ),
+    RoleInvitationStateDTO,
+    name="RoleInvitationState",
+)
+
+
+# -- Node --
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A role invitation.",
+    ),
+    name="RoleInvitation",
+)
+class RoleInvitationGQL(PydanticNodeMixin[RoleInvitationNodeDTO]):
+    id: NodeID[str]
+    inviter_user_id: UUID | None = gql_field(description="Inviter user ID.")
+    invitee_user_id: UUID = gql_field(description="Invitee user ID.")
+    role_id: UUID = gql_field(description="Role ID.")
+    state: RoleInvitationStateGQL = gql_field(description="Invitation state.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime | None = gql_field(description="Last update timestamp.")
+
+
+# -- Connection --
+
+RoleInvitationEdge = Edge[RoleInvitationGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Role invitation connection.",
+    )
+)
+class RoleInvitationConnection(Connection[RoleInvitationGQL]):
+    count: int
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count
+
+
+# -- Inputs --
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for creating role invitations.",
+    ),
+)
+class CreateRoleInvitationInput(PydanticInputMixin[CreateRoleInvitationInputDTO]):
+    role_id: UUID
+    emails: list[str]
+
+
+# -- Payloads --
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for role invitation creation.",
+    ),
+    model=CreateRoleInvitationPayloadDTO,
+    name="CreateRoleInvitationPayload",
+)
+class CreateRoleInvitationPayload(PydanticOutputMixin[CreateRoleInvitationPayloadDTO]):
+    ok: bool = gql_field(description="Always true for a successful request.")

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -141,6 +141,4 @@ class CreateRoleInvitationInput(PydanticInputMixin[CreateRoleInvitationInputDTO]
     name="CreateRoleInvitationPayload",
 )
 class CreateRoleInvitationPayload(PydanticOutputMixin[CreateRoleInvitationPayloadDTO]):
-    items: list[RoleInvitationGQL] = gql_field(
-        description="List of created role invitations."
-    )
+    items: list[RoleInvitationGQL] = gql_field(description="List of created role invitations.")

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, Self
+from typing import TYPE_CHECKING, Annotated, Any, Self
 from uuid import UUID
 
+import strawberry
+from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.rbac.types.role import RoleGQL
+    from ai.backend.manager.api.gql.user.types.node import UserV2GQL
 
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
     AcceptRoleInvitationInput as AcceptRoleInvitationInputDTO,
@@ -114,6 +120,58 @@ class RoleInvitationGQL(PydanticNodeMixin[RoleInvitationNodeDTO]):
     state: RoleInvitationStateGQL = gql_field(description="Invitation state.")
     created_at: datetime = gql_field(description="Creation timestamp.")
     updated_at: datetime | None = gql_field(description="Last update timestamp.")
+
+    @gql_field(description="The user who sent this invitation. Null for system-issued invitations.")  # type: ignore[misc]
+    async def inviter(
+        self,
+        info: Info,
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        if self.inviter_user_id is None:
+            return None
+        inviter: UserV2GQL | None = await info.context.data_loaders.user_loader.load(
+            self.inviter_user_id
+        )
+        return inviter
+
+    @gql_field(
+        description="The user who received this invitation. Null if the user no longer exists."
+    )  # type: ignore[misc]
+    async def invitee(
+        self,
+        info: Info,
+    ) -> (
+        Annotated[
+            UserV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
+        invitee: UserV2GQL | None = await info.context.data_loaders.user_loader.load(
+            self.invitee_user_id
+        )
+        return invitee
+
+    @gql_field(
+        description="The role this invitation grants on acceptance. Null if the role no longer exists."
+    )  # type: ignore[misc]
+    async def role(
+        self,
+        info: Info,
+    ) -> (
+        Annotated[
+            RoleGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.rbac.types.role"),
+        ]
+        | None
+    ):
+        role: RoleGQL | None = await info.context.data_loaders.role_loader.load(self.role_id)
+        return role
 
 
 # -- Connection --

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -43,7 +43,7 @@ from ai.backend.common.dto.manager.v2.role_invitation.response import (
     RoleInvitationNode as RoleInvitationNodeDTO,
 )
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_connection_type,
@@ -204,6 +204,7 @@ class RoleInvitationUserNestedFilterGQL(PydanticInputMixin[UserNestedFilterDTO])
 )
 class RoleInvitationFilterGQL(PydanticInputMixin[RoleInvitationFilterDTO]):
     state: RoleInvitationStateFilterGQL | None = None
+    role_id: UUIDFilter | None = None
     role: RoleInvitationRoleNestedFilterGQL | None = None
     inviter: RoleInvitationUserNestedFilterGQL | None = None
     invitee: RoleInvitationUserNestedFilterGQL | None = None

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
@@ -10,6 +11,9 @@ from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationOrderBy as RoleInvitationOrderByDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
     CreateRoleInvitationPayload as CreateRoleInvitationPayloadDTO,
@@ -19,6 +23,7 @@ from ai.backend.common.dto.manager.v2.role_invitation.response import (
 )
 from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import OrderDirection
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_connection_type,
@@ -33,6 +38,7 @@ from ai.backend.manager.api.gql.pydantic_compat import (
     PydanticNodeMixin,
     PydanticOutputMixin,
 )
+from ai.backend.manager.api.gql.types import GQLOrderBy
 
 RoleInvitationStateGQL: type[RoleInvitationStateDTO] = gql_enum(
     BackendAIGQLMeta(
@@ -81,6 +87,32 @@ class RoleInvitationConnection(Connection[RoleInvitationGQL]):
     def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.count = count
+
+
+# -- OrderBy --
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Role invitation ordering field.",
+    )
+)
+class RoleInvitationOrderField(StrEnum):
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+    STATE = "state"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Order by specification for role invitations.",
+    ),
+)
+class RoleInvitationOrderByGQL(PydanticInputMixin[RoleInvitationOrderByDTO], GQLOrderBy):
+    field: RoleInvitationOrderField
+    direction: OrderDirection = OrderDirection.DESC
 
 
 # -- Inputs --

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -4,16 +4,37 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Self
 from uuid import UUID
 
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    AcceptRoleInvitationInput as AcceptRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CancelRoleInvitationInput as CancelRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput as CreateRoleInvitationInputDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RejectRoleInvitationInput as RejectRoleInvitationInputDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationFilter as RoleInvitationFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
     RoleInvitationOrderBy as RoleInvitationOrderByDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleInvitationStateFilter as RoleInvitationStateFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    RoleNestedFilter as RoleNestedFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    UserNestedFilter as UserNestedFilterDTO,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
     CreateRoleInvitationPayload as CreateRoleInvitationPayloadDTO,
@@ -21,9 +42,8 @@ from ai.backend.common.dto.manager.v2.role_invitation.response import (
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
     RoleInvitationNode as RoleInvitationNodeDTO,
 )
-from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.manager.api.gql.base import OrderDirection
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_connection_type,
@@ -40,14 +60,40 @@ from ai.backend.manager.api.gql.pydantic_compat import (
 )
 from ai.backend.manager.api.gql.types import GQLOrderBy
 
-RoleInvitationStateGQL: type[RoleInvitationStateDTO] = gql_enum(
+# -- Enums --
+
+
+@gql_enum(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description="Role invitation state.",
     ),
-    RoleInvitationStateDTO,
     name="RoleInvitationState",
 )
+class RoleInvitationStateGQL(StrEnum):
+    """GraphQL enum for role invitation state.
+
+    Kept separate from `RoleInvitationStateDTO` with matching values; the Pydantic
+    compatibility layer performs 1:1 conversion via `.value` coercion.
+    """
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    CANCELED = "canceled"
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Role invitation ordering field.",
+    ),
+    name="RoleInvitationOrderField",
+)
+class RoleInvitationOrderFieldGQL(StrEnum):
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+    STATE = "state"
 
 
 # -- Node --
@@ -92,27 +138,78 @@ class RoleInvitationConnection(Connection[RoleInvitationGQL]):
 # -- OrderBy --
 
 
-@gql_enum(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description="Role invitation ordering field.",
-    )
-)
-class RoleInvitationOrderField(StrEnum):
-    CREATED_AT = "created_at"
-    UPDATED_AT = "updated_at"
-    STATE = "state"
-
-
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description="Order by specification for role invitations.",
     ),
+    name="RoleInvitationOrderBy",
 )
 class RoleInvitationOrderByGQL(PydanticInputMixin[RoleInvitationOrderByDTO], GQLOrderBy):
-    field: RoleInvitationOrderField
+    field: RoleInvitationOrderFieldGQL
     direction: OrderDirection = OrderDirection.DESC
+
+
+# -- Filters --
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter for role invitation state.",
+    ),
+    name="RoleInvitationStateFilter",
+)
+class RoleInvitationStateFilterGQL(PydanticInputMixin[RoleInvitationStateFilterDTO]):
+    equals: RoleInvitationStateGQL | None = None
+    in_: list[RoleInvitationStateGQL] | None = gql_field(
+        description="Match any of the provided states.", name="in", default=None
+    )
+    not_equals: RoleInvitationStateGQL | None = gql_field(
+        description="Exclude exact state match.", name="notEquals", default=None
+    )
+    not_in: list[RoleInvitationStateGQL] | None = gql_field(
+        description="Exclude any of the provided states.", name="notIn", default=None
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Nested filter for the role associated with an invitation.",
+    ),
+    name="RoleInvitationRoleNestedFilter",
+)
+class RoleInvitationRoleNestedFilterGQL(PydanticInputMixin[RoleNestedFilterDTO]):
+    name: StringFilter | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Nested filter for a user (inviter or invitee) of an invitation.",
+    ),
+    name="RoleInvitationUserNestedFilter",
+)
+class RoleInvitationUserNestedFilterGQL(PydanticInputMixin[UserNestedFilterDTO]):
+    email: StringFilter | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter for role invitations.",
+    ),
+    name="RoleInvitationFilter",
+)
+class RoleInvitationFilterGQL(PydanticInputMixin[RoleInvitationFilterDTO]):
+    state: RoleInvitationStateFilterGQL | None = None
+    role: RoleInvitationRoleNestedFilterGQL | None = None
+    inviter: RoleInvitationUserNestedFilterGQL | None = None
+    invitee: RoleInvitationUserNestedFilterGQL | None = None
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
 
 
 # -- Inputs --
@@ -123,10 +220,44 @@ class RoleInvitationOrderByGQL(PydanticInputMixin[RoleInvitationOrderByDTO], GQL
         added_version=NEXT_RELEASE_VERSION,
         description="Input for creating role invitations.",
     ),
+    name="CreateRoleInvitationInput",
 )
-class CreateRoleInvitationInput(PydanticInputMixin[CreateRoleInvitationInputDTO]):
+class CreateRoleInvitationInputGQL(PydanticInputMixin[CreateRoleInvitationInputDTO]):
     role_id: UUID
     emails: list[str]
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for accepting a role invitation.",
+    ),
+    name="AcceptRoleInvitationInput",
+)
+class AcceptRoleInvitationInputGQL(PydanticInputMixin[AcceptRoleInvitationInputDTO]):
+    invitation_id: UUID
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for rejecting a role invitation.",
+    ),
+    name="RejectRoleInvitationInput",
+)
+class RejectRoleInvitationInputGQL(PydanticInputMixin[RejectRoleInvitationInputDTO]):
+    invitation_id: UUID
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Input for canceling a role invitation.",
+    ),
+    name="CancelRoleInvitationInput",
+)
+class CancelRoleInvitationInputGQL(PydanticInputMixin[CancelRoleInvitationInputDTO]):
+    invitation_id: UUID
 
 
 # -- Payloads --

--- a/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role_invitation.py
@@ -141,4 +141,6 @@ class CreateRoleInvitationInput(PydanticInputMixin[CreateRoleInvitationInputDTO]
     name="CreateRoleInvitationPayload",
 )
 class CreateRoleInvitationPayload(PydanticOutputMixin[CreateRoleInvitationPayloadDTO]):
-    ok: bool = gql_field(description="Always true for a successful request.")
+    items: list[RoleInvitationGQL] = gql_field(
+        description="List of created role invitations."
+    )

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -257,9 +257,11 @@ from .prometheus_query_preset import (
     prometheus_query_presets,
 )
 from .rbac import (
+    accept_role_invitation,
     admin_assign_role,
     admin_bulk_assign_role,
     admin_bulk_revoke_role,
+    admin_cancel_role_invitation,
     admin_create_permission,
     admin_create_role,
     admin_delete_permission,
@@ -270,14 +272,18 @@ from .rbac import (
     admin_revoke_role,
     admin_role,
     admin_role_assignments,
+    admin_role_invitations,
     admin_roles,
     admin_update_permission,
     admin_update_role,
+    create_role_invitation,
+    my_role_invitations,
     my_roles,
     project_roles,
     rbac_entity_operation_combinations,
     rbac_permission_matrix,
     rbac_scope_entity_combinations,
+    reject_role_invitation,
 )
 from .reservoir_registry import (
     create_reservoir_registry,
@@ -536,6 +542,9 @@ class Query:
     my_login_history_v2 = my_login_history_v2
     # RBAC User APIs
     my_roles = my_roles
+    my_role_invitations = my_role_invitations
+    # RBAC Admin Invitation APIs
+    admin_role_invitations = admin_role_invitations
     # RBAC Scoped APIs
     project_roles = project_roles
     rbac_scope_entity_combinations = rbac_scope_entity_combinations
@@ -810,6 +819,11 @@ class Mutation:
     admin_revoke_role = admin_revoke_role
     admin_bulk_assign_role = admin_bulk_assign_role
     admin_bulk_revoke_role = admin_bulk_revoke_role
+    # RBAC Invitation Mutations
+    create_role_invitation = create_role_invitation
+    accept_role_invitation = accept_role_invitation
+    reject_role_invitation = reject_role_invitation
+    admin_cancel_role_invitation = admin_cancel_role_invitation
     # Resource Policy V2 APIs
     admin_create_keypair_resource_policy_v2 = admin_create_keypair_resource_policy_v2
     admin_update_keypair_resource_policy_v2 = admin_update_keypair_resource_policy_v2

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -284,6 +284,7 @@ from .rbac import (
     rbac_permission_matrix,
     rbac_scope_entity_combinations,
     reject_role_invitation,
+    role_scoped_role_invitations,
 )
 from .reservoir_registry import (
     create_reservoir_registry,
@@ -547,6 +548,7 @@ class Query:
     admin_role_invitations = admin_role_invitations
     # RBAC Scoped APIs
     project_roles = project_roles
+    role_scoped_role_invitations = role_scoped_role_invitations
     rbac_scope_entity_combinations = rbac_scope_entity_combinations
     rbac_entity_operation_combinations = rbac_entity_operation_combinations
     rbac_permission_matrix = rbac_permission_matrix

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -103,3 +103,7 @@ class CategoryIdPathParam(BaseRequestModel):
 
 class AccessKeyPathParam(BaseRequestModel):
     access_key: str = Field(description="Access key string")
+
+
+class InvitationIdPathParam(BaseRequestModel):
+    invitation_id: UUID = Field(description="Invitation UUID")

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
@@ -15,7 +15,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import InvitationIdPathParam, RoleIdPathParam
 
 if TYPE_CHECKING:
-    from ai.backend.manager.api.adapters.rbac import RBACAdapter
+    from ai.backend.manager.api.adapters.rbac.adapter import RBACAdapter
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
@@ -30,11 +30,7 @@ class V2RoleInvitationHandler:
         self,
         body: BodyParam[CreateRoleInvitationInput],
     ) -> APIResponse:
-        """Create role invitations by email.
-
-        Response is opaque: always 201 regardless of whether
-        the user existed or was eligible.
-        """
+        """Create role invitations by email."""
         result = await self._adapter.create_role_invitation(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
 

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
@@ -1,0 +1,80 @@
+"""REST v2 handler for role invitations."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput,
+    SearchRoleInvitationsInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import InvitationIdPathParam, RoleIdPathParam
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.rbac import RBACAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2RoleInvitationHandler:
+    """REST v2 handler for role invitation operations."""
+
+    def __init__(self, *, adapter: RBACAdapter) -> None:
+        self._adapter = adapter
+
+    async def create(
+        self,
+        body: BodyParam[CreateRoleInvitationInput],
+    ) -> APIResponse:
+        """Create role invitations by email.
+
+        Response is opaque: always 201 regardless of whether
+        the user existed or was eligible.
+        """
+        result = await self._adapter.create_role_invitation(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=result)
+
+    async def accept(
+        self,
+        path: PathParam[InvitationIdPathParam],
+    ) -> APIResponse:
+        """Invitee accepts a pending invitation."""
+        result = await self._adapter.accept_role_invitation(path.parsed.invitation_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def reject(
+        self,
+        path: PathParam[InvitationIdPathParam],
+    ) -> APIResponse:
+        """Invitee rejects a pending invitation."""
+        result = await self._adapter.reject_role_invitation(path.parsed.invitation_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def cancel(
+        self,
+        path: PathParam[InvitationIdPathParam],
+    ) -> APIResponse:
+        """Admin cancels a pending invitation."""
+        result = await self._adapter.cancel_role_invitation(path.parsed.invitation_id)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_search(
+        self,
+        body: BodyParam[SearchRoleInvitationsInput],
+    ) -> APIResponse:
+        """Search invitations addressed to the current user."""
+        result = await self._adapter.my_search_role_invitations(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def role_search(
+        self,
+        path: PathParam[RoleIdPathParam],
+        body: BodyParam[SearchRoleInvitationsInput],
+    ) -> APIResponse:
+        """Search invitations for a specific role (admin view)."""
+        result = await self._adapter.role_search_invitations(path.parsed.role_id, body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
@@ -74,3 +74,11 @@ class V2RoleInvitationHandler:
         """Search invitations for a specific role (admin view)."""
         result = await self._adapter.role_search_invitations(path.parsed.role_id, body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_search(
+        self,
+        body: BodyParam[SearchRoleInvitationsInput],
+    ) -> APIResponse:
+        """Search all invitations across the system (superadmin only)."""
+        result = await self._adapter.admin_search_role_invitations(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
@@ -1,0 +1,66 @@
+"""Route registry for REST v2 role invitation endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2RoleInvitationHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_role_invitation_routes(
+    handler: V2RoleInvitationHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all REST v2 role invitation routes."""
+    registry = RouteRegistry.create("role-invitations", route_deps.cors_options)
+
+    # Create invitation (admin)
+    registry.add(
+        "POST",
+        "",
+        handler.create,
+        middlewares=[auth_required],
+    )
+    # Accept invitation (invitee)
+    registry.add(
+        "POST",
+        "/{invitation_id}/accept",
+        handler.accept,
+        middlewares=[auth_required],
+    )
+    # Reject invitation (invitee)
+    registry.add(
+        "POST",
+        "/{invitation_id}/reject",
+        handler.reject,
+        middlewares=[auth_required],
+    )
+    # Cancel invitation (admin)
+    registry.add(
+        "DELETE",
+        "/{invitation_id}",
+        handler.cancel,
+        middlewares=[auth_required],
+    )
+    # Search own invitations (invitee)
+    registry.add(
+        "POST",
+        "/my/search",
+        handler.my_search,
+        middlewares=[auth_required],
+    )
+    # Search invitations by role (admin/project-admin)
+    registry.add(
+        "POST",
+        "/roles/{role_id}/search",
+        handler.role_search,
+        middlewares=[auth_required],
+    )
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ai.backend.manager.api.rest.middleware.auth import auth_required
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
 from ai.backend.manager.api.rest.routing import RouteRegistry
 
 from .handler import V2RoleInvitationHandler
@@ -55,12 +55,19 @@ def register_v2_role_invitation_routes(
         handler.my_search,
         middlewares=[auth_required],
     )
-    # Search invitations by role (admin/project-admin)
+    # Search invitations by role (scoped — non-admin with role permission also allowed)
     registry.add(
         "POST",
         "/roles/{role_id}/search",
         handler.role_search,
         middlewares=[auth_required],
+    )
+    # Search all invitations across the system (superadmin only)
+    registry.add(
+        "POST",
+        "/search",
+        handler.admin_search,
+        middlewares=[superadmin_required],
     )
 
     return registry

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -90,6 +90,8 @@ def build_v2_routes(
     from .resource_slot.registry import register_v2_resource_slot_routes
     from .resource_usage.handler import V2ResourceUsageHandler
     from .resource_usage.registry import register_v2_resource_usage_routes
+    from .role_invitation.handler import V2RoleInvitationHandler
+    from .role_invitation.registry import register_v2_role_invitation_routes
     from .runtime_variant.handler import V2RuntimeVariantHandler
     from .runtime_variant.registry import register_v2_runtime_variant_routes
     from .runtime_variant_preset.handler import V2RuntimeVariantPresetHandler
@@ -134,6 +136,7 @@ def build_v2_routes(
     notification_handler = V2NotificationHandler(adapter=adapters.notification)
     object_storage_handler = V2ObjectStorageHandler(adapter=adapters.object_storage)
     project_handler = V2ProjectHandler(adapter=adapters.project)
+    role_invitation_handler = V2RoleInvitationHandler(adapter=adapters.rbac)
     prometheus_query_preset_handler = V2PrometheusQueryPresetHandler(
         adapter=adapters.prometheus_query_preset
     )
@@ -201,6 +204,7 @@ def build_v2_routes(
     v2_reg.add_subregistry(register_v2_notification_routes(notification_handler, route_deps))
     v2_reg.add_subregistry(register_v2_object_storage_routes(object_storage_handler, route_deps))
     v2_reg.add_subregistry(register_v2_project_routes(project_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_role_invitation_routes(role_invitation_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_prometheus_query_preset_routes(prometheus_query_preset_handler, route_deps)
     )

--- a/src/ai/backend/manager/errors/role_invitation.py
+++ b/src/ai/backend/manager/errors/role_invitation.py
@@ -21,6 +21,18 @@ class RoleInvitationNotFound(ObjectNotFound):
         )
 
 
+class DuplicateRoleInvitationError(BackendAIError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/duplicate-role-invitation"
+    error_title = "Duplicate role invitation."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.ROLE_INVITATION,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
 class RoleInvitationInvalidState(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/role-invitation-invalid-state"
     error_title = "Invalid role invitation state transition."

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
+from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.models.user import UserRow
@@ -208,12 +209,7 @@ class RoleInvitationConditions:
 
         return inner
 
-    @staticmethod
-    def role_name_in(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return RoleRow.name.in_([spec.value])
-
-        return inner
+    role_name_in = staticmethod(make_string_in_factory(RoleRow.name))
 
     # -- nested user filter helpers (for EXISTS subquery) --
 
@@ -269,12 +265,7 @@ class RoleInvitationConditions:
 
         return inner
 
-    @staticmethod
-    def _user_email_in(spec: StringMatchSpec) -> QueryCondition:
-        def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return UserRow.email.in_([spec.value])
-
-        return inner
+    _user_email_in = staticmethod(make_string_in_factory(UserRow.email))
 
     @staticmethod
     def exists_invitee_with_conditions(

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Collection
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -116,28 +117,28 @@ class RoleInvitationConditions:
     # -- state filter --
 
     @staticmethod
-    def by_state_equals(state: str) -> QueryCondition:
+    def by_state_equals(state: RoleInvitationState) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.state == state
 
         return inner
 
     @staticmethod
-    def by_state_in(states: list[str]) -> QueryCondition:
+    def by_state_in(states: Collection[RoleInvitationState]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.state.in_(states)
 
         return inner
 
     @staticmethod
-    def by_state_not_equals(state: str) -> QueryCondition:
+    def by_state_not_equals(state: RoleInvitationState) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.state != state
 
         return inner
 
     @staticmethod
-    def by_state_not_in(states: list[str]) -> QueryCondition:
+    def by_state_not_in(states: Collection[RoleInvitationState]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.state.not_in(states)
 

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -8,7 +8,11 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.rbac_models.role import RoleRow
@@ -75,6 +79,26 @@ class RoleInvitationConditions:
     def by_role(role_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.role_id == role_id
+
+        return inner
+
+    @staticmethod
+    def by_role_id_filter_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = RoleInvitationRow.role_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_role_id_filter_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = RoleInvitationRow.role_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -1,7 +1,8 @@
-"""Query conditions for role invitation repository operations."""
+"""Query conditions and orders for role invitation repository operations."""
 
 from __future__ import annotations
 
+import uuid
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -9,6 +10,29 @@ import sqlalchemy as sa
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.repositories.base import QueryCondition
+from ai.backend.manager.repositories.base.types import QueryOrder
+
+
+class RoleInvitationOrders:
+    """Query orders for role invitations."""
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RoleInvitationRow.created_at.asc()
+        return RoleInvitationRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RoleInvitationRow.updated_at.asc()
+        return RoleInvitationRow.updated_at.desc()
+
+    @staticmethod
+    def state(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return RoleInvitationRow.state.asc()
+        return RoleInvitationRow.state.desc()
 
 
 class RoleInvitationConditions:
@@ -46,5 +70,41 @@ class RoleInvitationConditions:
     def by_role(role_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.role_id == role_id
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination (after cursor).
+
+        Default order is created_at DESC, so forward means created_at < cursor's created_at.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(RoleInvitationRow.created_at)
+                .where(RoleInvitationRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RoleInvitationRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination (before cursor).
+
+        Default order is created_at DESC, so backward means created_at > cursor's created_at.
+        """
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(RoleInvitationRow.created_at)
+                .where(RoleInvitationRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return RoleInvitationRow.created_at > subquery
 
         return inner

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -7,8 +7,11 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
+from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base import QueryCondition
 from ai.backend.manager.repositories.base.types import QueryOrder
 
@@ -106,5 +109,197 @@ class RoleInvitationConditions:
                 .scalar_subquery()
             )
             return RoleInvitationRow.created_at > subquery
+
+        return inner
+
+    # -- state filter --
+
+    @staticmethod
+    def by_state_equals(state: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.state == state
+
+        return inner
+
+    @staticmethod
+    def by_state_in(states: list[str]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.state.in_(states)
+
+        return inner
+
+    @staticmethod
+    def by_state_not_equals(state: str) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.state != state
+
+        return inner
+
+    @staticmethod
+    def by_state_not_in(states: list[str]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.state.not_in(states)
+
+        return inner
+
+    # -- nested role filter (EXISTS subquery) --
+
+    @staticmethod
+    def exists_role_with_conditions(role_conditions: list[QueryCondition]) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subq = sa.select(sa.literal(1)).where(
+                RoleRow.id == RoleInvitationRow.role_id,
+            )
+            for cond in role_conditions:
+                subq = subq.where(cond())
+            return sa.exists(subq)
+
+        return inner
+
+    @staticmethod
+    def role_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RoleRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = RoleRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def role_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(RoleRow.name) == spec.value.lower()
+            else:
+                condition = RoleRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def role_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RoleRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = RoleRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def role_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = RoleRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = RoleRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def role_name_in(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleRow.name.in_([spec.value])
+
+        return inner
+
+    # -- nested user filter helpers (for EXISTS subquery) --
+
+    @staticmethod
+    def _user_email_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"%{spec.value}%")
+            else:
+                condition = UserRow.email.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def _user_email_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(UserRow.email) == spec.value.lower()
+            else:
+                condition = UserRow.email == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def _user_email_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"{spec.value}%")
+            else:
+                condition = UserRow.email.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def _user_email_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = UserRow.email.ilike(f"%{spec.value}")
+            else:
+                condition = UserRow.email.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def _user_email_in(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return UserRow.email.in_([spec.value])
+
+        return inner
+
+    @staticmethod
+    def exists_invitee_with_conditions(
+        user_conditions: list[QueryCondition],
+    ) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subq = sa.select(sa.literal(1)).where(
+                UserRow.uuid == RoleInvitationRow.invitee_user_id,
+            )
+            for cond in user_conditions:
+                subq = subq.where(cond())
+            return sa.exists(subq)
+
+        return inner
+
+    @staticmethod
+    def exists_inviter_with_conditions(
+        user_conditions: list[QueryCondition],
+    ) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subq = sa.select(sa.literal(1)).where(
+                UserRow.uuid == RoleInvitationRow.inviter_user_id,
+            )
+            for cond in user_conditions:
+                subq = subq.where(cond())
+            return sa.exists(subq)
 
         return inner

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -1308,6 +1308,21 @@ class PermissionDBSource:
                 has_previous_page=result.has_previous_page,
             )
 
+    async def admin_search_invitations(
+        self,
+        querier: BatchQuerier,
+    ) -> RoleInvitationSearchResult:
+        async with self._db.begin_readonly_session_read_committed() as session:
+            query = sa.select(RoleInvitationRow)
+            result = await execute_batch_querier(session, query, querier)
+            items = [row.RoleInvitationRow.to_data() for row in result.rows]
+            return RoleInvitationSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
     async def accept_invitation(
         self,
         invitation_id: uuid.UUID,

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -16,11 +16,7 @@ from ai.backend.common.data.permission.types import (
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action.rbac_role_invitation import (
-    AcceptRoleInvitationAction,
-    CancelRoleInvitationAction,
-    CreateRoleInvitationByEmailAction,
     CreateRoleInvitationResult,
-    RejectRoleInvitationAction,
 )
 from ai.backend.manager.data.permission.entity import (
     ElementAssociationListResult,
@@ -1229,7 +1225,10 @@ class PermissionDBSource:
 
     async def create_invitation_by_email(
         self,
-        action: CreateRoleInvitationByEmailAction,
+        *,
+        invitee_emails: list[str],
+        inviter_user_id: uuid.UUID,
+        role_id: uuid.UUID,
     ) -> CreateRoleInvitationResult:
         """Resolve emails and create invitations in a single transaction.
 
@@ -1238,14 +1237,14 @@ class PermissionDBSource:
         are also silently skipped.
         """
         async with self._db.begin_session_read_committed() as session:
-            email_to_user_id = await self._resolve_invitation_emails(session, action.invitee_emails)
+            email_to_user_id = await self._resolve_invitation_emails(session, invitee_emails)
             specs = [
                 RoleInvitationCreatorSpec(
-                    inviter_user_id=action.inviter_user_id,
+                    inviter_user_id=inviter_user_id,
                     invitee_user_id=user_id,
-                    role_id=action.role_id,
+                    role_id=role_id,
                 )
-                for email in action.invitee_emails
+                for email in invitee_emails
                 if (user_id := email_to_user_id.get(email)) is not None
             ]
             if not specs:
@@ -1289,15 +1288,15 @@ class PermissionDBSource:
 
     async def accept_invitation(
         self,
-        action: AcceptRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
         """Transition PENDING→ACCEPTED and assign the role in one session."""
         async with self._db.begin_session_read_committed() as session:
             row = await self._update_invitation_state(
-                session, action.invitation_id, RoleInvitationState.ACCEPTED
+                session, invitation_id, RoleInvitationState.ACCEPTED
             )
             if row is None:
-                existing = await self._get_failed_invitation(session, action.invitation_id)
+                existing = await self._get_failed_invitation(session, invitation_id)
                 raise RoleInvitationInvalidState(
                     f"Cannot accept: invitation is {existing.state.value}, expected pending"
                 )
@@ -1309,15 +1308,15 @@ class PermissionDBSource:
 
     async def reject_invitation(
         self,
-        action: RejectRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
         async with self._db.begin_session_read_committed() as session:
             row = await self._update_invitation_state(
-                session, action.invitation_id, RoleInvitationState.REJECTED
+                session, invitation_id, RoleInvitationState.REJECTED
             )
             if row is not None:
                 return row.to_data()
-            existing = await self._get_failed_invitation(session, action.invitation_id)
+            existing = await self._get_failed_invitation(session, invitation_id)
             if existing.state == RoleInvitationState.REJECTED:
                 return existing.to_data()
             raise RoleInvitationInvalidState(
@@ -1326,15 +1325,15 @@ class PermissionDBSource:
 
     async def cancel_invitation(
         self,
-        action: CancelRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
         async with self._db.begin_session_read_committed() as session:
             row = await self._update_invitation_state(
-                session, action.invitation_id, RoleInvitationState.CANCELED
+                session, invitation_id, RoleInvitationState.CANCELED
             )
             if row is not None:
                 return row.to_data()
-            existing = await self._get_failed_invitation(session, action.invitation_id)
+            existing = await self._get_failed_invitation(session, invitation_id)
             if existing.state == RoleInvitationState.CANCELED:
                 return existing.to_data()
             raise RoleInvitationInvalidState(

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -67,6 +67,7 @@ from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.permission import RoleNotAssigned, RoleNotFound
 from ai.backend.manager.errors.role_invitation import (
+    DuplicateRoleInvitationError,
     RoleInvitationInvalidState,
     RoleInvitationNotFound,
 )
@@ -1238,20 +1239,41 @@ class PermissionDBSource:
         """
         async with self._db.begin_session_read_committed() as session:
             email_to_user_id = await self._resolve_invitation_emails(session, invitee_emails)
-            specs = [
-                RoleInvitationCreatorSpec(
-                    inviter_user_id=inviter_user_id,
-                    invitee_user_id=user_id,
-                    role_id=role_id,
+            creators = [
+                RBACEntityCreator(
+                    spec=RoleInvitationCreatorSpec(
+                        inviter_user_id=inviter_user_id,
+                        invitee_user_id=invitee_user_id,
+                        role_id=role_id,
+                    ),
+                    element_type=RBACElementType.ROLE_ASSIGNMENT,
+                    scope_ref=RBACElementRef(
+                        element_type=RBACElementType.USER,
+                        element_id=str(invitee_user_id),
+                    ),
+                    additional_scope_refs=[
+                        RBACElementRef(
+                            element_type=RBACElementType.ROLE,
+                            element_id=str(role_id),
+                        ),
+                    ],
                 )
                 for email in invitee_emails
-                if (user_id := email_to_user_id.get(email)) is not None
+                if (invitee_user_id := email_to_user_id.get(email)) is not None
             ]
-            if not specs:
+            if not creators:
                 return CreateRoleInvitationResult()
-            result = await execute_bulk_creator_partial(session, BulkCreator(specs=specs))
+
+            created_rows: list[RoleInvitationRow] = []
+            for creator in creators:
+                async with session.begin_nested():
+                    try:
+                        row = (await execute_rbac_entity_creator(session, creator)).row
+                    except DuplicateRoleInvitationError:
+                        continue
+                    created_rows.append(row)
             return CreateRoleInvitationResult(
-                created=[row.to_data() for row in result.successes],
+                created=[row.to_data() for row in created_rows],
             )
 
     async def search_invitations_by_invitee(

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -406,6 +406,13 @@ class PermissionControllerRepository:
         return await self._db_source.search_invitations_by_role(querier, scope)
 
     @permission_controller_repository_resilience.apply()
+    async def admin_search_invitations(
+        self,
+        querier: BatchQuerier,
+    ) -> RoleInvitationSearchResult:
+        return await self._db_source.admin_search_invitations(querier)
+
+    @permission_controller_repository_resilience.apply()
     async def accept_invitation(
         self,
         invitation_id: uuid.UUID,

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -11,11 +11,7 @@ from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPoli
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.manager.actions.action.rbac_role_invitation import (
-    AcceptRoleInvitationAction,
-    CancelRoleInvitationAction,
-    CreateRoleInvitationByEmailAction,
     CreateRoleInvitationResult,
-    RejectRoleInvitationAction,
 )
 from ai.backend.manager.data.permission.entity import ElementAssociationListResult, EntityListResult
 from ai.backend.manager.data.permission.id import ObjectId
@@ -382,9 +378,16 @@ class PermissionControllerRepository:
     @permission_controller_repository_resilience.apply()
     async def create_invitation_by_email(
         self,
-        action: CreateRoleInvitationByEmailAction,
+        *,
+        invitee_emails: list[str],
+        inviter_user_id: uuid.UUID,
+        role_id: uuid.UUID,
     ) -> CreateRoleInvitationResult:
-        return await self._db_source.create_invitation_by_email(action)
+        return await self._db_source.create_invitation_by_email(
+            invitee_emails=invitee_emails,
+            inviter_user_id=inviter_user_id,
+            role_id=role_id,
+        )
 
     @permission_controller_repository_resilience.apply()
     async def search_invitations_by_invitee(
@@ -405,20 +408,20 @@ class PermissionControllerRepository:
     @permission_controller_repository_resilience.apply()
     async def accept_invitation(
         self,
-        action: AcceptRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
-        return await self._db_source.accept_invitation(action)
+        return await self._db_source.accept_invitation(invitation_id)
 
     @permission_controller_repository_resilience.apply()
     async def reject_invitation(
         self,
-        action: RejectRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
-        return await self._db_source.reject_invitation(action)
+        return await self._db_source.reject_invitation(invitation_id)
 
     @permission_controller_repository_resilience.apply()
     async def cancel_invitation(
         self,
-        action: CancelRoleInvitationAction,
+        invitation_id: uuid.UUID,
     ) -> RoleInvitationData:
-        return await self._db_source.cancel_invitation(action)
+        return await self._db_source.cancel_invitation(invitation_id)

--- a/src/ai/backend/manager/repositories/role_invitation/creators.py
+++ b/src/ai/backend/manager/repositories/role_invitation/creators.py
@@ -8,8 +8,8 @@ from typing import override
 from uuid import UUID
 
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
-from ai.backend.manager.errors.common import GenericBadRequest
 from ai.backend.manager.errors.repository import UniqueConstraintViolationError
+from ai.backend.manager.errors.role_invitation import DuplicateRoleInvitationError
 from ai.backend.manager.models.role_invitation.row import RoleInvitationRow
 from ai.backend.manager.repositories.base import CreatorSpec, IntegrityErrorCheck
 
@@ -29,7 +29,7 @@ class RoleInvitationCreatorSpec(CreatorSpec[RoleInvitationRow]):
             IntegrityErrorCheck(
                 violation_type=UniqueConstraintViolationError,
                 constraint_name="uq_role_invitations_active",
-                error=GenericBadRequest(
+                error=DuplicateRoleInvitationError(
                     "An active invitation already exists for this user and role"
                 ),
             ),

--- a/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
@@ -217,11 +217,7 @@ class SearchMyRoleInvitationsActionResult(_InvitationScopeActionResult):
 
 @dataclass
 class SearchRoleInvitationsByRoleAction(_RoleScopedInvitationAction):
-    """Search invitations by role (admin/project-admin view).
-
-    Uses plain ActionProcessor without RBAC validator — RBAC enforcement
-    for this operation is deferred to a future iteration.
-    """
+    """Search invitations by role (admin/project-admin view)."""
 
     querier: BatchQuerier
     scope: RoleInvitationSearchScope

--- a/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
@@ -10,6 +10,7 @@ from typing import override
 from uuid import UUID
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
 from ai.backend.manager.actions.action.single_entity import (
     BaseSingleEntityAction,
@@ -230,6 +231,35 @@ class SearchRoleInvitationsByRoleAction(_RoleScopedInvitationAction):
 
 @dataclass
 class SearchRoleInvitationsByRoleActionResult(_InvitationScopeActionResult):
+    result: SearchResult[RoleInvitationData]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+
+# ------------------------------------------------------------------ admin_search (no scope, superadmin only)
+
+
+@dataclass
+class AdminSearchRoleInvitationsAction(BaseAction):
+    """Search all invitations across the system (superadmin only)."""
+
+    querier: BatchQuerier
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_ASSIGNMENT
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class AdminSearchRoleInvitationsActionResult(BaseActionResult):
     result: SearchResult[RoleInvitationData]
 
     @override

--- a/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
@@ -1,0 +1,241 @@
+"""Service-layer actions for role invitation operations.
+
+Scope mapping:
+- create, my_search, role_search → ``BaseScopeAction`` with ``ScopeActionRBACValidator``
+- accept, reject, cancel        → ``BaseSingleEntityAction`` with ``SingleEntityActionRBACValidator``
+"""
+
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
+from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
+from ai.backend.manager.actions.action.single_entity import (
+    BaseSingleEntityAction,
+    BaseSingleEntityActionResult,
+)
+from ai.backend.manager.actions.action.types import FieldData
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.common.types import SearchResult
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.role_invitation.types import RoleInvitationData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.role_invitation.types import (
+    InviteeSearchScope,
+    RoleInvitationSearchScope,
+)
+
+# ------------------------------------------------------------------ scope base (create, search)
+
+
+@dataclass
+class _RoleScopedInvitationAction(BaseScopeAction):
+    """Base for actions scoped to a ROLE (create, role_search)."""
+
+    role_id: UUID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_ASSIGNMENT
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.ROLE
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.role_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.ROLE, str(self.role_id))
+
+
+@dataclass
+class _UserScopedInvitationAction(BaseScopeAction):
+    """Base for actions scoped to a USER (my_search)."""
+
+    user_id: UUID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_ASSIGNMENT
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.USER
+
+    @override
+    def scope_id(self) -> str:
+        return str(self.user_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.USER, str(self.user_id))
+
+
+class _InvitationScopeActionResult(BaseScopeActionResult):
+    @override
+    def scope_type(self) -> ScopeType:
+        return ScopeType.ROLE
+
+    @override
+    def scope_id(self) -> str:
+        return ""
+
+
+# ------------------------------------------------------------------ single entity base (accept, reject, cancel)
+
+
+@dataclass
+class _InvitationSingleEntityAction(BaseSingleEntityAction):
+    """Base for actions targeting a specific invitation."""
+
+    invitation_id: UUID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_ASSIGNMENT
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.invitation_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.ROLE_ASSIGNMENT, str(self.invitation_id))
+
+    @override
+    def field_data(self) -> FieldData | None:
+        return None
+
+
+class _InvitationSingleEntityActionResult(BaseSingleEntityActionResult):
+    pass
+
+
+# ------------------------------------------------------------------ create
+
+
+@dataclass
+class CreateRoleInvitationAction(_RoleScopedInvitationAction):
+    """Create role invitations by email."""
+
+    invitee_emails: list[str]
+    inviter_user_id: UUID
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+
+@dataclass
+class CreateRoleInvitationActionResult(_InvitationScopeActionResult):
+    created: list[RoleInvitationData]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+
+# ------------------------------------------------------------------ accept / reject / cancel
+
+
+@dataclass
+class AcceptRoleInvitationAction(_InvitationSingleEntityAction):
+    """Invitee accepts a pending invitation."""
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class RejectRoleInvitationAction(_InvitationSingleEntityAction):
+    """Invitee rejects a pending invitation."""
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class CancelRoleInvitationAction(_InvitationSingleEntityAction):
+    """Admin cancels a pending invitation."""
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.DELETE
+
+
+@dataclass
+class RoleInvitationActionResult(_InvitationSingleEntityActionResult):
+    """Result wrapping a single RoleInvitationData."""
+
+    data: RoleInvitationData
+
+    @override
+    def target_entity_id(self) -> str:
+        return str(self.data.id)
+
+
+# ------------------------------------------------------------------ my_search
+
+
+@dataclass
+class SearchMyRoleInvitationsAction(_UserScopedInvitationAction):
+    """Search invitations addressed to the current user."""
+
+    querier: BatchQuerier
+    scope: InviteeSearchScope
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchMyRoleInvitationsActionResult(_InvitationScopeActionResult):
+    result: SearchResult[RoleInvitationData]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+
+# ------------------------------------------------------------------ role_search (no RBAC validator)
+
+
+@dataclass
+class SearchRoleInvitationsByRoleAction(_RoleScopedInvitationAction):
+    """Search invitations by role (admin/project-admin view).
+
+    Uses plain ActionProcessor without RBAC validator — RBAC enforcement
+    for this operation is deferred to a future iteration.
+    """
+
+    querier: BatchQuerier
+    scope: RoleInvitationSearchScope
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchRoleInvitationsByRoleActionResult(_InvitationScopeActionResult):
+    result: SearchResult[RoleInvitationData]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -143,7 +143,7 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     search_my_role_invitations: ScopeActionProcessor[
         SearchMyRoleInvitationsAction, SearchMyRoleInvitationsActionResult
     ]
-    search_role_invitations_by_role: ActionProcessor[
+    search_role_invitations_by_role: ScopeActionProcessor[
         SearchRoleInvitationsByRoleAction, SearchRoleInvitationsByRoleActionResult
     ]
 
@@ -204,8 +204,10 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=invitation_scope_validators,
         )
-        self.search_role_invitations_by_role = ActionProcessor(
-            service.search_role_invitations_by_role, action_monitors
+        self.search_role_invitations_by_role = ScopeActionProcessor(
+            service.search_role_invitations_by_role,
+            action_monitors,
+            validators=invitation_scope_validators,
         )
 
     @override

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -68,9 +68,8 @@ from .actions.search_role_invitations import (
     AcceptRoleInvitationAction as AcceptInvitationAction,
 )
 from .actions.search_role_invitations import (
-    CancelRoleInvitationAction as CancelInvitationAction,
-)
-from .actions.search_role_invitations import (
+    AdminSearchRoleInvitationsAction,
+    AdminSearchRoleInvitationsActionResult,
     CreateRoleInvitationAction,
     CreateRoleInvitationActionResult,
     RoleInvitationActionResult,
@@ -78,6 +77,9 @@ from .actions.search_role_invitations import (
     SearchMyRoleInvitationsActionResult,
     SearchRoleInvitationsByRoleAction,
     SearchRoleInvitationsByRoleActionResult,
+)
+from .actions.search_role_invitations import (
+    CancelRoleInvitationAction as CancelInvitationAction,
 )
 from .actions.search_role_invitations import (
     RejectRoleInvitationAction as RejectInvitationAction,
@@ -146,6 +148,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     search_role_invitations_by_role: ScopeActionProcessor[
         SearchRoleInvitationsByRoleAction, SearchRoleInvitationsByRoleActionResult
     ]
+    admin_search_role_invitations: ActionProcessor[
+        AdminSearchRoleInvitationsAction, AdminSearchRoleInvitationsActionResult
+    ]
 
     def __init__(
         self,
@@ -209,6 +214,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=invitation_scope_validators,
         )
+        self.admin_search_role_invitations = ActionProcessor(
+            service.admin_search_role_invitations, action_monitors
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -242,4 +250,5 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             CancelInvitationAction.spec(),
             SearchMyRoleInvitationsAction.spec(),
             SearchRoleInvitationsByRoleAction.spec(),
+            AdminSearchRoleInvitationsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -3,6 +3,7 @@ from typing import override
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
+from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
@@ -63,6 +64,24 @@ from .actions.search_permissions import (
     SearchPermissionsAction,
     SearchPermissionsActionResult,
 )
+from .actions.search_role_invitations import (
+    AcceptRoleInvitationAction as AcceptInvitationAction,
+)
+from .actions.search_role_invitations import (
+    CancelRoleInvitationAction as CancelInvitationAction,
+)
+from .actions.search_role_invitations import (
+    CreateRoleInvitationAction,
+    CreateRoleInvitationActionResult,
+    RoleInvitationActionResult,
+    SearchMyRoleInvitationsAction,
+    SearchMyRoleInvitationsActionResult,
+    SearchRoleInvitationsByRoleAction,
+    SearchRoleInvitationsByRoleActionResult,
+)
+from .actions.search_role_invitations import (
+    RejectRoleInvitationAction as RejectInvitationAction,
+)
 from .actions.search_scopes import (
     SearchScopesAction,
     SearchScopesActionResult,
@@ -109,6 +128,24 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     create_permission: ActionProcessor[CreatePermissionAction, CreatePermissionActionResult]
     update_permission: ActionProcessor[UpdatePermissionAction, UpdatePermissionActionResult]
     delete_permission: ActionProcessor[DeletePermissionAction, DeletePermissionActionResult]
+    create_role_invitation: ScopeActionProcessor[
+        CreateRoleInvitationAction, CreateRoleInvitationActionResult
+    ]
+    accept_role_invitation: SingleEntityActionProcessor[
+        AcceptInvitationAction, RoleInvitationActionResult
+    ]
+    reject_role_invitation: SingleEntityActionProcessor[
+        RejectInvitationAction, RoleInvitationActionResult
+    ]
+    cancel_role_invitation: SingleEntityActionProcessor[
+        CancelInvitationAction, RoleInvitationActionResult
+    ]
+    search_my_role_invitations: ScopeActionProcessor[
+        SearchMyRoleInvitationsAction, SearchMyRoleInvitationsActionResult
+    ]
+    search_role_invitations_by_role: ActionProcessor[
+        SearchRoleInvitationsByRoleAction, SearchRoleInvitationsByRoleActionResult
+    ]
 
     def __init__(
         self,
@@ -148,6 +185,28 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
         self.create_permission = ActionProcessor(service.create_permission, action_monitors)
         self.update_permission = ActionProcessor(service.update_permission, action_monitors)
         self.delete_permission = ActionProcessor(service.delete_permission, action_monitors)
+        invitation_scope_validators = [validators.rbac.scope]
+        invitation_entity_validators = [validators.rbac.single_entity]
+        self.create_role_invitation = ScopeActionProcessor(
+            service.create_role_invitation, action_monitors, validators=invitation_scope_validators
+        )
+        self.accept_role_invitation = SingleEntityActionProcessor(
+            service.accept_invitation, action_monitors, validators=invitation_entity_validators
+        )
+        self.reject_role_invitation = SingleEntityActionProcessor(
+            service.reject_invitation, action_monitors, validators=invitation_entity_validators
+        )
+        self.cancel_role_invitation = SingleEntityActionProcessor(
+            service.cancel_invitation, action_monitors, validators=invitation_entity_validators
+        )
+        self.search_my_role_invitations = ScopeActionProcessor(
+            service.search_my_role_invitations,
+            action_monitors,
+            validators=invitation_scope_validators,
+        )
+        self.search_role_invitations_by_role = ActionProcessor(
+            service.search_role_invitations_by_role, action_monitors
+        )
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -175,4 +234,10 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             CreatePermissionAction.spec(),
             UpdatePermissionAction.spec(),
             DeletePermissionAction.spec(),
+            CreateRoleInvitationAction.spec(),
+            AcceptInvitationAction.spec(),
+            RejectInvitationAction.spec(),
+            CancelInvitationAction.spec(),
+            SearchMyRoleInvitationsAction.spec(),
+            SearchRoleInvitationsByRoleAction.spec(),
         ]

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -9,18 +9,11 @@ from ai.backend.manager.actions.action.rbac import (
     RBACActionName,
     RBACRequiredPermission,
 )
-from ai.backend.manager.actions.action.rbac_role_invitation import (
-    AcceptRoleInvitationAction,
-    CancelRoleInvitationAction,
-    CreateRoleInvitationByEmailAction,
-    CreateRoleInvitationResult,
-    RejectRoleInvitationAction,
-)
+from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.permission.role import (
     EffectivePermissionsInput,
     UserRoleRevocationData,
 )
-from ai.backend.manager.data.role_invitation.types import RoleInvitationData
 from ai.backend.manager.repositories.group.repository import GroupRepository
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
@@ -94,6 +87,26 @@ from ai.backend.manager.services.permission_contoller.actions.search_entities im
 from ai.backend.manager.services.permission_contoller.actions.search_permissions import (
     SearchPermissionsAction,
     SearchPermissionsActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    AcceptRoleInvitationAction as AcceptRoleInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CancelRoleInvitationAction as CancelRoleInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CreateRoleInvitationAction as CreateRoleInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CreateRoleInvitationActionResult,
+    RoleInvitationActionResult,
+    SearchMyRoleInvitationsAction,
+    SearchMyRoleInvitationsActionResult,
+    SearchRoleInvitationsByRoleAction,
+    SearchRoleInvitationsByRoleActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    RejectRoleInvitationAction as RejectRoleInvitationServiceAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_roles import (
     SearchRolesAction,
@@ -383,30 +396,62 @@ class PermissionControllerService:
         )
         return ResolveEffectivePermissionsActionResult(permissions=result.permissions)
 
-    async def create_role_invitation_by_email(
-        self, action: CreateRoleInvitationByEmailAction
-    ) -> CreateRoleInvitationResult:
+    async def create_role_invitation(
+        self, action: CreateRoleInvitationServiceAction
+    ) -> CreateRoleInvitationActionResult:
         """Create role invitations by resolving invitee emails."""
-        return await self._repository.create_invitation_by_email(action)
+        result = await self._repository.create_invitation_by_email(
+            invitee_emails=action.invitee_emails,
+            inviter_user_id=action.inviter_user_id,
+            role_id=action.role_id,
+        )
+        return CreateRoleInvitationActionResult(created=result.created)
 
-    async def accept_role_invitation(
-        self, action: AcceptRoleInvitationAction
-    ) -> RoleInvitationData:
-        """Accept a PENDING invitation and assign the role.
+    async def accept_invitation(
+        self, action: AcceptRoleInvitationServiceAction
+    ) -> RoleInvitationActionResult:
+        """Accept a PENDING invitation and assign the role atomically."""
+        data = await self._repository.accept_invitation(action.invitation_id)
+        return RoleInvitationActionResult(data=data)
 
-        State transition and role assignment happen atomically
-        in a single DB session within the repository.
-        """
-        return await self._repository.accept_invitation(action)
-
-    async def reject_role_invitation(
-        self, action: RejectRoleInvitationAction
-    ) -> RoleInvitationData:
+    async def reject_invitation(
+        self, action: RejectRoleInvitationServiceAction
+    ) -> RoleInvitationActionResult:
         """Reject a PENDING invitation."""
-        return await self._repository.reject_invitation(action)
+        data = await self._repository.reject_invitation(action.invitation_id)
+        return RoleInvitationActionResult(data=data)
 
-    async def cancel_role_invitation(
-        self, action: CancelRoleInvitationAction
-    ) -> RoleInvitationData:
+    async def cancel_invitation(
+        self, action: CancelRoleInvitationServiceAction
+    ) -> RoleInvitationActionResult:
         """Cancel a PENDING invitation."""
-        return await self._repository.cancel_invitation(action)
+        data = await self._repository.cancel_invitation(action.invitation_id)
+        return RoleInvitationActionResult(data=data)
+
+    async def search_my_role_invitations(
+        self, action: SearchMyRoleInvitationsAction
+    ) -> SearchMyRoleInvitationsActionResult:
+        """Search invitations addressed to a specific user."""
+        result = await self._repository.search_invitations_by_invitee(action.querier, action.scope)
+        return SearchMyRoleInvitationsActionResult(
+            result=SearchResult(
+                items=result.items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+        )
+
+    async def search_role_invitations_by_role(
+        self, action: SearchRoleInvitationsByRoleAction
+    ) -> SearchRoleInvitationsByRoleActionResult:
+        """Search invitations for a specific role (admin/project-admin view)."""
+        result = await self._repository.search_invitations_by_role(action.querier, action.scope)
+        return SearchRoleInvitationsByRoleActionResult(
+            result=SearchResult(
+                items=result.items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+        )

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -92,18 +92,20 @@ from ai.backend.manager.services.permission_contoller.actions.search_role_invita
     AcceptRoleInvitationAction as AcceptRoleInvitationServiceAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
-    CancelRoleInvitationAction as CancelRoleInvitationServiceAction,
-)
-from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
-    CreateRoleInvitationAction as CreateRoleInvitationServiceAction,
-)
-from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    AdminSearchRoleInvitationsAction,
+    AdminSearchRoleInvitationsActionResult,
     CreateRoleInvitationActionResult,
     RoleInvitationActionResult,
     SearchMyRoleInvitationsAction,
     SearchMyRoleInvitationsActionResult,
     SearchRoleInvitationsByRoleAction,
     SearchRoleInvitationsByRoleActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CancelRoleInvitationAction as CancelRoleInvitationServiceAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
+    CreateRoleInvitationAction as CreateRoleInvitationServiceAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
     RejectRoleInvitationAction as RejectRoleInvitationServiceAction,
@@ -448,6 +450,20 @@ class PermissionControllerService:
         """Search invitations for a specific role (admin/project-admin view)."""
         result = await self._repository.search_invitations_by_role(action.querier, action.scope)
         return SearchRoleInvitationsByRoleActionResult(
+            result=SearchResult(
+                items=result.items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+        )
+
+    async def admin_search_role_invitations(
+        self, action: AdminSearchRoleInvitationsAction
+    ) -> AdminSearchRoleInvitationsActionResult:
+        """Search all invitations across the system (superadmin only)."""
+        result = await self._repository.admin_search_invitations(action.querier)
+        return AdminSearchRoleInvitationsActionResult(
             result=SearchResult(
                 items=result.items,
                 total_count=result.total_count,

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -312,7 +312,7 @@ class TestAcceptRejectCancelInvitation:
             )
         )
         # Find via role search
-        search_result = await admin_v2_registry.role_invitation.role_search(
+        search_result = await admin_v2_registry.role_invitation.search_by_role(
             target_role.role.id, SearchRoleInvitationsInput()
         )
         pending = [inv for inv in search_result.items if inv.state == "pending"]
@@ -370,7 +370,7 @@ class TestAcceptRejectCancelInvitation:
                 emails=[regular_user_fixture.email],
             )
         )
-        search_result = await admin_v2_registry.role_invitation.role_search(
+        search_result = await admin_v2_registry.role_invitation.search_by_role(
             target_role.role.id, SearchRoleInvitationsInput()
         )
         pending = [inv for inv in search_result.items if inv.state == "pending"]
@@ -423,7 +423,7 @@ class TestSearchInvitations:
                 emails=[regular_user_fixture.email],
             )
         )
-        result = await admin_v2_registry.role_invitation.role_search(
+        result = await admin_v2_registry.role_invitation.search_by_role(
             target_role.role.id, SearchRoleInvitationsInput()
         )
         assert isinstance(result, SearchRoleInvitationsPayload)

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -32,7 +32,7 @@ from ai.backend.common.dto.manager.v2.role_invitation.response import (
     SearchRoleInvitationsPayload,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
-from ai.backend.manager.api.adapters.rbac import RBACAdapter
+from ai.backend.manager.api.adapters.rbac.adapter import RBACAdapter
 from ai.backend.manager.api.rest.admin.handler import AdminHandler
 from ai.backend.manager.api.rest.admin.registry import register_admin_routes
 from ai.backend.manager.api.rest.rbac.handler import RBACHandler

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -12,7 +12,9 @@ import yarl
 
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.exceptions import InvalidRequestError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.rbac.request import SearchRoleAssignmentsInput
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput,
     SearchRoleInvitationsInput,
@@ -226,6 +228,41 @@ class TestAcceptRejectCancelInvitation:
         assert result.state == "accepted"
         assert result.role_id == target_role.role.id
 
+    async def test_accept_assigns_role_to_user(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Accept invitation must create a role assignment for the invitee."""
+        # Admin creates invitation
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        # User finds and accepts the invitation
+        search_result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput()
+        )
+        pending = [
+            inv
+            for inv in search_result.items
+            if inv.role_id == target_role.role.id and inv.state == "pending"
+        ]
+        assert len(pending) >= 1
+        await user_v2_registry.role_invitation.accept(pending[0].id)
+
+        # Verify the role is actually assigned to the user
+        assignments = await user_v2_registry.rbac.my_search_assignments(
+            SearchRoleAssignmentsInput()
+        )
+        assigned_role_ids = [a.role_id for a in assignments.items]
+        assert target_role.role.id in assigned_role_ids
+
     async def test_reject_transitions_to_rejected(
         self,
         admin_v2_registry: V2ClientRegistry,
@@ -286,6 +323,64 @@ class TestAcceptRejectCancelInvitation:
         result = await admin_v2_registry.role_invitation.cancel(invitation_id)
         assert isinstance(result, RoleInvitationNode)
         assert result.state == "canceled"
+
+    async def test_accept_rejected_invitation_fails(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Cannot accept an invitation that has already been rejected."""
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        search_result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput()
+        )
+        pending = [
+            inv
+            for inv in search_result.items
+            if inv.role_id == target_role.role.id and inv.state == "pending"
+        ]
+        assert len(pending) >= 1
+        invitation_id = pending[0].id
+
+        await user_v2_registry.role_invitation.reject(invitation_id)
+
+        with pytest.raises(InvalidRequestError):
+            await user_v2_registry.role_invitation.accept(invitation_id)
+
+    async def test_accept_canceled_invitation_fails(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Cannot accept an invitation that has already been canceled."""
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        search_result = await admin_v2_registry.role_invitation.role_search(
+            target_role.role.id, SearchRoleInvitationsInput()
+        )
+        pending = [inv for inv in search_result.items if inv.state == "pending"]
+        assert len(pending) >= 1
+        invitation_id = pending[0].id
+
+        await admin_v2_registry.role_invitation.cancel(invitation_id)
+
+        with pytest.raises(InvalidRequestError):
+            await user_v2_registry.role_invitation.accept(invitation_id)
 
 
 class TestSearchInvitations:

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -14,9 +14,16 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.exceptions import InvalidRequestError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.rbac.request import SearchRoleAssignmentsInput
 from ai.backend.common.dto.manager.v2.role_invitation.request import (
     CreateRoleInvitationInput,
+    RoleInvitationFilter,
+    RoleInvitationOrderBy,
+    RoleInvitationOrderField,
+    RoleInvitationStateFilter,
+    RoleNestedFilter,
     SearchRoleInvitationsInput,
 )
 from ai.backend.common.dto.manager.v2.role_invitation.response import (
@@ -24,6 +31,7 @@ from ai.backend.common.dto.manager.v2.role_invitation.response import (
     RoleInvitationNode,
     SearchRoleInvitationsPayload,
 )
+from ai.backend.common.dto.manager.v2.role_invitation.types import RoleInvitationStateDTO
 from ai.backend.manager.api.adapters.rbac import RBACAdapter
 from ai.backend.manager.api.rest.admin.handler import AdminHandler
 from ai.backend.manager.api.rest.admin.registry import register_admin_routes
@@ -48,6 +56,7 @@ from ai.backend.manager.services.permission_contoller.service import PermissionC
 
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
+    from tests.component.rbac.conftest import RoleFactory
 
     from ai.backend.client.v2.registry import BackendAIClientRegistry
     from ai.backend.common.dto.manager.rbac.response import CreateRoleResponse
@@ -442,3 +451,350 @@ class TestSearchInvitations:
         assert isinstance(result, SearchRoleInvitationsPayload)
         assert result.total_count == 0
         assert result.items == []
+
+
+class TestSearchInvitationsPagination:
+    """Filter and order coverage for role invitation search endpoints."""
+
+    async def test_my_search_filter_state_equals_pending(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Filter state.equals=pending returns only pending invitations."""
+        pending_role = await role_factory()
+        rejected_role = await role_factory()
+        for role in (pending_role, rejected_role):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        # Reject one invitation so not every invitation is PENDING
+        rejected_search = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    role=RoleNestedFilter(name=StringFilter(equals=rejected_role.role.name))
+                )
+            )
+        )
+        assert rejected_search.total_count == 1
+        await user_v2_registry.role_invitation.reject(rejected_search.items[0].id)
+
+        result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    state=RoleInvitationStateFilter(equals=RoleInvitationStateDTO.PENDING),
+                )
+            )
+        )
+        assert result.total_count >= 1
+        assert all(inv.state == RoleInvitationStateDTO.PENDING for inv in result.items)
+        assert all(inv.role_id != rejected_role.role.id for inv in result.items)
+
+    async def test_role_search_filter_state_in_multiple(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Filter state.in=[REJECTED, CANCELED] excludes PENDING/ACCEPTED."""
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        # Move the only invitation to REJECTED
+        my_search = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    role=RoleNestedFilter(name=StringFilter(equals=target_role.role.name))
+                )
+            )
+        )
+        assert my_search.total_count == 1
+        await user_v2_registry.role_invitation.reject(my_search.items[0].id)
+
+        result = await admin_v2_registry.role_invitation.search_by_role(
+            target_role.role.id,
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    state=RoleInvitationStateFilter(
+                        in_=[RoleInvitationStateDTO.REJECTED, RoleInvitationStateDTO.CANCELED],
+                    ),
+                )
+            ),
+        )
+        assert result.total_count == 1
+        assert result.items[0].state == RoleInvitationStateDTO.REJECTED
+
+    async def test_my_search_filter_state_not_equals(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Filter state.not_equals=PENDING excludes pending invitations."""
+        pending_role = await role_factory()
+        canceled_role = await role_factory()
+        for role in (pending_role, canceled_role):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        cancel_target = await admin_v2_registry.role_invitation.search_by_role(
+            canceled_role.role.id, SearchRoleInvitationsInput()
+        )
+        assert cancel_target.total_count == 1
+        await admin_v2_registry.role_invitation.cancel(cancel_target.items[0].id)
+
+        result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    state=RoleInvitationStateFilter(not_equals=RoleInvitationStateDTO.PENDING),
+                )
+            )
+        )
+        assert all(inv.state != RoleInvitationStateDTO.PENDING for inv in result.items)
+        assert any(inv.role_id == canceled_role.role.id for inv in result.items)
+        assert all(inv.role_id != pending_role.role.id for inv in result.items)
+
+    async def test_my_search_filter_role_name_equals(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Nested filter role.name.equals narrows results to one role."""
+        wanted_role = await role_factory()
+        other_role = await role_factory()
+        for role in (wanted_role, other_role):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    role=RoleNestedFilter(name=StringFilter(equals=wanted_role.role.name)),
+                )
+            )
+        )
+        assert result.total_count == 1
+        assert result.items[0].role_id == wanted_role.role.id
+
+    async def test_my_search_filter_role_name_contains(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Nested filter role.name.contains returns matches by substring."""
+        unique_token = secrets.token_hex(3)
+        prefixed_role = await role_factory(name=f"filter-contains-{unique_token}")
+        other_role = await role_factory()
+        for role in (prefixed_role, other_role):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    role=RoleNestedFilter(name=StringFilter(contains=unique_token)),
+                )
+            )
+        )
+        assert result.total_count == 1
+        assert result.items[0].role_id == prefixed_role.role.id
+
+    async def test_my_search_filter_and_combines_conditions(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """AND combines state and role filters — only rows matching both remain."""
+        matching_role = await role_factory()
+        other_role = await role_factory()
+        for role in (matching_role, other_role):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    AND=[
+                        RoleInvitationFilter(
+                            state=RoleInvitationStateFilter(equals=RoleInvitationStateDTO.PENDING),
+                        ),
+                        RoleInvitationFilter(
+                            role=RoleNestedFilter(
+                                name=StringFilter(equals=matching_role.role.name)
+                            ),
+                        ),
+                    ]
+                )
+            )
+        )
+        assert result.total_count == 1
+        assert result.items[0].role_id == matching_role.role.id
+        assert result.items[0].state == RoleInvitationStateDTO.PENDING
+
+    async def test_role_search_order_created_at_asc_vs_desc(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Order by created_at ASC returns oldest first; DESC reverses the order."""
+        # Create two invitations at distinct timestamps for the same role
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[admin_user_fixture.email],
+            )
+        )
+        asc = await admin_v2_registry.role_invitation.search_by_role(
+            target_role.role.id,
+            SearchRoleInvitationsInput(
+                order=[
+                    RoleInvitationOrderBy(
+                        field=RoleInvitationOrderField.CREATED_AT,
+                        direction=OrderDirection.ASC,
+                    )
+                ],
+            ),
+        )
+        desc = await admin_v2_registry.role_invitation.search_by_role(
+            target_role.role.id,
+            SearchRoleInvitationsInput(
+                order=[
+                    RoleInvitationOrderBy(
+                        field=RoleInvitationOrderField.CREATED_AT,
+                        direction=OrderDirection.DESC,
+                    )
+                ],
+            ),
+        )
+        assert asc.total_count >= 2
+        assert desc.total_count >= 2
+        # Same result set, reversed cursor order
+        assert [inv.id for inv in asc.items] == list(reversed([inv.id for inv in desc.items]))
+        # ASC: non-decreasing timestamps
+        asc_ts = [inv.created_at for inv in asc.items]
+        assert asc_ts == sorted(asc_ts)
+
+    async def test_role_search_order_state(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Order by state ASC produces a non-decreasing state sequence."""
+        role = await role_factory()
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=role.role.id,
+                emails=[admin_user_fixture.email],
+            )
+        )
+        # Cancel one so the two invitations have different states.
+        listed = await admin_v2_registry.role_invitation.search_by_role(
+            role.role.id, SearchRoleInvitationsInput()
+        )
+        assert listed.total_count == 2
+        await admin_v2_registry.role_invitation.cancel(listed.items[0].id)
+
+        result = await admin_v2_registry.role_invitation.search_by_role(
+            role.role.id,
+            SearchRoleInvitationsInput(
+                order=[
+                    RoleInvitationOrderBy(
+                        field=RoleInvitationOrderField.STATE,
+                        direction=OrderDirection.ASC,
+                    )
+                ],
+            ),
+        )
+        assert result.total_count == 2
+        states = [inv.state.value for inv in result.items]
+        assert states == sorted(states)
+
+    async def test_role_search_pagination_limit_offset(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """limit/offset walks through a stable-ordered page window without overlap."""
+        for user in (admin_user_fixture, regular_user_fixture):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=target_role.role.id,
+                    emails=[user.email],
+                )
+            )
+        order = [
+            RoleInvitationOrderBy(
+                field=RoleInvitationOrderField.CREATED_AT,
+                direction=OrderDirection.ASC,
+            )
+        ]
+        first_page = await admin_v2_registry.role_invitation.search_by_role(
+            target_role.role.id,
+            SearchRoleInvitationsInput(limit=1, offset=0, order=order),
+        )
+        second_page = await admin_v2_registry.role_invitation.search_by_role(
+            target_role.role.id,
+            SearchRoleInvitationsInput(limit=1, offset=1, order=order),
+        )
+        assert first_page.total_count >= 2
+        assert len(first_page.items) == 1
+        assert len(second_page.items) == 1
+        assert first_page.items[0].id != second_page.items[0].id
+        assert first_page.items[0].created_at <= second_page.items[0].created_at

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -61,6 +61,7 @@ def permission_controller_processors(
     )
     validators = MagicMock()
     validators.rbac.scope.validate = AsyncMock()
+    validators.rbac.single_entity.validate = AsyncMock()
     return PermissionControllerProcessors(
         service=service, action_monitors=[], validators=validators
     )

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -1,0 +1,346 @@
+"""Component tests for role invitations via v2 REST API."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.role_invitation.request import (
+    CreateRoleInvitationInput,
+    SearchRoleInvitationsInput,
+)
+from ai.backend.common.dto.manager.v2.role_invitation.response import (
+    CreateRoleInvitationPayload,
+    RoleInvitationNode,
+    SearchRoleInvitationsPayload,
+)
+from ai.backend.manager.api.adapters.rbac import RBACAdapter
+from ai.backend.manager.api.rest.admin.handler import AdminHandler
+from ai.backend.manager.api.rest.admin.registry import register_admin_routes
+from ai.backend.manager.api.rest.rbac.handler import RBACHandler
+from ai.backend.manager.api.rest.rbac.registry import register_rbac_routes
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.rbac.handler import V2RBACHandler
+from ai.backend.manager.api.rest.v2.rbac.registry import register_v2_rbac_routes
+from ai.backend.manager.api.rest.v2.role_invitation.handler import V2RoleInvitationHandler
+from ai.backend.manager.api.rest.v2.role_invitation.registry import (
+    register_v2_role_invitation_routes,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.services.permission_contoller.processors import (
+    PermissionControllerProcessors,
+)
+from ai.backend.manager.services.permission_contoller.service import PermissionControllerService
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+    from ai.backend.client.v2.registry import BackendAIClientRegistry
+    from ai.backend.common.dto.manager.rbac.response import CreateRoleResponse
+
+
+@pytest.fixture()
+def permission_controller_processors(
+    database_engine: ExtendedAsyncSAEngine,
+) -> PermissionControllerProcessors:
+    repo = PermissionControllerRepository(database_engine)
+    service = PermissionControllerService(
+        repo, group_repository=MagicMock(), rbac_action_registry=[]
+    )
+    validators = MagicMock()
+    validators.rbac.scope.validate = AsyncMock()
+    return PermissionControllerProcessors(
+        service=service, action_monitors=[], validators=validators
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    permission_controller_processors: PermissionControllerProcessors,
+) -> list[RouteRegistry]:
+    """Register v1 RBAC (for role creation) and v2 invitation routes."""
+    rbac_registry = register_rbac_routes(
+        RBACHandler(permission_controller=permission_controller_processors), route_deps
+    )
+    admin_registry = register_admin_routes(
+        AdminHandler(gql_schema=MagicMock(), gql_deps=MagicMock(), strawberry_schema=MagicMock()),
+        route_deps,
+        sub_registries=[rbac_registry],
+        gql_ws_handler=MagicMock(),
+    )
+
+    processors = MagicMock()
+    processors.permission_controller = permission_controller_processors
+    adapter = RBACAdapter(processors)
+
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_rbac_routes(V2RBACHandler(adapter=adapter), route_deps))
+    v2_reg.add_subregistry(
+        register_v2_role_invitation_routes(V2RoleInvitationHandler(adapter=adapter), route_deps)
+    )
+    return [admin_registry, v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+class TestCreateRoleInvitation:
+    """Test invitation creation."""
+
+    async def test_create_invitation_happy_path(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Create invitation for an existing ACTIVE user: 201 with opaque response."""
+        result = await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        assert isinstance(result, CreateRoleInvitationPayload)
+        assert result.ok is True
+
+    async def test_create_invitation_nonexistent_user(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+    ) -> None:
+        """Create invitation for non-existent user: 201 returned (opaque), no row inserted."""
+        fake_email = f"nobody-{secrets.token_hex(4)}@nonexistent.test"
+        result = await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[fake_email],
+            )
+        )
+        # Opaque response — always 201 regardless of user existence
+        assert isinstance(result, CreateRoleInvitationPayload)
+        assert result.ok is True
+
+    async def test_create_duplicate_pending_invitation(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Duplicate PENDING for (role_id, invitee_user_id): no new row, still 201."""
+        input_dto = CreateRoleInvitationInput(
+            role_id=target_role.role.id,
+            emails=[regular_user_fixture.email],
+        )
+        # First invitation
+        await admin_v2_registry.role_invitation.create(input_dto)
+        # Second invitation with the same parameters — should not create a new row
+        result = await admin_v2_registry.role_invitation.create(input_dto)
+        assert isinstance(result, CreateRoleInvitationPayload)
+        assert result.ok is True
+
+
+class TestAcceptRejectCancelInvitation:
+    """Test invitation state transitions."""
+
+    async def test_accept_transitions_to_accepted(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Accept transitions PENDING -> ACCEPTED and assigns the role."""
+        # Admin creates invitation
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        # Find the invitation
+        search_result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput()
+        )
+        pending = [
+            inv
+            for inv in search_result.items
+            if inv.role_id == target_role.role.id and inv.state == "pending"
+        ]
+        assert len(pending) >= 1
+        invitation_id = pending[0].id
+
+        # User accepts the invitation
+        result = await user_v2_registry.role_invitation.accept(invitation_id)
+        assert isinstance(result, RoleInvitationNode)
+        assert result.state == "accepted"
+        assert result.role_id == target_role.role.id
+
+    async def test_reject_transitions_to_rejected(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Reject transitions PENDING -> REJECTED without role assignment."""
+        # Admin creates invitation
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        # Find the invitation
+        search_result = await user_v2_registry.role_invitation.my_search(
+            SearchRoleInvitationsInput()
+        )
+        pending = [
+            inv
+            for inv in search_result.items
+            if inv.role_id == target_role.role.id and inv.state == "pending"
+        ]
+        assert len(pending) >= 1
+        invitation_id = pending[0].id
+
+        # User rejects the invitation
+        result = await user_v2_registry.role_invitation.reject(invitation_id)
+        assert isinstance(result, RoleInvitationNode)
+        assert result.state == "rejected"
+
+    async def test_cancel_transitions_to_canceled(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Cancel transitions PENDING -> CANCELED."""
+        # Admin creates invitation
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        # Find via role search
+        search_result = await admin_v2_registry.role_invitation.role_search(
+            target_role.role.id, SearchRoleInvitationsInput()
+        )
+        pending = [inv for inv in search_result.items if inv.state == "pending"]
+        assert len(pending) >= 1
+        invitation_id = pending[0].id
+
+        # Admin cancels the invitation
+        result = await admin_v2_registry.role_invitation.cancel(invitation_id)
+        assert isinstance(result, RoleInvitationNode)
+        assert result.state == "canceled"
+
+
+class TestSearchInvitations:
+    """Test invitation listing/search."""
+
+    async def test_my_search_returns_own_invitations(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Invitee can search their own invitations."""
+        # Admin creates invitation for the regular user
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        result = await user_v2_registry.role_invitation.my_search(SearchRoleInvitationsInput())
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        assert result.total_count >= 1
+        # All results should belong to the current user
+        assert all(inv.invitee_user_id == regular_user_fixture.user_uuid for inv in result.items)
+
+    async def test_role_search_returns_role_invitations(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Admin can search invitations by role."""
+        # Admin creates invitation
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        result = await admin_v2_registry.role_invitation.role_search(
+            target_role.role.id, SearchRoleInvitationsInput()
+        )
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        assert result.total_count >= 1
+        assert all(inv.role_id == target_role.role.id for inv in result.items)
+
+    async def test_my_search_empty_when_no_invitations(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+    ) -> None:
+        """Empty result when user has no invitations."""
+        result = await user_v2_registry.role_invitation.my_search(SearchRoleInvitationsInput())
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        assert result.total_count == 0
+        assert result.items == []

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -12,7 +12,7 @@ import yarl
 
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
-from ai.backend.client.v2.exceptions import InvalidRequestError
+from ai.backend.client.v2.exceptions import InvalidRequestError, PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
@@ -798,3 +798,107 @@ class TestSearchInvitationsPagination:
         assert len(second_page.items) == 1
         assert first_page.items[0].id != second_page.items[0].id
         assert first_page.items[0].created_at <= second_page.items[0].created_at
+
+
+class TestAdminSearchInvitations:
+    """admin_search — scope-less, superadmin only."""
+
+    async def test_admin_search_returns_all_invitations_across_roles(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Superadmin sees invitations spanning multiple roles without scope arg."""
+        role_a = await role_factory()
+        role_b = await role_factory()
+        for role, user in (
+            (role_a, regular_user_fixture),
+            (role_b, admin_user_fixture),
+        ):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[user.email],
+                )
+            )
+        result = await admin_v2_registry.role_invitation.admin_search(SearchRoleInvitationsInput())
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        role_ids = {inv.role_id for inv in result.items}
+        assert role_a.role.id in role_ids
+        assert role_b.role.id in role_ids
+
+    async def test_admin_search_respects_filter(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """admin_search honors RoleInvitationFilter (state equals)."""
+        role = await role_factory()
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        scoped = await admin_v2_registry.role_invitation.search_by_role(
+            role.role.id, SearchRoleInvitationsInput()
+        )
+        assert scoped.total_count == 1
+        await admin_v2_registry.role_invitation.cancel(scoped.items[0].id)
+
+        result = await admin_v2_registry.role_invitation.admin_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    state=RoleInvitationStateFilter(equals=RoleInvitationStateDTO.CANCELED),
+                    role=RoleNestedFilter(name=StringFilter(equals=role.role.name)),
+                )
+            )
+        )
+        assert result.total_count == 1
+        assert result.items[0].state == RoleInvitationStateDTO.CANCELED
+        assert result.items[0].role_id == role.role.id
+
+    async def test_admin_search_denies_regular_user(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+    ) -> None:
+        """Regular user hitting POST /v2/role-invitations/search is rejected by superadmin_required."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.role_invitation.admin_search(SearchRoleInvitationsInput())
+
+
+class TestRoleScopedSearchNonAdmin:
+    """role_search — now RBAC scope-validated, non-admin callers allowed by auth_required."""
+
+    async def test_regular_user_can_call_role_search(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Regular user (not superadmin) may invoke role_search; RBAC scope validator gates access.
+
+        In component tests the rbac.scope validator is mocked (see
+        ``permission_controller_processors`` fixture), so the call succeeds without
+        admin privileges — verifying that the endpoint itself is no longer gated by
+        ``superadmin_required``.
+        """
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        result = await user_v2_registry.role_invitation.search_by_role(
+            target_role.role.id, SearchRoleInvitationsInput()
+        )
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        assert all(inv.role_id == target_role.role.id for inv in result.items)

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -151,7 +151,10 @@ class TestCreateRoleInvitation:
             )
         )
         assert isinstance(result, CreateRoleInvitationPayload)
-        assert result.ok is True
+        assert len(result.items) == 1
+        node = result.items[0]
+        assert isinstance(node, RoleInvitationNode)
+        assert node.role_id == target_role.role.id
 
     async def test_create_invitation_nonexistent_user(
         self,
@@ -159,7 +162,7 @@ class TestCreateRoleInvitation:
         admin_registry: BackendAIClientRegistry,
         target_role: CreateRoleResponse,
     ) -> None:
-        """Create invitation for non-existent user: 201 returned (opaque), no row inserted."""
+        """Create invitation for non-existent user: 201, empty list (no matching user)."""
         fake_email = f"nobody-{secrets.token_hex(4)}@nonexistent.test"
         result = await admin_v2_registry.role_invitation.create(
             CreateRoleInvitationInput(
@@ -167,9 +170,8 @@ class TestCreateRoleInvitation:
                 emails=[fake_email],
             )
         )
-        # Opaque response — always 201 regardless of user existence
         assert isinstance(result, CreateRoleInvitationPayload)
-        assert result.ok is True
+        assert len(result.items) == 0
 
     async def test_create_duplicate_pending_invitation(
         self,
@@ -188,7 +190,7 @@ class TestCreateRoleInvitation:
         # Second invitation with the same parameters — should not create a new row
         result = await admin_v2_registry.role_invitation.create(input_dto)
         assert isinstance(result, CreateRoleInvitationPayload)
-        assert result.ok is True
+        assert len(result.items) == 0
 
 
 class TestAcceptRejectCancelInvitation:

--- a/tests/unit/manager/repositories/permission_controller/test_role_invitation.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_invitation.py
@@ -9,10 +9,7 @@ import pytest
 
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.actions.action.rbac_role_invitation import (
-    AcceptRoleInvitationAction,
-    CancelRoleInvitationAction,
     CreateRoleInvitationByEmailAction,
-    RejectRoleInvitationAction,
 )
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.role_invitation.types import RoleInvitationState
@@ -248,7 +245,11 @@ class TestCreateRoleInvitation:
         invitee: uuid.UUID,
         create_action: CreateRoleInvitationByEmailAction,
     ) -> None:
-        result = await perm_db.create_invitation_by_email(create_action)
+        result = await perm_db.create_invitation_by_email(
+            invitee_emails=create_action.invitee_emails,
+            inviter_user_id=create_action.inviter_user_id,
+            role_id=create_action.role_id,
+        )
 
         assert len(result.created) == 1
         assert result.created[0].invitee_user_id == invitee
@@ -265,7 +266,11 @@ class TestCreateRoleInvitation:
             inviter_user_id=inviter,
             role_id=role_id,
         )
-        result = await perm_db.create_invitation_by_email(action)
+        result = await perm_db.create_invitation_by_email(
+            invitee_emails=action.invitee_emails,
+            inviter_user_id=action.inviter_user_id,
+            role_id=action.role_id,
+        )
 
         assert len(result.created) == 0
 
@@ -280,7 +285,11 @@ class TestCreateRoleInvitation:
     ) -> None:
         await _insert_invitation(db, inviter, invitee, role_id)
 
-        result = await perm_db.create_invitation_by_email(create_action)
+        result = await perm_db.create_invitation_by_email(
+            invitee_emails=create_action.invitee_emails,
+            inviter_user_id=create_action.inviter_user_id,
+            role_id=create_action.role_id,
+        )
 
         assert len(result.created) == 0
 
@@ -328,33 +337,29 @@ class TestAcceptRoleInvitation:
         perm_db: PermissionDBSource,
         pending_id: uuid.UUID,
     ) -> None:
-        action = AcceptRoleInvitationAction(invitation_id=pending_id)
-        result = await perm_db.accept_invitation(action)
+        result = await perm_db.accept_invitation(pending_id)
 
         assert result.state == RoleInvitationState.ACCEPTED
 
     async def test_not_found(self, perm_db: PermissionDBSource) -> None:
-        action = AcceptRoleInvitationAction(invitation_id=uuid.uuid4())
         with pytest.raises(RoleInvitationNotFound):
-            await perm_db.accept_invitation(action)
+            await perm_db.accept_invitation(uuid.uuid4())
 
     async def test_already_rejected_fails(
         self,
         perm_db: PermissionDBSource,
         rejected_id: uuid.UUID,
     ) -> None:
-        action = AcceptRoleInvitationAction(invitation_id=rejected_id)
         with pytest.raises(RoleInvitationInvalidState):
-            await perm_db.accept_invitation(action)
+            await perm_db.accept_invitation(rejected_id)
 
     async def test_already_canceled_fails(
         self,
         perm_db: PermissionDBSource,
         canceled_id: uuid.UUID,
     ) -> None:
-        action = AcceptRoleInvitationAction(invitation_id=canceled_id)
         with pytest.raises(RoleInvitationInvalidState):
-            await perm_db.accept_invitation(action)
+            await perm_db.accept_invitation(canceled_id)
 
 
 # ── reject ───────────────────────────────────────────────────────
@@ -400,23 +405,20 @@ class TestRejectRoleInvitation:
         perm_db: PermissionDBSource,
         pending_id: uuid.UUID,
     ) -> None:
-        action = RejectRoleInvitationAction(invitation_id=pending_id)
-        result = await perm_db.reject_invitation(action)
+        result = await perm_db.reject_invitation(pending_id)
 
         assert result.state == RoleInvitationState.REJECTED
 
     async def test_not_found(self, perm_db: PermissionDBSource) -> None:
-        action = RejectRoleInvitationAction(invitation_id=uuid.uuid4())
         with pytest.raises(RoleInvitationNotFound):
-            await perm_db.reject_invitation(action)
+            await perm_db.reject_invitation(uuid.uuid4())
 
     async def test_already_rejected_is_idempotent(
         self,
         perm_db: PermissionDBSource,
         rejected_id: uuid.UUID,
     ) -> None:
-        action = RejectRoleInvitationAction(invitation_id=rejected_id)
-        result = await perm_db.reject_invitation(action)
+        result = await perm_db.reject_invitation(rejected_id)
 
         assert result.state == RoleInvitationState.REJECTED
 
@@ -425,9 +427,8 @@ class TestRejectRoleInvitation:
         perm_db: PermissionDBSource,
         accepted_id: uuid.UUID,
     ) -> None:
-        action = RejectRoleInvitationAction(invitation_id=accepted_id)
         with pytest.raises(RoleInvitationInvalidState):
-            await perm_db.reject_invitation(action)
+            await perm_db.reject_invitation(accepted_id)
 
 
 # ── cancel ───────────────────────────────────────────────────────
@@ -473,23 +474,20 @@ class TestCancelRoleInvitation:
         perm_db: PermissionDBSource,
         pending_id: uuid.UUID,
     ) -> None:
-        action = CancelRoleInvitationAction(invitation_id=pending_id)
-        result = await perm_db.cancel_invitation(action)
+        result = await perm_db.cancel_invitation(pending_id)
 
         assert result.state == RoleInvitationState.CANCELED
 
     async def test_not_found(self, perm_db: PermissionDBSource) -> None:
-        action = CancelRoleInvitationAction(invitation_id=uuid.uuid4())
         with pytest.raises(RoleInvitationNotFound):
-            await perm_db.cancel_invitation(action)
+            await perm_db.cancel_invitation(uuid.uuid4())
 
     async def test_already_canceled_is_idempotent(
         self,
         perm_db: PermissionDBSource,
         canceled_id: uuid.UUID,
     ) -> None:
-        action = CancelRoleInvitationAction(invitation_id=canceled_id)
-        result = await perm_db.cancel_invitation(action)
+        result = await perm_db.cancel_invitation(canceled_id)
 
         assert result.state == RoleInvitationState.CANCELED
 
@@ -498,6 +496,5 @@ class TestCancelRoleInvitation:
         perm_db: PermissionDBSource,
         accepted_id: uuid.UUID,
     ) -> None:
-        action = CancelRoleInvitationAction(invitation_id=accepted_id)
         with pytest.raises(RoleInvitationInvalidState):
-            await perm_db.cancel_invitation(action)
+            await perm_db.cancel_invitation(accepted_id)


### PR DESCRIPTION
## Summary
- Add the full API stack for blind role invitations: DTOs, service-layer actions with RBAC scope/single-entity validators, REST v2 endpoints (`/v2/role-invitations`), adapter, SDK client, CLI commands, and component tests
- Scope actions (create, my_search, role_search) use `ScopeActionProcessor` with `ScopeActionRBACValidator`; single-entity actions (accept, reject, cancel) use `SingleEntityActionProcessor` with `SingleEntityActionRBACValidator`
- Repository signatures changed from RBAC action types to plain parameters; `ScopeType.ROLE_ASSIGNMENT` added for single-entity RBAC validation

## Test plan
- [x] Component tests pass (`pants test tests/component/rbac/test_role_invitation.py`)
- [x] Type check passes (`pants check --changed-since=origin/main`)
- [x] Lint passes (`pants lint --changed-since=origin/main`)
- [x] Create invitation for existing user returns 201
- [x] Create invitation for non-existent user returns 201 (opaque)
- [x] Accept/reject/cancel state transitions work correctly
- [x] my_search returns only invitee's own invitations
- [x] role_search returns invitations for the given role

Resolves BA-5798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11239.org.readthedocs.build/en/11239/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11239.org.readthedocs.build/ko/11239/

<!-- readthedocs-preview sorna-ko end -->