### PR TITLE
feat(BA-5844): AppConfigPolicy REST v2 surface

### DIFF
--- a/changes/11312.feature.md
+++ b/changes/11312.feature.md
@@ -1,1 +1,1 @@
-Add `AppConfigPolicy` REST v2 surface (`POST /v2/app-config-policies/search`, `GET /v2/app-config-policies/{config_name}`, admin `bulk-create` / `bulk-update` / `bulk-purge`) — pairs with the GraphQL surface from BA-5815.
+Add `AppConfigPolicy` REST v2 surface (`POST /v2/app-config-policies/search`, `GET /v2/app-config-policies/{policy_id}`, admin `bulk-create` / `bulk-update` / `bulk-purge`) — pairs with the GraphQL surface from BA-5815.

--- a/changes/11312.feature.md
+++ b/changes/11312.feature.md
@@ -1,0 +1,1 @@
+Add `AppConfigPolicy` REST v2 surface (`POST /v2/app-config-policies/search`, `GET /v2/app-config-policies/{config_name}`, admin `bulk-create` / `bulk-update` / `bulk-purge`) — pairs with the GraphQL surface from BA-5815.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -202,7 +202,7 @@ type AddRevisionPayload
   revision: ModelRevision!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkCreateAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
 type AdminBulkCreateAppConfigPoliciesPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -213,7 +213,7 @@ type AdminBulkCreateAppConfigPoliciesPayload
   failed: [AppConfigPolicyBulkError!]!
 }
 
-"""Added in UNRELEASED. Admin bulk create input for app-config policies."""
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
 input AdminBulkCreateAppConfigPolicyInput
   @join__type(graph: STRAWBERRY)
 {
@@ -222,7 +222,7 @@ input AdminBulkCreateAppConfigPolicyInput
 }
 
 """
-Added in UNRELEASED. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
 """
 input AdminBulkCreateAppConfigPolicyItemInput
   @join__type(graph: STRAWBERRY)
@@ -234,7 +234,7 @@ input AdminBulkCreateAppConfigPolicyItemInput
   scopeSources: [String!]!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkPurgeAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
 type AdminBulkPurgeAppConfigPoliciesPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -246,7 +246,7 @@ type AdminBulkPurgeAppConfigPoliciesPayload
 }
 
 """
-Added in UNRELEASED. Admin bulk purge input for app-config policies (keyed on row id).
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
 """
 input AdminBulkPurgeAppConfigPolicyInput
   @join__type(graph: STRAWBERRY)
@@ -255,7 +255,7 @@ input AdminBulkPurgeAppConfigPolicyInput
   ids: [UUID!]!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkUpdateAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
 type AdminBulkUpdateAppConfigPoliciesPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -266,7 +266,7 @@ type AdminBulkUpdateAppConfigPoliciesPayload
   failed: [AppConfigPolicyBulkError!]!
 }
 
-"""Added in UNRELEASED. Admin bulk update input for app-config policies."""
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
 input AdminBulkUpdateAppConfigPolicyInput
   @join__type(graph: STRAWBERRY)
 {
@@ -275,7 +275,7 @@ input AdminBulkUpdateAppConfigPolicyInput
 }
 
 """
-Added in UNRELEASED. Per-item input for admin bulk update — target row id + new `scope_sources`.
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
 """
 input AdminBulkUpdateAppConfigPolicyItemInput
   @join__type(graph: STRAWBERRY)
@@ -970,7 +970,7 @@ type AllowedResourceGroupsPayload
   items: [String!]!
 }
 
-"""Added in UNRELEASED. Scoped app-config policy."""
+"""Added in 26.4.4. Scoped app-config policy."""
 type AppConfigPolicy implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -991,7 +991,7 @@ type AppConfigPolicy implements Node
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Per-item failure info for bulk Policy mutations."""
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
 type AppConfigPolicyBulkError
   @join__type(graph: STRAWBERRY)
 {
@@ -1003,7 +1003,7 @@ type AppConfigPolicyBulkError
 }
 
 """
