### PR TITLE
fix(BA-5873): prefer saved credentials.toml/config.toml over BACKEND_* env vars

### DIFF
--- a/changes/11353.fix.md
+++ b/changes/11353.fix.md
@@ -1,1 +1,1 @@
-v2 CLI now prefers saved `~/.backend.ai/credentials.toml` and `config.toml` values over `BACKEND_*` environment variables, preventing a stray `.env` from silently overriding logged-in credentials or flipping `endpoint_type`. Env vars remain a fallback when the corresponding file slot is empty.
+v2 CLI: saved `~/.backend.ai/credentials.toml` and `config.toml` now take precedence over `BACKEND_*` env vars.

--- a/changes/11353.fix.md
+++ b/changes/11353.fix.md
@@ -1,0 +1,1 @@
+v2 CLI now prefers saved `~/.backend.ai/credentials.toml` and `config.toml` values over `BACKEND_*` environment variables, preventing a stray `.env` from silently overriding logged-in credentials or flipping `endpoint_type`. Env vars remain a fallback when the corresponding file slot is empty.

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -46,38 +46,40 @@ def load_v2_config() -> V2ConnectionConfig:
     """Load v2 connection config from ``~/.backend.ai/``.
 
     Precedence (highest to lowest):
-    1. Environment variables (``BACKEND_ENDPOINT``, ``BACKEND_ACCESS_KEY``, etc.)
-    2. ``~/.backend.ai/credentials.toml``
-    3. ``~/.backend.ai/config.toml``
-    4. Built-in defaults
+    1. ``~/.backend.ai/credentials.toml`` (access/secret), ``~/.backend.ai/config.toml`` (endpoint/type)
+    2. Environment variables (``BACKEND_ENDPOINT``, ``BACKEND_ACCESS_KEY``, etc.) — also fed by a cwd ``.env``
+    3. Built-in defaults
+
+    Explicitly-saved files win over ambient env vars so a stray ``.env`` in
+    the cwd hierarchy cannot silently swap a logged-in user's saved
+    credentials. Use env vars / ``.env`` only when the corresponding file
+    leaves a slot empty.
     """
     import tomllib
 
     cfg: dict[str, Any] = dict(DEFAULTS)
+
+    # Env first — used only as a fallback when the file does not provide a value.
+    if env_endpoint := os.environ.get("BACKEND_ENDPOINT"):
+        cfg["endpoint"] = env_endpoint
+    if env_type := os.environ.get("BACKEND_ENDPOINT_TYPE"):
+        cfg["endpoint_type"] = env_type
 
     if CONFIG_FILE.exists():
         with CONFIG_FILE.open("rb") as f:
             file_cfg = tomllib.load(f).get("backend-ai", {})
         cfg.update({k: v for k, v in file_cfg.items() if v is not None})
 
-    access_key: str | None = None
-    secret_key: str | None = None
+    access_key: str | None = os.environ.get("BACKEND_ACCESS_KEY") or None
+    secret_key: str | None = os.environ.get("BACKEND_SECRET_KEY") or None
 
     if CREDENTIALS_FILE.exists():
         with CREDENTIALS_FILE.open("rb") as f:
             creds = tomllib.load(f).get("backend-ai", {})
-        access_key = creds.get("access_key")
-        secret_key = creds.get("secret_key")
-
-    # Environment variables override file settings
-    if env_endpoint := os.environ.get("BACKEND_ENDPOINT"):
-        cfg["endpoint"] = env_endpoint
-    if env_type := os.environ.get("BACKEND_ENDPOINT_TYPE"):
-        cfg["endpoint_type"] = env_type
-    if env_ak := os.environ.get("BACKEND_ACCESS_KEY"):
-        access_key = env_ak
-    if env_sk := os.environ.get("BACKEND_SECRET_KEY"):
-        secret_key = env_sk
+        if creds.get("access_key"):
+            access_key = creds["access_key"]
+        if creds.get("secret_key"):
+            secret_key = creds["secret_key"]
 
     # Defer cookie jar creation to async context (aiohttp >=3.13 requires event loop)
     cookie_file = None

