### PR TITLE
feat(BA-5832): AppConfig v2 SDK + CLI (BEP-1052)

### DIFF
--- a/changes/11282.feature.md
+++ b/changes/11282.feature.md
@@ -1,0 +1,1 @@
+Add `app_config_fragments` table and repository foundation — per-scope raw config rows keyed by `(scope_type, scope_id, name)` with a NO-ACTION FK to `app_config_policies.config_name`.

--- a/changes/11285.feature.md
+++ b/changes/11285.feature.md
@@ -1,0 +1,1 @@
+Add `AppConfigFragment` Strawberry GraphQL surface — `appConfigFragment` (by natural key), `scopedAppConfigFragments`, `adminAppConfigFragments`, and admin `create` / `update` / `purge` mutations.

--- a/changes/11286.feature.md
+++ b/changes/11286.feature.md
@@ -1,0 +1,1 @@
+Add `AppConfigFragment` REST v2 endpoints under `/v2/app-config-fragments` — `get` (body-carried natural key), scoped search `{scope_type}/{scope_id}/search`, admin cross-scope `search`, plus admin `create` / `update` / `purge`.

--- a/changes/11295.feature.md
+++ b/changes/11295.feature.md
@@ -1,0 +1,1 @@
+Add v2 SDK + CLI for the AppConfig surface — `app-config-policy` (get / search / bulk admin writes), `app-config-fragment` (get / scope-search / admin search / bulk admin writes), and the merged `app-config` view (`my` reads + writes, admin reads). Replaces the legacy domain/user upsert SDK + CLI whose endpoints were dropped in BA-5822.

