### PR TITLE
feat(BA-5684): migrate association_groups_users data to rbac

### DIFF
--- a/changes/11289.feature.md
+++ b/changes/11289.feature.md
@@ -1,0 +1,1 @@
+Add an idempotent Alembic migration that backfills `association_scopes_entities` with PROJECT/USER membership rows derived from `association_groups_users`, so RBAC read paths see consistent membership state on deployments that predate auto-sync.

--- a/src/ai/backend/manager/models/alembic/versions/ce69b746304e_migrate_association_groups_users_data_to_rbac.py
+++ b/src/ai/backend/manager/models/alembic/versions/ce69b746304e_migrate_association_groups_users_data_to_rbac.py
@@ -1,0 +1,44 @@
+"""migrate association_groups_users data to rbac
+
+Revision ID: ce69b746304e
+Revises: c2d3e4f5a6b7
+Create Date: 2026-04-24 21:34:36.543864
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ce69b746304e"
+down_revision = "c2d3e4f5a6b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Backfill association_scopes_entities with PROJECT/USER rows derived
+    from association_groups_users. Idempotent via ON CONFLICT.
+    """
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO association_scopes_entities
+                (scope_type, scope_id, entity_type, entity_id, relation_type)
+            SELECT
+                'project',
+                CAST(group_id AS text),
+                'user',
+                CAST(user_id AS text),
+                'auto'
+            FROM association_groups_users
+            ON CONFLICT (scope_type, scope_id, entity_id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """No-op: rows inserted here are indistinguishable from auto-synced rows."""

--- a/src/ai/backend/manager/models/group/row.py
+++ b/src/ai/backend/manager/models/group/row.py
@@ -122,6 +122,14 @@ container_registry_iv = t.Dict({}) | t.Dict({
 
 
 class AssocGroupUserRow(Base):  # type: ignore[misc]
+    """DEPRECATED -- scheduled for sunset.
+
+    Project membership is moving to ``association_scopes_entities`` (ASE) with
+    ``scope_type=PROJECT, entity_type=USER`` as the single source of truth. New
+    code MUST query ASE; do not add new readers or writers against this table.
+    The table itself will be dropped after every reader is migrated.
+    """
+
     __tablename__ = "association_groups_users"
     __table_args__ = (
         sa.UniqueConstraint("user_id", "group_id", name="uq_association_user_id_group_id"),
@@ -147,8 +155,8 @@ class AssocGroupUserRow(Base):  # type: ignore[misc]
     group: Mapped[GroupRow] = relationship("GroupRow", back_populates="users")
 
 
-# NOTE: Deprecated legacy table reference for backward compatibility.
-# Use AssocGroupUserRow class directly for new code.
+# DEPRECATED: scheduled for sunset; project membership lives in
+# `association_scopes_entities`. Do not use in new code.
 association_groups_users = AssocGroupUserRow.__table__
 
 


### PR DESCRIPTION
## Summary
Backfill `association_scopes_entities` with `PROJECT/USER` membership rows derived from `association_groups_users` so RBAC read paths see consistent membership on deployments that predate the auto-sync path.

- `INSERT ... SELECT` from agus (no JOIN; FKs are `ON DELETE CASCADE`)
- `ON CONFLICT (scope_type, scope_id, entity_id) DO NOTHING` — idempotent and safe under concurrent auto-sync
- `downgrade()` is a no-op; re-running `upgrade()` stays idempotent

## Performance

Measured on local halfstack PostgreSQL, all rows fresh (no pre-existing ASE matches):

| agus rows | First run (new inserts) | Re-run (all conflict) |
|-----------|-------------------------|-----------------------|
| 10,000 | 197 ms | 106 ms |
| 100,000 | 2,234 ms | 1,126 ms |

Scales near-linearly (~11x time for 10x data). Query plan is a sequential scan of agus plus a unique-index conflict check against `uq_scope_id_entity_id`.

## Test plan
- [x] Local halfstack: baseline drift healed, pre-existing ASE rows untouched (ON CONFLICT), re-run inserts 0 rows
- [x] Timed against 10k and 100k synthetic agus rows (see table above)

Resolves BA-5684