### PR TITLE
feat(BA-5867): split halfstack docker-compose into required and optional services via profiles

### DIFF
--- a/.claude/skills/halfstack/SKILL.md
+++ b/.claude/skills/halfstack/SKILL.md
@@ -44,21 +44,50 @@ docker compose -f docker-compose.halfstack.current.yml restart <service-name>
 docker compose -f docker-compose.halfstack.current.yml up -d --wait
 ```
 
-### Service Names
+### Service Names & Profiles
 
-| Service | Image | Purpose |
-|---------|-------|---------|
-| `backendai-half-db` | postgres:16.3-alpine | Main database |
-| `backendai-half-redis` | redis:7.2-alpine | Cache / pub-sub |
-| `backendai-half-etcd` | etcd v3.5 | Config store |
-| `backendai-half-minio` | MinIO | Object storage |
-| `backendai-half-prometheus` | Prometheus | Metrics |
-| `backendai-half-otel-collector` | OTel Collector | Telemetry |
-| `backendai-half-loki` | Loki | Log aggregation |
-| `backendai-half-tempo` | Tempo | Tracing |
-| `backendai-half-grafana` | Grafana | Dashboards |
-| `backendai-half-pyroscope` | Pyroscope | Profiling |
-| `backendai-half-apollo-router` | Hive Gateway | GraphQL federation |
+Optional services are gated behind Docker Compose profiles. By default (`docker compose up -d`)
+only the **required** services start. To include optional ones, pass `--profile <name>`.
+
+| Service | Image | Purpose | Profile |
+|---------|-------|---------|---------|
+| `backendai-half-db` | postgres:16.3-alpine | Main database | (required) |
+| `backendai-half-redis` | redis:7.2-alpine | Cache / pub-sub | (required) |
+| `backendai-half-etcd` | etcd v3.5 | Config store | (required) |
+| `backendai-half-apollo-router` | Hive Gateway | GraphQL federation (manager has 2 GQL servers federated through this) | (required) |
+| `backendai-half-prometheus` | Prometheus | Metrics | `observability` |
+| `backendai-half-grafana` | Grafana | Dashboards | `observability` |
+| `backendai-half-otel-collector` | OTel Collector | Telemetry | `observability` |
+| `backendai-half-loki` | Loki | Log aggregation | `observability` |
+| `backendai-half-tempo` | Tempo | Tracing | `observability` |
+| `backendai-half-pyroscope` | Pyroscope | Profiling | `observability` |
+| `backendai-half-db-exporter` | postgres-exporter | Postgres metrics | `observability` |
+| `backendai-half-redis-exporter` | redis_exporter | Redis metrics | `observability` |
+| `backendai-half-minio` | MinIO | Object storage | `storage` |
+
+### Enabling optional profiles
+
+```bash
+# Required only (default)
+docker compose -f docker-compose.halfstack.current.yml up -d --wait
+
+# + observability stack (Prometheus / Grafana / OTel / Loki / Tempo / Pyroscope / exporters)
+docker compose -f docker-compose.halfstack.current.yml --profile observability up -d --wait
+
+# + object storage (MinIO)
+docker compose -f docker-compose.halfstack.current.yml --profile storage up -d --wait
+
+# Everything
+docker compose -f docker-compose.halfstack.current.yml --profile observability --profile storage up -d --wait
+```
+
+When stopping/removing, profile flags must also be passed for those containers to be torn down:
+
+```bash
+docker compose -f docker-compose.halfstack.current.yml --profile observability --profile storage down
+```
+
+`scripts/delete-dev.sh` already passes both profiles so a clean wipe works regardless of what was enabled.
 
 ## Docker Configs — Files That Must Exist in Project Root
 

--- a/.claude/skills/halfstack/SKILL.md
+++ b/.claude/skills/halfstack/SKILL.md
@@ -55,7 +55,7 @@ only the **required** services start. To include optional ones, pass `--profile 
 | `backendai-half-redis` | redis:7.2-alpine | Cache / pub-sub | (required) |
 | `backendai-half-etcd` | etcd v3.5 | Config store | (required) |
 | `backendai-half-apollo-router` | Hive Gateway | GraphQL federation (manager has 2 GQL servers federated through this) | (required) |
-| `backendai-half-prometheus` | Prometheus | Metrics | `observability` |
+| `backendai-half-prometheus` | Prometheus | Metrics — manager queries it for deployment autoscale rule evaluation | (required) |
 | `backendai-half-grafana` | Grafana | Dashboards | `observability` |
 | `backendai-half-otel-collector` | OTel Collector | Telemetry | `observability` |
 | `backendai-half-loki` | Loki | Log aggregation | `observability` |
