### PR TITLE
fix(BA-5809): map new users to project member role on creation

### DIFF
--- a/changes/11249.fix.md
+++ b/changes/11249.fix.md
@@ -1,0 +1,1 @@
+Map newly created users to their project's member role so folder count and user storage usage queries work under RBAC enforcement.

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -50,7 +50,6 @@ from ai.backend.manager.models.group import (
     AssocGroupUserRow,
     GroupRow,
     ProjectType,
-    association_groups_users,
 )
 from ai.backend.manager.models.kernel import (
     AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES,
@@ -198,16 +197,15 @@ class UserDBSource:
             project_ids = await self._get_project_scope_ids_for_user(
                 db_session, domain_name, [UUID(gid) for gid in group_ids or []]
             )
-            project_scope_refs = [
-                RBACElementRef(RBACElementType.PROJECT, str(pid)) for pid in project_ids
-            ]
 
-            # Insert user with RBAC scope associations (domain + projects)
+            # Insert user with RBAC scope association at domain scope.
+            # Project-scope associations are created below by
+            # _add_user_to_project_in_session, sharing the same path as
+            # modifyGroup / modify_user.
             rbac_creator = RBACEntityCreator(
                 spec=creator.spec,
                 element_type=RBACElementType.USER,
                 scope_ref=RBACElementRef(RBACElementType.DOMAIN, domain_name),
-                additional_scope_refs=project_scope_refs,
             )
             result = await execute_rbac_entity_creator(db_session, rbac_creator)
             row = result.row
@@ -246,12 +244,16 @@ class UserDBSource:
             row.main_access_key = kp_data.access_key
             created_user.main_access_key = kp_data.access_key
 
-            # Add user to groups (using already-resolved project_ids)
-            if project_ids:
-                await self._add_user_to_groups(db_session, created_user.uuid, project_ids)
+            # Add user to each project using the same RBAC-aware path as
+            # modifyGroup / modify_user. This inserts association_groups_users,
+            # creates the project-scope RBAC binding, and maps the user to the
+            # project's member role.
+            for project_id in project_ids:
+                await self._add_user_to_project_in_session(
+                    db_session, created_user.uuid, project_id
+                )
 
             # Create RBAC role and map user to role
-            # Note: Entity-Scope association is handled by RBACEntityCreator above
             role = await self._role_manager.create_system_role(db_session, created_user)
             user_role_creator = Creator(
                 spec=UserRoleCreatorSpec(user_id=created_user.uuid, role_id=role.id)
@@ -298,16 +300,15 @@ class UserDBSource:
         project_ids = await self._get_project_scope_ids_for_user(
             db_session, spec.domain_name, [UUID(gid) for gid in item.group_ids or []]
         )
-        project_scope_refs = [
-            RBACElementRef(RBACElementType.PROJECT, str(pid)) for pid in project_ids
-        ]
 
-        # Insert user with RBAC scope associations (domain + projects)
+        # Insert user with RBAC scope association at domain scope.
+        # Project-scope associations are created below by
+        # _add_user_to_project_in_session, sharing the same path as
+        # modifyGroup / modify_user.
         rbac_creator = RBACEntityCreator(
             spec=item.creator.spec,
             element_type=RBACElementType.USER,
             scope_ref=RBACElementRef(RBACElementType.DOMAIN, spec.domain_name),
-            additional_scope_refs=project_scope_refs,
         )
         result = await execute_rbac_entity_creator(db_session, rbac_creator)
         row = result.row
@@ -345,9 +346,10 @@ class UserDBSource:
         row.main_access_key = kp_data.access_key
         created_user.main_access_key = kp_data.access_key
 
-        # Add user to groups (using already-resolved project_ids)
-        if project_ids:
-            await self._add_user_to_groups(db_session, created_user.uuid, project_ids)
+        # Add user to each project using the same RBAC-aware path as
+        # modifyGroup / modify_user.
+        for project_id in project_ids:
+            await self._add_user_to_project_in_session(db_session, created_user.uuid, project_id)
 
         # Create RBAC role and map user to role
         role = await self._role_manager.create_system_role(db_session, created_user)
@@ -868,18 +870,6 @@ class UserDBSource:
         if res is None:
             raise UserNotFound(f"User with UUID {user_uuid} not found.")
         return cast(UserRow, res)
-
-    async def _add_user_to_groups(
-        self, db_session: SASession, user_uuid: UUID, project_ids: Iterable[UUID]
-    ) -> None:
-        """Add user to groups using pre-resolved project IDs.
-
-        Note: RBAC scope associations are handled by RBACEntityCreator in create_user_validated().
-        This method only handles the association_groups_users table.
-        """
-        group_data = [{"user_id": user_uuid, "group_id": pid} for pid in project_ids]
-        if group_data:
-            await db_session.execute(sa.insert(association_groups_users).values(group_data))
 
     async def _get_project_scope_ids_for_user(
         self, db_session: SASession, domain_name: str, project_ids: Iterable[UUID]

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -403,7 +403,7 @@ class TestUserRepository:
         assert result.keypair is not None
         assert result.keypair.access_key is not None
 
-    async def test_create_user_validated_maps_project_member_role(
+    async def test_create_user_validated_syncs_rbac_with_project_assignment(
         self,
         user_repository: UserRepository,
         db_with_cleanup: ExtendedAsyncSAEngine,
@@ -412,9 +412,17 @@ class TestUserRepository:
         default_keypair_resource_policy: str,
         sample_group_id: str,
     ) -> None:
-        """New users must be mapped to their project's member role so that
-        project-scoped RBAC checks (vfolder listing, folder count, user
-        storage usage) succeed immediately after creation.
+        """Creating a user with a project assignment must produce the same
+        RBAC state as the modifyGroup / modify_user add paths:
+
+        - business association (`association_groups_users`),
+        - project-scope entity binding (`association_scopes_entities`,
+          scope=PROJECT, entity=USER),
+        - user-role mapping to the project's member role (and only the
+          member role — the admin role must not be granted).
+
+        Mirrors test_update_user_validated_group_ids_syncs_rbac so that
+        the create path is held to the same RBAC invariants.
         """
         spec = UserCreatorSpec(
             username=f"newuser-{uuid.uuid4().hex[:8]}",
@@ -440,21 +448,64 @@ class TestUserRepository:
             creator,
             group_ids=[sample_group_id],
         )
+        user_uuid = result.user.uuid
+        project_id = uuid.UUID(sample_group_id)
 
-        member_role_name = f"project-{sample_group_id[:8]}-member"
         async with db_with_cleanup.begin_readonly_session() as session:
-            mapped_role_name = await session.scalar(
-                sa.select(RoleRow.name)
-                .join(UserRoleRow, UserRoleRow.role_id == RoleRow.id)
-                .where(
-                    UserRoleRow.user_id == result.user.uuid,
-                    RoleRow.name == member_role_name,
+            business_assoc = await session.scalar(
+                sa.select(AssocGroupUserRow).where(
+                    AssocGroupUserRow.user_id == user_uuid,
+                    AssocGroupUserRow.group_id == project_id,
                 )
             )
-        assert mapped_role_name == member_role_name, (
-            f"newly created user {result.user.uuid} was not mapped to the "
-            f"project's member role {member_role_name}"
-        )
+            assert business_assoc is not None, (
+                "association_groups_users row missing for (user, project)"
+            )
+
+            scope_binding = await session.scalar(
+                sa.select(AssociationScopesEntitiesRow).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_uuid),
+                )
+            )
+            assert scope_binding is not None, (
+                "association_scopes_entities (PROJECT, USER) binding missing"
+            )
+
+            member_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(project_id)[:8]}-member")
+            )
+            assert member_role_id is not None, "project member role not found"
+
+            member_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == user_uuid,
+                        UserRoleRow.role_id == member_role_id,
+                    )
+                )
+            ).all()
+            assert len(member_mappings) == 1, (
+                "newly created user must be mapped to the project's member role"
+            )
+
+            admin_role_id = await session.scalar(
+                sa.select(RoleRow.id).where(RoleRow.name == f"project-{str(project_id)[:8]}-admin")
+            )
+            assert admin_role_id is not None
+            admin_mappings = (
+                await session.scalars(
+                    sa.select(UserRoleRow).where(
+                        UserRoleRow.user_id == user_uuid,
+                        UserRoleRow.role_id == admin_role_id,
+                    )
+                )
+            ).all()
+            assert len(admin_mappings) == 0, (
+                "create_user must not grant the project admin role to new members."
+            )
 
     async def test_create_user_validated_domain_not_exists(
         self,

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -403,6 +403,59 @@ class TestUserRepository:
         assert result.keypair is not None
         assert result.keypair.access_key is not None
 
+    async def test_create_user_validated_maps_project_member_role(
+        self,
+        user_repository: UserRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        sample_domain: str,
+        user_resource_policy: str,
+        default_keypair_resource_policy: str,
+        sample_group_id: str,
+    ) -> None:
+        """New users must be mapped to their project's member role so that
+        project-scoped RBAC checks (vfolder listing, folder count, user
+        storage usage) succeed immediately after creation.
+        """
+        spec = UserCreatorSpec(
+            username=f"newuser-{uuid.uuid4().hex[:8]}",
+            email=f"newuser-{uuid.uuid4().hex[:8]}@example.com",
+            password=create_test_password_info("new_password"),
+            need_password_change=False,
+            full_name="New User",
+            description="New User Description",
+            status=UserStatus.ACTIVE,
+            domain_name=sample_domain,
+            role=UserRole.USER,
+            resource_policy=user_resource_policy,
+            allowed_client_ip=None,
+            totp_activated=False,
+            sudo_session_enabled=False,
+            container_uid=None,
+            container_main_gid=None,
+            container_gids=None,
+        )
+        creator = Creator(spec=spec)
+
+        result = await user_repository.create_user_validated(
+            creator,
+            group_ids=[sample_group_id],
+        )
+
+        member_role_name = f"project-{sample_group_id[:8]}-member"
+        async with db_with_cleanup.begin_readonly_session() as session:
+            mapped_role_name = await session.scalar(
+                sa.select(RoleRow.name)
+                .join(UserRoleRow, UserRoleRow.role_id == RoleRow.id)
+                .where(
+                    UserRoleRow.user_id == result.user.uuid,
+                    RoleRow.name == member_role_name,
+                )
+            )
+        assert mapped_role_name == member_role_name, (
+            f"newly created user {result.user.uuid} was not mapped to the "
+            f"project's member role {member_role_name}"
+        )
+
     async def test_create_user_validated_domain_not_exists(
         self,
         user_repository: UserRepository,


### PR DESCRIPTION
## Summary
- Route project membership during user creation through `_add_user_to_project_in_session`, the same RBAC-aware path used by `modifyGroup` / `modify_user`.
- Drop `additional_scope_refs=project_scope_refs` from `RBACEntityCreator` (now only the DOMAIN primary scope), delete the now-redundant `_add_user_to_groups` helper, and inline a regression test asserting that newly created users are mapped to their project's member role.
- Fixes folder count / user storage usage coming back empty for users created with project assignments under RBAC enforcement.

## Test plan
- [x] `pants fmt / fix / lint --changed-since=origin/main` pass.
- [x] `pants test tests/unit/manager/repositories/user/test_user_repository.py` — all 13 relevant tests pass, including the new `test_create_user_validated_maps_project_member_role`.

Resolves BA-5809

🤖 Generated with [Claude Code](https://claude.com/claude-code)