### PR TITLE
fix(BA-5871): apply domain/keypair host policy on project vfolder create

### DIFF
--- a/changes/11347.fix.md
+++ b/changes/11347.fix.md
@@ -1,0 +1,1 @@
+Apply domain and keypair-resource-policy `allowed_vfolder_hosts` when creating a project-owned vfolder.

--- a/src/ai/backend/manager/data/vfolder/types.py
+++ b/src/ai/backend/manager/data/vfolder/types.py
@@ -6,13 +6,20 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, override
 
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.field import (
     VFolderOperationStatusField,
     VFolderOwnershipTypeField,
     VFolderPermissionField,
 )
 from ai.backend.common.identifier.vfolder import VFolderUUID
-from ai.backend.common.types import CIStrEnum, QuotaScopeID, VFolderID, VFolderUsageMode
+from ai.backend.common.types import (
+    CIStrEnum,
+    QuotaScopeID,
+    VFolderHostPermissionMap,
+    VFolderID,
+    VFolderUsageMode,
+)
 from ai.backend.manager.data.permission.types import OperationType
 from ai.backend.manager.errors.resource import DataTransformationFailed
 
@@ -140,6 +147,19 @@ class VFolderOperationStatus(enum.StrEnum):
 
     def to_field(self) -> VFolderOperationStatusField:
         return VFolderOperationStatusField(self)