@@ -71,7 +71,7 @@ only the **required** services start. To include optional ones, pass `--profile 
 # Required only (default)
 docker compose -f docker-compose.halfstack.current.yml up -d --wait
 
-# + observability stack (Prometheus / Grafana / OTel / Loki / Tempo / Pyroscope / exporters)
+# + observability stack (Grafana / OTel / Loki / Tempo / Pyroscope / exporters; Prometheus is already required)
 docker compose -f docker-compose.halfstack.current.yml --profile observability up -d --wait
 
 # + object storage (MinIO)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd backend.ai
 This script will:
 - Check required dependencies (Docker, Python, etc.)
 - Set up Python virtual environment with Pantsbuild
-- Start halfstack infrastructure (PostgreSQL, Redis, etcd, Grafana, etc.)
+- Start halfstack infrastructure (PostgreSQL, Redis, etcd, Apollo Router) — only required services by default; observability and object storage are opt-in via Compose profiles (`--profile observability`, `--profile storage`)
 - Initialize database schemas
 - Create default API keypairs and user accounts
 

--- a/changes/11341.enhance.md
+++ b/changes/11341.enhance.md
@@ -1,0 +1,1 @@
+Group optional halfstack services (observability stack and MinIO) behind Docker Compose profiles so a fresh `docker compose up -d` starts only the four services Backend.AI requires (PostgreSQL, Redis, etcd, Apollo Router); enable the rest with `--profile observability` or `--profile storage`.

--- a/configs/account-manager/halfstack.toml
+++ b/configs/account-manager/halfstack.toml
@@ -30,7 +30,7 @@ pid-file = "./account-manager.pid"             # env: BACKEND_PID_FILE
 
 
 [pyroscope]
-enabled = true
+enabled = false
 app_name = "backendai-half-account-manager"
 server_addr = "http://localhost:4040"
 sample-rate = 100

--- a/configs/agent/halfstack.toml
+++ b/configs/agent/halfstack.toml
@@ -48,7 +48,7 @@ soft-reset-available = false
 
 
 [pyroscope]
-enabled = true
+enabled = false
 app-name = "backendai-half-agent"
 server-addr = "http://localhost:4040"
 sample-rate = 100
@@ -107,6 +107,6 @@ backup-count = 10
 size-limit = "64M"
 
 [otel]
-enabled = true
+enabled = false
 log-level = "INFO"
 endpoint = "http://127.0.0.1:4317"

--- a/configs/manager/halfstack.toml
+++ b/configs/manager/halfstack.toml
@@ -40,7 +40,7 @@ agent-selection-resource-priority = ["cuda", "rocm", "tpu", "cpu", "mem"]
 ssl-verify = false
 
 [pyroscope]
-enabled = true
+enabled = false
 app-name = "backendai-half-manager"
 server-addr = "http://localhost:4040"
 sample-rate = 100
@@ -86,7 +86,7 @@ certfile = ""
 enabled = false
 
 [otel]
-enabled = true
+enabled = false
 log-level = "INFO"
 endpoint = "http://127.0.0.1:4317"
 

--- a/configs/storage-proxy/halfstack.toml
+++ b/configs/storage-proxy/halfstack.toml
@@ -64,7 +64,7 @@ secret = "some-secret-shared-with-manager"
 
 
 [pyroscope]
-enabled = true
+enabled = false
 app-name = "backendai-half-storage-proxy"
 server-addr = "http://localhost:4040"
 sample-rate = 100
@@ -103,7 +103,7 @@ backend = "vfs"
 path = "vfolder/local/volume1"
 
 [otel]
-enabled = true
+enabled = false
 log-level = "INFO"
 endpoint = "http://127.0.0.1:4317"
 

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -17,6 +17,7 @@ services:
 
   backendai-half-db-exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -29,6 +30,7 @@ services:
 
   backendai-half-redis-exporter-node01:
     image: oliver006/redis_exporter:v1.73.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -44,6 +46,7 @@ services:
 
   backendai-half-redis-exporter-node02:
     image: oliver006/redis_exporter:v1.73.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -59,6 +62,7 @@ services:
 
   backendai-half-redis-exporter-node03:
     image: oliver006/redis_exporter:v1.73.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -281,6 +285,7 @@ services:
 
   backendai-half-grafana:
     image: grafana/grafana-enterprise:11.4.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -297,6 +302,7 @@ services:
 
   backendai-half-pyroscope:
     image: grafana/pyroscope:1.9.2
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -307,6 +313,7 @@ services:
 
   backendai-half-prometheus:
     image: prom/prometheus:v3.1.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -321,6 +328,7 @@ services:
 
   backendai-half-otel-collector:
     image: otel/opentelemetry-collector-contrib:0.126.0
+    profiles: ["observability"]
     networks:
       - half
     command: ["--config=/etc/otel-collector-config.yaml"]
@@ -332,6 +340,7 @@ services:
 
   backendai-half-loki:
     image: grafana/loki:3.5.0
+    profiles: ["observability"]
     networks:
       - half
     command: -config.file=/etc/loki/local-config.yaml
@@ -342,6 +351,7 @@ services:
 
   backendai-half-tempo:
     image: grafana/tempo:2.7.2
+    profiles: ["observability"]
     networks:
       - half
     command: [ "-config.file=/etc/tempo.yaml" ]
@@ -371,6 +381,7 @@ services:
 
   backendai-half-minio:
     image: minio/minio:latest
+    profiles: ["storage"]
     restart: unless-stopped
     networks:
       - half

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -313,7 +313,6 @@ services:
 
   backendai-half-prometheus:
     image: prom/prometheus:v3.1.0
-    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -35,6 +35,7 @@ services:
 
   backendai-half-db-exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -65,6 +66,7 @@ services:
 
   backendai-half-redis-exporter:
     image: oliver006/redis_exporter:v1.73.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -107,6 +109,7 @@ services:
 
   backendai-half-grafana:
     image: grafana/grafana-enterprise:11.4.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -123,6 +126,7 @@ services:
 
   backendai-half-pyroscope:
     image: grafana/pyroscope:1.9.2
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -133,6 +137,7 @@ services:
 
   backendai-half-prometheus:
     image: prom/prometheus:v3.1.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -148,6 +153,7 @@ services:
 
   backendai-half-otel-collector:
     image: otel/opentelemetry-collector-contrib:0.126.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -161,6 +167,7 @@ services:
 
   backendai-half-loki:
     image: grafana/loki:3.5.0
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -173,6 +180,7 @@ services:
 
   backendai-half-tempo:
     image: grafana/tempo:2.7.2
+    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half
@@ -207,6 +215,7 @@ services:
 
   backendai-half-minio:
     image: minio/minio:latest
+    profiles: ["storage"]
     restart: unless-stopped
     networks:
       - half

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -137,7 +137,6 @@ services:
 
   backendai-half-prometheus:
     image: prom/prometheus:v3.1.0
-    profiles: ["observability"]
     restart: unless-stopped
     networks:
       - half

--- a/scripts/delete-dev.sh
+++ b/scripts/delete-dev.sh
@@ -138,7 +138,7 @@ fi
 if [ $REMOVE_CONTAINERS -eq 1 ]; then
   show_info "Removing Docker containers..."
   if [ -f "docker-compose.halfstack.current.yml" ]; then
-    $docker_sudo $DOCKER_COMPOSE -f "docker-compose.halfstack.current.yml" down
+    $docker_sudo $DOCKER_COMPOSE -f "docker-compose.halfstack.current.yml" --profile observability --profile storage down
     rm "docker-compose.halfstack.current.yml"
   else
     show_warning "The halfstack containers are already removed."


### PR DESCRIPTION
## Summary
- Group optional halfstack services behind Docker Compose profiles so a fresh `docker compose up -d` only starts the four services Backend.AI cannot run without (`backendai-half-db`, `-redis`, `-etcd`, `-apollo-router`).
- New profiles: `observability` (prometheus / grafana / otel-collector / loki / tempo / pyroscope / db-exporter / redis-exporter) and `storage` (minio).
- Apollo Router stays required because the manager federates two GraphQL servers through it. Both `docker-compose.halfstack-main.yml` and `docker-compose.halfstack-ha.yml` get the same profile mapping; `scripts/delete-dev.sh` passes both profiles on `down` so a clean wipe is unaffected by which profiles were active. Skill doc and root README updated.

## Test plan
- [x] `docker compose -f docker-compose.halfstack-main.yml config --services` lists only the 4 required services
- [x] `docker compose -f docker-compose.halfstack-main.yml --profile observability --profile storage config --services` lists all 13
- [x] `docker compose -f docker-compose.halfstack-ha.yml config --services` lists 12 required HA services (no exporters / no minio / no monitoring)
- [x] `docker compose -f docker-compose.halfstack-ha.yml --profile observability --profile storage config --services` lists all 23
- [x] `./scripts/install-dev.sh` on a clean checkout brings up only required services and the manager comes up healthy against them
- [x] `docker compose --profile observability up -d` afterwards adds prometheus/grafana/etc. without touching the running required services
- [x] `./scripts/delete-dev.sh` removes every container regardless of which profiles were activated previously

Resolves BA-5867