### PR TITLE
fix(common): cross-resolve EndpointLifecycle and ModelDeploymentStatus aliases

### DIFF
--- a/changes/11316.fix.md
+++ b/changes/11316.fix.md
@@ -1,0 +1,1 @@
+Cross-resolve `EndpointLifecycle` and `ModelDeploymentStatus` legacy aliases via `_missing_`, fixing HTTP 500 from `/v2/scheduling-history/deployments/search` when historical rows persist `EndpointLifecycle` values (`destroying`/`destroyed`).

--- a/src/ai/backend/common/data/endpoint/types.py
+++ b/src/ai/backend/common/data/endpoint/types.py
@@ -1,5 +1,6 @@
 from enum import Enum, StrEnum
 from functools import lru_cache
+from typing import Any, Self
 
 
 class EndpointStatus(StrEnum):
@@ -58,6 +59,25 @@ class EndpointLifecycle(Enum):
     @lru_cache(maxsize=1)
     def inactive_states(cls) -> set["EndpointLifecycle"]:
         return {cls.DESTROYING, cls.DESTROYED}
+
+    @classmethod
+    def _missing_(cls, value: Any) -> Self | None:
+        # Accept v2 :class:`ModelDeploymentStatus` aliases on the wire so
+        # historical / future callers that hand us the new naming still
+        # resolve to a valid lifecycle value.
+        if isinstance(value, str):
+            alias = _DEPLOYMENT_STATUS_TO_LIFECYCLE_ALIASES.get(value.lower())
+            if alias is not None:
+                return cls(alias)
+        return None
+
+
+# Map v2 :class:`ModelDeploymentStatus` values back onto the lowercase
+# :class:`EndpointLifecycle` form. Used by ``EndpointLifecycle._missing_``.
+_DEPLOYMENT_STATUS_TO_LIFECYCLE_ALIASES: dict[str, str] = {
+    "stopping": "destroying",
+    "stopped": "destroyed",
+}
 
 
 class ScalingState(StrEnum):

--- a/src/ai/backend/common/data/model_deployment/types.py
+++ b/src/ai/backend/common/data/model_deployment/types.py
@@ -1,3 +1,5 @@
+from typing import Any, Self
+
 from ai.backend.common.types import CIStrEnum
 
 
@@ -19,6 +21,17 @@ class ActivenessStatus(CIStrEnum):
     INACTIVE = "INACTIVE"
 
 
+# Map ``EndpointLifecycle`` (legacy lifecycle column form) values onto the
+# corresponding v2 :class:`ModelDeploymentStatus`. Read by ``_missing_`` to
+# resolve historical ``deployment_history`` rows where the writer stored
+# :class:`EndpointLifecycle` values instead of v2 status names.
+_LIFECYCLE_TO_DEPLOYMENT_STATUS_ALIASES: dict[str, str] = {
+    "destroying": "STOPPING",
+    "destroyed": "STOPPED",
+    "created": "READY",  # EndpointLifecycle deprecated alias of READY
+}
+
+
 class ModelDeploymentStatus(CIStrEnum):
     PENDING = "PENDING"
     SCALING = "SCALING"
@@ -26,6 +39,14 @@ class ModelDeploymentStatus(CIStrEnum):
     READY = "READY"
     STOPPING = "STOPPING"
     STOPPED = "STOPPED"
+
+    @classmethod
+    def _missing_(cls, value: Any) -> Self | None:
+        if isinstance(value, str):
+            alias = _LIFECYCLE_TO_DEPLOYMENT_STATUS_ALIASES.get(value.lower())
+            if alias is not None:
+                return cls(alias)
+        return super()._missing_(value)
 
 
 class DeploymentStrategy(CIStrEnum):

