### PR TITLE
fix(BA-1929): Surface AppProxy client endpoint errors as domain exceptions

### DIFF
--- a/changes/11328.fix.md
+++ b/changes/11328.fix.md
@@ -1,1 +1,0 @@
-Send `Accept: application/json` from the manager's AppProxy client so endpoint create/delete failures return parseable JSON instead of HTML error pages.

--- a/changes/11328.fix.md
+++ b/changes/11328.fix.md
@@ -1,0 +1,1 @@
+Send `Accept: application/json` from the manager's AppProxy client so endpoint create/delete failures return parseable JSON instead of HTML error pages.

--- a/changes/11333.fix.md
+++ b/changes/11333.fix.md
@@ -1,0 +1,1 @@
+Surface AppProxy coordinator failures from `AppProxyClient` as `AppProxyConnectionError` / `AppProxyResponseError` instead of silently dropping deletion errors or leaking raw `aiohttp` exceptions, and preserve the upstream error body as `extra_data` for diagnostics.

--- a/src/ai/backend/manager/clients/appproxy/client.py
+++ b/src/ai/backend/manager/clients/appproxy/client.py
@@ -97,12 +97,6 @@ class AppProxyClient:
                 extra_msg=f"Invalid response from AppProxy at {self._address}"
             ) from e
 
-    def _auth_headers(self) -> dict[str, str]:
-        return {
-            "Accept": "application/json",
-            "X-BackendAI-Token": self._token,
-        }
-
     @appproxy_client_resilience.apply()
     async def create_endpoint(
         self,
@@ -112,7 +106,10 @@ class AppProxyClient:
         async with self._client_session.post(
             f"/v2/endpoints/{endpoint_id}",
             json=body.model_dump(mode="json"),
-            headers=self._auth_headers(),
+            headers={
+                "Accept": "application/json",
+                "X-BackendAI-Token": self._token,
+            },
         ) as resp:
             resp.raise_for_status()
             result: dict[str, Any] = await resp.json()
@@ -133,7 +130,10 @@ class AppProxyClient:
         async with self._client_session.post(
             "/v2/endpoints/bulk",
             json=body.model_dump(mode="json"),
-            headers=self._auth_headers(),
+            headers={
+                "Accept": "application/json",
+                "X-BackendAI-Token": self._token,
+            },
         ) as resp:
             resp.raise_for_status()
             payload = await resp.json()
@@ -146,7 +146,10 @@ class AppProxyClient:
     ) -> None:
         async with self._client_session.delete(
             f"/v2/endpoints/{endpoint_id}",
-            headers=self._auth_headers(),
+            headers={
+                "Accept": "application/json",
+                "X-BackendAI-Token": self._token,
+            },
         ):
             pass
 
@@ -165,7 +168,10 @@ class AppProxyClient:
             "DELETE",
             "/v2/endpoints/bulk",
             json=body.model_dump(mode="json"),
-            headers=self._auth_headers(),
+            headers={
+                "Accept": "application/json",
+                "X-BackendAI-Token": self._token,
+            },
         ) as resp:
             resp.raise_for_status()
             payload = await resp.json()

--- a/src/ai/backend/manager/clients/appproxy/client.py
+++ b/src/ai/backend/manager/clients/appproxy/client.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 from uuid import UUID
 
@@ -97,22 +99,93 @@ class AppProxyClient:
                 extra_msg=f"Invalid response from AppProxy at {self._address}"
             ) from e
 
