### PR TITLE
chore(ci): add path filter and split lint/typecheck jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,50 @@ jobs:
       - uses: lablup/auto-labeler@main
 
 
-  lint-and-typecheck:
+  detect-changes:
     if: |
       !contains(github.event.pull_request.labels.*.name, 'skip:ci')
       && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
     runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
+    - uses: actions/checkout@v6
+      with:
+        lfs: false
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'src/**'
+            - 'tests/**'
+            - '**/BUILD'
+            - 'pants.toml'
+            - 'pants.ci.toml'
+            - 'python*.lock'
+            - 'tools/*.lock'
+            - '.github/workflows/ci.yml'
+
+
+  check-build-and-lint:
+    needs: detect-changes
+    if: |
+      always()
+      && !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.code == 'true'
+        || startsWith(github.ref, 'refs/tags/')
+      )
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify detect-changes
+      if: needs.detect-changes.result != 'success'
+      run: |
+        echo "detect-changes did not succeed: ${{ needs.detect-changes.result }}"
+        exit 1
     - name: Calculate the fetch depth
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
@@ -102,39 +140,129 @@ jobs:
           pants tailor --check update-build-files --check --changed-since=$BASE_REF
         fi
     - name: Lint
-      id: lint
-      continue-on-error: true
       run: |
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
-          echo "(skipping matchers for pull request from local branches)"
+        if [ "$IS_FORK_PR" == "true" ]; then
+          echo "(skipping matchers for fork pull request)"
         else
           echo "::add-matcher::.github/workflows/flake8-matcher.json"
         fi
-        pants lint --changed-since=$BASE_REF --changed-dependents=transitive
-    - name: Typecheck
-      id: typecheck
-      continue-on-error: true
+        pants lint --changed-since=$BASE_REF
+    - name: Upload pants log
+      uses: actions/upload-artifact@v5
+      with:
+        name: pants.check-build-and-lint.log
+        path: .pants.d/workdir/pants.log
+      if: always()  # We want the log even on failures.
+
+
+  typecheck:
+    needs: detect-changes
+    if: |
+      always()
+      && !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.code == 'true'
+        || startsWith(github.ref, 'refs/tags/')
+      )
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify detect-changes
+      if: needs.detect-changes.result != 'success'
       run: |
-        if [ "$GITHUB_EVENT_NAME" == "pull_request" -a -n "$GITHUB_HEAD_REF" ]; then
-          echo "(skipping matchers for pull request from local branches)"
+        echo "detect-changes did not succeed: ${{ needs.detect-changes.result }}"
+        exit 1
+    - name: Calculate the fetch depth
+      run: |
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+            echo "IS_FORK_PR=true" >> "${GITHUB_ENV}"
+            # Fork PRs need full history to find the merge base
+            echo "GIT_FETCH_DEPTH=0" >> "${GITHUB_ENV}"
+          else
+            echo "IS_FORK_PR=false" >> "${GITHUB_ENV}"
+            echo "GIT_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+          fi
+        else
+          echo "IS_FORK_PR=false" >> "${GITHUB_ENV}"
+          echo "GIT_FETCH_DEPTH=2" >> "${GITHUB_ENV}"
+        fi
+    - name: Check out the revision with minimal required history
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: ${{ env.GIT_FETCH_DEPTH }}
+        lfs: false
+    - name: Extract Python version from pants.toml
+      run: |
+        PYTHON_VERSION=$(grep -m 1 -oP '(?<=CPython==)([^"]+)' pants.toml)
+        echo "PANTS_CONFIG_FILES=pants.ci.toml" >> $GITHUB_ENV
+        echo "PROJECT_PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
+    - name: Set up Python as Runtime
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PROJECT_PYTHON_VERSION }}
+    - name: Set up remote cache backend (if applicable)
+      run: |
+        echo "PANTS_REMOTE_STORE_ADDRESS=${REMOTE_CACHE_BACKEND_ENDPOINT}" >> $GITHUB_ENV
+        echo "PANTS_REMOTE_CACHE_READ=true" >> $GITHUB_ENV
+        echo "PANTS_REMOTE_CACHE_WRITE=true" >> $GITHUB_ENV
+        echo "PANTS_REMOTE_INSTANCE_NAME=main" >> $GITHUB_ENV
+      env:
+        REMOTE_CACHE_BACKEND_ENDPOINT: ${{ secrets.PANTS_REMOTE_CACHE_ENDPOINT_ARC }}
+      if: ${{ env.REMOTE_CACHE_BACKEND_ENDPOINT != '' }}
+    - name: Bootstrap Pants
+      uses: pantsbuild/actions/init-pants@v10
+      with:
+        gha-cache-key: v0
+        named-caches-hash: ${{ hashFiles('python*.lock', 'tools/*.lock') }}
+        cache-lmdb-store: 'true'
+    - name: Calculate base ref
+      run: |
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          if [ "$IS_FORK_PR" == "true" ]; then
+            git fetch origin "${{ github.event.pull_request.base.sha }}"
+          else
+            git fetch --depth=50 origin "${{ github.event.pull_request.base.sha }}"
+          fi
+          BASE_REF="${{ github.event.pull_request.base.sha }}"
+        else
+          BASE_REF="HEAD~1"
+        fi
+        echo "BASE_REF=$BASE_REF" >> $GITHUB_ENV
+    - name: Typecheck
+      run: |
+        if [ "$IS_FORK_PR" == "true" ]; then
+          echo "(skipping matchers for fork pull request)"
         else
           echo "::add-matcher::.github/workflows/mypy-matcher.json"
         fi
         pants check --changed-since=$BASE_REF --changed-dependents=transitive
