### PR TITLE
fix(manager): consolidate runtime_variant_preset.ui_type into ui_option JSONB

### DIFF
--- a/changes/11315.fix.md
+++ b/changes/11315.fix.md
@@ -1,0 +1,1 @@
+Drop the redundant `ui_type` column on `runtime_variant_presets` after backfilling it into the `ui_option` JSONB; the JSONB now is the single source of truth, fixing HTTP 500 on preset search/get when historical rows had only the column populated.

--- a/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
@@ -155,7 +155,6 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
                 default_value=input.default_value,
                 key=input.key,
                 category=input.category,
-                ui_type=input.ui_option.ui_type.value if input.ui_option else None,
                 display_name=input.display_name,
                 ui_option=input.ui_option,
             )
@@ -207,13 +206,6 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
                 else TriState.nullify()
                 if input.category is None
                 else TriState.update(input.category)
-            ),
-            ui_type=(
-                TriState.nop()
-                if input.ui_option is SENTINEL
-                else TriState.nullify()
-                if input.ui_option is None
-                else TriState.update(input.ui_option.ui_type.value)
             ),
             display_name=(
                 TriState.nop()

--- a/src/ai/backend/manager/models/alembic/versions/d1c0f1e2b3a4_drop_runtime_variant_preset_ui_type_column.py
+++ b/src/ai/backend/manager/models/alembic/versions/d1c0f1e2b3a4_drop_runtime_variant_preset_ui_type_column.py
@@ -1,0 +1,69 @@
+"""drop runtime_variant_presets.ui_type column; ui_type lives in ui_option
+
+The :class:`UIOption` Pydantic model that backs
+``runtime_variant_presets.ui_option`` (a JSONB column) declares
+``ui_type`` as a *required* field. The table also kept a duplicate
+``ui_type`` *column*, and historical rows had the JSONB persisted
+without the ``ui_type`` key — relying on the sibling column alone.
+Reads of those rows fail with::
+
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for UIOption
+    ui_type
+      Field required
+
+so any list/get over the affected presets returns HTTP 500.
+
+This migration consolidates the storage by:
+
+1. Backfilling ``ui_option.ui_type`` from the column for rows where the
+   JSONB exists but lacks the key.
+2. Dropping the now-redundant ``ui_type`` column.
+
+The Pydantic model is unchanged; the JSONB becomes the single source of
+truth for ``ui_type``.
+
+Revision ID: d1c0f1e2b3a4
+Revises: ce69b746304e
+Create Date: 2026-04-26
+
+"""
+
+# Part of: 26.5.0
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "d1c0f1e2b3a4"
+down_revision = "ce69b746304e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "UPDATE runtime_variant_presets "
+            "SET ui_option = jsonb_set(ui_option, '{ui_type}', to_jsonb(ui_type::text)) "
+            "WHERE ui_option IS NOT NULL "
+            "  AND ui_type IS NOT NULL "
+            "  AND NOT (ui_option ? 'ui_type');"
+        )
+    )
+    op.drop_column("runtime_variant_presets", "ui_type")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "runtime_variant_presets",
+        sa.Column("ui_type", sa.String(length=32), nullable=True),
+    )
+    op.execute(
+        text(
+            "UPDATE runtime_variant_presets "
+            "SET ui_type = ui_option->>'ui_type' "
+            "WHERE ui_option IS NOT NULL "
+            "  AND ui_option ? 'ui_type';"
+        )
+    )

--- a/src/ai/backend/manager/models/runtime_variant_preset/row.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/row.py
@@ -63,10 +63,12 @@ class RuntimeVariantPresetRow(Base):  # type: ignore[misc]
 
     # UI metadata
     category: Mapped[str | None] = mapped_column("category", sa.String(length=64), nullable=True)
-    ui_type: Mapped[str | None] = mapped_column("ui_type", sa.String(length=32), nullable=True)
     display_name: Mapped[str | None] = mapped_column(
         "display_name", sa.String(length=256), nullable=True
     )
