### PR TITLE
refactor(BA-5804): drop valkey-based deployment live_stat path

### DIFF
--- a/changes/11245.breaking.md
+++ b/changes/11245.breaking.md
@@ -1,0 +1,1 @@
+Drop the valkey-based deployment live_stat path; Endpoint.live_stat and Routing.live_stat GraphQL fields now raise DeprecatedAPI and clients must migrate to the new metric query path

--- a/changes/11245.enhance.md
+++ b/changes/11245.enhance.md
@@ -1,1 +1,1 @@
-Drop the valkey-based deployment live_stat path; Endpoint.live_stat and Routing.live_stat GraphQL fields now raise InvalidAPIParameters and clients must migrate to the new metric query path
+Drop the valkey-based deployment live_stat path; Endpoint.live_stat and Routing.live_stat GraphQL fields now raise NotImplementedAPI and clients must migrate to the new metric query path

--- a/changes/11245.enhance.md
+++ b/changes/11245.enhance.md
@@ -1,0 +1,1 @@
+Drop the valkey-based deployment live_stat path; Endpoint.live_stat and Routing.live_stat GraphQL fields now raise InvalidAPIParameters and clients must migrate to the new metric query path

--- a/changes/11245.enhance.md
+++ b/changes/11245.enhance.md
@@ -1,1 +1,0 @@
-Drop the valkey-based deployment live_stat path; Endpoint.live_stat and Routing.live_stat GraphQL fields now raise NotImplementedAPI and clients must migrate to the new metric query path

--- a/src/ai/backend/appproxy/worker/metrics.py
+++ b/src/ai/backend/appproxy/worker/metrics.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from decimal import Decimal
-from typing import Any, Final
+from typing import Any
 from uuid import UUID
 
 from prometheus_client.parser import text_string_to_metric_families
@@ -27,8 +27,6 @@ from .types import (
 )
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-CACHE_LIFESPAN: Final[int] = 120
 
 
 def add_matrices(*ms: tuple[float | int | Decimal, ...]) -> tuple[Decimal, ...]:
@@ -404,7 +402,6 @@ async def collect_inference_metric(root_ctx: RootContext, _interval: float) -> N
                                     sum=replica_inference_metrics.sum,
                                 )
 
-        # push to the Redis server
         app_metrics_updates = {
             circuit.endpoint_id: {
                 key: obj.to_serializable_dict()
@@ -435,12 +432,6 @@ async def collect_inference_metric(root_ctx: RootContext, _interval: float) -> N
                 "stats: replica_updates: {}",
                 replica_metrics_updates,
             )
-
-        await root_ctx.valkey_stat.store_inference_metrics(
-            app_metrics_updates,
-            replica_metrics_updates,
-            CACHE_LIFESPAN,
-        )
     except Exception:
         log.exception("collect_inference_metrics(): error while collecting metric:")
         raise

--- a/src/ai/backend/appproxy/worker/metrics.py
+++ b/src/ai/backend/appproxy/worker/metrics.py
@@ -402,28 +402,28 @@ async def collect_inference_metric(root_ctx: RootContext, _interval: float) -> N
                                     sum=replica_inference_metrics.sum,
                                 )
 
-        app_metrics_updates = {
-            circuit.endpoint_id: {
-                key: obj.to_serializable_dict()
-                for key, obj in circuit._app_inference_metrics.items()
-            }
-            for circuit in inference_circuits
-            if circuit._app_inference_metrics and circuit.endpoint_id
-        }
-        replica_metrics_updates: dict[tuple[UUID, UUID], Any] = {}
-
-        for circuit in inference_circuits:
-            if not circuit._replica_inference_metrics or not circuit.endpoint_id:
-                continue
-            for key, metric_pair in circuit._replica_inference_metrics.items():
-                for route_id, obj in metric_pair.items():
-                    if (circuit.endpoint_id, route_id) not in replica_metrics_updates:
-                        replica_metrics_updates[(circuit.endpoint_id, route_id)] = {}
-                    replica_metrics_updates[(circuit.endpoint_id, route_id)][key] = (
-                        obj.to_serializable_dict()
-                    )
-
         if root_ctx.local_config.debug.log_stats:
