### PR TITLE
feat(BA-5835): add my_sent_role_invitations query

### DIFF
--- a/changes/11288.feature.md
+++ b/changes/11288.feature.md
@@ -1,0 +1,1 @@
+Add `my_sent_role_invitations` query so inviters can list the role invitations they have sent (REST, GraphQL, SDK, and CLI).

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13561,6 +13561,9 @@ type Query
   """Added in UNRELEASED. List the current user's role invitations."""
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. List role invitations sent by the current user."""
+  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+
   """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8722,6 +8722,9 @@ type Query {
   """Added in UNRELEASED. List the current user's role invitations."""
   myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
 
+  """Added in UNRELEASED. List role invitations sent by the current user."""
+  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+
   """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """

--- a/src/ai/backend/client/cli/v2/rbac/invitation.py
+++ b/src/ai/backend/client/cli/v2/rbac/invitation.py
@@ -133,6 +133,42 @@ def my_search(limit: int | None, offset: int | None, order_by: tuple[str, ...]) 
     asyncio.run(_run())
 
 
+@invitation.command(name="my-sent-search")
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc, state:asc).",
+)
+def my_sent_search(limit: int | None, offset: int | None, order_by: tuple[str, ...]) -> None:
+    """Search invitations you have sent."""
+    from ai.backend.client.cli.v2.helpers import parse_order_options
+    from ai.backend.common.dto.manager.v2.role_invitation.request import (
+        RoleInvitationOrderBy,
+        RoleInvitationOrderField,
+        SearchRoleInvitationsInput,
+    )
+
+    orders = (
+        parse_order_options(order_by, RoleInvitationOrderField, RoleInvitationOrderBy)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.role_invitation.my_sent_search(
+                SearchRoleInvitationsInput(order=orders, limit=limit, offset=offset),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
 @invitation.command(name="role-search")
 @click.argument("role_id", type=click.UUID)
 @click.option("--limit", type=int, default=None, help="Maximum items to return.")

--- a/src/ai/backend/client/v2/domains_v2/role_invitation.py
+++ b/src/ai/backend/client/v2/domains_v2/role_invitation.py
@@ -69,6 +69,18 @@ class V2RoleInvitationClient(BaseDomainClient):
             response_model=SearchRoleInvitationsPayload,
         )
 
+    async def my_sent_search(
+        self,
+        request: SearchRoleInvitationsInput,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations sent by the current user."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/sent-search",
+            request=request,
+            response_model=SearchRoleInvitationsPayload,
+        )
+
     async def search_by_role(
         self,
         role_id: UUID,

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -216,6 +216,7 @@ from ai.backend.manager.repositories.permission_controller.updaters import (
 )
 from ai.backend.manager.repositories.role_invitation.types import (
     InviteeSearchScope,
+    InviterSearchScope,
     RoleInvitationSearchScope,
 )
 from ai.backend.manager.services.permission_contoller.actions.assign_role import AssignRoleAction
@@ -257,6 +258,7 @@ from ai.backend.manager.services.permission_contoller.actions.search_role_invita
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
     AdminSearchRoleInvitationsAction,
     SearchMyRoleInvitationsAction,
+    SearchMySentRoleInvitationsAction,
     SearchRoleInvitationsByRoleAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.search_role_invitations import (
@@ -1745,6 +1747,43 @@ class RBACAdapter(BaseAdapter):
                 user_id=me.user_id,
                 querier=querier,
                 scope=InviteeSearchScope(invitee_user_id=me.user_id),
+            )
+        )
+        raw = action_result.result
+        return SearchRoleInvitationsPayload(
+            items=[self._invitation_data_to_node(item) for item in raw.items],
+            total_count=raw.total_count,
+            has_next_page=raw.has_next_page,
+            has_previous_page=raw.has_previous_page,
+        )
+
+    async def my_sent_search_role_invitations(
+        self,
+        input: SearchRoleInvitationsInputDTO,
+    ) -> SearchRoleInvitationsPayload:
+        """Search invitations sent by the current authenticated user."""
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        conditions = self._convert_invitation_filter(input.filter) if input.filter else []
+        orders = self._convert_invitation_orders(input.order) if input.order else []
+        querier = self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_invitation_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+            base_conditions=[RoleInvitationConditions.by_inviter(me.user_id)],
+        )
+        action_result = await self._processors.permission_controller.search_my_sent_role_invitations.wait_for_complete(
+            SearchMySentRoleInvitationsAction(
+                user_id=me.user_id,
+                querier=querier,
+                scope=InviterSearchScope(inviter_user_id=me.user_id),
             )
         )
         raw = action_result.result