--- a/changes/11296.feature.md
+++ b/changes/11296.feature.md
@@ -1,0 +1,1 @@
+Add the `AppConfigFragment` service / adapter / DTO surface — bulk-only writes (admin + self-service) with partial-success semantics, scope-bound + admin search reads. Layers on top of the foundation in #11282.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -202,6 +202,161 @@ type AddRevisionPayload
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
+type AdminBulkCreateAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Created policies."""
+  created: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
+input AdminBulkCreateAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policies to create."""
+  items: [AdminBulkCreateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+"""
+input AdminBulkCreateAppConfigPolicyItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
+type AdminBulkPurgeAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Ids of policies actually removed (absent ids no-oped)."""
+  purgedIds: [UUID!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
+"""
+input AdminBulkPurgeAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy row ids to purge."""
+  ids: [UUID!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
+type AdminBulkUpdateAppConfigPoliciesPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Updated policies."""
+  updated: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
+input AdminBulkUpdateAppConfigPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policies to update."""
+  items: [AdminBulkUpdateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
+"""
+input AdminBulkUpdateAppConfigPolicyItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy row id."""
+  id: UUID!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput
   @join__type(graph: STRAWBERRY)
@@ -883,6 +1038,252 @@ type AllowedResourceGroupsPayload
 {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig
+  @join__type(graph: STRAWBERRY)
+{
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment
+  @join__type(graph: STRAWBERRY)
+{
+  """Row ID."""
+  id: UUID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name (FK target)."""
+  name: String!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError
+  @join__type(graph: STRAWBERRY)
+{
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  SCOPE_TYPE @join__enumValue(graph: STRAWBERRY)
+  SCOPE_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  USER_ID @join__enumValue(graph: STRAWBERRY)
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Scoped app-config policy."""
+type AppConfigPolicy implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain (low → high merge priority)."""
+  scopeSources: [String!]!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
+type AppConfigPolicyBulkError
+  @join__type(graph: STRAWBERRY)
+{
+  """Original position in the input list."""
+  index: Int!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config policy results.
+"""
+type AppConfigPolicyConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigPolicyEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigPolicy!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config policies."""
+input AppConfigPolicyFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by config_name."""
+  configName: StringFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
+input AppConfigPolicyOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """The field to order by."""
+  field: AppConfigPolicyOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
+enum AppConfigPolicyOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  CONFIG_NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+enum AppConfigScopeType
+  @join__type(graph: STRAWBERRY)
+{
+  PUBLIC @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  DOMAIN_USER_DEFAULTS @join__enumValue(graph: STRAWBERRY)
+  USER @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -11522,6 +11923,46 @@ type Mutation
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload @join__field(graph: STRAWBERRY)
 
+  """
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
+  """
+  adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  """
+  adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  """
+  adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
@@ -11785,6 +12226,63 @@ type Mutation
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput
+  @join__type(graph: STRAWBERRY)
+{
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -13448,6 +13946,20 @@ input ProjectWeightInputItem
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey
+  @join__type(graph: STRAWBERRY)
+{
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """
 Completely delete domain from DB.
 
@@ -14258,6 +14770,41 @@ type Query
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
+  """
+  appConfigPolicy(id: UUID!): AppConfigPolicy @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
+  """
+  appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Caller's own merged AppConfig list (auth required). Chain per policy ; the adapter pins `(USER, current_user)` internally.
+  """
+  myAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]! @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
   """
   prometheusQueryPreset(id: ID!): QueryDefinition @join__field(graph: STRAWBERRY)
@@ -14947,6 +15494,7 @@ enum RBACElementType
   SESSION_TEMPLATE @join__enumValue(graph: STRAWBERRY)
   APP_CONFIG @join__enumValue(graph: STRAWBERRY)
   MODEL_CARD @join__enumValue(graph: STRAWBERRY)
+  APP_CONFIG_POLICY @join__enumValue(graph: STRAWBERRY)
   RESOURCE_PRESET @join__enumValue(graph: STRAWBERRY)
   USER_RESOURCE_POLICY @join__enumValue(graph: STRAWBERRY)
   KEYPAIR_RESOURCE_POLICY @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -156,6 +156,131 @@ type AddRevisionPayload {
   revision: ModelRevision!
 }
 
+"""Added in 26.4.4. Per-item input for admin bulk create / update."""
+input AdminAppConfigFragmentItemInput {
+  """Natural-key identifier."""
+  key: AppConfigFragmentKeyInput!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""Added in 26.4.4. Admin bulk create input — items carry any scope."""
+input AdminBulkCreateAppConfigFragmentInput {
+  """Rows to create."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigFragments`."""
+type AdminBulkCreateAppConfigFragmentsPayload {
+  """Created fragments."""
+  created: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
+type AdminBulkCreateAppConfigPoliciesPayload {
+  """Created policies."""
+  created: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
+input AdminBulkCreateAppConfigPolicyInput {
+  """Policies to create."""
+  items: [AdminBulkCreateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+"""
+input AdminBulkCreateAppConfigPolicyItemInput {
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input — keyed on `AppConfigFragmentKey`.
+"""
+input AdminBulkPurgeAppConfigFragmentInput {
+  """Natural keys to purge."""
+  keys: [AppConfigFragmentKeyInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigFragments`."""
+type AdminBulkPurgeAppConfigFragmentsPayload {
+  """Keys of rows actually removed (absent keys are no-oped)."""
+  purged: [PurgeAppConfigFragmentKey!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
+type AdminBulkPurgeAppConfigPoliciesPayload {
+  """Ids of policies actually removed (absent ids no-oped)."""
+  purgedIds: [UUID!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
+"""
+input AdminBulkPurgeAppConfigPolicyInput {
+  """Policy row ids to purge."""
+  ids: [UUID!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input."""
+input AdminBulkUpdateAppConfigFragmentInput {
+  """Rows to update."""
+  items: [AdminAppConfigFragmentItemInput!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigFragments`."""
+type AdminBulkUpdateAppConfigFragmentsPayload {
+  """Updated fragments."""
+  updated: [AppConfigFragment!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
+type AdminBulkUpdateAppConfigPoliciesPayload {
+  """Updated policies."""
+  updated: [AppConfigPolicy!]!
+
+  """Per-item failures."""
+  failed: [AppConfigPolicyBulkError!]!
+}
+
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
+input AdminBulkUpdateAppConfigPolicyInput {
+  """Policies to update."""
+  items: [AdminBulkUpdateAppConfigPolicyItemInput!]!
+}
+
+"""
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
+"""
+input AdminBulkUpdateAppConfigPolicyItemInput {
+  """Policy row id."""
+  id: UUID!
+
+  """Ordered scope chain."""
+  scopeSources: [String!]!
+}
+
 """Added in 26.4.2. Admin input for creating a keypair for a user."""
 input AdminCreateKeypairInput {
   """UUID of the target user."""
@@ -602,6 +727,215 @@ type AllowedProjectsPayload {
 type AllowedResourceGroupsPayload {
   """Allowed resource group names."""
   items: [String!]!
+}
+
+"""
+Added in 26.4.4. Merged per-user AppConfig view. `fragments` are ordered low → high merge priority; `config` is the deep-merge result and is null when every contributing fragment is empty.
+"""
+type AppConfig {
+  """Target user's UUID."""
+  userId: UUID!
+
+  """Policy / config name."""
+  name: String!
+
+  """Contributing fragments in merge order (low → high)."""
+  fragments: [AppConfigFragment!]!
+
+  """Deep-merged configuration, or null when every fragment is empty."""
+  config: JSON
+}
+
+"""Added in 26.4.4. Filter input for querying merged AppConfigs."""
+input AppConfigFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by target user id (admin cross-user search only)."""
+  userId: UUIDFilter = null
+
+  """Filter by the oldest contributing fragment's creation timestamp."""
+  createdAt: DateTimeFilter = null
+
+  """Filter by the latest contributing fragment's update timestamp."""
+  updatedAt: DateTimeFilter = null
+}
+
+"""Added in 26.4.4. Raw per-scope app-config fragment."""
+type AppConfigFragment {
+  """Row ID."""
+  id: UUID!
+
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name (FK target)."""
+  name: String!
+
+  """Raw configuration payload, or null."""
+  config: JSON
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Fragment mutations."""
+type AppConfigFragmentBulkError {
+  """Original position in the input list."""
+  index: Int!
+
+  """Scope type of the failed row."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id of the failed row."""
+  scopeId: String!
+
+  """Policy name of the failed row."""
+  name: String!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config fragments."""
+input AppConfigFragmentFilter {
+  """Filter by policy name."""
+  name: StringFilter = null
+
+  """Filter by scope_id."""
+  scopeId: StringFilter = null
+}
+
+"""Added in 26.4.4. Natural key for an app-config fragment row."""
+input AppConfigFragmentKeyInput {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config fragment results."""
+input AppConfigFragmentOrderBy {
+  """The field to order by."""
+  field: AppConfigFragmentOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config fragments."""
+enum AppConfigFragmentOrderField {
+  SCOPE_TYPE
+  SCOPE_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in 26.4.4. Specifies ordering for merged AppConfig results."""
+input AppConfigOrderBy {
+  """The field to order by."""
+  field: AppConfigOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = ASC
+}
+
+"""Added in 26.4.4. Fields available for ordering merged AppConfigs."""
+enum AppConfigOrderField {
+  USER_ID
+  NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""Added in 26.4.4. Scoped app-config policy."""
+type AppConfigPolicy implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Unique, immutable policy name."""
+  configName: String!
+
+  """Ordered scope chain (low → high merge priority)."""
+  scopeSources: [String!]!
+
+  """Creation timestamp."""
+  createdAt: DateTime!
+
+  """Last update timestamp."""
+  updatedAt: DateTime
+}
+
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
+type AppConfigPolicyBulkError {
+  """Original position in the input list."""
+  index: Int!
+
+  """Reason for the failure."""
+  message: String!
+}
+
+"""
+Added in 26.4.4. Connection type for paginated app-config policy results.
+"""
+type AppConfigPolicyConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [AppConfigPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type AppConfigPolicyEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AppConfigPolicy!
+}
+
+"""Added in 26.4.4. Filter input for querying app-config policies."""
+input AppConfigPolicyFilter {
+  """Filter by config_name."""
+  configName: StringFilter = null
+}
+
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
+input AppConfigPolicyOrderBy {
+  """The field to order by."""
+  field: AppConfigPolicyOrderField!
+
+  """Sort direction."""
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
+enum AppConfigPolicyOrderField {
+  CONFIG_NAME
+  CREATED_AT
+  UPDATED_AT
+}
+
+enum AppConfigScopeType {
+  PUBLIC
+  DOMAIN
+  DOMAIN_USER_DEFAULTS
+  USER
 }
 
 """
@@ -7406,6 +7740,46 @@ type Mutation {
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload
 
+  """
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
+  """
+  adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  """
+  adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  """
+  adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload!
+
+  """
+  Added in 26.4.4. Strict insert across any scope; each item runs in its own transaction and failures are collected per-item (admin only).
+  """
+  adminBulkCreateAppConfigFragments(input: AdminBulkCreateAppConfigFragmentInput!): AdminBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale JSON replacement; items with no existing row are returned as failures (admin only).
+  """
+  adminBulkUpdateAppConfigFragments(input: AdminBulkUpdateAppConfigFragmentInput!): AdminBulkUpdateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Cleanup-only deletion; absent keys are no-oped (admin only).
+  """
+  adminBulkPurgeAppConfigFragments(input: AdminBulkPurgeAppConfigFragmentInput!): AdminBulkPurgeAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Strict insert on the caller's USER row; duplicates fail per-item. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkCreateAppConfigFragments(input: MyBulkCreateAppConfigFragmentInput!): MyBulkCreateAppConfigFragmentsPayload!
+
+  """
+  Added in 26.4.4. Wholesale replacement on the caller's USER row; missing rows are returned as failures. Returns recomputed merged `AppConfig` views.
+  """
+  myBulkUpdateAppConfigFragments(input: MyBulkUpdateAppConfigFragmentInput!): MyBulkUpdateAppConfigFragmentsPayload!
+
   """Added in 26.3.0. Create a new query definition (admin only)"""
   adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload
 
@@ -7669,6 +8043,53 @@ type Mutation {
   Added in 26.4.4. Terminate one or more sessions by ID. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   terminateSessionsV2(sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload
+}
+
+"""Added in 26.4.4. Per-item input for self-service (`my`) bulk."""
+input MyAppConfigFragmentItemInput {
+  """Policy name."""
+  name: String!
+
+  """Raw configuration payload."""
+  config: JSON!
+}
+
+"""
+Added in 26.4.4. Self-service bulk create — scope is `USER` / `current_user`.
+"""
+input MyBulkCreateAppConfigFragmentInput {
+  """USER-scope rows to create."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkCreateAppConfigFragments` (recomputed views).
+"""
+type MyBulkCreateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each created USER fragment."""
+  created: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
+}
+
+"""
+Added in 26.4.4. Self-service bulk update — scope is `USER` / `current_user`.
+"""
+input MyBulkUpdateAppConfigFragmentInput {
+  """USER-scope rows to update."""
+  items: [MyAppConfigFragmentItemInput!]!
+}
+
+"""
+Added in 26.4.4. Payload for `myBulkUpdateAppConfigFragments` (recomputed views).
+"""
+type MyBulkUpdateAppConfigFragmentsPayload {
+  """Recomputed merged AppConfig views for each updated USER fragment."""
+  updated: [AppConfig!]!
+
+  """Per-item failures."""
+  failed: [AppConfigFragmentBulkError!]!
 }
 
 """
@@ -9023,6 +9444,18 @@ input ProjectWeightInputItem {
   weight: Decimal = null
 }
 
+"""Added in 26.4.4. Natural key of a purged fragment row."""
+type PurgeAppConfigFragmentKey {
+  """Scope type."""
+  scopeType: AppConfigScopeType!
+
+  """Scope id."""
+  scopeId: String!
+
+  """Policy name."""
+  name: String!
+}
+
 """Added in 26.4.2. Payload for domain permanent deletion mutation."""
 type PurgeDomainPayload {
   """Whether the purge was successful."""
@@ -9339,6 +9772,41 @@ type Query {
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
+
+  """
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
+  """
+  appConfigPolicy(id: UUID!): AppConfigPolicy
+
+  """
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
+  """
+  appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection!
+
+  """
+  Added in 26.4.4. Get a single app-config fragment by natural key `(scope_type, scope_id, name)`. Available to any authenticated user — service-layer authorization gates cross-scope reads.
+  """
+  appConfigFragment(scopeType: AppConfigScopeType!, scopeId: String!, name: String!): AppConfigFragment
+
+  """
+  Added in 26.4.4. Cross-scope admin search across all app-config fragments (admin only).
+  """
+  adminAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]!
+
+  """
+  Added in 26.4.4. Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of raw fragments that carry no personally-scoped data.
+  """
+  publicAppConfigFragments(filter: AppConfigFragmentFilter = null, orderBy: [AppConfigFragmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfigFragment!]!
+
+  """
+  Added in 26.4.4. Caller's own merged AppConfig list (auth required). Chain per policy ; the adapter pins `(USER, current_user)` internally.
+  """
+  myAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]!
+
+  """
+  Added in 26.4.4. Cross-user merged-view search (admin only). Resolves any user's AppConfig for audit / support. Pin to a single user with `filter.userId`; otherwise paginates across all users.
+  """
+  adminAppConfigs(filter: AppConfigFilter = null, orderBy: [AppConfigOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [AppConfig!]!
 
   """
   Added in 26.4.2. Get a single prometheus query preset by ID. Available to any authenticated user since presets are a shared catalog of metric query templates.
@@ -9977,6 +10445,7 @@ enum RBACElementType {
   SESSION_TEMPLATE
   APP_CONFIG
   MODEL_CARD
+  APP_CONFIG_POLICY
   RESOURCE_PRESET
   USER_RESOURCE_POLICY
   KEYPAIR_RESOURCE_POLICY

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -260,6 +260,11 @@ def notification() -> None:
     """Notification commands."""
 
 
+@v2.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2.app_config:app_config")
+def app_config() -> None:
+    """App config (merged-view) commands."""
+
+
 @v2.group(
     cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.prometheus_query_preset:prometheus_query_preset",

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -212,3 +212,21 @@ def invitation() -> None:
 )
 def role_preset() -> None:
     """Admin role preset commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config:app_config",
+    name="app-config",
+)
+def app_config() -> None:
+    """Admin merged AppConfig commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.app_config_fragment:app_config_fragment",
+    name="app-config-fragment",
+)
+def app_config_fragment() -> None:
+    """Admin AppConfigFragment commands (cross-scope search + bulk-only writes)."""

--- a/src/ai/backend/client/cli/v2/admin/app_config.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config.py
@@ -1,0 +1,92 @@
+"""Admin CLI commands for the merged AppConfig view."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Admin merged AppConfig commands."""
+
+
+@app_config.command()
+@click.argument("user_id", type=click.UUID)
+@click.argument("name", type=str)
+def get(user_id: UUID, name: str) -> None:
+    """Read a specific user's merged AppConfig (admin only)."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.admin_get(user_id, name)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option("--user-id", type=click.UUID, default=None, help="Pin to a single user (UUID).")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: name, user_id.",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    user_id: UUID | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Cross-user merged-view search (superadmin only)."""
+    from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+    from ai.backend.common.dto.manager.v2.app_config.request import (
+        AppConfigFilter,
+        AppConfigOrder,
+        SearchAppConfigsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField
+
+    filter_dto: AppConfigFilter | None = None
+    if name_contains is not None or user_id is not None:
+        filter_dto = AppConfigFilter(
+            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            user_id=UUIDFilter(equals=user_id) if user_id is not None else None,
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigOrderField, AppConfigOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.admin_search(
+                SearchAppConfigsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/admin/app_config_fragment.py
@@ -1,0 +1,181 @@
+"""Admin CLI commands for AppConfigFragment (cross-scope search + bulk-only writes)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config-fragment")
+def app_config_fragment() -> None:
+    """Admin AppConfigFragment commands (cross-scope search + bulk-only writes)."""
+
+
+def _load_items(items_arg: str) -> list[dict[str, Any]]:
+    """Accept JSON string or `@file.json` path."""
+    if items_arg.startswith("@"):
+        return cast("list[dict[str, Any]]", json.loads(Path(items_arg[1:]).read_text()))
+    return cast("list[dict[str, Any]]", json.loads(items_arg))
+
+
+@app_config_fragment.command()
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option("--scope-type", type=str, default=None, help="Filter by scope_type.")
+@click.option("--scope-id-contains", type=str, default=None, help="Filter `scope_id` by substring.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: scope_type, scope_id, name, created_at, updated_at.",
+)
+def search(
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    scope_type: str | None,
+    scope_id_contains: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Cross-scope fragment search (superadmin only)."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AppConfigFragmentFilter,
+        AppConfigFragmentOrder,
+        SearchAppConfigFragmentsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+        AppConfigFragmentOrderField,
+        AppConfigScopeType,
+    )
+
+    filter_dto: AppConfigFragmentFilter | None = None
+    if any([name_contains, scope_type, scope_id_contains]):
+        filter_dto = AppConfigFragmentFilter(
+            name=StringFilter(contains=name_contains) if name_contains is not None else None,
+            scope_type=AppConfigScopeType(scope_type) if scope_type is not None else None,
+            scope_id=(
+                StringFilter(contains=scope_id_contains) if scope_id_contains is not None else None
+            ),
+        )
+
+    orders = (
+        parse_order_options(order_by, AppConfigFragmentOrderField, AppConfigFragmentOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_search(
+                SearchAppConfigFragmentsInput(
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-create")
+@click.option(
+    "--items",
+    required=True,
+    help=(
+        "JSON list of `{key: {scope_type, scope_id, name}, config}` items, "
+        "or `@path/to/items.json`."
+    ),
+)
+def bulk_create(items: str) -> None:
+    """Bulk-create fragments (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminAppConfigFragmentItemInput,
+        AdminBulkCreateAppConfigFragmentsInput,
+    )
+
+    parsed = [AdminAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_create(
+                AdminBulkCreateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-update")
+@click.option(
+    "--items",
+    required=True,
+    help="Same shape as `bulk-create`; replaces `config` wholesale.",
+)
+def bulk_update(items: str) -> None:
+    """Bulk-update fragments (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminAppConfigFragmentItemInput,
+        AdminBulkUpdateAppConfigFragmentsInput,
+    )
+
+    parsed = [AdminAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_update(
+                AdminBulkUpdateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config_fragment.command(name="bulk-purge")
+@click.option(
+    "--keys",
+    required=True,
+    help="JSON list of `{scope_type, scope_id, name}` keys, or `@path/to/keys.json`.",
+)
+def bulk_purge(keys: str) -> None:
+    """Bulk-purge fragments by natural key (partial-success semantics)."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        AdminBulkPurgeAppConfigFragmentsInput,
+        AppConfigFragmentKeyInput,
+    )
+
+    parsed = [AppConfigFragmentKeyInput.model_validate(item) for item in _load_items(keys)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.admin_bulk_purge(
+                AdminBulkPurgeAppConfigFragmentsInput(keys=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/app_config/__init__.py
+++ b/src/ai/backend/client/cli/v2/app_config/__init__.py
@@ -1,0 +1,3 @@
+from .commands import app_config as app_config
+
+__all__ = ("app_config",)

--- a/src/ai/backend/client/cli/v2/app_config/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config/commands.py
@@ -1,0 +1,90 @@
+"""CLI commands for the merged AppConfig view.
+
+Public entrypoint exposes only the read paths that any authenticated
+user can hit. Self-service writes live under `bai my app-config`;
+admin operations live under `bai admin app-config`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Merged AppConfig commands (per-policy resolved view)."""
+
+
+@app_config.command()
+@click.option(
+    "--user-id",
+    "user_ids",
+    type=click.UUID,
+    multiple=True,
+    required=True,
+    help="Target user UUID to scope the search to (repeatable, OR'd). "
+    "Pass your own id for self-service.",
+)
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option("--name-contains", type=str, default=None, help="Filter `name` by substring.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction. Fields: name, user_id.",
+)
+def search(
+    user_ids: tuple[UUID, ...],
+    limit: int | None,
+    offset: int | None,
+    name_contains: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Scoped merged-view search (auth required, RBAC-gated).
+
+    `--user-id` is the scope; pass your own id for self-service.
+    """
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.app_config.request import (
+        AppConfigFilter,
+        AppConfigOrder,
+        AppConfigScope,
+        ScopedSearchAppConfigsInput,
+    )
+    from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField
+
+    filter_dto: AppConfigFilter | None = None
+    if name_contains is not None:
+        filter_dto = AppConfigFilter(name=StringFilter(contains=name_contains))
+
+    orders = (
+        parse_order_options(order_by, AppConfigOrderField, AppConfigOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.scoped_search(
+                ScopedSearchAppConfigsInput(
+                    scope=AppConfigScope(user_ids=list(user_ids)),
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/my/__init__.py
+++ b/src/ai/backend/client/cli/v2/my/__init__.py
@@ -82,3 +82,12 @@ def resource_policy() -> None:
 )
 def storage_host() -> None:
     """My storage host commands."""
+
+
+@my.group(
+    cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.my.app_config:app_config",
+    name="app-config",
+)
+def app_config() -> None:
+    """My merged AppConfig commands."""

--- a/src/ai/backend/client/cli/v2/my/app_config.py
+++ b/src/ai/backend/client/cli/v2/my/app_config.py
@@ -1,0 +1,88 @@
+"""Self-service CLI commands for the merged AppConfig view."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    print_result,
+)
+
+
+@click.group(name="app-config")
+def app_config() -> None:
+    """Self-service AppConfig commands for the current user.
+
+    Self-service search has moved to the scoped surface — use
+    `bai app-config search --user-id <your-id>`.
+    """
+
+
+def _load_items(items_arg: str) -> list[dict[str, Any]]:
+    """Accept JSON string or `@file.json` path."""
+    if items_arg.startswith("@"):
+        return cast("list[dict[str, Any]]", json.loads(Path(items_arg[1:]).read_text()))
+    return cast("list[dict[str, Any]]", json.loads(items_arg))
+
+
+@app_config.command(name="bulk-create")
+@click.option(
+    "--items",
+    required=True,
+    help="JSON list of `{name, config}` items, or `@path/to/items.json`.",
+)
+def bulk_create(items: str) -> None:
+    """Bulk-create USER-scope fragments; returns recomputed merged views."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyAppConfigFragmentItemInput,
+        MyBulkCreateAppConfigFragmentsInput,
+    )
+
+    parsed = [MyAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.my_bulk_create(
+                MyBulkCreateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@app_config.command(name="bulk-update")
+@click.option(
+    "--items",
+    required=True,
+    help="Same shape as `bulk-create`; replaces `config` wholesale.",
+)
+def bulk_update(items: str) -> None:
+    """Bulk-update USER-scope fragments; returns recomputed merged views."""
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyAppConfigFragmentItemInput,
+        MyBulkUpdateAppConfigFragmentsInput,
+    )
+
+    parsed = [MyAppConfigFragmentItemInput.model_validate(item) for item in _load_items(items)]
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config.my_bulk_update(
+                MyBulkUpdateAppConfigFragmentsInput(items=parsed),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/v2/domains_v2/app_config.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config.py
@@ -1,0 +1,85 @@
+"""V2 SDK client for the merged AppConfig view.
+
+Replaces the legacy upsert-style domain/user app-config SDK; the new
+surface is bulk-only writes against `USER`-scope fragments plus
+merged-view reads.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+)
+
+_PATH = "/v2/app-configs"
+_FRAGMENT_PATH = "/v2/app-config-fragments"
+
+
+class V2AppConfigClient(BaseDomainClient):
+    """SDK client for the merged AppConfig view + self-service writes."""
+
+    async def scoped_search(
+        self, request: ScopedSearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Scoped merged-view search; `scope.user_ids` are OR'd and
+        RBAC-gated. Self-service is a USER-scoped search over the caller's
+        own id."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/search",
+            request=request,
+            response_model=SearchAppConfigsPayload,
+        )
+
+    async def admin_get(self, user_id: UUID, name: str) -> GetUserAppConfigPayload:
+        """Read a specific user's merged AppConfig (admin only)."""
+        return await self._client.typed_request(
+            "GET",
+            f"{_PATH}/{user_id}/{name}",
+            response_model=GetUserAppConfigPayload,
+        )
+
+    async def admin_search(self, request: SearchAppConfigsInput) -> SearchAppConfigsPayload:
+        """Cross-user merged-view search (admin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchAppConfigsPayload,
+        )
+
+    async def my_bulk_create(
+        self, request: MyBulkCreateAppConfigFragmentsInput
+    ) -> MyBulkCreateAppConfigFragmentsPayload:
+        """Bulk-create USER-scope fragments; returns recomputed merged views."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_FRAGMENT_PATH}/my/bulk-create",
+            request=request,
+            response_model=MyBulkCreateAppConfigFragmentsPayload,
+        )
+
+    async def my_bulk_update(
+        self, request: MyBulkUpdateAppConfigFragmentsInput
+    ) -> MyBulkUpdateAppConfigFragmentsPayload:
+        """Bulk-update USER-scope fragments; returns recomputed merged views."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_FRAGMENT_PATH}/my/bulk-update",
+            request=request,
+            response_model=MyBulkUpdateAppConfigFragmentsPayload,
+        )

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -1,0 +1,76 @@
+"""V2 SDK client for the app-config fragment domain.
+
+Fragments are an admin-only surface — end users interact with the merged
+``AppConfig`` view (``V2AppConfigClient``) instead. Self-service
+``my_bulk_*`` writes that return the recomputed merged view also live on
+``V2AppConfigClient`` alongside the merged-view reads.
+"""
+
+from __future__ import annotations
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload,
+    AdminBulkPurgeAppConfigFragmentsPayload,
+    AdminBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigFragmentsPayload,
+)
+
+_PATH = "/v2/app-config-fragments"
+
+
+class V2AppConfigFragmentClient(BaseDomainClient):
+    """SDK client for AppConfigFragment admin operations.
+
+    Writes are bulk-only.
+    """
+
+    async def admin_search(
+        self, request: SearchAppConfigFragmentsInput
+    ) -> SearchAppConfigFragmentsPayload:
+        """Cross-scope admin search."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchAppConfigFragmentsPayload,
+        )
+
+    async def admin_bulk_create(
+        self, request: AdminBulkCreateAppConfigFragmentsInput
+    ) -> AdminBulkCreateAppConfigFragmentsPayload:
+        """Bulk-create fragments (admin only, partial-success semantics)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-create",
+            request=request,
+            response_model=AdminBulkCreateAppConfigFragmentsPayload,
+        )
+
+    async def admin_bulk_update(
+        self, request: AdminBulkUpdateAppConfigFragmentsInput
+    ) -> AdminBulkUpdateAppConfigFragmentsPayload:
+        """Bulk-update fragments (admin only, partial-success semantics)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-update",
+            request=request,
+            response_model=AdminBulkUpdateAppConfigFragmentsPayload,
+        )
+
+    async def admin_bulk_purge(
+        self, request: AdminBulkPurgeAppConfigFragmentsInput
+    ) -> AdminBulkPurgeAppConfigFragmentsPayload:
+        """Bulk-purge fragments (admin only, partial-success semantics)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/bulk-purge",
+            request=request,
+            response_model=AdminBulkPurgeAppConfigFragmentsPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -16,6 +16,8 @@ from .config import ClientConfig
 
 if TYPE_CHECKING:
     from .domains_v2.agent import V2AgentClient
+    from .domains_v2.app_config import V2AppConfigClient
+    from .domains_v2.app_config_fragment import V2AppConfigFragmentClient
     from .domains_v2.artifact import V2ArtifactClient
     from .domains_v2.artifact_registry import V2ArtifactRegistryClient
     from .domains_v2.audit_log import V2AuditLogClient
@@ -88,6 +90,18 @@ class V2ClientRegistry:
         from .domains_v2.agent import V2AgentClient
 
         return V2AgentClient(self._client)
+
+    @cached_property
+    def app_config(self) -> V2AppConfigClient:
+        from .domains_v2.app_config import V2AppConfigClient
+
+        return V2AppConfigClient(self._client)
+
+    @cached_property
+    def app_config_fragment(self) -> V2AppConfigFragmentClient:
+        from .domains_v2.app_config_fragment import V2AppConfigFragmentClient
+
+        return V2AppConfigFragmentClient(self._client)
 
     @cached_property
     def artifact(self) -> V2ArtifactClient:

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -96,6 +96,7 @@ class EntityType(enum.StrEnum):
     ARTIFACT = "artifact"
     ARTIFACT_REGISTRY = "artifact_registry"
     APP_CONFIG = "app_config"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     NOTIFICATION_CHANNEL = "notification_channel"
     NOTIFICATION_RULE = "notification_rule"
     MODEL_DEPLOYMENT = "model_deployment"
@@ -267,6 +268,7 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
+            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -404,6 +406,7 @@ class RBACElementType(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     SESSION_TEMPLATE = "session_template"
     APP_CONFIG = "app_config"
+    APP_CONFIG_FRAGMENT = "app_config_fragment"
     MODEL_CARD = "model_card"
 
     # === Root-query-enabled entities (superadmin-only) ===

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -268,7 +268,6 @@ class EntityType(enum.StrEnum):
             cls.ARTIFACT,
             cls.ARTIFACT_REGISTRY,
             cls.APP_CONFIG,
-            cls.APP_CONFIG_FRAGMENT,
             cls.NOTIFICATION_CHANNEL,
             cls.NOTIFICATION_RULE,
             cls.MODEL_DEPLOYMENT,
@@ -406,7 +405,6 @@ class RBACElementType(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     SESSION_TEMPLATE = "session_template"
     APP_CONFIG = "app_config"
-    APP_CONFIG_FRAGMENT = "app_config_fragment"
     MODEL_CARD = "model_card"
 
     # === Root-query-enabled entities (superadmin-only) ===

--- a/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/__init__.py
@@ -1,0 +1,41 @@
+"""
+AppConfig (merged view) DTOs v2 for Manager API.
+"""
+
+from .request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    AppConfigScope,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from .response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from .types import (
+    AppConfigOrderField,
+    AppConfigScopeType,
+    OrderDirection,
+)
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigNode",
+    "AppConfigOrder",
+    "AppConfigOrderField",
+    "AppConfigScope",
+    "AppConfigScopeType",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigInput",
+    "GetUserAppConfigPayload",
+    "OrderDirection",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+    "SearchAppConfigsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/request.py
@@ -1,0 +1,106 @@
+"""
+Request DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
+
+from .types import AppConfigOrderField, OrderDirection
+
+__all__ = (
+    "AppConfigFilter",
+    "AppConfigOrder",
+    "AppConfigScope",
+    "GetUserAppConfigInput",
+    "ScopedSearchAppConfigsInput",
+    "SearchAppConfigsInput",
+)
+
+
+class GetUserAppConfigInput(BaseRequestModel):
+    """Input for reading a single merged AppConfig for a target user
+    (admin path — the `my` variant resolves the user internally)."""
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+
+
+class AppConfigFilter(BaseRequestModel):
+    """Filter for AppConfig merged-view search.
+
+    `created_at` / `updated_at` filter against the **oldest** /
+    **latest** timestamp across the contributing fragments — the
+    natural projection of "when was this config first created" and
+    "when was it last touched".
+    """
+
+    name: StringFilter | None = Field(default=None, description="Filter by policy name.")
+    user_id: UUIDFilter | None = Field(
+        default=None,
+        description="Filter by target user id (admin cross-user search only).",
+    )
+    created_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the oldest contributing fragment's creation timestamp."),
+    )
+    updated_at: DateTimeFilter | None = Field(
+        default=None,
+        description=("Filter by the latest contributing fragment's update timestamp."),
+    )
+
+
+class AppConfigOrder(BaseRequestModel):
+    """Order specification for AppConfig merged-view results."""
+
+    field: AppConfigOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+class _AppConfigSearchInputBase(BaseRequestModel):
+    filter: AppConfigFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigOrder] | None = Field(default=None, description="Order specifications.")
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return.")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip.")
+
+
+class AppConfigScope(BaseRequestModel):
+    """Scope for the scoped merged-view AppConfig query (user_ids are OR'd)."""
+
+    user_ids: list[UUID] = Field(
+        description="Target user UUIDs to scope the merged-view search to.",
+    )
+
+    @model_validator(mode="after")
+    def validate_non_empty(self) -> Self:
+        if not self.user_ids:
+            raise ValueError("AppConfigScope requires a non-empty 'user_ids'")
+        return self
+
+
+class ScopedSearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for scoped (user-restricted) merged-view AppConfig search.
+
+    `scope.user_ids` are OR'd; non-admin callers are restricted to their
+    own user by RBAC at the adapter / processor boundary. Replaces the
+    former `my` variant — self-service is just a USER-scoped search.
+    """
+
+    scope: AppConfigScope = Field(description="Scope (OR across all user_ids).")
+
+
+class SearchAppConfigsInput(_AppConfigSearchInputBase):
+    """Input for admin cross-user merged-view search.
+
+    Optional `filter.user_id` pins the search to a single user.
+    """

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -62,7 +62,7 @@ class SearchAppConfigsPayload(BaseResponseModel):
 
 
 class MyBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
-    """Payload for `bulkCreateMyAppConfigFragments`.
+    """Payload for `myBulkCreateAppConfigFragments`.
 
     Each successfully created row produces a recomputed merged
     `AppConfigNode`; failures are collected per-item.
@@ -75,7 +75,7 @@ class MyBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
 
 
 class MyBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
-    """Payload for `bulkUpdateMyAppConfigFragments`."""
+    """Payload for `myBulkUpdateAppConfigFragments`."""
 
     updated: list[AppConfigNode] = Field(
         description="Recomputed merged AppConfig views for each updated USER fragment.",

--- a/src/ai/backend/common/dto/manager/v2/app_config/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/response.py
@@ -1,0 +1,83 @@
+"""
+Response DTOs for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+
+__all__ = (
+    "AppConfigNode",
+    "MyBulkCreateAppConfigFragmentsPayload",
+    "MyBulkUpdateAppConfigFragmentsPayload",
+    "GetUserAppConfigPayload",
+    "SearchAppConfigsPayload",
+)
+
+
+class AppConfigNode(BaseResponseModel):
+    """Merged per-user AppConfig view.
+
+    `fragments` are ordered low → high merge priority (by fragment
+    `rank`). `config` is the deep-merged result, projected to `None`
+    when every contributing fragment is empty (§3 null projection).
+    """
+
+    user_id: UUID = Field(description="Target user's UUID.")
+    name: str = Field(description="Policy / config name.")
+    fragments: list[AppConfigFragmentNode] = Field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: dict[str, Any] | None = Field(
+        default=None,
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+class GetUserAppConfigPayload(BaseResponseModel):
+    """Payload for reading a single merged AppConfig."""
+
+    item: AppConfigNode | None = Field(
+        default=None,
+        description="Merged AppConfig, or null when no fragments exist for the user.",
+    )
+
+
+class SearchAppConfigsPayload(BaseResponseModel):
+    """Payload for paginated merged-view AppConfig search."""
+
+    items: list[AppConfigNode] = Field(description="AppConfigs matching the filter.")
+    total_count: int = Field(description="Total number of AppConfigs matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+class MyBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkCreateMyAppConfigFragments`.
+
+    Each successfully created row produces a recomputed merged
+    `AppConfigNode`; failures are collected per-item.
+    """
+
+    created: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class MyBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `bulkUpdateMyAppConfigFragments`."""
+
+    updated: list[AppConfigNode] = Field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config/types.py
@@ -1,0 +1,25 @@
+"""
+Common types for AppConfig (merged view) DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "AppConfigOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
+)
+
+
+class AppConfigOrderField(StrEnum):
+    """Fields available for ordering AppConfig merged-view results."""
+
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/__init__.py
@@ -1,0 +1,53 @@
+from .request import (
+    AdminAppConfigFragmentItemInput,
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    AppConfigFragmentFilter,
+    AppConfigFragmentKeyInput,
+    AppConfigFragmentOrder,
+    MyAppConfigFragmentItemInput,
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+    SearchAppConfigFragmentsInput,
+)
+from .response import (
+    AdminBulkCreateAppConfigFragmentsPayload,
+    AdminBulkPurgeAppConfigFragmentsPayload,
+    AdminBulkUpdateAppConfigFragmentsPayload,
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+    GetAppConfigFragmentPayload,
+    PurgeAppConfigFragmentKey,
+    SearchAppConfigFragmentsPayload,
+)
+from .types import (
+    AppConfigFragmentOrderField,
+    AppConfigScopeType,
+    OrderDirection,
+)
+
+__all__ = (
+    "AdminAppConfigFragmentItemInput",
+    "AdminBulkCreateAppConfigFragmentsInput",
+    "AdminBulkCreateAppConfigFragmentsPayload",
+    "AdminBulkPurgeAppConfigFragmentsInput",
+    "AdminBulkPurgeAppConfigFragmentsPayload",
+    "AdminBulkUpdateAppConfigFragmentsInput",
+    "AdminBulkUpdateAppConfigFragmentsPayload",
+    "AppConfigFragmentBulkError",
+    "AppConfigFragmentFilter",
+    "AppConfigFragmentKeyInput",
+    "AppConfigFragmentNode",
+    "AppConfigFragmentOrder",
+    "AppConfigFragmentOrderField",
+    "AppConfigScopeType",
+    "MyBulkCreateAppConfigFragmentsInput",
+    "MyBulkUpdateAppConfigFragmentsInput",
+    "GetAppConfigFragmentPayload",
+    "MyAppConfigFragmentItemInput",
+    "OrderDirection",
+    "PurgeAppConfigFragmentKey",
+    "SearchAppConfigFragmentsInput",
+    "SearchAppConfigFragmentsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -1,0 +1,121 @@
+"""
+Request DTOs for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+
+from .types import AppConfigFragmentOrderField, AppConfigScopeType, OrderDirection
+
+__all__ = (
+    "AdminAppConfigFragmentItemInput",
+    "AdminBulkCreateAppConfigFragmentsInput",
+    "AdminBulkPurgeAppConfigFragmentsInput",
+    "AdminBulkUpdateAppConfigFragmentsInput",
+    "AppConfigFragmentFilter",
+    "AppConfigFragmentKeyInput",
+    "AppConfigFragmentOrder",
+    "MyBulkCreateAppConfigFragmentsInput",
+    "MyBulkUpdateAppConfigFragmentsInput",
+    "MyAppConfigFragmentItemInput",
+    "SearchAppConfigFragmentsInput",
+)
+
+
+class AppConfigFragmentKeyInput(BaseRequestModel):
+    """Natural-key identifier for a single fragment row."""
+
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id (e.g., domain name, user id, or `public`).")
+    name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Policy name.",
+    )
+
+
+class AppConfigFragmentFilter(BaseRequestModel):
+    """Filter for app-config fragment search."""
+
+    id: UUIDFilter | None = Field(default=None, description="Filter by row id.")
+    name: StringFilter | None = Field(default=None, description="Filter by policy name.")
+    scope_type: AppConfigScopeType | None = Field(default=None, description="Filter by scope_type.")
+    scope_id: StringFilter | None = Field(default=None, description="Filter by scope_id.")
+
+
+class AppConfigFragmentOrder(BaseRequestModel):
+    """Order specification for app-config fragments."""
+
+    field: AppConfigFragmentOrderField = Field(description="Field to order by.")
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Order direction.")
+
+
+# ── Bulk mutation inputs ─────────────────────────────────────────
+
+
+class AdminAppConfigFragmentItemInput(BaseRequestModel):
+    """Per-item input for admin bulk create / update (natural key + payload)."""
+
+    key: AppConfigFragmentKeyInput = Field(description="Natural-key identifier.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw configuration payload (empty dict clears the row).",
+    )
+
+
+class AdminBulkCreateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[AdminAppConfigFragmentItemInput] = Field(description="Rows to create.")
+
+
+class AdminBulkUpdateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[AdminAppConfigFragmentItemInput] = Field(description="Rows to update.")
+
+
+class AdminBulkPurgeAppConfigFragmentsInput(BaseRequestModel):
+    keys: list[AppConfigFragmentKeyInput] = Field(description="Natural keys to purge.")
+
+
+class MyAppConfigFragmentItemInput(BaseRequestModel):
+    """Per-item input for self-service (`my`) bulk — `scope_type`
+    / `scope_id` are server-injected, so `name` is the only identifier.
+    """
+
+    name: str = Field(description="Policy name.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw configuration payload (empty dict clears the row).",
+    )
+
+
+class MyBulkCreateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[MyAppConfigFragmentItemInput] = Field(description="USER-scope rows to create.")
+
+
+class MyBulkUpdateAppConfigFragmentsInput(BaseRequestModel):
+    items: list[MyAppConfigFragmentItemInput] = Field(description="USER-scope rows to update.")
+
+
+class SearchAppConfigFragmentsInput(BaseRequestModel):
+    """Input for searching fragments (raw rows) with filter / order / pagination.
+
+    Supports two pagination modes (mutually exclusive):
+    - Cursor-based: first/after (forward) or last/before (backward)
+    - Offset-based: limit/offset
+    """
+
+    filter: AppConfigFragmentFilter | None = Field(default=None, description="Filter conditions.")
+    order: list[AppConfigFragmentOrder] | None = Field(
+        default=None, description="Order specifications."
+    )
+    first: int | None = Field(default=None, ge=1, description="Number of items from the start.")
+    after: str | None = Field(default=None, description="Cursor to paginate forward from.")
+    last: int | None = Field(default=None, ge=1, description="Number of items from the end.")
+    before: str | None = Field(default=None, description="Cursor to paginate backward from.")
+    limit: int | None = Field(default=None, ge=1, le=1000, description="Maximum items to return.")
+    offset: int | None = Field(default=None, ge=0, description="Number of items to skip.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -1,0 +1,100 @@
+"""
+Response DTOs for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+from .types import AppConfigScopeType
+
+__all__ = (
+    "AdminBulkCreateAppConfigFragmentsPayload",
+    "AdminBulkPurgeAppConfigFragmentsPayload",
+    "AdminBulkUpdateAppConfigFragmentsPayload",
+    "AppConfigFragmentBulkError",
+    "AppConfigFragmentNode",
+    "GetAppConfigFragmentPayload",
+    "PurgeAppConfigFragmentKey",
+    "SearchAppConfigFragmentsPayload",
+)
+
+
+class AppConfigFragmentNode(BaseResponseModel):
+    """Node representing a single fragment row (raw per-scope payload)."""
+
+    id: AppConfigFragmentID = Field(description="Row ID.")
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id.")
+    name: str = Field(description="Config name.")
+    rank: int = Field(description="Merge priority within `name` (low → high).")
+    config: dict[str, Any] | None = Field(
+        default=None, description="Raw configuration payload, or null."
+    )
+    created_at: datetime = Field(description="Creation timestamp.")
+    updated_at: datetime = Field(description="Last update timestamp.")
+
+
+class GetAppConfigFragmentPayload(BaseResponseModel):
+    """Payload returned after reading a single fragment by natural key."""
+
+    item: AppConfigFragmentNode | None = Field(default=None, description="Fragment data, or null.")
+
+
+class SearchAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for paginated fragment search results."""
+
+    items: list[AppConfigFragmentNode] = Field(description="Fragments matching the filter.")
+    total_count: int = Field(description="Total number of fragments matching the filter.")
+    has_next_page: bool = Field(default=False, description="Whether there is a next page.")
+    has_previous_page: bool = Field(default=False, description="Whether there is a previous page.")
+
+
+# ── Bulk mutation payloads (bulk-only writes) ────────────────────
+
+
+class AppConfigFragmentBulkError(BaseResponseModel):
+    """Per-item failure information for bulk Fragment mutations."""
+
+    index: int = Field(description="Original position in the input list.")
+    scope_type: AppConfigScopeType = Field(description="Scope type of the failed row.")
+    scope_id: str = Field(description="Scope id of the failed row.")
+    name: str = Field(description="Policy name of the failed row.")
+    message: str = Field(description="Reason for the failure.")
+
+
+class PurgeAppConfigFragmentKey(BaseResponseModel):
+    """Natural-key identifier returned by bulk purge payloads."""
+
+    scope_type: AppConfigScopeType = Field(description="Scope type.")
+    scope_id: str = Field(description="Scope id.")
+    name: str = Field(description="Policy name.")
+
+
+class AdminBulkCreateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkCreateAppConfigFragments`."""
+
+    created: list[AppConfigFragmentNode] = Field(description="Created fragments.")
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkUpdateAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkUpdateAppConfigFragments`."""
+
+    updated: list[AppConfigFragmentNode] = Field(description="Updated fragments.")
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")
+
+
+class AdminBulkPurgeAppConfigFragmentsPayload(BaseResponseModel):
+    """Payload for `adminBulkPurgeAppConfigFragments`."""
+
+    purged: list[PurgeAppConfigFragmentKey] = Field(
+        description="Keys of rows actually removed (absent keys are no-oped).",
+    )
+    failed: list[AppConfigFragmentBulkError] = Field(description="Per-item failures.")

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
@@ -1,0 +1,34 @@
+"""
+Common types for app_config_fragment DTO v2.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "AppConfigFragmentOrderField",
+    "AppConfigScopeType",
+    "OrderDirection",
+)
+
+
+class AppConfigScopeType(StrEnum):
+    """Scope types for app-config fragments."""
+
+    PUBLIC = "public"
+    DOMAIN = "domain"
+    DOMAIN_USER_DEFAULTS = "domain_user_defaults"
+    USER = "user"
+
+
+class AppConfigFragmentOrderField(StrEnum):
+    """Fields available for ordering app-config fragments."""
+
+    SCOPE_TYPE = "scope_type"
+    SCOPE_ID = "scope_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/types.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 
 __all__ = (
@@ -13,15 +14,6 @@ __all__ = (
     "AppConfigScopeType",
     "OrderDirection",
 )
-
-
-class AppConfigScopeType(StrEnum):
-    """Scope types for app-config fragments."""
-
-    PUBLIC = "public"
-    DOMAIN = "domain"
-    DOMAIN_USER_DEFAULTS = "domain_user_defaults"
-    USER = "user"
 
 
 class AppConfigFragmentOrderField(StrEnum):

--- a/src/ai/backend/common/identifier/app_config_fragment.py
+++ b/src/ai/backend/common/identifier/app_config_fragment.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("AppConfigFragmentID",)
+
+
+AppConfigFragmentID = NewType("AppConfigFragmentID", UUID)

--- a/src/ai/backend/common/metrics/metric.py
+++ b/src/ai/backend/common/metrics/metric.py
@@ -417,6 +417,8 @@ class DomainType(enum.StrEnum):
 class LayerType(enum.StrEnum):
     # Repository layers with _REPOSITORY suffix
     AGENT_REPOSITORY = "agent_repository"
+    APP_CONFIG_FRAGMENT_ADMIN_REPOSITORY = "app_config_fragment_admin_repository"
+    APP_CONFIG_FRAGMENT_REPOSITORY = "app_config_fragment_repository"
     AUTH_REPOSITORY = "auth_repository"
     ARTIFACT_REPOSITORY = "artifact_repository"
     ARTIFACT_REGISTRY_REPOSITORY = "artifact_registry_repository"
@@ -459,6 +461,7 @@ class LayerType(enum.StrEnum):
     REPLICA_GROUP_REPOSITORY = "replica_group_repository"
 
     # DB Source layers
+    APP_CONFIG_FRAGMENT_DB_SOURCE = "app_config_fragment_db_source"
     AUDIT_LOG_DB_SOURCE = "audit_log_db_source"
     AUTH_DB_SOURCE = "auth_db_source"
     AGENT_DB_SOURCE = "agent_db_source"

--- a/src/ai/backend/manager/api/adapters/app_config.py
+++ b/src/ai/backend/manager/api/adapters/app_config.py
@@ -1,0 +1,278 @@
+"""AppConfig (merged view) domain adapter
+
+Reads the per-user merged AppConfig view and writes the underlying USER
+fragments via the same `app_config_fragment` service processors. The
+merged-view surface lives on its own adapter (separate from
+`AppConfigFragmentAdapter`) so each adapter handles a single domain
+DTO surface — convention in this repo.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter,
+    AppConfigOrder,
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    AppConfigNode,
+    GetUserAppConfigPayload,
+    MyBulkCreateAppConfigFragmentsPayload,
+    MyBulkUpdateAppConfigFragmentsPayload,
+    SearchAppConfigsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config.types import AppConfigOrderField, OrderDirection
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigScopeType as DTOAppConfigScopeType,
+)
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+    MyAppConfigFragmentBulkItem,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
+from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
+    MyBulkCreateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update import (
+    MyBulkUpdateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    UserAppConfigTarget,
+)
+
+from .base import BaseAdapter
+
+
+class AppConfigAdapter(BaseAdapter):
+    """Adapter for the merged AppConfig view.
+
+    Backed by the `app_config_fragment` service processors — the merged
+    view is computed from raw fragments — but exposed as a separate
+    transport-layer surface so the Fragment adapter stays focused on
+    raw-row operations.
+    """
+
+    # ── Reads ────────────────────────────────────────────────────────
+
+    async def my_app_config(self, name: str) -> GetUserAppConfigPayload:
+        """Read the caller's own merged AppConfig for `name`.
+
+        Resolves the current user from the context; there is no way to
+        target another user through this method.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=me.user_id, config_name=name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def admin_get_user_app_config(
+        self, input: GetUserAppConfigInput
+    ) -> GetUserAppConfigPayload:
+        """Read a specific user's merged AppConfig (admin only)."""
+        result = await self._processors.app_config_fragment.get_user_app_config.wait_for_complete(
+            GetUserAppConfigAction(user_id=input.user_id, config_name=input.name)
+        )
+        return GetUserAppConfigPayload(item=self._data_to_dto(result.app_config))
+
+    async def scoped_search_app_configs(
+        self, input: ScopedSearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Scoped merged-view search; `scope.user_ids` are OR'd and each
+        target is RBAC-gated per item before the service runs. Self-service
+        is just a USER-scoped search over the caller's own user_id.
+        """
+        querier = self._build_querier_from_input(input)
+        targets: list[SearchableActionTarget] = [
+            UserAppConfigTarget(user_id=user_id) for user_id in input.scope.user_ids
+        ]
+        result = (
+            await self._processors.app_config_fragment.scoped_search_app_configs.wait_for_complete(
+                ScopedSearchAppConfigsAction(items=targets, querier=querier)
+            )
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, input: SearchAppConfigsInput
+    ) -> SearchAppConfigsPayload:
+        """Cross-user merged-view search (admin only).
+
+        `filter.user_id` pins the query to a single user; otherwise
+        pagination walks across every user.
+        """
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment_admin.admin_search_app_configs.wait_for_complete(
+            AdminSearchAppConfigsAction(querier=querier)
+        )
+        return SearchAppConfigsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    # ── Self-service bulk writes ───────────────────────
+
+    async def my_bulk_create(
+        self, input: MyBulkCreateAppConfigFragmentsInput
+    ) -> MyBulkCreateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_create.wait_for_complete(
+            MyBulkCreateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkCreateAppConfigFragmentsPayload(
+            created=[self._data_to_dto(item) for item in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def my_bulk_update(
+        self, input: MyBulkUpdateAppConfigFragmentsInput
+    ) -> MyBulkUpdateAppConfigFragmentsPayload:
+        items = [
+            MyAppConfigFragmentBulkItem(name=item.name, config=dict(item.config))
+            for item in input.items
+        ]
+        result = await self._processors.app_config_fragment.my_bulk_update.wait_for_complete(
+            MyBulkUpdateAppConfigFragmentsAction(items=items)
+        )
+        return MyBulkUpdateAppConfigFragmentsPayload(
+            updated=[self._data_to_dto(item) for item in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    # ── Querier / DTO helpers ────────────────────────────────────────
+
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
+    def _build_querier_from_input(
+        self,
+        input: ScopedSearchAppConfigsInput | SearchAppConfigsInput,
+    ) -> BatchQuerier:
+        """Querier builder for the merged-view searches.
+
+        The merged-view SQL resolves cursor / order internally via the
+        repository layer; this helper forwards only the filter / order /
+        pagination fields so cursor tiebreakers stay consistent with
+        the raw-fragment querier.
+        """
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=self._PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.name is not None:
+            condition = self.convert_string_filter(
+                filter.name,
+                contains_factory=AppConfigFragmentConditions.by_name_contains,
+                equals_factory=AppConfigFragmentConditions.by_name_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_name_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_name_ends_with,
+                in_factory=AppConfigFragmentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        # `filter.user_id` handling lives inside the merged-view SQL
+        # (repository layer) rather than in a BatchQuerier condition —
+        # see `AppConfigFragmentDBSource.admin_search_app_configs`.
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigOrderField.NAME:
+                    result.append(AppConfigFragmentOrders.name(ascending))
+                case AppConfigOrderField.USER_ID:
+                    # USER_ID ordering is applied inside the merged-view SQL
+                    # because the raw `app_config_fragments` row does not
+                    # carry a user_id column directly.
+                    continue
+        return result
+
+    def _data_to_dto(self, data: AppConfigData) -> AppConfigNode:
+        return AppConfigNode(
+            user_id=data.user_id,
+            name=data.name,
+            fragments=[self._fragment_data_to_dto(fragment) for fragment in data.fragments],
+            config=dict(data.config) if data.config is not None else None,
+        )
+
+    @staticmethod
+    def _fragment_data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
+            scope_id=data.scope_id,
+            name=data.name,
+            config=dict(data.config) if data.config is not None else None,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        return AppConfigFragmentBulkError(
+            index=err.index,
+            scope_type=DTOAppConfigScopeType(err.scope_type),
+            scope_id=err.scope_id,
+            name=err.name,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/app_config_fragment.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment.py
@@ -1,0 +1,297 @@
+"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    AppConfigFragmentFilter,
+    AppConfigFragmentKeyInput,
+    AppConfigFragmentOrder,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload,
+    AdminBulkPurgeAppConfigFragmentsPayload,
+    AdminBulkUpdateAppConfigFragmentsPayload,
+    AppConfigFragmentBulkError,
+    AppConfigFragmentNode,
+    GetAppConfigFragmentPayload,
+    PurgeAppConfigFragmentKey,
+    SearchAppConfigFragmentsPayload,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigFragmentOrderField,
+    OrderDirection,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
+    AppConfigScopeType as AppConfigScopeTypeDTO,
+)
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItem,
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigScopeType,
+)
+from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
+from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigFragmentSearchScope,
+)
+from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
+    AdminBulkCreateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_purge import (
+    AdminBulkPurgeAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_update import (
+    AdminBulkUpdateAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
+    AdminSearchAppConfigFragmentsAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get import GetAppConfigFragmentAction
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+)
+
+from .base import BaseAdapter
+
+_PAGINATION_SPEC = PaginationSpec(
+    forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+    backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+    forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+    backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+    tiebreaker_order=AppConfigFragmentRow.id.asc(),
+)
+
+
+class AppConfigFragmentAdapter(BaseAdapter):
+    """Adapter for AppConfigFragment domain operations.
+
+    Writes are bulk-only; single-item create / update / purge entry
+    points are intentionally absent. Self-service my_bulk methods are
+    added with the merged-view DTOs in BA-5829.
+    """
+
+    async def get(self, key_input: AppConfigFragmentKeyInput) -> GetAppConfigFragmentPayload:
+        key = self._input_to_key(key_input)
+        result = await self._processors.app_config_fragment.get.wait_for_complete(
+            GetAppConfigFragmentAction(key=key)
+        )
+        return GetAppConfigFragmentPayload(
+            item=self._data_to_dto(result.fragment),
+        )
+
+    async def search(
+        self,
+        scope_type: AppConfigScopeType,
+        scope_id: str,
+        input: SearchAppConfigFragmentsInput,
+    ) -> SearchAppConfigFragmentsPayload:
+        """Scope-bound search — caller pins `(scope_type, scope_id)` so
+        non-admin users only see fragments within their own scope.
+        """
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment.search.wait_for_complete(
+            SearchAppConfigFragmentsAction(
+                scope=AppConfigFragmentSearchScope(
+                    scope_type=scope_type,
+                    scope_id=scope_id,
+                ),
+                querier=querier,
+            )
+        )
+        return SearchAppConfigFragmentsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search(
+        self, input: SearchAppConfigFragmentsInput
+    ) -> SearchAppConfigFragmentsPayload:
+        """Cross-scope admin search — authorization is enforced upstream."""
+        querier = self._build_querier_from_input(input)
+        result = await self._processors.app_config_fragment_admin.admin_search.wait_for_complete(
+            AdminSearchAppConfigFragmentsAction(querier=querier)
+        )
+        return SearchAppConfigFragmentsPayload(
+            items=[self._data_to_dto(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    def _build_querier_from_input(self, input: SearchAppConfigFragmentsInput) -> BatchQuerier:
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _convert_filter(self, filter: AppConfigFragmentFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if filter.id is not None:
+            condition = self.convert_uuid_filter(
+                filter.id,
+                equals_factory=AppConfigFragmentConditions.by_id_equals,
+                in_factory=AppConfigFragmentConditions.by_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.name is not None:
+            condition = self.convert_string_filter(
+                filter.name,
+                contains_factory=AppConfigFragmentConditions.by_name_contains,
+                equals_factory=AppConfigFragmentConditions.by_name_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_name_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_name_ends_with,
+                in_factory=AppConfigFragmentConditions.by_name_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if filter.scope_type is not None:
+            conditions.append(
+                AppConfigFragmentConditions.by_scope_type_equals(filter.scope_type.value)
+            )
+        if filter.scope_id is not None:
+            condition = self.convert_string_filter(
+                filter.scope_id,
+                contains_factory=AppConfigFragmentConditions.by_scope_id_contains,
+                equals_factory=AppConfigFragmentConditions.by_scope_id_equals,
+                starts_with_factory=AppConfigFragmentConditions.by_scope_id_starts_with,
+                ends_with_factory=AppConfigFragmentConditions.by_scope_id_ends_with,
+                in_factory=AppConfigFragmentConditions.by_scope_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[AppConfigFragmentOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for order in orders:
+            ascending = order.direction == OrderDirection.ASC
+            match order.field:
+                case AppConfigFragmentOrderField.SCOPE_TYPE:
+                    result.append(AppConfigFragmentOrders.scope_type(ascending))
+                case AppConfigFragmentOrderField.SCOPE_ID:
+                    result.append(AppConfigFragmentOrders.scope_id(ascending))
+                case AppConfigFragmentOrderField.NAME:
+                    result.append(AppConfigFragmentOrders.name(ascending))
+                case AppConfigFragmentOrderField.CREATED_AT:
+                    result.append(AppConfigFragmentOrders.created_at(ascending))
+                case AppConfigFragmentOrderField.UPDATED_AT:
+                    result.append(AppConfigFragmentOrders.updated_at(ascending))
+        return result
+
+    @staticmethod
+    def _input_to_key(key_input: AppConfigFragmentKeyInput) -> AppConfigFragmentKey:
+        return AppConfigFragmentKey(
+            scope_type=AppConfigScopeType(key_input.scope_type.value),
+            scope_id=key_input.scope_id,
+            name=key_input.name,
+        )
+
+    @staticmethod
+    def _data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
+        return AppConfigFragmentNode(
+            id=data.id,
+            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_id=data.scope_id,
+            name=data.name,
+            rank=data.rank,
+            config=dict(data.config) if data.config is not None else None,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+    # ── Bulk mutations ─────────────────────────────────────────────
+
+    async def admin_bulk_create(
+        self, input: AdminBulkCreateAppConfigFragmentsInput
+    ) -> AdminBulkCreateAppConfigFragmentsPayload:
+        items = [
+            AppConfigFragmentBulkItem(
+                key=self._input_to_key(item.key),
+                config=dict(item.config),
+            )
+            for item in input.items
+        ]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_create.wait_for_complete(
+                AdminBulkCreateAppConfigFragmentsAction(items=items)
+            )
+        )
+        return AdminBulkCreateAppConfigFragmentsPayload(
+            created=[self._data_to_dto(fragment) for fragment in result.created],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_update(
+        self, input: AdminBulkUpdateAppConfigFragmentsInput
+    ) -> AdminBulkUpdateAppConfigFragmentsPayload:
+        items = [
+            AppConfigFragmentBulkItem(
+                key=self._input_to_key(item.key),
+                config=dict(item.config),
+            )
+            for item in input.items
+        ]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_update.wait_for_complete(
+                AdminBulkUpdateAppConfigFragmentsAction(items=items)
+            )
+        )
+        return AdminBulkUpdateAppConfigFragmentsPayload(
+            updated=[self._data_to_dto(fragment) for fragment in result.updated],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    async def admin_bulk_purge(
+        self, input: AdminBulkPurgeAppConfigFragmentsInput
+    ) -> AdminBulkPurgeAppConfigFragmentsPayload:
+        keys = [self._input_to_key(key) for key in input.keys]
+        result = (
+            await self._processors.app_config_fragment_admin.admin_bulk_purge.wait_for_complete(
+                AdminBulkPurgeAppConfigFragmentsAction(keys=keys)
+            )
+        )
+        return AdminBulkPurgeAppConfigFragmentsPayload(
+            purged=[
+                PurgeAppConfigFragmentKey(
+                    scope_type=AppConfigScopeTypeDTO(key.scope_type.value),
+                    scope_id=key.scope_id,
+                    name=key.name,
+                )
+                for key in result.purged
+            ],
+            failed=[self._bulk_error_to_dto(err) for err in result.failed],
+        )
+
+    @staticmethod
+    def _bulk_error_to_dto(err: AppConfigFragmentBulkItemError) -> AppConfigFragmentBulkError:
+        return AppConfigFragmentBulkError(
+            index=err.index,
+            scope_type=AppConfigScopeTypeDTO(err.scope_type),
+            scope_id=err.scope_id,
+            name=err.name,
+            message=err.message,
+        )

--- a/src/ai/backend/manager/api/adapters/app_config_fragment.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment.py
@@ -1,4 +1,8 @@
-"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer."""
+"""AppConfigFragment domain adapter — Pydantic-in / Pydantic-out transport layer.
+
+Raw fragment-row operations only. The merged-view (AppConfig) surface
+and the self-service `my_bulk_*` writes live on `AppConfigAdapter`.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +30,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     OrderDirection,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
-    AppConfigScopeType as AppConfigScopeTypeDTO,
+    AppConfigScopeType as DTOAppConfigScopeType,
 )
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.data.app_config_fragment.bulk_types import (
@@ -41,9 +45,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.models.app_config_fragment.conditions import AppConfigFragmentConditions
 from ai.backend.manager.models.app_config_fragment.orders import AppConfigFragmentOrders
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    AppConfigFragmentSearchScope,
-)
+from ai.backend.manager.repositories.app_config_fragment.types import AppConfigFragmentSearchScope
 from ai.backend.manager.repositories.base import BatchQuerier, QueryCondition, QueryOrder
 from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
     AdminBulkCreateAppConfigFragmentsAction,
@@ -64,21 +66,14 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
 
 from .base import BaseAdapter
 
-_PAGINATION_SPEC = PaginationSpec(
-    forward_order=AppConfigFragmentOrders.created_at(ascending=False),
-    backward_order=AppConfigFragmentOrders.created_at(ascending=True),
-    forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
-    backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
-    tiebreaker_order=AppConfigFragmentRow.id.asc(),
-)
-
 
 class AppConfigFragmentAdapter(BaseAdapter):
-    """Adapter for AppConfigFragment domain operations.
+    """Adapter for AppConfigFragment raw-row operations.
 
-    Writes are bulk-only; single-item create / update / purge entry
-    points are intentionally absent. Self-service my_bulk methods are
-    added with the merged-view DTOs in BA-5829.
+    Writes are bulk-only; single-item create / update /
+    purge entry points are intentionally absent. Self-service my_bulk
+    writes (which return the recomputed merged view) live on
+    `AppConfigAdapter` alongside the merged-view reads.
     """
 
     async def get(self, key_input: AppConfigFragmentKeyInput) -> GetAppConfigFragmentPayload:
@@ -131,13 +126,21 @@ class AppConfigFragmentAdapter(BaseAdapter):
             has_previous_page=result.has_previous_page,
         )
 
+    _PAGINATION_SPEC = PaginationSpec(
+        forward_order=AppConfigFragmentOrders.created_at(ascending=False),
+        backward_order=AppConfigFragmentOrders.created_at(ascending=True),
+        forward_condition_factory=AppConfigFragmentConditions.by_cursor_forward,
+        backward_condition_factory=AppConfigFragmentConditions.by_cursor_backward,
+        tiebreaker_order=AppConfigFragmentRow.id.asc(),
+    )
+
     def _build_querier_from_input(self, input: SearchAppConfigFragmentsInput) -> BatchQuerier:
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
         return self._build_querier(
             conditions=conditions,
             orders=orders,
-            pagination_spec=_PAGINATION_SPEC,
+            pagination_spec=self._PAGINATION_SPEC,
             first=input.first,
             after=input.after,
             last=input.last,
@@ -214,7 +217,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     def _data_to_dto(data: AppConfigFragmentData) -> AppConfigFragmentNode:
         return AppConfigFragmentNode(
             id=data.id,
-            scope_type=AppConfigScopeTypeDTO(data.scope_type.value),
+            scope_type=DTOAppConfigScopeType(data.scope_type.value),
             scope_id=data.scope_id,
             name=data.name,
             rank=data.rank,
@@ -223,7 +226,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             updated_at=data.updated_at,
         )
 
-    # ── Bulk mutations ─────────────────────────────────────────────
+    # ── Bulk mutations ───────────────────────────────
 
     async def admin_bulk_create(
         self, input: AdminBulkCreateAppConfigFragmentsInput
@@ -268,7 +271,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     async def admin_bulk_purge(
         self, input: AdminBulkPurgeAppConfigFragmentsInput
     ) -> AdminBulkPurgeAppConfigFragmentsPayload:
-        keys = [self._input_to_key(key) for key in input.keys]
+        keys = [self._input_to_key(key_input) for key_input in input.keys]
         result = (
             await self._processors.app_config_fragment_admin.admin_bulk_purge.wait_for_complete(
                 AdminBulkPurgeAppConfigFragmentsAction(keys=keys)
@@ -277,7 +280,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         return AdminBulkPurgeAppConfigFragmentsPayload(
             purged=[
                 PurgeAppConfigFragmentKey(
-                    scope_type=AppConfigScopeTypeDTO(key.scope_type.value),
+                    scope_type=DTOAppConfigScopeType(key.scope_type.value),
                     scope_id=key.scope_id,
                     name=key.name,
                 )
@@ -287,10 +290,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def _bulk_error_to_dto(err: AppConfigFragmentBulkItemError) -> AppConfigFragmentBulkError:
+    def _bulk_error_to_dto(
+        err: AppConfigFragmentBulkItemError,
+    ) -> AppConfigFragmentBulkError:
+        """Convert the service-layer error dataclass to its DTO mirror."""
         return AppConfigFragmentBulkError(
             index=err.index,
-            scope_type=AppConfigScopeTypeDTO(err.scope_type),
+            scope_type=DTOAppConfigScopeType(err.scope_type),
             scope_id=err.scope_id,
             name=err.name,
             message=err.message,

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
 from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
@@ -72,6 +73,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config_fragment: AppConfigFragmentAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
         audit_log: AuditLogAdapter,
@@ -113,6 +115,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config_fragment = app_config_fragment
         self.artifact = artifact
         self.artifact_registry = artifact_registry
         self.audit_log = audit_log
@@ -173,6 +176,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config_fragment=AppConfigFragmentAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.api.adapters.app_config import AppConfigAdapter
 from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
@@ -73,6 +74,7 @@ class Adapters:
     def __init__(
         self,
         agent: AgentAdapter,
+        app_config: AppConfigAdapter,
         app_config_fragment: AppConfigFragmentAdapter,
         artifact: ArtifactAdapter,
         artifact_registry: ArtifactRegistryAdapter,
@@ -115,6 +117,7 @@ class Adapters:
         vfs_storage: VFSStorageAdapter,
     ) -> None:
         self.agent = agent
+        self.app_config = app_config
         self.app_config_fragment = app_config_fragment
         self.artifact = artifact
         self.artifact_registry = artifact_registry
@@ -176,6 +179,7 @@ class Adapters:
         """
         return cls(
             agent=AgentAdapter(processors),
+            app_config=AppConfigAdapter(processors),
             app_config_fragment=AppConfigFragmentAdapter(processors),
             artifact=ArtifactAdapter(processors),
             artifact_registry=ArtifactRegistryAdapter(processors),

--- a/src/ai/backend/manager/api/gql/app_config/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/__init__.py
@@ -1,0 +1,29 @@
+"""AppConfig (merged view) GraphQL API package."""
+
+from .resolver import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .types import (
+    AppConfigConnectionGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+    AppConfigScopeGQL,
+)
+
+__all__ = [
+    # Queries
+    "scoped_app_configs",
+    "admin_app_configs",
+    "public_app_config_fragments",
+    # Types
+    "AppConfigGQL",
+    "AppConfigConnectionGQL",
+    "AppConfigFilterGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/__init__.py
@@ -1,0 +1,11 @@
+from .query import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+
+__all__ = [
+    "admin_app_configs",
+    "public_app_config_fragments",
+    "scoped_app_configs",
+]

--- a/src/ai/backend/manager/api/gql/app_config/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config/resolver/query.py
@@ -1,0 +1,181 @@
+"""AppConfig (merged view) GQL query resolvers."""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigFilterGQL,
+    AppConfigGQL,
+    AppConfigOrderByGQL,
+    AppConfigScopeGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+
+
+def _app_config_id(user_id: object, name: str) -> str:
+    """Composite Relay id for the merged view (keyed by `(user_id, name)`)."""
+    return f"{user_id}:{name}"
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Scoped merged-view AppConfig search (auth required, RBAC-gated). "
+            "`scope.userIds` are OR'd; non-admin callers are restricted to "
+            "their own user. Self-service is just a USER-scoped search."
+        ),
+    )
+)  # type: ignore[misc]
+async def scoped_app_configs(
+    info: Info[StrawberryGQLContext],
+    scope: AppConfigScopeGQL,
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    payload = await info.context.adapters.app_config.scoped_search_app_configs(
+        ScopedSearchAppConfigsInput(
+            scope=scope.to_pydantic(),
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Cross-user merged-view search (admin only). Resolves any user's "
+            "AppConfig for audit / support. Pin to a single user with "
+            "`filter.userId`; otherwise paginates across all users."
+        ),
+    )
+)  # type: ignore[misc]
+async def admin_app_configs(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFilterGQL | None = None,
+    order_by: list[AppConfigOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config.admin_search_app_configs(
+        SearchAppConfigsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [
+        AppConfigGQL.from_pydantic(item, extra={"id": _app_config_id(item.user_id, item.name)})
+        for item in payload.items
+    ]
+    edges = [AppConfigEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Public (no-auth) `PUBLIC`-scope app-config fragments — the subset of "
+            "raw fragments that carry no personally-scoped data."
+        ),
+    )
+)  # type: ignore[misc]
+async def public_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> list[AppConfigFragmentGQL]:
+    payload = await info.context.adapters.app_config_fragment.search(
+        scope_type=AppConfigScopeType.PUBLIC,
+        scope_id=AppConfigScopeType.PUBLIC.value,
+        input=SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]

--- a/src/ai/backend/manager/api/gql/app_config/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/__init__.py
@@ -1,0 +1,21 @@
+from .filters import (
+    AppConfigFilterGQL,
+    AppConfigOrderByGQL,
+    AppConfigOrderFieldGQL,
+)
+from .node import (
+    AppConfigConnectionGQL,
+    AppConfigEdgeGQL,
+    AppConfigGQL,
+)
+from .scope import AppConfigScopeGQL
+
+__all__ = [
+    "AppConfigConnectionGQL",
+    "AppConfigEdgeGQL",
+    "AppConfigFilterGQL",
+    "AppConfigGQL",
+    "AppConfigOrderByGQL",
+    "AppConfigOrderFieldGQL",
+    "AppConfigScopeGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/bulk_payloads.py
@@ -1,0 +1,55 @@
+"""AppConfig (merged-view) GQL payloads for self-service bulk mutations."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkCreateAppConfigFragmentsPayload as MyBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.response import (
+    MyBulkUpdateAppConfigFragmentsPayload as MyBulkUpdatePayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.node import AppConfigGQL
+from ai.backend.manager.api.gql.app_config_fragment.types.bulk_payloads import (
+    AppConfigFragmentBulkErrorGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkCreateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkCreatePayloadDTO,
+    name="MyBulkCreateAppConfigFragmentsPayload",
+)
+class MyBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkCreatePayloadDTO]):
+    created: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each created USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `myBulkUpdateAppConfigFragments` (recomputed views).",
+    ),
+    model=MyBulkUpdatePayloadDTO,
+    name="MyBulkUpdateAppConfigFragmentsPayload",
+)
+class MyBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[MyBulkUpdatePayloadDTO]):
+    updated: list[AppConfigGQL] = gql_field(
+        description="Recomputed merged AppConfig views for each updated USER fragment.",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(
+        description="Per-item failures.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/filters.py
@@ -1,0 +1,78 @@
+"""AppConfig (merged view) GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigFilter as AppConfigFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    AppConfigOrder as AppConfigOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import (
+    DateTimeFilter,
+    OrderDirection,
+    StringFilter,
+    UUIDFilter,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying merged AppConfigs.",
+    ),
+    name="AppConfigFilter",
+)
+class AppConfigFilterGQL(PydanticInputMixin[AppConfigFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    user_id: UUIDFilter | None = gql_field(
+        description="Filter by target user id (admin cross-user search only).",
+        default=None,
+    )
+    created_at: DateTimeFilter | None = gql_field(
+        description="Filter by the oldest contributing fragment's creation timestamp.",
+        default=None,
+    )
+    updated_at: DateTimeFilter | None = gql_field(
+        description="Filter by the latest contributing fragment's update timestamp.",
+        default=None,
+    )
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering merged AppConfigs.",
+    ),
+    name="AppConfigOrderField",
+)
+class AppConfigOrderFieldGQL(StrEnum):
+    USER_ID = "user_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for merged AppConfig results.",
+    ),
+    name="AppConfigOrderBy",
+)
+class AppConfigOrderByGQL(PydanticInputMixin[AppConfigOrderDTO]):
+    field: AppConfigOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.ASC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/node.py
@@ -1,0 +1,75 @@
+"""AppConfig (merged view) GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+import strawberry
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config.response import AppConfigNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Merged per-user AppConfig view. `id` is the composite "
+            "`{userId}:{name}` (the merged view is a derived value, not a "
+            "table row); `fragments` are ordered low → high merge priority; "
+            "`config` is the deep-merge result and is null when every "
+            "contributing fragment is empty."
+        ),
+    ),
+    name="AppConfig",
+)
+class AppConfigGQL(PydanticNodeMixin[AppConfigNode]):
+    id: NodeID[str] = gql_field(description="Composite id `{userId}:{name}`.")
+    user_id: UUID = gql_field(description="Target user's UUID.")
+    name: str = gql_field(description="Policy / config name.")
+    # Use `strawberry.lazy()` to break the import cycle between
+    # `app_config.types.node` and `app_config_fragment.types.node`:
+    # the fragment package's `__init__.py` eagerly loads its resolver,
+    # which imports `MyBulkCreate*` payloads back from `app_config.types`.
+    fragments: list[
+        Annotated[
+            AppConfigFragmentGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.app_config_fragment.types.node"),
+        ]
+    ] = gql_field(
+        description="Contributing fragments in merge order (low → high).",
+    )
+    config: JSON | None = gql_field(
+        description="Deep-merged configuration, or null when every fragment is empty.",
+    )
+
+
+AppConfigEdgeGQL = Edge[AppConfigGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated merged AppConfig results.",
+    ),
+    name="AppConfigConnection",
+)
+class AppConfigConnectionGQL(Connection[AppConfigGQL]):
+    count: int = gql_field(description="Total number of AppConfigs matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/app_config/types/scope.py
+++ b/src/ai/backend/manager/api/gql/app_config/types/scope.py
@@ -1,0 +1,30 @@
+"""AppConfig (merged view) GraphQL scope input types."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.common.dto.manager.v2.app_config.request import AppConfigScope
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Scope for the scoped merged-view AppConfig query. "
+            "`userIds` are OR'd; raises an error when empty."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="AppConfigScope",
+)
+class AppConfigScopeGQL(PydanticInputMixin[AppConfigScope]):
+    user_ids: list[UUID] = gql_field(
+        description="Target user UUIDs to scope the merged-view search to (OR'd).",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
@@ -1,0 +1,9 @@
+"""AppConfigFragment GraphQL API package.
+
+Resolver and type names are re-exported by ``schema.py`` directly via
+their submodules to keep this package's ``__init__`` import-light: a
+top-level ``from app_config_fragment import ...`` would otherwise drag
+in the mutation resolvers, which back-import from
+``app_config.types.bulk_payloads`` and form an import cycle when
+``AppConfigGQL`` is loading.
+"""

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/__init__.py
@@ -1,0 +1,21 @@
+from .mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
+
+__all__ = [
+    "admin_app_config_fragments",
+    "admin_bulk_create_app_config_fragments",
+    "admin_bulk_purge_app_config_fragments",
+    "admin_bulk_update_app_config_fragments",
+    "app_config_fragment",
+    "my_bulk_create_app_config_fragments",
+    "my_bulk_update_app_config_fragments",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/mutation.py
@@ -1,0 +1,112 @@
+"""AppConfigFragment GQL mutation resolvers (bulk-only)."""
+
+from __future__ import annotations
+
+from strawberry import Info
+
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config.types.bulk_payloads import (
+    MyBulkCreateAppConfigFragmentsPayloadGQL,
+    MyBulkUpdateAppConfigFragmentsPayloadGQL,
+)
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert across any scope; each item runs in its own transaction "
+            "and failures are collected per-item (admin only)."
+        ),
+    )
+)
+async def admin_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkCreateAppConfigFragmentInputGQL,
+) -> AdminBulkCreateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_create(input.to_pydantic())
+    return AdminBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale JSON replacement; items with no existing row are returned as failures "
+            "(admin only)."
+        ),
+    )
+)
+async def admin_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkUpdateAppConfigFragmentInputGQL,
+) -> AdminBulkUpdateAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_update(input.to_pydantic())
+    return AdminBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cleanup-only deletion; absent keys are no-oped (admin only).",
+    )
+)
+async def admin_bulk_purge_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: AdminBulkPurgeAppConfigFragmentInputGQL,
+) -> AdminBulkPurgeAppConfigFragmentsPayloadGQL:
+    check_admin_only()
+    result = await info.context.adapters.app_config_fragment.admin_bulk_purge(input.to_pydantic())
+    return AdminBulkPurgeAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Strict insert on the caller's USER row; duplicates fail per-item. "
+            "Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_create_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkCreateAppConfigFragmentInputGQL,
+) -> MyBulkCreateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_create(input.to_pydantic())
+    return MyBulkCreateAppConfigFragmentsPayloadGQL.from_pydantic(result)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Wholesale replacement on the caller's USER row; missing rows are returned as "
+            "failures. Returns recomputed merged `AppConfig` views."
+        ),
+    )
+)
+async def my_bulk_update_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    input: MyBulkUpdateAppConfigFragmentInputGQL,
+) -> MyBulkUpdateAppConfigFragmentsPayloadGQL:
+    result = await info.context.adapters.app_config.my_bulk_update(input.to_pydantic())
+    return MyBulkUpdateAppConfigFragmentsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver/query.py
@@ -1,0 +1,103 @@
+"""AppConfigFragment GQL query resolvers.
+
+Per the scope-bound list is exposed via child fields on
+`DomainV2.appConfigFragments` / `UserV2.appConfigFragments`, not as a
+root resolver. Only the single-row read and the cross-scope admin
+search live here. The scope-bound REST endpoint
+`POST /v2/app-config-fragments/{scope_type}/{scope_id}/search`
+continues to use the adapter's `search()` method directly.
+"""
+
+from __future__ import annotations
+
+import strawberry
+from strawberry import Info
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentGQL,
+    AppConfigFragmentOrderByGQL,
+)
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Get a single app-config fragment by natural key "
+            "`(scope_type, scope_id, name)`. Available to any authenticated user "
+            "— service-layer authorization gates cross-scope reads."
+        ),
+    )
+)  # type: ignore[misc]
+async def app_config_fragment(
+    info: Info[StrawberryGQLContext],
+    scope_type: AppConfigScopeType,
+    scope_id: str,
+    name: str,
+) -> AppConfigFragmentGQL | None:
+    payload = await info.context.adapters.app_config_fragment.get(
+        AppConfigFragmentKeyInput(scope_type=scope_type, scope_id=scope_id, name=name)
+    )
+    if payload.item is None:
+        return None
+    return AppConfigFragmentGQL.from_pydantic(payload.item)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Cross-scope admin search across all app-config fragments (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_app_config_fragments(
+    info: Info[StrawberryGQLContext],
+    filter: AppConfigFragmentFilterGQL | None = None,
+    order_by: list[AppConfigFragmentOrderByGQL] | None = None,
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> AppConfigFragmentConnectionGQL:
+    check_admin_only()
+    payload = await info.context.adapters.app_config_fragment.admin_search(
+        SearchAppConfigFragmentsInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=[o.to_pydantic() for o in order_by] if order_by else None,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    edges = [AppConfigFragmentEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes]
+    return AppConfigFragmentConnectionGQL(
+        edges=edges,
+        page_info=strawberry.relay.PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/__init__.py
@@ -1,0 +1,51 @@
+from .bulk_inputs import (
+    AdminAppConfigFragmentItemInputGQL,
+    AdminBulkCreateAppConfigFragmentInputGQL,
+    AdminBulkPurgeAppConfigFragmentInputGQL,
+    AdminBulkUpdateAppConfigFragmentInputGQL,
+    MyAppConfigFragmentItemInputGQL,
+    MyBulkCreateAppConfigFragmentInputGQL,
+    MyBulkUpdateAppConfigFragmentInputGQL,
+)
+from .bulk_payloads import (
+    AdminBulkCreateAppConfigFragmentsPayloadGQL,
+    AdminBulkPurgeAppConfigFragmentsPayloadGQL,
+    AdminBulkUpdateAppConfigFragmentsPayloadGQL,
+    AppConfigFragmentBulkErrorGQL,
+    PurgeAppConfigFragmentKeyGQL,
+)
+from .filters import (
+    AppConfigFragmentFilterGQL,
+    AppConfigFragmentOrderByGQL,
+    AppConfigFragmentOrderFieldGQL,
+)
+from .inputs import AppConfigFragmentKeyInputGQL
+from .node import (
+    AppConfigFragmentConnectionGQL,
+    AppConfigFragmentEdgeGQL,
+    AppConfigFragmentGQL,
+    AppConfigScopeTypeGQL,
+)
+
+__all__ = [
+    "AdminAppConfigFragmentItemInputGQL",
+    "AdminBulkCreateAppConfigFragmentInputGQL",
+    "AdminBulkCreateAppConfigFragmentsPayloadGQL",
+    "AdminBulkPurgeAppConfigFragmentInputGQL",
+    "AdminBulkPurgeAppConfigFragmentsPayloadGQL",
+    "AdminBulkUpdateAppConfigFragmentInputGQL",
+    "AdminBulkUpdateAppConfigFragmentsPayloadGQL",
+    "AppConfigFragmentBulkErrorGQL",
+    "AppConfigFragmentConnectionGQL",
+    "AppConfigFragmentEdgeGQL",
+    "AppConfigFragmentFilterGQL",
+    "AppConfigFragmentGQL",
+    "AppConfigFragmentKeyInputGQL",
+    "AppConfigFragmentOrderByGQL",
+    "AppConfigFragmentOrderFieldGQL",
+    "AppConfigScopeTypeGQL",
+    "MyBulkCreateAppConfigFragmentInputGQL",
+    "MyBulkUpdateAppConfigFragmentInputGQL",
+    "MyAppConfigFragmentItemInputGQL",
+    "PurgeAppConfigFragmentKeyGQL",
+]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_inputs.py
@@ -1,0 +1,120 @@
+"""AppConfigFragment bulk-mutation GQL input types."""
+
+from __future__ import annotations
+
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminAppConfigFragmentItemInput as AdminItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput as AdminBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkPurgeAppConfigFragmentsInput as AdminBulkPurgeInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkUpdateAppConfigFragmentsInput as AdminBulkUpdateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyAppConfigFragmentItemInput as MyItemInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkCreateAppConfigFragmentsInput as MyBulkCreateInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    MyBulkUpdateAppConfigFragmentsInput as MyBulkUpdateInputDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.inputs import (
+    AppConfigFragmentKeyInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for admin bulk create / update.",
+    ),
+    name="AdminAppConfigFragmentItemInput",
+)
+class AdminAppConfigFragmentItemInputGQL(PydanticInputMixin[AdminItemInputDTO]):
+    key: AppConfigFragmentKeyInputGQL = gql_field(description="Natural-key identifier.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk create input — items carry any scope.",
+    ),
+    name="AdminBulkCreateAppConfigFragmentInput",
+)
+class AdminBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkCreateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to create.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk update input.",
+    ),
+    name="AdminBulkUpdateAppConfigFragmentInput",
+)
+class AdminBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkUpdateInputDTO]):
+    items: list[AdminAppConfigFragmentItemInputGQL] = gql_field(description="Rows to update.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Admin bulk purge input — keyed on `AppConfigFragmentKey`.",
+    ),
+    name="AdminBulkPurgeAppConfigFragmentInput",
+)
+class AdminBulkPurgeAppConfigFragmentInputGQL(PydanticInputMixin[AdminBulkPurgeInputDTO]):
+    keys: list[AppConfigFragmentKeyInputGQL] = gql_field(description="Natural keys to purge.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item input for self-service (`my`) bulk.",
+    ),
+    name="MyAppConfigFragmentItemInput",
+)
+class MyAppConfigFragmentItemInputGQL(PydanticInputMixin[MyItemInputDTO]):
+    name: str = gql_field(description="Policy name.")
+    config: JSON = gql_field(description="Raw configuration payload.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk create — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkCreateAppConfigFragmentInput",
+)
+class MyBulkCreateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkCreateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to create.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Self-service bulk update — scope is `USER` / `current_user`.",
+    ),
+    name="MyBulkUpdateAppConfigFragmentInput",
+)
+class MyBulkUpdateAppConfigFragmentInputGQL(PydanticInputMixin[MyBulkUpdateInputDTO]):
+    items: list[MyAppConfigFragmentItemInputGQL] = gql_field(
+        description="USER-scope rows to update.",
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/bulk_payloads.py
@@ -1,0 +1,105 @@
+"""AppConfigFragment bulk-mutation GQL payload types (admin only).
+
+Self-service `my_*` bulk payloads return recomputed merged AppConfig
+views, so they live in `app_config/types/bulk_payloads.py` to keep the
+import direction `app_config -> app_config_fragment` (one-way) and
+avoid a circular import.
+"""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkCreateAppConfigFragmentsPayload as AdminBulkCreatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkPurgeAppConfigFragmentsPayload as AdminBulkPurgePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AdminBulkUpdateAppConfigFragmentsPayload as AdminBulkUpdatePayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentBulkError as AppConfigFragmentBulkErrorDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    PurgeAppConfigFragmentKey as PurgeAppConfigFragmentKeyDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.app_config_fragment.types.node import AppConfigFragmentGQL
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Per-item failure info for bulk Fragment mutations.",
+    ),
+    model=AppConfigFragmentBulkErrorDTO,
+    name="AppConfigFragmentBulkError",
+)
+class AppConfigFragmentBulkErrorGQL(PydanticOutputMixin[AppConfigFragmentBulkErrorDTO]):
+    index: int = gql_field(description="Original position in the input list.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type of the failed row.")
+    scope_id: str = gql_field(description="Scope id of the failed row.")
+    name: str = gql_field(description="Policy name of the failed row.")
+    message: str = gql_field(description="Reason for the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key of a purged fragment row.",
+    ),
+    model=PurgeAppConfigFragmentKeyDTO,
+    name="PurgeAppConfigFragmentKey",
+)
+class PurgeAppConfigFragmentKeyGQL(PydanticOutputMixin[PurgeAppConfigFragmentKeyDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkCreateAppConfigFragments`.",
+    ),
+    model=AdminBulkCreatePayloadDTO,
+    name="AdminBulkCreateAppConfigFragmentsPayload",
+)
+class AdminBulkCreateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkCreatePayloadDTO]):
+    created: list[AppConfigFragmentGQL] = gql_field(description="Created fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkUpdateAppConfigFragments`.",
+    ),
+    model=AdminBulkUpdatePayloadDTO,
+    name="AdminBulkUpdateAppConfigFragmentsPayload",
+)
+class AdminBulkUpdateAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkUpdatePayloadDTO]):
+    updated: list[AppConfigFragmentGQL] = gql_field(description="Updated fragments.")
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload for `adminBulkPurgeAppConfigFragments`.",
+    ),
+    model=AdminBulkPurgePayloadDTO,
+    name="AdminBulkPurgeAppConfigFragmentsPayload",
+)
+class AdminBulkPurgeAppConfigFragmentsPayloadGQL(PydanticOutputMixin[AdminBulkPurgePayloadDTO]):
+    purged: list[PurgeAppConfigFragmentKeyGQL] = gql_field(
+        description="Keys of rows actually removed (absent keys are no-oped).",
+    )
+    failed: list[AppConfigFragmentBulkErrorGQL] = gql_field(description="Per-item failures.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/filters.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL filter / order types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentFilter as AppConfigFragmentFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentOrder as AppConfigFragmentOrderDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter input for querying app-config fragments.",
+    ),
+    name="AppConfigFragmentFilter",
+)
+class AppConfigFragmentFilterGQL(PydanticInputMixin[AppConfigFragmentFilterDTO]):
+    name: StringFilter | None = gql_field(description="Filter by policy name.", default=None)
+    scope_id: StringFilter | None = gql_field(description="Filter by scope_id.", default=None)
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Fields available for ordering app-config fragments.",
+    ),
+    name="AppConfigFragmentOrderField",
+)
+class AppConfigFragmentOrderFieldGQL(StrEnum):
+    SCOPE_TYPE = "scope_type"
+    SCOPE_ID = "scope_id"
+    NAME = "name"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Specifies ordering for app-config fragment results.",
+    ),
+    name="AppConfigFragmentOrderBy",
+)
+class AppConfigFragmentOrderByGQL(PydanticInputMixin[AppConfigFragmentOrderDTO]):
+    field: AppConfigFragmentOrderFieldGQL = gql_field(description="The field to order by.")
+    direction: OrderDirection = gql_field(
+        description="Sort direction.",
+        default=OrderDirection.DESC,
+    )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/inputs.py
@@ -1,0 +1,28 @@
+"""AppConfigFragment GQL natural-key input shared by bulk types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AppConfigFragmentKeyInput as AppConfigFragmentKeyInputDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Natural key for an app-config fragment row.",
+    ),
+    name="AppConfigFragmentKeyInput",
+)
+class AppConfigFragmentKeyInputGQL(PydanticInputMixin[AppConfigFragmentKeyInputDTO]):
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Policy name.")

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types/node.py
@@ -1,0 +1,63 @@
+"""AppConfigFragment GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+from strawberry.scalars import JSON
+
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import AppConfigFragmentNode
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+# The shared DTO enum is auto-registered by Strawberry the first time it
+# is referenced as a typed field. Re-export under the ``GQL`` suffix so
+# other modules can write `from ... import AppConfigScopeTypeGQL`. Calling
+# `strawberry.enum(...)` here would clash with that auto-registration
+# under the same `"AppConfigScopeType"` name.
+AppConfigScopeTypeGQL = AppConfigScopeType
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Raw per-scope app-config fragment.",
+    ),
+    name="AppConfigFragment",
+)
+class AppConfigFragmentGQL(PydanticNodeMixin[AppConfigFragmentNode]):
+    id: NodeID[str] = gql_field(description="Fragment row UUID.")
+    scope_type: AppConfigScopeType = gql_field(description="Scope type.")
+    scope_id: str = gql_field(description="Scope id.")
+    name: str = gql_field(description="Config name.")
+    rank: int = gql_field(description="Merge priority within `name` (low → high).")
+    config: JSON | None = gql_field(description="Raw configuration payload, or null.")
+    created_at: datetime = gql_field(description="Creation timestamp.")
+    updated_at: datetime | None = gql_field(description="Last update timestamp.")
+
+
+AppConfigFragmentEdgeGQL = Edge[AppConfigFragmentGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Connection type for paginated app-config fragment results.",
+    ),
+    name="AppConfigFragmentConnection",
+)
+class AppConfigFragmentConnectionGQL(Connection[AppConfigFragmentGQL]):
+    count: int = gql_field(description="Total number of fragments matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
     from ai.backend.manager.api.adapters.registry import Adapters  # pants: no-infer-dep
     from ai.backend.manager.api.gql.agent.types import AgentV2GQL  # pants: no-infer-dep
+    from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+        AppConfigFragmentGQL,
+    )
     from ai.backend.manager.api.gql.artifact.types import (  # pants: no-infer-dep
         ArtifactRevision,
     )
@@ -115,6 +118,38 @@ class DataLoaders:
 
     def __init__(self, adapters: Adapters) -> None:
         self._adapters = adapters
+
+    @cached_property
+    def app_config_fragment_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, AppConfigFragmentGQL | None]:
+        adapter = self._adapters.app_config_fragment
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[AppConfigFragmentGQL | None]:
+            from ai.backend.common.dto.manager.query import UUIDFilter  # pants: no-infer-dep
+            from ai.backend.common.dto.manager.v2.app_config_fragment.request import (  # pants: no-infer-dep
+                AppConfigFragmentFilter,
+                SearchAppConfigFragmentsInput,
+            )
+            from ai.backend.common.identifier.app_config_fragment import (  # pants: no-infer-dep
+                AppConfigFragmentID,
+            )
+            from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
+                AppConfigFragmentGQL as F,
+            )
+
+            if not ids:
+                return []
+            payload = await adapter.admin_search(
+                SearchAppConfigFragmentsInput(
+                    filter=AppConfigFragmentFilter(id=UUIDFilter.model_validate({"in": list(ids)})),
+                    limit=len(ids),
+                ),
+            )
+            by_id = {dto.id: F.from_pydantic(dto) for dto in payload.items}
+            return [by_id.get(AppConfigFragmentID(fragment_id)) for fragment_id in ids]
+
+        return DataLoader(load_fn=load_fn)
 
     @cached_property
     def audit_log_loader(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -15,6 +15,22 @@ from .agent import (
     agent_stats,
     agents_v2,
 )
+from .app_config import (
+    admin_app_configs,
+    public_app_config_fragments,
+    scoped_app_configs,
+)
+from .app_config_fragment.resolver.mutation import (
+    admin_bulk_create_app_config_fragments,
+    admin_bulk_purge_app_config_fragments,
+    admin_bulk_update_app_config_fragments,
+    my_bulk_create_app_config_fragments,
+    my_bulk_update_app_config_fragments,
+)
+from .app_config_fragment.resolver.query import (
+    admin_app_config_fragments,
+    app_config_fragment,
+)
 from .artifact import (
     approve_artifact_revision,
     artifact,
@@ -523,6 +539,13 @@ class Query:
     resource_slot_type = resource_slot_type
     resource_slot_types = resource_slot_types
     admin_image_aliases = admin_image_aliases
+    # App Config Fragment APIs
+    app_config_fragment = app_config_fragment
+    admin_app_config_fragments = admin_app_config_fragments
+    public_app_config_fragments = public_app_config_fragments
+    # App Config merged view APIs
+    scoped_app_configs = scoped_app_configs
+    admin_app_configs = admin_app_configs
     # Prometheus Query Preset APIs (read available to any authenticated user)
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
@@ -804,6 +827,12 @@ class Mutation:
     admin_unblock_user = admin_unblock_user
     # IP allowlist self-service mutation
     update_my_allowed_client_ip = update_my_allowed_client_ip
+    # App Config Fragment - Bulk mutations
+    admin_bulk_create_app_config_fragments = admin_bulk_create_app_config_fragments
+    admin_bulk_update_app_config_fragments = admin_bulk_update_app_config_fragments
+    admin_bulk_purge_app_config_fragments = admin_bulk_purge_app_config_fragments
+    my_bulk_create_app_config_fragments = my_bulk_create_app_config_fragments
+    my_bulk_update_app_config_fragments = my_bulk_update_app_config_fragments
     # Prometheus Query Preset - Admin APIs
     admin_create_prometheus_query_preset = admin_create_prometheus_query_preset
     admin_modify_prometheus_query_preset = admin_modify_prometheus_query_preset

--- a/src/ai/backend/manager/api/rest/v2/app_config/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/handler.py
@@ -1,0 +1,69 @@
+"""REST v2 handler for the AppConfig merged-view domain."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.app_config.request import (
+    GetUserAppConfigInput,
+    ScopedSearchAppConfigsInput,
+    SearchAppConfigsInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import (
+    AppConfigUserNamePathParam,
+)
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.app_config import AppConfigAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2AppConfigHandler:
+    """REST v2 handler for the merged-view `AppConfig` surface.
+
+    Mounted at `/v2/app-configs/...`. The merged view is computed from
+    fragment rows joined against `app_config_policies` and is exposed via
+    its own `AppConfigAdapter`. Search has exactly two variants — scoped
+    (non-admin, scope required) and admin (superadmin, no scope). There is
+    no `my` variant: self-service is just a USER-scoped search.
+    """
+
+    def __init__(self, *, adapter: AppConfigAdapter) -> None:
+        self._adapter = adapter
+
+    # ── Scoped (non-admin) ───────────────────────────────────────
+
+    async def scoped_search(
+        self,
+        body: BodyParam[ScopedSearchAppConfigsInput],
+    ) -> APIResponse:
+        """Scoped merged-view search; `scope.userIds` are OR'd and
+        RBAC-gated. Self-service is a USER-scoped search over the
+        caller's own id."""
+        result = await self._adapter.scoped_search_app_configs(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    # ── Admin ────────────────────────────────────────────────────
+
+    async def admin_get(
+        self,
+        path: PathParam[AppConfigUserNamePathParam],
+    ) -> APIResponse:
+        """Read a specific user's merged AppConfig (admin only)."""
+        result = await self._adapter.admin_get_user_app_config(
+            GetUserAppConfigInput(user_id=path.parsed.user_id, name=path.parsed.name)
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_search(
+        self,
+        body: BodyParam[SearchAppConfigsInput],
+    ) -> APIResponse:
+        """Cross-user merged-view search (admin only)."""
+        result = await self._adapter.admin_search_app_configs(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config/registry.py
@@ -1,0 +1,35 @@
+"""Route registration for v2 AppConfig merged-view endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2AppConfigHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_app_config_routes(
+    handler: V2AppConfigHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all v2 `/v2/app-configs/*` routes.
+
+    Read-only surface — writes go through `/v2/app-config-fragments/...`
+    (§4). Search has two variants: scoped (non-admin, scope in the body)
+    and admin (superadmin). There is no `/my/...` route — self-service is
+    a USER-scoped search.
+    """
+    reg = RouteRegistry.create("app-configs", route_deps.cors_options)
+
+    # Scoped (non-admin) — scope required in the request body
+    reg.add("POST", "/scoped/search", handler.scoped_search, middlewares=[auth_required])
+    # Admin
+    reg.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
+    reg.add("GET", "/{user_id}/{name}", handler.admin_get, middlewares=[superadmin_required])
+
+    return reg

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -1,0 +1,136 @@
+"""REST v2 handler for the app-config fragment domain.
+
+Writes are **bulk-only** per BEP §3 — the single-item create / update /
+purge endpoints were removed in favour of `/bulk-create`,
+`/bulk-update`, `/bulk-purge` (admin) and `/my/bulk-create`,
+`/my/bulk-update` (self-service).
+"""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+    AdminBulkCreateAppConfigFragmentsInput,
+    AdminBulkPurgeAppConfigFragmentsInput,
+    AdminBulkUpdateAppConfigFragmentsInput,
+    AppConfigFragmentKeyInput,
+    MyBulkCreateAppConfigFragmentsInput,
+    MyBulkUpdateAppConfigFragmentsInput,
+    SearchAppConfigFragmentsInput,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.types import AppConfigScopeType
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import AppConfigFragmentScopePathParam
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigScopeType as DataAppConfigScopeType,
+)
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.app_config import AppConfigAdapter
+    from ai.backend.manager.api.adapters.app_config_fragment import AppConfigFragmentAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2AppConfigFragmentHandler:
+    """REST v2 handler for app-config fragment operations.
+
+    Self-service `my_bulk_*` writes return recomputed merged
+    `AppConfig` views, so they are dispatched to `AppConfigAdapter`;
+    everything else is the raw-row Fragment surface.
+    """
+
+    def __init__(
+        self,
+        *,
+        adapter: AppConfigFragmentAdapter,
+        app_config_adapter: AppConfigAdapter,
+    ) -> None:
+        self._adapter = adapter
+        self._app_config_adapter = app_config_adapter
+
+    # ── Reads ────────────────────────────────────────────────────
+
+    async def get(
+        self,
+        body: BodyParam[AppConfigFragmentKeyInput],
+    ) -> APIResponse:
+        """Read a single fragment by natural key (any authenticated user)."""
+        result = await self._adapter.get(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def scoped_search(
+        self,
+        path: PathParam[AppConfigFragmentScopePathParam],
+        body: BodyParam[SearchAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Scope-bound fragment search — caller is pinned to a specific
+        `(scope_type, scope_id)` pair via the URL path.
+        """
+        result = await self._adapter.search(
+            scope_type=DataAppConfigScopeType(path.parsed.scope_type),
+            scope_id=path.parsed.scope_id,
+            input=body.parsed,
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_search(
+        self,
+        body: BodyParam[SearchAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Cross-scope admin search (admin only)."""
+        result = await self._adapter.admin_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    # ── Admin bulk writes ──────────────────────────
+
+    async def admin_bulk_create(
+        self,
+        body: BodyParam[AdminBulkCreateAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Strict insert across any scope; per-item transactions (admin only)."""
+        result = await self._adapter.admin_bulk_create(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_bulk_update(
+        self,
+        body: BodyParam[AdminBulkUpdateAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Wholesale JSON replacement; per-item transactions (admin only)."""
+        result = await self._adapter.admin_bulk_update(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_bulk_purge(
+        self,
+        body: BodyParam[AdminBulkPurgeAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Cleanup-only deletion; absent keys are no-oped (admin only)."""
+        result = await self._adapter.admin_bulk_purge(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    # ── Self-service bulk writes ───────────────────
+
+    async def my_bulk_create(
+        self,
+        body: BodyParam[MyBulkCreateAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Self-service bulk create on the caller's `USER` row."""
+        result = await self._app_config_adapter.my_bulk_create(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_bulk_update(
+        self,
+        body: BodyParam[MyBulkUpdateAppConfigFragmentsInput],
+    ) -> APIResponse:
+        """Self-service bulk update on the caller's `USER` row."""
+        result = await self._app_config_adapter.my_bulk_update(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+
+# ``AppConfigScopeType`` is imported for OpenAPI schema visibility of the
+# string-form path parameter; keep the import alive.
+_ = AppConfigScopeType

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -1,0 +1,48 @@
+"""Route registration for v2 app-config fragment endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2AppConfigFragmentHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_app_config_fragment_routes(
+    handler: V2AppConfigFragmentHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all v2 app-config fragment routes.
+
+    - `POST /get` reads a single row via body (three-field natural key).
+    - Scoped search mounts at `/{scope_type}/{scope_id}/search`.
+    - Admin cross-scope search + bulk writes are admin-only.
+    - `/my/bulk-create` and `/my/bulk-update` are self-service writes
+      on the caller's `USER` row (no `/my/bulk-purge` — admin-only
+      cleanup ).
+    """
+    reg = RouteRegistry.create("app-config-fragments", route_deps.cors_options)
+
+    # Reads
+    reg.add("POST", "/get", handler.get, middlewares=[auth_required])
+    reg.add(
+        "POST",
+        "/{scope_type}/{scope_id}/search",
+        handler.scoped_search,
+        middlewares=[auth_required],
+    )
+    reg.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
+    # Admin bulk writes (bulk-only)
+    reg.add("POST", "/bulk-create", handler.admin_bulk_create, middlewares=[superadmin_required])
+    reg.add("POST", "/bulk-update", handler.admin_bulk_update, middlewares=[superadmin_required])
+    reg.add("POST", "/bulk-purge", handler.admin_bulk_purge, middlewares=[superadmin_required])
+    # Self-service bulk writes
+    reg.add("POST", "/my/bulk-create", handler.my_bulk_create, middlewares=[auth_required])
+    reg.add("POST", "/my/bulk-update", handler.my_bulk_update, middlewares=[auth_required])
+
+    return reg

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -10,6 +10,17 @@ from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.identifier.role_preset import RolePresetID
 
 
+class AppConfigFragmentScopePathParam(BaseRequestModel):
+    scope_type: str = Field(description="App-config scope type (public/domain/user/...).")
+    scope_id: str = Field(description="Scope id (domain name, user id, or `public`).")
+
+
+class AppConfigUserNamePathParam(BaseRequestModel):
+    user_id: UUID = Field(description="Target user's UUID (admin only).")
+    name: str = Field(description="Config name.")
+
+
+
 class DomainNamePathParam(BaseRequestModel):
     domain_name: str = Field(description="Domain name")
 

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -28,6 +28,10 @@ def build_v2_routes(
     # Lazy imports to avoid circular dependencies at module level
     from .agent.handler import V2AgentHandler
     from .agent.registry import register_v2_agent_routes
+    from .app_config.handler import V2AppConfigHandler
+    from .app_config.registry import register_v2_app_config_routes
+    from .app_config_fragment.handler import V2AppConfigFragmentHandler
+    from .app_config_fragment.registry import register_v2_app_config_fragment_routes
     from .artifact.handler import V2ArtifactHandler
     from .artifact.registry import register_v2_artifact_routes
     from .artifact_registry.handler import V2ArtifactRegistryHandler
@@ -117,6 +121,11 @@ def build_v2_routes(
 
     # Build all handlers (each takes its individual adapter)
     agent_handler = V2AgentHandler(adapter=adapters.agent)
+    app_config_handler = V2AppConfigHandler(adapter=adapters.app_config)
+    app_config_fragment_handler = V2AppConfigFragmentHandler(
+        adapter=adapters.app_config_fragment,
+        app_config_adapter=adapters.app_config,
+    )
     artifact_handler = V2ArtifactHandler(adapter=adapters.artifact)
     artifact_registry_handler = V2ArtifactRegistryHandler(adapter=adapters.artifact_registry)
     audit_log_handler = V2AuditLogHandler(adapter=adapters.audit_log)
@@ -174,6 +183,10 @@ def build_v2_routes(
 
     # Add all domain sub-registries
     v2_reg.add_subregistry(register_v2_agent_routes(agent_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_app_config_routes(app_config_handler, route_deps))
+    v2_reg.add_subregistry(
+        register_v2_app_config_fragment_routes(app_config_fragment_handler, route_deps)
+    )
     v2_reg.add_subregistry(register_v2_artifact_routes(artifact_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_artifact_registry_routes(artifact_registry_handler, route_deps)

--- a/src/ai/backend/manager/data/app_config/types.py
+++ b/src/ai/backend/manager/data/app_config/types.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+
+
+@dataclass(frozen=True)
+class AppConfigData:
+    """Service-layer return type for the merged AppConfig view.
+
+    `fragments` are ordered low → high merge priority (by fragment
+    `rank`). `config` is the deep-merged result, projected to `None`
+    when every contributing fragment is empty.
+    """
+
+    user_id: uuid.UUID
+    name: str
+    fragments: Sequence[AppConfigFragmentData]
+    config: Mapping[str, Any] | None
+
+
+@dataclass(frozen=True)
+class AppConfigSearchResult:
+    """Result from searching merged `AppConfig` views."""
+
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool

--- a/src/ai/backend/manager/data/app_config_fragment/bulk_types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/bulk_types.py
@@ -1,0 +1,44 @@
+"""Bulk-mutation service-layer dataclasses for app_config_fragments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentKey
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentBulkItem:
+    """One item for `adminBulkCreate/Update` — natural key + payload."""
+
+    key: AppConfigFragmentKey
+    config: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class MyAppConfigFragmentBulkItem:
+    """One item for `bulkCreate/UpdateMy` — `name` + payload.
+
+    `scope_type` is always `USER` and `scope_id` is resolved from the
+    current user at the adapter layer.
+    """
+
+    name: str
+    config: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentBulkItemError:
+    """Per-item failure carried through bulk action results.
+
+    `scope_type` / `scope_id` / `name` identify which input row failed;
+    `index` preserves the caller's original list position.
+    """
+
+    index: int
+    scope_type: str
+    scope_id: str
+    name: str
+    message: str

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+
+__all__ = (
+    "DEFAULT_RANK_BY_SCOPE_TYPE",
+    "AppConfigFragmentData",
+    "AppConfigFragmentKey",
+    "AppConfigFragmentSearchResult",
+    "AppConfigScopeType",
+    "default_rank_for_scope_type",
+)
+
+# Tier-based default merge `rank` per scope_type (low → high merge priority).
+# Gaps of 100 leave room for explicit overrides between tiers.
+DEFAULT_RANK_BY_SCOPE_TYPE: Mapping[AppConfigScopeType, int] = {
+    AppConfigScopeType.PUBLIC: 100,
+    AppConfigScopeType.DOMAIN: 200,
+    AppConfigScopeType.DOMAIN_USER_DEFAULTS: 300,
+    AppConfigScopeType.USER: 400,
+}
+
+
+def default_rank_for_scope_type(scope_type: AppConfigScopeType | str) -> int:
+    """Merge `rank` default derived from `scope_type` (low → high priority)."""
+    return DEFAULT_RANK_BY_SCOPE_TYPE[AppConfigScopeType(scope_type)]
+
+
+@dataclass(frozen=True, slots=True)
+class AppConfigFragmentKey:
+    """Natural-key identifier for a single `app_config_fragments` row."""
+
+    scope_type: AppConfigScopeType
+    scope_id: str
+    name: str
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentData:
+    id: AppConfigFragmentID
+    scope_type: AppConfigScopeType
+    scope_id: str
+    name: str
+    rank: int
+    config: Mapping[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+
+    @property
+    def key(self) -> AppConfigFragmentKey:
+        return AppConfigFragmentKey(
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            name=self.name,
+        )
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentSearchResult:
+    """Result from searching raw `app_config_fragments` rows."""
+
+    items: list[AppConfigFragmentData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -1,0 +1,35 @@
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+from ai.backend.manager.errors.common import ObjectNotFound
+
+
+class AppConfigFragmentConflict(BackendAIError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/app-config-fragment-conflict"
+    error_title = (
+        "An app config fragment with the same (scope_type, scope_id, name) already exists."
+    )
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.BACKENDAI,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class AppConfigFragmentNotFound(ObjectNotFound):
+    object_name = "app config fragment"
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.BACKENDAI,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )

--- a/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/84d5c6daf8cc_drop_legacy_app_configs_table.py
@@ -1,7 +1,7 @@
 """drop legacy app_configs table
 
 Removes the predecessor `app_configs` table and its enum type as
-preparation for BEP-1052 (Scoped App Config Redesign). The
+preparation for the scoped app-config redesign. The
 replacement tables (`app_config_fragments`, `app_config_policies`)
 are introduced in a follow-up migration on top of this one — the
 new shape is incompatible with the old (different scope enum,

--- a/src/ai/backend/manager/models/alembic/versions/a662131d5603_add_app_config_fragments.py
+++ b/src/ai/backend/manager/models/alembic/versions/a662131d5603_add_app_config_fragments.py
@@ -1,0 +1,78 @@
+"""add app_config_fragments table
+
+Adds the per-scope raw fragment table keyed by
+`(scope_type, scope_id, name)`. `rank` (low → high) drives merge priority
+within a `name`; it defaults to a per-scope_type tier on create and is
+overridable. There is no separate policy table — `name` is a free-form
+config key.
+
+Revision ID: a662131d5603
+Revises: c6648c039bd4
+Create Date: 2026-04-24
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql as pgsql
+
+from ai.backend.manager.models.base import IDColumn
+
+# revision identifiers, used by Alembic.
+revision = "a662131d5603"
+down_revision = "c6648c039bd4"
+# Part of: 26.6.0
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_config_fragments",
+        IDColumn(),
+        sa.Column(
+            "scope_type",
+            sa.String(length=32),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("scope_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "name",
+            sa.String(length=128),
+            nullable=False,
+        ),
+        sa.Column(
+            "rank",
+            sa.Integer(),
+            nullable=False,
+        ),
+        sa.Column(
+            "config",
+            pgsql.JSONB(),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "scope_type",
+            "scope_id",
+            "name",
+            name="uq_app_config_fragments_scope_name",
+        ),
+        sa.Index("ix_app_config_fragments_name_rank", "name", "rank"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_config_fragments")

--- a/src/ai/backend/manager/models/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/models/app_config_fragment/__init__.py
@@ -1,0 +1,8 @@
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+
+from .row import AppConfigFragmentRow
+
+__all__ = (
+    "AppConfigFragmentRow",
+    "AppConfigScopeType",
+)

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -1,0 +1,191 @@
+"""Query conditions for the app_config_fragment domain."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Collection
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.repositories.base import QueryCondition
+
+
+class AppConfigFragmentConditions:
+    """QueryCondition factories for app-config fragment filtering."""
+
+    @staticmethod
+    def by_ids(fragment_ids: Collection[uuid.UUID]) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            return AppConfigFragmentRow.id.in_(fragment_ids)
+
+        return inner
+
+    @staticmethod
+    def by_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            condition = AppConfigFragmentRow.id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            condition = AppConfigFragmentRow.id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigFragmentRow.name) == spec.value.lower()
+            else:
+                condition = AppConfigFragmentRow.name == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_name_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.name.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigFragmentRow.name.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_name_in = staticmethod(make_string_in_factory(AppConfigFragmentRow.name))
+
+    @staticmethod
+    def by_scope_id_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"%{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AppConfigFragmentRow.scope_id) == spec.value.lower()
+            else:
+                condition = AppConfigFragmentRow.scope_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"{spec.value}%")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_scope_id_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AppConfigFragmentRow.scope_id.ilike(f"%{spec.value}")
+            else:
+                condition = AppConfigFragmentRow.scope_id.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_scope_id_in = staticmethod(make_string_in_factory(AppConfigFragmentRow.scope_id))
+
+    @staticmethod
+    def by_scope_type_equals(scope_type: str) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            return AppConfigFragmentRow.scope_type == scope_type
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigFragmentRow.created_at)
+                .where(AppConfigFragmentRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigFragmentRow.created_at < subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.ColumnElement[bool]:
+            subquery = (
+                sa.select(AppConfigFragmentRow.created_at)
+                .where(AppConfigFragmentRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return AppConfigFragmentRow.created_at > subquery
+
+        return inner

--- a/src/ai/backend/manager/models/app_config_fragment/orders.py
+++ b/src/ai/backend/manager/models/app_config_fragment/orders.py
@@ -1,0 +1,40 @@
+"""Query orders for the app_config_fragment domain."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import QueryOrder
+
+
+class AppConfigFragmentOrders:
+    """QueryOrder factories for app-config fragment sorting."""
+
+    @staticmethod
+    def scope_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.scope_type.asc()
+        return AppConfigFragmentRow.scope_type.desc()
+
+    @staticmethod
+    def scope_id(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.scope_id.asc()
+        return AppConfigFragmentRow.scope_id.desc()
+
+    @staticmethod
+    def name(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.name.asc()
+        return AppConfigFragmentRow.name.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.created_at.asc()
+        return AppConfigFragmentRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return AppConfigFragmentRow.updated_at.asc()
+        return AppConfigFragmentRow.updated_at.desc()

--- a/src/ai/backend/manager/models/app_config_fragment/row.py
+++ b/src/ai/backend/manager/models/app_config_fragment/row.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pgsql
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigScopeType,
+)
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+
+
+class AppConfigFragmentRow(Base):  # type: ignore[misc]
+    __tablename__ = "app_config_fragments"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "scope_type",
+            "scope_id",
+            "name",
+            name="uq_app_config_fragments_scope_name",
+        ),
+        sa.Index("ix_app_config_fragments_name_rank", "name", "rank"),
+    )
+
+    id: Mapped[AppConfigFragmentID] = mapped_column(
+        GUID(AppConfigFragmentID), primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    scope_type: Mapped[AppConfigScopeType] = mapped_column(
+        "scope_type",
+        StrEnumType(AppConfigScopeType, length=32),
+        nullable=False,
+        index=True,
+    )
+    scope_id: Mapped[str] = mapped_column(
+        "scope_id",
+        sa.String(length=255),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(
+        "name",
+        sa.String(length=128),
+        nullable=False,
+    )
+    # Merge priority within a `name` (low → high). Defaults to a per-scope_type
+    # tier on create (see `default_rank_for_scope_type`); overridable.
+    rank: Mapped[int] = mapped_column(
+        "rank",
+        sa.Integer,
+        nullable=False,
+    )
+    config: Mapped[Mapping[str, Any] | None] = mapped_column(
+        "config",
+        pgsql.JSONB,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.current_timestamp(),
+    )
+
+    def to_data(self) -> AppConfigFragmentData:
+        return AppConfigFragmentData(
+            id=self.id,
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            name=self.name,
+            rank=self.rank,
+            config=dict(self.config) if self.config is not None else None,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config.types import AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.creators import (
+    AppConfigFragmentCreatorSpec,
+)
+from ai.backend.manager.repositories.app_config_fragment.db_source import (
+    AppConfigFragmentDBSource,
+)
+from ai.backend.manager.repositories.app_config_fragment.updaters import (
+    AppConfigFragmentUpdaterSpec,
+)
+from ai.backend.manager.repositories.base.creator import Creator
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.updater import Updater
+
+app_config_fragment_admin_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_FRAGMENT_ADMIN_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigFragmentAdminRepository:
+    """Admin-only operations on AppConfigFragment.
+
+    All mutations (`create` / `update` / `purge`) and cross-scope
+    reads (`admin_search` raw, `admin_search_app_configs` merged)
+    live here — read-side scope-bound operations are on
+    `AppConfigFragmentRepository`. Authorization is enforced at the
+    service layer before reaching either repository. The required-
+    policy invariant is enforced upstream by the service layer; the
+    DB-level FK on ``app_config_fragments.name`` is the defense-in-
+    depth backstop and surfaces as a generic integrity error.
+
+    Mutations are routed through the shared Creator / Updater / Purger
+    helpers so the same execution / resilience plumbing applies as in
+    sister repositories.
+    """
+
+    _db_source: AppConfigFragmentDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = AppConfigFragmentDBSource(db)
+
+    # ── Mutations ─────────────────────────────────────────────────
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def create(
+        self,
+        key: AppConfigFragmentKey,
+        config: Mapping[str, Any],
+    ) -> AppConfigFragmentData:
+        creator: Creator[AppConfigFragmentRow] = Creator(
+            spec=AppConfigFragmentCreatorSpec(
+                scope_type=key.scope_type,
+                scope_id=key.scope_id,
+                name=key.name,
+                config=config,
+            ),
+        )
+        return await self._db_source.create(creator)
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def update(
+        self,
+        key: AppConfigFragmentKey,
+        config: Mapping[str, Any],
+    ) -> AppConfigFragmentData:
+        """Update a fragment by natural key. Resolves the natural key
+        to the row's UUID, builds an ``Updater``, and delegates to the
+        DB source. Raises :class:`AppConfigFragmentNotFound` when the
+        row is missing (or vanishes between resolve and write)."""
+        pk_value = await self._db_source.resolve_pk_by_key(key)
+        if pk_value is None:
+            raise AppConfigFragmentNotFound(
+                extra_msg=(
+                    f"scope_type={key.scope_type.value!r}, "
+                    f"scope_id={key.scope_id!r}, name={key.name!r}"
+                ),
+            )
+        updater: Updater[AppConfigFragmentRow] = Updater(
+            spec=AppConfigFragmentUpdaterSpec(config=config),
+            pk_value=pk_value,
+        )
+        result = await self._db_source.update(updater)
+        if result is None:
+            raise AppConfigFragmentNotFound(
+                extra_msg=(
+                    f"scope_type={key.scope_type.value!r}, "
+                    f"scope_id={key.scope_id!r}, name={key.name!r}"
+                ),
+            )
+        return result
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def purge(self, key: AppConfigFragmentKey) -> bool:
+        """Delete a fragment by natural key. Resolves the natural key,
+        builds a ``Purger``, and delegates to the DB source. Returns
+        ``True`` only when a row was actually removed."""
+        pk_value = await self._db_source.resolve_pk_by_key(key)
+        if pk_value is None:
+            return False
+        purger: Purger[AppConfigFragmentRow] = Purger(
+            row_class=AppConfigFragmentRow,
+            pk_value=pk_value,
+        )
+        return await self._db_source.purge(purger)
+
+    # ── Cross-scope reads ────────────────────────────────────────
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def admin_search(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigFragmentSearchResult:
+        return await self._db_source.admin_search(querier)
+
+    @app_config_fragment_admin_repository_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        return await self._db_source.admin_search_app_configs(querier)

--- a/src/ai/backend/manager/repositories/app_config_fragment/creators.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/creators.py
@@ -1,0 +1,55 @@
+"""CreatorSpec for AppConfigFragment rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.manager.data.app_config_fragment.types import default_rank_for_scope_type
+from ai.backend.manager.errors.app_config import AppConfigFragmentConflict
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
+
+
+@dataclass
+class AppConfigFragmentCreatorSpec(CreatorSpec[AppConfigFragmentRow]):
+    """CreatorSpec for `app_config_fragments`.
+
+    Maps the natural-key UNIQUE violation to a typed domain error
+    (:class:`AppConfigFragmentConflict`). `rank` (merge priority) defaults
+    to a per-scope_type tier when not explicitly provided.
+    """
+
+    scope_type: str
+    scope_id: str
+    name: str
+    config: Mapping[str, Any]
+    rank: int | None = None
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=UniqueConstraintViolationError,
+                error=AppConfigFragmentConflict(
+                    extra_msg=(
+                        f"Duplicate fragment for ({self.scope_type}, {self.scope_id}, {self.name})"
+                    ),
+                ),
+            ),
+        )
+
+    @override
+    def build_row(self) -> AppConfigFragmentRow:
+        rank = self.rank if self.rank is not None else default_rank_for_scope_type(self.scope_type)
+        return AppConfigFragmentRow(
+            scope_type=self.scope_type,
+            scope_id=self.scope_id,
+            name=self.name,
+            rank=rank,
+            config=dict(self.config),
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/__init__.py
@@ -1,0 +1,3 @@
+from .db_source import AppConfigFragmentDBSource
+
+__all__ = ("AppConfigFragmentDBSource",)

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -25,9 +25,6 @@ from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
-)
 from ai.backend.manager.repositories.base.creator import Creator, execute_creator
 from ai.backend.manager.repositories.base.purger import Purger, execute_purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
@@ -276,85 +273,26 @@ class AppConfigFragmentDBSource:
             config=merged.config,
         )
 
-    @app_config_fragment_db_source_resilience.apply()
-    async def search_user_app_configs(
-        self,
-        scope: UserAppConfigSearchScope,
-        querier: BatchQuerier,
-    ) -> AppConfigSearchResult:
-        """Connection counterpart of `get_user_app_config`. Groups the
-        scoped page of applicable fragments by `name` and feeds each group
-        through `_merge_chain` (rank-ordered) to produce one `AppConfigData`.
-
-        Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`); the per-user
-        restriction lives in the `scope_id_match` predicate while
-        `UserAppConfigSearchScope` stays a passthrough so it composes
-        with the `BatchQuerier` without double-filtering.
-        """
-        user_id = scope.user_id
-        user_domain_sq = (
-            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
-        )
-        scope_id_match = sa.case(
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
-                sa.literal("public"),
-            ),
-            (
-                AppConfigFragmentRow.scope_type.in_([
-                    AppConfigScopeType.DOMAIN,
-                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
-                ]),
-                user_domain_sq,
-            ),
-            (
-                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
-                sa.literal(str(user_id)),
-            ),
-        )
-        query = sa.select(AppConfigFragmentRow).where(
-            AppConfigFragmentRow.scope_id == scope_id_match,
-        )
-        async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
-
-        groups: dict[str, list[AppConfigFragmentRow]] = {}
-        for row in result.rows:
-            fragment_row = row.AppConfigFragmentRow
-            groups.setdefault(fragment_row.name, []).append(fragment_row)
-
-        items: list[AppConfigData] = []
-        for name, rows in groups.items():
-            merged = self._merge_chain(rows)
-            items.append(
-                AppConfigData(
-                    user_id=user_id,
-                    name=name,
-                    fragments=merged.fragments,
-                    config=merged.config,
-                )
-            )
-
-        return AppConfigSearchResult(
-            items=items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    @app_config_fragment_db_source_resilience.apply()
-    async def admin_search_app_configs(
+    async def _search_merged_app_configs(
         self,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope] | None,
     ) -> AppConfigSearchResult:
-        """Cross-user merged search (admin only). Joins `users` so each
-        `(user_id, name)` combination is produced; the scoped page of rows
-        is grouped and rank-merged the same way as `search_user_app_configs`.
+        """Cross-user merged search shared by the scoped and admin paths.
+
+        Joins `users` so each `(user_id, name)` view is produced, then
+        groups the scoped page of applicable fragments by `(user_id, name)`
+        and feeds each group through `_merge_chain` (rank-ordered) to
+        produce one `AppConfigData`.
+
+        When `scopes` is given the user set is the OR-union of those scopes
+        (each `UserAppConfigSearchScope` matches `UserRow.uuid`); `None` is
+        the global admin path. `execute_batch_querier` ORs the scopes and
+        the `(user_id, name)` grouping deduplicates any overlap — a user
+        reached via two scopes still yields exactly one AppConfig.
 
         Filtering / ordering / pagination run through the shared
-        scoped-search helper (`execute_batch_querier`) on the global
-        (unscoped) admin path.
+        scoped-search helper (`execute_batch_querier`).
         """
         scope_id_match = sa.case(
             (
@@ -385,7 +323,10 @@ class AppConfigFragmentDBSource:
             )
         )
         async with self._db.begin_readonly_session() as db_sess:
-            result = await execute_batch_querier(db_sess, query, querier)
+            if scopes is not None:
+                result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
+            else:
+                result = await execute_batch_querier(db_sess, query, querier)
 
         groups: dict[tuple[uuid.UUID, str], list[AppConfigFragmentRow]] = {}
         for row in result.rows:
@@ -410,3 +351,20 @@ class AppConfigFragmentDBSource:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def scoped_search_app_configs(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigSearchResult:
+        """Merged-view search restricted to `scopes` (OR across users)."""
+        return await self._search_merged_app_configs(querier, scopes)
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Cross-user merged search (admin only) — no scope restriction."""
+        return await self._search_merged_app_configs(querier, None)

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import sqlalchemy as sa
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.common.utils import deep_merge
+from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+    AppConfigScopeType,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    UserAppConfigSearchScope,
+)
+from ai.backend.manager.repositories.base.creator import Creator, execute_creator
+from ai.backend.manager.repositories.base.purger import Purger, execute_purger
+from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
+from ai.backend.manager.repositories.base.types import SearchScope
+from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+
+app_config_fragment_db_source_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.DB_SOURCE,
+                layer=LayerType.APP_CONFIG_FRAGMENT_DB_SOURCE,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MergedChain:
+    """Internal return type of `_merge_chain` — the ordered fragments
+    that contributed to the merge plus the deep-merged config (or
+    `None` when every contributing fragment is empty).
+
+    Re-shaped into `AppConfigData` by callers that also know the
+    `(user_id, name)` they were resolving for.
+    """
+
+    fragments: list[AppConfigFragmentData]
+    config: Mapping[str, Any] | None
+
+
+class AppConfigFragmentDBSource:
+    """Database operations for `app_config_fragments`.
+
+    Two roles:
+    1. Raw CRUD on `(scope_type, scope_id, name)` rows.
+    2. Merge-side reads that resolve a user's `AppConfig` view by ordering
+       the applicable fragments by `rank` (low → high) and deep-merging.
+    """
+
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    # ── Raw fragment CRUD ──────────────────────────────────────────
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_by_key(self, key: AppConfigFragmentKey) -> AppConfigFragmentData:
+        """Look up a fragment by natural key. Raises
+        :class:`AppConfigFragmentNotFound` when no row matches."""
+        async with self._db.begin_readonly_session() as db_sess:
+            row = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow).where(
+                    AppConfigFragmentRow.scope_type == key.scope_type,
+                    AppConfigFragmentRow.scope_id == key.scope_id,
+                    AppConfigFragmentRow.name == key.name,
+                )
+            )
+            if row is None:
+                raise AppConfigFragmentNotFound(
+                    extra_msg=(
+                        f"scope_type={key.scope_type.value!r}, "
+                        f"scope_id={key.scope_id!r}, name={key.name!r}"
+                    ),
+                )
+            return row.to_data()
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+        async with self._db.begin_readonly_session() as db_sess:
+            row = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow).where(AppConfigFragmentRow.id == id)
+            )
+            return row.to_data() if row is not None else None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def create(self, creator: Creator[AppConfigFragmentRow]) -> AppConfigFragmentData:
+        """Insert a new fragment via the shared Creator helper.
+
+        The natural-key UNIQUE violation translates to
+        :class:`AppConfigFragmentConflict` via the spec's
+        ``integrity_error_checks``. The required-policy invariant
+        (FK on ``name``) is enforced upstream by the service layer;
+        a bypass here surfaces as a generic integrity error.
+        """
+        async with self._db.begin_session() as db_sess:
+            result = await execute_creator(db_sess, creator)
+            return result.row.to_data()
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def resolve_pk_by_key(
+        self,
+        key: AppConfigFragmentKey,
+    ) -> AppConfigFragmentID | None:
+        """Resolve the natural key ``(scope_type, scope_id, name)`` to
+        the row's ``id``. Returns ``None`` when no row matches —
+        callers translate to a domain-appropriate response."""
+        async with self._db.begin_readonly_session() as db_sess:
+            pk: AppConfigFragmentID | None = await db_sess.scalar(
+                sa.select(AppConfigFragmentRow.id).where(
+                    AppConfigFragmentRow.scope_type == key.scope_type,
+                    AppConfigFragmentRow.scope_id == key.scope_id,
+                    AppConfigFragmentRow.name == key.name,
+                )
+            )
+            return pk
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def update(self, updater: Updater[AppConfigFragmentRow]) -> AppConfigFragmentData | None:
+        """Apply a pre-built Updater. Returns ``None`` when the row
+        vanished between PK resolution and write; the caller maps this
+        to :class:`AppConfigFragmentNotFound`."""
+        async with self._db.begin_session() as db_sess:
+            result = await execute_updater(db_sess, updater)
+            return result.row.to_data() if result is not None else None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def purge(self, purger: Purger[AppConfigFragmentRow]) -> bool:
+        """Apply a pre-built Purger. Returns ``True`` when a row was
+        actually removed (``False`` if the row vanished concurrently)."""
+        async with self._db.begin_session() as db_sess:
+            result = await execute_purger(db_sess, purger)
+            return result is not None
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigFragmentSearchResult:
+        """Paginated search over fragment rows matching any of ``scopes`` (OR),
+        narrowed by ``querier``."""
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(AppConfigFragmentRow)
+            result = await execute_batch_querier(db_sess, query, querier, scopes=scopes)
+            items = [row.AppConfigFragmentRow.to_data() for row in result.rows]
+            return AppConfigFragmentSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigFragmentSearchResult:
+        """Cross-scope admin search — no scope binding. Authorization
+        is enforced at the service layer before this is reached."""
+        async with self._db.begin_readonly_session() as db_sess:
+            query = sa.select(AppConfigFragmentRow)
+            result = await execute_batch_querier(db_sess, query, querier)
+            items = [row.AppConfigFragmentRow.to_data() for row in result.rows]
+            return AppConfigFragmentSearchResult(
+                items=items,
+                total_count=result.total_count,
+                has_next_page=result.has_next_page,
+                has_previous_page=result.has_previous_page,
+            )
+
+    # ── Merged-view reads (AppConfig) ─────────────────────────────
+
+    @staticmethod
+    def _merge_chain(rows: Sequence[AppConfigFragmentRow]) -> _MergedChain:
+        """Order `rows` by `rank` (low → high) and deep-merge their
+        `config` in that order. Empty result projects to `None`.
+
+        Shared by the single-doc and search merge methods so both paths
+        produce the same shape.
+        """
+        ordered = sorted(rows, key=lambda row: row.rank)
+        merged: Mapping[str, Any] = {}
+        for row in ordered:
+            if row.config is None:
+                continue
+            merged = deep_merge(merged, row.config)
+        return _MergedChain(
+            fragments=[row.to_data() for row in ordered],
+            config=(merged or None),
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def get_user_app_config(
+        self,
+        user_id: uuid.UUID,
+        config_name: str,
+    ) -> AppConfigData:
+        """Resolve a single AppConfig view for `(user_id, config_name)`.
+
+        One SQL: resolves `domain_name` via a `users` subquery and fetches
+        the fragments applicable to the caller (`scope_id_match` gates
+        PUBLIC / the user's DOMAIN / the user's USER rows). Ordering and
+        deep-merge happen by `rank` in `_merge_chain`.
+        """
+        user_domain_sq = (
+            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
+        )
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                user_domain_sq,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.literal(str(user_id)),
+            ),
+        )
+        query = sa.select(AppConfigFragmentRow).where(
+            AppConfigFragmentRow.name == config_name,
+            AppConfigFragmentRow.scope_id == scope_id_match,
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            rows = (await db_sess.execute(query)).scalars().all()
+
+        if not rows:
+            return AppConfigData(
+                user_id=user_id,
+                name=config_name,
+                fragments=[],
+                config=None,
+            )
+
+        merged = self._merge_chain(rows)
+        return AppConfigData(
+            user_id=user_id,
+            name=config_name,
+            fragments=merged.fragments,
+            config=merged.config,
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def search_user_app_configs(
+        self,
+        scope: UserAppConfigSearchScope,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Connection counterpart of `get_user_app_config`. Groups the
+        scoped page of applicable fragments by `name` and feeds each group
+        through `_merge_chain` (rank-ordered) to produce one `AppConfigData`.
+
+        Filtering / ordering / pagination run through the shared
+        scoped-search helper (`execute_batch_querier`); the per-user
+        restriction lives in the `scope_id_match` predicate while
+        `UserAppConfigSearchScope` stays a passthrough so it composes
+        with the `BatchQuerier` without double-filtering.
+        """
+        user_id = scope.user_id
+        user_domain_sq = (
+            sa.select(UserRow.domain_name).where(UserRow.uuid == user_id).scalar_subquery()
+        )
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                user_domain_sq,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.literal(str(user_id)),
+            ),
+        )
+        query = sa.select(AppConfigFragmentRow).where(
+            AppConfigFragmentRow.scope_id == scope_id_match,
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])
+
+        groups: dict[str, list[AppConfigFragmentRow]] = {}
+        for row in result.rows:
+            fragment_row = row.AppConfigFragmentRow
+            groups.setdefault(fragment_row.name, []).append(fragment_row)
+
+        items: list[AppConfigData] = []
+        for name, rows in groups.items():
+            merged = self._merge_chain(rows)
+            items.append(
+                AppConfigData(
+                    user_id=user_id,
+                    name=name,
+                    fragments=merged.fragments,
+                    config=merged.config,
+                )
+            )
+
+        return AppConfigSearchResult(
+            items=items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    @app_config_fragment_db_source_resilience.apply()
+    async def admin_search_app_configs(
+        self,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        """Cross-user merged search (admin only). Joins `users` so each
+        `(user_id, name)` combination is produced; the scoped page of rows
+        is grouped and rank-merged the same way as `search_user_app_configs`.
+
+        Filtering / ordering / pagination run through the shared
+        scoped-search helper (`execute_batch_querier`) on the global
+        (unscoped) admin path.
+        """
+        scope_id_match = sa.case(
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.PUBLIC,
+                sa.literal("public"),
+            ),
+            (
+                AppConfigFragmentRow.scope_type.in_([
+                    AppConfigScopeType.DOMAIN,
+                    AppConfigScopeType.DOMAIN_USER_DEFAULTS,
+                ]),
+                UserRow.domain_name,
+            ),
+            (
+                AppConfigFragmentRow.scope_type == AppConfigScopeType.USER,
+                sa.cast(UserRow.uuid, sa.Text),
+            ),
+        )
+        query = (
+            sa.select(
+                UserRow.uuid.label("user_id"),
+                AppConfigFragmentRow,
+            )
+            .select_from(UserRow)
+            .join(
+                AppConfigFragmentRow,
+                AppConfigFragmentRow.scope_id == scope_id_match,
+            )
+        )
+        async with self._db.begin_readonly_session() as db_sess:
+            result = await execute_batch_querier(db_sess, query, querier)
+
+        groups: dict[tuple[uuid.UUID, str], list[AppConfigFragmentRow]] = {}
+        for row in result.rows:
+            fragment_row = row.AppConfigFragmentRow
+            groups.setdefault((row.user_id, fragment_row.name), []).append(fragment_row)
+
+        items: list[AppConfigData] = []
+        for (user_id, name), rows in groups.items():
+            merged = self._merge_chain(rows)
+            items.append(
+                AppConfigData(
+                    user_id=user_id,
+                    name=name,
+                    fragments=merged.fragments,
+                    config=merged.config,
+                )
+            )
+
+        return AppConfigSearchResult(
+            items=items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.repository import (
+    AppConfigFragmentRepository,
+)
+from ai.backend.manager.repositories.types import RepositoryArgs
+
+
+@dataclass
+class AppConfigFragmentRepositories:
+    repository: AppConfigFragmentRepository
+    admin_repository: AppConfigFragmentAdminRepository
+
+    @classmethod
+    def create(cls, args: RepositoryArgs) -> Self:
+        return cls(
+            repository=AppConfigFragmentRepository(args.db),
+            admin_repository=AppConfigFragmentAdminRepository(args.db),
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from ai.backend.common.exception import BackendAIError
+from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.metrics.metric import DomainType, LayerType
+from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
+from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
+from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigSearchResult
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+    AppConfigFragmentSearchResult,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.db_source import (
+    AppConfigFragmentDBSource,
+)
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    UserAppConfigSearchScope,
+)
+from ai.backend.manager.repositories.base.querier import BatchQuerier
+from ai.backend.manager.repositories.base.types import SearchScope
+
+app_config_fragment_repository_resilience = Resilience(
+    policies=[
+        MetricPolicy(
+            MetricArgs(
+                domain=DomainType.REPOSITORY,
+                layer=LayerType.APP_CONFIG_FRAGMENT_REPOSITORY,
+            )
+        ),
+        RetryPolicy(
+            RetryArgs(
+                max_retries=5,
+                retry_delay=0.1,
+                backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
+            )
+        ),
+    ]
+)
+
+
+class AppConfigFragmentRepository:
+    """Non-admin repository for AppConfigFragment.
+
+    Holds operations available to any authenticated user: scope-bound
+    reads on raw fragments plus the per-user merged `AppConfig` view.
+    """
+
+    _db_source: AppConfigFragmentDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = AppConfigFragmentDBSource(db)
+
+    # ── Raw fragment reads ────────────────────────────────────────
+
+    @app_config_fragment_repository_resilience.apply()
+    async def get_by_key(self, key: AppConfigFragmentKey) -> AppConfigFragmentData:
+        return await self._db_source.get_by_key(key)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def get_by_id(self, id: AppConfigFragmentID) -> AppConfigFragmentData | None:
+        return await self._db_source.get_by_id(id)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def scoped_search(
+        self,
+        querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
+    ) -> AppConfigFragmentSearchResult:
+        return await self._db_source.scoped_search(querier, scopes)
+
+    # ── Merged view (AppConfig) ───────────────────────────────────
+
+    @app_config_fragment_repository_resilience.apply()
+    async def app_config(
+        self,
+        user_id: uuid.UUID,
+        config_name: str,
+    ) -> AppConfigData:
+        return await self._db_source.get_user_app_config(user_id, config_name)
+
+    @app_config_fragment_repository_resilience.apply()
+    async def search_app_configs(
+        self,
+        scope: UserAppConfigSearchScope,
+        querier: BatchQuerier,
+    ) -> AppConfigSearchResult:
+        return await self._db_source.search_user_app_configs(scope, querier)

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -19,9 +19,6 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
 )
-from ai.backend.manager.repositories.app_config_fragment.types import (
-    UserAppConfigSearchScope,
-)
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.types import SearchScope
 
@@ -86,9 +83,9 @@ class AppConfigFragmentRepository:
         return await self._db_source.get_user_app_config(user_id, config_name)
 
     @app_config_fragment_repository_resilience.apply()
-    async def search_app_configs(
+    async def scoped_search_app_configs(
         self,
-        scope: UserAppConfigSearchScope,
         querier: BatchQuerier,
+        scopes: Sequence[SearchScope],
     ) -> AppConfigSearchResult:
-        return await self._db_source.search_user_app_configs(scope, querier)
+        return await self._db_source.scoped_search_app_configs(querier, scopes)

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 
@@ -40,17 +41,21 @@ class AppConfigFragmentSearchScope(SearchScope):
 
 @dataclass(frozen=True)
 class UserAppConfigSearchScope(SearchScope):
-    """Pin merged-view search to a target `user_id`."""
+    """Pin merged-view search to a target `user_id`.
+
+    The merged-view query joins `users`, so this matches `UserRow.uuid`.
+    `execute_batch_querier` ORs multiple scopes together and the
+    `(user_id, name)` grouping downstream deduplicates any overlap
+    between scopes — a user reached via two scopes yields one AppConfig.
+    """
 
     user_id: uuid.UUID
 
     def to_condition(self) -> QueryCondition:
-        # Merge search joins multiple scope rows per user; the per-user
-        # restriction is applied by the merge-specific SQL builder rather
-        # than this generic predicate. Returning a `True` condition keeps
-        # this scope BatchQuerier-compatible without double-filtering.
+        user_id = self.user_id
+
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return sa.true()
+            return UserRow.uuid == user_id
 
         return inner
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/types.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/types.py
@@ -1,0 +1,60 @@
+"""SearchScope types for app-config-fragment repository operations."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentSearchScope(SearchScope):
+    """Pin search to a single `(scope_type, scope_id)` slice of the table."""
+
+    scope_type: AppConfigScopeType
+    scope_id: str
+
+    def to_condition(self) -> QueryCondition:
+        scope_type = self.scope_type
+        scope_id = self.scope_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.and_(
+                AppConfigFragmentRow.scope_type == scope_type,
+                AppConfigFragmentRow.scope_id == scope_id,
+            )
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[str]]:
+        # Scope existence (domain / user) is validated upstream by RBAC.
+        return []
+
+
+@dataclass(frozen=True)
+class UserAppConfigSearchScope(SearchScope):
+    """Pin merged-view search to a target `user_id`."""
+
+    user_id: uuid.UUID
+
+    def to_condition(self) -> QueryCondition:
+        # Merge search joins multiple scope rows per user; the per-user
+        # restriction is applied by the merge-specific SQL builder rather
+        # than this generic predicate. Returning a `True` condition keeps
+        # this scope BatchQuerier-compatible without double-filtering.
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.true()
+
+        return inner
+
+    @property
+    def existence_checks(self) -> Sequence[ExistenceCheck[uuid.UUID]]:
+        # User existence is guaranteed by RBAC authentication upstream.
+        return []

--- a/src/ai/backend/manager/repositories/app_config_fragment/updaters.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/updaters.py
@@ -1,0 +1,35 @@
+"""UpdaterSpec for AppConfigFragment rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, override
+
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.repositories.base.updater import UpdaterSpec
+from ai.backend.manager.types import OptionalState
+
+
+@dataclass
+class AppConfigFragmentUpdaterSpec(UpdaterSpec[AppConfigFragmentRow]):
+    """UpdaterSpec for `app_config_fragments`.
+
+    `config` is replaced wholesale; `rank` (merge priority) is optionally
+    updatable. The ``(scope_type, scope_id, name)`` natural key is fixed —
+    changing any of those is a new row, not an update.
+    """
+
+    config: Mapping[str, Any]
+    rank: OptionalState[int] = field(default_factory=OptionalState[int].nop)
+
+    @property
+    @override
+    def row_class(self) -> type[AppConfigFragmentRow]:
+        return AppConfigFragmentRow
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        to_update: dict[str, Any] = {"config": dict(self.config)}
+        self.rank.update_dict(to_update, "rank")
+        return to_update

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import Self
 
 from ai.backend.manager.repositories.agent.repositories import AgentRepositories
+from ai.backend.manager.repositories.app_config_fragment.repositories import (
+    AppConfigFragmentRepositories,
+)
 from ai.backend.manager.repositories.artifact.repositories import ArtifactRepositories
 from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
@@ -85,6 +88,7 @@ from ai.backend.manager.repositories.vfs_storage.repositories import VFSStorageR
 @dataclass
 class Repositories:
     agent: AgentRepositories
+    app_config_fragment: AppConfigFragmentRepositories
     auth: AuthRepositories
     container_registry: ContainerRegistryRepositories
     deployment: DeploymentRepositories
@@ -136,6 +140,7 @@ class Repositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         agent_repositories = AgentRepositories.create(args)
+        app_config_fragment_repositories = AppConfigFragmentRepositories.create(args)
         auth_repositories = AuthRepositories.create(args)
         container_registry_repositories = ContainerRegistryRepositories.create(args)
         deployment_repositories = DeploymentRepositories.create(args)
@@ -188,6 +193,7 @@ class Repositories:
 
         return cls(
             agent=agent_repositories,
+            app_config_fragment=app_config_fragment_repositories,
             auth=auth_repositories,
             container_registry=container_registry_repositories,
             deployment=deployment_repositories,

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_create.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_create.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItem,
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentTarget
+
+
+@dataclass
+class AdminBulkCreateAppConfigFragmentsAction(BaseBulkAction[AppConfigFragmentTarget]):
+    """Bulk-create rows. `items` carries the per-item payloads; targets
+    are keyed by each item's natural key (row ids do not exist at
+    action-creation time)."""
+
+    items: list[AppConfigFragmentBulkItem] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @override
+    def targets(self) -> Sequence[AppConfigFragmentTarget]:
+        return [AppConfigFragmentTarget(key=item.key) for item in self.items]
+
+
+@dataclass
+class AdminBulkCreateAppConfigFragmentsActionResult(BaseBulkActionResult):
+    created: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentBulkItemError]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(
+                element_type=RBACElementType.APP_CONFIG,
+                element_id=str(fragment.id),
+            )
+            for fragment in self.created
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_purge.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_purge.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentKey
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentTarget
+
+
+@dataclass
+class AdminBulkPurgeAppConfigFragmentsAction(BaseBulkAction[AppConfigFragmentTarget]):
+    """`keys` carries the parsed natural keys of the rows to purge."""
+
+    keys: list[AppConfigFragmentKey] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.PURGE
+
+    @override
+    def targets(self) -> Sequence[AppConfigFragmentTarget]:
+        return [AppConfigFragmentTarget(key=key) for key in self.keys]
+
+
+@dataclass
+class AdminBulkPurgeAppConfigFragmentsActionResult(BaseBulkActionResult):
+    purged: list[AppConfigFragmentKey]
+    failed: list[AppConfigFragmentBulkItemError]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [AppConfigFragmentTarget(key=key).to_rbac_element_ref() for key in self.purged]

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_update.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_bulk_update.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItem,
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentTarget
+
+
+@dataclass
+class AdminBulkUpdateAppConfigFragmentsAction(BaseBulkAction[AppConfigFragmentTarget]):
+    """Bulk-update rows. `items` carries the per-item payloads; targets
+    are keyed by each item's natural key."""
+
+    items: list[AppConfigFragmentBulkItem] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+    @override
+    def targets(self) -> Sequence[AppConfigFragmentTarget]:
+        return [AppConfigFragmentTarget(key=item.key) for item in self.items]
+
+
+@dataclass
+class AdminBulkUpdateAppConfigFragmentsActionResult(BaseBulkActionResult):
+    updated: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentBulkItemError]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(
+                element_type=RBACElementType.APP_CONFIG,
+                element_id=str(fragment.id),
+            )
+            for fragment in self.updated
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_search.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_search.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class AdminSearchAppConfigFragmentsAction(AppConfigFragmentAction):
+    """Cross-scope raw-row search (admin only)."""
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class AdminSearchAppConfigFragmentsActionResult(BaseActionResult):
+    items: list[AppConfigFragmentData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/admin_search_app_configs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class AdminSearchAppConfigsAction(AppConfigFragmentAction):
+    """Cross-user merged-view search(admin only)."""
+
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class AdminSearchAppConfigsActionResult(BaseActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/app_config_fragment/actions/base.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/base.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action import BaseAction
+from ai.backend.manager.actions.action.types import ActionTarget
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentKey
+from ai.backend.manager.data.permission.types import RBACElementRef
+
+
+@dataclass
+class AppConfigFragmentAction(BaseAction):
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG_FRAGMENT
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentTarget(ActionTarget):
+    """Bulk-action target identifying a fragment row by its natural key."""
+
+    key: AppConfigFragmentKey
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_id=f"{self.key.scope_type}:{self.key.scope_id}:{self.key.name}",
+        )
+
+
+@dataclass(frozen=True)
+class MyAppConfigFragmentTarget(ActionTarget):
+    """Bulk-action target for self-service fragments, keyed by `name`
+    (the owning USER scope is resolved from the current user)."""
+
+    name: str
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_id=self.name,
+        )

--- a/src/ai/backend/manager/services/app_config_fragment/actions/base.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/base.py
@@ -13,7 +13,7 @@ class AppConfigFragmentAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.APP_CONFIG_FRAGMENT
+        return EntityType.APP_CONFIG
 
 
 @dataclass(frozen=True)
@@ -25,7 +25,7 @@ class AppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=f"{self.key.scope_type}:{self.key.scope_id}:{self.key.name}",
         )
 
@@ -40,6 +40,6 @@ class MyAppConfigFragmentTarget(ActionTarget):
     @override
     def to_rbac_element_ref(self) -> RBACElementRef:
         return RBACElementRef(
-            element_type=RBACElementType.APP_CONFIG_FRAGMENT,
+            element_type=RBACElementType.APP_CONFIG,
             element_id=self.name,
         )

--- a/src/ai/backend/manager/services/app_config_fragment/actions/get.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/get.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentKey,
+)
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class GetAppConfigFragmentAction(AppConfigFragmentAction):
+    key: AppConfigFragmentKey
+
+    @override
+    def entity_id(self) -> str | None:
+        # Row id is not known at action time (lookup is by natural key).
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetAppConfigFragmentActionResult(BaseActionResult):
+    fragment: AppConfigFragmentData
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.fragment.id)

--- a/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/get_user_app_config.py
@@ -1,0 +1,34 @@
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class GetUserAppConfigAction(AppConfigFragmentAction):
+    """Resolve a single per-user merged AppConfig."""
+
+    user_id: uuid.UUID
+    config_name: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.user_id}:{self.config_name}"
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetUserAppConfigActionResult(BaseActionResult):
+    app_config: AppConfigData
+
+    @override
+    def entity_id(self) -> str | None:
+        return f"{self.app_config.user_id}:{self.app_config.name}"

--- a/src/ai/backend/manager/services/app_config_fragment/actions/my_bulk_create.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/my_bulk_create.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+    MyAppConfigFragmentBulkItem,
+)
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.app_config_fragment.actions.base import MyAppConfigFragmentTarget
+
+
+@dataclass
+class MyBulkCreateAppConfigFragmentsAction(BaseBulkAction[MyAppConfigFragmentTarget]):
+    """Self-service bulk create — scope is `USER` / `current_user.user_id`.
+
+    The owning `user_id` is resolved from the request `ContextVar`
+    (`current_user()`) inside the service, never carried on the action.
+    Targets are keyed by the per-item `name` (USER-scope, so name alone
+    is unique inside a single user).
+    """
+
+    items: list[MyAppConfigFragmentBulkItem] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @override
+    def targets(self) -> Sequence[MyAppConfigFragmentTarget]:
+        return [MyAppConfigFragmentTarget(name=item.name) for item in self.items]
+
+
+@dataclass
+class MyBulkCreateAppConfigFragmentsActionResult(BaseBulkActionResult):
+    """`created` carries the recomputed merged view per successfully
+    created fragment; `failed` carries per-item errors.
+    """
+
+    created: list[AppConfigData]
+    failed: list[AppConfigFragmentBulkItemError]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(
+                element_type=RBACElementType.APP_CONFIG,
+                element_id=item.name,
+            )
+            for item in self.created
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/actions/my_bulk_update.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/my_bulk_update.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+    MyAppConfigFragmentBulkItem,
+)
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.services.app_config_fragment.actions.base import MyAppConfigFragmentTarget
+
+
+@dataclass
+class MyBulkUpdateAppConfigFragmentsAction(BaseBulkAction[MyAppConfigFragmentTarget]):
+    """Self-service bulk update — see `MyBulkCreateAppConfigFragmentsAction`."""
+
+    items: list[MyAppConfigFragmentBulkItem] = field(default_factory=list)
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+    @override
+    def targets(self) -> Sequence[MyAppConfigFragmentTarget]:
+        return [MyAppConfigFragmentTarget(name=item.name) for item in self.items]
+
+
+@dataclass
+class MyBulkUpdateAppConfigFragmentsActionResult(BaseBulkActionResult):
+    updated: list[AppConfigData]
+    failed: list[AppConfigFragmentBulkItemError]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return [
+            RBACElementRef(
+                element_type=RBACElementType.APP_CONFIG,
+                element_id=item.name,
+            )
+            for item in self.updated
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/scoped_search_app_configs.py
@@ -1,0 +1,74 @@
+"""Scoped merged-view (AppConfig) search action and its searchable targets."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType, RBACElementType
+from ai.backend.manager.actions.action.bulk import BaseBulkAction, BaseBulkActionResult
+from ai.backend.manager.actions.action.types import SearchableActionTarget
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.app_config_fragment.types import UserAppConfigSearchScope
+from ai.backend.manager.repositories.base import BatchQuerier, SearchScope
+
+
+@dataclass(frozen=True)
+class UserAppConfigTarget(SearchableActionTarget):
+    """Scope item keyed by a target ``user_id`` in the merged view."""
+
+    user_id: uuid.UUID
+
+    @override
+    def to_rbac_element_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.USER,
+            element_id=str(self.user_id),
+        )
+
+    @override
+    def to_search_scope(self) -> SearchScope:
+        return UserAppConfigSearchScope(user_id=self.user_id)
+
+
+@dataclass
+class ScopedSearchAppConfigsAction(BaseBulkAction[SearchableActionTarget]):
+    """Scoped merged-view search; targets are OR'd and RBAC-gated per target."""
+
+    items: list[SearchableActionTarget]
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.APP_CONFIG
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    def targets(self) -> Sequence[SearchableActionTarget]:
+        return list(self.items)
+
+
+@dataclass
+class ScopedSearchAppConfigsActionResult(BaseBulkActionResult):
+    items: list[AppConfigData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+    queried_refs: list[RBACElementRef]
+
+    @override
+    def element_refs(self) -> list[RBACElementRef]:
+        return list(self.queried_refs)

--- a/src/ai/backend/manager/services/app_config_fragment/actions/search.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/search.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigFragmentSearchScope,
+)
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.app_config_fragment.actions.base import AppConfigFragmentAction
+
+
+@dataclass
+class SearchAppConfigFragmentsAction(AppConfigFragmentAction):
+    """Scope-bound raw-row search (single `(scope_type, scope_id)` slice)."""
+
+    scope: AppConfigFragmentSearchScope
+    querier: BatchQuerier
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+
+@dataclass
+class SearchAppConfigFragmentsActionResult(BaseActionResult):
+    items: list[AppConfigFragmentData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
@@ -21,6 +21,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.admin_service import (
     AppConfigFragmentAdminService,
 )
@@ -29,6 +33,9 @@ from ai.backend.manager.services.app_config_fragment.admin_service import (
 class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     admin_search: ActionProcessor[
         AdminSearchAppConfigFragmentsAction, AdminSearchAppConfigFragmentsActionResult
+    ]
+    admin_search_app_configs: ActionProcessor[
+        AdminSearchAppConfigsAction, AdminSearchAppConfigsActionResult
     ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
@@ -51,6 +58,9 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
         validators: ActionValidators,
     ) -> None:
         self.admin_search = ActionProcessor(service.admin_search, action_monitors)
+        self.admin_search_app_configs = ActionProcessor(
+            service.admin_search_app_configs, action_monitors
+        )
         self.admin_bulk_create = BulkActionProcessor(service.admin_bulk_create, action_monitors)
         self.admin_bulk_update = BulkActionProcessor(service.admin_bulk_update, action_monitors)
         self.admin_bulk_purge = BulkActionProcessor(service.admin_bulk_purge, action_monitors)
@@ -59,6 +69,7 @@ class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
     def supported_actions(self) -> list[ActionSpec]:
         return [
             AdminSearchAppConfigFragmentsAction.spec(),
+            AdminSearchAppConfigsAction.spec(),
             AdminBulkCreateAppConfigFragmentsAction.spec(),
             AdminBulkUpdateAppConfigFragmentsAction.spec(),
             AdminBulkPurgeAppConfigFragmentsAction.spec(),

--- a/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_processors.py
@@ -1,0 +1,65 @@
+from typing import override
+
+from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.processor import ActionProcessor
+from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
+from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
+    AdminBulkCreateAppConfigFragmentsAction,
+    AdminBulkCreateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_purge import (
+    AdminBulkPurgeAppConfigFragmentsAction,
+    AdminBulkPurgeAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_update import (
+    AdminBulkUpdateAppConfigFragmentsAction,
+    AdminBulkUpdateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
+    AdminSearchAppConfigFragmentsAction,
+    AdminSearchAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.admin_service import (
+    AppConfigFragmentAdminService,
+)
+
+
+class AppConfigFragmentAdminProcessors(AbstractProcessorPackage):
+    admin_search: ActionProcessor[
+        AdminSearchAppConfigFragmentsAction, AdminSearchAppConfigFragmentsActionResult
+    ]
+    # Bulk mutations — wrapped by BulkActionProcessor so validators
+    # (RBAC, etc.) can filter entity_ids per-item before the service
+    # runs. No bulk validators are wired today; the processor simply
+    # forwards to the service.
+    admin_bulk_create: BulkActionProcessor[
+        AdminBulkCreateAppConfigFragmentsAction, AdminBulkCreateAppConfigFragmentsActionResult
+    ]
+    admin_bulk_update: BulkActionProcessor[
+        AdminBulkUpdateAppConfigFragmentsAction, AdminBulkUpdateAppConfigFragmentsActionResult
+    ]
+    admin_bulk_purge: BulkActionProcessor[
+        AdminBulkPurgeAppConfigFragmentsAction, AdminBulkPurgeAppConfigFragmentsActionResult
+    ]
+
+    def __init__(
+        self,
+        service: AppConfigFragmentAdminService,
+        action_monitors: list[ActionMonitor],
+        validators: ActionValidators,
+    ) -> None:
+        self.admin_search = ActionProcessor(service.admin_search, action_monitors)
+        self.admin_bulk_create = BulkActionProcessor(service.admin_bulk_create, action_monitors)
+        self.admin_bulk_update = BulkActionProcessor(service.admin_bulk_update, action_monitors)
+        self.admin_bulk_purge = BulkActionProcessor(service.admin_bulk_purge, action_monitors)
+
+    @override
+    def supported_actions(self) -> list[ActionSpec]:
+        return [
+            AdminSearchAppConfigFragmentsAction.spec(),
+            AdminBulkCreateAppConfigFragmentsAction.spec(),
+            AdminBulkUpdateAppConfigFragmentsAction.spec(),
+            AdminBulkPurgeAppConfigFragmentsAction.spec(),
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/admin_service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_service.py
@@ -1,0 +1,123 @@
+import logging
+
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentKey
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_create import (
+    AdminBulkCreateAppConfigFragmentsAction,
+    AdminBulkCreateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_purge import (
+    AdminBulkPurgeAppConfigFragmentsAction,
+    AdminBulkPurgeAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_bulk_update import (
+    AdminBulkUpdateAppConfigFragmentsAction,
+    AdminBulkUpdateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
+    AdminSearchAppConfigFragmentsAction,
+    AdminSearchAppConfigFragmentsActionResult,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class AppConfigFragmentAdminService:
+    """Admin-only (superadmin) operations on AppConfigFragment."""
+
+    _admin_repository: AppConfigFragmentAdminRepository
+
+    def __init__(self, admin_repository: AppConfigFragmentAdminRepository) -> None:
+        self._admin_repository = admin_repository
+
+    async def admin_search(
+        self, action: AdminSearchAppConfigFragmentsAction
+    ) -> AdminSearchAppConfigFragmentsActionResult:
+        result = await self._admin_repository.admin_search(action.querier)
+        return AdminSearchAppConfigFragmentsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    # ── Bulk mutations (per-item transaction) ─────────────────────
+
+    async def admin_bulk_create(
+        self, action: AdminBulkCreateAppConfigFragmentsAction
+    ) -> AdminBulkCreateAppConfigFragmentsActionResult:
+        """Strict insert across any scope; each item in its own
+        transaction so failures are collected per-item."""
+        created = []
+        failed: list[AppConfigFragmentBulkItemError] = []
+        for index, item in enumerate(action.items):
+            try:
+                fragment = await self._admin_repository.create(item.key, item.config)
+                created.append(fragment)
+            except Exception as e:
+                log.warning("admin_bulk_create item {} failed: {}", index, e)
+                failed.append(
+                    AppConfigFragmentBulkItemError(
+                        index=index,
+                        scope_type=item.key.scope_type.value,
+                        scope_id=item.key.scope_id,
+                        name=item.key.name,
+                        message=str(e),
+                    )
+                )
+        return AdminBulkCreateAppConfigFragmentsActionResult(created=created, failed=failed)
+
+    async def admin_bulk_update(
+        self, action: AdminBulkUpdateAppConfigFragmentsAction
+    ) -> AdminBulkUpdateAppConfigFragmentsActionResult:
+        """Wholesale JSON replacement; items without an existing row
+        are collected as failures (not auto-inserted)."""
+        updated = []
+        failed: list[AppConfigFragmentBulkItemError] = []
+        for index, item in enumerate(action.items):
+            try:
+                fragment = await self._admin_repository.update(item.key, item.config)
+                updated.append(fragment)
+            except Exception as e:
+                log.warning("admin_bulk_update item {} failed: {}", index, e)
+                failed.append(
+                    AppConfigFragmentBulkItemError(
+                        index=index,
+                        scope_type=item.key.scope_type.value,
+                        scope_id=item.key.scope_id,
+                        name=item.key.name,
+                        message=str(e),
+                    )
+                )
+        return AdminBulkUpdateAppConfigFragmentsActionResult(updated=updated, failed=failed)
+
+    async def admin_bulk_purge(
+        self, action: AdminBulkPurgeAppConfigFragmentsAction
+    ) -> AdminBulkPurgeAppConfigFragmentsActionResult:
+        """Cleanup-only deletion; absent keys are no-oped."""
+        purged: list[AppConfigFragmentKey] = []
+        failed: list[AppConfigFragmentBulkItemError] = []
+        for index, key in enumerate(action.keys):
+            try:
+                ok = await self._admin_repository.purge(key)
+                if ok:
+                    purged.append(key)
+                # Absent keys are intentionally no-oped (no failure entry).
+            except Exception as e:
+                log.warning("admin_bulk_purge item {} failed: {}", index, e)
+                failed.append(
+                    AppConfigFragmentBulkItemError(
+                        index=index,
+                        scope_type=key.scope_type.value,
+                        scope_id=key.scope_id,
+                        name=key.name,
+                        message=str(e),
+                    )
+                )
+        return AdminBulkPurgeAppConfigFragmentsActionResult(purged=purged, failed=failed)

--- a/src/ai/backend/manager/services/app_config_fragment/admin_service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/admin_service.py
@@ -24,6 +24,10 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
     AdminSearchAppConfigFragmentsAction,
     AdminSearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.admin_search_app_configs import (
+    AdminSearchAppConfigsAction,
+    AdminSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -41,6 +45,17 @@ class AppConfigFragmentAdminService:
     ) -> AdminSearchAppConfigFragmentsActionResult:
         result = await self._admin_repository.admin_search(action.querier)
         return AdminSearchAppConfigFragmentsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_search_app_configs(
+        self, action: AdminSearchAppConfigsAction
+    ) -> AdminSearchAppConfigsActionResult:
+        result = await self._admin_repository.admin_search_app_configs(action.querier)
+        return AdminSearchAppConfigsActionResult(
             items=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -1,0 +1,59 @@
+from typing import override
+
+from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.processor import ActionProcessor
+from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
+from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.services.app_config_fragment.actions.get import (
+    GetAppConfigFragmentAction,
+    GetAppConfigFragmentActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
+    MyBulkCreateAppConfigFragmentsAction,
+    MyBulkCreateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update import (
+    MyBulkUpdateAppConfigFragmentsAction,
+    MyBulkUpdateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+    SearchAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
+
+
+class AppConfigFragmentProcessors(AbstractProcessorPackage):
+    get: ActionProcessor[GetAppConfigFragmentAction, GetAppConfigFragmentActionResult]
+    search: ActionProcessor[SearchAppConfigFragmentsAction, SearchAppConfigFragmentsActionResult]
+    # Bulk mutations — wrapped by BulkActionProcessor so validators
+    # (RBAC, etc.) can filter entity_ids per-item before the service
+    # runs. No bulk validators are wired today; the processor simply
+    # forwards to the service.
+    my_bulk_create: BulkActionProcessor[
+        MyBulkCreateAppConfigFragmentsAction, MyBulkCreateAppConfigFragmentsActionResult
+    ]
+    my_bulk_update: BulkActionProcessor[
+        MyBulkUpdateAppConfigFragmentsAction, MyBulkUpdateAppConfigFragmentsActionResult
+    ]
+
+    def __init__(
+        self,
+        service: AppConfigFragmentService,
+        action_monitors: list[ActionMonitor],
+        validators: ActionValidators,
+    ) -> None:
+        self.get = ActionProcessor(service.get, action_monitors)
+        self.search = ActionProcessor(service.search, action_monitors)
+        self.my_bulk_create = BulkActionProcessor(service.my_bulk_create, action_monitors)
+        self.my_bulk_update = BulkActionProcessor(service.my_bulk_update, action_monitors)
+
+    @override
+    def supported_actions(self) -> list[ActionSpec]:
+        return [
+            GetAppConfigFragmentAction.spec(),
+            SearchAppConfigFragmentsAction.spec(),
+            MyBulkCreateAppConfigFragmentsAction.spec(),
+            MyBulkUpdateAppConfigFragmentsAction.spec(),
+        ]

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -9,6 +9,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -21,12 +25,20 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
 
 
 class AppConfigFragmentProcessors(AbstractProcessorPackage):
     get: ActionProcessor[GetAppConfigFragmentAction, GetAppConfigFragmentActionResult]
     search: ActionProcessor[SearchAppConfigFragmentsAction, SearchAppConfigFragmentsActionResult]
+    get_user_app_config: ActionProcessor[GetUserAppConfigAction, GetUserAppConfigActionResult]
+    scoped_search_app_configs: BulkActionProcessor[
+        ScopedSearchAppConfigsAction, ScopedSearchAppConfigsActionResult
+    ]
     # Bulk mutations — wrapped by BulkActionProcessor so validators
     # (RBAC, etc.) can filter entity_ids per-item before the service
     # runs. No bulk validators are wired today; the processor simply
@@ -46,6 +58,10 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
     ) -> None:
         self.get = ActionProcessor(service.get, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
+        self.get_user_app_config = ActionProcessor(service.get_user_app_config, action_monitors)
+        self.scoped_search_app_configs = BulkActionProcessor(
+            service.scoped_search_app_configs, action_monitors
+        )
         self.my_bulk_create = BulkActionProcessor(service.my_bulk_create, action_monitors)
         self.my_bulk_update = BulkActionProcessor(service.my_bulk_update, action_monitors)
 
@@ -54,6 +70,8 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         return [
             GetAppConfigFragmentAction.spec(),
             SearchAppConfigFragmentsAction.spec(),
+            GetUserAppConfigAction.spec(),
+            ScopedSearchAppConfigsAction.spec(),
             MyBulkCreateAppConfigFragmentsAction.spec(),
             MyBulkUpdateAppConfigFragmentsAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -1,0 +1,141 @@
+import logging
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.exception import UnreachableError
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.app_config_fragment.bulk_types import (
+    AppConfigFragmentBulkItemError,
+)
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentKey,
+    AppConfigScopeType,
+)
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.repository import (
+    AppConfigFragmentRepository,
+)
+from ai.backend.manager.services.app_config_fragment.actions.get import (
+    GetAppConfigFragmentAction,
+    GetAppConfigFragmentActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
+    MyBulkCreateAppConfigFragmentsAction,
+    MyBulkCreateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.my_bulk_update import (
+    MyBulkUpdateAppConfigFragmentsAction,
+    MyBulkUpdateAppConfigFragmentsActionResult,
+)
+from ai.backend.manager.services.app_config_fragment.actions.search import (
+    SearchAppConfigFragmentsAction,
+    SearchAppConfigFragmentsActionResult,
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class AppConfigFragmentService:
+    """Non-admin operations available to any authenticated user.
+
+    Self-service writes (`my_bulk_*`) target the caller's own `USER`
+    scope; the actual row write goes through the shared admin repository
+    while reads use the non-admin repository.
+    """
+
+    _repository: AppConfigFragmentRepository
+    _admin_repository: AppConfigFragmentAdminRepository
+
+    def __init__(
+        self,
+        repository: AppConfigFragmentRepository,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        self._repository = repository
+        self._admin_repository = admin_repository
+
+    async def get(self, action: GetAppConfigFragmentAction) -> GetAppConfigFragmentActionResult:
+        fragment = await self._repository.get_by_key(action.key)
+        return GetAppConfigFragmentActionResult(fragment=fragment)
+
+    async def search(
+        self, action: SearchAppConfigFragmentsAction
+    ) -> SearchAppConfigFragmentsActionResult:
+        result = await self._repository.scoped_search(action.querier, [action.scope])
+        return SearchAppConfigFragmentsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def my_bulk_create(
+        self, action: MyBulkCreateAppConfigFragmentsAction
+    ) -> MyBulkCreateAppConfigFragmentsActionResult:
+        """Self-service bulk create on the caller's `USER` row; each
+        success recomputes the merged `AppConfig` view.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        user_id = me.user_id
+        user_id_str = str(user_id)
+        created = []
+        failed: list[AppConfigFragmentBulkItemError] = []
+        for index, item in enumerate(action.items):
+            key = AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.USER,
+                scope_id=user_id_str,
+                name=item.name,
+            )
+            try:
+                await self._admin_repository.create(key, item.config)
+                merged = await self._repository.app_config(user_id, item.name)
+                created.append(merged)
+            except Exception as e:
+                log.warning("my_bulk_create item {} failed: {}", index, e)
+                failed.append(
+                    AppConfigFragmentBulkItemError(
+                        index=index,
+                        scope_type=AppConfigScopeType.USER.value,
+                        scope_id=user_id_str,
+                        name=item.name,
+                        message=str(e),
+                    )
+                )
+        return MyBulkCreateAppConfigFragmentsActionResult(created=created, failed=failed)
+
+    async def my_bulk_update(
+        self, action: MyBulkUpdateAppConfigFragmentsAction
+    ) -> MyBulkUpdateAppConfigFragmentsActionResult:
+        """Self-service bulk update on the caller's `USER` row."""
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        user_id = me.user_id
+        user_id_str = str(user_id)
+        updated = []
+        failed: list[AppConfigFragmentBulkItemError] = []
+        for index, item in enumerate(action.items):
+            key = AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.USER,
+                scope_id=user_id_str,
+                name=item.name,
+            )
+            try:
+                await self._admin_repository.update(key, item.config)
+                merged = await self._repository.app_config(user_id, item.name)
+                updated.append(merged)
+            except Exception as e:
+                log.warning("my_bulk_update item {} failed: {}", index, e)
+                failed.append(
+                    AppConfigFragmentBulkItemError(
+                        index=index,
+                        scope_type=AppConfigScopeType.USER.value,
+                        scope_id=user_id_str,
+                        name=item.name,
+                        message=str(e),
+                    )
+                )
+        return MyBulkUpdateAppConfigFragmentsActionResult(updated=updated, failed=failed)

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -20,6 +20,10 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
     GetAppConfigFragmentAction,
     GetAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.get_user_app_config import (
+    GetUserAppConfigAction,
+    GetUserAppConfigActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.my_bulk_create import (
     MyBulkCreateAppConfigFragmentsAction,
     MyBulkCreateAppConfigFragmentsActionResult,
@@ -32,6 +36,10 @@ from ai.backend.manager.services.app_config_fragment.actions.search import (
     SearchAppConfigFragmentsAction,
     SearchAppConfigFragmentsActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.scoped_search_app_configs import (
+    ScopedSearchAppConfigsAction,
+    ScopedSearchAppConfigsActionResult,
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -39,8 +47,9 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class AppConfigFragmentService:
     """Non-admin operations available to any authenticated user.
 
-    Self-service writes (`my_bulk_*`) target the caller's own `USER`
-    scope; the actual row write goes through the shared admin repository
+    Covers raw-fragment reads, the per-user merged `AppConfig` views,
+    and self-service writes (`my_bulk_*`) on the caller's own `USER`
+    scope. The actual row write goes through the shared admin repository
     while reads use the non-admin repository.
     """
 
@@ -69,6 +78,30 @@ class AppConfigFragmentService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
+
+    # ── Merged-view reads (AppConfig) ─────────────────────────────
+
+    async def get_user_app_config(
+        self, action: GetUserAppConfigAction
+    ) -> GetUserAppConfigActionResult:
+        app_config = await self._repository.app_config(action.user_id, action.config_name)
+        return GetUserAppConfigActionResult(app_config=app_config)
+
+    async def scoped_search_app_configs(
+        self, action: ScopedSearchAppConfigsAction
+    ) -> ScopedSearchAppConfigsActionResult:
+        targets = list(action.targets())
+        scopes = [t.to_search_scope() for t in targets]
+        result = await self._repository.scoped_search_app_configs(action.querier, scopes)
+        return ScopedSearchAppConfigsActionResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            queried_refs=[t.to_rbac_element_ref() for t in targets],
+        )
+
+    # ── Self-service bulk mutations (per-item transaction) ────────
 
     async def my_bulk_create(
         self, action: MyBulkCreateAppConfigFragmentsAction

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -6,6 +6,14 @@ from ai.backend.manager.repositories.resource_allocation.repository import (
 )
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.agent.service import AgentService
+from ai.backend.manager.services.app_config_fragment.admin_processors import (
+    AppConfigFragmentAdminProcessors,
+)
+from ai.backend.manager.services.app_config_fragment.admin_service import (
+    AppConfigFragmentAdminService,
+)
+from ai.backend.manager.services.app_config_fragment.processors import AppConfigFragmentProcessors
+from ai.backend.manager.services.app_config_fragment.service import AppConfigFragmentService
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
@@ -161,6 +169,13 @@ def create_services(args: ServiceArgs) -> Services:
             args.hook_plugin_ctx,
             args.event_producer,
             args.agent_cache,
+        ),
+        app_config_fragment=AppConfigFragmentService(
+            repository=repositories.app_config_fragment.repository,
+            admin_repository=repositories.app_config_fragment.admin_repository,
+        ),
+        app_config_fragment_admin=AppConfigFragmentAdminService(
+            admin_repository=repositories.app_config_fragment.admin_repository,
         ),
         domain=DomainService(repositories.domain.repository),
         dotfile=DotfileService(
@@ -424,6 +439,12 @@ def create_processors(
     services = create_services(args.service_args)
     return Processors(
         agent=AgentProcessors(services.agent, action_monitors, validators),
+        app_config_fragment=AppConfigFragmentProcessors(
+            services.app_config_fragment, action_monitors, validators
+        ),
+        app_config_fragment_admin=AppConfigFragmentAdminProcessors(
+            services.app_config_fragment_admin, action_monitors, validators
+        ),
         domain=DomainProcessors(services.domain, action_monitors, validators),
         dotfile=DotfileProcessors(services.dotfile, action_monitors, validators),
         error_log=ErrorLogProcessors(services.error_log, action_monitors, validators),

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -45,6 +45,18 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.services.agent.processors import AgentProcessors
     from ai.backend.manager.services.agent.service import AgentService
+    from ai.backend.manager.services.app_config_fragment.admin_processors import (
+        AppConfigFragmentAdminProcessors,
+    )
+    from ai.backend.manager.services.app_config_fragment.admin_service import (
+        AppConfigFragmentAdminService,
+    )
+    from ai.backend.manager.services.app_config_fragment.processors import (
+        AppConfigFragmentProcessors,
+    )
+    from ai.backend.manager.services.app_config_fragment.service import (
+        AppConfigFragmentService,
+    )
     from ai.backend.manager.services.artifact.processors import (
         ArtifactProcessors,
     )
@@ -363,6 +375,8 @@ class ServiceArgs:
 @dataclass
 class Services:
     agent: AgentService
+    app_config_fragment: AppConfigFragmentService
+    app_config_fragment_admin: AppConfigFragmentAdminService
     domain: DomainService
     dotfile: DotfileService
     error_log: ErrorLogService
@@ -428,6 +442,8 @@ class ProcessorArgs:
 @dataclass
 class Processors(AbstractProcessorPackage):
     agent: AgentProcessors
+    app_config_fragment: AppConfigFragmentProcessors
+    app_config_fragment_admin: AppConfigFragmentAdminProcessors
     domain: DomainProcessors
     dotfile: DotfileProcessors
     error_log: ErrorLogProcessors
@@ -486,6 +502,8 @@ class Processors(AbstractProcessorPackage):
     def supported_actions(self) -> list[ActionSpec]:
         return [
             *self.agent.supported_actions(),
+            *self.app_config_fragment.supported_actions(),
+            *self.app_config_fragment_admin.supported_actions(),
             *self.domain.supported_actions(),
             *self.dotfile.supported_actions(),
             *self.error_log.supported_actions(),

--- a/tests/unit/manager/repositories/app_config_fragment/BUILD
+++ b/tests/unit/manager/repositories/app_config_fragment/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
@@ -1,0 +1,189 @@
+"""Repository tests for AppConfigFragment with real database."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentKey,
+    AppConfigScopeType,
+)
+from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
+    AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.repository import (
+    AppConfigFragmentRepository,
+)
+from ai.backend.testutils.db import with_tables
+
+
+class TestAppConfigFragmentRepository:
+    """Read-side tests for AppConfigFragmentRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                AppConfigFragmentRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
+        return AppConfigFragmentRepository(db)
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db)
+
+    async def test_create_and_get_by_key(
+        self,
+        repository: AppConfigFragmentRepository,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        created = await admin_repository.create(
+            key=key,
+            config={"color": "blue"},
+        )
+        assert created.scope_type == AppConfigScopeType.DOMAIN
+        assert created.scope_id == "default"
+        assert created.name == "theme"
+        # rank defaults to the DOMAIN tier when not explicitly provided.
+        assert created.rank == 200
+        assert created.config is not None
+        assert dict(created.config) == {"color": "blue"}
+
+        fetched = await repository.get(key)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.config is not None
+        assert dict(fetched.config) == {"color": "blue"}
+
+    async def test_get_by_id(
+        self,
+        repository: AppConfigFragmentRepository,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        created = await admin_repository.create(
+            key=AppConfigFragmentKey(
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id="public",
+                name="theme",
+            ),
+            config={"density": "comfortable"},
+        )
+        # rank defaults to the PUBLIC tier.
+        assert created.rank == 100
+
+        fetched = await repository.get_by_id(created.id)
+        assert fetched is not None
+        assert fetched.scope_type == AppConfigScopeType.PUBLIC
+        assert fetched.config is not None
+        assert dict(fetched.config) == {"density": "comfortable"}
+
+    async def test_get_raises_for_missing_key(
+        self,
+        repository: AppConfigFragmentRepository,
+    ) -> None:
+        with pytest.raises(AppConfigFragmentNotFound):
+            await repository.get(
+                AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                )
+            )
+
+
+class TestAppConfigFragmentAdminRepository:
+    """Mutation-side tests for AppConfigFragmentAdminRepository."""
+
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                AppConfigFragmentRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db)
+
+    async def test_update_replaces_config(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        await admin_repository.create(key=key, config={"color": "blue"})
+        updated = await admin_repository.update(
+            key=key, config={"color": "red", "density": "compact"}
+        )
+        assert updated is not None
+        assert updated.config is not None
+        assert dict(updated.config) == {"color": "red", "density": "compact"}
+
+    async def test_update_raises_for_missing_key(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        with pytest.raises(AppConfigFragmentNotFound):
+            await admin_repository.update(
+                key=AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                ),
+                config={"color": "blue"},
+            )
+
+    async def test_purge_existing_fragment_returns_true(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        key = AppConfigFragmentKey(
+            scope_type=AppConfigScopeType.DOMAIN,
+            scope_id="default",
+            name="theme",
+        )
+        await admin_repository.create(key=key, config={})
+        assert await admin_repository.purge(key) is True
+
+    async def test_purge_missing_fragment_returns_false(
+        self,
+        admin_repository: AppConfigFragmentAdminRepository,
+    ) -> None:
+        assert (
+            await admin_repository.purge(
+                AppConfigFragmentKey(
+                    scope_type=AppConfigScopeType.DOMAIN,
+                    scope_id="missing",
+                    name="theme",
+                )
+            )
+            is False
+        )


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 6-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation (rank-based, no policy)`
2. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
3. ⬇️ **#11285** — `feat(BA-5829): AppConfig/Fragment GraphQL (scoped + admin)`
4. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
5. 👉 **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI` ← you are here
6. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads`

## Summary

Adds the v2 SDK + v2 CLI surface for the three AppConfig entities from BEP-1052, calling the REST v2 endpoints landed in #11286. Replaces the legacy domain/user `upsert`/`delete` SDK + CLI whose backing endpoints were dropped in #11265.

**SDK** (`client/v2/domains_v2/`), all registered as `@cached_property` on `V2ClientRegistry`:

| Client | Methods |
|---|---|
| `V2AppConfigPolicyClient` (new) | `admin_bulk_create` / `admin_bulk_update` / `admin_bulk_purge` |
| `V2AppConfigFragmentClient` (new) | `admin_search` / `admin_bulk_create` / `admin_bulk_update` / `admin_bulk_purge` |
| `V2AppConfigClient` (rewritten) | `my_get` / `my_search` / `admin_get` / `admin_search` / `my_bulk_create` / `my_bulk_update` |

Policies and fragments are admin-only surfaces; end users observe their effects through the merged `AppConfig` view. The self-service `my_bulk_*` writes return the recomputed merged view and live on `V2AppConfigClient` (backed by the `/v2/app-config-fragments/my/*` endpoints), not on the fragment client.

**CLI** (`client/cli/v2/`):

| Group | Commands |
|---|---|
| `bai v2 app-config` | `my-get` |
| `bai v2 my app-config` | `search`, `bulk-create`, `bulk-update` |
| `bai v2 admin app-config` | `get`, `search` |
| `bai v2 admin app-config-fragment` | `search`, `bulk-create`, `bulk-update`, `bulk-purge` |
| `bai v2 admin app-config-policy` | `bulk-create`, `bulk-update`, `bulk-purge` |

Bulk write commands take JSON list inputs via `--items` / `--keys` / `--ids`, each accepting an inline JSON string or an `@path/to/file.json` shorthand. Policy `bulk-purge` takes `--ids` (comma-separated UUIDs or a JSON list file); fragment `bulk-purge` takes `--keys` (JSON list of `{scope_type, scope_id, name}`). Search commands expose per-field `--*-contains` / `--order-by` filter flags.

```bash
bai v2 admin app-config-policy bulk-create --items '[{"config_name":"theme","scope_sources":["public","user"]}]'
bai v2 admin app-config-fragment bulk-purge --keys @keys.json
bai v2 my app-config bulk-update --items @my-fragments.json
```


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11295.org.readthedocs.build/en/11295/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11295.org.readthedocs.build/ko/11295/

<!-- readthedocs-preview sorna-ko end -->