--- a/tests/unit/client/cli/test_v2_config_precedence.py
+++ b/tests/unit/client/cli/test_v2_config_precedence.py
@@ -1,0 +1,98 @@
+"""Tests for ``load_v2_config`` precedence (BA-5873).
+
+Explicitly-saved files in ``~/.backend.ai/`` must win over ambient
+``BACKEND_*`` env vars so a stray ``.env`` cannot silently swap a
+logged-in user's saved credentials.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ai.backend.client.cli.v2 import helpers
+
+
+@pytest.fixture
+def isolated_config_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[Path]:
+    """Point the loader at a clean ~/.backend.ai/ replacement."""
+    monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "config.toml")
+    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "credentials.toml")
+    monkeypatch.setattr(helpers, "COOKIE_FILE", tmp_path / "session" / "cookie.dat")
+    for key in (
+        "BACKEND_ENDPOINT",
+        "BACKEND_ENDPOINT_TYPE",
+        "BACKEND_ACCESS_KEY",
+        "BACKEND_SECRET_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    yield tmp_path
+
+
+def test_credentials_toml_wins_over_env_vars(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (isolated_config_dir / "credentials.toml").write_text(
+        '[backend-ai]\naccess_key = "ak-from-file"\nsecret_key = "sk-from-file"\n',
+    )
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
+
+    cfg = helpers.load_v2_config()
+
+    assert cfg.access_key == "ak-from-file"
+    assert cfg.secret_key == "sk-from-file"
+
+
+def test_config_toml_wins_over_env_vars(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (isolated_config_dir / "config.toml").write_text(
+        '[backend-ai]\nendpoint = "https://from-file.example"\nendpoint_type = "session"\n',
+    )
+    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
+    monkeypatch.setenv("BACKEND_ENDPOINT_TYPE", "api")
+
+    cfg = helpers.load_v2_config()
+
+    assert str(cfg.endpoint) == "https://from-file.example"
+    assert cfg.endpoint_type == "session"
+
+
+def test_env_vars_used_when_files_absent(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
+
+    cfg = helpers.load_v2_config()
+
+    assert str(cfg.endpoint) == "https://from-env.example"
+    assert cfg.access_key == "ak-from-env"
+    assert cfg.secret_key == "sk-from-env"
+
+
+def test_partial_credentials_file_falls_back_to_env_per_field(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the file provides only one of access/secret, env supplies the other."""
+    (isolated_config_dir / "credentials.toml").write_text(
+        '[backend-ai]\naccess_key = "ak-from-file"\n',
+    )
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
+
+    cfg = helpers.load_v2_config()
+
+    assert cfg.access_key == "ak-from-file"
+    assert cfg.secret_key == "sk-from-env"

--- a/tests/unit/client/cli/test_v2_config_precedence.py
+++ b/tests/unit/client/cli/test_v2_config_precedence.py
@@ -7,7 +7,6 @@ logged-in user's saved credentials.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -15,84 +14,27 @@ import pytest
 from ai.backend.client.cli.v2 import helpers
 
 
-@pytest.fixture
-def isolated_config_dir(
+def test_saved_files_win_over_env_vars(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-) -> Iterator[Path]:
-    """Point the loader at a clean ~/.backend.ai/ replacement."""
+) -> None:
     monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "config.toml")
     monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "credentials.toml")
     monkeypatch.setattr(helpers, "COOKIE_FILE", tmp_path / "session" / "cookie.dat")
