### PR TITLE
feat(agent): introduce PortPool with FIFO ordering and reuse cooldown

### DIFF
--- a/changes/11345.feature.md
+++ b/changes/11345.feature.md
@@ -1,0 +1,1 @@
+Replace the agent's set-based host port pool with `PortPool`, a FIFO queue + per-port reuse cooldown (configurable via `container.port_reuse_cooldown_sec`, default 60s) so recently released ports are not immediately reallocated and TCP TIME_WAIT / stale firewall and monitoring state no longer collide with new containers.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -73,6 +73,7 @@ from ai.backend.agent.metrics.metric import (
     StatTaskObserver,
     SyncContainerLifecycleObserver,
 )
+from ai.backend.agent.port_pool import PortPool
 from ai.backend.common import msgpack
 from ai.backend.common.asyncio import cancel_tasks, current_loop
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
@@ -819,7 +820,7 @@ class AbstractAgent[
     slots: Mapping[SlotName, Decimal]
     computers: Mapping[DeviceName, ComputerContext]
     images: Mapping[ImageCanonical, InstalledImageInfo]
-    port_pool: set[int]
+    port_pool: PortPool
 
     restarting_kernels: MutableMapping[KernelId, RestartTracker]
     timer_tasks: MutableSequence[asyncio.Task[Any]]
@@ -913,11 +914,9 @@ class AbstractAgent[
             else None,
         )
         self.timer_tasks = []
-        self.port_pool = set(
-            range(
-                local_config.container.port_range[0],
-                local_config.container.port_range[1] + 1,
-            )
+        self.port_pool = PortPool(
+            local_config.container.port_range,
+            cooldown_sec=local_config.container.port_reuse_cooldown_sec,
         )
         self.stats_monitor = stats_monitor
         self.error_monitor = error_monitor
@@ -1541,59 +1540,10 @@ class AbstractAgent[
         )
 
     def _restore_ports(self, host_ports: Iterable[int]) -> None:
-        # Restore used ports to the port pool.
-        port_range = self.local_config.container.port_range
-        # Exclude out-of-range ports, because when the agent restarts
-        # with a different port range, existing containers' host ports
-        # may not belong to the new port range.
-        restored_ports = [
-            *filter(
-                lambda p: port_range[0] <= p <= port_range[1],
-                host_ports,
-            )
-        ]
-        self.port_pool.update(restored_ports)
-
-    def current_used_port_set(self) -> set[int]:
-        """
-        Get the current port pool.
-        """
-        total_port_set = set(
-            range(
-                self.local_config.container.port_range[0],
-                self.local_config.container.port_range[1] + 1,
-            )
-        )
-        return total_port_set - self.port_pool
-
-    def release_unused_ports(self, unused_ports: set[int]) -> None:
-        """
-        Release the given unused ports back to the port pool.
-        """
-        if not unused_ports:
-            return
-        log.info(
-            "releasing unused ports back to port pool. current port-pool length: {}, releasing length: {}",
-            len(self.port_pool),
-            len(unused_ports),
-        )
-        self.port_pool.update(unused_ports)
-
-    def reset_port_pool(self, used_ports: Iterable[int]) -> None:
-        """
-        Reset the port pool by excluding the given used ports.
-        """
-        used_port_set = set(used_ports)
-        port_range = self.local_config.container.port_range
-        log.info(
-            "reset port pool with used ports. current port-pool length: {}, used ports length: {}",
-            len(self.port_pool),
-            len(used_port_set),
-        )
-        original_port_pool: set[int] = {
-            p for p in range(port_range[0], port_range[1] + 1) if p not in used_port_set
-        }
-        self.port_pool = original_port_pool
+        # PortPool.release ignores out-of-range ports, which handles the
+        # case where the agent restarts with a different port_range and
+        # existing containers still hold ports from the old range.
+        self.port_pool.release_many(host_ports)
 
     def update_scaling_group(self, scaling_group: str) -> None:
         self.local_config.update(agent_update={"scaling_group": scaling_group})

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -1332,6 +1332,27 @@ class OverridableContainerConfig(BaseConfigSchema):
             example=ConfigExample(local="[30000, 31000]", prod="[30000, 32000]"),
         ),
     ]