+    @asynccontextmanager
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        operation: str,
+        json_body: Any = None,
+    ) -> AsyncIterator[aiohttp.ClientResponse]:
+        """Issue an authenticated request and translate transport errors.
+
+        Connection failures become ``AppProxyConnectionError``. Non-2xx
+        responses become ``AppProxyResponseError`` with the upstream body
+        attached as ``extra_data`` so a structured ``BackendAIError``
+        payload returned by the coordinator survives the translation.
+        """
+        try:
+            async with self._client_session.request(
+                method,
+                path,
+                headers={
+                    "Accept": "application/json",
+                    "X-BackendAI-Token": self._token,
+                },
+                json=json_body,
+            ) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    try:
+                        error_body: Any = json.loads(text) if text else None
+                    except json.JSONDecodeError:
+                        error_body = text
+                    log.error(
+                        "AppProxy at {} returned {} during {}: {!r}",
+                        self._address,
+                        resp.status,
+                        operation,
+                        error_body,
+                    )
+                    raise AppProxyResponseError(
+                        extra_msg=(f"AppProxy returned HTTP {resp.status} during {operation}"),
+                        extra_data={"status": resp.status, "body": error_body},
+                    )
+                yield resp
+        except aiohttp.ClientConnectorError as e:
+            log.error(
+                "Failed to connect to AppProxy at {} during {}: {}",
+                self._address,
+                operation,
+                e,
+            )
+            raise AppProxyConnectionError(
+                extra_msg=f"Failed to connect to AppProxy at {self._address}"
+            ) from e
+
+    async def _parse_json(
+        self,
+        resp: aiohttp.ClientResponse,
+        *,
+        operation: str,
+    ) -> Any:
+        try:
+            return await resp.json()
+        except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+            log.error(
+                "Failed to parse AppProxy {} response from {}: {}",
+                operation,
+                self._address,
+                e,
+            )
+            raise AppProxyResponseError(
+                extra_msg=(f"Invalid response from AppProxy at {self._address} during {operation}"),
+            ) from e
+
     @appproxy_client_resilience.apply()
     async def create_endpoint(
         self,
         endpoint_id: UUID,
         body: CreateEndpointRequestBody,
     ) -> dict[str, Any]:
-        async with self._client_session.post(
+        async with self._request(
+            "POST",
             f"/v2/endpoints/{endpoint_id}",
-            json=body.model_dump(mode="json"),
-            headers={
-                "Accept": "application/json",
-                "X-BackendAI-Token": self._token,
-            },
+            operation="create_endpoint",
+            json_body=body.model_dump(mode="json"),
         ) as resp:
-            resp.raise_for_status()
-            result: dict[str, Any] = await resp.json()
+            result: dict[str, Any] = await self._parse_json(resp, operation="create_endpoint")
             return result
 
     @appproxy_client_resilience.apply()
@@ -127,16 +200,13 @@ class AppProxyClient:
         so this is the preferred way to register many deployments at
         once (e.g. from the deployment provisioning handler).
         """
-        async with self._client_session.post(
+        async with self._request(
+            "POST",
             "/v2/endpoints/bulk",
-            json=body.model_dump(mode="json"),
-            headers={
-                "Accept": "application/json",
-                "X-BackendAI-Token": self._token,
-            },
+            operation="create_endpoints_bulk",
+            json_body=body.model_dump(mode="json"),
         ) as resp:
-            resp.raise_for_status()
-            payload = await resp.json()
+            payload = await self._parse_json(resp, operation="create_endpoints_bulk")
             return BulkCreateEndpointResponse.model_validate(payload)
 
     @appproxy_client_resilience.apply()
@@ -144,12 +214,10 @@ class AppProxyClient:
         self,
         endpoint_id: UUID,
     ) -> None:
-        async with self._client_session.delete(
+        async with self._request(
+            "DELETE",
             f"/v2/endpoints/{endpoint_id}",
-            headers={
-                "Accept": "application/json",
-                "X-BackendAI-Token": self._token,
-            },
+            operation="delete_endpoint",
         ):
             pass
 
@@ -164,15 +232,11 @@ class AppProxyClient:
         per-endpoint result in input order, so the caller can decide how
         to treat partial failures (retry, log, etc.).
         """
-        async with self._client_session.request(
+        async with self._request(
             "DELETE",
             "/v2/endpoints/bulk",
-            json=body.model_dump(mode="json"),
-            headers={
-                "Accept": "application/json",
-                "X-BackendAI-Token": self._token,
-            },
+            operation="delete_endpoints_bulk",
+            json_body=body.model_dump(mode="json"),
         ) as resp:
-            resp.raise_for_status()
-            payload = await resp.json()
+            payload = await self._parse_json(resp, operation="delete_endpoints_bulk")
             return BulkDeleteEndpointResponse.model_validate(payload)

--- a/src/ai/backend/manager/clients/appproxy/client.py
+++ b/src/ai/backend/manager/clients/appproxy/client.py
@@ -97,6 +97,12 @@ class AppProxyClient:
                 extra_msg=f"Invalid response from AppProxy at {self._address}"
             ) from e
 
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "X-BackendAI-Token": self._token,
+        }
+
     @appproxy_client_resilience.apply()
     async def create_endpoint(
         self,
@@ -106,9 +112,7 @@ class AppProxyClient:
         async with self._client_session.post(
             f"/v2/endpoints/{endpoint_id}",
             json=body.model_dump(mode="json"),
-            headers={
-                "X-BackendAI-Token": self._token,
-            },
+            headers=self._auth_headers(),
         ) as resp:
             resp.raise_for_status()
             result: dict[str, Any] = await resp.json()
@@ -129,9 +133,7 @@ class AppProxyClient:
         async with self._client_session.post(
             "/v2/endpoints/bulk",
             json=body.model_dump(mode="json"),
-            headers={
-                "X-BackendAI-Token": self._token,
-            },
+            headers=self._auth_headers(),
         ) as resp:
             resp.raise_for_status()
             payload = await resp.json()
@@ -144,9 +146,7 @@ class AppProxyClient:
     ) -> None:
         async with self._client_session.delete(
             f"/v2/endpoints/{endpoint_id}",
-            headers={
-                "X-BackendAI-Token": self._token,
-            },
+            headers=self._auth_headers(),
         ):
             pass
 