+            app_metrics_updates = {
+                circuit.endpoint_id: {
+                    key: obj.to_serializable_dict()
+                    for key, obj in circuit._app_inference_metrics.items()
+                }
+                for circuit in inference_circuits
+                if circuit._app_inference_metrics and circuit.endpoint_id
+            }
+            replica_metrics_updates: dict[tuple[UUID, UUID], Any] = {}
+
+            for circuit in inference_circuits:
+                if not circuit._replica_inference_metrics or not circuit.endpoint_id:
+                    continue
+                for key, metric_pair in circuit._replica_inference_metrics.items():
+                    for route_id, obj in metric_pair.items():
+                        if (circuit.endpoint_id, route_id) not in replica_metrics_updates:
+                            replica_metrics_updates[(circuit.endpoint_id, route_id)] = {}
+                        replica_metrics_updates[(circuit.endpoint_id, route_id)][key] = (
+                            obj.to_serializable_dict()
+                        )
+
             log.debug(
                 "stats: app_updates: {}",
                 app_metrics_updates,
@@ -433,5 +433,5 @@ async def collect_inference_metric(root_ctx: RootContext, _interval: float) -> N
                 replica_metrics_updates,
             )
     except Exception:
-        log.exception("collect_inference_metrics(): error while collecting metric:")
+        log.exception("collect_inference_metric(): error while collecting metric:")
         raise

--- a/src/ai/backend/common/clients/valkey_client/valkey_stat/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_stat/client.py
@@ -8,7 +8,6 @@ from typing import (
     Self,
     cast,
 )
-from uuid import UUID
 
 from glide import (
     Batch,
@@ -34,7 +33,7 @@ from ai.backend.common.resilience import (
     RetryPolicy,
 )
 from ai.backend.common.resource.types import TotalResourceData
-from ai.backend.common.types import AccessKey, MetricKey, MetricValue, ValkeyTarget
+from ai.backend.common.types import AccessKey, ValkeyTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -479,55 +478,6 @@ class ValkeyStatClient:
             ):
                 log.warning(
                     "Failed to unpack inference app statistics for key {}: {}",
-                    keys[i],
-                    result.decode("utf-8"),
-                )
-                stats.append(None)
-        return stats
-
-    def _get_inference_replica_key(self, endpoint_id: str, replica_id: str) -> str:
-        """
-        Generate inference replica key.
-
-        :param endpoint_id: The endpoint ID.
-        :param replica_id: The replica ID.
-        :return: The generated key.
-        """
-        return f"{_INFERENCE_PREFIX}.{endpoint_id}.replica.{replica_id}"
-
-    @valkey_stat_resilience.apply()
-    async def get_inference_replica_statistics_batch(
-        self, endpoint_replica_pairs: list[tuple[str, str]]
-    ) -> list[dict[str, Any] | None]:
-        """
-        Get inference replica statistics for multiple endpoint-replica pairs.
-
-        :param endpoint_replica_pairs: List of (endpoint_id, replica_id) tuples.
-        :return: List of inference replica statistics, with None for non-existent entries.
-        """
-        if not endpoint_replica_pairs:
-            return []
-
-        keys = [
-            self._get_inference_replica_key(endpoint_id, replica_id)
-            for endpoint_id, replica_id in endpoint_replica_pairs
-        ]
-        results = await self._get_multiple_keys(keys)
-
-        stats: list[dict[str, Any] | None] = []
-        for i, result in enumerate(results):
-            if result is None:
-                stats.append(None)
-                continue
-            try:
-                stats.append(msgpack.unpackb(result))
-            except (
-                ExtraData,
-                UnpackException,
-                ValueError,
-            ):
-                log.warning(
-                    "Failed to unpack inference replica statistics for key {}: {}",
                     keys[i],
                     result.decode("utf-8"),
                 )
@@ -1429,42 +1379,6 @@ class ValkeyStatClient:
 
         if updates:
             await self.set_multiple_keys(updates)
