### PR TITLE
feat(BA-5829): AppConfigFragment + AppConfig GraphQL

### DIFF
--- a/changes/11285.feature.md
+++ b/changes/11285.feature.md
@@ -1,0 +1,1 @@
+Add `AppConfigFragment` Strawberry GraphQL surface — `appConfigFragment` (by natural key), `scopedAppConfigFragments`, `adminAppConfigFragments`, and admin `create` / `update` / `purge` mutations.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -202,6 +202,161 @@ type AddRevisionPayload
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
+type AdminBulkCreateAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created policies."""
+  created: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
+input AdminBulkCreateAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policies to create."""
+  items: [AdminBulkCreateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+"""
+input AdminBulkCreateAppConfigPolicyItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
+type AdminBulkPurgeAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Ids of policies actually removed (absent ids no-oped)."""
+  purgedIds: [UUID!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
+"""
+input AdminBulkPurgeAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy row ids to purge."""
+  ids: [UUID!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
+type AdminBulkUpdateAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated policies."""
+  updated: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
+input AdminBulkUpdateAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policies to update."""
+  items: [AdminBulkUpdateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
+"""
+input AdminBulkUpdateAppConfigPolicyItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy row id."""
+  id: UUID!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput
   @join__type(graph: STRAWBERRY)
@@ -883,6 +1038,252 @@ type AllowedResourceGroupsPayload
 {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig
+  @join__type(graph: STRAWBERRY)
+{
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment
+  @join__type(graph: STRAWBERRY)
+{
+  """Row ID."""
+  id: UUID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name (FK target)."""
+  name: String!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError
+  @join__type(graph: STRAWBERRY)
+{
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  SCOPE_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  USER_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Scoped app-config policy."""
+type AppConfigPolicy implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain (low → high merge priority)."""
+  scopeSources: [String!]!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
+type AppConfigPolicyBulkError
+  @join__type(graph: STRAWBERRY)
+{
+  """Original position in the input list."""
+  index: Int!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config policy results.
+"""
+type AppConfigPolicyConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigPolicyEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigPolicy!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config policies."""
+input AppConfigPolicyFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by config_name."""
+  configName: StringFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
+input AppConfigPolicyOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigPolicyOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
+enum AppConfigPolicyOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+enum AppConfigScopeType
+  @join__type(graph: STRAWBERRY)
+{
+  PUBLIC @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  DOMAIN_USER_DEFAULTS @join__enumValue(graph: STRAWBERRY)
+  USER @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -11522,6 +11923,46 @@ type Mutation
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload @join__field(graph: STRAWBERRY)
 
+  """
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
+  """
+  adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  """
+  adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  """
+  adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
@@ -11785,6 +12226,63 @@ type Mutation
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -13448,6 +13946,20 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """
 Completely delete domain from DB.
 
@@ -14258,6 +14770,41 @@ type Query
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
+  """
+  appConfigPolicy(id: UUID!): AppConfigPolicy @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
+  """
+  appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Caller's own merged AppConfig list (auth required). Chain per policy ; the adapter pins `(USER, current_user)` internally.
+  """
+  myAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]! @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
   """
   prometheusQueryPreset(id: ID!): QueryDefinition @join__field(graph: STRAWBERRY)
@@ -14947,6 +15494,7 @@ enum RBACElementType
   SESSION_TEMPLATE @join__enumValue(graph: STRAWBERRY)
   APP_CONFIG @join__enumValue(graph: STRAWBERRY)
   MODEL_CARD @join__enumValue(graph: STRAWBERRY)
+  APP_CONFIG_POLICY @join__enumValue(graph: STRAWBERRY)
   RESOURCE_PRESET @join__enumValue(graph: STRAWBERRY)
   USER_RESOURCE_POLICY @join__enumValue(graph: STRAWBERRY)
   KEYPAIR_RESOURCE_POLICY @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -156,6 +156,131 @@ type AddRevisionPayload {
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput {
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput {
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload {
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
+type AdminBulkCreateAppConfigPoliciesPayload {
+  """Created policies."""
+  created: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
+input AdminBulkCreateAppConfigPolicyInput {
+  """Policies to create."""
+  items: [AdminBulkCreateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+"""
+input AdminBulkCreateAppConfigPolicyItemInput {
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput {
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload {
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
+type AdminBulkPurgeAppConfigPoliciesPayload {
+  """Ids of policies actually removed (absent ids no-oped)."""
+  purgedIds: [UUID!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
+"""
+input AdminBulkPurgeAppConfigPolicyInput {
+  """Policy row ids to purge."""
+  ids: [UUID!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput {
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload {
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
+type AdminBulkUpdateAppConfigPoliciesPayload {
+  """Updated policies."""
+  updated: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
+input AdminBulkUpdateAppConfigPolicyInput {
+  """Policies to update."""
+  items: [AdminBulkUpdateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
+"""
+input AdminBulkUpdateAppConfigPolicyItemInput {
+  """Policy row id."""
+  id: UUID!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput {
   """UUID of the target user."""
@@ -602,6 +727,215 @@ type AllowedProjectsPayload {
 type AllowedResourceGroupsPayload {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig {
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment {
+  """Row ID."""
+  id: UUID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name (FK target)."""
+  name: String!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError {
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy {
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField {
+  SCOPE_TYPE
+  SCOPE_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy {
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField {
+  USER_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in 26.4.4. Scoped app-config policy."""
+type AppConfigPolicy implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain (low → high merge priority)."""
+  scopeSources: [String!]!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
+type AppConfigPolicyBulkError {
+  """Original position in the input list."""
+  index: Int!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config policy results.
+"""
+type AppConfigPolicyConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigPolicyEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigPolicy!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config policies."""
+input AppConfigPolicyFilter {
+  """Filter by config_name."""
+  configName: StringFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
+input AppConfigPolicyOrderBy {
+  """The field to order by."""
+  field: AppConfigPolicyOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
+enum AppConfigPolicyOrderField {
+  CONFIG_NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+enum AppConfigScopeType {
+  PUBLIC
+  DOMAIN
+  DOMAIN_USER_DEFAULTS
+  USER
 }
 
 """
@@ -7406,6 +7740,46 @@ type Mutation {
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload
 
+  """
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
+  """
+  adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  """
+  adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  """
+  adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload!
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload
 
@@ -7669,6 +8043,53 @@ type Mutation {
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput {
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput {
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput {
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -9023,6 +9444,18 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
 type PurgeDomainPayload {
   """Whether the purge was successful."""
@@ -9339,6 +9772,41 @@ type Query {
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
+
+  """
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
+  """
+  appConfigPolicy(id: UUID!): AppConfigPolicy
+
+  """
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
+  """
+  appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection!
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]!
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]!
+
+  """
+  Added in 26.4.4. Caller's own merged AppConfig list (auth required). Chain per policy ; the adapter pins `(USER, current_user)` internally.
+  """
+  myAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]!
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]!
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
@@ -9977,6 +10445,7 @@ enum RBACElementType {
   SESSION_TEMPLATE
   APP_CONFIG
   MODEL_CARD
+  APP_CONFIG_POLICY
   RESOURCE_PRESET
   USER_RESOURCE_POLICY
   KEYPAIR_RESOURCE_POLICY

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -268,7 +268,6 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
-            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -406,7 +405,6 @@ class RBACElementType(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     SESSION_TEMPLATE = "session_template"
     APP_CONFIG = "app_config"
-    APP_CONFIG_FRAGMENT = "app_config_fragment"
     MODEL_CARD = "model_card"
 
     # === Root-query-enabled entities (superadmin-only) ===

--- a/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
@@ -1,0 +1,41 @@
+"""
+AppConfig (merged view) DTOs v2 for Manager API.
+"""
+
+from .request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    AppConfigScope,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from .response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from .types import (
+    AppConfigOrderField,
+    AppConfigScopeType,
+    OrderDirection,
+)
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigNode",
+    "AppConfigOrder",
+    "AppConfigOrderField",
+    "AppConfigScope",
+    "AppConfigScopeType",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigInput",
+    "GetUserAppConfigPayload",
+    "OrderDirection",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+    "SearchAppConfigsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -1,0 +1,106 @@
+"""
+Request DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
+
+from .types import AppConfigOrderField, OrderDirection
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigOrder",
+    "AppConfigScope",
+    "GetUserAppConfigInput",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+)
+
+
+class GetUserAppConfigInput(BaseRequestModel):
+    """Input for reading a single merged AppConfig for a target user
+    (admin path — the `my` variant resolves the user internally)."""
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+
+
+class AppConfigFilter(BaseRequestModel):
+    """Filter for AppConfig merged-view search.
+
+    `created_at` / `updated_at` filter against the **oldest** /
+    **latest** timestamp across the contributing fragments — the
+    natural projection of "when was this config first created" and
+    "when was it last touched".
+    """
+
+    name: StringFilter | None = Field(default=None, description="Filter by policy name.")
+    user_id: UUIDFilter | None = Field(
+        default=None,
+        description="Filter by target user id (admin cross-user search only).",
+    )
+    created_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the oldest contributing fragment's creation timestamp."),
+    )
+    updated_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the latest contributing fragment's update timestamp."),
+    )
+
+
+class AppConfigOrder(BaseRequestModel):
+    """Order specification for AppConfig merged-view results."""
+
+    field: AppConfigOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+class _AppConfigSearchInputBase(BaseRequestModel):
+    filter: AppConfigFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigOrder] | None = Field(default=None, description="Order specifications.")
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return.")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip.")
+
+
+class AppConfigScope(BaseRequestModel):
+    """Scope for the scoped merged-view AppConfig query (user_ids are OR'd)."""
+
+    user_ids: list[UUID] = Field(
+        description="Target user UUIDs to scope the merged-view search to.",
+    )
+
+    @model_validator(mode="after")
+    def validate_non_empty(self) -> Self:
+        if not self.user_ids:
+            raise ValueError("AppConfigScope requires a non-empty 'user_ids'")
+        return self
+
+
+class ScopedSearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for scoped (user-restricted) merged-view AppConfig search.
+
+    `scope.user_ids` are OR'd; non-admin callers are restricted to their
+    own user by RBAC at the adapter / processor boundary. Replaces the
+    former `my` variant — self-service is just a USER-scoped search.
+    """
+
+    scope: AppConfigScope = Field(description="Scope (OR across all user_ids).")
+
+
+class SearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for admin cross-user merged-view search.
+
+    Optional `filter.user_id` pins the search to a single user.
+    """

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -1,0 +1,83 @@
+"""
+Response DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+
+__all__ = (
+    "AppConfigNode",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigPayload",
+    "SearchAppConfigsPayload",
+)
+
+
+class AppConfigNode(BaseResponseModel):
+    """Merged per-user AppConfig view.
+
+    `fragments` are ordered low → high merge priority (by fragment
+    `rank`). `config` is the deep-merged result, projected to `None`
+    when every contributing fragment is empty (§3 null projection).
+    """
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+    fragments: list[AppConfigFragmentNode] = Field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: dict[str, Any] | None = Field(
+        default=None,
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+class GetUserAppConfigPayload(BaseResponseModel):
+    """Payload for reading a single merged AppConfig."""
+
+    item: AppConfigNode | None = Field(
+        default=None,
+        description="Merged AppConfig, or null when no fragments exist for the user.",
+    )
+
+
+class SearchAppConfigsPayload(BaseResponseModel):
+    """Payload for paginated merged-view AppConfig search."""
+
+    items: list[AppConfigNode] = Field(description="AppConfigs matching the filter.")
+    total_count: int = Field(description="Total number of AppConfigs matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+class MyBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkCreateMyAppConfigFragments`.
+
+    Each successfully created row produces a recomputed merged
+    `AppConfigNode`; failures are collected per-item.
+    """
+
+    created: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class MyBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkUpdateMyAppConfigFragments`."""
+
+    updated: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/types.py
@@ -1,0 +1,25 @@
+"""
+Common types for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "AppConfigOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
+)
+
+
+class AppConfigOrderField(StrEnum):
+    """Fields available for ordering AppConfig merged-view results."""
+
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 __all__ = (
@@ -13,15 +14,6 @@ __all__ = (
     "AppConfigScopeType",
     "OrderDirection",
 )
-
-
-class AppConfigScopeType(StrEnum):
-    """Scope types for app-config fragments."""
-
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    DOMAIN_USER_DEFAULTS = "domain_user_defaults"
-    USER = "user"
 
 
 class AppConfigFragmentOrderField(StrEnum):

--- a/src/ai/backend/manager/api/adapters/app_config.py
+++ b/src/ai/backend/manager/api/adapters/app_config.py
@@ -1,0 +1,278 @@
+"""AppConfig (merged view) domain adapter
+
+Reads the per-user merged AppConfig view and writes the underlying USER
+fragments via the same `app_config_fragment` service processors. The
+merged-view surface lives on its own adapter (separate from
+`AppConfigFragmentAdapter`) so each adapter handles a single domain
+DTO surface — convention in this repo.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField, OrderDirection
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigScopeType as DTOAppConfigScopeType,
+)
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+    MyAppConfigFragmentBulkItem,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
+from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
+    MyBulkCreateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update import (
+    MyBulkUpdateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    UserAppConfigTarget,
+)
+
+from .base import BaseAdapter
+
+
+class AppConfigAdapter(BaseAdapter):
+    """Adapter for the merged AppConfig view.
+
+    Backed by the `app_config_fragment` service processors — the merged
+    view is computed from raw fragments — but exposed as a separate
+    transport-layer surface so the Fragment adapter stays focused on
+    raw-row operations.
+    """
+
+    # ── Reads ────────────────────────────────────────────────────────
+
+    async def my_app_config(self, name: str) -> GetUserAppConfigPayload:
+        """Read the caller's own merged AppConfig for `name`.
+
+        Resolves the current user from the context; there is no way to
+        target another user through this method.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=me.user_id, config_name=name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def admin_get_user_app_config(
+        self, input: GetUserAppConfigInput
+    ) -> GetUserAppConfigPayload:
+        """Read a specific user's merged AppConfig (admin only)."""
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=input.user_id, config_name=input.name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def scoped_search_app_configs(
+        self, input: ScopedSearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Scoped merged-view search; `scope.user_ids` are OR'd and each
+        target is RBAC-gated per item before the service runs. Self-service
+        is just a USER-scoped search over the caller's own user_id.
+        """
+        querier = self._build_querier_from_input(input)
+        targets: list[SearchableActionTarget] = [
+            UserAppConfigTarget(user_id=user_id) for user_id in input.scope.user_ids
+        ]
+        result = (
+            await self._processors.app_config_fragment.scoped_search_app_configs.wait_for_complete(
+                ScopedSearchAppConfigsAction(items=targets, querier=querier)
+            )
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, input: SearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Cross-user merged-view search (admin only).
+
+        `filter.user_id` pins the query to a single user; otherwise
+        pagination walks across every user.
+        """
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment_admin.admin_search_app_configs.wait_for_complete(
+            AdminSearchAppConfigsAction(querier=querier)
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    # ── Self-service bulk writes ───────────────────────
+
+    async def my_bulk_create(
+        self, input: MyBulkCreateAppConfigFragmentsInput
+    ) -> MyBulkCreateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_create.wait_for_complete(
+            MyBulkCreateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkCreateAppConfigFragmentsPayload(
+            created=[self._data_to_dto(item) for item in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def my_bulk_update(
+        self, input: MyBulkUpdateAppConfigFragmentsInput
+    ) -> MyBulkUpdateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_update.wait_for_complete(
+            MyBulkUpdateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkUpdateAppConfigFragmentsPayload(
+            updated=[self._data_to_dto(item) for item in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    # ── Querier / DTO helpers ────────────────────────────────────────
+
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
+    def _build_querier_from_input(
+        self,
+        input: ScopedSearchAppConfigsInput | SearchAppConfigsInput,
+    ) -> BatchQuerier:
+        """Querier builder for the merged-view searches.
+
+        The merged-view SQL resolves cursor / order internally via the
+        repository layer; this helper forwards only the filter / order /
+        pagination fields so cursor tiebreakers stay consistent with
+        the raw-fragment querier.
+        """
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=self._PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.name is not None:
+            condition = self.convert_string_filter(
+                filter.name,
+                contains_factory=AppConfigFragmentConditions.by_name_contains,
+                equals_factory=AppConfigFragmentConditions.by_name_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_name_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_name_ends_with,
+                in_factory=AppConfigFragmentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        # `filter.user_id` handling lives inside the merged-view SQL
+        # (repository layer) rather than in a BatchQuerier condition —
+        # see `AppConfigFragmentDBSource.admin_search_app_configs`.
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigOrderField.NAME:
+                    result.append(AppConfigFragmentOrders.name(ascending))
+                case AppConfigOrderField.USER_ID:
+                    # USER_ID ordering is applied inside the merged-view SQL
+                    # because the raw `app_config_fragments` row does not
+                    # carry a user_id column directly.
+                    continue
+        return result
+
+    def _data_to_dto(self, data: AppConfigData) -> AppConfigNode:
+        return AppConfigNode(
+            user_id=data.user_id,
+            name=data.name,
+            fragments=[self._fragment_data_to_dto(fragment) for fragment in data.fragments],
+            config=dict(data.config) if data.config is not None else None,
+        )
+
+    @staticmethod
+    def _fragment_data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
+            scope_id=data.scope_id,
+            name=data.name,
+            config=dict(data.config) if data.config is not None else None,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        return AppConfigFragmentBulkError(
+            index=err.index,
+            scope_type=DTOAppConfigScopeType(err.scope_type),
+            scope_id=err.scope_id,
+            name=err.name,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/app_config_fragment.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment.py
@@ -1,4 +1,8 @@
-"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer."""
+"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer.
+
+Raw fragment-row operations only. The merged-view (AppConfig) surface
+and the self-service `my_bulk_*` writes live on `AppConfigAdapter`.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +30,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     OrderDirection,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
-    AppConfigScopeType as AppConfigScopeTypeDTO,
+    AppConfigScopeType as DTOAppConfigScopeType,
 )
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.data.app_config_fragment.bulk_types import (
@@ -41,9 +45,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    AppConfigFragmentSearchScope,
-)
+from ai.backend.manager.repositories.app_config_fragment.types import AppConfigFragmentSearchScope
 from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
 from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
     AdminBulkCreateAppConfigFragmentsAction,
@@ -64,21 +66,14 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
 
 from .base import BaseAdapter
 
-_PAGINATION_SPEC = PaginationSpec(
-    forward_order=AppConfigFragmentOrders.created_at(ascending=False),
-    backward_order=AppConfigFragmentOrders.created_at(ascending=True),
-    forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
-    backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
-    tiebreaker_order=AppConfigFragmentRow.id.asc(),
-)
-
 
 class AppConfigFragmentAdapter(BaseAdapter):
-    """Adapter for AppConfigFragment domain operations.
+    """Adapter for AppConfigFragment raw-row operations.
 
-    Writes are bulk-only; single-item create / update / purge entry
-    points are intentionally absent. Self-service my_bulk methods are
-    added with the merged-view DTOs in BA-5829.
+    Writes are bulk-only; single-item create / update /
+    purge entry points are intentionally absent. Self-service my_bulk
+    writes (which return the recomputed merged view) live on
+    `AppConfigAdapter` alongside the merged-view reads.
     """
 
     async def get(self, key_input: AppConfigFragmentKeyInput) -> GetAppConfigFragmentPayload:
@@ -131,13 +126,21 @@ class AppConfigFragmentAdapter(BaseAdapter):
             has_previous_page=result.has_previous_page,
         )
 
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
     def _build_querier_from_input(self, input: SearchAppConfigFragmentsInput) -> BatchQuerier:
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
             orders=orders,
-            pagination_spec=_PAGINATION_SPEC,
+            pagination_spec=self._PAGINATION_SPEC,
             first=input.first,
             after=input.after,
             last=input.last,
@@ -214,7 +217,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     def _data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
         return AppConfigFragmentNode(
             id=data.id,
-            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
             scope_id=data.scope_id,
             name=data.name,
             rank=data.rank,
@@ -223,7 +226,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             updated_at=data.updated_at,
         )
 
-    # ── Bulk mutations ─────────────────────────────────────────────
+    # ── Bulk mutations ───────────────────────────────
 
     async def admin_bulk_create(
         self, input: AdminBulkCreateAppConfigFragmentsInput
@@ -268,7 +271,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     async def admin_bulk_purge(
         self, input: AdminBulkPurgeAppConfigFragmentsInput
     ) -> AdminBulkPurgeAppConfigFragmentsPayload:
-        keys = [self._input_to_key(key) for key in input.keys]
+        keys = [self._input_to_key(key_input) for key_input in input.keys]
         result = (
             await self._processors.app_config_fragment_admin.admin_bulk_purge.wait_for_complete(
                 AdminBulkPurgeAppConfigFragmentsAction(keys=keys)
@@ -277,7 +280,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         return AdminBulkPurgeAppConfigFragmentsPayload(
             purged=[
                 PurgeAppConfigFragmentKey(
-                    scope_type=AppConfigScopeTypeDTO(key.scope_type.value),
+                    scope_type=DTOAppConfigScopeType(key.scope_type.value),
                     scope_id=key.scope_id,
                     name=key.name,
                 )
@@ -287,10 +290,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def _bulk_error_to_dto(err: AppConfigFragmentBulkItemError) -> AppConfigFragmentBulkError:
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        """Convert the service-layer error dataclass to its DTO mirror."""
         return AppConfigFragmentBulkError(
             index=err.index,
-            scope_type=AppConfigScopeTypeDTO(err.scope_type),
+            scope_type=DTOAppConfigScopeType(err.scope_type),
             scope_id=err.scope_id,
             name=err.name,
             message=err.message,

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config import AppConfigAdapter
 from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
@@ -73,6 +74,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config: AppConfigAdapter,
         app_config_fragment: AppConfigFragmentAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
@@ -115,6 +117,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config = app_config
         self.app_config_fragment = app_config_fragment
         self.artifact = artifact
         self.artifact_registry = artifact_registry
@@ -176,6 +179,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config=AppConfigAdapter(processors),
             app_config_fragment=AppConfigFragmentAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),

--- a/src/ai/backend/manager/api/gql/app_config/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/__init__.py
@@ -1,0 +1,29 @@
+"""AppConfig (merged view) GraphQL API package."""
+
+from .resolver import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .types import (
+    AppConfigConnectionGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+    AppConfigScopeGQL,
+)
+
+__all__ = [
+    # Queries
+    "scoped_app_configs",
+    "admin_app_configs",
+    "public_app_config_fragments",
+    # Types
+    "AppConfigGQL",
+    "AppConfigConnectionGQL",
+    "AppConfigFilterGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
@@ -1,0 +1,11 @@
+from .query import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+
+__all__ = [
+    "admin_app_configs",
+    "public_app_config_fragments",
+    "scoped_app_configs",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/query.py
@@ -1,0 +1,181 @@
+"""AppConfig (merged view) GQL query resolvers."""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigScopeGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+
+
+def _app_config_id(user_id: object, name: str) -> str:
+    """Composite Relay id for the merged view (keyed by `(user_id, name)`)."""
+    return f"{user_id}:{name}"
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Scoped merged-view AppConfig search (auth required, RBAC-gated). "
+            "`scope.userIds` are OR'd; non-admin callers are restricted to "
+            "their own user. Self-service is just a USER-scoped search."
+        ),
+    )
+)  # type: ignore[misc]
+async def scoped_app_configs(
+    info: Info[StrawberryGQLContext],
+    scope: AppConfigScopeGQL,
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    payload = await info.context.adapters.app_config.scoped_search_app_configs(
+        ScopedSearchAppConfigsInput(
+            scope=scope.to_pydantic(),
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Cross-user merged-view search (admin only). Resolves any user's "
+            "AppConfig for audit / support. Pin to a single user with "
+            "`filter.userId`; otherwise paginates across all users."
+        ),
+    )
+)  # type: ignore[misc]
+async def admin_app_configs(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config.admin_search_app_configs(
+        SearchAppConfigsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of "
+            "raw fragments that carry no personally-scoped data."
+        ),
+    )
+)  # type: ignore[misc]
+async def public_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> list[AppConfigFragmentGQL]:
+    payload = await info.context.adapters.app_config_fragment.search(
+        scope_type=AppConfigScopeType.PUBLIC,
+        scope_id=AppConfigScopeType.PUBLIC.value,
+        input=SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]

--- a/src/ai/backend/manager/api/gql/app_config/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/__init__.py
@@ -1,0 +1,21 @@
+from .filters import (
+    AppConfigFilterGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+)
+from .node import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigGQL,
+)
+from .scope import AppConfigScopeGQL
+
+__all__ = [
+    "AppConfigConnectionGQL",
+    "AppConfigEdgeGQL",
+    "AppConfigFilterGQL",
+    "AppConfigGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
@@ -1,0 +1,55 @@
+"""AppConfig (merged-view) GQL payloads for self-service bulk mutations."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkCreateAppConfigFragmentsPayload as MyBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkUpdateAppConfigFragmentsPayload as MyBulkUpdatePayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.node import AppConfigGQL
+from ai.backend.manager.api.gql.app_config_fragment.types.bulk_payloads import (
+    AppConfigFragmentBulkErrorGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkCreateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkCreatePayloadDTO,
+    name="MyBulkCreateAppConfigFragmentsPayload",
+)
+class MyBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkCreatePayloadDTO]):
+    created: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkUpdateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkUpdatePayloadDTO,
+    name="MyBulkUpdateAppConfigFragmentsPayload",
+)
+class MyBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkUpdatePayloadDTO]):
+    updated: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/filters.py
@@ -1,0 +1,78 @@
+"""AppConfig (merged view) GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter as AppConfigFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigOrder as AppConfigOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import (
+    DateTimeFilter,
+    OrderDirection,
+    StringFilter,
+    UUIDFilter,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying merged AppConfigs.",
+    ),
+    name="AppConfigFilter",
+)
+class AppConfigFilterGQL(PydanticInputMixin[AppConfigFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    user_id: UUIDFilter | None = gql_field(
+        description="Filter by target user id (admin cross-user search only).",
+        default=None,
+    )
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by the oldest contributing fragment's creation timestamp.",
+        default=None,
+    )
+    updated_at: DateTimeFilter | None = gql_field(
+        description="Filter by the latest contributing fragment's update timestamp.",
+        default=None,
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering merged AppConfigs.",
+    ),
+    name="AppConfigOrderField",
+)
+class AppConfigOrderFieldGQL(StrEnum):
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for merged AppConfig results.",
+    ),
+    name="AppConfigOrderBy",
+)
+class AppConfigOrderByGQL(PydanticInputMixin[AppConfigOrderDTO]):
+    field: AppConfigOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.ASC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/node.py
@@ -1,0 +1,75 @@
+"""AppConfig (merged view) GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+import strawberry
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config.response import AppConfigNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Merged per-user AppConfig view. `id` is the composite "
+            "`{userId}:{name}` (the merged view is a derived value, not a "
+            "table row); `fragments` are ordered low → high merge priority; "
+            "`config` is the deep-merge result and is null when every "
+            "contributing fragment is empty."
+        ),
+    ),
+    name="AppConfig",
+)
+class AppConfigGQL(PydanticNodeMixin[AppConfigNode]):
+    id: NodeID[str] = gql_field(description="Composite id `{userId}:{name}`.")
+    user_id: UUID = gql_field(description="Target user's UUID.")
+    name: str = gql_field(description="Policy / config name.")
+    # Use `strawberry.lazy()` to break the import cycle between
+    # `app_config.types.node` and `app_config_fragment.types.node`:
+    # the fragment package's `__init__.py` eagerly loads its resolver,
+    # which imports `MyBulkCreate*` payloads back from `app_config.types`.
+    fragments: list[
+        Annotated[
+            AppConfigFragmentGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.app_config_fragment.types.node"),
+        ]
+    ] = gql_field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: JSON | None = gql_field(
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+AppConfigEdgeGQL = Edge[AppConfigGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated merged AppConfig results.",
+    ),
+    name="AppConfigConnection",
+)
+class AppConfigConnectionGQL(Connection[AppConfigGQL]):
+    count: int = gql_field(description="Total number of AppConfigs matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/app_config/types/scope.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/scope.py
@@ -1,0 +1,30 @@
+"""AppConfig (merged view) GraphQL scope input types."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.app_config.request import AppConfigScope
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Scope for the scoped merged-view AppConfig query. "
+            "`userIds` are OR'd; raises an error when empty."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigScope",
+)
+class AppConfigScopeGQL(PydanticInputMixin[AppConfigScope]):
+    user_ids: list[UUID] = gql_field(
+        description="Target user UUIDs to scope the merged-view search to (OR'd).",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
@@ -1,0 +1,9 @@
+"""AppConfigFragment GraphQL API package.
+
+Resolver and type names are re-exported by ``schema.py`` directly via
+their submodules to keep this package's ``__init__`` import-light: a
+top-level ``from app_config_fragment import ...`` would otherwise drag
+in the mutation resolvers, which back-import from
+``app_config.types.bulk_payloads`` and form an import cycle when
+``AppConfigGQL`` is loading.
+"""

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
@@ -1,0 +1,21 @@
+from .mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
+
+__all__ = [
+    "admin_app_config_fragments",
+    "admin_bulk_create_app_config_fragments",
+    "admin_bulk_purge_app_config_fragments",
+    "admin_bulk_update_app_config_fragments",
+    "app_config_fragment",
+    "my_bulk_create_app_config_fragments",
+    "my_bulk_update_app_config_fragments",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
@@ -1,0 +1,112 @@
+"""AppConfigFragment GQL mutation resolvers (bulk-only)."""
+
+from __future__ import annotations
+
+from strawberry import Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.bulk_payloads import (
+    MyBulkCreateAppConfigFragmentsPayloadGQL,
+    MyBulkUpdateAppConfigFragmentsPayloadGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert across any scope; each item runs in its own transaction "
+            "and failures are collected per-item (admin only)."
+        ),
+    )
+)
+async def admin_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkCreateAppConfigFragmentInputGQL,
+) -> AdminBulkCreateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_create(input.to_pydantic())
+    return AdminBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale JSON replacement; items with no existing row are returned as failures "
+            "(admin only)."
+        ),
+    )
+)
+async def admin_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkUpdateAppConfigFragmentInputGQL,
+) -> AdminBulkUpdateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_update(input.to_pydantic())
+    return AdminBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cleanup-only deletion; absent keys are no-oped (admin only).",
+    )
+)
+async def admin_bulk_purge_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkPurgeAppConfigFragmentInputGQL,
+) -> AdminBulkPurgeAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_purge(input.to_pydantic())
+    return AdminBulkPurgeAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert on the caller's USER row; duplicates fail per-item. "
+            "Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkCreateAppConfigFragmentInputGQL,
+) -> MyBulkCreateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_create(input.to_pydantic())
+    return MyBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale replacement on the caller's USER row; missing rows are returned as "
+            "failures. Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkUpdateAppConfigFragmentInputGQL,
+) -> MyBulkUpdateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_update(input.to_pydantic())
+    return MyBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
@@ -1,0 +1,103 @@
+"""AppConfigFragment GQL query resolvers.
+
+Per the scope-bound list is exposed via child fields on
+`DomainV2.appConfigFragments` / `UserV2.appConfigFragments`, not as a
+root resolver. Only the single-row read and the cross-scope admin
+search live here. The scope-bound REST endpoint
+`POST /v2/app-config-fragments/{scope_type}/{scope_id}/search`
+continues to use the adapter's `search()` method directly.
+"""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Get a single app-config fragment by natural key "
+            "`(scope_type, scope_id, name)`. Available to any authenticated user "
+            "— service-layer authorization gates cross-scope reads."
+        ),
+    )
+)  # type: ignore[misc]
+async def app_config_fragment(
+    info: Info[StrawberryGQLContext],
+    scope_type: AppConfigScopeType,
+    scope_id: str,
+    name: str,
+) -> AppConfigFragmentGQL | None:
+    payload = await info.context.adapters.app_config_fragment.get(
+        AppConfigFragmentKeyInput(scope_type=scope_type, scope_id=scope_id, name=name)
+    )
+    if payload.item is None:
+        return None
+    return AppConfigFragmentGQL.from_pydantic(payload.item)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cross-scope admin search across all app-config fragments (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigFragmentConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_fragment.admin_search(
+        SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    edges = [AppConfigFragmentEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigFragmentConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
@@ -1,0 +1,51 @@
+from .bulk_inputs import (
+    AdminAppConfigFragmentItemInputGQL,
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    MyAppConfigFragmentItemInputGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from .bulk_payloads import (
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    AppConfigFragmentBulkErrorGQL,
+    PurgeAppConfigFragmentKeyGQL,
+)
+from .filters import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentOrderByGQL,
+    AppConfigFragmentOrderFieldGQL,
+)
+from .inputs import AppConfigFragmentKeyInputGQL
+from .node import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentGQL,
+    AppConfigScopeTypeGQL,
+)
+
+__all__ = [
+    "AdminAppConfigFragmentItemInputGQL",
+    "AdminBulkCreateAppConfigFragmentInputGQL",
+    "AdminBulkCreateAppConfigFragmentsPayloadGQL",
+    "AdminBulkPurgeAppConfigFragmentInputGQL",
+    "AdminBulkPurgeAppConfigFragmentsPayloadGQL",
+    "AdminBulkUpdateAppConfigFragmentInputGQL",
+    "AdminBulkUpdateAppConfigFragmentsPayloadGQL",
+    "AppConfigFragmentBulkErrorGQL",
+    "AppConfigFragmentConnectionGQL",
+    "AppConfigFragmentEdgeGQL",
+    "AppConfigFragmentFilterGQL",
+    "AppConfigFragmentGQL",
+    "AppConfigFragmentKeyInputGQL",
+    "AppConfigFragmentOrderByGQL",
+    "AppConfigFragmentOrderFieldGQL",
+    "AppConfigScopeTypeGQL",
+    "MyBulkCreateAppConfigFragmentInputGQL",
+    "MyBulkUpdateAppConfigFragmentInputGQL",
+    "MyAppConfigFragmentItemInputGQL",
+    "PurgeAppConfigFragmentKeyGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
@@ -1,0 +1,120 @@
+"""AppConfigFragment bulk-mutation GQL input types."""
+
+from __future__ import annotations
+
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminAppConfigFragmentItemInput as AdminItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput as AdminBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkPurgeAppConfigFragmentsInput as AdminBulkPurgeInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkUpdateAppConfigFragmentsInput as AdminBulkUpdateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyAppConfigFragmentItemInput as MyItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput as MyBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkUpdateAppConfigFragmentsInput as MyBulkUpdateInputDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.inputs import (
+    AppConfigFragmentKeyInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for admin bulk create / update.",
+    ),
+    name="AdminAppConfigFragmentItemInput",
+)
+class AdminAppConfigFragmentItemInputGQL(PydanticInputMixin[AdminItemInputDTO]):
+    key: AppConfigFragmentKeyInputGQL = gql_field(description="Natural-key identifier.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk create input — items carry any scope.",
+    ),
+    name="AdminBulkCreateAppConfigFragmentInput",
+)
+class AdminBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkCreateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to create.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk update input.",
+    ),
+    name="AdminBulkUpdateAppConfigFragmentInput",
+)
+class AdminBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkUpdateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to update.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk purge input — keyed on `AppConfigFragmentKey`.",
+    ),
+    name="AdminBulkPurgeAppConfigFragmentInput",
+)
+class AdminBulkPurgeAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkPurgeInputDTO]):
+    keys: list[AppConfigFragmentKeyInputGQL] = gql_field(description="Natural keys to purge.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for self-service (`my`) bulk.",
+    ),
+    name="MyAppConfigFragmentItemInput",
+)
+class MyAppConfigFragmentItemInputGQL(PydanticInputMixin[MyItemInputDTO]):
+    name: str = gql_field(description="Policy name.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk create — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkCreateAppConfigFragmentInput",
+)
+class MyBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkCreateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to create.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk update — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkUpdateAppConfigFragmentInput",
+)
+class MyBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkUpdateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to update.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
@@ -1,0 +1,105 @@
+"""AppConfigFragment bulk-mutation GQL payload types (admin only).
+
+Self-service `my_*` bulk payloads return recomputed merged AppConfig
+views, so they live in `app_config/types/bulk_payloads.py` to keep the
+import direction `app_config -> app_config_fragment` (one-way) and
+avoid a circular import.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload as AdminBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkPurgeAppConfigFragmentsPayload as AdminBulkPurgePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkUpdateAppConfigFragmentsPayload as AdminBulkUpdatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError as AppConfigFragmentBulkErrorDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    PurgeAppConfigFragmentKey as PurgeAppConfigFragmentKeyDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item failure info for bulk Fragment mutations.",
+    ),
+    model=AppConfigFragmentBulkErrorDTO,
+    name="AppConfigFragmentBulkError",
+)
+class AppConfigFragmentBulkErrorGQL(PydanticOutputMixin[AppConfigFragmentBulkErrorDTO]):
+    index: int = gql_field(description="Original position in the input list.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type of the failed row.")
+    scope_id: str = gql_field(description="Scope id of the failed row.")
+    name: str = gql_field(description="Policy name of the failed row.")
+    message: str = gql_field(description="Reason for the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key of a purged fragment row.",
+    ),
+    model=PurgeAppConfigFragmentKeyDTO,
+    name="PurgeAppConfigFragmentKey",
+)
+class PurgeAppConfigFragmentKeyGQL(PydanticOutputMixin[PurgeAppConfigFragmentKeyDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkCreateAppConfigFragments`.",
+    ),
+    model=AdminBulkCreatePayloadDTO,
+    name="AdminBulkCreateAppConfigFragmentsPayload",
+)
+class AdminBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkCreatePayloadDTO]):
+    created: list[AppConfigFragmentGQL] = gql_field(description="Created fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkUpdateAppConfigFragments`.",
+    ),
+    model=AdminBulkUpdatePayloadDTO,
+    name="AdminBulkUpdateAppConfigFragmentsPayload",
+)
+class AdminBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkUpdatePayloadDTO]):
+    updated: list[AppConfigFragmentGQL] = gql_field(description="Updated fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkPurgeAppConfigFragments`.",
+    ),
+    model=AdminBulkPurgePayloadDTO,
+    name="AdminBulkPurgeAppConfigFragmentsPayload",
+)
+class AdminBulkPurgeAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkPurgePayloadDTO]):
+    purged: list[PurgeAppConfigFragmentKeyGQL] = gql_field(
+        description="Keys of rows actually removed (absent keys are no-oped).",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentFilter as AppConfigFragmentFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentOrder as AppConfigFragmentOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying app-config fragments.",
+    ),
+    name="AppConfigFragmentFilter",
+)
+class AppConfigFragmentFilterGQL(PydanticInputMixin[AppConfigFragmentFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    scope_id: StringFilter | None = gql_field(description="Filter by scope_id.", default=None)
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering app-config fragments.",
+    ),
+    name="AppConfigFragmentOrderField",
+)
+class AppConfigFragmentOrderFieldGQL(StrEnum):
+    SCOPE_TYPE = "scope_type"
+    SCOPE_ID = "scope_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for app-config fragment results.",
+    ),
+    name="AppConfigFragmentOrderBy",
+)
+class AppConfigFragmentOrderByGQL(PydanticInputMixin[AppConfigFragmentOrderDTO]):
+    field: AppConfigFragmentOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.DESC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
@@ -1,0 +1,28 @@
+"""AppConfigFragment GQL natural-key input shared by bulk types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput as AppConfigFragmentKeyInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key for an app-config fragment row.",
+    ),
+    name="AppConfigFragmentKeyInput",
+)
+class AppConfigFragmentKeyInputGQL(PydanticInputMixin[AppConfigFragmentKeyInputDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+# The shared DTO enum is auto-registered by Strawberry the first time it
+# is referenced as a typed field. Re-export under the ``GQL`` suffix so
+# other modules can write `from ... import AppConfigScopeTypeGQL`. Calling
+# `strawberry.enum(...)` here would clash with that auto-registration
+# under the same `"AppConfigScopeType"` name.
+AppConfigScopeTypeGQL = AppConfigScopeType
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Raw per-scope app-config fragment.",
+    ),
+    name="AppConfigFragment",
+)
+class AppConfigFragmentGQL(PydanticNodeMixin[AppConfigFragmentNode]):
+    id: NodeID[str] = gql_field(description="Fragment row UUID.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Config name.")
+    rank: int = gql_field(description="Merge priority within `name` (low → high).")
+    config: JSON | None = gql_field(description="Raw configuration payload, or null.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime | None = gql_field(description="Last update timestamp.")
+
+
+AppConfigFragmentEdgeGQL = Edge[AppConfigFragmentGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated app-config fragment results.",
+    ),
+    name="AppConfigFragmentConnection",
+)
+class AppConfigFragmentConnectionGQL(Connection[AppConfigFragmentGQL]):
+    count: int = gql_field(description="Total number of fragments matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
     from ai.backend.manager.api.adapters.registry import Adapters  # pants: no-infer-dep
     from ai.backend.manager.api.gql.agent.types import AgentV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+        AppConfigFragmentGQL,
+    )
     from ai.backend.manager.api.gql.artifact.types import (  # pants: no-infer-dep
         ArtifactRevision,
     )
@@ -115,6 +118,38 @@ class DataLoaders:
 
     def __init__(self, adapters: Adapters) -> None:
         self._adapters = adapters
+
+    @cached_property
+    def app_config_fragment_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, AppConfigFragmentGQL | None]:
+        adapter = self._adapters.app_config_fragment
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigFragmentGQL | None]:
+            from ai.backend.common.dto.manager.query import UUIDFilter  # pants: no-infer-dep
+            from ai.backend.common.dto.manager.v2.app_config_fragment.request import (  # pants: no-infer-dep
+                AppConfigFragmentFilter,
+                SearchAppConfigFragmentsInput,
+            )
+            from ai.backend.common.identifier.app_config_fragment import (  # pants: no-infer-dep
+                AppConfigFragmentID,
+            )
+            from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+                AppConfigFragmentGQL as F,
+            )
+
+            if not ids:
+                return []
+            payload = await adapter.admin_search(
+                SearchAppConfigFragmentsInput(
+                    filter=AppConfigFragmentFilter(id=UUIDFilter.model_validate({"in": list(ids)})),
+                    limit=len(ids),
+                ),
+            )
+            by_id = {dto.id: F.from_pydantic(dto) for dto in payload.items}
+            return [by_id.get(AppConfigFragmentID(fragment_id)) for fragment_id in ids]
+
+        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,22 @@ from .agent import (
     agent_stats,
     agents_v2,
 )
+from .app_config import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .app_config_fragment.resolver.mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .app_config_fragment.resolver.query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
 from .artifact import (
     approve_artifact_revision,
     artifact,
@@ -523,6 +539,13 @@ class Query:
     resource_slot_type = resource_slot_type
     resource_slot_types = resource_slot_types
     admin_image_aliases = admin_image_aliases
+    # App Config Fragment APIs
+    app_config_fragment = app_config_fragment
+    admin_app_config_fragments = admin_app_config_fragments
+    public_app_config_fragments = public_app_config_fragments
+    # App Config merged view APIs
+    scoped_app_configs = scoped_app_configs
+    admin_app_configs = admin_app_configs
     # Prometheus Query Preset APIs (read available to any authenticated user)
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
@@ -804,6 +827,12 @@ class Mutation:
     admin_unblock_user = admin_unblock_user
     # IP allowlist self-service mutation
     update_my_allowed_client_ip = update_my_allowed_client_ip
+    # App Config Fragment - Bulk mutations
+    admin_bulk_create_app_config_fragments = admin_bulk_create_app_config_fragments
+    admin_bulk_update_app_config_fragments = admin_bulk_update_app_config_fragments
+    admin_bulk_purge_app_config_fragments = admin_bulk_purge_app_config_fragments
+    my_bulk_create_app_config_fragments = my_bulk_create_app_config_fragments
+    my_bulk_update_app_config_fragments = my_bulk_update_app_config_fragments
     # Prometheus Query Preset - Admin APIs
     admin_create_prometheus_query_preset = admin_create_prometheus_query_preset
     admin_modify_prometheus_query_preset = admin_modify_prometheus_query_preset

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -25,9 +25,6 @@ from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
-)
 from ai.backend.manager.repositories.base.creator import Creator, execute_creator
 from ai.backend.manager.repositories.base.purger import Purger, execute_purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
@@ -276,85 +273,26 @@ class AppConfigFragmentDBSource:
             config=merged.config,
         )
 
-    @app_config_fragment_db_source_resilience.apply()
-    async def search_user_app_configs(
-        self,
-        scope: UserAppConfigSearchScope,
-        querier: BatchQuerier,
-    ) -> AppConfigSearchResult:
-        """Connection counterpart of `get_user_app_config`. Groups the
-        scoped page of applicable fragments by `name` and feeds each group
-        through `_merge_chain` (rank-ordered) to produce one `AppConfigData`.
-
-        Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`); the per-user
-        restriction lives in the `scope_id_match` predicate while
-        `UserAppConfigSearchScope` stays a passthrough so it composes
-        with the `BatchQuerier` without double-filtering.
-        """
-        user_id = scope.user_id
-        user_domain_sq = (
-            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
-        )
-        scope_id_match = sa.case(
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
-                sa.literal("public"),
-            ),
-            (
-                AppConfigFragmentRow.scope_type.in_([
-                    AppConfigScopeType.DOMAIN,
-                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
-                ]),
-                user_domain_sq,
-            ),
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
-                sa.literal(str(user_id)),
-            ),
-        )
-        query = sa.select(AppConfigFragmentRow).where(
-            AppConfigFragmentRow.scope_id == scope_id_match,
-        )
-        async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
-
-        groups: dict[str, list[AppConfigFragmentRow]] = {}
-        for row in result.rows:
-            fragment_row = row.AppConfigFragmentRow
-            groups.setdefault(fragment_row.name, []).append(fragment_row)
-
-        items: list[AppConfigData] = []
-        for name, rows in groups.items():
-            merged = self._merge_chain(rows)
-            items.append(
-                AppConfigData(
-                    user_id=user_id,
-                    name=name,
-                    fragments=merged.fragments,
-                    config=merged.config,
-                )
-            )
-
-        return AppConfigSearchResult(
-            items=items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def admin_search_app_configs(
+    async def _search_merged_app_configs(
         self,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope] | None,
     ) -> AppConfigSearchResult:
-        """Cross-user merged search (admin only). Joins `users` so each
-        `(user_id, name)` combination is produced; the scoped page of rows
-        is grouped and rank-merged the same way as `search_user_app_configs`.
+        """Cross-user merged search shared by the scoped and admin paths.
+
+        Joins `users` so each `(user_id, name)` view is produced, then
+        groups the scoped page of applicable fragments by `(user_id, name)`
+        and feeds each group through `_merge_chain` (rank-ordered) to
+        produce one `AppConfigData`.
+
+        When `scopes` is given the user set is the OR-union of those scopes
+        (each `UserAppConfigSearchScope` matches `UserRow.uuid`); `None` is
+        the global admin path. `execute_batch_querier` ORs the scopes and
+        the `(user_id, name)` grouping deduplicates any overlap — a user
+        reached via two scopes still yields exactly one AppConfig.
 
         Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`) on the global
-        (unscoped) admin path.
+        scoped-search helper (`execute_batch_querier`).
         """
         scope_id_match = sa.case(
             (
@@ -385,7 +323,10 @@ class AppConfigFragmentDBSource:
             )
         )
         async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier)
+            if scopes is not None:
+                result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
+            else:
+                result = await execute_batch_querier(db_sess, query, querier)
 
         groups: dict[tuple[uuid.UUID, str], list[AppConfigFragmentRow]] = {}
         for row in result.rows:
@@ -410,3 +351,20 @@ class AppConfigFragmentDBSource:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def scoped_search_app_configs(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigSearchResult:
+        """Merged-view search restricted to `scopes` (OR across users)."""
+        return await self._search_merged_app_configs(querier, scopes)
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Cross-user merged search (admin only) — no scope restriction."""
+        return await self._search_merged_app_configs(querier, None)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -19,9 +19,6 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
-)
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.types import SearchScope
 
@@ -86,9 +83,9 @@ class AppConfigFragmentRepository:
         return await self._db_source.get_user_app_config(user_id, config_name)
 
     @app_config_fragment_repository_resilience.apply()
-    async def search_app_configs(
+    async def scoped_search_app_configs(
         self,
-        scope: UserAppConfigSearchScope,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
     ) -> AppConfigSearchResult:
-        return await self._db_source.search_user_app_configs(scope, querier)
+        return await self._db_source.scoped_search_app_configs(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 
@@ -40,17 +41,21 @@ class AppConfigFragmentSearchScope(SearchScope):
 
 @dataclass(frozen=True)
 class UserAppConfigSearchScope(SearchScope):
-    """Pin merged-view search to a target `user_id`."""
+    """Pin merged-view search to a target `user_id`.
+
+    The merged-view query joins `users`, so this matches `UserRow.uuid`.
+    `execute_batch_querier` ORs multiple scopes together and the
+    `(user_id, name)` grouping downstream deduplicates any overlap
+    between scopes — a user reached via two scopes yields one AppConfig.
+    """
 
     user_id: uuid.UUID
 
     def to_condition(self) -> QueryCondition:
-        # Merge search joins multiple scope rows per user; the per-user
-        # restriction is applied by the merge-specific SQL builder rather
-        # than this generic predicate. Returning a `True` condition keeps
-        # this scope BatchQuerier-compatible without double-filtering.
+        user_id = self.user_id
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return sa.true()
+            return UserRow.uuid == user_id
 
         return inner
 

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class AdminSearchAppConfigsAction(AppConfigFragmentAction):
+    """Cross-user merged-view search(admin only)."""
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class AdminSearchAppConfigsActionResult(BaseActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/app_config_fragment/actions/base.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/base.py
@@ -13,7 +13,7 @@ class AppConfigFragmentAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.APP_CONFIG_FRAGMENT
+        return EntityType.APP_CONFIG
 
 
 @dataclass(frozen=True)
@@ -25,7 +25,7 @@ class AppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=f"{self.key.scope_type}:{self.key.scope_id}:{self.key.name}",
         )
 
@@ -40,6 +40,6 @@ class MyAppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=self.name,
         )

--- a/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
@@ -1,0 +1,34 @@
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class GetUserAppConfigAction(AppConfigFragmentAction):
+    """Resolve a single per-user merged AppConfig."""
+
+    user_id: uuid.UUID
+    config_name: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.user_id}:{self.config_name}"
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetUserAppConfigActionResult(BaseActionResult):
+    app_config: AppConfigData
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.app_config.user_id}:{self.app_config.name}"

--- a/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
@@ -1,0 +1,74 @@
+"""Scoped merged-view (AppConfig) search action and its searchable targets."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.app_config_fragment.types import UserAppConfigSearchScope
+from ai.backend.manager.repositories.base import BatchQuerier, SearchScope
+
+
+@dataclass(frozen=True)
+class UserAppConfigTarget(SearchableActionTarget):
+    """Scope item keyed by a target ``user_id`` in the merged view."""
+
+    user_id: uuid.UUID
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.USER,
+            element_id=str(self.user_id),
+        )
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return UserAppConfigSearchScope(user_id=self.user_id)
+
+
+@dataclass
+class ScopedSearchAppConfigsAction(BaseBulkAction[SearchableActionTarget]):
+    """Scoped merged-view search; targets are OR'd and RBAC-gated per target."""
+
+    items: list[SearchableActionTarget]
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[SearchableActionTarget]:
+        return list(self.items)
+
+
+@dataclass
+class ScopedSearchAppConfigsActionResult(BaseBulkActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+    queried_refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.queried_refs)

--- a/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
@@ -21,6 +21,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.admin_service import (
     AppConfigFragmentAdminService,
 )
@@ -29,6 +33,9 @@ from ai.backend.manager.services.app_config_fragment.admin_service import (
 class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     admin_search: ActionProcessor[
         AdminSearchAppConfigFragmentsAction, AdminSearchAppConfigFragmentsActionResult
+    ]
+    admin_search_app_configs: ActionProcessor[
+        AdminSearchAppConfigsAction, AdminSearchAppConfigsActionResult
     ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
@@ -51,6 +58,9 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
         validators: ActionValidators,
     ) -> None:
         self.admin_search = ActionProcessor(service.admin_search, action_monitors)
+        self.admin_search_app_configs = ActionProcessor(
+            service.admin_search_app_configs, action_monitors
+        )
         self.admin_bulk_create = BulkActionProcessor(service.admin_bulk_create, action_monitors)
         self.admin_bulk_update = BulkActionProcessor(service.admin_bulk_update, action_monitors)
         self.admin_bulk_purge = BulkActionProcessor(service.admin_bulk_purge, action_monitors)
@@ -59,6 +69,7 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     def supported_actions(self) -> list[ActionSpec]:
         return [
             AdminSearchAppConfigFragmentsAction.spec(),
+            AdminSearchAppConfigsAction.spec(),
             AdminBulkCreateAppConfigFragmentsAction.spec(),
             AdminBulkUpdateAppConfigFragmentsAction.spec(),
             AdminBulkPurgeAppConfigFragmentsAction.spec(),

--- a/src/ai/backend/manager/services/app_config_fragment/admin_service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_service.py
@@ -24,6 +24,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -41,6 +45,17 @@ class AppConfigFragmentAdminService:
     ) -> AdminSearchAppConfigFragmentsActionResult:
         result = await self._admin_repository.admin_search(action.querier)
         return AdminSearchAppConfigFragmentsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, action: AdminSearchAppConfigsAction
+    ) -> AdminSearchAppConfigsActionResult:
+        result = await self._admin_repository.admin_search_app_configs(action.querier)
+        return AdminSearchAppConfigsActionResult(
             items=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -9,6 +9,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -21,12 +25,20 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
 
 
 class AppConfigFragmentProcessors(AbstractProcessorPackage):
     get: ActionProcessor[GetAppConfigFragmentAction, GetAppConfigFragmentActionResult]
     search: ActionProcessor[SearchAppConfigFragmentsAction, SearchAppConfigFragmentsActionResult]
+    get_user_app_config: ActionProcessor[GetUserAppConfigAction, GetUserAppConfigActionResult]
+    scoped_search_app_configs: BulkActionProcessor[
+        ScopedSearchAppConfigsAction, ScopedSearchAppConfigsActionResult
+    ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
     # runs. No bulk validators are wired today; the processor simply
@@ -46,6 +58,10 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
     ) -> None:
         self.get = ActionProcessor(service.get, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
+        self.get_user_app_config = ActionProcessor(service.get_user_app_config, action_monitors)
+        self.scoped_search_app_configs = BulkActionProcessor(
+            service.scoped_search_app_configs, action_monitors
+        )
         self.my_bulk_create = BulkActionProcessor(service.my_bulk_create, action_monitors)
         self.my_bulk_update = BulkActionProcessor(service.my_bulk_update, action_monitors)
 
@@ -54,6 +70,8 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         return [
             GetAppConfigFragmentAction.spec(),
             SearchAppConfigFragmentsAction.spec(),
+            GetUserAppConfigAction.spec(),
+            ScopedSearchAppConfigsAction.spec(),
             MyBulkCreateAppConfigFragmentsAction.spec(),
             MyBulkUpdateAppConfigFragmentsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -20,6 +20,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -32,6 +36,10 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -39,8 +47,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class AppConfigFragmentService:
     """Non-admin operations available to any authenticated user.
 
-    Self-service writes (`my_bulk_*`) target the caller's own `USER`
-    scope; the actual row write goes through the shared admin repository
+    Covers raw-fragment reads, the per-user merged `AppConfig` views,
+    and self-service writes (`my_bulk_*`) on the caller's own `USER`
+    scope. The actual row write goes through the shared admin repository
     while reads use the non-admin repository.
     """
 
@@ -69,6 +78,30 @@ class AppConfigFragmentService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    # ── Merged-view reads (AppConfig) ─────────────────────────────
+
+    async def get_user_app_config(
+        self, action: GetUserAppConfigAction
+    ) -> GetUserAppConfigActionResult:
+        app_config = await self._repository.app_config(action.user_id, action.config_name)
+        return GetUserAppConfigActionResult(app_config=app_config)
+
+    async def scoped_search_app_configs(
+        self, action: ScopedSearchAppConfigsAction
+    ) -> ScopedSearchAppConfigsActionResult:
+        targets = list(action.targets())
+        scopes = [t.to_search_scope() for t in targets]
+        result = await self._repository.scoped_search_app_configs(action.querier, scopes)
+        return ScopedSearchAppConfigsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            queried_refs=[t.to_rbac_element_ref() for t in targets],
+        )
+
+    # ── Self-service bulk mutations (per-item transaction) ────────
 
     async def my_bulk_create(
         self, action: MyBulkCreateAppConfigFragmentsAction


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 6-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation (rank-based, no policy)`
2. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
3. 👉 **#11285** — `feat(BA-5829): AppConfig/Fragment GraphQL (scoped + admin)` ← you are here
4. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
5. ⬇️ **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI`
6. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Wires the `AppConfigFragment` domain and the per-user merged `AppConfig` view (BEP-1052) into the Strawberry GraphQL layer, adding the service/adapter surface they need.

- **New merged-view DTO package** `common/dto/manager/v2/app_config/`: `AppConfigNode` (carries the contributing `fragments` in merge order plus the deep-merged `config`, projected to `null` when every fragment is empty), search request/response DTOs, and `AppConfigOrderField`. The `AppConfigScopeType` enum is hoisted out of the fragment DTO types into `common.data.app_config.types` and re-exported.
- **Service / processor (non-admin)**: new `get_user_app_config`, `search_user_app_configs` merged-view reads plus their action/result dataclasses, wired into `AppConfigFragmentProcessors` and `supported_actions`.
- **Service / processor (admin)**: new `admin_search_app_configs` cross-user merged-view search, wired into `AppConfigFragmentAdminProcessors`.
- **New `AppConfigAdapter`** for the merged-view surface (`my_search` / `admin_search` reads, single-user `get`, public-fragment search) and the self-service `my_bulk_create` / `my_bulk_update` writes that return recomputed `AppConfigNode` views; registered in the `Adapters` registry. The existing `AppConfigFragmentAdapter` is narrowed to raw fragment-row operations only.
- **`app_config` GQL package**: `AppConfigGQL` node (`fragments` uses `strawberry.lazy()` to break the cycle with the fragment package) plus root queries `myAppConfigs`, `adminAppConfigs` (admin-gated), and `publicAppConfigFragments`; filter/order inputs and the self-service bulk payloads (placed here because they carry `AppConfigGQL`).
- **`app_config_fragment` GQL package**: `appConfigFragment` (by natural key `(scope_type, scope_id, name)`), `adminAppConfigFragments` (admin cross-scope search), and bulk-only mutations — admin `create` / `update` / `purge` and self-service `my` create / `update`; node, filter/order, key/item/bulk inputs, bulk payloads, and an `AppConfigScopeTypeGQL` re-export.
- Adds an `app_config_fragment_loader` DataLoader (batches fragment lookups by id to avoid N+1), registers all new root queries/mutations in `schema.py`, and regenerates the v2 / supergraph GraphQL reference schemas.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11285.org.readthedocs.build/en/11285/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11285.org.readthedocs.build/ko/11285/

<!-- readthedocs-preview sorna-ko end -->