+    # ``ui_option`` JSONB carries both ``ui_type`` and the type-specific
+    # sub-field config (slider/number/choices/text). The previously
+    # separate ``ui_type`` column has been folded into this JSONB.
     ui_option: Mapped[UIOption | None] = mapped_column(
         "ui_option", PydanticColumn(UIOption), nullable=True
     )
@@ -108,6 +110,7 @@ class RuntimeVariantPresetRow(Base):  # type: ignore[misc]
         )
 
     def to_data(self) -> RuntimeVariantPresetData:
+        ui_option_data = self._convert_ui_option_to_data(self.ui_option)
         return RuntimeVariantPresetData(
             id=self.id,
             runtime_variant_id=self.runtime_variant,
@@ -119,9 +122,9 @@ class RuntimeVariantPresetRow(Base):  # type: ignore[misc]
             default_value=self.default_value,
             key=self.key,
             category=self.category,
-            ui_type=self.ui_type,
+            ui_type=ui_option_data.ui_type if ui_option_data is not None else None,
             display_name=self.display_name,
-            ui_option=self._convert_ui_option_to_data(self.ui_option),
+            ui_option=ui_option_data,
             created_at=self.created_at,
             updated_at=self.updated_at,
         )

--- a/src/ai/backend/manager/repositories/runtime_variant_preset/creators.py
+++ b/src/ai/backend/manager/repositories/runtime_variant_preset/creators.py
@@ -28,7 +28,6 @@ class RuntimeVariantPresetCreatorSpec(CreatorSpec[RuntimeVariantPresetRow]):
     default_value: str | None
     key: str
     category: str | None
-    ui_type: str | None
     display_name: str | None
     ui_option: UIOption | None
 
@@ -56,7 +55,6 @@ class RuntimeVariantPresetCreatorSpec(CreatorSpec[RuntimeVariantPresetRow]):
         row.default_value = self.default_value
         row.key = self.key
         row.category = self.category
-        row.ui_type = self.ui_type
         row.display_name = self.display_name
         row.ui_option = self.ui_option
         return row

--- a/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
+++ b/src/ai/backend/manager/repositories/runtime_variant_preset/updaters.py
@@ -27,7 +27,6 @@ class RuntimeVariantPresetUpdaterSpec(UpdaterSpec[RuntimeVariantPresetRow]):
     default_value: TriState[str] = field(default_factory=TriState[str].nop)
     key: OptionalState[str] = field(default_factory=OptionalState[str].nop)
     category: TriState[str] = field(default_factory=TriState[str].nop)
-    ui_type: TriState[str] = field(default_factory=TriState[str].nop)
     display_name: TriState[str] = field(default_factory=TriState[str].nop)
     ui_option: TriState[UIOption] = field(default_factory=TriState[UIOption].nop)
 
@@ -47,7 +46,6 @@ class RuntimeVariantPresetUpdaterSpec(UpdaterSpec[RuntimeVariantPresetRow]):
         self.default_value.update_dict(to_update, "default_value")
         self.key.update_dict(to_update, "key")
         self.category.update_dict(to_update, "category")
-        self.ui_type.update_dict(to_update, "ui_type")
         self.display_name.update_dict(to_update, "display_name")
         self.ui_option.update_dict(to_update, "ui_option")
         return to_update

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -7,320 +7,320 @@ from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpe
 
 # fmt: off
 if TYPE_CHECKING:
-    from ai.backend.common.bgtask.bgtask import BackgroundTaskManager  # pants: no-infer-dep
-    from ai.backend.common.clients.prometheus.client import PrometheusClient  # pants: no-infer-dep
+    from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
+    from ai.backend.common.clients.prometheus.client import PrometheusClient
     from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