+    port_reuse_cooldown_sec: Annotated[
+        int,
+        Field(
+            default=60,
+            ge=0,
+            validation_alias=AliasChoices("port-reuse-cooldown-sec", "port_reuse_cooldown_sec"),
+            serialization_alias="port-reuse-cooldown-sec",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Minimum seconds between releasing a host port and reallocating it to a new "
+                "container. Mitigates TCP TIME_WAIT and stale firewall/monitoring state by "
+                "ensuring recently freed ports are not immediately reused. "
+                "Set to 0 to disable cooldown (any released port may be reused immediately). "
+                "Note: this cooldown only applies to container-driven allocations; the "
+                "RPC assign_port path bypasses cooldown for emergency/dynamic allocation."
+            ),
+            added_version="26.5.0",
+            example=ConfigExample(local="60", prod="60"),
+        ),
+    ]
     stats_type: Annotated[
         StatModes | None,
         Field(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -50,6 +50,7 @@ from ai.backend.agent.agent import (
     ScanImagesResult,
 )
 from ai.backend.agent.config.unified import AgentUnifiedConfig, ContainerSandboxType, ScratchType
+from ai.backend.agent.errors.resources import PortPoolExhaustedError
 from ai.backend.agent.etcd import AgentEtcdClientView
 from ai.backend.agent.exception import (
     ContainerCreationError,
@@ -79,6 +80,7 @@ from ai.backend.agent.plugin.network import (
     ContainerNetworkInfo,
     NetworkPluginContext,
 )
+from ai.backend.agent.port_pool import PortPool
 from ai.backend.agent.proxy import DomainSocketProxy, proxy_connection
 from ai.backend.agent.resources import (
     AbstractComputePlugin,
@@ -295,7 +297,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
     container_configs: list[Mapping[str, Any]]
     domain_socket_proxies: list[DomainSocketProxy]
     computer_docker_args: dict[str, Any]
-    port_pool: set[int]
+    port_pool: PortPool
     agent_sockpath: Path
     resource_lock: asyncio.Lock
     cluster_ssh_port_mapping: ClusterSSHPortMapping | None
@@ -312,7 +314,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         distro: str,
         local_config: AgentUnifiedConfig,
         computers: Mapping[DeviceName, ComputerContext],
-        port_pool: set[int],
+        port_pool: PortPool,
         agent_sockpath: Path,
         resource_lock: asyncio.Lock,
         network_plugin_ctx: NetworkPluginContext,
@@ -1105,11 +1107,12 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         container_bind_host = self.local_config.container.bind_host
         advertised_kernel_host = self.local_config.container.advertised_host
         if len(service_ports) + len(self.repl_ports) > len(self.port_pool):
-            raise RuntimeError(
-                f"Container ports are not sufficiently available. (remaining ports: {self.port_pool})"
+            raise PortPoolExhaustedError(
+                f"Container ports are not sufficiently available. "
+                f"(remaining ports: {self.port_pool.remaining()})"
             )
         exposed_ports = [*self.repl_ports]
-        host_ports = [self.port_pool.pop() for _ in self.repl_ports]
+        host_ports = [self.port_pool.acquire() for _ in self.repl_ports]
         host_ips = []
         for sport in service_ports:
             exposed_ports.extend(sport["container_ports"])
@@ -1124,7 +1127,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             ):
                 host_ports.append(ssh_host_port[1])
             else:
-                hport = self.port_pool.pop()
+                hport = self.port_pool.acquire()
                 host_ports.append(hport)
         protected_service_ports: set[int] = set()
         for sport in service_ports:
@@ -1275,7 +1278,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 self.local_config.container.scratch_root,
                 self.kernel_id,
             )
-            self.port_pool.update(host_ports)
+            self.port_pool.release_many(host_ports)
             async with self.resource_lock:
                 for dev_name, device_alloc in resource_spec.allocations.items():
                     self.computers[dev_name].alloc_map.free(device_alloc)

--- a/src/ai/backend/agent/errors/resources.py
+++ b/src/ai/backend/agent/errors/resources.py
@@ -139,3 +139,21 @@ class InvalidContainerMeasurementError(BackendAIError, web.HTTPInternalServerErr
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.INVALID_DATA_FORMAT,
         )
+
+
+class PortPoolExhaustedError(BackendAIError, web.HTTPServiceUnavailable):
+    """Raised when no host ports are available for allocation.
+
+    This covers two cases: the pool is fully empty, or every remaining
+    port is still within its post-release cooldown window.
+    """
+
+    error_type = "https://api.backend.ai/probs/agent/port-pool-exhausted"
+    error_title = "Host port pool exhausted."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.UNAVAILABLE,
+        )

--- a/src/ai/backend/agent/observer/host_port.py
+++ b/src/ai/backend/agent/observer/host_port.py
@@ -42,18 +42,26 @@ class HostPortObserver(AbstractObserver):
             for container_port in container.ports:
                 occupied_host_ports.add(container_port.host_port)
 
-        unused_ports = self._agent.current_used_port_set() - occupied_host_ports
+        port_pool = self._agent.port_pool
+        unused_ports = port_pool.used_ports() - occupied_host_ports
         for previous_unused_port in list(self._port_unused_counts.keys()):
             if previous_unused_port not in unused_ports:
                 del self._port_unused_counts[previous_unused_port]
 
-        ports_to_release = set()
+        ports_to_release: set[int] = set()
         for unused_port in unused_ports:
             self._port_unused_counts[unused_port] += 1
             if self._port_unused_counts[unused_port] >= PORT_USAGE_THRESHOLD:
                 ports_to_release.add(unused_port)
                 del self._port_unused_counts[unused_port]
-        self._agent.release_unused_ports(ports_to_release)
+        if ports_to_release:
+            log.info(
+                "releasing unused ports back to port pool. "
+                "current port-pool length: {}, releasing length: {}",
+                len(port_pool),
+                len(ports_to_release),
+            )
+            port_pool.release_many(ports_to_release)
 
     @override
     def observe_interval(self) -> float:

--- a/src/ai/backend/agent/port_pool.py
+++ b/src/ai/backend/agent/port_pool.py
@@ -1,0 +1,105 @@
+"""
+Host port allocator for the agent.
+
+This module provides :class:`PortPool`, a FIFO queue with per-port reuse
+cooldown. It replaces the previous ``set[int]`` + ``set.pop()`` pattern
+which was non-deterministic and could re-allocate a port immediately
+after release, conflicting with TCP TIME_WAIT and stale firewall or
+monitoring state.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable
+from time import monotonic
+
+from ai.backend.agent.errors.resources import PortPoolExhaustedError
+
+__all__ = ("PortPool",)
+
+
+class PortPool:
+    """Host port allocator with FIFO ordering and time-based reuse cooldown.
+
+    Released ports are pushed to the end of the queue and excluded from
+    re-allocation until ``cooldown_sec`` has elapsed. The oldest port
+    (either never used or longest released) is always allocated first.
+    """
+
+    _ports: OrderedDict[int, float]
+    _start: int
+    _end: int
+    _cooldown_sec: float
+
+    def __init__(self, port_range: tuple[int, int], cooldown_sec: float) -> None:
+        start, end = port_range
+        if start > end:
+            raise ValueError(f"invalid port_range: start={start} > end={end}")
+        self._start = start
+        self._end = end
+        self._cooldown_sec = cooldown_sec
+        # Initial unused ports get released_at=0.0 so they always pass cooldown.
+        self._ports = OrderedDict.fromkeys(range(start, end + 1), 0.0)
+
+    def __len__(self) -> int:
+        return len(self._ports)
+
+    def __contains__(self, port: object) -> bool:
+        return port in self._ports
+
+    def acquire(self, *, respect_cooldown: bool = True) -> int:
+        """Allocate the oldest available port.
+
+        Raises :class:`PortPoolExhaustedError` when the pool is empty or,
+        if ``respect_cooldown`` is True, when the oldest port is still
+        within its cooldown window.
+        """
+        if not self._ports:
+            raise PortPoolExhaustedError("no host ports available in pool")
+        port, released_at = next(iter(self._ports.items()))
+        if respect_cooldown and self._cooldown_sec > 0:
+            elapsed = monotonic() - released_at
+            if elapsed < self._cooldown_sec:
+                raise PortPoolExhaustedError(
+                    f"all available host ports are in cooldown "
+                    f"(oldest released {elapsed:.1f}s ago, "
+                    f"cooldown={self._cooldown_sec}s)"
+                )
+        del self._ports[port]
+        return port
+
+    def release(self, port: int) -> None:
+        """Return a port to the pool, marking it as just released.
+
+        The port is moved to the tail of the queue and its release
+        timestamp is refreshed. Out-of-range ports are silently ignored,
+        which matches the prior ``_restore_ports`` behavior when the
+        agent restarts with a different ``port_range``.
+        """
+        if not (self._start <= port <= self._end):
+            return
+        self._ports.pop(port, None)
+        self._ports[port] = monotonic()
+
+    def release_many(self, ports: Iterable[int]) -> None:
+        """Release multiple ports at once. See :meth:`release`."""
+        for p in ports:
+            self.release(p)
+
+    def discard(self, port: int) -> None:
+        """Remove a port from the pool without scheduling reuse.
+
+        Used during startup scans when an existing container is found to
+        already occupy a port; that port should not appear in the pool
+        until the container is gone.
+        """
+        self._ports.pop(port, None)
+
+    def used_ports(self) -> set[int]:
+        """Return the set of ports currently allocated (not in the pool)."""
+        return set(range(self._start, self._end + 1)) - self._ports.keys()
+
+    def remaining(self) -> list[int]:
+        """Return ports currently in the pool, in FIFO (allocation) order."""
+        return list(self._ports.keys())

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -1251,14 +1251,17 @@ class AgentRPCServer(aobject):
     async def assign_port(self, agent_id: AgentId | None = None) -> int:
         log.debug("rpc::assign_port()")
         agent = self.runtime.get_agent(agent_id)
-        return agent.port_pool.pop()
+        # RPC path bypasses cooldown: callers (e.g. manager scheduler)
+        # use this for ad-hoc/emergency allocation outside the normal
+        # container creation flow.
+        return agent.port_pool.acquire(respect_cooldown=False)
 
     @rpc_function
     @collect_error
     async def release_port(self, port_no: int, agent_id: AgentId | None = None) -> None:
         log.debug("rpc::release_port(port_no:{})", port_no)
         agent = self.runtime.get_agent(agent_id)
-        agent.port_pool.add(port_no)
+        agent.port_pool.release(port_no)
 
     @rpc_function
     @collect_error

--- a/tests/unit/agent/test_port_pool.py
+++ b/tests/unit/agent/test_port_pool.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from ai.backend.agent.errors.resources import PortPoolExhaustedError
+from ai.backend.agent.port_pool import PortPool
+
+
+@pytest.fixture
+def fake_clock() -> Iterator[list[float]]:
+    """Replace ``monotonic`` inside port_pool with a controllable clock.
+
+    The list holds a single mutable ``now`` value; tests advance time by
+    overwriting it.
+    """
+    now = [1000.0]
+
+    def _now() -> float:
+        return now[0]
+
+    with patch("ai.backend.agent.port_pool.monotonic", _now):
+        yield now
+
+
+class TestAcquireOrdering:
+    def test_initial_ports_are_returned_in_range_order(self) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=60)
+        assert [pool.acquire() for _ in range(3)] == [30000, 30001, 30002]
+
+    def test_released_port_is_pushed_to_tail(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        first = pool.acquire()
+        second = pool.acquire()
+        pool.release(first)
+        # cooldown_sec=0 disables waiting; first should be at the tail now,
+        # so acquire() returns the remaining 30002 before circling back.
+        third = pool.acquire()
+        assert third == 30002
+        fourth = pool.acquire()
+        assert fourth == first
+        assert second == 30001
+
+    def test_release_refreshes_position_for_already_pooled_port(
+        self, fake_clock: list[float]
+    ) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        # Releasing a port that was never acquired still moves it to the tail.
+        pool.release(30000)
+        assert pool.acquire() == 30001
+        assert pool.acquire() == 30002
+        assert pool.acquire() == 30000
+
+
+class TestCooldown:
+    def test_release_then_acquire_within_cooldown_raises(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30000), cooldown_sec=60)
+        port = pool.acquire()
+        pool.release(port)
+        # Still within cooldown.
+        with pytest.raises(PortPoolExhaustedError):
+            pool.acquire()
+
+    def test_acquire_succeeds_after_cooldown_elapses(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30000), cooldown_sec=60)
+        port = pool.acquire()
+        pool.release(port)
+        fake_clock[0] += 60.0
+        assert pool.acquire() == port
+
+    def test_respect_cooldown_false_bypasses_wait(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30000), cooldown_sec=60)
+        port = pool.acquire()
+        pool.release(port)
+        # RPC path: cooldown bypassed.
+        assert pool.acquire(respect_cooldown=False) == port
+
+    def test_cooldown_zero_disables_waiting(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30000), cooldown_sec=0)
+        port = pool.acquire()
+        pool.release(port)
+        assert pool.acquire() == port
+
+    def test_initial_unused_ports_bypass_cooldown(self, fake_clock: list[float]) -> None:
+        # Ports that were never acquired hold released_at=0.0 and should be
+        # immediately available even with a non-zero cooldown.
+        pool = PortPool((30000, 30002), cooldown_sec=60)
+        assert pool.acquire() == 30000
+        assert pool.acquire() == 30001
+
+
+class TestPoolExhaustion:
+    def test_empty_pool_raises(self) -> None:
+        pool = PortPool((30000, 30000), cooldown_sec=0)
+        pool.acquire()
+        with pytest.raises(PortPoolExhaustedError):
+            pool.acquire()
+
+    def test_invalid_port_range_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PortPool((30001, 30000), cooldown_sec=0)
+
+
+class TestReleaseEdgeCases:
+    def test_release_out_of_range_is_ignored(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        pool.release(29999)
+        pool.release(40000)
+        assert len(pool) == 3
+        assert 29999 not in pool
+        assert 40000 not in pool
+
+    def test_release_many_releases_each_in_order(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        a = pool.acquire()
+        b = pool.acquire()
+        c = pool.acquire()
+        pool.release_many([b, a, c])
+        # release_many releases in iteration order, so b is oldest, then a, then c.
+        assert pool.acquire() == b
+        assert pool.acquire() == a
+        assert pool.acquire() == c
+
+
+class TestDiscard:
+    def test_discard_removes_port_from_pool(self) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        pool.discard(30001)
+        assert 30001 not in pool
+        assert pool.acquire() == 30000
+        assert pool.acquire() == 30002
+
+    def test_discard_unknown_port_is_noop(self) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        pool.discard(40000)
+        assert len(pool) == 3
+
+
+class TestUsedPorts:
+    def test_used_ports_reports_allocated(self) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        a = pool.acquire()
+        b = pool.acquire()
+        assert pool.used_ports() == {a, b}
+
+    def test_used_ports_excludes_released(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        a = pool.acquire()
+        pool.release(a)
+        assert pool.used_ports() == set()
+
+
+class TestRemaining:
+    def test_remaining_reflects_allocation_order(self, fake_clock: list[float]) -> None:
+        pool = PortPool((30000, 30002), cooldown_sec=0)
+        assert pool.remaining() == [30000, 30001, 30002]
+        first = pool.acquire()
+        pool.release(first)
+        assert pool.remaining() == [30001, 30002, first]


### PR DESCRIPTION
## Summary
- Replace the agent's `port_pool: set[int]` (non-deterministic `set.pop`) with a dedicated `PortPool` class backed by `OrderedDict[int, float]`, allocating the oldest available port first.
- Released ports stay out of allocation for `container.port_reuse_cooldown_sec` (default 60s) to avoid TCP TIME_WAIT and stale firewall/monitoring state on rapid container churn. Set to 0 to disable.
- RPC `assign_port` calls `acquire(respect_cooldown=False)` so the manager scheduler's ad-hoc allocations bypass cooldown; container creation, observer release, and rollback paths use the cooldown-respecting `release_many()`.
- Drop unused `current_used_port_set`, `release_unused_ports`, and `reset_port_pool` wrappers; the host-port observer now talks to `PortPool` directly.

## Test plan
- [x] `pants test tests/unit/agent/test_port_pool.py` (21 new unit tests covering FIFO order, cooldown enforcement, RPC bypass, exhaustion, out-of-range release, discard)
- [x] `pants test tests/unit/agent/test_agent.py tests/unit/agent/test_docker_agent.py tests/unit/agent/test_server.py tests/unit/agent/test_config_validation.py`
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main && pants check --changed-since=origin/main`
- [ ] Manually verify on a running agent: create/destroy 5 containers in quick succession and confirm host ports are not immediately reused; verify `port_reuse_cooldown_sec=0` re-enables instant reuse.