### PR TITLE
fix(BA-5838): return null for unassigned `ModelReplica.sessionId`

### DIFF
--- a/changes/11326.fix.md
+++ b/changes/11326.fix.md
@@ -1,0 +1,1 @@
+Fix `ModelReplica.sessionId` returning the replica's own ID instead of `null` while the compute session is still being provisioned, which previously caused the deployment Replicas tab to open a session drawer with a permission error.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9283,7 +9283,7 @@ type ModelReplica implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
-  sessionId: ID!
+  sessionId: ID
   revisionId: ID!
 
   """Whether the replica has been checked and its health state."""
@@ -9299,9 +9299,9 @@ type ModelReplica implements Node
   createdAt: DateTime!
 
   """
-  The session ID associated with the replica. This can be null right after replica creation.
+  The session associated with the replica. Can be null if the replica is still provisioning.
   """
-  session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
+  session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
   """
   Added in 26.4.3. The compute session running this replica, resolved via DataLoader.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6090,7 +6090,7 @@ Added in 25.19.0. A single replica instance of a model deployment. Each replica 
 type ModelReplica implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
-  sessionId: ID!
+  sessionId: ID
   revisionId: ID!
 
   """Whether the replica has been checked and its health state."""
@@ -6106,9 +6106,9 @@ type ModelReplica implements Node {
   createdAt: DateTime!
 
   """
-  The session ID associated with the replica. This can be null right after replica creation.
+  The session associated with the replica. Can be null if the replica is still provisioning.
   """
-  session: ComputeSessionNode! @deprecated(reason: "Use session_v2 instead.")
+  session: ComputeSessionNode @deprecated(reason: "Use session_v2 instead.")
 
   """
   Added in 26.4.3. The compute session running this replica, resolved via DataLoader.

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -411,7 +411,10 @@ class ReplicaNode(BaseResponseModel):
 
     id: UUID = Field(description="Replica ID")
     revision_id: UUID = Field(description="Associated revision ID")
-    session_id: UUID = Field(description="Associated session ID")
+    session_id: UUID | None = Field(
+        default=None,
+        description="Associated session ID. Null while the replica is still provisioning and no compute session has been assigned yet.",
+    )
     readiness_status: ReadinessStatus = Field(description="Readiness status")
     liveness_status: LivenessStatus = Field(description="Liveness status")
     activeness_status: ActivenessStatus = Field(description="Activeness status")

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -179,7 +179,7 @@ class ReplicaOrderBy(PydanticInputMixin[ReplicaOrderDTO]):
 )
 class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
     id: NodeID[str]
-    session_id: ID
+    session_id: ID | None
     revision_id: ID
     readiness_status: ReadinessStatus = gql_field(
         description="Whether the replica has been checked and its health state."
@@ -193,10 +193,12 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
     created_at: datetime = gql_field(description="Timestamp when the replica was created.")
 
     @gql_field(
-        description="The session ID associated with the replica. This can be null right after replica creation.",
+        description="The session associated with the replica. Can be null if the replica is still provisioning.",
         deprecation_reason="Use session_v2 instead.",
     )  # type: ignore[misc]
-    async def session(self, info: Info[StrawberryGQLContext]) -> Session:
+    async def session(self, info: Info[StrawberryGQLContext]) -> Session | None:
+        if self.session_id is None:
+            return None
         session_global_id = to_global_id(
             ComputeSessionNode, UUID(str(self.session_id)), is_target_graphene_object=True
         )
@@ -217,6 +219,8 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
         ]
         | None
     ):
+        if self.session_id is None:
+            return None
         from ai.backend.common.types import SessionId
 
         return await info.context.data_loaders.session_loader.load(

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -860,7 +860,7 @@ class ModelDeploymentAccessTokenData:
 class ModelReplicaData:
     id: UUID
     revision_id: UUID
-    session_id: UUID
+    session_id: UUID | None
     readiness_status: ReadinessStatus
     liveness_status: LivenessStatus
     activeness_status: ActivenessStatus

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -340,7 +340,7 @@ def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
     return ModelReplicaData(
         id=route.route_id,
         revision_id=route.revision_id or route.deployment_id,
-        session_id=route.session_id or route.route_id,
+        session_id=route.session_id,
         readiness_status=readiness,
         liveness_status=liveness,
         activeness_status=_resolve_activeness(route.traffic_status, readiness, liveness),

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -362,6 +362,33 @@ class TestGetReplicaById(DeploymentCRUDBaseFixtures):
         assert result.data is not None
         assert result.data.activeness_status == ActivenessStatus.INACTIVE
 
+    async def test_unassigned_session_id_is_none(
+        self,
+        processors: DeploymentProcessors,
+        mock_deployment_repository: MagicMock,
+        endpoint_id: uuid.UUID,
+    ) -> None:
+        """Regression for BA-5838: a route without a compute session must yield
+        ``session_id=None``, not a fallback to ``route_id``."""
+        route = RouteInfo(
+            route_id=uuid.uuid4(),
+            deployment_id=DeploymentID(endpoint_id),
+            session_id=None,
+            status=RouteStatus.PROVISIONING,
+            health_status=RouteHealthStatus.NOT_CHECKED,
+            traffic_ratio=1.0,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            revision_id=uuid.uuid4(),
+            traffic_status=RouteTrafficStatus.ACTIVE,
+        )
+        mock_deployment_repository.get_route = AsyncMock(return_value=route)
+
+        action = GetReplicaByIdAction(replica_id=route.route_id)
+        result = await processors.get_replica_by_id.wait_for_complete(action)
+
+        assert result.data is not None
+        assert result.data.session_id is None
+
 
 class TestSearchReplicas(DeploymentCRUDBaseFixtures):
     """Tests for DeploymentService.search_replicas"""


### PR DESCRIPTION
## Summary
- `_convert_route_info_to_replica_data` was falling back to `route.route_id` whenever a route had no compute session yet, so `ModelReplica.sessionId` returned the replica's own UUID and the WebUI session drawer failed with a "no permission / not found" error.
- Root cause: `ModelReplicaData.session_id` (data layer) and `ModelReplica.session_id` (GQL) were declared non-null while `RouteInfo.session_id` is legitimately nullable during provisioning. The bogus fallback existed only to satisfy the non-null type.
- Make `session_id` nullable end-to-end (`ModelReplicaData`, `ReplicaNode` v2 DTO, GQL `ModelReplica`) and add the same `if self.session_id is None: return None` guard to `session()` / `session_v2()` resolvers as `Route` already has.

Resolves BA-5838.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11326.org.readthedocs.build/en/11326/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11326.org.readthedocs.build/ko/11326/

<!-- readthedocs-preview sorna-ko end -->