-        ValkeyArtifactDownloadTrackingClient,  # pants: no-infer-dep
+        ValkeyArtifactDownloadTrackingClient,
     )
     from ai.backend.common.clients.valkey_client.valkey_live.client import (
-        ValkeyLiveClient,  # pants: no-infer-dep
+        ValkeyLiveClient,
     )
     from ai.backend.common.clients.valkey_client.valkey_session.client import (
-        ValkeySessionClient,  # pants: no-infer-dep
+        ValkeySessionClient,
     )
     from ai.backend.common.clients.valkey_client.valkey_stat.client import (
-        ValkeyStatClient,  # pants: no-infer-dep
+        ValkeyStatClient,
     )
-    from ai.backend.common.etcd import AsyncEtcd  # pants: no-infer-dep
+    from ai.backend.common.etcd import AsyncEtcd
     from ai.backend.common.events.dispatcher import (
-        EventDispatcher,  # pants: no-infer-dep
-        EventProducer,  # pants: no-infer-dep
+        EventDispatcher,
+        EventProducer,
     )
-    from ai.backend.common.events.fetcher import EventFetcher  # pants: no-infer-dep
-    from ai.backend.common.events.hub.hub import EventHub  # pants: no-infer-dep
-    from ai.backend.common.plugin.hook import HookPluginContext  # pants: no-infer-dep
-    from ai.backend.common.plugin.monitor import ErrorPluginContext  # pants: no-infer-dep
-    from ai.backend.manager.agent_cache import AgentRPCCache  # pants: no-infer-dep
-    from ai.backend.manager.clients.appproxy.client import AppProxyClientPool  # pants: no-infer-dep
-    from ai.backend.manager.config.provider import ManagerConfigProvider  # pants: no-infer-dep
-    from ai.backend.manager.idle import IdleCheckerHost  # pants: no-infer-dep
-    from ai.backend.manager.models.storage import StorageSessionManager  # pants: no-infer-dep
-    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine  # pants: no-infer-dep
-    from ai.backend.manager.notification import NotificationCenter  # pants: no-infer-dep
-    from ai.backend.manager.registry import AgentRegistry  # pants: no-infer-dep
-    from ai.backend.manager.repositories.repositories import Repositories  # pants: no-infer-dep
+    from ai.backend.common.events.fetcher import EventFetcher
+    from ai.backend.common.events.hub.hub import EventHub
+    from ai.backend.common.plugin.hook import HookPluginContext
+    from ai.backend.common.plugin.monitor import ErrorPluginContext
+    from ai.backend.manager.agent_cache import AgentRPCCache
+    from ai.backend.manager.clients.appproxy.client import AppProxyClientPool
+    from ai.backend.manager.config.provider import ManagerConfigProvider
+    from ai.backend.manager.idle import IdleCheckerHost
+    from ai.backend.manager.models.storage import StorageSessionManager
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+    from ai.backend.manager.notification import NotificationCenter
+    from ai.backend.manager.registry import AgentRegistry
+    from ai.backend.manager.repositories.repositories import Repositories
     from ai.backend.manager.service.container_registry.harbor import (
-        AbstractPerProjectContainerRegistryQuotaService,  # pants: no-infer-dep
+        AbstractPerProjectContainerRegistryQuotaService,
     )
-    from ai.backend.manager.services.agent.processors import AgentProcessors  # pants: no-infer-dep
-    from ai.backend.manager.services.agent.service import AgentService  # pants: no-infer-dep
+    from ai.backend.manager.services.agent.processors import AgentProcessors
+    from ai.backend.manager.services.agent.service import AgentService
     from ai.backend.manager.services.app_config.processors import (
-        AppConfigProcessors,  # pants: no-infer-dep
+        AppConfigProcessors,
     )
     from ai.backend.manager.services.app_config.service import (
-        AppConfigService,  # pants: no-infer-dep
+        AppConfigService,
     )
     from ai.backend.manager.services.artifact.processors import (
-        ArtifactProcessors,  # pants: no-infer-dep
+        ArtifactProcessors,
     )
