### PR TITLE
Security: SSH host key verification disabled (MITM risk)

### DIFF
--- a/scripts/agent/deploy-static/deploy_static_files.py
+++ b/scripts/agent/deploy-static/deploy_static_files.py
@@ -11,7 +11,8 @@ if len(sys.argv) == 1:
 STATIC_FILE = 'https://backend-ai-k8s-agent-static.s3.ap-northeast-2.amazonaws.com/bai-static.tar.gz'
 
 ssh = paramiko.SSHClient()
-ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+ssh.load_system_host_keys()
+ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
 
 for ip in sys.argv[1:]:
     ssh.connect(ip)


### PR DESCRIPTION
## Summary

Security: SSH host key verification disabled (MITM risk)

## Problem

**Severity**: `High` | **File**: `scripts/agent/deploy-static/deploy_static_files.py:L13`

The deployment script sets `AutoAddPolicy`, which trusts unknown SSH host keys automatically. This allows man-in-the-middle attacks during deployment, potentially exposing credentials and enabling command interception/modification.

## Solution

Use strict host key verification (`RejectPolicy`) and pre-provision known host keys (e.g., via `load_system_host_keys()` or a managed known_hosts file). Fail deployment on host key mismatch.

## Changes

- `scripts/agent/deploy-static/deploy_static_files.py` (modified)