@@ -165,9 +165,7 @@ class AppProxyClient:
             "DELETE",
             "/v2/endpoints/bulk",
             json=body.model_dump(mode="json"),
-            headers={
-                "X-BackendAI-Token": self._token,
-            },
+            headers=self._auth_headers(),
         ) as resp:
             resp.raise_for_status()
             payload = await resp.json()

--- a/src/ai/backend/manager/clients/appproxy/client.py
+++ b/src/ai/backend/manager/clients/appproxy/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager as actxmgr
 from typing import Any
 from uuid import UUID
 


### PR DESCRIPTION
## Summary

Closes #11331. Builds on #11328 (LTS hotfix) so this branch contains its commits — once #11328 merges, the diff here will collapse to just the error-mapping change.

`AppProxyClient`'s four mutating methods had inconsistent error handling:

- `delete_endpoint` did `async with ... as resp: pass` — non-2xx responses were silently dropped, so a failed deletion looked successful to the manager.
- `create_endpoint`, `create_endpoints_bulk`, `delete_endpoints_bulk` called `resp.raise_for_status()` then `await resp.json()`, leaking raw `aiohttp.ClientResponseError` / `aiohttp.ContentTypeError` to callers. Neither inherits from `BackendAIError`, so the deployment executor saw a non-domain exception and the eventual `DeploymentExecutionError` lost the AppProxy domain context.
- The structured `BackendAIError` JSON body returned by the coordinator (now reliable after #11328 / #11329) was discarded.

This PR introduces two small helpers on `AppProxyClient`:

- `_request` (async context manager): wraps `ClientConnectorError` → `AppProxyConnectionError`, and any non-2xx status → `AppProxyResponseError` with the upstream body attached as `extra_data` (parsed JSON when possible, raw text otherwise).
- `_parse_json`: maps `ContentTypeError` / `JSONDecodeError` from the success path → `AppProxyResponseError`.

All four endpoint methods now route through `_request`. `fetch_status` is left alone — it already maps to the domain exceptions and exercises a different code path.

## Suggested merge order

1. **#11328** — manager-side `Accept: application/json` (LTS hotfix half)
2. **#11329** — coordinator-side default-to-JSON (LTS hotfix half)
3. **#11333** — this PR (broader hardening)

#11328 and #11329 are independent of each other and resolve the user-visible #5228 symptom on their own. #11333 depends on #11328 and should land last.

## Why this can wait for the next normal cycle (not a hotfix)

#11328 + #11329 already eliminate the user-reported HTML-vs-JSON symptom from #5228. This PR is the broader hardening so the manager doesn't lose error context the next time the coordinator returns a non-2xx — separately reviewable, separately revertable.

## Test plan

- [ ] Force a 400 from the coordinator (invalid `CreateEndpointRequestBody`) and confirm the manager raises `AppProxyResponseError` with the coordinator's `BackendAIError` JSON body attached as `extra_data`.
- [ ] Force a 500 from the coordinator and confirm the same.
- [ ] Force a non-JSON 4xx response (e.g. via reverse proxy) and confirm `AppProxyResponseError` carries the raw text in `extra_data["body"]`.
- [ ] Take down the AppProxy and confirm `AppProxyConnectionError` is raised, not raw `ClientConnectorError`.
- [ ] Force `delete_endpoint` to receive a 4xx and confirm it now raises (was silently swallowed before).
- [ ] Verify `pants check` / `pants lint` pass.

## Notes for reviewer

- This branch is based on `fix/BA-1929-appproxy-client-accept-json` (#11328) so the `Accept: application/json` change is a parent commit, not a duplicate.
- After #11328 lands, this branch can be rebased onto main; the diff will then show only the error-mapping commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)