-    from ai.backend.manager.services.artifact.service import ArtifactService  # pants: no-infer-dep
+    from ai.backend.manager.services.artifact.service import ArtifactService
     from ai.backend.manager.services.artifact_registry.processors import (
-        ArtifactRegistryProcessors,  # pants: no-infer-dep
+        ArtifactRegistryProcessors,
     )
     from ai.backend.manager.services.artifact_registry.service import (
-        ArtifactRegistryService,  # pants: no-infer-dep
+        ArtifactRegistryService,
     )
     from ai.backend.manager.services.artifact_revision.processors import (
-        ArtifactRevisionProcessors,  # pants: no-infer-dep
+        ArtifactRevisionProcessors,
     )
     from ai.backend.manager.services.artifact_revision.service import (
-        ArtifactRevisionService,  # pants: no-infer-dep
+        ArtifactRevisionService,
     )
     from ai.backend.manager.services.audit_log.processors import (
-        AuditLogProcessors,  # pants: no-infer-dep
+        AuditLogProcessors,
     )
-    from ai.backend.manager.services.audit_log.service import AuditLogService  # pants: no-infer-dep
-    from ai.backend.manager.services.auth.processors import AuthProcessors  # pants: no-infer-dep
-    from ai.backend.manager.services.auth.service import AuthService  # pants: no-infer-dep
+    from ai.backend.manager.services.audit_log.service import AuditLogService
+    from ai.backend.manager.services.auth.processors import AuthProcessors
+    from ai.backend.manager.services.auth.service import AuthService
     from ai.backend.manager.services.container_registry.processors import (
-        ContainerRegistryProcessors,  # pants: no-infer-dep
+        ContainerRegistryProcessors,
     )
     from ai.backend.manager.services.container_registry.service import (
-        ContainerRegistryService,  # pants: no-infer-dep
+        ContainerRegistryService,
     )
     from ai.backend.manager.services.deployment.processors import (
-        DeploymentProcessors,  # pants: no-infer-dep
+        DeploymentProcessors,
     )
     from ai.backend.manager.services.deployment.service import (
-        DeploymentService,  # pants: no-infer-dep
+        DeploymentService,
     )
     from ai.backend.manager.services.deployment_revision_preset.processors import (
-        DeploymentRevisionPresetProcessors,  # pants: no-infer-dep
+        DeploymentRevisionPresetProcessors,
     )
     from ai.backend.manager.services.deployment_revision_preset.service import (
-        DeploymentRevisionPresetService,  # pants: no-infer-dep
+        DeploymentRevisionPresetService,
     )
     from ai.backend.manager.services.domain.processors import (
-        DomainProcessors,  # pants: no-infer-dep
+        DomainProcessors,
     )
-    from ai.backend.manager.services.domain.service import DomainService  # pants: no-infer-dep
+    from ai.backend.manager.services.domain.service import DomainService
     from ai.backend.manager.services.dotfile.processors import (
-        DotfileProcessors,  # pants: no-infer-dep
+        DotfileProcessors,
     )
-    from ai.backend.manager.services.dotfile.service import DotfileService  # pants: no-infer-dep
+    from ai.backend.manager.services.dotfile.service import DotfileService
     from ai.backend.manager.services.error_log.processors import (
-        ErrorLogProcessors,  # pants: no-infer-dep
+        ErrorLogProcessors,
     )
-    from ai.backend.manager.services.error_log.service import ErrorLogService  # pants: no-infer-dep
+    from ai.backend.manager.services.error_log.service import ErrorLogService
     from ai.backend.manager.services.etcd_config.processors import (
-        EtcdConfigProcessors,  # pants: no-infer-dep
+        EtcdConfigProcessors,
     )
     from ai.backend.manager.services.etcd_config.service import (
-        EtcdConfigService,  # pants: no-infer-dep
+        EtcdConfigService,
     )
     from ai.backend.manager.services.events.processors import (
-        EventsProcessors,  # pants: no-infer-dep
+        EventsProcessors,
     )
