### PR TITLE
fix(BA-5794): auto-load .env in v2 CLI to restore v1 behavior

### DIFF
--- a/changes/11327.fix.md
+++ b/changes/11327.fix.md
@@ -1,0 +1,1 @@
+Auto-load `.env` from the working directory in the v2 CLI, restoring the v1 behavior where `BACKEND_*` variables are picked up implicitly.

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -63,6 +63,13 @@ def resource_usage() -> None:
 @cli_main.group(cls=LazyGroup, import_name="ai.backend.client.cli.v2:v2")
 def v2() -> None:
     """V2 REST API commands."""
+    # Auto-load .env from cwd so BACKEND_* vars are picked up before any
+    # subcommand reads os.environ. The v2/__init__.py callback is unreachable
+    # because LazyGroup only wraps click.Group methods, not MultiCommand.invoke,
+    # so this wrapper is the actual entry point for `./bai v2 ...`.
+    from ai.backend.client.cli.v2.helpers import _load_cwd_dotenv
+
+    _load_cwd_dotenv()
 
 
 # Groups with aliases in subcommands - still eager load

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -67,9 +67,9 @@ def v2() -> None:
     # subcommand reads os.environ. The v2/__init__.py callback is unreachable
     # because LazyGroup only wraps click.Group methods, not MultiCommand.invoke,
     # so this wrapper is the actual entry point for `./bai v2 ...`.
-    from ai.backend.client.cli.v2.helpers import load_cwd_dotenv
+    from dotenv import find_dotenv, load_dotenv
 
-    load_cwd_dotenv()
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
 
 
 # Groups with aliases in subcommands - still eager load

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -67,9 +67,9 @@ def v2() -> None:
     # subcommand reads os.environ. The v2/__init__.py callback is unreachable
     # because LazyGroup only wraps click.Group methods, not MultiCommand.invoke,
     # so this wrapper is the actual entry point for `./bai v2 ...`.
-    from ai.backend.client.cli.v2.helpers import _load_cwd_dotenv
+    from ai.backend.client.cli.v2.helpers import load_cwd_dotenv
 
-    _load_cwd_dotenv()
+    load_cwd_dotenv()
 
 
 # Groups with aliases in subcommands - still eager load

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -16,7 +16,7 @@ from ai.backend.common.cli import LazyGroup
 from .admin import admin
 from .config_cmd import config
 from .gql_cmd import gql
-from .helpers import _load_dotenv_once
+from .helpers import _load_cwd_dotenv
 from .login_cmd import login, logout
 from .my import my
 
@@ -26,7 +26,7 @@ def v2() -> None:
     """V2 REST API commands."""
     # Auto-load .env from the working directory so BACKEND_* vars are picked up
     # before any subcommand reads os.environ (matches v1 CLI behavior).
-    _load_dotenv_once()
+    _load_cwd_dotenv()
 
 
 # Infrastructure commands

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -29,9 +29,9 @@ def v2() -> None:
     # when the inner group is invoked directly (e.g. tests, REPL), so we
     # mirror the wrapper's `.env` auto-load here as a safety net.
     # `load_dotenv` is idempotent — running on both paths is harmless.
-    from .helpers import _load_cwd_dotenv
+    from .helpers import load_cwd_dotenv
 
-    _load_cwd_dotenv()
+    load_cwd_dotenv()
 
 
 # Infrastructure commands

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -16,7 +16,6 @@ from ai.backend.common.cli import LazyGroup
 from .admin import admin
 from .config_cmd import config
 from .gql_cmd import gql
-from .helpers import _load_cwd_dotenv
 from .login_cmd import login, logout
 from .my import my
 
@@ -24,8 +23,14 @@ from .my import my
 @click.group()
 def v2() -> None:
     """V2 REST API commands."""