+
+
+@dataclass(frozen=True)
+class UserWithVFolderHostPermissions:
+    """
+    Minimal user fields paired with the union of ``allowed_vfolder_hosts``
+    across the user's active keypair resource policies. The host permission
+    map is the merged set used for vfolder host-permission validation.
+    """
+
+    email: str
+    role: UserRole
+    allowed_vfolder_hosts: VFolderHostPermissionMap
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -38,6 +38,7 @@ from ai.backend.manager.data.permission.types import (
 )
 from ai.backend.manager.data.vfolder.dto import UserIdentity
 from ai.backend.manager.data.vfolder.types import (
+    UserWithVFolderHostPermissions,
     ValidatedVFolderInfo,
     VFolderAccessInfo,
     VFolderCreateParams,
@@ -253,6 +254,45 @@ class VfolderRepository:
                 raise ObjectNotFound(object_name="User keypair resource policy")
 
             return user_row.main_keypair.resource_policy_row.allowed_vfolder_hosts
+
+    @vfolder_repository_resilience.apply()
+    async def get_user_with_keypair_policy_vfolder_hosts(
+        self, user_uuid: uuid.UUID
+    ) -> UserWithVFolderHostPermissions:
+        """
+        Load user data together with the merged ``allowed_vfolder_hosts`` from
+        all of the user's active keypair resource policies.
+
+        A user can hold multiple keypairs, each pointing to its own keypair
+        resource policy. This method unions ``allowed_vfolder_hosts`` across
+        every active keypair so that the host-permission check reflects the
+        full set of hosts available to the user (rather than only the main
+        keypair).
+        """
+        async with self._db.begin_readonly_session_read_committed() as db_session:
+            user_row: UserRow | None = await db_session.scalar(
+                sa.select(UserRow)
+                .where(UserRow.uuid == user_uuid)
+                .options(
+                    selectinload(UserRow.keypairs).selectinload(KeyPairRow.resource_policy_row)
+                )
+            )
+            if user_row is None:
+                raise UserNotFound(f"User with UUID {user_uuid} not found.")
+            if user_row.role is None or user_row.domain_name is None:
+                raise UserNotFound(f"User with UUID {user_uuid} has invalid role or domain data.")
+            merged_hosts = VFolderHostPermissionMap()
+            for keypair in user_row.keypairs:
+                if not keypair.is_active:
+                    continue
+                merged_hosts = VFolderHostPermissionMap(
+                    merged_hosts | keypair.resource_policy_row.allowed_vfolder_hosts
+                )
+            return UserWithVFolderHostPermissions(
+                email=user_row.email,
+                role=user_row.role,
+                allowed_vfolder_hosts=merged_hosts,
+            )
 
     @vfolder_repository_resilience.apply()
     async def get_max_vfolder_count(

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -268,29 +268,50 @@ class VfolderRepository:
         every active keypair so that the host-permission check reflects the
         full set of hosts available to the user (rather than only the main
         keypair).
+
+        Implementation note: a single LEFT OUTER JOIN is used (instead of an
+        ORM ``selectinload`` on ``UserRow.keypairs``) so that only the columns
+        needed for the host-permission check are loaded. This avoids loading
+        sensitive keypair columns such as ``secret_key`` and
+        ``ssh_private_key``.
         """
         async with self._db.begin_readonly_session_read_committed() as db_session:
-            user_row: UserRow | None = await db_session.scalar(
-                sa.select(UserRow)
-                .where(UserRow.uuid == user_uuid)
-                .options(
-                    selectinload(UserRow.keypairs).selectinload(KeyPairRow.resource_policy_row)
+            stmt = (
+                sa.select(
+                    UserRow.email,
+                    UserRow.role,
+                    UserRow.domain_name,
+                    keypair_resource_policies.c.allowed_vfolder_hosts,
                 )
+                .select_from(UserRow)
+                .outerjoin(
+                    KeyPairRow,
+                    sa.and_(
+                        KeyPairRow.user == UserRow.uuid,
+                        KeyPairRow.is_active.is_(True),
+                    ),
+                )
+                .outerjoin(
+                    keypair_resource_policies,
+                    keypair_resource_policies.c.name == KeyPairRow.resource_policy,
+                )
+                .where(UserRow.uuid == user_uuid)
             )
-            if user_row is None:
+            rows = (await db_session.execute(stmt)).all()
+            if not rows:
                 raise UserNotFound(f"User with UUID {user_uuid} not found.")
-            if user_row.role is None or user_row.domain_name is None:
+            email, role, domain_name, _ = rows[0]
+            if role is None or domain_name is None:
                 raise UserNotFound(f"User with UUID {user_uuid} has invalid role or domain data.")
             merged_hosts = VFolderHostPermissionMap()
-            for keypair in user_row.keypairs:
-                if not keypair.is_active:
+            for row in rows:
+                policy_hosts = row.allowed_vfolder_hosts
+                if policy_hosts is None:
                     continue
-                merged_hosts = VFolderHostPermissionMap(
-                    merged_hosts | keypair.resource_policy_row.allowed_vfolder_hosts
-                )
+                merged_hosts = VFolderHostPermissionMap(merged_hosts | policy_hosts)
             return UserWithVFolderHostPermissions(
-                email=user_row.email,
-                role=user_row.role,
+                email=email,
+                role=role,
                 allowed_vfolder_hosts=merged_hosts,
             )
 

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1441,13 +1441,6 @@ class VFolderService:
             await _check_vfolder_status(row["status"], action.required_status)
         return GetAccessibleVFolderActionResult(row=row)
 
-    async def _load_user(self, user_uuid: uuid.UUID) -> tuple[str, UserRole]:
-        """Load user and return ``(email, role)``. Raises if the record is incomplete."""
-        user = await self._user_repository.get_user_by_uuid(user_uuid)
-        if user.role is None or user.domain_name is None:
-            raise ObjectNotFound(object_name="User")
-        return user.email, user.role
-
     def _check_user_role_for_group(
         self, user_role: UserRole, group_type: ProjectType | None
     ) -> None:
@@ -1557,7 +1550,11 @@ class VFolderService:
         domain_name = action.domain_name
         project_id = action.project_id
 
-        email, user_role = await self._load_user(user_uuid)
+        user_with_hosts = await self._vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(
+            user_uuid
+        )
+        email = user_with_hosts.email
+        user_role = user_with_hosts.role
         folder_host = await self._resolve_host(action.host)
         self._check_name_parameter(action.name, is_group=project_id is not None)
 
@@ -1698,7 +1695,12 @@ class VFolderService:
         domain_name = action.domain_name
         project_id = action.project_id
 
-        email, user_role = await self._load_user(user_uuid)
+        user_with_hosts = await self._vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(
+            user_uuid
+        )
+        email = user_with_hosts.email
+        user_role = user_with_hosts.role
+        allowed_vfolder_hosts = user_with_hosts.allowed_vfolder_hosts
         folder_host = await self._resolve_host(action.host)
         self._check_name_parameter(action.name, is_group=True)
 
@@ -1712,11 +1714,14 @@ class VFolderService:
         allowed_types = await self._check_ownership_allowed("group")
         self._check_model_store_usage_mode(group_type, action.usage_mode)
 
-        # Host permission check
-        await self._vfolder_repository.ensure_host_permission_allowed_by_user(
+        # Host permission check — merges domain, group, and keypair policy
+        await self._vfolder_repository.ensure_host_permission_allowed(
             folder_host,
             permission=VFolderHostPermission.CREATE,
+            allowed_vfolder_types=allowed_types,
             user_uuid=user_uuid,
+            resource_policy={"allowed_vfolder_hosts": allowed_vfolder_hosts},
+            domain_name=domain_name,
             group_id=group_uuid,
         )
 

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -13,7 +13,9 @@ import sqlalchemy as sa
 
 from ai.backend.common.types import (
     BinarySize,
+    DefaultForUnspecified,
     ResourceSlot,
+    VFolderHostPermission,
     VFolderHostPermissionMap,
     VFolderUsageMode,
 )
@@ -27,6 +29,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOwnershipType,
 )
 from ai.backend.manager.errors.storage import VFolderFilterStatusFailed, VFolderNotFound
+from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
@@ -345,6 +348,7 @@ class TestVfolderRepositoryAllowedVfolderHosts:
                 UserResourcePolicyRow,
                 ProjectResourcePolicyRow,
                 KeyPairResourcePolicyRow,
+                RoleRow,
                 UserRoleRow,
                 UserRow,
                 KeyPairRow,
@@ -501,6 +505,85 @@ class TestVfolderRepositoryAllowedVfolderHosts:
         )
 
         assert isinstance(result, VFolderHostPermissionMap)
+
+    # -- get_user_with_keypair_policy_vfolder_hosts --
+
+    @pytest.fixture
+    async def keypair_policy_with_hosts(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> str:
+        """KeyPair resource policy with non-empty allowed_vfolder_hosts."""
+        policy_name = f"test-kp-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as db_sess:
+            policy = KeyPairResourcePolicyRow(
+                name=policy_name,
+                default_for_unspecified=DefaultForUnspecified.LIMITED,
+                total_resource_slots=ResourceSlot(),
+                max_session_lifetime=0,
+                max_concurrent_sessions=10,
+                max_concurrent_sftp_sessions=1,
+                max_containers_per_session=1,
+                idle_timeout=0,
+                allowed_vfolder_hosts=VFolderHostPermissionMap({
+                    "local:volume1": {
+                        VFolderHostPermission.CREATE,
+                        VFolderHostPermission.MODIFY,
+                    },
+                }),
+            )
+            db_sess.add(policy)
+            await db_sess.flush()
+        return policy_name
+
+    @pytest.fixture
+    async def user_with_active_keypair(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_user: uuid.UUID,
+        keypair_policy_with_hosts: str,
+    ) -> uuid.UUID:
+        """Bind an active keypair (pointing to keypair_policy_with_hosts) to ``test_user``."""
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                KeyPairRow(
+                    user_id=f"test-{test_user.hex[:8]}@example.com",
+                    user=test_user,
+                    access_key=f"AK{test_user.hex[:14]}",
+                    secret_key="test-secret",
+                    is_active=True,
+                    is_admin=False,
+                    resource_policy=keypair_policy_with_hosts,
+                    rate_limit=1000,
+                )
+            )
+            await db_sess.flush()
+        return test_user
+
+    async def test_get_user_with_keypair_policy_vfolder_hosts_success(
+        self,
+        vfolder_repository: VfolderRepository,
+        user_with_active_keypair: uuid.UUID,
+    ) -> None:
+        """Returns email/role and the merged allowed_vfolder_hosts from active keypairs."""
+        result = await vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(
+            user_with_active_keypair
+        )
+        assert result.email == f"test-{user_with_active_keypair.hex[:8]}@example.com"
+        assert result.role == UserRole.USER
+        assert "local:volume1" in result.allowed_vfolder_hosts
+        assert result.allowed_vfolder_hosts["local:volume1"] == {
+            VFolderHostPermission.CREATE,
+            VFolderHostPermission.MODIFY,
+        }
+
+    async def test_get_user_with_keypair_policy_vfolder_hosts_user_not_found(
+        self,
+        vfolder_repository: VfolderRepository,
+    ) -> None:
+        """Unknown user UUID raises UserNotFound."""
+        with pytest.raises(UserNotFound):
+            await vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(uuid.uuid4())
 
 
 class TestVfolderRepositoryPurge:


### PR DESCRIPTION
## Summary
- `create_in_project` was using `ensure_host_permission_allowed_by_user`, which only consults the project's `allowed_vfolder_hosts` and ignores the domain and keypair-resource-policy `allowed_vfolder_hosts`. This let users create project vfolders on hosts that should be blocked by their domain admin or keypair policy.
- Switch to the full `ensure_host_permission_allowed`, passing `allowed_vfolder_types`, `domain_name`, `group_id`, and a merged keypair resource policy so domain + group + keypair host permissions are all honored.
- Add `VFolderRepository.get_user_with_keypair_policy_vfolder_hosts(user_uuid)` returning a frozen dataclass `UserWithVFolderHostPermissions(email, role, allowed_vfolder_hosts)`. The map is the union of `allowed_vfolder_hosts` across all of the user's active keypair resource policies. Replaces the `_load_user` helper.

## Test plan
- [x] Existing vfolder unit/component tests pass (covered by repo + adapter + service suites).
- [x] Manual: as a user whose domain or keypair policy excludes a storage host, attempt `POST /vfolders/projects/{project_id}/create` against that host — expect `InsufficientStoragePermission`.
- [x] Manual: as a user whose domain/keypair allows the host, project create still succeeds.

Resolves BA-5871