-Added in UNRELEASED. Connection type for paginated app-config policy results.
+Added in 26.4.4. Connection type for paginated app-config policy results.
 """
 type AppConfigPolicyConnection
   @join__type(graph: STRAWBERRY)
@@ -1029,7 +1029,7 @@ type AppConfigPolicyEdge
   node: AppConfigPolicy!
 }
 
-"""Added in UNRELEASED. Filter input for querying app-config policies."""
+"""Added in 26.4.4. Filter input for querying app-config policies."""
 input AppConfigPolicyFilter
   @join__type(graph: STRAWBERRY)
 {
@@ -1037,7 +1037,7 @@ input AppConfigPolicyFilter
   configName: StringFilter = null
 }
 
-"""Added in UNRELEASED. Specifies ordering for app-config policy results."""
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
 input AppConfigPolicyOrderBy
   @join__type(graph: STRAWBERRY)
 {
@@ -1048,9 +1048,7 @@ input AppConfigPolicyOrderBy
   direction: OrderDirection! = DESC
 }
 
-"""
-Added in UNRELEASED. Fields available for ordering app-config policies.
-"""
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
 enum AppConfigPolicyOrderField
   @join__type(graph: STRAWBERRY)
 {
@@ -11697,17 +11695,17 @@ type Mutation
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Strict insert keyed on `configName` (admin only, per-item transaction).
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
   """
   adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
   """
   adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
   """
   adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload! @join__field(graph: STRAWBERRY)
 
@@ -14447,12 +14445,12 @@ type Query
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. Get a single app-config policy by row id. Available to any authenticated user.
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
   """
   appConfigPolicy(id: UUID!): AppConfigPolicy @join__field(graph: STRAWBERRY)
 
   """