-    for key in (
-        "BACKEND_ENDPOINT",
-        "BACKEND_ENDPOINT_TYPE",
-        "BACKEND_ACCESS_KEY",
-        "BACKEND_SECRET_KEY",
-    ):
-        monkeypatch.delenv(key, raising=False)
-    yield tmp_path
-
-
-def test_credentials_toml_wins_over_env_vars(
-    isolated_config_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    (isolated_config_dir / "credentials.toml").write_text(
-        '[backend-ai]\naccess_key = "ak-from-file"\nsecret_key = "sk-from-file"\n',
-    )
-    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
-    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
-
-    cfg = helpers.load_v2_config()
-
-    assert cfg.access_key == "ak-from-file"
-    assert cfg.secret_key == "sk-from-file"
-
-
-def test_config_toml_wins_over_env_vars(
-    isolated_config_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    (isolated_config_dir / "config.toml").write_text(
+    (tmp_path / "config.toml").write_text(
         '[backend-ai]\nendpoint = "https://from-file.example"\nendpoint_type = "session"\n',
+    )
+    (tmp_path / "credentials.toml").write_text(
+        '[backend-ai]\naccess_key = "ak-from-file"\nsecret_key = "sk-from-file"\n',
     )
     monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
     monkeypatch.setenv("BACKEND_ENDPOINT_TYPE", "api")
+    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
+    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
 
     cfg = helpers.load_v2_config()
 
     assert str(cfg.endpoint) == "https://from-file.example"
     assert cfg.endpoint_type == "session"
-
-
-def test_env_vars_used_when_files_absent(
-    isolated_config_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
-    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
-    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
-
-    cfg = helpers.load_v2_config()
-
-    assert str(cfg.endpoint) == "https://from-env.example"
-    assert cfg.access_key == "ak-from-env"
-    assert cfg.secret_key == "sk-from-env"
-
-
-def test_partial_credentials_file_falls_back_to_env_per_field(
-    isolated_config_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the file provides only one of access/secret, env supplies the other."""
-    (isolated_config_dir / "credentials.toml").write_text(
-        '[backend-ai]\naccess_key = "ak-from-file"\n',
-    )
-    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
-    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
-
-    cfg = helpers.load_v2_config()
-
     assert cfg.access_key == "ak-from-file"
-    assert cfg.secret_key == "sk-from-env"
+    assert cfg.secret_key == "sk-from-file"

--- a/tests/unit/client/cli/test_v2_config_precedence.py
+++ b/tests/unit/client/cli/test_v2_config_precedence.py
@@ -14,27 +14,31 @@ import pytest
 from ai.backend.client.cli.v2 import helpers
 
 
-def test_saved_files_win_over_env_vars(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "config.toml")
-    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "credentials.toml")
-    monkeypatch.setattr(helpers, "COOKIE_FILE", tmp_path / "session" / "cookie.dat")
-    (tmp_path / "config.toml").write_text(
-        '[backend-ai]\nendpoint = "https://from-file.example"\nendpoint_type = "session"\n',
-    )
-    (tmp_path / "credentials.toml").write_text(
-        '[backend-ai]\naccess_key = "ak-from-file"\nsecret_key = "sk-from-file"\n',
-    )
-    monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
-    monkeypatch.setenv("BACKEND_ENDPOINT_TYPE", "api")
-    monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
-    monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
+class TestLoadV2ConfigPrecedence:
+    """Tests for ``load_v2_config`` source precedence."""
 
-    cfg = helpers.load_v2_config()
+    def test_saved_files_win_over_env_vars(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "config.toml")
+        monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "credentials.toml")
+        monkeypatch.setattr(helpers, "COOKIE_FILE", tmp_path / "session" / "cookie.dat")
+        (tmp_path / "config.toml").write_text(
+            '[backend-ai]\nendpoint = "https://from-file.example"\nendpoint_type = "session"\n',
+        )
+        (tmp_path / "credentials.toml").write_text(
+            '[backend-ai]\naccess_key = "ak-from-file"\nsecret_key = "sk-from-file"\n',
+        )
+        monkeypatch.setenv("BACKEND_ENDPOINT", "https://from-env.example")
+        monkeypatch.setenv("BACKEND_ENDPOINT_TYPE", "api")
+        monkeypatch.setenv("BACKEND_ACCESS_KEY", "ak-from-env")
+        monkeypatch.setenv("BACKEND_SECRET_KEY", "sk-from-env")
 
-    assert str(cfg.endpoint) == "https://from-file.example"
-    assert cfg.endpoint_type == "session"
-    assert cfg.access_key == "ak-from-file"
-    assert cfg.secret_key == "sk-from-file"
+        cfg = helpers.load_v2_config()
+
+        assert str(cfg.endpoint) == "https://from-file.example"
+        assert cfg.endpoint_type == "session"
+        assert cfg.access_key == "ak-from-file"
+        assert cfg.secret_key == "sk-from-file"


### PR DESCRIPTION
## Summary
- Flip `load_v2_config()` precedence so explicitly-saved files in `~/.backend.ai/` win over ambient `BACKEND_*` env vars.
- Closes the silent-override risk surfaced after BA-5794 (#11327) restored `.env` auto-loading: a stray `.env` in cwd or any parent directory could swap a user's saved keypair or flip `endpoint_type` to bypass session-mode cookie auth.

## Behavior change

**Before** (env > file):

1. Environment variables (`BACKEND_*`)
2. `~/.backend.ai/credentials.toml`, `config.toml`
3. Defaults

**After** (file > env):

1. `~/.backend.ai/credentials.toml` (access/secret), `~/.backend.ai/config.toml` (endpoint/type)
2. Environment variables — also fed by a cwd `.env`
3. Defaults

Env vars still apply when the corresponding file slot is empty, so partial setups and pure-env CI usage keep working.

## Why this matters

Two concrete scenarios that became reachable after BA-5794:

1. **Session login bypass** — User runs `./bai login` (cookie auth, `endpoint_type=session`). A `.env` somewhere in the cwd hierarchy contains `BACKEND_ENDPOINT_TYPE=api` and a different keypair. Subsequent `./bai` calls silently switch to HMAC against that keypair while the user believes they are still on their session login.
2. **Explicit keypair overridden** — User stored a production keypair via `./bai config set access-key/secret-key`. A `.env` in a parent directory (created for an unrelated project) silently overrides it, sending requests under the wrong identity.

Both are eliminated when saved files take precedence.

## Compatibility note

Users who relied on env vars to override saved file values must remove the corresponding entry from `credentials.toml` / `config.toml` (or use `./bai config set` to update it). Pure env-var setups (no file) are unaffected.

## Test plan
- [x] `pants test tests/unit/client/cli/test_v2_config_precedence.py` — 4 cases covering file-wins, env fallback, and per-field partial-file fallback.
- [x] `pants lint --changed-since=origin/main` and `pants check --changed-since=origin/main`.
- [ ] Manual: `./bai config set access-key XXX` then export `BACKEND_ACCESS_KEY=YYY` and confirm `./bai config show` reports `XXX`.