-    - name: Check results
-      if: always()
-      run: |
-        if [ "${{ steps.lint.outcome }}" != "success" ] || [ "${{ steps.typecheck.outcome }}" != "success" ]; then
-          echo "Lint outcome: ${{ steps.lint.outcome }}"
-          echo "Typecheck outcome: ${{ steps.typecheck.outcome }}"
-          exit 1
-        fi
     - name: Upload pants log
       uses: actions/upload-artifact@v5
       with:
-        name: pants.lint-and-typecheck.log
+        name: pants.typecheck.log
         path: .pants.d/workdir/pants.log
       if: always()  # We want the log even on failures.
+
+
+  lint-and-typecheck:
+    needs: [check-build-and-lint, typecheck]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        lint_result="${{ needs.check-build-and-lint.result }}"
+        typecheck_result="${{ needs.typecheck.result }}"
+        echo "check-build-and-lint: $lint_result"
+        echo "typecheck: $typecheck_result"
+        for r in "$lint_result" "$typecheck_result"; do
+          if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+            echo "FAIL: unexpected result $r"
+            exit 1
+          fi
+        done
+        echo "OK"
 
 
   check-alembic-migrations:
@@ -213,15 +341,27 @@ jobs:
 
 
   test-unit:
+    needs: detect-changes
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      always()
+      && !contains(github.event.pull_request.labels.*.name, 'skip:ci')
       && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.code == 'true'
+        || startsWith(github.ref, 'refs/tags/')
+      )
     runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         shard: ${{ fromJSON('["0/3","1/3","2/3"]') }}
     steps:
+    - name: Verify detect-changes
+      if: needs.detect-changes.result != 'success'
+      run: |
+        echo "detect-changes did not succeed: ${{ needs.detect-changes.result }}"
+        exit 1
     - name: Calculate the fetch depth
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
@@ -271,7 +411,7 @@ jobs:
           else
             BASE_REF="HEAD~1"
           fi
-          pants test --changed-since=$BASE_REF --changed-dependents=transitive \
+          pants test --changed-since=$BASE_REF --changed-dependents=direct \
             --shard='${{ matrix.shard }}' \
             --filter-address-regex='tests/unit/' -- -v
         fi
@@ -284,15 +424,27 @@ jobs:
 
 
   test-component:
+    needs: detect-changes
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      always()
+      && !contains(github.event.pull_request.labels.*.name, 'skip:ci')
       && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.code == 'true'
+        || startsWith(github.ref, 'refs/tags/')
+      )
     runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         shard: ${{ fromJSON('["0/2","1/2"]') }}
     steps:
+    - name: Verify detect-changes
+      if: needs.detect-changes.result != 'success'
+      run: |
+        echo "detect-changes did not succeed: ${{ needs.detect-changes.result }}"
+        exit 1
     - name: Calculate the fetch depth
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
@@ -359,7 +511,7 @@ jobs:
           else
             BASE_REF="HEAD~1"
           fi
-          pants test --changed-since=$BASE_REF --changed-dependents=transitive \
+          pants test --changed-since=$BASE_REF --changed-dependents=direct \
             --shard='${{ matrix.shard }}' \
             --filter-address-regex='tests/component/' -- -v
         fi
@@ -372,15 +524,27 @@ jobs:
 
 
   test-integration:
+    needs: detect-changes
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci')
+      always()
+      && !contains(github.event.pull_request.labels.*.name, 'skip:ci')
       && !contains(toJSON(github.event.head_commit.message), 'skip:ci')
+      && (
+        needs.detect-changes.result != 'success'
+        || needs.detect-changes.outputs.code == 'true'
+        || startsWith(github.ref, 'refs/tags/')
+      )
     runs-on: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         shard: ${{ fromJSON('["0/2","1/2"]') }}
     steps:
+    - name: Verify detect-changes
+      if: needs.detect-changes.result != 'success'
+      run: |
+        echo "detect-changes did not succeed: ${{ needs.detect-changes.result }}"
+        exit 1
     - name: Calculate the fetch depth
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
@@ -453,10 +617,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
-        if [ "${{ needs.test-unit.result }}" = "success" ]; then
-          echo "All test-unit shards passed"
+        r="${{ needs.test-unit.result }}"
+        echo "test-unit: $r"
+        if [ "$r" = "success" ] || [ "$r" = "skipped" ]; then
+          echo "OK"
         else
-          echo "test-unit failed: ${{ needs.test-unit.result }}"
+          echo "FAIL"
           exit 1
         fi
 