--- a/tests/unit/common/data/model_deployment/BUILD
+++ b/tests/unit/common/data/model_deployment/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/common/data/model_deployment/test_status_aliases.py
+++ b/tests/unit/common/data/model_deployment/test_status_aliases.py
@@ -1,0 +1,80 @@
+"""Verify the cross-enum legacy aliases for ModelDeploymentStatus and
+EndpointLifecycle.
+
+Historical ``deployment_history`` rows persist :class:`EndpointLifecycle`
+values (lowercase ``destroying``/``destroyed``/``created``); current
+readers materialise those rows through :class:`ModelDeploymentStatus`.
+The two enums therefore each accept the other's name on lookup so a
+single ``Enum(value)`` call resolves regardless of which form the row
+carries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.common.data.endpoint.types import EndpointLifecycle
+from ai.backend.common.data.model_deployment.types import ModelDeploymentStatus
+
+
+class TestModelDeploymentStatusLegacyAliases:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("destroying", ModelDeploymentStatus.STOPPING),
+            ("DESTROYING", ModelDeploymentStatus.STOPPING),
+            ("destroyed", ModelDeploymentStatus.STOPPED),
+            ("DESTROYED", ModelDeploymentStatus.STOPPED),
+            ("created", ModelDeploymentStatus.READY),
+            ("CREATED", ModelDeploymentStatus.READY),
+        ],
+    )
+    def test_lifecycle_value_resolves_to_v2_status(
+        self, value: str, expected: ModelDeploymentStatus
+    ) -> None:
+        assert ModelDeploymentStatus(value) is expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("STOPPING", ModelDeploymentStatus.STOPPING),
+            ("stopping", ModelDeploymentStatus.STOPPING),
+            ("PENDING", ModelDeploymentStatus.PENDING),
+            ("pending", ModelDeploymentStatus.PENDING),
+            ("ready", ModelDeploymentStatus.READY),
+        ],
+    )
+    def test_canonical_value_still_resolves(
+        self, value: str, expected: ModelDeploymentStatus
+    ) -> None:
+        assert ModelDeploymentStatus(value) is expected
+
+
+class TestEndpointLifecycleV2Aliases:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("STOPPING", EndpointLifecycle.DESTROYING),
+            ("stopping", EndpointLifecycle.DESTROYING),
+            ("STOPPED", EndpointLifecycle.DESTROYED),
+            ("stopped", EndpointLifecycle.DESTROYED),
+        ],
+    )
+    def test_v2_status_value_resolves_to_lifecycle(
+        self, value: str, expected: EndpointLifecycle
+    ) -> None:
+        assert EndpointLifecycle(value) is expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("destroying", EndpointLifecycle.DESTROYING),
+            ("destroyed", EndpointLifecycle.DESTROYED),
+            ("pending", EndpointLifecycle.PENDING),
+            ("ready", EndpointLifecycle.READY),
+        ],
+    )
+    def test_canonical_lowercase_still_resolves(
+        self, value: str, expected: EndpointLifecycle
+    ) -> None:
+        assert EndpointLifecycle(value) is expected


### PR DESCRIPTION
## Summary
- The deployment_history table is written by the lifecycle path with `EndpointLifecycle.value` (lowercase `destroying`/`destroyed`/...), but read with `ModelDeploymentStatus(value)`. The v2 enum uses the renamed tokens (`STOPPING`/`STOPPED`), so `ModelDeploymentStatus("destroying")` raises `ValueError` → `/v2/scheduling-history/deployments/search` returns HTTP 500 for any historical row.
- Add cross-enum legacy aliases via `_missing_` so each enum resolves the other's name without changing the persisted form or the writer:
  - `ModelDeploymentStatus` accepts `destroying`/`destroyed`/`created` → folds onto `STOPPING`/`STOPPED`/`READY`.
  - `EndpointLifecycle` accepts `stopping`/`stopped` → folds onto `DESTROYING`/`DESTROYED` (symmetry).
- No DB migration; no writer change. CIStrEnum's case-insensitive matching is preserved by delegating to `super()._missing_` for canonical values.

## Test plan
- [ ] `ModelDeploymentStatus("destroying") is ModelDeploymentStatus.STOPPING` (and reverse for `EndpointLifecycle`).
- [ ] Canonical values still resolve case-insensitively.
- [ ] `./bai scheduling-history deployment search` returns 200 (was 500) on a DB containing legacy `destroying`/`destroyed` rows; response shows `STOPPING`/`STOPPED` after translation.
- [ ] Added unit tests under `tests/unit/common/data/model_deployment/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)