### PR TITLE
feat(BA-5817): migrate model card membership check from agus to ASE

### DIFF
--- a/changes/11299.feature.md
+++ b/changes/11299.feature.md
@@ -1,0 +1,1 @@
+Migrate model card project membership check from `association_groups_users` to `association_scopes_entities` (ASE).

--- a/src/ai/backend/manager/repositories/model_card/types.py
+++ b/src/ai/backend/manager/repositories/model_card/types.py
@@ -10,9 +10,13 @@ import sqlalchemy as sa
 
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
 from ai.backend.manager.data.model_card.types import ModelCardData
+from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.errors.resource import ProjectNotFound
-from ai.backend.manager.models.group.row import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.group.row import GroupRow
 from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 __all__ = (
@@ -76,7 +80,9 @@ class ProjectModelCardSearchScope(SearchScope):
         """Query to validate user is a member of this project."""
         return sa.select(sa.literal(True)).where(
             sa.and_(
-                AssocGroupUserRow.user_id == self.user_id,
-                AssocGroupUserRow.group_id == self.project_id,
+                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                AssociationScopesEntitiesRow.scope_id == str(self.project_id),
+                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.entity_id == str(self.user_id),
             )
         )

--- a/tests/component/model_card/BUILD
+++ b/tests/component/model_card/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.permission.types import EntityType, ScopeType
+from ai.backend.common.data.permission.types import EntityType, OperationType, ScopeType
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
@@ -45,6 +45,7 @@ from ai.backend.manager.models.model_card.row import ModelCardRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
@@ -70,7 +71,7 @@ if TYPE_CHECKING:
 
 def _build_validators(
     database_engine: ExtendedAsyncSAEngine,
-    config_provider: ManagerConfigProvider | MagicMock,
+    config_provider: ManagerConfigProvider,
 ) -> ActionValidators:
     permission_repo = PermissionControllerRepository(database_engine)
     return ActionValidators(
@@ -85,10 +86,9 @@ def _build_validators(
 def model_card_processors(
     database_engine: ExtendedAsyncSAEngine,
     storage_manager: AsyncMock,
-    config_provider: MagicMock,
+    config_provider: ManagerConfigProvider,
 ) -> ModelCardProcessors:
-    """Real ModelCardProcessors with RBAC enforcement disabled."""
-    config_provider.config.manager.rbac.enforcement_enabled = False
+    """Real ModelCardProcessors with real RBAC enforcement."""
     repo = ModelCardRepository(database_engine)
     service = ModelCardService(repo, storage_manager)
     return ModelCardProcessors(
@@ -102,11 +102,10 @@ def model_card_processors(
 def group_processors(
     database_engine: ExtendedAsyncSAEngine,
     storage_manager: AsyncMock,
-    config_provider: MagicMock,
+    config_provider: ManagerConfigProvider,
     valkey_clients: ValkeyClients,
 ) -> GroupProcessors:
-    """Real GroupProcessors with RBAC enforcement disabled."""
-    config_provider.config.manager.rbac.enforcement_enabled = False
+    """Real GroupProcessors with real RBAC enforcement."""
     repo = GroupRepository(
         database_engine,
         config_provider,
@@ -131,7 +130,7 @@ def group_processors(
 def permission_controller_processors(
     database_engine: ExtendedAsyncSAEngine,
     storage_manager: AsyncMock,
-    config_provider: MagicMock,
+    config_provider: ManagerConfigProvider,
     valkey_clients: ValkeyClients,
 ) -> PermissionControllerProcessors:
     """Real PermissionControllerProcessors for role assign/revoke SDK calls."""
@@ -142,11 +141,10 @@ def permission_controller_processors(
     service = PermissionControllerService(
         perm_repo, group_repository=group_repo, rbac_action_registry=[]
     )
-    validators = MagicMock()
-    validators.rbac.scope.validate = AsyncMock()
-    validators.rbac.single_entity.validate = AsyncMock()
     return PermissionControllerProcessors(
-        service=service, action_monitors=[], validators=validators
+        service=service,
+        action_monitors=[],
+        validators=_build_validators(database_engine, config_provider),
     )
 
 
@@ -311,6 +309,36 @@ async def _register_role_in_project(
                     AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.ROLE,
                     AssociationScopesEntitiesRow.__table__.c.entity_id == str(role_fixture),
                 )
+            )
+        )
+
+
+@pytest.fixture(autouse=True)
+async def _grant_model_card_read_permission(
+    db_engine: SAEngine,
+    role_fixture: uuid.UUID,
+    model_store_project_fixture: uuid.UUID,
+) -> AsyncIterator[None]:
+    """Grant model_card:read permission to the test role at the project scope.
+
+    Required for the regular user to pass RBAC enforcement on
+    search_in_project (ScopeActionRBACValidator checks this permission).
+    """
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(PermissionRow.__table__).values(
+                role_id=role_fixture,
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(model_store_project_fixture),
+                entity_type=EntityType.MODEL_CARD,
+                operation=OperationType.READ,
+            )
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(
+                PermissionRow.__table__.c.role_id == role_fixture
             )
         )
 

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.validators import ActionValidators
@@ -41,6 +42,9 @@ from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.group.row import GroupRow
 from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
@@ -277,6 +281,38 @@ async def role_fixture(
     yield role_id
     async with db_engine.begin() as conn:
         await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+@pytest.fixture(autouse=True)
+async def _register_role_in_project(
+    db_engine: SAEngine,
+    role_fixture: uuid.UUID,
+    model_store_project_fixture: uuid.UUID,
+) -> AsyncIterator[None]:
+    """Register the test role in the primary project scope via ASE.
+
+    This ensures revoke_role() can detect the role as project-scoped
+    and properly calls unbind_user_from_project() to clean up agus entries.
+    """
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(model_store_project_fixture),
+                entity_type=EntityType.ROLE,
+                entity_id=str(role_fixture),
+            )
+        )
+    yield
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                sa.and_(
+                    AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.ROLE,
+                    AssociationScopesEntitiesRow.__table__.c.entity_id == str(role_fixture),
+                )
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -1,0 +1,322 @@
+"""Component test fixtures for model card RBAC / project membership scenarios."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import sqlalchemy as sa
+import yarl
+from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.identifier.vfolder import VFolderUUID
+from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import RBACValidators
+from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
+from ai.backend.manager.actions.validators.rbac.single_entity import (
+    SingleEntityActionRBACValidator,
+)
+from ai.backend.manager.api.adapters.model_card.adapter import ModelCardAdapter
+from ai.backend.manager.api.adapters.project.adapter import ProjectAdapter
+from ai.backend.manager.api.adapters.rbac.adapter import RBACAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.model_card.handler import V2ModelCardHandler
+from ai.backend.manager.api.rest.v2.model_card.registry import register_v2_model_card_routes
+from ai.backend.manager.api.rest.v2.project.handler import V2ProjectHandler
+from ai.backend.manager.api.rest.v2.project.registry import register_v2_project_routes
+from ai.backend.manager.api.rest.v2.rbac.handler import V2RBACHandler
+from ai.backend.manager.api.rest.v2.rbac.registry import register_v2_rbac_routes
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.group.types import ProjectType
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
+from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import vfolders
+from ai.backend.manager.repositories.group.repositories import GroupRepositories
+from ai.backend.manager.repositories.group.repository import GroupRepository
+from ai.backend.manager.repositories.model_card.repository import ModelCardRepository
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+from ai.backend.manager.services.group.processors import GroupProcessors
+from ai.backend.manager.services.group.service import GroupService
+from ai.backend.manager.services.model_card.processors import ModelCardProcessors
+from ai.backend.manager.services.model_card.service import ModelCardService
+from ai.backend.manager.services.permission_contoller.processors import (
+    PermissionControllerProcessors,
+)
+from ai.backend.manager.services.permission_contoller.service import PermissionControllerService
+from ai.backend.manager.services.processors import Processors
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+def _build_validators(
+    database_engine: ExtendedAsyncSAEngine,
+    config_provider: ManagerConfigProvider | MagicMock,
+) -> ActionValidators:
+    permission_repo = PermissionControllerRepository(database_engine)
+    return ActionValidators(
+        rbac=RBACValidators(
+            scope=ScopeActionRBACValidator(permission_repo, config_provider),
+            single_entity=SingleEntityActionRBACValidator(permission_repo, config_provider),
+        ),
+    )
+
+
+@pytest.fixture()
+def model_card_processors(
+    database_engine: ExtendedAsyncSAEngine,
+    storage_manager: AsyncMock,
+    config_provider: MagicMock,
+) -> ModelCardProcessors:
+    """Real ModelCardProcessors with RBAC enforcement disabled."""
+    config_provider.config.manager.rbac.enforcement_enabled = False
+    repo = ModelCardRepository(database_engine)
+    service = ModelCardService(repo, storage_manager)
+    return ModelCardProcessors(
+        service=service,
+        action_monitors=[],
+        validators=_build_validators(database_engine, config_provider),
+    )
+
+
+@pytest.fixture()
+def group_processors(
+    database_engine: ExtendedAsyncSAEngine,
+    storage_manager: AsyncMock,
+    config_provider: MagicMock,
+    valkey_clients: ValkeyClients,
+) -> GroupProcessors:
+    """Real GroupProcessors with RBAC enforcement disabled."""
+    config_provider.config.manager.rbac.enforcement_enabled = False
+    repo = GroupRepository(
+        database_engine,
+        config_provider,
+        valkey_clients.stat,
+        storage_manager,
+    )
+    repositories = GroupRepositories(repository=repo)
+    service = GroupService(
+        storage_manager=storage_manager,
+        config_provider=config_provider,
+        valkey_stat_client=valkey_clients.stat,
+        group_repositories=repositories,
+    )
+    return GroupProcessors(
+        group_service=service,
+        action_monitors=[],
+        validators=_build_validators(database_engine, config_provider),
+    )
+
+
+@pytest.fixture()
+def permission_controller_processors(
+    database_engine: ExtendedAsyncSAEngine,
+    storage_manager: AsyncMock,
+    config_provider: MagicMock,
+    valkey_clients: ValkeyClients,
+) -> PermissionControllerProcessors:
+    """Real PermissionControllerProcessors for role assign/revoke SDK calls."""
+    perm_repo = PermissionControllerRepository(database_engine)
+    group_repo = GroupRepository(
+        database_engine, config_provider, valkey_clients.stat, storage_manager
+    )
+    service = PermissionControllerService(
+        perm_repo, group_repository=group_repo, rbac_action_registry=[]
+    )
+    validators = MagicMock()
+    validators.rbac.scope.validate = AsyncMock()
+    validators.rbac.single_entity.validate = AsyncMock()
+    return PermissionControllerProcessors(
+        service=service, action_monitors=[], validators=validators
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    model_card_processors: ModelCardProcessors,
+    group_processors: GroupProcessors,
+    permission_controller_processors: PermissionControllerProcessors,
+) -> list[RouteRegistry]:
+    """Register v2 model-card, project, and RBAC routes for testing."""
+    processors = MagicMock(spec=Processors)
+    processors.model_card = model_card_processors
+    processors.group = group_processors
+    processors.permission_controller = permission_controller_processors
+
+    mc_handler = V2ModelCardHandler(adapter=ModelCardAdapter(processors))
+    proj_handler = V2ProjectHandler(adapter=ProjectAdapter(processors))
+    rbac_handler = V2RBACHandler(adapter=RBACAdapter(processors))
+
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_model_card_routes(mc_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_project_routes(proj_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_rbac_routes(rbac_handler, route_deps))
+    return [v2_reg]
+
+
+# ---------------------------------------------------------------------------
+# DB-seeded fixtures (entities not exposed via SDK or requiring storage proxy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def model_store_project_fixture(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    resource_policy_fixture: str,
+) -> AsyncIterator[uuid.UUID]:
+    """Insert a MODEL_STORE type project and yield its UUID."""
+    project_id = uuid.uuid4()
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(GroupRow.__table__).values(
+                id=project_id,
+                name=f"model-store-{secrets.token_hex(6)}",
+                description="Test MODEL_STORE project",
+                is_active=True,
+                domain_name=domain_fixture,
+                resource_policy=resource_policy_fixture,
+                type=ProjectType.MODEL_STORE,
+            )
+        )
+    yield project_id
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            ModelCardRow.__table__.delete().where(ModelCardRow.__table__.c.project == project_id)
+        )
+        await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
+
+
+@pytest.fixture()
+async def second_project_fixture(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    resource_policy_fixture: str,
+) -> AsyncIterator[uuid.UUID]:
+    """Insert a second MODEL_STORE project for cross-project isolation tests."""
+    project_id = uuid.uuid4()
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(GroupRow.__table__).values(
+                id=project_id,
+                name=f"model-store-b-{secrets.token_hex(6)}",
+                description="Second MODEL_STORE project",
+                is_active=True,
+                domain_name=domain_fixture,
+                resource_policy=resource_policy_fixture,
+                type=ProjectType.MODEL_STORE,
+            )
+        )
+    yield project_id
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            ModelCardRow.__table__.delete().where(ModelCardRow.__table__.c.project == project_id)
+        )
+        await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
+
+
+@pytest.fixture()
+async def vfolder_fixture(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    admin_user_fixture: Any,
+) -> AsyncIterator[VFolderUUID]:
+    """Insert a MODEL-usage vfolder (storage proxy is mocked)."""
+    vfolder_id = VFolderUUID(uuid.uuid4())
+    user_uuid = admin_user_fixture.user_uuid
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(vfolders).values(
+                id=vfolder_id,
+                name=f"test-model-vfolder-{secrets.token_hex(4)}",
+                host="local",
+                domain_name=domain_fixture,
+                quota_scope_id=str(QuotaScopeID(QuotaScopeType.USER, user_uuid)),
+                usage_mode=VFolderUsageMode.MODEL,
+                user=str(user_uuid),
+            )
+        )
+    yield vfolder_id
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            ModelCardRow.__table__.delete().where(ModelCardRow.__table__.c.vfolder == vfolder_id)
+        )
+        await conn.execute(vfolders.delete().where(vfolders.c.id == vfolder_id))
+
+
+@pytest.fixture()
+async def role_fixture(
+    db_engine: SAEngine,
+) -> AsyncIterator[uuid.UUID]:
+    """Insert a project member role for assign_users SDK calls."""
+    role_id = uuid.uuid4()
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values(
+                id=role_id,
+                name=f"test-member-{secrets.token_hex(4)}",
+                status=RoleStatus.ACTIVE,
+            )
+        )
+    yield role_id
+    async with db_engine.begin() as conn:
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+# ---------------------------------------------------------------------------
+# V2 SDK client registries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2ClientRegistry authenticated as superadmin."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    """V2ClientRegistry authenticated as regular user."""
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()

--- a/tests/component/model_card/test_model_card_project_assign.py
+++ b/tests/component/model_card/test_model_card_project_assign.py
@@ -3,12 +3,6 @@
 All mutations (assign, unassign, create model card) go through the SDK;
 only DB-level fixtures are used for entities that require a storage proxy
 (vfolders) or that have no v2 SDK yet (MODEL_STORE project type).
-
-Scenarios:
-1. Assign user → create model card → user searches → finds the card.
-2. Non-member user → search → 403.
-3. Assign → unassign → search → 403.
-4. Cross-project isolation: member of A, not B → A succeeds, B fails.
 """
 
 from __future__ import annotations

--- a/tests/component/model_card/test_model_card_project_assign.py
+++ b/tests/component/model_card/test_model_card_project_assign.py
@@ -1,0 +1,189 @@
+"""Component tests for model card project-scoped RBAC.
+
+All mutations (assign, unassign, create model card) go through the SDK;
+only DB-level fixtures are used for entities that require a storage proxy
+(vfolders) or that have no v2 SDK yet (MODEL_STORE project type).
+
+Scenarios:
+1. Assign user → create model card → user searches → finds the card.
+2. Non-member user → search → 403.
+3. Assign → unassign → search → 403.
+4. Cross-project isolation: member of A, not B → A succeeds, B fails.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.client.v2.exceptions import PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.group.request import (
+    AssignUsersToProjectInput,
+    UnassignUsersFromProjectInput,
+)
+from ai.backend.common.dto.manager.v2.model_card.request import (
+    CreateModelCardInput,
+    SearchModelCardsInput,
+)
+from ai.backend.common.identifier.vfolder import VFolderUUID
+
+if TYPE_CHECKING:
+    from tests.component.conftest import UserFixtureData
+
+
+class TestModelCardRBAC:
+    """Verify ASE-based project membership gating for model card operations."""
+
+    async def test_member_searches_created_model_card(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """Assign user via SDK, create model card via SDK, user searches and finds it."""
+        project_id = model_store_project_fixture
+
+        # Assign regular user to project (admin SDK)
+        await admin_v2_registry.project.assign_users(
+            project_id,
+            AssignUsersToProjectInput(
+                user_ids=[regular_user_fixture.user_uuid],
+                role_id=role_fixture,
+            ),
+        )
+
+        # Create model card in the project (admin SDK — superadmin_required)
+        created = await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="member-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        # Regular user searches in project scope
+        result = await user_v2_registry.model_card.project_search(
+            project_id, SearchModelCardsInput()
+        )
+
+        assert result.total_count == 1
+        assert result.items[0].id == created.model_card.id
+
+    async def test_non_member_is_rejected(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+    ) -> None:
+        """Non-member user cannot search model cards in the project."""
+        project_id = model_store_project_fixture
+
+        # Create model card (admin SDK) — user is NOT assigned
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="hidden-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        # Regular user search → 403
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_id, SearchModelCardsInput())
+
+    async def test_unassigned_user_loses_access(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """After SDK unassign, a previously accessible search fails."""
+        project_id = model_store_project_fixture
+        user_id = regular_user_fixture.user_uuid
+
+        # Assign + create card
+        await admin_v2_registry.project.assign_users(
+            project_id,
+            AssignUsersToProjectInput(user_ids=[user_id], role_id=role_fixture),
+        )
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="ephemeral-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        # Confirm search works while assigned
+        result = await user_v2_registry.model_card.project_search(
+            project_id, SearchModelCardsInput()
+        )
+        assert result.total_count == 1
+
+        # Unassign via SDK
+        await admin_v2_registry.project.unassign_users(
+            project_id,
+            UnassignUsersFromProjectInput(user_ids=[user_id]),
+        )
+
+        # Search now rejected
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_id, SearchModelCardsInput())
+
+    async def test_cross_project_isolation(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        second_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """Membership in project A does not grant access to project B."""
+        project_a = model_store_project_fixture
+        project_b = second_project_fixture
+        user_id = regular_user_fixture.user_uuid
+
+        # Assign user to project A only
+        await admin_v2_registry.project.assign_users(
+            project_a,
+            AssignUsersToProjectInput(user_ids=[user_id], role_id=role_fixture),
+        )
+
+        # Create cards in both projects
+        card_a = await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="card-in-a",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_a,
+            ),
+        )
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="card-in-b",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_b,
+            ),
+        )
+
+        # Project A: success
+        result_a = await user_v2_registry.model_card.project_search(
+            project_a, SearchModelCardsInput()
+        )
+        assert result_a.total_count == 1
+        assert result_a.items[0].id == card_a.model_card.id
+
+        # Project B: rejected
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_b, SearchModelCardsInput())

--- a/tests/component/model_card/test_model_card_role_assign.py
+++ b/tests/component/model_card/test_model_card_role_assign.py
@@ -4,12 +4,6 @@ Tests the same membership gating scenarios as test_model_card_project_assign,
 but membership is acquired/revoked through the RBAC role assignment SDK
 (rbac.assign_role / rbac.revoke_role with project_id) instead of
 project.assign_users / project.unassign_users.
-
-Scenarios:
-1. Assign role with project → create model card → user searches → finds it.
-2. Non-member user → search → 403.
-3. Assign role → revoke role → search → 403.
-4. Cross-project isolation: role assigned in project A only → A succeeds, B fails.
 """
 
 from __future__ import annotations

--- a/tests/component/model_card/test_model_card_role_assign.py
+++ b/tests/component/model_card/test_model_card_role_assign.py
@@ -1,0 +1,185 @@
+"""Component tests for model card access via role assignment.
+
+Tests the same membership gating scenarios as test_model_card_project_assign,
+but membership is acquired/revoked through the RBAC role assignment SDK
+(rbac.assign_role / rbac.revoke_role with project_id) instead of
+project.assign_users / project.unassign_users.
+
+Scenarios:
+1. Assign role with project → create model card → user searches → finds it.
+2. Non-member user → search → 403.
+3. Assign role → revoke role → search → 403.
+4. Cross-project isolation: role assigned in project A only → A succeeds, B fails.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.client.v2.exceptions import PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.model_card.request import (
+    CreateModelCardInput,
+    SearchModelCardsInput,
+)
+from ai.backend.common.dto.manager.v2.rbac.request import (
+    AssignRoleInput,
+    RevokeRoleInput,
+)
+from ai.backend.common.identifier.vfolder import VFolderUUID
+
+if TYPE_CHECKING:
+    from tests.component.conftest import UserFixtureData
+
+
+class TestModelCardRoleAssign:
+    """Verify ASE-based membership gating when membership comes from role assignment."""
+
+    async def test_role_member_searches_created_model_card(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """Assign role with project_id, create model card, user searches and finds it."""
+        project_id = model_store_project_fixture
+
+        # Assign role with project binding (admin SDK)
+        await admin_v2_registry.rbac.assign_role(
+            AssignRoleInput(
+                user_id=regular_user_fixture.user_uuid,
+                role_id=role_fixture,
+                project_id=project_id,
+            ),
+        )
+
+        # Create model card (admin SDK — superadmin_required)
+        created = await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="role-member-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        # Regular user searches
+        result = await user_v2_registry.model_card.project_search(
+            project_id, SearchModelCardsInput()
+        )
+
+        assert result.total_count == 1
+        assert result.items[0].id == created.model_card.id
+
+    async def test_non_member_is_rejected(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+    ) -> None:
+        """User without role assignment cannot search model cards."""
+        project_id = model_store_project_fixture
+
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="hidden-role-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_id, SearchModelCardsInput())
+
+    async def test_revoked_role_loses_access(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """After role revocation, a previously accessible search fails."""
+        project_id = model_store_project_fixture
+        user_id = regular_user_fixture.user_uuid
+
+        # Assign role + create card
+        await admin_v2_registry.rbac.assign_role(
+            AssignRoleInput(user_id=user_id, role_id=role_fixture, project_id=project_id),
+        )
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="ephemeral-role-card",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_id,
+            ),
+        )
+
+        # Confirm search works while role is assigned
+        result = await user_v2_registry.model_card.project_search(
+            project_id, SearchModelCardsInput()
+        )
+        assert result.total_count == 1
+
+        # Revoke role via SDK
+        await admin_v2_registry.rbac.revoke_role(
+            RevokeRoleInput(user_id=user_id, role_id=role_fixture),
+        )
+
+        # Search now rejected
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_id, SearchModelCardsInput())
+
+    async def test_cross_project_isolation(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        user_v2_registry: V2ClientRegistry,
+        regular_user_fixture: UserFixtureData,
+        model_store_project_fixture: uuid.UUID,
+        second_project_fixture: uuid.UUID,
+        vfolder_fixture: VFolderUUID,
+        role_fixture: uuid.UUID,
+    ) -> None:
+        """Role assigned in project A does not grant access to project B."""
+        project_a = model_store_project_fixture
+        project_b = second_project_fixture
+        user_id = regular_user_fixture.user_uuid
+
+        # Assign role with project A only
+        await admin_v2_registry.rbac.assign_role(
+            AssignRoleInput(user_id=user_id, role_id=role_fixture, project_id=project_a),
+        )
+
+        # Create cards in both projects
+        card_a = await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="role-card-in-a",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_a,
+            ),
+        )
+        await admin_v2_registry.model_card.create(
+            CreateModelCardInput(
+                name="role-card-in-b",
+                vfolder_id=vfolder_fixture,
+                model_store_project_id=project_b,
+            ),
+        )
+
+        # Project A: success
+        result_a = await user_v2_registry.model_card.project_search(
+            project_a, SearchModelCardsInput()
+        )
+        assert result_a.total_count == 1
+        assert result_a.items[0].id == card_a.model_card.id
+
+        # Project B: rejected
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.model_card.project_search(project_b, SearchModelCardsInput())

--- a/tests/unit/manager/repositories/model_card/test_model_card_search_in_project.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_search_in_project.py
@@ -1,0 +1,262 @@
+"""Tests for ModelCardDBSource.search_in_project membership check.
+
+Verifies that the ASE-based membership_check_query on
+ProjectModelCardSearchScope correctly gates access:
+- A user who IS a project member (via association_scopes_entities) can search.
+- A user who is NOT a project member is rejected with GenericForbidden.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ai.backend.common.data.permission.types import EntityType, ScopeType
+from ai.backend.common.types import ResourceSlot
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.errors.common import GenericForbidden
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.model_card.row import ModelCardRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.base.pagination import OffsetPagination
+from ai.backend.manager.repositories.model_card.db_source.db_source import ModelCardDBSource
+from ai.backend.manager.repositories.model_card.types import ProjectModelCardSearchScope
+from ai.backend.testutils.db import with_tables
+
+if TYPE_CHECKING:
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+class TestSearchInProjectMembership:
+    """Verify ASE-based membership gating in search_in_project."""
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                AgentRow,
+                ImageRow,
+                VFolderRow,
+                SessionRow,
+                KernelRow,
+                ModelCardRow,
+                AssociationScopesEntitiesRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def test_domain(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> DomainRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            domain = DomainRow(
+                name=f"test-domain-{uuid.uuid4().hex[:8]}",
+                description="Test domain",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+                allowed_docker_registries=[],
+            )
+            db_sess.add(domain)
+            await db_sess.flush()
+        return domain
+
+    @pytest.fixture
+    async def test_user_resource_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> UserResourcePolicyRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy = UserResourcePolicyRow(
+                name=f"test-user-policy-{uuid.uuid4().hex[:8]}",
+                max_vfolder_count=10,
+                max_quota_scope_size=10 * (1024**3),
+                max_session_count_per_model_session=5,
+                max_customized_image_count=3,
+            )
+            db_sess.add(policy)
+            await db_sess.flush()
+        return policy
+
+    @pytest.fixture
+    async def test_project_resource_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> ProjectResourcePolicyRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy = ProjectResourcePolicyRow(
+                name=f"test-proj-policy-{uuid.uuid4().hex[:8]}",
+                max_vfolder_count=10,
+                max_quota_scope_size=100 * (1024**3),
+                max_network_count=5,
+            )
+            db_sess.add(policy)
+            await db_sess.flush()
+        return policy
+
+    @pytest.fixture
+    async def test_project(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_project_resource_policy: ProjectResourcePolicyRow,
+    ) -> GroupRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            group = GroupRow(
+                id=uuid.uuid4(),
+                name=f"test-project-{uuid.uuid4().hex[:8]}",
+                description="Test project",
+                is_active=True,
+                domain_name=test_domain.name,
+                resource_policy=test_project_resource_policy.name,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+            )
+            db_sess.add(group)
+            await db_sess.flush()
+        return group
+
+    @pytest.fixture
+    async def member_user(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_user_resource_policy: UserResourcePolicyRow,
+        test_project: GroupRow,
+    ) -> UserRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            user = UserRow(
+                uuid=uuid.uuid4(),
+                username=f"member-{uuid.uuid4().hex[:8]}",
+                email=f"member-{uuid.uuid4().hex[:8]}@example.com",
+                password=PasswordInfo(
+                    password="test_password",
+                    algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                    rounds=100_000,
+                    salt_size=32,
+                ),
+                need_password_change=False,
+                full_name="Member User",
+                domain_name=test_domain.name,
+                role=UserRole.USER,
+                status=UserStatus.ACTIVE,
+                status_info="active",
+                resource_policy=test_user_resource_policy.name,
+            )
+            db_sess.add(user)
+            await db_sess.flush()
+            # Register as project member via ASE
+            db_sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(test_project.id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(user.uuid),
+                )
+            )
+            await db_sess.flush()
+        return user
+
+    @pytest.fixture
+    async def non_member_user(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_user_resource_policy: UserResourcePolicyRow,
+    ) -> UserRow:
+        async with db_with_cleanup.begin_session() as db_sess:
+            user = UserRow(
+                uuid=uuid.uuid4(),
+                username=f"nonmember-{uuid.uuid4().hex[:8]}",
+                email=f"nonmember-{uuid.uuid4().hex[:8]}@example.com",
+                password=PasswordInfo(
+                    password="test_password",
+                    algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                    rounds=100_000,
+                    salt_size=32,
+                ),
+                need_password_change=False,
+                full_name="Non-Member User",
+                domain_name=test_domain.name,
+                role=UserRole.USER,
+                status=UserStatus.ACTIVE,
+                status_info="active",
+                resource_policy=test_user_resource_policy.name,
+            )
+            db_sess.add(user)
+            await db_sess.flush()
+        return user
+
+    @pytest.fixture
+    def db_source(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> ModelCardDBSource:
+        return ModelCardDBSource(db_with_cleanup)
+
+    async def test_member_can_search(
+        self,
+        db_source: ModelCardDBSource,
+        test_project: GroupRow,
+        member_user: UserRow,
+    ) -> None:
+        scope = ProjectModelCardSearchScope(
+            project_id=test_project.id,
+            user_id=member_user.uuid,
+        )
+        querier = BatchQuerier(pagination=OffsetPagination(limit=10, offset=0))
+        result = await db_source.search_in_project(querier, scope)
+        assert result.items == []
+        assert result.total_count == 0
+
+    async def test_non_member_is_rejected(
+        self,
+        db_source: ModelCardDBSource,
+        test_project: GroupRow,
+        non_member_user: UserRow,
+    ) -> None:
+        scope = ProjectModelCardSearchScope(
+            project_id=test_project.id,
+            user_id=non_member_user.uuid,
+        )
+        querier = BatchQuerier(pagination=OffsetPagination(limit=10, offset=0))
+        with pytest.raises(GenericForbidden):
+            await db_source.search_in_project(querier, scope)


### PR DESCRIPTION
## Summary
- Migrate `ProjectModelCardSearchScope.membership_check_query` from `AssocGroupUserRow` to `AssociationScopesEntitiesRow` (ASE) with `scope_type=PROJECT, entity_type=USER`
- Add unit tests verifying ASE-based membership check at the DB layer (member passes, non-member rejected)
- Add component tests exercising the full HTTP API flow via SDK for two membership acquisition paths:
  - **project assign**: `project.assign_users()` / `project.unassign_users()`
  - **role assign**: `rbac.assign_role(project_id=...)` / `rbac.revoke_role()`

## Test plan
- [x] Unit test: member can search, non-member is rejected (`test_model_card_search_in_project.py`)
- [x] Component test — project assign path (`test_model_card_project_assign.py`):
  - [x] Assigned member searches and finds model card
  - [x] Non-member is rejected with 403
  - [x] Unassigned user loses access
  - [x] Cross-project isolation
- [x] Component test — role assign path (`test_model_card_role_assign.py`):
  - [x] Role-assigned member searches and finds model card
  - [x] Non-member is rejected with 403
  - [x] Revoked role loses access
  - [x] Cross-project isolation

Resolves BA-5817