-  Added in UNRELEASED. List app-config policies with filtering and pagination. Available to any authenticated user.
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
   """
   appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection! @join__field(graph: STRAWBERRY)
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -156,7 +156,7 @@ type AddRevisionPayload {
   revision: ModelRevision!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkCreateAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkCreateAppConfigPolicies`."""
 type AdminBulkCreateAppConfigPoliciesPayload {
   """Created policies."""
   created: [AppConfigPolicy!]!
@@ -165,14 +165,14 @@ type AdminBulkCreateAppConfigPoliciesPayload {
   failed: [AppConfigPolicyBulkError!]!
 }
 
-"""Added in UNRELEASED. Admin bulk create input for app-config policies."""
+"""Added in 26.4.4. Admin bulk create input for app-config policies."""
 input AdminBulkCreateAppConfigPolicyInput {
   """Policies to create."""
   items: [AdminBulkCreateAppConfigPolicyItemInput!]!
 }
 
 """
-Added in UNRELEASED. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
+Added in 26.4.4. Per-item input for admin bulk create — `config_name` + initial `scope_sources`.
 """
 input AdminBulkCreateAppConfigPolicyItemInput {
   """Unique, immutable policy name."""
@@ -182,7 +182,7 @@ input AdminBulkCreateAppConfigPolicyItemInput {
   scopeSources: [String!]!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkPurgeAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkPurgeAppConfigPolicies`."""
 type AdminBulkPurgeAppConfigPoliciesPayload {
   """Ids of policies actually removed (absent ids no-oped)."""
   purgedIds: [UUID!]!
@@ -192,14 +192,14 @@ type AdminBulkPurgeAppConfigPoliciesPayload {
 }
 
 """
-Added in UNRELEASED. Admin bulk purge input for app-config policies (keyed on row id).
+Added in 26.4.4. Admin bulk purge input for app-config policies (keyed on row id).
 """
 input AdminBulkPurgeAppConfigPolicyInput {
   """Policy row ids to purge."""
   ids: [UUID!]!
 }
 
-"""Added in UNRELEASED. Payload for `adminBulkUpdateAppConfigPolicies`."""
+"""Added in 26.4.4. Payload for `adminBulkUpdateAppConfigPolicies`."""
 type AdminBulkUpdateAppConfigPoliciesPayload {
   """Updated policies."""
   updated: [AppConfigPolicy!]!
@@ -208,14 +208,14 @@ type AdminBulkUpdateAppConfigPoliciesPayload {
   failed: [AppConfigPolicyBulkError!]!
 }
 
-"""Added in UNRELEASED. Admin bulk update input for app-config policies."""
+"""Added in 26.4.4. Admin bulk update input for app-config policies."""
 input AdminBulkUpdateAppConfigPolicyInput {
   """Policies to update."""
   items: [AdminBulkUpdateAppConfigPolicyItemInput!]!
 }
 
 """
-Added in UNRELEASED. Per-item input for admin bulk update — target row id + new `scope_sources`.
+Added in 26.4.4. Per-item input for admin bulk update — target row id + new `scope_sources`.
 """
 input AdminBulkUpdateAppConfigPolicyItemInput {
   """Policy row id."""
@@ -673,7 +673,7 @@ type AllowedResourceGroupsPayload {
   items: [String!]!
 }
 
-"""Added in UNRELEASED. Scoped app-config policy."""
+"""Added in 26.4.4. Scoped app-config policy."""
 type AppConfigPolicy implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -691,7 +691,7 @@ type AppConfigPolicy implements Node {
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Per-item failure info for bulk Policy mutations."""
+"""Added in 26.4.4. Per-item failure info for bulk Policy mutations."""
 type AppConfigPolicyBulkError {
   """Original position in the input list."""
   index: Int!
@@ -701,7 +701,7 @@ type AppConfigPolicyBulkError {
 }
 
 """
-Added in UNRELEASED. Connection type for paginated app-config policy results.
+Added in 26.4.4. Connection type for paginated app-config policy results.
 """
 type AppConfigPolicyConnection {
   """Pagination data for this connection"""
@@ -723,13 +723,13 @@ type AppConfigPolicyEdge {
   node: AppConfigPolicy!
 }
 
-"""Added in UNRELEASED. Filter input for querying app-config policies."""
+"""Added in 26.4.4. Filter input for querying app-config policies."""
 input AppConfigPolicyFilter {
   """Filter by config_name."""
   configName: StringFilter = null
 }
 
-"""Added in UNRELEASED. Specifies ordering for app-config policy results."""
+"""Added in 26.4.4. Specifies ordering for app-config policy results."""
 input AppConfigPolicyOrderBy {
   """The field to order by."""
   field: AppConfigPolicyOrderField!
@@ -738,9 +738,7 @@ input AppConfigPolicyOrderBy {
   direction: OrderDirection! = DESC
 }
 
-"""
-Added in UNRELEASED. Fields available for ordering app-config policies.
-"""
+"""Added in 26.4.4. Fields available for ordering app-config policies."""
 enum AppConfigPolicyOrderField {
   CONFIG_NAME
   CREATED_AT
@@ -7550,17 +7548,17 @@ type Mutation {
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload
 
   """
-  Added in UNRELEASED. Strict insert keyed on `configName` (admin only, per-item transaction).
+  Added in 26.4.4. Strict insert keyed on `configName` (admin only, per-item transaction).
   """
   adminBulkCreateAppConfigPolicies(input: AdminBulkCreateAppConfigPolicyInput!): AdminBulkCreateAppConfigPoliciesPayload!
 
   """
-  Added in UNRELEASED. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
+  Added in 26.4.4. Replace `scope_sources`; `config_name` is immutable. Admin only, per-item transaction.
   """
   adminBulkUpdateAppConfigPolicies(input: AdminBulkUpdateAppConfigPolicyInput!): AdminBulkUpdateAppConfigPoliciesPayload!
 
   """
-  Added in UNRELEASED. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
+  Added in 26.4.4. Hard-delete policies by row id; rows still referenced by fragments surface in `failed`. Admin only.
   """
   adminBulkPurgeAppConfigPolicies(input: AdminBulkPurgeAppConfigPolicyInput!): AdminBulkPurgeAppConfigPoliciesPayload!
 
@@ -9499,12 +9497,12 @@ type Query {
   adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection
 
   """
-  Added in UNRELEASED. Get a single app-config policy by row id. Available to any authenticated user.
+  Added in 26.4.4. Get a single app-config policy by row id. Available to any authenticated user.
   """
   appConfigPolicy(id: UUID!): AppConfigPolicy
 
   """
-  Added in UNRELEASED. List app-config policies with filtering and pagination. Available to any authenticated user.
+  Added in 26.4.4. List app-config policies with filtering and pagination. Available to any authenticated user.
   """
   appConfigPolicies(filter: AppConfigPolicyFilter = null, orderBy: [AppConfigPolicyOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AppConfigPolicyConnection!
 

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
@@ -19,7 +19,7 @@ from ai.backend.common.dto.manager.v2.app_config_policy.request import (
     SearchAppConfigPoliciesInput,
 )
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.api.rest.v2.path_params import AppConfigPolicyConfigNamePathParam
+from ai.backend.manager.api.rest.v2.path_params import AppConfigPolicyIdPathParam
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.adapters.app_config_policy import AppConfigPolicyAdapter
@@ -37,10 +37,10 @@ class V2AppConfigPolicyHandler:
 
     async def get(
         self,
-        path: PathParam[AppConfigPolicyConfigNamePathParam],
+        path: PathParam[AppConfigPolicyIdPathParam],
     ) -> APIResponse:
-        """Read a single policy by `config_name` (any authenticated user)."""
-        result = await self._adapter.get(path.parsed.config_name)
+        """Read a single policy by row id (any authenticated user)."""
+        result = await self._adapter.get(path.parsed.policy_id)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def search(
@@ -73,6 +73,6 @@ class V2AppConfigPolicyHandler:
         self,
         body: BodyParam[AdminBulkPurgeAppConfigPoliciesInput],
     ) -> APIResponse:
-        """Hard-delete (admin only); referenced `config_name`s fail per-item."""
+        """Hard-delete by row id (admin only); rows still referenced by fragments fail per-item."""
         result = await self._adapter.admin_bulk_purge(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
@@ -1,0 +1,78 @@
+"""REST v2 handler for the app-config policy domain.
+
+Writes are **bulk-only** — the single-item create / update / purge
+endpoints were removed in favour of `/bulk-create`, `/bulk-update`,
+`/bulk-purge` (admin-only).
+"""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
+from ai.backend.common.dto.manager.v2.app_config_policy.request import (
+    AdminBulkCreateAppConfigPoliciesInput,
+    AdminBulkPurgeAppConfigPoliciesInput,
+    AdminBulkUpdateAppConfigPoliciesInput,
+    SearchAppConfigPoliciesInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.api.rest.v2.path_params import AppConfigPolicyConfigNamePathParam
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.app_config_policy import AppConfigPolicyAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class V2AppConfigPolicyHandler:
+    """REST v2 handler for app-config policy operations."""
+
+    def __init__(self, *, adapter: AppConfigPolicyAdapter) -> None:
+        self._adapter = adapter
+
+    # ── Reads ────────────────────────────────────────────────────
+
+    async def get(
+        self,
+        path: PathParam[AppConfigPolicyConfigNamePathParam],
+    ) -> APIResponse:
+        """Read a single policy by `config_name` (any authenticated user)."""
+        result = await self._adapter.get(path.parsed.config_name)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def search(
+        self,
+        body: BodyParam[SearchAppConfigPoliciesInput],
+    ) -> APIResponse:
+        """Paginated policy search (any authenticated user)."""
+        result = await self._adapter.search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    # ── Admin bulk writes ────────────────────────────────────────
+
+    async def admin_bulk_create(
+        self,
+        body: BodyParam[AdminBulkCreateAppConfigPoliciesInput],
+    ) -> APIResponse:
+        """Strict insert; per-item transactions (admin only)."""
+        result = await self._adapter.admin_bulk_create(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_bulk_update(
+        self,
+        body: BodyParam[AdminBulkUpdateAppConfigPoliciesInput],
+    ) -> APIResponse:
+        """Replace `scope_sources` (admin only). `config_name` is immutable."""
+        result = await self._adapter.admin_bulk_update(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_bulk_purge(
+        self,
+        body: BodyParam[AdminBulkPurgeAppConfigPoliciesInput],
+    ) -> APIResponse:
+        """Hard-delete (admin only); referenced `config_name`s fail per-item."""
+        result = await self._adapter.admin_bulk_purge(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
@@ -43,7 +43,7 @@ class V2AppConfigPolicyHandler:
         result = await self._adapter.get(path.parsed.policy_id)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
-    async def search(
+    async def admin_search(
         self,
         body: BodyParam[AdminSearchAppConfigPoliciesInput],
     ) -> APIResponse:

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/handler.py
@@ -16,7 +16,7 @@ from ai.backend.common.dto.manager.v2.app_config_policy.request import (
     AdminBulkCreateAppConfigPoliciesInput,
     AdminBulkPurgeAppConfigPoliciesInput,
     AdminBulkUpdateAppConfigPoliciesInput,
-    SearchAppConfigPoliciesInput,
+    AdminSearchAppConfigPoliciesInput,
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import AppConfigPolicyIdPathParam
@@ -45,10 +45,10 @@ class V2AppConfigPolicyHandler:
 
     async def search(
         self,
-        body: BodyParam[SearchAppConfigPoliciesInput],
+        body: BodyParam[AdminSearchAppConfigPoliciesInput],
     ) -> APIResponse:
-        """Paginated policy search (any authenticated user)."""
-        result = await self._adapter.search(body.parsed)
+        """Paginated system-wide policy search (superadmin only)."""
+        result = await self._adapter.admin_search(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     # ── Admin bulk writes ────────────────────────────────────────

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
@@ -19,16 +19,16 @@ def register_v2_app_config_policy_routes(
 ) -> RouteRegistry:
     """Register all v2 app-config policy routes.
 
-    Reads (`GET /{policy_id}`, `POST /search`) are available to any
-    authenticated user. Writes are bulk-only and admin-only —
-    `/bulk-create`, `/bulk-update`, `/bulk-purge`.
+    `GET /{policy_id}` is available to any authenticated user. The
+    system-wide search and the bulk writes are admin-only —
+    `/search`, `/bulk-create`, `/bulk-update`, `/bulk-purge`.
     """
     reg = RouteRegistry.create("app-config-policies", route_deps.cors_options)
 
     # Reads
-    reg.add("POST", "/search", handler.search, middlewares=[auth_required])
     reg.add("GET", "/{policy_id}", handler.get, middlewares=[auth_required])
-    # Admin bulk writes
+    # Admin reads / bulk writes
+    reg.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
     reg.add("POST", "/bulk-create", handler.admin_bulk_create, middlewares=[superadmin_required])
     reg.add("POST", "/bulk-update", handler.admin_bulk_update, middlewares=[superadmin_required])
     reg.add("POST", "/bulk-purge", handler.admin_bulk_purge, middlewares=[superadmin_required])

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
@@ -19,7 +19,7 @@ def register_v2_app_config_policy_routes(
 ) -> RouteRegistry:
     """Register all v2 app-config policy routes.
 
-    Reads (`GET /{config_name}`, `POST /search`) are available to any
+    Reads (`GET /{policy_id}`, `POST /search`) are available to any
     authenticated user. Writes are bulk-only and admin-only —
     `/bulk-create`, `/bulk-update`, `/bulk-purge`.
     """
@@ -27,7 +27,7 @@ def register_v2_app_config_policy_routes(
 
     # Reads
     reg.add("POST", "/search", handler.search, middlewares=[auth_required])
-    reg.add("GET", "/{config_name}", handler.get, middlewares=[auth_required])
+    reg.add("GET", "/{policy_id}", handler.get, middlewares=[auth_required])
     # Admin bulk writes
     reg.add("POST", "/bulk-create", handler.admin_bulk_create, middlewares=[superadmin_required])
     reg.add("POST", "/bulk-update", handler.admin_bulk_update, middlewares=[superadmin_required])

--- a/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_policy/registry.py
@@ -1,0 +1,36 @@
+"""Route registration for v2 app-config policy endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2AppConfigPolicyHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_app_config_policy_routes(
+    handler: V2AppConfigPolicyHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all v2 app-config policy routes.
+
+    Reads (`GET /{config_name}`, `POST /search`) are available to any
+    authenticated user. Writes are bulk-only and admin-only —
+    `/bulk-create`, `/bulk-update`, `/bulk-purge`.
+    """
+    reg = RouteRegistry.create("app-config-policies", route_deps.cors_options)
+
+    # Reads
+    reg.add("POST", "/search", handler.search, middlewares=[auth_required])
+    reg.add("GET", "/{config_name}", handler.get, middlewares=[auth_required])
+    # Admin bulk writes
+    reg.add("POST", "/bulk-create", handler.admin_bulk_create, middlewares=[superadmin_required])
+    reg.add("POST", "/bulk-update", handler.admin_bulk_update, middlewares=[superadmin_required])
+    reg.add("POST", "/bulk-purge", handler.admin_bulk_purge, middlewares=[superadmin_required])
+
+    return reg

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -10,8 +10,8 @@ from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.identifier.role_preset import RolePresetID
 
 
-class AppConfigPolicyConfigNamePathParam(BaseRequestModel):
-    config_name: str = Field(description="App-config policy `config_name`")
+class AppConfigPolicyIdPathParam(BaseRequestModel):
+    policy_id: UUID = Field(description="App-config policy row UUID")
 
 
 class DomainNamePathParam(BaseRequestModel):

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -10,6 +10,10 @@ from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.identifier.role_preset import RolePresetID
 
 
+class AppConfigPolicyConfigNamePathParam(BaseRequestModel):
+    config_name: str = Field(description="App-config policy `config_name`")
+
+
 class DomainNamePathParam(BaseRequestModel):
     domain_name: str = Field(description="Domain name")
 

--- a/src/ai/backend/manager/api/rest/v2/path_params.py
+++ b/src/ai/backend/manager/api/rest/v2/path_params.py
@@ -7,11 +7,12 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.identifier.app_config_policy import AppConfigPolicyID
 from ai.backend.common.identifier.role_preset import RolePresetID
 
 
 class AppConfigPolicyIdPathParam(BaseRequestModel):
-    policy_id: UUID = Field(description="App-config policy row UUID")
+    policy_id: AppConfigPolicyID = Field(description="App-config policy row UUID")
 
 
 class DomainNamePathParam(BaseRequestModel):

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -28,6 +28,8 @@ def build_v2_routes(
     # Lazy imports to avoid circular dependencies at module level
     from .agent.handler import V2AgentHandler
     from .agent.registry import register_v2_agent_routes
+    from .app_config_policy.handler import V2AppConfigPolicyHandler
+    from .app_config_policy.registry import register_v2_app_config_policy_routes
     from .artifact.handler import V2ArtifactHandler
     from .artifact.registry import register_v2_artifact_routes
     from .artifact_registry.handler import V2ArtifactRegistryHandler
@@ -117,6 +119,7 @@ def build_v2_routes(
 
     # Build all handlers (each takes its individual adapter)
     agent_handler = V2AgentHandler(adapter=adapters.agent)
+    app_config_policy_handler = V2AppConfigPolicyHandler(adapter=adapters.app_config_policy)
     artifact_handler = V2ArtifactHandler(adapter=adapters.artifact)
     artifact_registry_handler = V2ArtifactRegistryHandler(adapter=adapters.artifact_registry)
     audit_log_handler = V2AuditLogHandler(adapter=adapters.audit_log)
@@ -174,6 +177,9 @@ def build_v2_routes(
 
     # Add all domain sub-registries
     v2_reg.add_subregistry(register_v2_agent_routes(agent_handler, route_deps))
+    v2_reg.add_subregistry(
+        register_v2_app_config_policy_routes(app_config_policy_handler, route_deps)
+    )
     v2_reg.add_subregistry(register_v2_artifact_routes(artifact_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_artifact_registry_routes(artifact_registry_handler, route_deps)


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 14-PR stack delivering BEP-1052. **Merge in order:**

1. ⬇️ **#11265** — `chore(BA-5822): drop legacy AppConfig layer`
2. ⬇️ **#12178** — `feat(BA-6481): AppConfigPolicy foundation`
3. ⬇️ **#12179** — `feat(BA-6482): AppConfigPolicy repository layer`
4. ⬇️ **#12180** — `feat(BA-6483): AppConfigPolicy service layer`
5. ⬇️ **#12181** — `feat(BA-6484): AppConfigPolicy v2 DTO and API adapter`
6. ⬇️ **#12182** — `test(BA-6485): AppConfigPolicy repository tests`
7. ⬇️ **#11269** — `feat(BA-5815): AppConfigPolicy GraphQL`
8. 👉 **#11312** — `feat(BA-5844): AppConfigPolicy REST v2` ← you are here
9. ⬇️ **#11282** — `feat(BA-5827): AppConfigFragment foundation`
10. ⬇️ **#11296** — `feat(BA-5836): AppConfigFragment service vertical`
11. ⬇️ **#11285** — `feat(BA-5829): AppConfigFragment + AppConfig GraphQL`
12. ⬇️ **#11286** — `feat(BA-5830): AppConfigFragment + AppConfig REST v2`
13. ⬇️ **#11295** — `feat(BA-5832): AppConfig v2 SDK + CLI`
14. ⬇️ **#11298** — `feat(BA-5837): ValkeyCache for AppConfigFragment merged-view reads`

## Summary

- Adds the AppConfigPolicy REST v2 surface, mounted under `/v2/app-config-policies/`, pairing with the GraphQL surface from #11269.
- Read endpoints: `GET /{policy_id}` (any authenticated user) and `POST /search` (system-wide paginated search, superadmin only).
- Writes are **bulk-only** (admin only): `POST /bulk-create`, `/bulk-update`, `/bulk-purge`. There are no single-item write endpoints.
  - `bulk-create` is a strict insert with per-item transactions; `bulk-update` replaces `scope_sources` (`config_name` is immutable); `bulk-purge` hard-deletes by row id, failing per-item for rows still referenced by fragments.
- `V2AppConfigPolicyHandler` is a thin layer that delegates to `AppConfigPolicyAdapter`; new `AppConfigPolicyIdPathParam` parses the policy row UUID, and the routes are wired into `tree.py` via `adapters.app_config_policy`.
