### PR TITLE
fix(appproxy): accept project_id alias on SessionConfig

### DIFF
--- a/changes/11308.fix.md
+++ b/changes/11308.fix.md
@@ -1,0 +1,1 @@
+Accept `project_id` (v2 naming) on app-proxy coordinator's `SessionConfig` payload by renaming the field and aliasing the legacy `group_id` key, fixing HTTP 500 from `/v2/endpoints/bulk` when the manager sends the v2 form.

--- a/src/ai/backend/appproxy/common/types.py
+++ b/src/ai/backend/appproxy/common/types.py
@@ -253,9 +253,14 @@ class SerializableToken(BaseModel):
 
 
 class SessionConfig(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     id: Annotated[UUID | None, Field(default=None)]
     user_uuid: UUID
-    group_id: UUID
+    # Renamed from ``group_id`` to ``project_id`` to align with v2 naming.
+    # ``group_id`` is accepted as a validation alias so older Manager peers
+    # that still send the legacy key continue to work on the wire.
+    project_id: UUID = Field(validation_alias=AliasChoices("project_id", "group_id"))
     access_key: Annotated[str | None, Field(default=None)]
     domain_name: str
 

--- a/src/ai/backend/appproxy/coordinator/api/conf.py
+++ b/src/ai/backend/appproxy/coordinator/api/conf.py
@@ -49,7 +49,7 @@ async def conf_v2(
             params.kernel_port,
             params.session.id,
             params.session.user_uuid,
-            params.session.group_id,
+            params.session.project_id,
             params.session.access_key,
             params.session.domain_name,
         )

--- a/src/ai/backend/appproxy/coordinator/api/proxy.py
+++ b/src/ai/backend/appproxy/coordinator/api/proxy.py
@@ -169,7 +169,7 @@ async def proxy(
                 SessionConfig(
                     id=token.session_id,
                     user_uuid=token.user_uuid,
-                    group_id=token.group_id,
+                    project_id=token.group_id,
                     access_key=token.access_key,
                     domain_name=token.domain_name,
                 ),


### PR DESCRIPTION
## Summary
- Manager v2 sends `project_id` via `SessionTagsModel`, but the coordinator's `SessionConfig` still expected `group_id` — causing HTTP 500 on `/v2/endpoints/bulk` whenever the manager registered a deployment endpoint.
- Rename `SessionConfig.group_id` → `project_id` (UUID type unchanged) and accept the legacy `group_id` key as a `validation_alias` so older Manager peers keep working on the wire.
- Update the two coordinator-internal call sites (`coordinator/api/conf.py`, `coordinator/api/proxy.py`) to pass the new keyword.

## Test plan
- [ ] Verify validation accepts both `project_id` (v2 manager) and `group_id` (legacy peer) payloads.
- [ ] Restart `proxy-coordinator` against a manager that emits `project_id`; confirm `/v2/endpoints/bulk` returns 2xx (no `Field required` ValidationError in logs).
- [ ] Existing internal callers (`SessionConfig(...)`, `params.session.project_id`) compile and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)