-    from ai.backend.manager.services.events.service import EventsService  # pants: no-infer-dep
+    from ai.backend.manager.services.events.service import EventsService
     from ai.backend.manager.services.export.processors import (
-        ExportProcessors,  # pants: no-infer-dep
+        ExportProcessors,
     )
-    from ai.backend.manager.services.export.service import ExportService  # pants: no-infer-dep
+    from ai.backend.manager.services.export.service import ExportService
     from ai.backend.manager.services.fair_share.processors import (
-        FairShareProcessors,  # pants: no-infer-dep
+        FairShareProcessors,
     )
     from ai.backend.manager.services.fair_share.service import (
-        FairShareService,  # pants: no-infer-dep
+        FairShareService,
     )
-    from ai.backend.manager.services.group.processors import GroupProcessors  # pants: no-infer-dep
-    from ai.backend.manager.services.group.service import GroupService  # pants: no-infer-dep
-    from ai.backend.manager.services.image.processors import ImageProcessors  # pants: no-infer-dep
-    from ai.backend.manager.services.image.service import ImageService  # pants: no-infer-dep
+    from ai.backend.manager.services.group.processors import GroupProcessors
+    from ai.backend.manager.services.group.service import GroupService
+    from ai.backend.manager.services.image.processors import ImageProcessors
+    from ai.backend.manager.services.image.service import ImageService
     from ai.backend.manager.services.keypair_resource_policy.processors import (
-        KeypairResourcePolicyProcessors,  # pants: no-infer-dep
+        KeypairResourcePolicyProcessors,
     )
     from ai.backend.manager.services.keypair_resource_policy.service import (
-        KeypairResourcePolicyService,  # pants: no-infer-dep
+        KeypairResourcePolicyService,
     )
     from ai.backend.manager.services.login_client_type.admin_service import (
-        LoginClientTypeAdminService,  # pants: no-infer-dep
+        LoginClientTypeAdminService,
     )
     from ai.backend.manager.services.login_client_type.processors import (
-        LoginClientTypeAdminProcessors,  # pants: no-infer-dep
-        LoginClientTypeProcessors,  # pants: no-infer-dep
+        LoginClientTypeAdminProcessors,
+        LoginClientTypeProcessors,
     )
     from ai.backend.manager.services.login_client_type.service import (
-        LoginClientTypeService,  # pants: no-infer-dep
+        LoginClientTypeService,
     )
     from ai.backend.manager.services.manager_admin.processors import (
-        ManagerAdminProcessors,  # pants: no-infer-dep
+        ManagerAdminProcessors,
     )
     from ai.backend.manager.services.manager_admin.service import (
-        ManagerAdminService,  # pants: no-infer-dep
+        ManagerAdminService,
     )
     from ai.backend.manager.services.metric.processors import (
-        MetricProcessors,  # pants: no-infer-dep
+        MetricProcessors,
     )
     from ai.backend.manager.services.metric.service import (
-        MetricService,  # pants: no-infer-dep
+        MetricService,
     )
     from ai.backend.manager.services.model_card.processors import (
-        ModelCardProcessors,  # pants: no-infer-dep
+        ModelCardProcessors,
     )
     from ai.backend.manager.services.model_card.service import (
-        ModelCardService,  # pants: no-infer-dep
+        ModelCardService,
     )
     from ai.backend.manager.services.model_serving.processors.auto_scaling import (
-        ModelServingAutoScalingProcessors,  # pants: no-infer-dep
+        ModelServingAutoScalingProcessors,
     )
     from ai.backend.manager.services.model_serving.processors.model_serving import (
-        ModelServingProcessors,  # pants: no-infer-dep
+        ModelServingProcessors,
     )
     from ai.backend.manager.services.model_serving.services.auto_scaling import (
-        AutoScalingService,  # pants: no-infer-dep
+        AutoScalingService,
     )
     from ai.backend.manager.services.model_serving.services.model_serving import (
-        ModelServingService,  # pants: no-infer-dep
+        ModelServingService,
     )
     from ai.backend.manager.services.notification.processors import (
-        NotificationProcessors,  # pants: no-infer-dep
+        NotificationProcessors,
     )
     from ai.backend.manager.services.notification.service import (
-        NotificationService,  # pants: no-infer-dep
+        NotificationService,
     )
     from ai.backend.manager.services.object_storage.processors import (
-        ObjectStorageProcessors,  # pants: no-infer-dep
+        ObjectStorageProcessors,
     )
     from ai.backend.manager.services.object_storage.service import (
-        ObjectStorageService,  # pants: no-infer-dep
+        ObjectStorageService,
     )
     from ai.backend.manager.services.permission_contoller.processors import (
-        PermissionControllerProcessors,  # pants: no-infer-dep
+        PermissionControllerProcessors,
     )
     from ai.backend.manager.services.permission_contoller.service import (
-        PermissionControllerService,  # pants: no-infer-dep
+        PermissionControllerService,
     )
     from ai.backend.manager.services.project_resource_policy.processors import (
-        ProjectResourcePolicyProcessors,  # pants: no-infer-dep
+        ProjectResourcePolicyProcessors,
     )
     from ai.backend.manager.services.project_resource_policy.service import (
-        ProjectResourcePolicyService,  # pants: no-infer-dep
+        ProjectResourcePolicyService,
     )
     from ai.backend.manager.services.prometheus_query_preset.processors import (
-        PrometheusQueryPresetProcessors,  # pants: no-infer-dep
+        PrometheusQueryPresetProcessors,
     )
     from ai.backend.manager.services.prometheus_query_preset.service import (
-        PrometheusQueryPresetService,  # pants: no-infer-dep
+        PrometheusQueryPresetService,
     )
     from ai.backend.manager.services.prometheus_query_preset_category.processors import (
-        PrometheusQueryPresetCategoryProcessors,  # pants: no-infer-dep
+        PrometheusQueryPresetCategoryProcessors,
     )
     from ai.backend.manager.services.prometheus_query_preset_category.service import (
-        PrometheusQueryPresetCategoryService,  # pants: no-infer-dep
+        PrometheusQueryPresetCategoryService,
     )
     from ai.backend.manager.services.resource_allocation.processors import (
-        ResourceAllocationProcessors,  # pants: no-infer-dep
+        ResourceAllocationProcessors,
     )
     from ai.backend.manager.services.resource_allocation.service import (
-        ResourceAllocationService,  # pants: no-infer-dep
+        ResourceAllocationService,
     )
     from ai.backend.manager.services.resource_preset.processors import (
-        ResourcePresetProcessors,  # pants: no-infer-dep
+        ResourcePresetProcessors,
     )
     from ai.backend.manager.services.resource_preset.service import (
-        ResourcePresetService,  # pants: no-infer-dep
+        ResourcePresetService,
     )
     from ai.backend.manager.services.resource_slot.processors import (
-        ResourceSlotProcessors,  # pants: no-infer-dep
+        ResourceSlotProcessors,
     )
     from ai.backend.manager.services.resource_slot.service import (
-        ResourceSlotService,  # pants: no-infer-dep
+        ResourceSlotService,
     )
     from ai.backend.manager.services.resource_usage.processors import (
-        ResourceUsageProcessors,  # pants: no-infer-dep
+        ResourceUsageProcessors,
     )
     from ai.backend.manager.services.resource_usage.service import (
-        ResourceUsageService,  # pants: no-infer-dep
+        ResourceUsageService,
     )
     from ai.backend.manager.services.runtime_variant.processors import (
-        RuntimeVariantProcessors,  # pants: no-infer-dep
+        RuntimeVariantProcessors,
     )
     from ai.backend.manager.services.runtime_variant.service import (
-        RuntimeVariantService,  # pants: no-infer-dep
+        RuntimeVariantService,
     )
     from ai.backend.manager.services.runtime_variant_preset.processors import (
-        RuntimeVariantPresetProcessors,  # pants: no-infer-dep
+        RuntimeVariantPresetProcessors,
     )
     from ai.backend.manager.services.runtime_variant_preset.service import (
-        RuntimeVariantPresetService,  # pants: no-infer-dep
+        RuntimeVariantPresetService,
     )
     from ai.backend.manager.services.scaling_group.processors import (
-        ScalingGroupProcessors,  # pants: no-infer-dep
+        ScalingGroupProcessors,
     )
     from ai.backend.manager.services.scaling_group.service import (
-        ScalingGroupService,  # pants: no-infer-dep
+        ScalingGroupService,
     )
     from ai.backend.manager.services.scheduling_history.processors import (
-        SchedulingHistoryProcessors,  # pants: no-infer-dep
+        SchedulingHistoryProcessors,
     )
     from ai.backend.manager.services.scheduling_history.service import (
-        SchedulingHistoryService,  # pants: no-infer-dep
+        SchedulingHistoryService,
     )
     from ai.backend.manager.services.service_catalog.processors import (
-        ServiceCatalogProcessors,  # pants: no-infer-dep
+        ServiceCatalogProcessors,
     )
     from ai.backend.manager.services.service_catalog.service import (
-        ServiceCatalogService,  # pants: no-infer-dep
+        ServiceCatalogService,
     )
     from ai.backend.manager.services.session.processors import (
-        SessionProcessors,  # pants: no-infer-dep
+        SessionProcessors,
     )