-    # Auto-load .env from the working directory so BACKEND_* vars are picked up
-    # before any subcommand reads os.environ (matches v1 CLI behavior).
+    # The real entry point for `./bai v2 ...` is the `LazyGroup` wrapper in
+    # `client/cli/__init__.py`, because `LazyGroup` does not delegate
+    # `MultiCommand.invoke` to the underlying group. This callback only runs
+    # when the inner group is invoked directly (e.g. tests, REPL), so we
+    # mirror the wrapper's `.env` auto-load here as a safety net.
+    # `load_dotenv` is idempotent — running on both paths is harmless.
+    from .helpers import _load_cwd_dotenv
+
     _load_cwd_dotenv()
 
 

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -16,6 +16,7 @@ from ai.backend.common.cli import LazyGroup
 from .admin import admin
 from .config_cmd import config
 from .gql_cmd import gql
+from .helpers import _load_dotenv_once
 from .login_cmd import login, logout
 from .my import my
 
@@ -23,6 +24,9 @@ from .my import my
 @click.group()
 def v2() -> None:
     """V2 REST API commands."""
+    # Auto-load .env from the working directory so BACKEND_* vars are picked up
+    # before any subcommand reads os.environ (matches v1 CLI behavior).
+    _load_dotenv_once()
 
 
 # Infrastructure commands

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -29,9 +29,9 @@ def v2() -> None:
     # when the inner group is invoked directly (e.g. tests, REPL), so we
     # mirror the wrapper's `.env` auto-load here as a safety net.
     # `load_dotenv` is idempotent — running on both paths is harmless.
-    from .helpers import load_cwd_dotenv
+    from dotenv import find_dotenv, load_dotenv
 
