### PR TITLE
fix(BA-5808): pass config_provider to RBAC validators for hot-reload support

### DIFF
--- a/changes/11254.fix.md
+++ b/changes/11254.fix.md
@@ -1,0 +1,1 @@
+Pass ManagerConfigProvider to RBAC validators for runtime hot-reload support

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -9,6 +9,7 @@ from ai.backend.manager.actions.validator.bulk import (
     BulkValidationResult,
     DeniedEntity,
 )
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import BulkPermissionCheckInput
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -21,10 +22,10 @@ class BulkActionRBACValidator(BulkActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        enabled: bool,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
-        self._enabled = enabled
+        self._config_provider = config_provider
 
     @classmethod
     @override
@@ -36,7 +37,7 @@ class BulkActionRBACValidator(BulkActionValidator):
         self, action: BaseBulkAction[Any], meta: BaseActionTriggerMeta
     ) -> BulkValidationResult:
         entity_ids = list(action.entity_ids)
-        if not self._enabled:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return BulkValidationResult(
                 allowed_entity_ids=entity_ids,
                 denied_entities=[],

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -5,6 +5,7 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
 from ai.backend.manager.actions.validator.scope import ScopeActionValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -16,14 +17,14 @@ class ScopeActionRBACValidator(ScopeActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        enabled: bool,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
-        self._enabled = enabled
+        self._config_provider = config_provider
 
     @override
     async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
-        if not self._enabled:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return
 
         user = current_user()

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -5,6 +5,7 @@ from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.role import ScopeChainPermissionCheckInput
 from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.repositories.permission_controller.repository import (
@@ -16,14 +17,14 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
     def __init__(
         self,
         repository: PermissionControllerRepository,
-        enabled: bool,
+        config_provider: ManagerConfigProvider,
     ) -> None:
         self._repository = repository
-        self._enabled = enabled
+        self._config_provider = config_provider
 
     @override
     async def validate(self, action: BaseSingleEntityAction, meta: BaseActionTriggerMeta) -> None:
-        if not self._enabled:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
             return
 
         user = current_user()

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -259,15 +259,11 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         )
 
         permission_controller_repository = setup_input.repositories.permission_controller.repository
-        rbac_enforcement_enabled = (
-            setup_input.config_provider.config.manager.rbac.enforcement_enabled
-        )
+        config_provider = setup_input.config_provider
         rbac_validators = RBACValidators(
-            scope=ScopeActionRBACValidator(
-                permission_controller_repository, rbac_enforcement_enabled
-            ),
+            scope=ScopeActionRBACValidator(permission_controller_repository, config_provider),
             single_entity=SingleEntityActionRBACValidator(
-                permission_controller_repository, rbac_enforcement_enabled
+                permission_controller_repository, config_provider
             ),
         )
         legacy_rbac_validators = LegacyRBACValidators(

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -79,8 +79,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -4,7 +4,7 @@ import secrets
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import sqlalchemy as sa
@@ -146,8 +146,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -81,8 +81,10 @@ def model_serving_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )
@@ -101,8 +103,10 @@ def auto_scaling_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )
@@ -139,8 +143,10 @@ def deployment_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_controller_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_controller_repo, True),
+                scope=ScopeActionRBACValidator(permission_controller_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(
+                    permission_controller_repo, MagicMock()
+                ),
             ),
         ),
     )

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -127,8 +127,8 @@ def group_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(permission_repo, True),
-                single_entity=SingleEntityActionRBACValidator(permission_repo, True),
+                scope=ScopeActionRBACValidator(permission_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(permission_repo, MagicMock()),
             ),
         ),
     )

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -111,7 +111,9 @@ async def session_processors(
         user_repository=AsyncMock(),
     )
     service = SessionService(args)
-    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo, True)
+    real_single_entity_validator = SingleEntityActionRBACValidator(
+        rbac_permission_repo, MagicMock()
+    )
     return SessionProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -103,7 +103,9 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=MagicMock(),
     )
-    real_single_entity_validator = SingleEntityActionRBACValidator(rbac_permission_repo, True)
+    real_single_entity_validator = SingleEntityActionRBACValidator(
+        rbac_permission_repo, MagicMock()
+    )
     return VFolderProcessors(
         service=service,
         action_monitors=[],

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -120,8 +120,8 @@ def vfolder_processors(
         action_monitors=[],
         validators=ActionValidators(
             rbac=RBACValidators(
-                scope=ScopeActionRBACValidator(rbac_permission_repo, True),
-                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, True),
+                scope=ScopeActionRBACValidator(rbac_permission_repo, MagicMock()),
+                single_entity=SingleEntityActionRBACValidator(rbac_permission_repo, MagicMock()),
             )
         ),
     )

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import override
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -362,7 +363,7 @@ class TestScopeActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must succeed regardless.
-        validator = ScopeActionRBACValidator(repository, True)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             await validator.validate(scope_action, trigger_meta)
 
@@ -372,7 +373,7 @@ class TestScopeActionRBACValidator:
         scope_action: _ProjectCreateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, True)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(scope_action, trigger_meta)
 
@@ -383,7 +384,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_project_create: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, True)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_project_create):
             await validator.validate(scope_action, trigger_meta)
 
@@ -394,7 +395,7 @@ class TestScopeActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = ScopeActionRBACValidator(repository, True)
+        validator = ScopeActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(scope_action, trigger_meta)
@@ -408,7 +409,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         superadmin_user: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, True)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -418,7 +419,7 @@ class TestSingleEntityActionRBACValidator:
         single_entity_action: _VfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, True)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -429,7 +430,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_vfolder_update: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, True)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_vfolder_update):
             await validator.validate(single_entity_action, trigger_meta)
 
@@ -440,7 +441,7 @@ class TestSingleEntityActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = SingleEntityActionRBACValidator(repository, True)
+        validator = SingleEntityActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             with pytest.raises(NotEnoughPermission):
                 await validator.validate(single_entity_action, trigger_meta)
@@ -545,7 +546,7 @@ class TestBulkActionRBACValidator:
         superadmin_user: UserData,
     ) -> None:
         # No permission rows seeded; bypass must approve every entity_id.
-        validator = BulkActionRBACValidator(repository, True)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(superadmin_user):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -558,7 +559,7 @@ class TestBulkActionRBACValidator:
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, True)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with pytest.raises(UnreachableError):
             await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -569,7 +570,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_with_partial_bulk_vfolder_update: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, True)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_with_partial_bulk_vfolder_update):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -585,7 +586,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, True)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(bulk_vfolder_action, trigger_meta)
 
@@ -601,7 +602,7 @@ class TestBulkActionRBACValidator:
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:
-        validator = BulkActionRBACValidator(repository, True)
+        validator = BulkActionRBACValidator(repository, MagicMock())
         with with_user(regular_user_without_permission):
             result = await validator.validate(
                 _BulkVfolderUpdateAction(entity_ids=[]),


### PR DESCRIPTION
## Summary
- Restore `ManagerConfigProvider` injection into RBAC validators (`ScopeActionRBACValidator`, `SingleEntityActionRBACValidator`, `BulkActionRBACValidator`) so that `enforcement_enabled` is evaluated at each `validate()` call
- This enables runtime toggle of RBAC enforcement via etcd without requiring a manager restart
- Reverts the bool-narrowing refactor from #11248 which broke hot-reload capability

## Test plan
- [x] Verify `pants lint`, `pants check` pass on all changed files
- [ ] Verify manager starts and RBAC validators read config dynamically
- [ ] Toggle `enforcement_enabled` via etcd and confirm behavior changes without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)