### PR TITLE
feat(BA-5808): add runtime feature flag to toggle RBAC enforcement

### DIFF
--- a/changes/11248.feature.md
+++ b/changes/11248.feature.md
@@ -1,0 +1,1 @@
+Add `manager.rbac.enforcement-enabled` runtime feature flag to toggle RBAC enforcement without a manager restart.

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -9,6 +9,7 @@ from ai.backend.manager.actions.validator.bulk import (
     BulkValidationResult,
     DeniedEntity,
 )
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import BulkPermissionCheckInput
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -21,8 +22,10 @@ class BulkActionRBACValidator(BulkActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
+        self._config_provider = config_provider
 
     @classmethod
     @override
@@ -33,10 +36,16 @@ class BulkActionRBACValidator(BulkActionValidator):
     async def validate(
         self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
+        entity_ids = list(action.entity_ids)
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return BulkValidationResult(
+                allowed_entity_ids=entity_ids,
+                denied_entities=[],
+            )
+
         user = current_user()
         if user is None:
             raise UnreachableError("User context is not available")
-        entity_ids = list(action.entity_ids)
         if user.is_superadmin:
             return BulkValidationResult(
                 allowed_entity_ids=entity_ids,

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -9,7 +9,6 @@ from ai.backend.manager.actions.validator.bulk import (
     BulkValidationResult,
     DeniedEntity,
 )
-from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import BulkPermissionCheckInput
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -22,10 +21,10 @@ class BulkActionRBACValidator(BulkActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        config_provider: ManagerConfigProvider,
+        enabled: bool,
     ) -> None:
         self._repository = repository
-        self._config_provider = config_provider
+        self._enabled = enabled
 
     @classmethod
     @override
@@ -37,7 +36,7 @@ class BulkActionRBACValidator(BulkActionValidator):
         self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
         entity_ids = list(action.entity_ids)
-        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+        if not self._enabled:
             return BulkValidationResult(
                 allowed_entity_ids=entity_ids,
                 denied_entities=[],

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -5,7 +5,6 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.validator.scope import ScopeActionValidator
-from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -17,14 +16,14 @@ class ScopeActionRBACValidator(ScopeActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        config_provider: ManagerConfigProvider,
+        enabled: bool,
     ) -> None:
         self._repository = repository
-        self._config_provider = config_provider
+        self._enabled = enabled
 
     @override
     async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
-        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+        if not self._enabled:
             return
 
         user = current_user()

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -5,6 +5,7 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.validator.scope import ScopeActionValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -16,11 +17,16 @@ class ScopeActionRBACValidator(ScopeActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
+        self._config_provider = config_provider
 
     @override
     async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return
+
         user = current_user()
         if user is None:
             raise UnreachableError("User context is not available")

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -5,7 +5,6 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
-from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -17,14 +16,14 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        config_provider: ManagerConfigProvider,
+        enabled: bool,
     ) -> None:
         self._repository = repository
-        self._config_provider = config_provider
+        self._enabled = enabled
 
     @override
     async def validate(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
-        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+        if not self._enabled:
             return
 
         user = current_user()

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -5,6 +5,7 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -16,11 +17,16 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
+        self._config_provider = config_provider
 
     @override
     async def validate(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return
+
         user = current_user()
         if user is None:
             raise UnreachableError("User context is not available")

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -539,8 +539,8 @@ class RBACConfig(BaseConfigSchema):
             description=(
                 "Whether to enable RBAC enforcement on the manager's read/validation path. "
                 "When true (default), all RBAC validators run normally. "
-                "When false, RBAC validators short-circuit and fall back to the legacy "
-                "permission path (user.role / is_admin / domain and project membership). "
+                "When false, RBAC validators short-circuit so that only the legacy "
+                "permission path (user.role / is_admin / domain and project membership) applies. "
                 "RBAC write paths continue to populate association and role-mapping rows "
                 "regardless of this flag, so re-enabling does not require data backfill."
             ),

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -527,6 +527,29 @@ class AuthConfig(BaseConfigSchema):
     ]
 
 
+class RBACConfig(BaseConfigSchema):
+    enforcement_enabled: Annotated[
+        bool,
+        Field(
+            default=True,
+            validation_alias=AliasChoices("enforcement-enabled", "enforcement_enabled", "enabled"),
+            serialization_alias="enforcement-enabled",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Whether to enable RBAC enforcement on the manager's read/validation path. "
+                "When true (default), all RBAC validators run normally. "
+                "When false, RBAC validators short-circuit and fall back to the legacy "
+                "permission path (user.role / is_admin / domain and project membership). "
+                "RBAC write paths continue to populate association and role-mapping rows "
+                "regardless of this flag, so re-enabling does not require data backfill."
+            ),
+            added_version="26.4.4",
+            example=ConfigExample(local="true", prod="true"),
+        ),
+    ]
+
+
 class ManagerConfig(BaseConfigSchema):
     ipc_base_path: Annotated[
         AutoDirectoryPath,
@@ -1229,6 +1252,19 @@ class ManagerConfig(BaseConfigSchema):
             ),
             added_version="25.8.0",
             example=ConfigExample(local="", prod="9090"),
+        ),
+    ]
+    rbac: Annotated[
+        RBACConfig,
+        Field(default_factory=RBACConfig),
+        BackendAIConfigMeta(
+            description=(
+                "RBAC (Role-Based Access Control) configuration. "
+                "Controls runtime RBAC enforcement behavior including "
+                "the ability to toggle enforcement on or off without a restart."
+            ),
+            added_version="26.4.4",
+            composite=CompositeType.FIELD,
         ),
     ]
 

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -259,11 +259,15 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         )
 
         permission_controller_repository = setup_input.repositories.permission_controller.repository
-        config_provider = setup_input.config_provider
+        rbac_enforcement_enabled = (
+            setup_input.config_provider.config.manager.rbac.enforcement_enabled
+        )
         rbac_validators = RBACValidators(
-            scope=ScopeActionRBACValidator(permission_controller_repository, config_provider),
+            scope=ScopeActionRBACValidator(
+                permission_controller_repository, rbac_enforcement_enabled
+            ),
             single_entity=SingleEntityActionRBACValidator(
-                permission_controller_repository, config_provider
+                permission_controller_repository, rbac_enforcement_enabled
             ),
         )
         legacy_rbac_validators = LegacyRBACValidators(

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -259,9 +259,12 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         )
 
         permission_controller_repository = setup_input.repositories.permission_controller.repository
+        config_provider = setup_input.config_provider
         rbac_validators = RBACValidators(
-            scope=ScopeActionRBACValidator(permission_controller_repository),
-            single_entity=SingleEntityActionRBACValidator(permission_controller_repository),
+            scope=ScopeActionRBACValidator(permission_controller_repository, config_provider),
+            single_entity=SingleEntityActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
         )
         legacy_rbac_validators = LegacyRBACValidators(
             scope=LegacyScopeActionRBACValidator(permission_controller_repository),

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -79,8 +79,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -79,10 +79,8 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(
-                    permission_controller_repo, MagicMock()
-                ),
+                scope=ScopeActionRBACValidator(permission_controller_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
             ),
         ),
     )

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -4,7 +4,7 @@ import secrets
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 import sqlalchemy as sa
@@ -146,10 +146,8 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(
-                    permission_controller_repo, MagicMock()
-                ),
+                scope=ScopeActionRBACValidator(permission_controller_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
             ),
         ),
     )

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -4,7 +4,7 @@ import secrets
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import sqlalchemy as sa
@@ -146,8 +146,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -81,10 +81,8 @@ def model_serving_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(
-                    permission_controller_repo, MagicMock()
-                ),
+                scope=ScopeActionRBACValidator(permission_controller_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
             ),
         ),
     )