@@ -466,10 +632,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
-        if [ "${{ needs.test-component.result }}" = "success" ]; then
-          echo "All test-component shards passed"
+        r="${{ needs.test-component.result }}"
+        echo "test-component: $r"
+        if [ "$r" = "success" ] || [ "$r" = "skipped" ]; then
+          echo "OK"
         else
-          echo "test-component failed: ${{ needs.test-component.result }}"
+          echo "FAIL"
           exit 1
         fi
 
@@ -479,10 +647,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
-        if [ "${{ needs.test-integration.result }}" = "success" ]; then
-          echo "All test-integration shards passed"
+        r="${{ needs.test-integration.result }}"
+        echo "test-integration: $r"
+        if [ "$r" = "success" ] || [ "$r" = "skipped" ]; then
+          echo "OK"
         else
-          echo "test-integration failed: ${{ needs.test-integration.result }}"
+          echo "FAIL"
           exit 1
         fi
 

--- a/changes/11306.misc.md
+++ b/changes/11306.misc.md
@@ -1,0 +1,1 @@
+Speed up PR CI by adding path filter, splitting lint/typecheck jobs, and narrowing test dependents scope to `direct`.

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -23,9 +23,11 @@ CURRENT_COMMIT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if ! command -v gh &> /dev/null; then
-  echo "GitHub CLI (gh) is not installed. Running lint on HEAD~1."
+  echo "GitHub CLI (gh) is not installed. Running lint/check/test on HEAD~1."
   pants tailor --check update-build-files --check --changed-since=HEAD~1
   pants lint --changed-since=HEAD~1
+  pants check --changed-since=HEAD~1 --changed-dependents=direct
+  pants test --changed-since=HEAD~1 --changed-dependents=direct
 else
   # Get the base branch name from GitHub if we are on a pull request.
   BASE_BRANCH=$(gh pr view "$CURRENT_BRANCH" --json baseRefName -q '.baseRefName' 2>/dev/null || true)
@@ -53,6 +55,8 @@ else
   else
     ORIGIN="origin"
   fi
-  echo "Performing lint and check on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
+  echo "Performing lint/check/test on ${ORIGIN}/${BASE_BRANCH}..HEAD@${CURRENT_COMMIT} ..."
   pants lint --changed-since="${ORIGIN}/${BASE_BRANCH}"
+  pants check --changed-since="${ORIGIN}/${BASE_BRANCH}" --changed-dependents=direct
+  pants test --changed-since="${ORIGIN}/${BASE_BRANCH}" --changed-dependents=direct
 fi


### PR DESCRIPTION
## Summary

- **CI 단축**: docs/proposals/configs-only PR에서 `detect-changes` job이 path filter로 판정 → workload 5개(check-build-and-lint, typecheck, test-unit, test-component, test-integration) 모두 skipped로 떨어짐
- **로그 가시성 개선**: `lint-and-typecheck` job을 `check-build-and-lint` + `typecheck` 두 개로 분리해 각자 독립 실행/실패 표시. `lint-and-typecheck`는 gate job으로 남겨 기존 branch protection rule 호환 유지
- **dependents 범위 축소**: `pants lint`는 `--changed-dependents` 제거(none), `pants test` (unit/component)는 `transitive` → `direct`. PR CI wall-clock 단축. release tag push에서는 풀 스윕 유지(안전망)
- **Problem matcher 활성화**: non-fork PR에서 lint/typecheck 에러가 PR diff에 inline annotation으로 표시 (기존엔 모든 PR에서 비활성)
- **pre-push 강화**: `pants check`/`pants test`를 `--changed-dependents=direct`로 추가해 CI 빨강→재push 사이클 절감

### Broken-setup 안전장치

- 각 workload job은 `if: always() && (needs.detect-changes.result != 'success' || code 변경 || tag)`로 진입
- 첫 step `Verify detect-changes`가 `result != 'success'`면 명시적으로 `exit 1` → broken setup일 때 `failure`로 전파(silent skipped 방지)
- gate들은 `success` 또는 `skipped`만 통과(`failure`/`cancelled`는 차단)

### Path filter 포함/제외

- 포함: `src/**`, `tests/**`, `**/BUILD`, `pants.toml`, `pants.ci.toml`, `python*.lock`, `tools/*.lock`, `.github/workflows/ci.yml`
- 제외: `configs/**`, `scripts/**`, `docs/**`, `proposals/**`, `*.md`, 기타 workflow 파일

## Test plan

- [ ] docs-only PR(예: README 한 줄 수정)에서 5개 workload가 모두 `skipped`로 떨어지고 4개 gate가 모두 통과하는지 확인
- [ ] 코드 변경 PR에서 평소대로 lint/typecheck/test가 정상 실행되는지 확인
- [ ] PR diff에 lint/typecheck 에러가 inline annotation으로 표시되는지 확인 (의도적으로 lint 에러 추가 후 검증)
- [ ] release tag push에서 path filter 무관하게 풀 스윕이 도는지 확인 (다음 release 시점)
- [ ] pre-push hook이 변경 양에 따라 합리적 시간 내 끝나는지 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)