--- a/src/ai/backend/manager/api/gql/rbac/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/__init__.py
@@ -23,6 +23,7 @@ from .resolver import (
     create_role_invitation,
     my_role_invitations,
     my_roles,
+    my_sent_role_invitations,
     project_roles,
     rbac_entity_operation_combinations,
     rbac_permission_matrix,
@@ -143,6 +144,7 @@ __all__ = (
     "admin_bulk_revoke_role",
     # Role invitation resolvers
     "my_role_invitations",
+    "my_sent_role_invitations",
     "role_scoped_role_invitations",
     "admin_role_invitations",
     "create_role_invitation",

--- a/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/__init__.py
@@ -31,6 +31,7 @@ from .role_invitation import (
     admin_role_invitations,
     create_role_invitation,
     my_role_invitations,
+    my_sent_role_invitations,
     reject_role_invitation,
     role_scoped_role_invitations,
 )
@@ -64,6 +65,7 @@ __all__ = [
     "admin_bulk_revoke_role",
     # Role invitation queries
     "my_role_invitations",
+    "my_sent_role_invitations",
     "role_scoped_role_invitations",
     "admin_role_invitations",
     # Role invitation mutations

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -86,6 +86,54 @@ async def my_role_invitations(
 @gql_root_field(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
+        description="List role invitations sent by the current user.",
+    )
+)  # type: ignore[misc]
+async def my_sent_role_invitations(
+    info: Info[StrawberryGQLContext],
+    filter: RoleInvitationFilterGQL | None = None,
+    order_by: list[RoleInvitationOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> RoleInvitationConnection:
+    result = await info.context.adapters.rbac.my_sent_search_role_invitations(
+        SearchRoleInvitationsInput(
+            filter=filter.to_pydantic() if filter is not None else None,
+            order=[o.to_pydantic() for o in order_by] if order_by is not None else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    edges = [
+        RoleInvitationEdge(
+            node=RoleInvitationGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return RoleInvitationConnection(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
         description="List invitations for a specific role.",
     )
 )  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -279,6 +279,7 @@ from .rbac import (
     create_role_invitation,
     my_role_invitations,
     my_roles,
+    my_sent_role_invitations,
     project_roles,
     rbac_entity_operation_combinations,
     rbac_permission_matrix,
@@ -544,6 +545,7 @@ class Query:
     # RBAC User APIs
     my_roles = my_roles
     my_role_invitations = my_role_invitations
+    my_sent_role_invitations = my_sent_role_invitations
     # RBAC Admin Invitation APIs
     admin_role_invitations = admin_role_invitations
     # RBAC Scoped APIs

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/handler.py
@@ -66,6 +66,14 @@ class V2RoleInvitationHandler:
         result = await self._adapter.my_search_role_invitations(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
+    async def my_sent_search(
+        self,
+        body: BodyParam[SearchRoleInvitationsInput],
+    ) -> APIResponse:
+        """Search invitations sent by the current user."""
+        result = await self._adapter.my_sent_search_role_invitations(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
     async def role_search(
         self,
         path: PathParam[RoleIdPathParam],

--- a/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/role_invitation/registry.py
@@ -55,6 +55,13 @@ def register_v2_role_invitation_routes(
         handler.my_search,
         middlewares=[auth_required],
     )
+    # Search invitations sent by the current user (inviter)
+    registry.add(
+        "POST",
+        "/my/sent-search",
+        handler.my_sent_search,
+        middlewares=[auth_required],
+    )
     # Search invitations by role (scoped — non-admin with role permission also allowed)
     registry.add(
         "POST",

--- a/src/ai/backend/manager/models/role_invitation/conditions.py
+++ b/src/ai/backend/manager/models/role_invitation/conditions.py
@@ -76,6 +76,13 @@ class RoleInvitationConditions:
         return inner
 
     @staticmethod
+    def by_inviter(inviter_user_id: UUID) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.inviter_user_id == inviter_user_id
+
+        return inner
+
+    @staticmethod
     def by_role(role_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RoleInvitationRow.role_id == role_id

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -111,6 +111,7 @@ from ai.backend.manager.repositories.role_invitation.creators import (
 )
 from ai.backend.manager.repositories.role_invitation.types import (
     InviteeSearchScope,
+    InviterSearchScope,
     RoleInvitationSearchResult,
     RoleInvitationSearchScope,
 )
@@ -1280,6 +1281,22 @@ class PermissionDBSource:
         self,
         querier: BatchQuerier,
         scope: InviteeSearchScope,
+    ) -> RoleInvitationSearchResult:
+        async with self._db.begin_readonly_session_read_committed() as session:
+            query = sa.select(RoleInvitationRow)
+            result = await execute_batch_querier(session, query, querier, scope=scope)
+            items = [row.RoleInvitationRow.to_data() for row in result.rows]
+            return RoleInvitationSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    async def search_invitations_by_inviter(
+        self,
+        querier: BatchQuerier,
+        scope: InviterSearchScope,
     ) -> RoleInvitationSearchResult:
         async with self._db.begin_readonly_session_read_committed() as session:
             query = sa.select(RoleInvitationRow)

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -60,6 +60,7 @@ from ai.backend.manager.repositories.permission_controller.types import (
 )
 from ai.backend.manager.repositories.role_invitation.types import (
     InviteeSearchScope,
+    InviterSearchScope,
     RoleInvitationSearchResult,
     RoleInvitationSearchScope,
 )
@@ -396,6 +397,14 @@ class PermissionControllerRepository:
         scope: InviteeSearchScope,
     ) -> RoleInvitationSearchResult:
         return await self._db_source.search_invitations_by_invitee(querier, scope)
+
+    @permission_controller_repository_resilience.apply()
+    async def search_invitations_by_inviter(
+        self,
+        querier: BatchQuerier,
+        scope: InviterSearchScope,
+    ) -> RoleInvitationSearchResult:
+        return await self._db_source.search_invitations_by_inviter(querier, scope)
 
     @permission_controller_repository_resilience.apply()
     async def search_invitations_by_role(

--- a/src/ai/backend/manager/repositories/role_invitation/types.py
+++ b/src/ai/backend/manager/repositories/role_invitation/types.py
@@ -44,6 +44,26 @@ class InviteeSearchScope(SearchScope):
 
 
 @dataclass(frozen=True)
+class InviterSearchScope(SearchScope):
+    """Scope for searching invitations sent by a specific user."""
+
+    inviter_user_id: UUID
+
+    def to_condition(self) -> QueryCondition:
+        inviter_user_id = self.inviter_user_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoleInvitationRow.inviter_user_id == inviter_user_id
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[UUID]]:
+        # Inviter existence is guaranteed by RBAC authentication before reaching here.
+        return []
+
+
+@dataclass(frozen=True)
 class RoleInvitationSearchScope(SearchScope):
     """Scope for searching invitations for a specific role."""
 

--- a/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/search_role_invitations.py
@@ -24,6 +24,7 @@ from ai.backend.manager.data.role_invitation.types import RoleInvitationData
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.role_invitation.types import (
     InviteeSearchScope,
+    InviterSearchScope,
     RoleInvitationSearchScope,
 )
 
@@ -206,6 +207,31 @@ class SearchMyRoleInvitationsAction(_UserScopedInvitationAction):
 
 @dataclass
 class SearchMyRoleInvitationsActionResult(_InvitationScopeActionResult):
+    result: SearchResult[RoleInvitationData]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+
+# ------------------------------------------------------------------ my_sent_search
+
+
+@dataclass
+class SearchMySentRoleInvitationsAction(_UserScopedInvitationAction):
+    """Search invitations sent by the current user."""
+
+    querier: BatchQuerier
+    scope: InviterSearchScope
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchMySentRoleInvitationsActionResult(_InvitationScopeActionResult):
     result: SearchResult[RoleInvitationData]
 
     @override

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -75,6 +75,8 @@ from .actions.search_role_invitations import (
     RoleInvitationActionResult,
     SearchMyRoleInvitationsAction,
     SearchMyRoleInvitationsActionResult,
+    SearchMySentRoleInvitationsAction,
+    SearchMySentRoleInvitationsActionResult,
     SearchRoleInvitationsByRoleAction,
     SearchRoleInvitationsByRoleActionResult,
 )
@@ -145,6 +147,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     search_my_role_invitations: ScopeActionProcessor[
         SearchMyRoleInvitationsAction, SearchMyRoleInvitationsActionResult
     ]
+    search_my_sent_role_invitations: ScopeActionProcessor[
+        SearchMySentRoleInvitationsAction, SearchMySentRoleInvitationsActionResult
+    ]
     search_role_invitations_by_role: ScopeActionProcessor[
         SearchRoleInvitationsByRoleAction, SearchRoleInvitationsByRoleActionResult
     ]
@@ -209,6 +214,11 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=invitation_scope_validators,
         )
+        self.search_my_sent_role_invitations = ScopeActionProcessor(
+            service.search_my_sent_role_invitations,
+            action_monitors,
+            validators=invitation_scope_validators,
+        )
         self.search_role_invitations_by_role = ScopeActionProcessor(
             service.search_role_invitations_by_role,
             action_monitors,
@@ -249,6 +259,7 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             RejectInvitationAction.spec(),
             CancelInvitationAction.spec(),
             SearchMyRoleInvitationsAction.spec(),
+            SearchMySentRoleInvitationsAction.spec(),
             SearchRoleInvitationsByRoleAction.spec(),
             AdminSearchRoleInvitationsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -98,6 +98,8 @@ from ai.backend.manager.services.permission_contoller.actions.search_role_invita
     RoleInvitationActionResult,
     SearchMyRoleInvitationsAction,
     SearchMyRoleInvitationsActionResult,
+    SearchMySentRoleInvitationsAction,
+    SearchMySentRoleInvitationsActionResult,
     SearchRoleInvitationsByRoleAction,
     SearchRoleInvitationsByRoleActionResult,
 )
@@ -436,6 +438,20 @@ class PermissionControllerService:
         """Search invitations addressed to a specific user."""
         result = await self._repository.search_invitations_by_invitee(action.querier, action.scope)
         return SearchMyRoleInvitationsActionResult(
+            result=SearchResult(
+                items=result.items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+        )
+
+    async def search_my_sent_role_invitations(
+        self, action: SearchMySentRoleInvitationsAction
+    ) -> SearchMySentRoleInvitationsActionResult:
+        """Search invitations sent by a specific user."""
+        result = await self._repository.search_invitations_by_inviter(action.querier, action.scope)
+        return SearchMySentRoleInvitationsActionResult(
             result=SearchResult(
                 items=result.items,
                 total_count=result.total_count,

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -945,8 +945,9 @@ class TestMySentSearchInvitations:
             )
         )
         sent = await user_v2_registry.role_invitation.my_sent_search(SearchRoleInvitationsInput())
-        # Invitation rows in which regular user is invitee should NOT appear in their my_sent.
-        assert all(inv.invitee_user_id != regular_user_fixture.user_uuid for inv in sent.items)
+        # Regular user has not sent any invitation — my_sent must be strictly empty.
+        assert sent.total_count == 0
+        assert sent.items == []
 
     async def test_my_sent_search_respects_filter_and_order(
         self,

--- a/tests/component/rbac/test_role_invitation.py
+++ b/tests/component/rbac/test_role_invitation.py
@@ -902,3 +902,90 @@ class TestRoleScopedSearchNonAdmin:
         )
         assert isinstance(result, SearchRoleInvitationsPayload)
         assert all(inv.role_id == target_role.role.id for inv in result.items)
+
+
+class TestMySentSearchInvitations:
+    """my_sent_search — invitations sent by the current authenticated user."""
+
+    async def test_my_sent_search_returns_invitations_sent_by_caller(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Inviter sees only invitations they created."""
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        result = await admin_v2_registry.role_invitation.my_sent_search(
+            SearchRoleInvitationsInput()
+        )
+        assert isinstance(result, SearchRoleInvitationsPayload)
+        assert result.total_count == 1
+        assert all(inv.inviter_user_id == admin_user_fixture.user_uuid for inv in result.items)
+
+    async def test_my_sent_search_excludes_received_invitations(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        target_role: CreateRoleResponse,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """Invitee (not inviter) sees nothing in my_sent_search for an invitation they received."""
+        await admin_v2_registry.role_invitation.create(
+            CreateRoleInvitationInput(
+                role_id=target_role.role.id,
+                emails=[regular_user_fixture.email],
+            )
+        )
+        sent = await user_v2_registry.role_invitation.my_sent_search(SearchRoleInvitationsInput())
+        # Invitation rows in which regular user is invitee should NOT appear in their my_sent.
+        assert all(inv.invitee_user_id != regular_user_fixture.user_uuid for inv in sent.items)
+
+    async def test_my_sent_search_respects_filter_and_order(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        admin_registry: BackendAIClientRegistry,
+        role_factory: RoleFactory,
+        admin_user_fixture: UserFixtureData,
+        regular_user_fixture: UserFixtureData,
+    ) -> None:
+        """my_sent_search honors RoleInvitationFilter and RoleInvitationOrderBy."""
+        role_a = await role_factory()
+        role_b = await role_factory()
+        for role in (role_a, role_b):
+            await admin_v2_registry.role_invitation.create(
+                CreateRoleInvitationInput(
+                    role_id=role.role.id,
+                    emails=[regular_user_fixture.email],
+                )
+            )
+        filtered = await admin_v2_registry.role_invitation.my_sent_search(
+            SearchRoleInvitationsInput(
+                filter=RoleInvitationFilter(
+                    role=RoleNestedFilter(name=StringFilter(equals=role_a.role.name)),
+                )
+            )
+        )
+        assert filtered.total_count == 1
+        assert filtered.items[0].role_id == role_a.role.id
+        assert filtered.items[0].inviter_user_id == admin_user_fixture.user_uuid
+
+        ordered = await admin_v2_registry.role_invitation.my_sent_search(
+            SearchRoleInvitationsInput(
+                order=[
+                    RoleInvitationOrderBy(
+                        field=RoleInvitationOrderField.CREATED_AT,
+                        direction=OrderDirection.ASC,
+                    )
+                ],
+            )
+        )
+        ts = [inv.created_at for inv in ordered.items]
+        assert ts == sorted(ts)


### PR DESCRIPTION
## Summary
- Add a `my_sent_role_invitations` search variant (REST `POST /v2/role-invitations/my/sent-search`, GraphQL `mySentRoleInvitations`, SDK `my_sent_search`, CLI `my-sent-search`) so inviters can self-service their dispatched invitations — symmetrical to the existing `my_role_invitations` (invitee view).
- New stack: `InviterSearchScope` + `search_invitations_by_inviter` repository path → `SearchMySentRoleInvitationsAction` (USER scope, RBAC scope validator) → `RBACAdapter.my_sent_search_role_invitations` resolving `current_user()` internally.
- Reuses `SearchRoleInvitationsInput` / `Payload` / `RoleInvitationFilter` (including the `role_id` UUIDFilter). No new DTO types, no permission model changes.

## Test plan
- [x] Component tests: `pants test tests/component/rbac/test_role_invitation.py` — 28/28 PASS
  - `test_my_sent_search_returns_invitations_sent_by_caller` — inviter sees exactly their sent invitation
  - `test_my_sent_search_excludes_received_invitations` — invitee-only rows hidden from the inviter view
  - `test_my_sent_search_respects_filter_and_order` — `RoleInvitationFilter(role.name)` + `RoleInvitationOrderBy(created_at ASC)` honored
- [x] `pants fmt / fix / lint --changed-since=origin/main` pass
- [x] Verify via `./bai v2 invitation my-sent-search`

Resolves BA-5835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11288.org.readthedocs.build/en/11288/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11288.org.readthedocs.build/ko/11288/

<!-- readthedocs-preview sorna-ko end -->