### PR TITLE
feat(BA-5837): ValkeyCache for AppConfigFragment merged-view reads

### DIFF
--- a/changes/11297.feature.md
+++ b/changes/11297.feature.md
@@ -1,0 +1,1 @@
+Front the `AppConfigFragment` merged-view repository with a Valkey cache. Read path is cache-aside (`get_merged_config(user_id, name)` → DB fallback → cache write); admin / self-service bulk writes invalidate per-user or per-domain via membership indexes (no `SCAN`). Cache failures fall through to the DB.

--- a/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/admin_repository.py
@@ -17,6 +17,9 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.cache_source import (
+    AppConfigFragmentCacheSource,
+)
 from ai.backend.manager.repositories.app_config_fragment.creators import (
     AppConfigFragmentCreatorSpec,
 )
@@ -66,9 +69,16 @@ class AppConfigFragmentAdminRepository:
     """
 
     _db_source: AppConfigFragmentDBSource
+    _cache_source: AppConfigFragmentCacheSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
+    def __init__(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ops_provider: DBOpsProvider,
+        cache_source: AppConfigFragmentCacheSource,
+    ) -> None:
         self._db_source = AppConfigFragmentDBSource(db, ops_provider)
+        self._cache_source = cache_source
 
     # ── Mutations ─────────────────────────────────────────────────
 
@@ -86,7 +96,9 @@ class AppConfigFragmentAdminRepository:
             name=key.name,
             config=config,
         )
-        return await self._db_source.create(spec)
+        result = await self._db_source.create(spec)
+        await self._cache_source.invalidate_for_scope(key.scope_type, key.scope_id)
+        return result
 
     @app_config_fragment_admin_repository_resilience.apply()
     async def update(
@@ -110,7 +122,9 @@ class AppConfigFragmentAdminRepository:
             spec=AppConfigFragmentUpdaterSpec(config=config),
             pk_value=pk_value,
         )
-        return await self._db_source.update(updater)
+        result = await self._db_source.update(updater)
+        await self._cache_source.invalidate_for_scope(key.scope_type, key.scope_id)
+        return result
 
     @app_config_fragment_admin_repository_resilience.apply()
     async def purge(self, key: AppConfigFragmentKey) -> bool:
@@ -124,7 +138,10 @@ class AppConfigFragmentAdminRepository:
             row_class=AppConfigFragmentRow,
             pk_value=pk_value,
         )
-        return await self._db_source.purge(purger)
+        removed = await self._db_source.purge(purger)
+        if removed:
+            await self._cache_source.invalidate_for_scope(key.scope_type, key.scope_id)
+        return removed
 
     # ── Cross-scope reads ────────────────────────────────────────
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/cache_source/__init__.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/cache_source/__init__.py
@@ -1,0 +1,3 @@
+from .cache_source import AppConfigFragmentCacheSource
+
+__all__ = ("AppConfigFragmentCacheSource",)

--- a/src/ai/backend/manager/repositories/app_config_fragment/cache_source/cache_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/cache_source/cache_source.py
@@ -1,0 +1,203 @@
+"""Cache source for AppConfigFragment merged-view reads.
+
+The hot path is `AppConfigFragmentRepository.app_config(user_id, name)`,
+the per-`(user, name)` deep-merge of every contributing fragment ordered
+by `rank` (low → high). Each merged value gets cached under
+`app_config:merged:{user_id}:{name}` with a TTL, and is invalidated
+whenever a contributing fragment changes.
+
+Membership indexes let invalidation work without `SCAN`:
+
+- ``app_config:user_keys:{user_id}`` — set of `(user_id, name)` cache
+  keys this user currently has cached. Per-user invalidation pops the
+  set in one `SMEMBERS` + `DEL`.
+- ``app_config:domain_users:{domain_name}`` — set of `user_id`s
+  currently observed in this domain. Per-domain invalidation expands
+  to a per-user invalidation for each member.
+
+Cache failures never break a request — every public method is wrapped
+in `suppress_with_log` so any Valkey error falls through to the DB.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Mapping
+from typing import Any, cast
+
+from glide import Batch, ExpirySet, ExpiryType
+
+from ai.backend.common.json import dump_json, load_json
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.clients.valkey_client.valkey_cache import ValkeyCache
+from ai.backend.manager.data.app_config.types import AppConfigData
+from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+from ai.backend.manager.repositories.utils import suppress_with_log
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class AppConfigFragmentCacheSource:
+    """Valkey-backed cache for the per-`(user, name)` merged AppConfig view."""
+
+    _valkey_cache: ValkeyCache
+    _cache_ttl: int
+
+    def __init__(self, valkey_cache: ValkeyCache, cache_ttl: int = 600) -> None:
+        """Args:
+        valkey_cache: Manager-side Valkey cache client.
+        cache_ttl: TTL in seconds (default: 10 minutes).
+        """
+        self._valkey_cache = valkey_cache
+        self._cache_ttl = cache_ttl
+
+    # ── Key derivation ─────────────────────────────────────────────
+
+    @staticmethod
+    def _merged_key(user_id: uuid.UUID | str, name: str) -> str:
+        return f"app_config:merged:{user_id}:{name}"
+
+    @staticmethod
+    def _user_keys_set(user_id: uuid.UUID | str) -> str:
+        return f"app_config:user_keys:{user_id}"
+
+    @staticmethod
+    def _domain_users_set(domain_name: str) -> str:
+        return f"app_config:domain_users:{domain_name}"
+
+    # ── Read ───────────────────────────────────────────────────────
+
+    async def get_merged_config(
+        self,
+        user_id: uuid.UUID,
+        name: str,
+    ) -> Mapping[str, Any] | None:
+        """Return the cached `config` payload, or `None` on miss / failure.
+
+        Only the merged `config` mapping is cached — `fragments` are
+        cheap to recompute when needed and would bloat the cache.
+        """
+        with suppress_with_log([Exception], "Failed to read merged config from cache"):
+            cache_key = self._merged_key(user_id, name)
+            async with self._valkey_cache.client() as conn:
+                cached_value = await conn.get(cache_key)
+            if cached_value:
+                log.debug("Cache hit for merged config: {} {}", user_id, name)
+                return cast(Mapping[str, Any] | None, load_json(cached_value))
+            log.debug("Cache miss for merged config: {} {}", user_id, name)
+        return None
+
+    # ── Write ──────────────────────────────────────────────────────
+
+    async def set_merged_config(
+        self,
+        merged: AppConfigData,
+        domain_name: str | None = None,
+    ) -> None:
+        """Cache the merged `config` payload + index it for invalidation.
+
+        Indexes the cache key in the user's key set; if `domain_name`
+        is supplied, also adds the user to the domain's user set so
+        domain-level invalidation can cascade.
+        """
+        if merged.config is None:
+            # Nothing useful to cache — leave as miss-on-next-read.
+            return
+        with suppress_with_log([Exception], "Failed to write merged config to cache"):
+            user_id = str(merged.user_id)
+            cache_key = self._merged_key(user_id, merged.name)
+
+            batch = Batch(is_atomic=False)
+            batch.set(
+                cache_key,
+                dump_json(merged.config),
+                expiry=ExpirySet(ExpiryType.SEC, self._cache_ttl),
+            )
+            user_keys = self._user_keys_set(user_id)
+            batch.sadd(user_keys, [cache_key])
+            batch.expire(user_keys, self._cache_ttl)
+            if domain_name is not None:
+                domain_users = self._domain_users_set(domain_name)
+                batch.sadd(domain_users, [user_id])
+                batch.expire(domain_users, self._cache_ttl)
+
+            async with self._valkey_cache.client() as conn:
+                await conn.exec(batch, raise_on_error=True)
+
+            log.trace(
+                "Cached merged config for user {} name {} (domain={})",
+                user_id,
+                merged.name,
+                domain_name,
+            )
+
+    # ── Invalidate ────────────────────────────────────────────────
+
+    async def invalidate_for_scope(
+        self,
+        scope_type: AppConfigScopeType,
+        scope_id: str,
+    ) -> None:
+        """Invalidate every cached merged view affected by a fragment write.
+
+        `scope_id` is the user UUID for `USER`, the domain name for
+        `DOMAIN` / `DOMAIN_USER_DEFAULTS`, or the literal `"public"`
+        for `PUBLIC`. `PUBLIC` invalidation is intentionally not
+        wired here — its blast radius is the whole cache; rely on TTL
+        for now (admin-only, low-frequency operation).
+        """
+        with suppress_with_log([Exception], "Failed to invalidate merged-config cache"):
+            match scope_type:
+                case AppConfigScopeType.USER:
+                    await self._invalidate_user(scope_id)
+                case AppConfigScopeType.DOMAIN | AppConfigScopeType.DOMAIN_USER_DEFAULTS:
+                    await self._invalidate_domain(scope_id)
+                case AppConfigScopeType.PUBLIC:
+                    log.debug(
+                        "PUBLIC-scope invalidation not wired; relying on TTL ({}s)",
+                        self._cache_ttl,
+                    )
+
+    async def invalidate_for_user(self, user_id: uuid.UUID | str) -> None:
+        """Drop every cached merged view owned by `user_id`.
+
+        Convenience wrapper used by self-service bulk writes that
+        always operate on the caller's `USER` row.
+        """
+        with suppress_with_log([Exception], "Failed to invalidate user merged-config cache"):
+            await self._invalidate_user(str(user_id))
+
+    async def _invalidate_user(self, user_id: str) -> None:
+        user_keys = self._user_keys_set(user_id)
+        async with self._valkey_cache.client() as conn:
+            cached_keys = await conn.smembers(user_keys)
+        if not cached_keys:
+            log.debug("No cached keys for user {}, skipping invalidation", user_id)
+            return
+        keys_to_delete: list[str | bytes] = list(cached_keys)
+        keys_to_delete.append(user_keys)
+        async with self._valkey_cache.client() as conn:
+            removed = await conn.delete(keys_to_delete)
+        log.debug("Invalidated {} merged-config keys for user {}", removed, user_id)
+
+    async def _invalidate_domain(self, domain_name: str) -> None:
+        domain_users = self._domain_users_set(domain_name)
+        async with self._valkey_cache.client() as conn:
+            user_ids = await conn.smembers(domain_users)
+        if not user_ids:
+            log.debug(
+                "No tracked users for domain {}, skipping cache invalidation",
+                domain_name,
+            )
+            return
+        for raw in user_ids:
+            user_id = raw.decode() if isinstance(raw, bytes) else str(raw)
+            await self._invalidate_user(user_id)
+        async with self._valkey_cache.client() as conn:
+            await conn.delete([domain_users])
+        log.debug(
+            "Invalidated merged-config caches for {} users in domain {}",
+            len(user_ids),
+            domain_name,
+        )

