### PR TITLE
refactor(BA-5818): migrate query_userinfo off association_groups_users

### DIFF
--- a/changes/11310.enhance.md
+++ b/changes/11310.enhance.md
@@ -1,0 +1,1 @@
+Migrate `query_userinfo` and `query_userinfo_from_session` off `association_groups_users` to read project membership from `association_scopes_entities`.

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -7,14 +7,15 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.types import AccessKey
 
+from .data.permission.types import EntityType, ScopeType
 from .data.user.types import SessionOwnerContext
 from .errors.api import InvalidAPIParameters
 from .errors.auth import AccessKeyNotFound, UserNotFound
 from .errors.common import InternalServerError
 from .models.domain import domains
-from .models.group import association_groups_users as agus
 from .models.group import groups
 from .models.keypair import keypairs
+from .models.rbac_models.association_scopes_entities import AssociationScopesEntitiesRow
 from .models.resource_policy import keypair_resource_policies
 from .models.user import UserRole, users
 
@@ -159,8 +160,7 @@ async def query_userinfo(
         owner_uuid = requester_uuid
         actual_owner_role = requester_role
         # Own-session creation always goes through the USER path to enforce
-        # explicit project membership via the agus table, regardless of the
-        # requester's actual role.
+        # explicit project membership, regardless of the requester's actual role.
         role_for_group_resolution = UserRole.USER
         resource_policy = keypair_resource_policy or {}
 
@@ -211,10 +211,17 @@ async def query_userinfo(
         if requesting_domain != owner_domain:
             raise InvalidAPIParameters("You can only set the domain to your domain.")
         query = (
-            sa.select(agus.c.group_id)
-            .select_from(agus.join(groups, agus.c.group_id == groups.c.id))
+            sa.select(groups.c.id)
+            .select_from(
+                groups.join(
+                    AssociationScopesEntitiesRow,
+                    AssociationScopesEntitiesRow.scope_id == sa.cast(groups.c.id, sa.String),
+                )
+            )
             .where(
-                (agus.c.user_id == owner_uuid)
+                (AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT)
+                & (AssociationScopesEntitiesRow.entity_type == EntityType.USER)
+                & (AssociationScopesEntitiesRow.entity_id == str(owner_uuid))
                 & (groups.c.domain_name == owner_domain)
                 & (group_match_query)
                 & (groups.c.is_active),
@@ -314,8 +321,7 @@ async def query_userinfo_from_session(
         owner_uuid = requester_uuid
         actual_owner_role = requester_role
         # Own-session creation always goes through the USER path to enforce
-        # explicit project membership via the agus table, regardless of the
-        # requester's actual role.
+        # explicit project membership, regardless of the requester's actual role.
         role_for_group_resolution = UserRole.USER
         resource_policy = keypair_resource_policy or {}
 
@@ -366,10 +372,17 @@ async def query_userinfo_from_session(
         if requesting_domain != owner_domain:
             raise InvalidAPIParameters("You can only set the domain to your domain.")
         query = (
-            sa.select(agus.c.group_id)
-            .select_from(agus.join(groups, agus.c.group_id == groups.c.id))
+            sa.select(groups.c.id)
+            .select_from(
+                groups.join(
+                    AssociationScopesEntitiesRow,
+                    AssociationScopesEntitiesRow.scope_id == sa.cast(groups.c.id, sa.String),
+                )
+            )
             .where(
-                (agus.c.user_id == owner_uuid)
+                (AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT)
+                & (AssociationScopesEntitiesRow.entity_type == EntityType.USER)
+                & (AssociationScopesEntitiesRow.entity_id == str(owner_uuid))
                 & (groups.c.domain_name == owner_domain)
                 & (group_match_query)
                 & (groups.c.is_active),

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.data.permission.types import EntityType, RelationType, ScopeType
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import AccessKey, ResourceSlot
 from ai.backend.manager.errors.api import InvalidAPIParameters
@@ -24,11 +25,14 @@ from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -56,7 +60,7 @@ ALL_ROWS = [
     UserRow,
     KeyPairRow,
     GroupRow,
-    AssocGroupUserRow,
+    AssociationScopesEntitiesRow,
     ImageRow,
     VFolderRow,
     EndpointRow,
@@ -201,7 +205,15 @@ class TestQueryUserinfo:
                 )
             )
             await sess.flush()
-            sess.add(AssocGroupUserRow(user_id=user_uuid, group_id=group_id))
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(user_uuid),
+                    relation_type=RelationType.AUTO,
+                )
+            )
             await sess.commit()
 
         yield SeedData(
@@ -563,7 +575,15 @@ class TestQueryUserinfoFromSession:
                 )
             )
             await sess.flush()
-            sess.add(AssocGroupUserRow(user_id=user_uuid, group_id=group_id))
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(user_uuid),
+                    relation_type=RelationType.AUTO,
+                )
+            )
             await sess.commit()
 
         yield SeedData(


### PR DESCRIPTION
## Summary
- Replace `association_groups_users` (agus) JOIN with `AssociationScopesEntitiesRow` predicates (`scope_type=PROJECT`, `entity_type=USER`) in both `query_userinfo` and `query_userinfo_from_session` in `manager/utils.py`.
- Removes the legacy table dependency from session, deployment, and model-serving creation paths in one place — all callers continue to use the same function signatures.
- Update `tests/unit/manager/test_query_userinfo.py` fixtures to seed `AssociationScopesEntitiesRow` (and drop the now-unused `AssocGroupUserRow` setup).

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main`
- [x] `pants check src/ai/backend/manager/utils.py tests/unit/manager/test_query_userinfo.py`
- [x] `pants test tests/unit/manager/test_query_userinfo.py`
- [x] CI green

Resolves BA-5818