@@ -103,10 +101,8 @@ def auto_scaling_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(
-                    permission_controller_repo, MagicMock()
-                ),
+                scope=ScopeActionRBACValidator(permission_controller_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
             ),
         ),
     )
@@ -143,10 +139,8 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(
-                    permission_controller_repo, MagicMock()
-                ),
+                scope=ScopeActionRBACValidator(permission_controller_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
             ),
         ),
     )

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -81,8 +81,10 @@ def model_serving_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )
@@ -101,8 +103,10 @@ def auto_scaling_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )
@@ -139,8 +143,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -127,8 +127,8 @@ def group_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(permission_repo, MagicMock()),
+                scope=ScopeActionRBACValidator(permission_repo, True),
+                single_entity=SingleEntityActionRBACValidator(permission_repo, True),
             ),
         ),
     )

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -127,8 +127,8 @@ def group_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_repo),
-                single_entity=SingleEntityActionRBACValidator(permission_repo),
+                scope=ScopeActionRBACValidator(permission_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(permission_repo, MagicMock()),
             ),
         ),
     )

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -111,9 +111,7 @@ async def session_processors(
         user_repository=AsyncMock(),
     )
     service = SessionService(args)
-    real_single_entity_validator = SingleEntityActionRBACValidator(
-        rbac_permission_repo, MagicMock()
-    )
+    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo, True)
     return SessionProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -111,7 +111,9 @@ async def session_processors(
         user_repository=AsyncMock(),
     )
     service = SessionService(args)
-    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo)
+    real_single_entity_validator = SingleEntityActionRBACValidator(
+        rbac_permission_repo, MagicMock()
+    )
     return SessionProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -103,7 +103,9 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=MagicMock(),
     )
-    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo)
+    real_single_entity_validator = SingleEntityActionRBACValidator(
+        rbac_permission_repo, MagicMock()
+    )
     return VFolderProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -103,9 +103,7 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=MagicMock(),
     )
-    real_single_entity_validator = SingleEntityActionRBACValidator(
-        rbac_permission_repo, MagicMock()
-    )
+    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo, True)
     return VFolderProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -120,8 +120,8 @@ def vfolder_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(rbac_permission_repo),
