### PR TITLE
refactor(BA-5819): migrate vfolder code from agus to ASE

### DIFF
--- a/changes/11318.enhance.md
+++ b/changes/11318.enhance.md
@@ -1,0 +1,1 @@
+Migrate vfolder project membership checks from `association_groups_users` to `association_scopes_entities` (ASE).

--- a/src/ai/backend/manager/api/gql_legacy/vfolder.py
+++ b/src/ai/backend/manager/api/gql_legacy/vfolder.py
@@ -35,6 +35,12 @@ from ai.backend.common.types import (
     VFolderUsageMode,
 )
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermissionEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermissionScopeType,
+)
 from ai.backend.manager.errors.resource import DataTransformationFailed
 from ai.backend.manager.errors.storage import (
     ModelCardParseError,
@@ -53,6 +59,9 @@ from ai.backend.manager.models.rbac import (
 from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.rbac.permission_defs import (
     VFolderPermission as VFolderRBACPermission,
+)
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.vfolder import (
@@ -1220,16 +1229,20 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
         user_id: uuid.UUID | None = None,
         filter: str | None = None,
     ) -> int:
-        from ai.backend.manager.models.group import association_groups_users as agus
         from ai.backend.manager.models.group import groups
 
-        query = sa.select(agus.c.group_id).select_from(agus).where(agus.c.user_id == user_id)
+        ase = AssociationScopesEntitiesRow.__table__
+        query = sa.select(ase.c.scope_id).where(
+            ase.c.scope_type == PermissionScopeType.PROJECT,
+            ase.c.entity_type == PermissionEntityType.USER,
+            ase.c.entity_id == str(user_id),
+        )
 
         async with graph_ctx.db.begin_readonly() as conn:
             result = await conn.execute(query)
 
         grps = result.fetchall()
-        group_ids = [g.group_id for g in grps]
+        group_ids = [uuid.UUID(g.scope_id) for g in grps]
         j = sa.join(vfolders, groups, vfolders.c.group == groups.c.id)
         query = sa.select(sa.func.count()).select_from(j).where(vfolders.c.group.in_(group_ids))
 
@@ -1255,14 +1268,18 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
         filter: str | None = None,
         order: str | None = None,
     ) -> list[VirtualFolder]:
-        from ai.backend.manager.models.group import association_groups_users as agus
         from ai.backend.manager.models.group import groups
 
-        query = sa.select(agus.c.group_id).select_from(agus).where(agus.c.user_id == user_id)
+        ase = AssociationScopesEntitiesRow.__table__
+        query = sa.select(ase.c.scope_id).where(
+            ase.c.scope_type == PermissionScopeType.PROJECT,
+            ase.c.entity_type == PermissionEntityType.USER,
+            ase.c.entity_id == str(user_id),
+        )
         async with graph_ctx.db.begin_readonly() as conn:
             result = await conn.execute(query)
         grps = result.fetchall()
-        group_ids = [g.group_id for g in grps]
+        group_ids = [uuid.UUID(g.scope_id) for g in grps]
         j = vfolders.join(groups, vfolders.c.group == groups.c.id)
         query = (
             sa.select(

--- a/src/ai/backend/manager/api/gql_legacy/vfolder.py
+++ b/src/ai/backend/manager/api/gql_legacy/vfolder.py
@@ -1231,17 +1231,16 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
     ) -> int:
         from ai.backend.manager.models.group import groups
 
-        ase = AssociationScopesEntitiesRow.__table__
-        query = sa.select(ase.c.scope_id).where(
-            ase.c.scope_type == PermissionScopeType.PROJECT,
-            ase.c.entity_type == PermissionEntityType.USER,
-            ase.c.entity_id == str(user_id),
+        membership_query = sa.select(AssociationScopesEntitiesRow.scope_id).where(
+            AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+            AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+            AssociationScopesEntitiesRow.entity_id == str(user_id),
         )
 
         async with graph_ctx.db.begin_readonly() as conn:
-            result = await conn.execute(query)
+            membership_result = await conn.execute(membership_query)
 
-        grps = result.fetchall()
+        grps = membership_result.fetchall()
         group_ids = [uuid.UUID(g.scope_id) for g in grps]
         j = sa.join(vfolders, groups, vfolders.c.group == groups.c.id)
         query = sa.select(sa.func.count()).select_from(j).where(vfolders.c.group.in_(group_ids))
@@ -1270,15 +1269,14 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
     ) -> list[VirtualFolder]:
         from ai.backend.manager.models.group import groups
 
-        ase = AssociationScopesEntitiesRow.__table__
-        query = sa.select(ase.c.scope_id).where(
-            ase.c.scope_type == PermissionScopeType.PROJECT,
-            ase.c.entity_type == PermissionEntityType.USER,
-            ase.c.entity_id == str(user_id),
+        membership_query = sa.select(AssociationScopesEntitiesRow.scope_id).where(
+            AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+            AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+            AssociationScopesEntitiesRow.entity_id == str(user_id),
         )
         async with graph_ctx.db.begin_readonly() as conn:
-            result = await conn.execute(query)
-        grps = result.fetchall()
+            membership_result = await conn.execute(membership_query)
+        grps = membership_result.fetchall()
         group_ids = [uuid.UUID(g.scope_id) for g in grps]
         j = vfolders.join(groups, vfolders.c.group == groups.c.id)
         query = (

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -842,19 +842,19 @@ async def get_allowed_vfolder_hosts_by_user(
         allowed_hosts = result_hosts
     # User's Groups' allowed_vfolder_hosts.
     ase = AssociationScopesEntitiesRow.__table__
-    project_ids_subq = sa.select(ase.c.scope_id).where(
+    join_cond = sa.and_(
+        sa.cast(groups.c.id, sa.String) == ase.c.scope_id,
         ase.c.scope_type == PermissionScopeType.PROJECT,
         ase.c.entity_type == PermissionEntityType.USER,
         ase.c.entity_id == str(user_uuid),
     )
-    where_conds = [
-        groups.c.domain_name == domain_name,
-        groups.c.is_active,
-        sa.cast(groups.c.id, sa.String).in_(project_ids_subq),
-    ]
     if group_id is not None:
-        where_conds.append(groups.c.id == group_id)
-    query = sa.select(groups.c.allowed_vfolder_hosts).where(*where_conds)
+        join_cond = sa.and_(join_cond, groups.c.id == group_id)
+    query = (
+        sa.select(groups.c.allowed_vfolder_hosts)
+        .select_from(groups.join(ase, join_cond))
+        .where(groups.c.domain_name == domain_name, groups.c.is_active)
+    )
     if rows := (await conn.execute(query)).fetchall():
         for row in rows:
             result_hosts = allowed_hosts | row.allowed_vfolder_hosts
@@ -1717,17 +1717,18 @@ class VFolderPermissionContextBuilder(
         result = VFolderPermissionContext()
 
         ase = AssociationScopesEntitiesRow.__table__
-        project_ids_subq = sa.select(ase.c.scope_id).where(
-            ase.c.scope_type == PermissionScopeType.PROJECT,
-            ase.c.entity_type == PermissionEntityType.USER,
-            ase.c.entity_id == str(ctx.user_id),
-        )
         _project_stmt = (
             sa.select(GroupRow)
-            .where(
-                GroupRow.domain_name == domain_name,
-                sa.cast(GroupRow.id, sa.String).in_(project_ids_subq),
+            .join(
+                ase,
+                sa.and_(
+                    sa.cast(GroupRow.id, sa.String) == ase.c.scope_id,
+                    ase.c.scope_type == PermissionScopeType.PROJECT,
+                    ase.c.entity_type == PermissionEntityType.USER,
+                    ase.c.entity_id == str(ctx.user_id),
+                ),
             )
+            .where(GroupRow.domain_name == domain_name)
             .options(load_only(GroupRow.id))
         )
         for row in await self.db_session.scalars(_project_stmt):

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -706,11 +706,10 @@ async def query_accessible_vfolders(
             grps = result.fetchall()
             group_ids = [g.id for g in grps]
         else:
-            ase = AssociationScopesEntitiesRow.__table__
-            query = sa.select(ase.c.scope_id).where(
-                ase.c.scope_type == PermissionScopeType.PROJECT,
-                ase.c.entity_type == PermissionEntityType.USER,
-                ase.c.entity_id == str(user_uuid),
+            query = sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+                AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+                AssociationScopesEntitiesRow.entity_id == str(user_uuid),
             )
             result = await conn.execute(query)
             grps = result.fetchall()
@@ -841,18 +840,17 @@ async def get_allowed_vfolder_hosts_by_user(
         result_hosts: VFolderHostPermissionMap = allowed_hosts | values
         allowed_hosts = result_hosts
     # User's Groups' allowed_vfolder_hosts.
-    ase = AssociationScopesEntitiesRow.__table__
     join_cond = sa.and_(
-        sa.cast(groups.c.id, sa.String) == ase.c.scope_id,
-        ase.c.scope_type == PermissionScopeType.PROJECT,
-        ase.c.entity_type == PermissionEntityType.USER,
-        ase.c.entity_id == str(user_uuid),
+        sa.cast(groups.c.id, sa.String) == AssociationScopesEntitiesRow.scope_id,
+        AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+        AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+        AssociationScopesEntitiesRow.entity_id == str(user_uuid),
     )
     if group_id is not None:
         join_cond = sa.and_(join_cond, groups.c.id == group_id)
     query = (
         sa.select(groups.c.allowed_vfolder_hosts)
-        .select_from(groups.join(ase, join_cond))
+        .select_from(groups.join(AssociationScopesEntitiesRow, join_cond))
         .where(groups.c.domain_name == domain_name, groups.c.is_active)
     )
     if rows := (await conn.execute(query)).fetchall():
@@ -1417,14 +1415,13 @@ async def ensure_quota_scope_accessible_by_user(
                 if quota_scope_group.domain_name == user["domain_name"]:
                     return
             case _:
-                ase = AssociationScopesEntitiesRow.__table__
-                query = sa.select(ase.c.scope_id).where(
-                    ase.c.scope_type == PermissionScopeType.PROJECT,
-                    ase.c.entity_type == PermissionEntityType.USER,
-                    ase.c.scope_id == str(quota_scope.scope_id),
-                    ase.c.entity_id == str(user["uuid"]),
+                membership_query = sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+                    AssociationScopesEntitiesRow.scope_id == str(quota_scope.scope_id),
+                    AssociationScopesEntitiesRow.entity_id == str(user["uuid"]),
                 )
-                matched_group_id = await conn.scalar(query)
+                matched_group_id = await conn.scalar(membership_query)
                 if matched_group_id:
                     return
 
@@ -1716,15 +1713,14 @@ class VFolderPermissionContextBuilder(
     ) -> VFolderPermissionContext:
         result = VFolderPermissionContext()
 
-        ase = AssociationScopesEntitiesRow.__table__
         j = sa.join(
             GroupRow,
-            ase,
+            AssociationScopesEntitiesRow,
             sa.and_(
-                sa.cast(GroupRow.id, sa.String) == ase.c.scope_id,
-                ase.c.scope_type == PermissionScopeType.PROJECT,
-                ase.c.entity_type == PermissionEntityType.USER,
-                ase.c.entity_id == str(ctx.user_id),
+                sa.cast(GroupRow.id, sa.String) == AssociationScopesEntitiesRow.scope_id,
+                AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+                AssociationScopesEntitiesRow.entity_type == PermissionEntityType.USER,
+                AssociationScopesEntitiesRow.entity_id == str(ctx.user_id),
             ),
         )
         _project_stmt = (

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -42,6 +42,12 @@ from ai.backend.common.types import (
     VFolderUsageMode,
 )
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermissionEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermissionScopeType,
+)
 from ai.backend.manager.data.vfolder.types import (
     VFolderData,
     VFolderInvitationState,
@@ -71,7 +77,7 @@ from ai.backend.manager.models.base import (
     StrEnumType,
     metadata,
 )
-from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.rbac import (
     AbstractPermissionContext,
     AbstractPermissionContextBuilder,
@@ -89,6 +95,9 @@ from ai.backend.manager.models.rbac.exceptions import NotEnoughPermission
 from ai.backend.manager.models.rbac.permission_defs import StorageHostPermission
 from ai.backend.manager.models.rbac.permission_defs import (
     VFolderPermission as VFolderRBACPermission,
+)
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
 )
 from ai.backend.manager.models.session import DEAD_SESSION_STATUSES, SessionRow
 from ai.backend.manager.models.storage import PermissionContext as StorageHostPermissionContext
@@ -567,7 +576,6 @@ async def query_accessible_vfolders(
     extra_vf_group_conds: Any = None,
     allowed_status_set: VFolderStatusSet | None = None,
 ) -> Sequence[Mapping[str, Any]]:
-    from ai.backend.manager.models.group import association_groups_users as agus
     from ai.backend.manager.models.group import groups
     from ai.backend.manager.models.user import users
 
@@ -698,11 +706,15 @@ async def query_accessible_vfolders(
             grps = result.fetchall()
             group_ids = [g.id for g in grps]
         else:
-            j = sa.join(agus, users, agus.c.user_id == users.c.uuid)
-            query = sa.select(agus.c.group_id).select_from(j).where(agus.c.user_id == user_uuid)
+            ase = AssociationScopesEntitiesRow.__table__
+            query = sa.select(ase.c.scope_id).where(
+                ase.c.scope_type == PermissionScopeType.PROJECT,
+                ase.c.entity_type == PermissionEntityType.USER,
+                ase.c.entity_id == str(user_uuid),
+            )
             result = await conn.execute(query)
             grps = result.fetchall()
-            group_ids = [g.group_id for g in grps]
+            group_ids = [uuid.UUID(g.scope_id) for g in grps]
             # Include MODEL_STORE projects in the same domain for cross-project model access
             from ai.backend.manager.data.group.types import ProjectType
 
@@ -818,7 +830,7 @@ async def get_allowed_vfolder_hosts_by_user(
     All available `allowed_vfolder_hosts` of groups which requester associated will be merged.
     """
     from ai.backend.manager.models.domain import domains
-    from ai.backend.manager.models.group import association_groups_users, groups
+    from ai.backend.manager.models.group import groups
 
     # Domain's allowed_vfolder_hosts.
     allowed_hosts = VFolderHostPermissionMap()
@@ -829,30 +841,20 @@ async def get_allowed_vfolder_hosts_by_user(
         result_hosts: VFolderHostPermissionMap = allowed_hosts | values
         allowed_hosts = result_hosts
     # User's Groups' allowed_vfolder_hosts.
-    if group_id is not None:
-        j = groups.join(
-            association_groups_users,
-            (
-                (groups.c.id == association_groups_users.c.group_id)
-                & (groups.c.id == group_id)
-                & (association_groups_users.c.user_id == user_uuid)
-            ),
-        )
-    else:
-        j = groups.join(
-            association_groups_users,
-            (
-                (groups.c.id == association_groups_users.c.group_id)
-                & (association_groups_users.c.user_id == user_uuid)
-            ),
-        )
-    query = (
-        sa.select(groups.c.allowed_vfolder_hosts)
-        .select_from(j)
-        .where(
-            (groups.c.domain_name == domain_name) & (groups.c.is_active),
-        )
+    ase = AssociationScopesEntitiesRow.__table__
+    project_ids_subq = sa.select(ase.c.scope_id).where(
+        ase.c.scope_type == PermissionScopeType.PROJECT,
+        ase.c.entity_type == PermissionEntityType.USER,
+        ase.c.entity_id == str(user_uuid),
     )
+    where_conds = [
+        groups.c.domain_name == domain_name,
+        groups.c.is_active,
+        sa.cast(groups.c.id, sa.String).in_(project_ids_subq),
+    ]
+    if group_id is not None:
+        where_conds.append(groups.c.id == group_id)
+    query = sa.select(groups.c.allowed_vfolder_hosts).where(*where_conds)
     if rows := (await conn.execute(query)).fetchall():
         for row in rows:
             result_hosts = allowed_hosts | row.allowed_vfolder_hosts
@@ -1389,8 +1391,6 @@ async def ensure_quota_scope_accessible_by_user(
     quota_scope: QuotaScopeID,
     user: Mapping[str, Any],
 ) -> None:
-    from ai.backend.manager.models.group import association_groups_users as agus
-
     # Lookup user table to match if quota is scoped to the user
     query = sa.select(UserRow).where(UserRow.uuid == quota_scope.scope_id)
     quota_scope_user: UserRow | None = await conn.scalar(query)
@@ -1417,12 +1417,12 @@ async def ensure_quota_scope_accessible_by_user(
                 if quota_scope_group.domain_name == user["domain_name"]:
                     return
             case _:
-                query = (
-                    sa.select(agus.c.group_id)
-                    .select_from(agus)
-                    .where(
-                        (agus.c.group_id == quota_scope.scope_id) & (agus.c.user_id == user["uuid"])
-                    )
+                ase = AssociationScopesEntitiesRow.__table__
+                query = sa.select(ase.c.scope_id).where(
+                    ase.c.scope_type == PermissionScopeType.PROJECT,
+                    ase.c.entity_type == PermissionEntityType.USER,
+                    ase.c.scope_id == str(quota_scope.scope_id),
+                    ase.c.entity_id == str(user["uuid"]),
                 )
                 matched_group_id = await conn.scalar(query)
                 if matched_group_id:
@@ -1716,18 +1716,17 @@ class VFolderPermissionContextBuilder(
     ) -> VFolderPermissionContext:
         result = VFolderPermissionContext()
 
-        j = sa.join(
-            GroupRow,
-            AssocGroupUserRow,
-            GroupRow.id == AssocGroupUserRow.group_id,
+        ase = AssociationScopesEntitiesRow.__table__
+        project_ids_subq = sa.select(ase.c.scope_id).where(
+            ase.c.scope_type == PermissionScopeType.PROJECT,
+            ase.c.entity_type == PermissionEntityType.USER,
+            ase.c.entity_id == str(ctx.user_id),
         )
         _project_stmt = (
             sa.select(GroupRow)
-            .select_from(j)
             .where(
-                sa.and_(
-                    GroupRow.domain_name == domain_name, AssocGroupUserRow.user_id == ctx.user_id
-                )
+                GroupRow.domain_name == domain_name,
+                sa.cast(GroupRow.id, sa.String).in_(project_ids_subq),
             )
             .options(load_only(GroupRow.id))
         )

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -1717,17 +1717,19 @@ class VFolderPermissionContextBuilder(
         result = VFolderPermissionContext()
 
         ase = AssociationScopesEntitiesRow.__table__
+        j = sa.join(
+            GroupRow,
+            ase,
+            sa.and_(
+                sa.cast(GroupRow.id, sa.String) == ase.c.scope_id,
+                ase.c.scope_type == PermissionScopeType.PROJECT,
+                ase.c.entity_type == PermissionEntityType.USER,
+                ase.c.entity_id == str(ctx.user_id),
+            ),
+        )
         _project_stmt = (
             sa.select(GroupRow)
-            .join(
-                ase,
-                sa.and_(
-                    sa.cast(GroupRow.id, sa.String) == ase.c.scope_id,
-                    ase.c.scope_type == PermissionScopeType.PROJECT,
-                    ase.c.entity_type == PermissionEntityType.USER,
-                    ase.c.entity_id == str(ctx.user_id),
-                ),
-            )
+            .select_from(j)
             .where(GroupRow.domain_name == domain_name)
             .options(load_only(GroupRow.id))
         )

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -63,7 +63,6 @@ from ai.backend.manager.errors.storage import (
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.agent import agents
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.group import association_groups_users as agus
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.keypair import KeyPairRow, keypairs
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -1504,15 +1503,21 @@ class VfolderRepository:
             )
 
             users_table = UserRow.__table__
-            j = users_table.join(agus, users_table.c.uuid == agus.c.user_id)
+            ase_table = AssociationScopesEntitiesRow.__table__
+            j = users_table.join(
+                ase_table,
+                sa.cast(users_table.c.uuid, sa.String) == ase_table.c.entity_id,
+            )
             db_query = (
                 sa.select(users_table.c.uuid, users_table.c.email)
                 .select_from(j)
                 .where(
-                    (users_table.c.email.in_(emails))
-                    & (users_table.c.email != requester_email)
-                    & (agus.c.group_id == vfolder_group)
-                    & (users_table.c.status.in_(ACTIVE_USER_STATUSES)),
+                    ase_table.c.scope_type == ScopeType.PROJECT,
+                    ase_table.c.entity_type == EntityType.USER,
+                    ase_table.c.scope_id == str(vfolder_group),
+                    users_table.c.email.in_(emails),
+                    users_table.c.email != requester_email,
+                    users_table.c.status.in_(ACTIVE_USER_STATUSES),
                 )
             )
             result = await session.execute(db_query)

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -1503,18 +1503,17 @@ class VfolderRepository:
             )
 
             users_table = UserRow.__table__
-            ase_table = AssociationScopesEntitiesRow.__table__
             j = users_table.join(
-                ase_table,
-                sa.cast(users_table.c.uuid, sa.String) == ase_table.c.entity_id,
+                AssociationScopesEntitiesRow,
+                sa.cast(users_table.c.uuid, sa.String) == AssociationScopesEntitiesRow.entity_id,
             )
             db_query = (
                 sa.select(users_table.c.uuid, users_table.c.email)
                 .select_from(j)
                 .where(
-                    ase_table.c.scope_type == ScopeType.PROJECT,
-                    ase_table.c.entity_type == EntityType.USER,
-                    ase_table.c.scope_id == str(vfolder_group),
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.scope_id == str(vfolder_group),
                     users_table.c.email.in_(emails),
                     users_table.c.email != requester_email,
                     users_table.c.status.in_(ACTIVE_USER_STATUSES),

--- a/tests/unit/manager/models/test_get_allowed_vfolder_hosts_by_user.py
+++ b/tests/unit/manager/models/test_get_allowed_vfolder_hosts_by_user.py
@@ -1,0 +1,379 @@
+"""Tests for `get_allowed_vfolder_hosts_by_user` project-membership behavior.
+
+Only the membership filter (powered by `association_scopes_entities`) is verified.
+The function's domain-level and resource-policy-level merge behavior is not the
+focus of this test module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+
+from ai.backend.common.types import (
+    BinarySize,
+    ResourceSlot,
+    VFolderHostPermission,
+    VFolderHostPermissionMap,
+)
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermissionEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermissionScopeType,
+)
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.user import (
+    PasswordHashAlgorithm,
+    UserRole,
+    UserRow,
+    UserStatus,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import get_allowed_vfolder_hosts_by_user
+from ai.backend.testutils.db import with_tables
+
+HOST_A = "host-a"
+HOST_B = "host-b"
+HOST_C = "host-c"
+HOSTS_A: VFolderHostPermissionMap = VFolderHostPermissionMap({
+    HOST_A: {VFolderHostPermission.CREATE}
+})
+HOSTS_B: VFolderHostPermissionMap = VFolderHostPermissionMap({
+    HOST_B: {VFolderHostPermission.CREATE}
+})
+HOSTS_C: VFolderHostPermissionMap = VFolderHostPermissionMap({
+    HOST_C: {VFolderHostPermission.CREATE}
+})
+
+
+def _password() -> PasswordInfo:
+    return PasswordInfo(
+        password="dummy",
+        algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+        rounds=600_000,
+        salt_size=32,
+    )
+
+
+class TestGetAllowedVFolderHostsByUserMembership:
+    """Project-membership filter for `get_allowed_vfolder_hosts_by_user`.
+
+    Each test seeds a domain, two groups in that domain, and a regular user.
+    Membership is granted by inserting the corresponding ASE row.
+    """
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                AgentRow,
+                AssociationScopesEntitiesRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def domain_name(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        name = f"test-domain-{uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=name,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    allowed_docker_registries=[],
+                )
+            )
+            await sess.flush()
+        yield name
+
+    @pytest.fixture
+    async def project_resource_policy(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        policy_name = f"test-proj-policy-{uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+                    max_network_count=5,
+                )
+            )
+            await sess.flush()
+        yield policy_name
+
+    @pytest.fixture
+    async def user_resource_policy(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        policy_name = f"test-user-policy-{uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+                    max_session_count_per_model_session=5,
+                    max_customized_image_count=3,
+                )
+            )
+            await sess.flush()
+        yield policy_name
+
+    @pytest.fixture
+    async def regular_user(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        user_uuid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"user_{user_uuid.hex[:8]}",
+                    email=f"user-{user_uuid.hex[:8]}@example.com",
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            await sess.flush()
+        yield user_uuid
+
+    @pytest.fixture
+    async def group_a(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        gid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                GroupRow(
+                    id=gid,
+                    name=f"group-a-{gid.hex[:8]}",
+                    domain_name=domain_name,
+                    resource_policy=project_resource_policy,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=HOSTS_A,
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await sess.flush()
+        yield gid
+
+    @pytest.fixture
+    async def group_b(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        gid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                GroupRow(
+                    id=gid,
+                    name=f"group-b-{gid.hex[:8]}",
+                    domain_name=domain_name,
+                    resource_policy=project_resource_policy,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=HOSTS_B,
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await sess.flush()
+        yield gid
+
+    @pytest.fixture
+    async def membership_in_group_a(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        regular_user: UUID,
+        group_a: UUID,
+    ) -> AsyncGenerator[None, None]:
+        """Insert ASE row binding regular_user to group_a."""
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(group_a),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(regular_user),
+                )
+            )
+            await sess.flush()
+        yield
+
+    @pytest.fixture
+    async def membership_in_group_b(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        regular_user: UUID,
+        group_b: UUID,
+    ) -> AsyncGenerator[None, None]:
+        """Insert ASE row binding regular_user to group_b."""
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(group_b),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(regular_user),
+                )
+            )
+            await sess.flush()
+        yield
+
+    async def test_member_groups_contribute_their_hosts(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        regular_user: UUID,
+        group_a: UUID,
+        group_b: UUID,
+        membership_in_group_a: None,
+        membership_in_group_b: None,
+    ) -> None:
+        """Without `group_id`, hosts from every group the user is a member of are merged."""
+        async with db_with_cleanup.begin_readonly() as conn:
+            result = await get_allowed_vfolder_hosts_by_user(
+                conn,
+                resource_policy={},
+                domain_name=domain_name,
+                user_uuid=regular_user,
+            )
+
+        assert HOST_A in result
+        assert HOST_B in result
+
+    async def test_non_member_groups_do_not_contribute(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        regular_user: UUID,
+        group_a: UUID,
+        group_b: UUID,
+        membership_in_group_a: None,
+    ) -> None:
+        """Only groups with an ASE membership row are merged into the result."""
+        async with db_with_cleanup.begin_readonly() as conn:
+            result = await get_allowed_vfolder_hosts_by_user(
+                conn,
+                resource_policy={},
+                domain_name=domain_name,
+                user_uuid=regular_user,
+            )
+
+        assert HOST_A in result
+        assert HOST_B not in result
+
+    async def test_group_id_filter_with_membership(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        regular_user: UUID,
+        group_a: UUID,
+        group_b: UUID,
+        membership_in_group_a: None,
+        membership_in_group_b: None,
+    ) -> None:
+        """`group_id` restricts merging to that single group when the user is a member."""
+        async with db_with_cleanup.begin_readonly() as conn:
+            result = await get_allowed_vfolder_hosts_by_user(
+                conn,
+                resource_policy={},
+                domain_name=domain_name,
+                user_uuid=regular_user,
+                group_id=group_a,
+            )
+
+        assert HOST_A in result
+        assert HOST_B not in result
+
+    async def test_group_id_filter_without_membership(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        regular_user: UUID,
+        group_a: UUID,
+    ) -> None:
+        """`group_id` for a group the user is not a member of yields no group hosts."""
+        async with db_with_cleanup.begin_readonly() as conn:
+            result = await get_allowed_vfolder_hosts_by_user(
+                conn,
+                resource_policy={},
+                domain_name=domain_name,
+                user_uuid=regular_user,
+                group_id=group_a,
+            )
+
+        assert HOST_A not in result
+
+    async def test_resource_policy_hosts_merge_independent_of_membership(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        regular_user: UUID,
+    ) -> None:
+        """Hosts from `resource_policy` are merged regardless of project membership.
+
+        Sanity check that the membership filter does not gate non-membership inputs.
+        """
+        async with db_with_cleanup.begin_readonly() as conn:
+            result = await get_allowed_vfolder_hosts_by_user(
+                conn,
+                resource_policy={"allowed_vfolder_hosts": HOSTS_C},
+                domain_name=domain_name,
+                user_uuid=regular_user,
+            )
+
+        assert HOST_C in result

--- a/tests/unit/manager/models/test_vfolder_quota_scope.py
+++ b/tests/unit/manager/models/test_vfolder_quota_scope.py
@@ -5,6 +5,12 @@ from uuid import UUID, uuid4
 import pytest
 
 from ai.backend.common.types import BinarySize, QuotaScopeID, ResourceSlot
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermissionEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermissionScopeType,
+)
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -17,6 +23,9 @@ from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
@@ -74,6 +83,7 @@ class TestEnsureQuotaScopeAccessibleByUser:
                 SessionRow,
                 KernelRow,
                 RoutingRow,
+                AssociationScopesEntitiesRow,
             ],
         ):
             yield database_connection
@@ -355,3 +365,124 @@ class TestEnsureQuotaScopeAccessibleByUser:
                 quota_scope,
                 domain_user_data_dict,
             )
+
+    @pytest.fixture
+    def regular_user_data_dict(
+        self,
+        regular_user: UUID,
+        test_domain_name: str,
+    ) -> dict[str, Any]:
+        """User dict for a regular user (USER role)."""
+        return {
+            "uuid": regular_user,
+            "role": UserRole.USER,
+            "domain_name": test_domain_name,
+        }
+
+    @pytest.fixture
+    async def regular_user_membership_in_test_group(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        regular_user: UUID,
+        test_group: UUID,
+    ) -> AsyncGenerator[None, None]:
+        """Insert ASE row binding regular_user to test_group."""
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(test_group),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(regular_user),
+                )
+            )
+            await session.flush()
+        yield
+
+    @pytest.fixture
+    async def other_group_with_regular_user_membership(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        regular_user: UUID,
+        test_domain_name: str,
+        test_project_resource_policy_name: str,
+    ) -> AsyncGenerator[UUID, None]:
+        """Insert a separate group in the same domain plus an ASE row for regular_user."""
+        other_group_id = uuid4()
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                GroupRow(
+                    id=other_group_id,
+                    name=f"other_group_{other_group_id.hex[:8]}",
+                    domain_name=test_domain_name,
+                    resource_policy=test_project_resource_policy_name,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts={},
+                    type=ProjectType.GENERAL,
+                )
+            )
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(other_group_id),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(regular_user),
+                )
+            )
+            await session.flush()
+        yield other_group_id
+
+    async def test_user_can_access_group_quota_when_ase_membership_present(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_group: UUID,
+        regular_user_data_dict: dict[str, Any],
+        regular_user_membership_in_test_group: None,
+    ) -> None:
+        """Regular user with ASE (PROJECT, group, USER) row passes the project quota check."""
+        quota_scope = QuotaScopeID.parse(f"project:{test_group}")
+
+        async with db_with_cleanup.begin_session() as session:
+            # Should not raise any exception
+            await ensure_quota_scope_accessible_by_user(
+                session,
+                quota_scope,
+                regular_user_data_dict,
+            )
+
+    async def test_user_cannot_access_group_quota_without_ase_membership(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_group: UUID,
+        regular_user_data_dict: dict[str, Any],
+    ) -> None:
+        """Regular user without ASE membership row is rejected at the project quota check."""
+        quota_scope = QuotaScopeID.parse(f"project:{test_group}")
+
+        async with db_with_cleanup.begin_session() as session:
+            with pytest.raises(InvalidAPIParameters):
+                await ensure_quota_scope_accessible_by_user(
+                    session,
+                    quota_scope,
+                    regular_user_data_dict,
+                )
+
+    async def test_user_membership_in_other_project_does_not_grant_access(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_group: UUID,
+        regular_user_data_dict: dict[str, Any],
+        other_group_with_regular_user_membership: UUID,
+    ) -> None:
+        """Membership in project A does not grant quota access to project B."""
+        quota_scope = QuotaScopeID.parse(f"project:{test_group}")
+
+        async with db_with_cleanup.begin_session() as session:
+            with pytest.raises(InvalidAPIParameters):
+                await ensure_quota_scope_accessible_by_user(
+                    session,
+                    quota_scope,
+                    regular_user_data_dict,
+                )

--- a/tests/unit/manager/repositories/vfolder/test_share_vfolder_membership.py
+++ b/tests/unit/manager/repositories/vfolder/test_share_vfolder_membership.py
@@ -1,0 +1,526 @@
+"""Tests for `VfolderRepository.share_vfolder_with_users` project-membership lookup.
+
+Only the membership filter — powered by `association_scopes_entities` after BA-5819 —
+is verified. The host-permission gate is patched out so the test focuses purely on
+which users can or cannot be returned by the membership lookup.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from ai.backend.common.types import (
+    BinarySize,
+    ResourceSlot,
+    VFolderHostPermissionMap,
+)
+from ai.backend.manager.data.permission.types import (
+    EntityType as PermissionEntityType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as PermissionScopeType,
+)
+from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow, ProjectType
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.scaling_group import ScalingGroupRow
+from ai.backend.manager.models.user import (
+    PasswordHashAlgorithm,
+    UserRole,
+    UserRow,
+    UserStatus,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import (
+    VFolderOperationStatus,
+    VFolderOwnershipType,
+    VFolderPermission,
+    VFolderPermissionRow,
+    VFolderRow,
+)
+from ai.backend.manager.repositories.vfolder import repository as vfolder_repo_module
+from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
+from ai.backend.testutils.db import with_tables
+
+REQUESTER_EMAIL = "requester@example.com"
+DOMAIN_NAME_FIXED = "test-domain-share"
+
+
+def _password() -> PasswordInfo:
+    return PasswordInfo(
+        password="dummy",
+        algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+        rounds=600_000,
+        salt_size=32,
+    )
+
+
+class TestShareVfolderWithUsersMembership:
+    """Membership-lookup behavior of `share_vfolder_with_users`.
+
+    `ensure_host_permission_allowed` is patched to a no-op so the test isolates the
+    project-membership branch.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_host_permission(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            vfolder_repo_module,
+            "ensure_host_permission_allowed",
+            AsyncMock(return_value=None),
+        )
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                ScalingGroupRow,
+                UserResourcePolicyRow,
+                ProjectResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                GroupRow,
+                VFolderRow,
+                VFolderPermissionRow,
+                AssociationScopesEntitiesRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    async def domain_name(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                DomainRow(
+                    name=DOMAIN_NAME_FIXED,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    allowed_docker_registries=[],
+                )
+            )
+            await sess.flush()
+        yield DOMAIN_NAME_FIXED
+
+    @pytest.fixture
+    async def project_resource_policy(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        policy_name = f"proj-{uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+                    max_network_count=5,
+                )
+            )
+            await sess.flush()
+        yield policy_name
+
+    @pytest.fixture
+    async def user_resource_policy(
+        self, db_with_cleanup: ExtendedAsyncSAEngine
+    ) -> AsyncGenerator[str, None]:
+        policy_name = f"user-{uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=10,
+                    max_quota_scope_size=BinarySize.finite_from_str("10GiB"),
+                    max_session_count_per_model_session=5,
+                    max_customized_image_count=3,
+                )
+            )
+            await sess.flush()
+        yield policy_name
+
+    @pytest.fixture
+    async def project(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        gid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                GroupRow(
+                    id=gid,
+                    name=f"proj-{gid.hex[:8]}",
+                    domain_name=domain_name,
+                    resource_policy=project_resource_policy,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await sess.flush()
+        yield gid
+
+    @pytest.fixture
+    async def requester(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        user_uuid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"requester_{user_uuid.hex[:8]}",
+                    email=REQUESTER_EMAIL,
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            await sess.flush()
+        yield user_uuid
+
+    @pytest.fixture
+    async def vfolder(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+    ) -> AsyncGenerator[UUID, None]:
+        vfolder_id = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                VFolderRow(
+                    id=vfolder_id,
+                    name=f"vf-{vfolder_id.hex[:8]}",
+                    host="local",
+                    domain_name=domain_name,
+                    quota_scope_id=f"project:{project}",
+                    ownership_type=VFolderOwnershipType.GROUP,
+                    user=None,
+                    group=project,
+                    creator=REQUESTER_EMAIL,
+                    creator_id=requester,
+                    unmanaged_path=None,
+                    cloneable=False,
+                    status=VFolderOperationStatus.READY,
+                )
+            )
+            await sess.flush()
+        yield vfolder_id
+
+    @pytest.fixture
+    async def member_user_email(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+        project: UUID,
+    ) -> AsyncGenerator[str, None]:
+        """An ACTIVE user with an ASE membership row in `project`."""
+        user_uuid = uuid4()
+        email = f"member-{user_uuid.hex[:8]}@example.com"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"u_{user_uuid.hex[:8]}",
+                    email=email,
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(project),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(user_uuid),
+                )
+            )
+            await sess.flush()
+        yield email
+
+    @pytest.fixture
+    async def non_member_user_email(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+    ) -> AsyncGenerator[str, None]:
+        """An ACTIVE user with no project membership."""
+        user_uuid = uuid4()
+        email = f"stranger-{user_uuid.hex[:8]}@example.com"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"u_{user_uuid.hex[:8]}",
+                    email=email,
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            await sess.flush()
+        yield email
+
+    @pytest.fixture
+    async def inactive_member_user_email(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+        project: UUID,
+    ) -> AsyncGenerator[str, None]:
+        """An INACTIVE user that nonetheless has an ASE membership row in `project`."""
+        user_uuid = uuid4()
+        email = f"inactive-{user_uuid.hex[:8]}@example.com"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"u_{user_uuid.hex[:8]}",
+                    email=email,
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.INACTIVE,
+                    status_info="inactive",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(project),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(user_uuid),
+                )
+            )
+            await sess.flush()
+        yield email
+
+    @pytest.fixture
+    async def other_project(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project_resource_policy: str,
+    ) -> AsyncGenerator[UUID, None]:
+        """A separate project in the same domain (used to verify cross-project isolation)."""
+        gid = uuid4()
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                GroupRow(
+                    id=gid,
+                    name=f"other-{gid.hex[:8]}",
+                    domain_name=domain_name,
+                    resource_policy=project_resource_policy,
+                    description="",
+                    is_active=True,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    type=ProjectType.GENERAL,
+                )
+            )
+            await sess.flush()
+        yield gid
+
+    @pytest.fixture
+    async def other_project_member_email(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        user_resource_policy: str,
+        other_project: UUID,
+    ) -> AsyncGenerator[str, None]:
+        """An ACTIVE user with an ASE membership row in `other_project` (not `project`)."""
+        user_uuid = uuid4()
+        email = f"elsewhere-{user_uuid.hex[:8]}@example.com"
+        async with db_with_cleanup.begin_session() as sess:
+            sess.add(
+                UserRow(
+                    uuid=user_uuid,
+                    username=f"u_{user_uuid.hex[:8]}",
+                    email=email,
+                    password=_password(),
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=domain_name,
+                    role=UserRole.USER,
+                    resource_policy=user_resource_policy,
+                )
+            )
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType.PROJECT,
+                    scope_id=str(other_project),
+                    entity_type=PermissionEntityType.USER,
+                    entity_id=str(user_uuid),
+                )
+            )
+            await sess.flush()
+        yield email
+
+    def _share_kwargs(
+        self,
+        vfolder_id: UUID,
+        project: UUID,
+        requester: UUID,
+        domain_name: str,
+        emails: list[str],
+    ) -> dict[str, Any]:
+        return {
+            "vfolder_id": vfolder_id,
+            "vfolder_host": "local",
+            "vfolder_group": project,
+            "requester_uuid": requester,
+            "requester_email": REQUESTER_EMAIL,
+            "domain_name": domain_name,
+            "resource_policy": {},
+            "emails": emails,
+            "permission": VFolderPermission.READ_ONLY,
+            "allowed_vfolder_types": ["group"],
+        }
+
+    async def test_member_is_returned(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+        vfolder: UUID,
+        member_user_email: str,
+    ) -> None:
+        """A user that is a project member is returned in the share result."""
+        repo = VfolderRepository(db_with_cleanup)
+        result = await repo.share_vfolder_with_users(
+            **self._share_kwargs(vfolder, project, requester, domain_name, [member_user_email])
+        )
+
+        assert result == [member_user_email]
+
+    async def test_non_member_raises_object_not_found(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+        vfolder: UUID,
+        non_member_user_email: str,
+    ) -> None:
+        """A user without an ASE membership row triggers ObjectNotFound."""
+        repo = VfolderRepository(db_with_cleanup)
+        with pytest.raises(ObjectNotFound):
+            await repo.share_vfolder_with_users(
+                **self._share_kwargs(
+                    vfolder, project, requester, domain_name, [non_member_user_email]
+                )
+            )
+
+    async def test_partial_membership_raises_object_not_found(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+        vfolder: UUID,
+        member_user_email: str,
+        non_member_user_email: str,
+    ) -> None:
+        """When some emails are not project members, the call must reject the whole batch."""
+        repo = VfolderRepository(db_with_cleanup)
+        with pytest.raises(ObjectNotFound):
+            await repo.share_vfolder_with_users(
+                **self._share_kwargs(
+                    vfolder,
+                    project,
+                    requester,
+                    domain_name,
+                    [member_user_email, non_member_user_email],
+                )
+            )
+
+    async def test_membership_in_other_project_does_not_grant_share(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+        vfolder: UUID,
+        other_project_member_email: str,
+    ) -> None:
+        """Membership in a different project does not satisfy this folder's group filter."""
+        repo = VfolderRepository(db_with_cleanup)
+        with pytest.raises(ObjectNotFound):
+            await repo.share_vfolder_with_users(
+                **self._share_kwargs(
+                    vfolder, project, requester, domain_name, [other_project_member_email]
+                )
+            )
+
+    async def test_inactive_member_is_filtered_out(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        domain_name: str,
+        project: UUID,
+        requester: UUID,
+        vfolder: UUID,
+        inactive_member_user_email: str,
+    ) -> None:
+        """Membership alone is not enough — inactive users are excluded by status filter."""
+        repo = VfolderRepository(db_with_cleanup)
+        with pytest.raises(ObjectNotFound):
+            await repo.share_vfolder_with_users(
+                **self._share_kwargs(
+                    vfolder, project, requester, domain_name, [inactive_member_user_email]
+                )
+            )


### PR DESCRIPTION
## Summary
- Migrate vfolder code paths off `association_groups_users` (agus) to `association_scopes_entities` (ASE) using `scope_type=PROJECT, entity_type=USER`. Touches `models/vfolder/row.py` (4 sites), `repositories/vfolder/repository.py` (1 site), and `api/gql_legacy/vfolder.py` (2 sites) — all 7 READ sites listed in the ticket plus the legacy permission context in `_build_at_project_scopes_in_domain`.
- Use safe cast direction throughout: cast UUID columns to `String` (or compare with `str(uuid)`) instead of casting ASE's `String(64)` `scope_id`/`entity_id` to GUID. ASE may hold non-UUID values (DOMAIN scope storing domain names, GLOBAL scope storing `"global"`), and a JOIN-side cast to GUID can trigger `invalid input syntax for type uuid` when PostgreSQL evaluates the cast before the `WHERE scope_type=...` filter. Where a JOIN is unavoidable, ASE is pre-filtered in a subquery and matched via `IN`.
- Component tests intentionally out of scope per discussion — most migrated functions are legacy paths not directly exercised by the v2 SDK test pattern.

## Test plan
- [x] Existing vfolder repository tests pass under CI (`pants test`)

Resolves BA-5819