-
-    @valkey_stat_resilience.apply()
-    async def store_inference_metrics(
-        self,
-        app_metrics_updates: dict[UUID, dict[MetricKey, MetricValue | Mapping[str, Any]]],
-        replica_metrics_updates: dict[
-            tuple[UUID, UUID], dict[MetricKey, MetricValue | Mapping[str, Any]]
-        ],
-        cache_lifespan: int = 120,
-    ) -> None:
-        """
-        Store inference metrics for apps and replicas with proper serialization and expiration.
-
-        :param app_metrics_updates: Dictionary mapping endpoint_id to app metrics
-        :param replica_metrics_updates: Dictionary mapping (endpoint_id, replica_id) to replica metrics
-        :param cache_lifespan: TTL in seconds for the stored metrics
-        """
-        if not app_metrics_updates and not replica_metrics_updates:
-            return
-
-        batch = self._create_batch()
-
-        # Store app metrics
-        for endpoint_id, app_measures in app_metrics_updates.items():
-            key = f"inference.{endpoint_id}.app"
-            value = msgpack.packb(app_measures)
-            batch.set(key, value, expiry=ExpirySet(ExpiryType.SEC, cache_lifespan))
-
-        # Store replica metrics
-        for (endpoint_id, replica_id), replica_measures in replica_metrics_updates.items():
-            key = f"inference.{endpoint_id}.replica.{replica_id}"
-            value = msgpack.packb(replica_measures)
-            batch.set(key, value, expiry=ExpirySet(ExpiryType.SEC, cache_lifespan))
-
-        async with self._client.client() as conn:
-            await conn.exec(batch, raise_on_error=True)
 
     async def get_total_resource_slots(self) -> TotalResourceData | None:
         """

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -443,6 +443,18 @@ class InvalidAPIParameters(BackendAIError, web.HTTPBadRequest):
         )
 
 
+class DeprecatedAPI(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/deprecated"
+    error_title = "This API is deprecated."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.API,
+            operation=ErrorOperation.GENERIC,
+            error_detail=ErrorDetail.DEPRECATED,
+        )
+
+
 class InvalidResourceSlotQuantity(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-resource-slot-quantity"
     error_title = "Invalid resource slot quantity."

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -4,7 +4,7 @@ import datetime
 import decimal
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID
 
 import graphene
@@ -963,11 +963,7 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
         return errors
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        graph_ctx: GraphQueryContext = info.context
-        loader = graph_ctx.dataloader_manager.get_loader(
-            graph_ctx, "EndpointStatistics.by_endpoint"
-        )
-        return cast(Mapping[str, Any] | None, await loader.load(self.endpoint_id))
+        raise InvalidAPIParameters("Endpoint live_stat is no longer supported.")
 
 
 class EndpointList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload, selectinload
 
 from ai.backend.common.data.endpoint.types import EndpointStatus
-from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.exception import DeprecatedAPI, InvalidAPIParameters
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import (
     MODEL_SERVICE_RUNTIME_PROFILES,
@@ -42,7 +42,6 @@ from ai.backend.manager.data.model_serving.types import (
     EndpointAutoScalingRuleData,
     EndpointData,
 )
-from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.common import (
     GenericForbidden,
     ObjectNotFound,
@@ -964,7 +963,7 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
         return errors
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        raise NotImplementedAPI(extra_msg="Endpoint live_stat is no longer supported.")
+        raise DeprecatedAPI(extra_msg="Endpoint live_stat is no longer supported.")
 
 
 class EndpointList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/endpoint.py
+++ b/src/ai/backend/manager/api/gql_legacy/endpoint.py
@@ -42,6 +42,7 @@ from ai.backend.manager.data.model_serving.types import (
     EndpointAutoScalingRuleData,
     EndpointData,
 )
+from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.common import (
     GenericForbidden,
     ObjectNotFound,
@@ -963,7 +964,7 @@ class Endpoint(graphene.ObjectType):  # type: ignore[misc]
         return errors
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        raise InvalidAPIParameters("Endpoint live_stat is no longer supported.")
+        raise NotImplementedAPI(extra_msg="Endpoint live_stat is no longer supported.")
 
 
 class EndpointList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/routing.py
+++ b/src/ai/backend/manager/api/gql_legacy/routing.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.exc import NoResultFound
 
+from ai.backend.common.exception import DeprecatedAPI
 from ai.backend.manager.data.deployment.types import RouteStatus
-from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.service import RoutingNotFound
 from ai.backend.manager.models.routing import RoutingRow
 
@@ -200,7 +200,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
         )
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        raise NotImplementedAPI(extra_msg="Routing live_stat is no longer supported.")
+        raise DeprecatedAPI(extra_msg="Routing live_stat is no longer supported.")
 
 
 class RoutingList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/routing.py
+++ b/src/ai/backend/manager/api/gql_legacy/routing.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.exc import NoResultFound
 
-from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.manager.data.deployment.types import RouteStatus
+from ai.backend.manager.errors.api import NotImplementedAPI
 from ai.backend.manager.errors.service import RoutingNotFound
 from ai.backend.manager.models.routing import RoutingRow
 
@@ -200,7 +200,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
         )
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        raise InvalidAPIParameters("Routing live_stat is no longer supported")
+        raise NotImplementedAPI(extra_msg="Routing live_stat is no longer supported.")
 
 
 class RoutingList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/routing.py
+++ b/src/ai/backend/manager/api/gql_legacy/routing.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self
 
 import graphene
 import sqlalchemy as sa
 from graphene.types.datetime import DateTime as GQLDateTime
 from sqlalchemy.exc import NoResultFound
 
+from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.manager.data.deployment.types import RouteStatus
 from ai.backend.manager.errors.service import RoutingNotFound
 from ai.backend.manager.models.routing import RoutingRow
@@ -199,11 +200,7 @@ class Routing(graphene.ObjectType):  # type: ignore[misc]
         )
 
     async def resolve_live_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
-        graph_ctx: GraphQueryContext = info.context
-        loader = graph_ctx.dataloader_manager.get_loader(graph_ctx, "EndpointStatistics.by_replica")
-        return cast(
-            Mapping[str, Any] | None, await loader.load((self._endpoint_row.id, self.routing_id))
-        )
+        raise InvalidAPIParameters("Routing live_stat is no longer supported")
 
 
 class RoutingList(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql_legacy/statistics.py
+++ b/src/ai/backend/manager/api/gql_legacy/statistics.py
@@ -56,22 +56,3 @@ class EndpointStatistics:
     ) -> Sequence[Mapping[str, Any] | None]:
         endpoint_id_strs = [str(endpoint_id) for endpoint_id in endpoint_ids]
         return await valkey_stat_client.get_inference_app_statistics_batch(endpoint_id_strs)
-
-    @classmethod
-    async def batch_load_by_endpoint(
-        cls,
-        ctx: GraphQueryContext,
-        endpoint_ids: Sequence[UUID],
-    ) -> Sequence[Mapping[str, Any] | None]:
-        return await cls.batch_load_by_endpoint_impl(ctx.valkey_stat, endpoint_ids)
-
-    @classmethod
-    async def batch_load_by_replica(
-        cls,
-        ctx: GraphQueryContext,
-        endpoint_replica_ids: Sequence[tuple[UUID, UUID]],
-    ) -> Sequence[Mapping[str, Any] | None]:
-        endpoint_replica_pairs = [
-            (str(endpoint_id), str(replica_id)) for endpoint_id, replica_id in endpoint_replica_ids
-        ]
-        return await ctx.valkey_stat.get_inference_replica_statistics_batch(endpoint_replica_pairs)

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -39,10 +39,10 @@ from aiohttp.typedefs import Handler
 from pydantic import Field, TypeAdapter, ValidationError
 
 from ai.backend.common.api_handlers import BaseRequestModel, BaseResponseModel
+from ai.backend.common.exception import DeprecatedAPI
 from ai.backend.common.json import load_json
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.api import (
-    DeprecatedAPI,
     InvalidAPIParameters,
     NotImplementedAPI,
 )

--- a/src/ai/backend/manager/errors/api.py
+++ b/src/ai/backend/manager/errors/api.py
@@ -39,18 +39,6 @@ class NotImplementedAPI(BackendAIError, web.HTTPNotImplemented):
         )
 
 
-class DeprecatedAPI(BackendAIError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/deprecated"
-    error_title = "This API is deprecated."
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.API,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.DEPRECATED,
-        )
-
-
 class InvalidAPIParameters(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-api-params"
     error_title = "Missing or invalid API parameters."


### PR DESCRIPTION
resolves #BA-5804

## Summary

Remove the inference live-stat machinery that previously fed the `Endpoint.live_stat` and `Routing.live_stat` GraphQL fields. The valkey/redis-based caching path for deployment live stats is no longer used; this PR deletes it and makes the corresponding resolvers raise `InvalidAPIParameters`.

## What changed

- **`gql_legacy/endpoint.py`** — `Endpoint.resolve_live_stat` raises `InvalidAPIParameters("Endpoint live_stat is no longer supported.")` instead of going through the dataloader.
- **`gql_legacy/routing.py`** — `Routing.resolve_live_stat` raises `InvalidAPIParameters("Routing live_stat is no longer supported")`.
- **`gql_legacy/statistics.py`** — removed `EndpointStatistics.batch_load_by_endpoint` and `batch_load_by_replica` (the dataloader wrappers).
- **`common/clients/valkey_client/valkey_stat/client.py`** — removed `_get_inference_replica_key`, `get_inference_replica_statistics_batch`, and `store_inference_metrics`; cleaned up the now-unused `UUID` / `MetricKey` / `MetricValue` imports.
- **`appproxy/worker/metrics.py`** — dropped `CACHE_LIFESPAN` and the `valkey_stat.store_inference_metrics(...)` push that was the producer side of the cache.

Net diff: 5 files, +7 / -128.

## Notes

- `EndpointStatistics.batch_load_by_endpoint_impl` and `ValkeyStatClient.get_inference_app_statistics_batch` are kept (still consumed by `DeploymentRepository.get_metrics_for_auto_scaling`).
- Clients that relied on the GraphQL `live_stat` fields will receive `InvalidAPIParameters` and need to migrate to the new metric query path.