-                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo),
+                scope=ScopeActionRBACValidator(rbac_permission_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, MagicMock()),
             )
         ),
     )

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -120,8 +120,8 @@ def vfolder_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(rbac_permission_repo, MagicMock()),
-                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, MagicMock()),
+                scope=ScopeActionRBACValidator(rbac_permission_repo, True),
+                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, True),
             )
         ),
     )

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -16,7 +16,6 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import override
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -363,7 +362,7 @@ class TestScopeActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must succeed regardless.
-        validator = ScopeActionRBACValidator(repository, MagicMock())
+        validator = ScopeActionRBACValidator(repository, True)
         with with_user(superadmin_user):
             await validator.validate(scope_action, trigger_meta)
 
@@ -373,7 +372,7 @@ class TestScopeActionRBACValidator:
         scope_action: _ProjectCreateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, MagicMock())
+        validator = ScopeActionRBACValidator(repository, True)
         with pytest.raises(UnreachableError):
             await validator.validate(scope_action, trigger_meta)
 
@@ -384,7 +383,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_project_create: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, MagicMock())
+        validator = ScopeActionRBACValidator(repository, True)
         with with_user(regular_user_with_project_create):
             await validator.validate(scope_action, trigger_meta)
 
@@ -395,7 +394,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, MagicMock())
+        validator = ScopeActionRBACValidator(repository, True)
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(scope_action, trigger_meta)
@@ -409,7 +408,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         superadmin_user: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, MagicMock())
+        validator = SingleEntityActionRBACValidator(repository, True)
         with with_user(superadmin_user):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -419,7 +418,7 @@ class TestSingleEntityActionRBACValidator:
         single_entity_action: _VfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, MagicMock())
+        validator = SingleEntityActionRBACValidator(repository, True)
         with pytest.raises(UnreachableError):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -430,7 +429,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_vfolder_update: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, MagicMock())
+        validator = SingleEntityActionRBACValidator(repository, True)
         with with_user(regular_user_with_vfolder_update):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -441,7 +440,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, MagicMock())
+        validator = SingleEntityActionRBACValidator(repository, True)
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(single_entity_action, trigger_meta)
@@ -546,7 +545,7 @@ class TestBulkActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must approve every entity_id.
-        validator = BulkActionRBACValidator(repository, MagicMock())
+        validator = BulkActionRBACValidator(repository, True)
         with with_user(superadmin_user):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -559,7 +558,7 @@ class TestBulkActionRBACValidator:
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, MagicMock())
+        validator = BulkActionRBACValidator(repository, True)
         with pytest.raises(UnreachableError):
             await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -570,7 +569,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_partial_bulk_vfolder_update: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, MagicMock())
+        validator = BulkActionRBACValidator(repository, True)
         with with_user(regular_user_with_partial_bulk_vfolder_update):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -586,7 +585,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, MagicMock())
+        validator = BulkActionRBACValidator(repository, True)
         with with_user(regular_user_without_permission):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -602,7 +601,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, MagicMock())
+        validator = BulkActionRBACValidator(repository, True)
         with with_user(regular_user_without_permission):
             result = await validator.validate(
                 _BulkVfolderUpdateAction(entity_ids=[]),

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import override
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -362,7 +363,7 @@ class TestScopeActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must succeed regardless.
-        validator = ScopeActionRBACValidator(repository)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             await validator.validate(scope_action, trigger_meta)
 
@@ -372,7 +373,7 @@ class TestScopeActionRBACValidator:
         scope_action: _ProjectCreateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(scope_action, trigger_meta)
 
@@ -383,7 +384,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_project_create: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_project_create):
             await validator.validate(scope_action, trigger_meta)
 
@@ -394,7 +395,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(scope_action, trigger_meta)
@@ -408,7 +409,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         superadmin_user: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -418,7 +419,7 @@ class TestSingleEntityActionRBACValidator:
         single_entity_action: _VfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -429,7 +430,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_vfolder_update: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_vfolder_update):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -440,7 +441,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(single_entity_action, trigger_meta)
@@ -545,7 +546,7 @@ class TestBulkActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must approve every entity_id.
-        validator = BulkActionRBACValidator(repository)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -558,7 +559,7 @@ class TestBulkActionRBACValidator:
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = BulkActionRBACValidator(repository)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -569,7 +570,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_partial_bulk_vfolder_update: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_partial_bulk_vfolder_update):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -585,7 +586,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -601,7 +602,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(
                 _BulkVfolderUpdateAction(entity_ids=[]),


### PR DESCRIPTION
## Summary
- Add `RBACConfig` with `enforcement_enabled` flag (default: `true`) to the unified manager config under `manager.rbac`
- Wire `ManagerConfigProvider` into all three RBAC validators (`ScopeActionRBACValidator`, `SingleEntityActionRBACValidator`, `BulkActionRBACValidator`) to short-circuit when the flag is disabled
- RBAC write paths remain unaffected — association and role-mapping rows continue to be populated regardless of flag state

## Test plan
- [x] Verify manager starts with default config (`enforcement_enabled=true`) and RBAC validators run normally
- [x] Set `manager.rbac.enforcement-enabled = false` in config and verify RBAC validators short-circuit
- [x] Confirm RBAC write paths still populate rows when flag is disabled
- [x] Verify hot-reload via etcd toggles enforcement without restart

Resolves BA-5808