### PR TITLE
fix(BA-2959): Cap CLI paginated output at user-supplied --limit value

### DIFF
--- a/changes/11332.fix.md
+++ b/changes/11332.fix.md
@@ -1,0 +1,1 @@
+Fix `--limit` on CLI list commands so it caps the total number of returned items instead of being treated only as a per-request page size.

--- a/src/ai/backend/client/output/console.py
+++ b/src/ai/backend/client/output/console.py
@@ -151,10 +151,15 @@ class ConsoleOutputHandler(BaseOutputHandler):
         plain: bool = False,
     ) -> None:
         fields: list[FieldSpec] = []
+        # When the user passes --limit (page_size is not None), it should cap the
+        # total number of items returned. When page_size is None, the pager-driven
+        # flow streams pages until exhaustion as before.
+        max_items: int | None = page_size
 
         def infinite_fetch(_page_size: int) -> Iterator[_Item]:
             nonlocal fields
             current_offset = initial_page_offset
+            yielded = 0
             while True:
                 result = fetch_func(current_offset, _page_size)
                 if not fields:
@@ -166,7 +171,11 @@ class ConsoleOutputHandler(BaseOutputHandler):
                     else:
                         raise NoItems
                 current_offset += len(result.items)
-                yield from cast(Sequence[_Item], result.items)
+                for item in cast(Sequence[_Item], result.items):
+                    yield item
+                    yielded += 1
+                    if max_items is not None and yielded >= max_items:
+                        return
                 if current_offset >= result.total_count:
                     break
 


### PR DESCRIPTION
## Summary
- `--limit N` on CLI list commands (e.g. `admin vfolder list`) now caps the total number of items returned to N, instead of streaming all items while only using N as the per-request page size.
- Related issue: #6632 (BA-2959). Sibling PR addresses the column-width inconsistency reported in the same issue.

## Test plan
- [ ] `./backend.ai admin vfolder list --limit 3` returns exactly 3 rows.
- [ ] `./backend.ai admin vfolder list --limit 3 --offset 3` returns the next 3 rows.
- [ ] `./backend.ai admin vfolder list` (no `--limit`) still paginates via the pager as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)