--- a/src/ai/backend/manager/repositories/app_config_fragment/cache_source/cache_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/cache_source/cache_source.py
@@ -31,8 +31,7 @@ from glide import Batch, ExpirySet, ExpiryType
 from ai.backend.common.json import dump_json, load_json
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.valkey_client.valkey_cache import ValkeyCache
-from ai.backend.manager.data.app_config.types import AppConfigData
-from ai.backend.manager.data.app_config_fragment.types import AppConfigScopeType
+from ai.backend.manager.data.app_config_fragment.types import AppConfigData, AppConfigScopeType
 from ai.backend.manager.repositories.utils import suppress_with_log
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -125,6 +125,20 @@ class AppConfigFragmentDBSource:
             return row.to_data()
 
     @app_config_fragment_db_source_resilience.apply()
+    async def get_user_domain_name(self, user_id: uuid.UUID) -> str | None:
+        """Single-column lookup of a user's `domain_name`.
+
+        Used by the cache layer to tag merged-view entries with their
+        owning domain so domain-scoped fragment writes can target a
+        bounded user set during invalidation.
+        """
+        async with self._db.begin_readonly_session() as db_sess:
+            domain_name: str | None = await db_sess.scalar(
+                sa.select(UserRow.domain_name).where(UserRow.uuid == user_id)
+            )
+            return domain_name
+
+    @app_config_fragment_db_source_resilience.apply()
     async def create(self, spec: AppConfigFragmentCreatorSpec) -> AppConfigFragmentData:
         """Insert a fragment, assigning the next-value `rank`
         (``MAX(rank) + gap`` within the `name`) race-free — the same

--- a/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repositories.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass
 from typing import Self
 
+from ai.backend.manager.clients.valkey_client.valkey_cache import ValkeyCache
 from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
     AppConfigFragmentAdminRepository,
+)
+from ai.backend.manager.repositories.app_config_fragment.cache_source import (
+    AppConfigFragmentCacheSource,
 )
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
@@ -17,7 +21,16 @@ class AppConfigFragmentRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
+        # The merged-view read path is fronted by a Valkey cache; the
+        # repository falls through to the DB transparently if the
+        # cache layer fails.
+        valkey_cache = ValkeyCache(args.valkey_stat_client._client)
+        cache_source = AppConfigFragmentCacheSource(valkey_cache)
         return cls(
-            repository=AppConfigFragmentRepository(args.db, args.ops_provider),
-            admin_repository=AppConfigFragmentAdminRepository(args.db, args.ops_provider),
+            repository=AppConfigFragmentRepository(
+                args.db, args.ops_provider, cache_source=cache_source
+            ),
+            admin_repository=AppConfigFragmentAdminRepository(
+                args.db, args.ops_provider, cache_source=cache_source
+            ),
         )

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -17,6 +17,9 @@ from ai.backend.manager.data.app_config_fragment.types import (
     ScopedAppConfigSearchResult,
 )
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.app_config_fragment.cache_source import (
+    AppConfigFragmentCacheSource,
+)
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
     AppConfigFragmentDBSource,
 )
@@ -52,9 +55,16 @@ class AppConfigFragmentRepository:
     """
 
     _db_source: AppConfigFragmentDBSource
+    _cache_source: AppConfigFragmentCacheSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
+    def __init__(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ops_provider: DBOpsProvider,
+        cache_source: AppConfigFragmentCacheSource,
+    ) -> None:
         self._db_source = AppConfigFragmentDBSource(db, ops_provider)
+        self._cache_source = cache_source
 
     # ── Raw fragment reads ────────────────────────────────────────
 
@@ -82,7 +92,11 @@ class AppConfigFragmentRepository:
         user_id: UserID,
         config_name: str,
     ) -> AppConfigData:
-        return await self._db_source.get_user_app_config(user_id, config_name)
+        result = await self._db_source.get_user_app_config(user_id, config_name)
+        # Write-through populate. Read-through is a follow-up: the cache
+        # stores only the merged `config`, not the contributing fragments.
+        await self._cache_source.set_merged_config(result)
+        return result
 
     @app_config_fragment_repository_resilience.apply()
     async def scoped_search_app_configs(

--- a/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_app_config_fragment.py
@@ -6,6 +6,10 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
+from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
+from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
+from ai.backend.common.types import ValkeyTarget
+from ai.backend.manager.clients.valkey_client.valkey_cache import ValkeyCache
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentKey,
     AppConfigScopeType,
@@ -16,11 +20,34 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.app_config_fragment.admin_repository import (
     AppConfigFragmentAdminRepository,
 )
+from ai.backend.manager.repositories.app_config_fragment.cache_source import (
+    AppConfigFragmentCacheSource,
+)
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
+
+
+@pytest.fixture
+async def cache_source(
+    redis_container: tuple[str, HostPortPairModel],
+) -> AsyncGenerator[AppConfigFragmentCacheSource, None]:
+    """Real Valkey-backed cache source (write-through populate + invalidate)."""
+    redis_addr = redis_container[1]
+    valkey_target = ValkeyTarget(
+        addr=f"{redis_addr.host}:{redis_addr.port}",
+        sentinel=None,
+        service_name=None,
+    )
+    valkey_stat = await ValkeyStatClient.create(
+        valkey_target=valkey_target,
+        db_id=0,
+        human_readable_name="test-app-config-fragment-cache",
+    )
+    yield AppConfigFragmentCacheSource(ValkeyCache(valkey_stat._client))
+    await valkey_stat.close()
 
 
 class TestAppConfigFragmentRepository:
@@ -40,12 +67,20 @@ class TestAppConfigFragmentRepository:
             yield database_connection
 
     @pytest.fixture
-    def repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
-        return AppConfigFragmentRepository(db, DBOpsProvider(db))
+    def repository(
+        self,
+        db: ExtendedAsyncSAEngine,
+        cache_source: AppConfigFragmentCacheSource,
+    ) -> AppConfigFragmentRepository:
+        return AppConfigFragmentRepository(db, DBOpsProvider(db), cache_source=cache_source)
 
     @pytest.fixture
-    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
-        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db))
+    def admin_repository(
+        self,
+        db: ExtendedAsyncSAEngine,
+        cache_source: AppConfigFragmentCacheSource,
+    ) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db), cache_source=cache_source)
 
     async def test_create_and_get_by_key(
         self,
@@ -128,8 +163,12 @@ class TestAppConfigFragmentAdminRepository:
             yield database_connection
 
     @pytest.fixture
-    def admin_repository(self, db: ExtendedAsyncSAEngine) -> AppConfigFragmentAdminRepository:
-        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db))
+    def admin_repository(
+        self,
+        db: ExtendedAsyncSAEngine,
+        cache_source: AppConfigFragmentCacheSource,
+    ) -> AppConfigFragmentAdminRepository:
+        return AppConfigFragmentAdminRepository(db, DBOpsProvider(db), cache_source=cache_source)
 
     async def test_update_replaces_config(
         self,


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 12-PR stack delivering BEP-1052 (rank-based AppConfig). **Merge in order:**

1. ⬇️ **#12224** — `feat(BA-6510): AppConfigFragment schema, value types & repo specs`
2. ⬇️ **#12225** — `feat(BA-6511): AppConfigFragment repository (CRUD + rank merge)`
3. ⬇️ **#12226** — `feat(BA-6512): AppConfigFragment v2 DTOs + conditions/orders`
4. ⬇️ **#12244** — `feat(BA-6513): AppConfigFragment service layer (actions, processors)`
5. ⬇️ **#12228** — `feat(BA-6514): AppConfigFragment adapter`
6. ⬇️ **#12229** — `feat(BA-6515): merged-view scoped/admin backend + DTO + adapter`
7. ⬇️ **#12230** — `feat(BA-6516): AppConfigFragment GraphQL`
8. ⬇️ **#12231** — `feat(BA-6517): merged AppConfig GraphQL`
9. ⬇️ **#11286** — `feat(BA-5830): AppConfig/Fragment REST v2`
10. ⬇️ **#12232** — `feat(BA-6518): AppConfig v2 SDK`
11. ⬇️ **#12233** — `feat(BA-6519): AppConfig v2 CLI`
12. 👉 **#11298** — `feat(BA-5837): ValkeyCache for merged-view reads` ← you are here

## Summary

Fronts the `AppConfigFragment` merged-view read path with a Valkey cache, so repeated WebUI bootstrap reads of the per-`(user, name)` merged `AppConfig` view don't hit the DB on every request.

- New `repositories/app_config_fragment/cache_source/cache_source.py` — `AppConfigFragmentCacheSource` (Valkey-backed, TTL default 600s):
  - `get_merged_config(user_id, name)` / `set_merged_config(merged, domain_name=...)`: caches only the deep-merged `config` payload under `app_config:merged:{user_id}:{name}` (fragments stay cheap to recompute and are not cached).
  - `set_merged_config` writes via a non-atomic `Batch` and maintains two membership indexes so invalidation never needs `SCAN`: `app_config:user_keys:{user_id}` (cache keys per user) and `app_config:domain_users:{domain_name}` (users seen per domain).
  - `invalidate_for_scope(scope_type, scope_id)`: `USER` drops the user's key set; `DOMAIN` / `DOMAIN_USER_DEFAULTS` cascade through the domain's user set; `PUBLIC` is intentionally left to TTL. `invalidate_for_user(...)` is a convenience wrapper for self-service bulk writes.
  - Every public method is wrapped in `suppress_with_log`, so any Valkey error logs a warning and falls through to the DB.
- `AppConfigFragmentRepository.app_config(...)` is now cache-aside: on a hit it still re-fetches the fragment list from the DB and returns the cached `config` (response shape unchanged); on a miss it reads from the DB and write-throughs, tagging the entry with the user's domain.
- `AppConfigFragmentAdminRepository.{create,update,purge}` invalidate the affected scope after each successful DB write (purge only when a row was actually removed).
- `db_source.get_user_domain_name(user_id)`: single-column lookup used to tag merged-view entries with their owning domain.
- `repositories.py` wraps `args.valkey_stat_client` in a `ValkeyCache` and threads the cache source into both repos; both accept `cache_source=None` and degrade to plain DB reads when absent.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11298.org.readthedocs.build/en/11298/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11298.org.readthedocs.build/ko/11298/

<!-- readthedocs-preview sorna-ko end -->