-    from ai.backend.manager.services.session.service import SessionService  # pants: no-infer-dep
+    from ai.backend.manager.services.session.service import SessionService
     from ai.backend.manager.services.storage_namespace.processors import (
-        StorageNamespaceProcessors,  # pants: no-infer-dep
+        StorageNamespaceProcessors,
     )
     from ai.backend.manager.services.storage_namespace.service import (
-        StorageNamespaceService,  # pants: no-infer-dep
+        StorageNamespaceService,
     )
     from ai.backend.manager.services.stream.processors import (
-        StreamProcessors,  # pants: no-infer-dep
+        StreamProcessors,
     )
-    from ai.backend.manager.services.stream.service import StreamService  # pants: no-infer-dep
+    from ai.backend.manager.services.stream.service import StreamService
     from ai.backend.manager.services.template.processors import (
-        TemplateProcessors,  # pants: no-infer-dep
+        TemplateProcessors,
     )
-    from ai.backend.manager.services.template.service import TemplateService  # pants: no-infer-dep
-    from ai.backend.manager.services.user.processors import UserProcessors  # pants: no-infer-dep
-    from ai.backend.manager.services.user.service import UserService  # pants: no-infer-dep
+    from ai.backend.manager.services.template.service import TemplateService
+    from ai.backend.manager.services.user.processors import UserProcessors
+    from ai.backend.manager.services.user.service import UserService
     from ai.backend.manager.services.user_resource_policy.processors import (
-        UserResourcePolicyProcessors,  # pants: no-infer-dep
+        UserResourcePolicyProcessors,
     )
     from ai.backend.manager.services.user_resource_policy.service import (
-        UserResourcePolicyService,  # pants: no-infer-dep
+        UserResourcePolicyService,
     )
     from ai.backend.manager.services.vfolder.processors import (
-        VFolderFileProcessors,  # pants: no-infer-dep
-        VFolderInviteProcessors,  # pants: no-infer-dep
-        VFolderProcessors,  # pants: no-infer-dep
-        VFolderSharingProcessors,  # pants: no-infer-dep
+        VFolderFileProcessors,
+        VFolderInviteProcessors,
+        VFolderProcessors,
+        VFolderSharingProcessors,
     )
     from ai.backend.manager.services.vfolder.processors.vfolder_admin import (
-        VFolderAdminProcessors,  # pants: no-infer-dep
+        VFolderAdminProcessors,
     )
     from ai.backend.manager.services.vfolder.services.file import (
-        VFolderFileService,  # pants: no-infer-dep
+        VFolderFileService,
     )
     from ai.backend.manager.services.vfolder.services.invite import (
-        VFolderInviteService,  # pants: no-infer-dep
+        VFolderInviteService,
     )
     from ai.backend.manager.services.vfolder.services.sharing import (
-        VFolderSharingService,  # pants: no-infer-dep
+        VFolderSharingService,
     )
     from ai.backend.manager.services.vfolder.services.vfolder import (
-        VFolderService,  # pants: no-infer-dep
+        VFolderService,
     )
     from ai.backend.manager.services.vfolder.services.vfolder_admin import (
-        VFolderAdminService,  # pants: no-infer-dep
+        VFolderAdminService,
     )
     from ai.backend.manager.services.vfs_storage.processors import (
-        VFSStorageProcessors,  # pants: no-infer-dep
+        VFSStorageProcessors,
     )
     from ai.backend.manager.services.vfs_storage.service import (
-        VFSStorageService,  # pants: no-infer-dep
+        VFSStorageService,
     )