-    load_cwd_dotenv()
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
 
 
 # Infrastructure commands

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -33,9 +33,10 @@ DEFAULTS = {
 def _load_cwd_dotenv() -> None:
     """Load ``.env`` from the current working directory (walking upward).
 
-    Mirrors v1 CLI behavior where ``get_env()`` implicitly called ``load_dotenv()``
-    on every lookup. ``override=True`` preserves v1 semantics where ``.env`` wins
-    over pre-existing shell env vars.
+    Called from the ``v2()`` Click group callback so all v2 subcommands see
+    ``BACKEND_*`` variables defined in a project-local ``.env``. Mirrors v1
+    CLI behavior; ``override=True`` preserves v1 semantics where ``.env``
+    wins over pre-existing shell env vars.
     """
     load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
 
@@ -63,8 +64,6 @@ def load_v2_config() -> V2ConnectionConfig:
     4. Built-in defaults
     """
     import tomllib
-
-    _load_cwd_dotenv()
 
     cfg: dict[str, Any] = dict(DEFAULTS)
 

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -29,20 +29,15 @@ DEFAULTS = {
     "skip_ssl_verification": False,
 }
 
-_dotenv_loaded = False
 
+def _load_cwd_dotenv() -> None:
+    """Load ``.env`` from the current working directory (walking upward).
 
-def _load_dotenv_once() -> None:
-    """Load ``.env`` from the current working directory (walking upward) once per process.
-
-    Mirrors v1 CLI behavior where ``get_env()`` implicitly loaded ``.env`` on every lookup.
-    Uses ``override=True`` to preserve v1 semantics (``.env`` wins over pre-existing env vars).
+    Mirrors v1 CLI behavior where ``get_env()`` implicitly called ``load_dotenv()``
+    on every lookup. ``override=True`` preserves v1 semantics where ``.env`` wins
+    over pre-existing shell env vars.
     """
-    global _dotenv_loaded
-    if _dotenv_loaded:
-        return
     load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
-    _dotenv_loaded = True
 
 
 @dataclass(frozen=True)
@@ -69,7 +64,7 @@ def load_v2_config() -> V2ConnectionConfig:
     """
     import tomllib
 
-    _load_dotenv_once()
+    _load_cwd_dotenv()
 
     cfg: dict[str, Any] = dict(DEFAULTS)
 

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -56,6 +56,10 @@ class V2ConnectionConfig:
 def load_v2_config() -> V2ConnectionConfig:
     """Load v2 connection config from ``~/.backend.ai/``.
 
+    ``.env`` auto-loading happens once in the ``v2`` Click group callback;
+    callers reaching this function outside that group must invoke
+    ``_load_cwd_dotenv()`` themselves if they want ``.env`` picked up.
+
     Precedence (highest to lowest):
     1. Environment variables (``BACKEND_ENDPOINT``, ``BACKEND_ACCESS_KEY``, etc.)
     2. ``~/.backend.ai/credentials.toml``
@@ -63,8 +67,6 @@ def load_v2_config() -> V2ConnectionConfig:
     4. Built-in defaults
     """
     import tomllib
-
-    _load_cwd_dotenv()
 
     cfg: dict[str, Any] = dict(DEFAULTS)
 

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-from dotenv import find_dotenv, load_dotenv
 from yarl import URL
 
 if TYPE_CHECKING:
@@ -28,17 +27,6 @@ DEFAULTS = {
     "api_version": "v9.20250722",
     "skip_ssl_verification": False,
 }
-
-
-def load_cwd_dotenv() -> None:
-    """Load ``.env`` from the current working directory (walking upward).
-
-    Called from the v2 CLI entry point so all v2 subcommands see
-    ``BACKEND_*`` variables defined in a project-local ``.env``. Mirrors v1
-    CLI behavior; ``override=True`` preserves v1 semantics where ``.env``
-    wins over pre-existing shell env vars.
-    """
-    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -30,10 +30,10 @@ DEFAULTS = {
 }
 
 
-def _load_cwd_dotenv() -> None:
+def load_cwd_dotenv() -> None:
     """Load ``.env`` from the current working directory (walking upward).
 
-    Called from the ``v2()`` Click group callback so all v2 subcommands see
+    Called from the v2 CLI entry point so all v2 subcommands see
     ``BACKEND_*`` variables defined in a project-local ``.env``. Mirrors v1
     CLI behavior; ``override=True`` preserves v1 semantics where ``.env``
     wins over pre-existing shell env vars.
@@ -56,10 +56,6 @@ class V2ConnectionConfig:
 
 def load_v2_config() -> V2ConnectionConfig:
     """Load v2 connection config from ``~/.backend.ai/``.
-
-    ``.env`` auto-loading happens once in the ``v2`` Click group callback;
-    callers reaching this function outside that group must invoke
-    ``_load_cwd_dotenv()`` themselves if they want ``.env`` picked up.
 
     Precedence (highest to lowest):
     1. Environment variables (``BACKEND_ENDPOINT``, ``BACKEND_ACCESS_KEY``, etc.)

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
+from dotenv import find_dotenv, load_dotenv
 from yarl import URL
 
 if TYPE_CHECKING:
@@ -27,6 +28,21 @@ DEFAULTS = {
     "api_version": "v9.20250722",
     "skip_ssl_verification": False,
 }
+
+_dotenv_loaded = False
+
+
+def _load_dotenv_once() -> None:
+    """Load ``.env`` from the current working directory (walking upward) once per process.
+
+    Mirrors v1 CLI behavior where ``get_env()`` implicitly loaded ``.env`` on every lookup.
+    Uses ``override=True`` to preserve v1 semantics (``.env`` wins over pre-existing env vars).
+    """
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
+    _dotenv_loaded = True
 
 
 @dataclass(frozen=True)
@@ -52,6 +68,8 @@ def load_v2_config() -> V2ConnectionConfig:
     4. Built-in defaults
     """
     import tomllib
+
+    _load_dotenv_once()
 
     cfg: dict[str, Any] = dict(DEFAULTS)
 

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -1,0 +1,92 @@
+"""Tests for v2 CLI ``.env`` auto-loading (BA-5794)."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ai.backend.client.cli.v2 import helpers
+
+
+@pytest.fixture
+def reset_dotenv_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[Path]:
+    """Force ``_load_dotenv_once`` to re-run and isolate cwd / env vars."""
+    monkeypatch.setattr(helpers, "_dotenv_loaded", False)
+    monkeypatch.chdir(tmp_path)
+    for key in (
+        "BACKEND_ENDPOINT",
+        "BACKEND_ENDPOINT_TYPE",
+        "BACKEND_ACCESS_KEY",
+        "BACKEND_SECRET_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    yield tmp_path
+
+
+def test_load_dotenv_once_picks_up_cwd_dotenv(
+    reset_dotenv_state: Path,
+) -> None:
+    (reset_dotenv_state / ".env").write_text(
+        "BACKEND_ENDPOINT=https://from-dotenv.example\nBACKEND_ACCESS_KEY=ak-from-dotenv\n",
+    )
+
+    helpers._load_dotenv_once()
+
+    assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
+    assert os.environ["BACKEND_ACCESS_KEY"] == "ak-from-dotenv"
+
+
+def test_load_dotenv_once_overrides_existing_env(
+    reset_dotenv_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-shell.example")
+    (reset_dotenv_state / ".env").write_text(
+        "BACKEND_ENDPOINT=https://from-dotenv.example\n",
+    )
+
+    helpers._load_dotenv_once()
+
+    # ``override=True`` preserves v1 semantics — .env wins over pre-existing env.
+    assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
+
+
+def test_load_v2_config_reads_dotenv(
+    reset_dotenv_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Point CONFIG_FILE/CREDENTIALS_FILE to non-existent paths so only env applies.
+    monkeypatch.setattr(helpers, "CONFIG_FILE", reset_dotenv_state / "missing-config.toml")
+    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", reset_dotenv_state / "missing-creds.toml")
+
+    (reset_dotenv_state / ".env").write_text(
+        "BACKEND_ENDPOINT=https://dotenv.example\n"
+        "BACKEND_ACCESS_KEY=ak-x\n"
+        "BACKEND_SECRET_KEY=sk-x\n",
+    )
+
+    cfg = helpers.load_v2_config()
+
+    assert str(cfg.endpoint) == "https://dotenv.example"
+    assert cfg.access_key == "ak-x"
+    assert cfg.secret_key == "sk-x"
+
+
+def test_load_dotenv_once_is_idempotent(
+    reset_dotenv_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (reset_dotenv_state / ".env").write_text("BACKEND_ENDPOINT=https://first.example\n")
+    helpers._load_dotenv_once()
+    assert os.environ["BACKEND_ENDPOINT"] == "https://first.example"
+
+    # Replace .env and call again — should be a no-op (already loaded).
+    (reset_dotenv_state / ".env").write_text("BACKEND_ENDPOINT=https://second.example\n")
+    helpers._load_dotenv_once()
+    assert os.environ["BACKEND_ENDPOINT"] == "https://first.example"

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -12,12 +12,11 @@ from ai.backend.client.cli.v2 import helpers
 
 
 @pytest.fixture
-def reset_dotenv_state(
+def isolated_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> Iterator[Path]:
-    """Force ``_load_dotenv_once`` to re-run and isolate cwd / env vars."""
-    monkeypatch.setattr(helpers, "_dotenv_loaded", False)
+    """Isolate cwd and clear BACKEND_* env vars for each test."""
     monkeypatch.chdir(tmp_path)
     for key in (
         "BACKEND_ENDPOINT",
@@ -29,46 +28,44 @@ def reset_dotenv_state(
     yield tmp_path
 
 
-def test_load_dotenv_once_picks_up_cwd_dotenv(
-    reset_dotenv_state: Path,
+def test_load_cwd_dotenv_picks_up_cwd_dotenv(
+    isolated_env: Path,
 ) -> None:
-    (reset_dotenv_state / ".env").write_text(
+    (isolated_env / ".env").write_text(
         "BACKEND_ENDPOINT=https://from-dotenv.example\nBACKEND_ACCESS_KEY=ak-from-dotenv\n",
     )
 
-    helpers._load_dotenv_once()
+    helpers._load_cwd_dotenv()
 
     assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
     assert os.environ["BACKEND_ACCESS_KEY"] == "ak-from-dotenv"
 
 
-def test_load_dotenv_once_overrides_existing_env(
-    reset_dotenv_state: Path,
+def test_load_cwd_dotenv_overrides_existing_env(
+    isolated_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-shell.example")
-    (reset_dotenv_state / ".env").write_text(
+    (isolated_env / ".env").write_text(
         "BACKEND_ENDPOINT=https://from-dotenv.example\n",
     )
 
-    helpers._load_dotenv_once()
+    helpers._load_cwd_dotenv()
 
     # ``override=True`` preserves v1 semantics — .env wins over pre-existing env.
     assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
 
 
 def test_load_v2_config_reads_dotenv(
-    reset_dotenv_state: Path,
+    isolated_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Point CONFIG_FILE/CREDENTIALS_FILE to non-existent paths so only env applies.
-    monkeypatch.setattr(helpers, "CONFIG_FILE", reset_dotenv_state / "missing-config.toml")
-    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", reset_dotenv_state / "missing-creds.toml")
+    monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
+    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
 
-    (reset_dotenv_state / ".env").write_text(
-        "BACKEND_ENDPOINT=https://dotenv.example\n"
-        "BACKEND_ACCESS_KEY=ak-x\n"
-        "BACKEND_SECRET_KEY=sk-x\n",
+    (isolated_env / ".env").write_text(
+        "BACKEND_ENDPOINT=https://dotenv.example\nBACKEND_ACCESS_KEY=ak-x\nBACKEND_SECRET_KEY=sk-x\n",
     )
 
     cfg = helpers.load_v2_config()
@@ -76,17 +73,3 @@ def test_load_v2_config_reads_dotenv(
     assert str(cfg.endpoint) == "https://dotenv.example"
     assert cfg.access_key == "ak-x"
     assert cfg.secret_key == "sk-x"
-
-
-def test_load_dotenv_once_is_idempotent(
-    reset_dotenv_state: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    (reset_dotenv_state / ".env").write_text("BACKEND_ENDPOINT=https://first.example\n")
-    helpers._load_dotenv_once()
-    assert os.environ["BACKEND_ENDPOINT"] == "https://first.example"
-
-    # Replace .env and call again — should be a no-op (already loaded).
-    (reset_dotenv_state / ".env").write_text("BACKEND_ENDPOINT=https://second.example\n")
-    helpers._load_dotenv_once()
-    assert os.environ["BACKEND_ENDPOINT"] == "https://first.example"

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -73,7 +73,7 @@ def test_v2_group_callback_loads_dotenv(
 
     assert result.exit_code == 0, result.output
     assert os.environ["BACKEND_ENDPOINT"] == "https://group-cb.example"
-    assert "https://group-cb.example" in result.output
+    assert "group-cb.example" in result.output
     assert "ak-x" in result.output
 
 

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -7,8 +7,9 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
-from ai.backend.client.cli.v2 import helpers
+from ai.backend.client.cli.v2 import helpers, v2
 
 
 @pytest.fixture
@@ -56,11 +57,32 @@ def test_load_cwd_dotenv_overrides_existing_env(
     assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
 
 
-def test_load_v2_config_reads_dotenv(
+def test_load_v2_config_reads_env_vars(
     isolated_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Point CONFIG_FILE/CREDENTIALS_FILE to non-existent paths so only env applies.
+    """``load_v2_config`` itself only reads env vars; ``.env`` loading is the
+    v2 group callback's responsibility."""
+    monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
+    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
+
+    monkeypatch.setenv("BACKEND_ENDPOINT", "https://env.example")
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-x")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-x")
+
+    cfg = helpers.load_v2_config()
+
+    assert str(cfg.endpoint) == "https://env.example"
+    assert cfg.access_key == "ak-x"
+    assert cfg.secret_key == "sk-x"
+
+
+def test_v2_group_callback_loads_dotenv_for_subcommands(
+    isolated_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invoking any v2 subcommand triggers the group callback, which loads
+    ``.env`` so ``BACKEND_*`` env vars are available to the subcommand."""
     monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
     monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
 
@@ -68,8 +90,9 @@ def test_load_v2_config_reads_dotenv(
         "BACKEND_ENDPOINT=https://dotenv.example\nBACKEND_ACCESS_KEY=ak-x\nBACKEND_SECRET_KEY=sk-x\n",
     )
 
-    cfg = helpers.load_v2_config()
+    result = CliRunner().invoke(v2, ["config", "show"])
 
-    assert str(cfg.endpoint) == "https://dotenv.example"
-    assert cfg.access_key == "ak-x"
-    assert cfg.secret_key == "sk-x"
+    assert result.exit_code == 0, result.output
+    assert os.environ["BACKEND_ENDPOINT"] == "https://dotenv.example"
+    assert "https://dotenv.example" in result.output
+    assert "ak-x" in result.output

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
-from ai.backend.cli.main import main as cli_main
-from ai.backend.client.cli import v2 as _v2_register  # noqa: F401  # registers v2 on cli_main
 from ai.backend.client.cli.v2 import helpers
 
 
@@ -35,9 +34,13 @@ def dotenv_environment(
     yield tmp_path
 
 
-def test_v2_cli_auto_loads_dotenv(dotenv_environment: Path) -> None:
+def test_v2_cli_auto_loads_dotenv(
+    runner: CliRunner,
+    cli_entrypoint: Callable[[], click.Group],
+    dotenv_environment: Path,
+) -> None:
     """``./bai v2 ...`` auto-loads ``.env`` from cwd, matching v1 CLI behavior."""
-    result = CliRunner().invoke(cli_main, ["v2", "config", "show"])
+    result = runner.invoke(cli_entrypoint, ["v2", "config", "show"])
 
     assert result.exit_code == 0, result.output
     assert "from-dotenv.example" in result.output

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -7,8 +7,9 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
-from ai.backend.client.cli.v2 import helpers
+from ai.backend.client.cli.v2 import helpers, v2
 
 
 @pytest.fixture
@@ -56,20 +57,31 @@ def test_load_cwd_dotenv_overrides_existing_env(
     assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
 
 
-def test_load_v2_config_reads_dotenv(
+def test_v2_group_callback_loads_dotenv(
+    isolated_env: Path,
+) -> None:
+    """End-to-end: invoking a v2 subcommand fires the group callback which loads ``.env``."""
+    (isolated_env / ".env").write_text("BACKEND_ENDPOINT=https://group-cb.example\n")
+
+    # ``config show`` is a no-network command that triggers the group callback.
+    result = CliRunner().invoke(v2, ["config", "show"])
+    assert result.exit_code == 0, result.output
+    assert os.environ["BACKEND_ENDPOINT"] == "https://group-cb.example"
+
+
+def test_load_v2_config_reads_env_vars(
     isolated_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Point CONFIG_FILE/CREDENTIALS_FILE to non-existent paths so only env applies.
+    """``load_v2_config`` reads ``BACKEND_*`` from ``os.environ`` (already-loaded state)."""
     monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
     monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
-
-    (isolated_env / ".env").write_text(
-        "BACKEND_ENDPOINT=https://dotenv.example\nBACKEND_ACCESS_KEY=ak-x\nBACKEND_SECRET_KEY=sk-x\n",
-    )
+    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-x")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-x")
 
     cfg = helpers.load_v2_config()
 
-    assert str(cfg.endpoint) == "https://dotenv.example"
+    assert str(cfg.endpoint) == "https://from-env.example"
     assert cfg.access_key == "ak-x"
     assert cfg.secret_key == "sk-x"

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -2,22 +2,23 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
-from ai.backend.client.cli.v2 import helpers, v2
+from ai.backend.cli.main import main as cli_main
+from ai.backend.client.cli import v2 as _v2_register  # noqa: F401  # registers v2 on cli_main
+from ai.backend.client.cli.v2 import helpers
 
 
 @pytest.fixture
-def isolated_env(
+def dotenv_environment(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> Iterator[Path]:
-    """Isolate cwd and clear BACKEND_* env vars for each test."""
+    """Place a ``.env`` in an isolated cwd with no fallback config/credentials."""
     monkeypatch.chdir(tmp_path)
     for key in (
         "BACKEND_ENDPOINT",
@@ -26,70 +27,18 @@ def isolated_env(
         "BACKEND_SECRET_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "missing-config.toml")
+    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "missing-creds.toml")
+    (tmp_path / ".env").write_text(
+        "BACKEND_ENDPOINT=https://from-dotenv.example\nBACKEND_ACCESS_KEY=ak-from-dotenv\n",
+    )
     yield tmp_path
 
 
-def test_load_cwd_dotenv_picks_up_cwd_dotenv(
-    isolated_env: Path,
-) -> None:
-    (isolated_env / ".env").write_text(
-        "BACKEND_ENDPOINT=https://from-dotenv.example\nBACKEND_ACCESS_KEY=ak-from-dotenv\n",
-    )
-
-    helpers._load_cwd_dotenv()
-
-    assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
-    assert os.environ["BACKEND_ACCESS_KEY"] == "ak-from-dotenv"
-
-
-def test_load_cwd_dotenv_overrides_existing_env(
-    isolated_env: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-shell.example")
-    (isolated_env / ".env").write_text(
-        "BACKEND_ENDPOINT=https://from-dotenv.example\n",
-    )
-
-    helpers._load_cwd_dotenv()
-
-    # ``override=True`` preserves v1 semantics — .env wins over pre-existing env.
-    assert os.environ["BACKEND_ENDPOINT"] == "https://from-dotenv.example"
-
-
-def test_v2_group_callback_loads_dotenv(
-    isolated_env: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """End-to-end: invoking a v2 subcommand fires the group callback which loads ``.env``."""
-    monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
-    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
-    (isolated_env / ".env").write_text(
-        "BACKEND_ENDPOINT=https://group-cb.example\nBACKEND_ACCESS_KEY=ak-x\n",
-    )
-
-    # ``config show`` is a no-network command that triggers the group callback.
-    result = CliRunner().invoke(v2, ["config", "show"])
+def test_v2_cli_auto_loads_dotenv(dotenv_environment: Path) -> None:
+    """``./bai v2 ...`` auto-loads ``.env`` from cwd, matching v1 CLI behavior."""
+    result = CliRunner().invoke(cli_main, ["v2", "config", "show"])
 
     assert result.exit_code == 0, result.output
-    assert os.environ["BACKEND_ENDPOINT"] == "https://group-cb.example"
-    assert "group-cb.example" in result.output
-    assert "ak-x" in result.output
-
-
-def test_load_v2_config_reads_env_vars(
-    isolated_env: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``load_v2_config`` reads ``BACKEND_*`` from ``os.environ`` (already-loaded state)."""
-    monkeypatch.setattr(helpers, "CONFIG_FILE", isolated_env / "missing-config.toml")
-    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", isolated_env / "missing-creds.toml")
-    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
-    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-x")
-    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-x")
-
-    cfg = helpers.load_v2_config()
-
-    assert str(cfg.endpoint) == "https://from-env.example"
-    assert cfg.access_key == "ak-x"
-    assert cfg.secret_key == "sk-x"
+    assert "from-dotenv.example" in result.output
+    assert "ak-from-dotenv" in result.output


### PR DESCRIPTION
## Summary

- v2 CLI was reading `BACKEND_*` env vars via `os.environ` directly without ever invoking `load_dotenv()`, so users with a local `.env` file had to manually `export` variables — a regression from v1 where `get_env()` implicitly loaded `.env` on every lookup.
- Add a process-level `_load_dotenv_once()` helper in `cli/v2/helpers.py` and invoke it from the `v2()` Click group callback (covers all subcommands including `login`/`logout`) and from `load_v2_config()` (defense-in-depth for non-Click callers).
- Use `override=True` to preserve v1 semantics where `.env` wins over pre-existing shell env.

## Test plan

- [x] New unit tests in `tests/unit/client/cli/test_v2_dotenv.py` cover: `.env` is picked up from cwd, `override=True` semantics, idempotency of `_load_dotenv_once()`, and `load_v2_config()` reads values from `.env`.
- [x] `pants fmt fix lint check` pass on the changed files.
- [ ] Manual: drop a `.env` with `BACKEND_ENDPOINT=...` in cwd, run `backend.ai v2 config show`, confirm the value is applied.

Resolves BA-5794