-    from ai.backend.manager.sokovan.deployment import DeploymentController  # pants: no-infer-dep
+    from ai.backend.manager.sokovan.deployment import DeploymentController
     from ai.backend.manager.sokovan.scheduling_controller import (
-        SchedulingController,  # pants: no-infer-dep
+        SchedulingController,
     )
 # fmt: on
 

--- a/tests/unit/manager/models/test_runtime_variant_preset_fixture.py
+++ b/tests/unit/manager/models/test_runtime_variant_preset_fixture.py
@@ -54,7 +54,6 @@ class TestRuntimeVariantPresetFixture:
                     "default_value": "auto",
                     "key": "--dtype",
                     "category": "model_loading",
-                    "ui_type": "select",
                     "display_name": "DType",
                     "ui_option": {
                         "ui_type": "select",

--- a/tests/unit/manager/repositories/runtime_variant_preset/test_repository.py
+++ b/tests/unit/manager/repositories/runtime_variant_preset/test_repository.py
@@ -80,7 +80,6 @@ class TestRuntimeVariantPresetRepositoryFlag:
             default_value="true",
             key="--verbose",
             category=None,
-            ui_type=None,
             display_name=None,
             ui_option=None,
         )


### PR DESCRIPTION
## Summary
- The `UIOption` Pydantic model that backs `runtime_variant_presets.ui_option` declares `ui_type` as a *required* field, but historical rows persisted the JSONB without that key — they relied on the redundant sibling `ui_type` *column* alone. Reads of those rows fail with `ValidationError: ui_type Field required`, so any list/get over the affected presets returns HTTP 500.
- Consolidate the storage so the JSONB is the single source of truth: a new alembic migration backfills `ui_option.ui_type` from the column, then drops the column. Row, CreatorSpec, UpdaterSpec, and the adapter no longer thread `ui_type` separately.
- Also drop `# pants: no-infer-dep` markers from `services/processors.py` so mypy can resolve its TYPE_CHECKING imports — required to make `pants check --changed-dependents=direct` pass for any change in this neighbourhood.

## Test plan
- [ ] Migration backfills `ui_option.ui_type` from the column when the JSONB exists but lacks the key (idempotent on re-run).
- [ ] Migration drops the column; downgrade re-adds and repopulates from JSONB.
- [ ] `./bai admin runtime-variant-preset search` returns 200 (was 500) and exposes top-level `ui_type` derived from `ui_option.ui_type`.
- [ ] Existing repository / fixture tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)