### PR TITLE
fix(BA-5874): expose missing GQL input fields and strong-type model_definition for deployment revision preset

### DIFF
--- a/changes/11354.fix.md
+++ b/changes/11354.fix.md
@@ -1,1 +1,1 @@
-Expose missing image, cluster, resource, and execution fields on the GraphQL `CreateDeploymentRevisionPresetInput` and `UpdateDeploymentRevisionPresetInput`.
+Expose missing image, cluster, resource, and execution fields on the GraphQL `CreateDeploymentRevisionPresetInput` and `UpdateDeploymentRevisionPresetInput`, and fix the response type mismatch on `PresetExecutionSpec.environ` so that querying environment variables on a deployment revision preset no longer fails.

--- a/changes/11354.fix.md
+++ b/changes/11354.fix.md
@@ -1,0 +1,1 @@
+Expose missing image, cluster, resource, and execution fields on the GraphQL `CreateDeploymentRevisionPresetInput` and `UpdateDeploymentRevisionPresetInput`.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5173,6 +5173,19 @@ type DeploymentRevisionPresetEdge
 }
 
 """
+Added in 26.4.2. A single environment variable key-value pair injected into the inference container when a deployment revision preset is applied.
+"""
+type DeploymentRevisionPresetEnvironEntry
+  @join__type(graph: STRAWBERRY)
+{
+  """Environment variable key."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
+}
+
+"""
 Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
 """
 input DeploymentRevisionPresetEnvironEntryInput
@@ -11925,7 +11938,7 @@ type PresetExecutionSpec
   bootstrapScript: String
 
   """Environment variables."""
-  environ: [EnvironmentVariableEntry!]!
+  environ: [DeploymentRevisionPresetEnvironEntry!]!
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3103,6 +3103,57 @@ input CreateDeploymentRevisionPresetInput
 
   """Default deployment strategy for deployments created from this preset."""
   deploymentStrategy: PresetDeploymentStrategyInput = null
+
+  """Added in UNRELEASED. Container image to run the inference server."""
+  imageId: UUID!
+
+  """
+  Added in UNRELEASED. Detailed explanation of when and why to use this preset configuration.
+  """
+  description: String = null
+
+  """
+  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  """
+  modelDefinition: ModelDefinitionInput = null
+
+  """
+  Added in UNRELEASED. Resource slot allocations (e.g. cpu, mem, cuda.device).
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Additional resource options such as shared memory (shmem) size.
+  """
+  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Deployment topology mode (single-node or multi-node).
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. Number of worker nodes in the cluster."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Command to start the inference server process inside the container.
+  """
+  startupCommand: String = null
+
+  """
+  Added in UNRELEASED. Script executed before the main process starts (e.g. to download model weights).
+  """
+  bootstrapScript: String = null
+
+  """
+  Added in UNRELEASED. Environment variables injected into the inference container.
+  """
+  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Runtime variant preset values applied when using this deployment preset.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
@@ -5121,6 +5172,19 @@ type DeploymentRevisionPresetEdge
   node: DeploymentRevisionPreset!
 }
 
+"""
+Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
+"""
+input DeploymentRevisionPresetEnvironEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The environment variable name."""
+  key: String!
+
+  """The value assigned to the environment variable."""
+  value: String!
+}
+
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter
   @join__type(graph: STRAWBERRY)
@@ -5153,6 +5217,19 @@ enum DeploymentRevisionPresetOrderField
 }
 
 """
+Added in UNRELEASED. A single additional resource option (e.g. shared memory size) for a deployment revision preset.
+"""
+input DeploymentRevisionPresetResourceOptsEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Resource option name (e.g. 'shmem')."""
+  name: String!
+
+  """Resource option value (e.g. '1g')."""
+  value: String!
+}
+
+"""
 Added in 26.4.2. A mapping of a runtime variant preset to a specific value, used to auto-configure runtime parameters when this deployment preset is applied.
 """
 type DeploymentRevisionPresetValueEntry
@@ -5162,6 +5239,19 @@ type DeploymentRevisionPresetValueEntry
   presetId: UUID!
 
   """Value for this preset."""
+  value: String!
+}
+
+"""
+Added in UNRELEASED. A mapping of a runtime variant preset to a concrete value, used to auto-configure runtime parameters when this deployment preset is applied.
+"""
+input DeploymentRevisionPresetValueEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The runtime variant preset that this value applies to."""
+  presetId: UUID!
+
+  """The concrete value to set for the referenced preset parameter."""
   value: String!
 }
 
@@ -17733,6 +17823,50 @@ input UpdateDeploymentRevisionPresetInput
   Default deployment strategy for deployments created from this preset. Set to null to clear.
   """
   deploymentStrategy: PresetDeploymentStrategyInput
+
+  """
+  Added in UNRELEASED. Container image for the inference server. Set to null to clear.
+  """
+  imageId: UUID
+
+  """Added in UNRELEASED. Parsed model definition. Set to null to clear."""
+  modelDefinition: ModelDefinitionInput
+
+  """Added in UNRELEASED. Container startup command. Set to null to clear."""
+  startupCommand: String
+
+  """
+  Added in UNRELEASED. Bootstrap script run before the main process. Set to null to clear.
+  """
+  bootstrapScript: String
+
+  """
+  Added in UNRELEASED. Replace resource slot allocations. Omit to leave unchanged.
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace additional resource options. Omit to leave unchanged.
+  """
+  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. New cluster topology mode. Omit to leave unchanged.
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. New cluster size. Omit to leave unchanged."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Replace environment variables. Omit to leave unchanged.
+  """
+  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace runtime variant preset values. Omit to leave unchanged.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3125,7 +3125,7 @@ input CreateDeploymentRevisionPresetInput
   """
   Added in UNRELEASED. Additional resource options such as shared memory (shmem) size.
   """
-  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+  resourceOpts: [ResourceOptsEntryInput!] = null
 
   """
   Added in UNRELEASED. Deployment topology mode (single-node or multi-node).
@@ -3148,7 +3148,7 @@ input CreateDeploymentRevisionPresetInput
   """
   Added in UNRELEASED. Environment variables injected into the inference container.
   """
-  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+  environ: [EnvironEntryInput!] = null
 
   """
   Added in UNRELEASED. Runtime variant preset values applied when using this deployment preset.
@@ -5185,19 +5185,6 @@ type DeploymentRevisionPresetEnvironEntry
   value: String!
 }
 
-"""
-Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
-"""
-input DeploymentRevisionPresetEnvironEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The environment variable name."""
-  key: String!
-
-  """The value assigned to the environment variable."""
-  value: String!
-}
-
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter
   @join__type(graph: STRAWBERRY)
@@ -5227,19 +5214,6 @@ enum DeploymentRevisionPresetOrderField
   NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
-}
-
-"""
-Added in UNRELEASED. A single additional resource option (e.g. shared memory size) for a deployment revision preset.
-"""
-input DeploymentRevisionPresetResourceOptsEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource option name (e.g. 'shmem')."""
-  name: String!
-
-  """Resource option value (e.g. '1g')."""
-  value: String!
 }
 
 """
@@ -6540,6 +6514,19 @@ type EntityTimestamps
 
   """Timestamp when this entity was last modified."""
   modifiedAt: DateTime
+}
+
+"""
+Added in UNRELEASED. A single environment variable entry with key and value.
+"""
+input EnvironEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Environment variable key (e.g., 'CUDA_VISIBLE_DEVICES')."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
 }
 
 """
@@ -17861,7 +17848,7 @@ input UpdateDeploymentRevisionPresetInput
   """
   Added in UNRELEASED. Replace additional resource options. Omit to leave unchanged.
   """
-  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+  resourceOpts: [ResourceOptsEntryInput!] = null
 
   """
   Added in UNRELEASED. New cluster topology mode. Omit to leave unchanged.
@@ -17874,7 +17861,7 @@ input UpdateDeploymentRevisionPresetInput
   """
   Added in UNRELEASED. Replace environment variables. Omit to leave unchanged.
   """
-  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+  environ: [EnvironEntryInput!] = null
 
   """
   Added in UNRELEASED. Replace runtime variant preset values. Omit to leave unchanged.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1926,7 +1926,7 @@ input CreateDeploymentRevisionPresetInput {
   """
   Added in UNRELEASED. Additional resource options such as shared memory (shmem) size.
   """
-  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+  resourceOpts: [ResourceOptsEntryInput!] = null
 
   """
   Added in UNRELEASED. Deployment topology mode (single-node or multi-node).
@@ -1949,7 +1949,7 @@ input CreateDeploymentRevisionPresetInput {
   """
   Added in UNRELEASED. Environment variables injected into the inference container.
   """
-  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+  environ: [EnvironEntryInput!] = null
 
   """
   Added in UNRELEASED. Runtime variant preset values applied when using this deployment preset.
@@ -3456,17 +3456,6 @@ type DeploymentRevisionPresetEnvironEntry {
   value: String!
 }
 
-"""
-Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
-"""
-input DeploymentRevisionPresetEnvironEntryInput {
-  """The environment variable name."""
-  key: String!
-
-  """The value assigned to the environment variable."""
-  value: String!
-}
-
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter {
   """Name filter."""
@@ -3490,17 +3479,6 @@ enum DeploymentRevisionPresetOrderField {
   NAME
   RANK
   CREATED_AT
-}
-
-"""
-Added in UNRELEASED. A single additional resource option (e.g. shared memory size) for a deployment revision preset.
-"""
-input DeploymentRevisionPresetResourceOptsEntryInput {
-  """Resource option name (e.g. 'shmem')."""
-  name: String!
-
-  """Resource option value (e.g. '1g')."""
-  value: String!
 }
 
 """
@@ -4278,6 +4256,17 @@ type EntityTimestamps {
 
   """Timestamp when this entity was last modified."""
   modifiedAt: DateTime
+}
+
+"""
+Added in UNRELEASED. A single environment variable entry with key and value.
+"""
+input EnvironEntryInput {
+  """Environment variable key (e.g., 'CUDA_VISIBLE_DEVICES')."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
 }
 
 """
@@ -12160,7 +12149,7 @@ input UpdateDeploymentRevisionPresetInput {
   """
   Added in UNRELEASED. Replace additional resource options. Omit to leave unchanged.
   """
-  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+  resourceOpts: [ResourceOptsEntryInput!] = null
 
   """
   Added in UNRELEASED. New cluster topology mode. Omit to leave unchanged.
@@ -12173,7 +12162,7 @@ input UpdateDeploymentRevisionPresetInput {
   """
   Added in UNRELEASED. Replace environment variables. Omit to leave unchanged.
   """
-  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+  environ: [EnvironEntryInput!] = null
 
   """
   Added in UNRELEASED. Replace runtime variant preset values. Omit to leave unchanged.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1904,6 +1904,57 @@ input CreateDeploymentRevisionPresetInput {
 
   """Default deployment strategy for deployments created from this preset."""
   deploymentStrategy: PresetDeploymentStrategyInput = null
+
+  """Added in UNRELEASED. Container image to run the inference server."""
+  imageId: UUID!
+
+  """
+  Added in UNRELEASED. Detailed explanation of when and why to use this preset configuration.
+  """
+  description: String = null
+
+  """
+  Added in UNRELEASED. Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  """
+  modelDefinition: ModelDefinitionInput = null
+
+  """
+  Added in UNRELEASED. Resource slot allocations (e.g. cpu, mem, cuda.device).
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Additional resource options such as shared memory (shmem) size.
+  """
+  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Deployment topology mode (single-node or multi-node).
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. Number of worker nodes in the cluster."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Command to start the inference server process inside the container.
+  """
+  startupCommand: String = null
+
+  """
+  Added in UNRELEASED. Script executed before the main process starts (e.g. to download model weights).
+  """
+  bootstrapScript: String = null
+
+  """
+  Added in UNRELEASED. Environment variables injected into the inference container.
+  """
+  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Runtime variant preset values applied when using this deployment preset.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Create deployment revision preset payload."""
@@ -3394,6 +3445,17 @@ type DeploymentRevisionPresetEdge {
   node: DeploymentRevisionPreset!
 }
 
+"""
+Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
+"""
+input DeploymentRevisionPresetEnvironEntryInput {
+  """The environment variable name."""
+  key: String!
+
+  """The value assigned to the environment variable."""
+  value: String!
+}
+
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter {
   """Name filter."""
@@ -3420,6 +3482,17 @@ enum DeploymentRevisionPresetOrderField {
 }
 
 """
+Added in UNRELEASED. A single additional resource option (e.g. shared memory size) for a deployment revision preset.
+"""
+input DeploymentRevisionPresetResourceOptsEntryInput {
+  """Resource option name (e.g. 'shmem')."""
+  name: String!
+
+  """Resource option value (e.g. '1g')."""
+  value: String!
+}
+
+"""
 Added in 26.4.2. A mapping of a runtime variant preset to a specific value, used to auto-configure runtime parameters when this deployment preset is applied.
 """
 type DeploymentRevisionPresetValueEntry {
@@ -3427,6 +3500,17 @@ type DeploymentRevisionPresetValueEntry {
   presetId: UUID!
 
   """Value for this preset."""
+  value: String!
+}
+
+"""
+Added in UNRELEASED. A mapping of a runtime variant preset to a concrete value, used to auto-configure runtime parameters when this deployment preset is applied.
+"""
+input DeploymentRevisionPresetValueEntryInput {
+  """The runtime variant preset that this value applies to."""
+  presetId: UUID!
+
+  """The concrete value to set for the referenced preset parameter."""
   value: String!
 }
 
@@ -12040,6 +12124,50 @@ input UpdateDeploymentRevisionPresetInput {
   Default deployment strategy for deployments created from this preset. Set to null to clear.
   """
   deploymentStrategy: PresetDeploymentStrategyInput
+
+  """
+  Added in UNRELEASED. Container image for the inference server. Set to null to clear.
+  """
+  imageId: UUID
+
+  """Added in UNRELEASED. Parsed model definition. Set to null to clear."""
+  modelDefinition: ModelDefinitionInput
+
+  """Added in UNRELEASED. Container startup command. Set to null to clear."""
+  startupCommand: String
+
+  """
+  Added in UNRELEASED. Bootstrap script run before the main process. Set to null to clear.
+  """
+  bootstrapScript: String
+
+  """
+  Added in UNRELEASED. Replace resource slot allocations. Omit to leave unchanged.
+  """
+  resourceSlots: [ResourceSlotEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace additional resource options. Omit to leave unchanged.
+  """
+  resourceOpts: [DeploymentRevisionPresetResourceOptsEntryInput!] = null
+
+  """
+  Added in UNRELEASED. New cluster topology mode. Omit to leave unchanged.
+  """
+  clusterMode: ClusterMode = null
+
+  """Added in UNRELEASED. New cluster size. Omit to leave unchanged."""
+  clusterSize: Int = null
+
+  """
+  Added in UNRELEASED. Replace environment variables. Omit to leave unchanged.
+  """
+  environ: [DeploymentRevisionPresetEnvironEntryInput!] = null
+
+  """
+  Added in UNRELEASED. Replace runtime variant preset values. Omit to leave unchanged.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntryInput!] = null
 }
 
 """Added in 26.4.2. Update deployment revision preset payload."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3446,6 +3446,17 @@ type DeploymentRevisionPresetEdge {
 }
 
 """
+Added in 26.4.2. A single environment variable key-value pair injected into the inference container when a deployment revision preset is applied.
+"""
+type DeploymentRevisionPresetEnvironEntry {
+  """Environment variable key."""
+  key: String!
+
+  """Environment variable value."""
+  value: String!
+}
+
+"""
 Added in UNRELEASED. A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.
 """
 input DeploymentRevisionPresetEnvironEntryInput {
@@ -7718,7 +7729,7 @@ type PresetExecutionSpec {
   bootstrapScript: String
 
   """Environment variables."""
-  environ: [EnvironmentVariableEntry!]!
+  environ: [DeploymentRevisionPresetEnvironEntry!]!
 }
 
 """

--- a/src/ai/backend/common/dto/manager/v2/common.py
+++ b/src/ai/backend/common/dto/manager/v2/common.py
@@ -13,6 +13,10 @@ from ai.backend.common.api_handlers import BaseRequestModel, BaseResponseModel
 __all__ = (
     "BinarySizeInfo",
     "BinarySizeInput",
+    "EnvironmentVariableEntryInfo",
+    "EnvironmentVariableEntryInput",
+    "EnvironmentVariablesInfo",
+    "EnvironmentVariablesInput",
     "OrderDirection",
     "ResourceLimitEntryInfo",
     "ResourceSlotEntryInfo",
@@ -109,4 +113,37 @@ class VFolderHostPermissionEntryInput(BaseRequestModel):
     host: str = Field(description="Virtual folder host name (e.g., 'default', 'nfs-vol1').")
     permissions: list[str] = Field(
         description="List of permission values (e.g., 'mount-in-session', 'upload-file')."
+    )
+
+
+class EnvironmentVariableEntryInput(BaseRequestModel):
+    """A single environment variable entry with key and value.
+
+    Shared across all domains that accept environment variable lists (session, deployment, etc.).
+    """
+
+    key: str = Field(description="Environment variable key.")
+    value: str = Field(description="Environment variable value.")
+
+
+class EnvironmentVariablesInput(BaseRequestModel):
+    """A collection of environment variable entries."""
+
+    entries: list[EnvironmentVariableEntryInput] = Field(
+        description="List of environment variable entries."
+    )
+
+
+class EnvironmentVariableEntryInfo(BaseResponseModel):
+    """A single environment variable entry with key and value."""
+
+    key: str = Field(description="Environment variable key.")
+    value: str = Field(description="Environment variable value.")
+
+
+class EnvironmentVariablesInfo(BaseResponseModel):
+    """A collection of environment variable entries."""
+
+    entries: list[EnvironmentVariableEntryInfo] = Field(
+        description="List of environment variable entries."
     )

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -152,14 +152,27 @@ class ImageInput(BaseRequestModel):
 
 
 class EnvironmentVariableEntryInput(BaseRequestModel):
-    """A single environment variable entry with name and value."""
+    """A single environment variable entry with name and value.
+
+    .. deprecated::
+        Retained only for legacy deployment/session DTOs that already expose ``name``.
+        New code should use
+        :class:`ai.backend.common.dto.manager.v2.common.EnvironmentVariableEntryInput`
+        (``key``/``value``) instead.
+    """
 
     name: str = Field(description="Environment variable name")
     value: str = Field(description="Environment variable value")
 
 
 class EnvironmentVariablesInput(BaseRequestModel):
-    """A collection of environment variable entries."""
+    """A collection of environment variable entries.
+
+    .. deprecated::
+        Retained only for legacy deployment/session DTOs.
+        New code should use
+        :class:`ai.backend.common.dto.manager.v2.common.EnvironmentVariablesInput`.
+    """
 
     entries: list[EnvironmentVariableEntryInput] = Field(
         description="List of environment variable entries"

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -235,14 +235,27 @@ class ReplicaOrderField(StrEnum):
 
 
 class EnvironmentVariableEntryInfoDTO(BaseResponseModel):
-    """A single environment variable entry with name and value."""
+    """A single environment variable entry with name and value.
+
+    .. deprecated::
+        Retained only for legacy deployment/session response DTOs that already expose ``name``.
+        New code should use
+        :class:`ai.backend.common.dto.manager.v2.common.EnvironmentVariableEntryInfo`
+        (``key``/``value``) instead.
+    """
 
     name: str
     value: str
 
 
 class EnvironmentVariablesInfoDTO(BaseResponseModel):
-    """A collection of environment variable entries."""
+    """A collection of environment variable entries.
+
+    .. deprecated::
+        Retained only for legacy deployment/session response DTOs.
+        New code should use
+        :class:`ai.backend.common.dto.manager.v2.common.EnvironmentVariablesInfo`.
+    """
 
     entries: list[EnvironmentVariableEntryInfoDTO]
 

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -7,23 +7,18 @@ from pydantic import Field
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.dto.manager.query import StringFilter
-from ai.backend.common.dto.manager.v2.common import OrderDirection, ResourceSlotEntryInput
+from ai.backend.common.dto.manager.v2.common import (
+    EnvironmentVariableEntryInput,
+    OrderDirection,
+    ResourceSlotEntryInput,
+)
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.types import (
     DeploymentRevisionPresetOrderField,
 )
+from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsEntryDTO
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
-
-
-class EnvironEntryInput(BaseRequestModel):
-    key: str = Field(description="Environment variable key.")
-    value: str = Field(description="Environment variable value.")
-
-
-class ResourceOptsEntryInput(BaseRequestModel):
-    name: str = Field(description="Resource option name (e.g. shmem).")
-    value: str = Field(description="Resource option value (e.g. 1g).")
 
 
 class PresetValueInput(BaseRequestModel):
@@ -44,14 +39,14 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
     resource_slots: list[ResourceSlotEntryInput] | None = Field(
         default=None, description="Resource slot allocations."
     )
-    resource_opts: list[ResourceOptsEntryInput] | None = Field(
+    resource_opts: list[ResourceOptsEntryDTO] | None = Field(
         default=None, description="Additional resource options."
     )
     cluster_mode: str | None = Field(default=None, max_length=16, description="Cluster mode.")
     cluster_size: int | None = Field(default=None, ge=1, description="Cluster size.")
     startup_command: str | None = Field(default=None, description="Startup command.")
     bootstrap_script: str | None = Field(default=None, description="Bootstrap script.")
-    environ: list[EnvironEntryInput] | None = Field(
+    environ: list[EnvironmentVariableEntryInput] | None = Field(
         default=None, description="Environment variables."
     )
     preset_values: list[PresetValueInput] | None = Field(
@@ -86,12 +81,12 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     image_id: ImageID | Sentinel | None = Field(default=SENTINEL)
     model_definition: ModelDefinition | Sentinel | None = Field(default=SENTINEL)
     resource_slots: list[ResourceSlotEntryInput] | None = Field(default=None)
-    resource_opts: list[ResourceOptsEntryInput] | None = Field(default=None)
+    resource_opts: list[ResourceOptsEntryDTO] | None = Field(default=None)
     cluster_mode: str | None = Field(default=None, max_length=16)
     cluster_size: int | None = Field(default=None, ge=1)
     startup_command: str | Sentinel | None = Field(default=SENTINEL)
     bootstrap_script: str | Sentinel | None = Field(default=SENTINEL)
-    environ: list[EnvironEntryInput] | None = Field(default=None)
+    environ: list[EnvironmentVariableEntryInput] | None = Field(default=None)
     preset_values: list[PresetValueInput] | None = Field(default=None)
     open_to_public: bool | Sentinel | None = Field(default=SENTINEL)
     replica_count: int | Sentinel | None = Field(default=SENTINEL, ge=0)

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
 from uuid import UUID
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection, ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
@@ -38,7 +38,7 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
     name: str = Field(min_length=1, max_length=256, description="Preset name.")
     description: str | None = Field(default=None, description="Description.")
     image_id: ImageID = Field(description="Container image UUID.")
-    model_definition: dict[str, Any] | None = Field(
+    model_definition: ModelDefinition | None = Field(
         default=None, description="Model definition configuration."
     )
     resource_slots: list[ResourceSlotEntryInput] | None = Field(
@@ -84,7 +84,7 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)
     image_id: ImageID | Sentinel | None = Field(default=SENTINEL)
-    model_definition: dict[str, Any] | Sentinel | None = Field(default=SENTINEL)
+    model_definition: ModelDefinition | Sentinel | None = Field(default=SENTINEL)
     resource_slots: list[ResourceSlotEntryInput] | None = Field(default=None)
     resource_opts: list[ResourceOptsEntryInput] | None = Field(default=None)
     cluster_mode: str | None = Field(default=None, max_length=16)

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
@@ -14,6 +14,15 @@ from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
 
 class EnvironEntryInfo(BaseResponseModel):
+    """A single environment variable entry with key and value.
+
+    .. deprecated::
+        Equivalent to
+        :class:`ai.backend.common.dto.manager.v2.common.EnvironmentVariableEntryInfo`.
+        New code should prefer the common type; this class is retained only for
+        the deployment revision preset response schema.
+    """
+
     key: str = Field(description="Environment variable key.")
     value: str = Field(description="Environment variable value.")
 
@@ -24,6 +33,15 @@ class ResourceSlotEntryInfo(BaseResponseModel):
 
 
 class ResourceOptsEntryInfo(BaseResponseModel):
+    """A single resource option entry with name and value.
+
+    .. deprecated::
+        Equivalent to
+        :class:`ai.backend.common.dto.manager.v2.resource_slot.types.ResourceOptsEntryInfoDTO`.
+        New code should prefer the common type; this class is retained only for
+        the deployment revision preset response schema.
+    """
+
     name: str = Field(description="Resource option name (e.g. shmem).")
     value: str = Field(description="Resource option value (e.g. 1g).")
 

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
@@ -92,7 +93,7 @@ class DeploymentRevisionPresetNode(BaseResponseModel):
         default_factory=PresetDeploymentDefaults,
         description="Deployment-level default values provided by this preset.",
     )
-    model_definition: dict[str, Any] | None = Field(
+    model_definition: ModelDefinition | None = Field(
         default=None, description="Model definition configuration."
     )
     preset_values: list[PresetValueInfo] = Field(default_factory=list, description="Preset values.")

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from ai.backend.common.api_handlers import SENTINEL
+from ai.backend.common.api_handlers import SENTINEL, Sentinel
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
@@ -165,11 +165,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         resource_opts = self._convert_resource_opts_input(input.resource_opts)
         environ = self._convert_environ_input(input.environ)
         preset_values = self._convert_preset_values_input(input.preset_values)
-        model_def = (
-            ModelDefinition.model_validate(input.model_definition)
-            if input.model_definition
-            else None
-        )
+        model_def = input.model_definition
         strategy, strategy_spec = self._convert_strategy_input(input.deployment_strategy)
 
         creator = Creator(
@@ -451,13 +447,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
 
     @staticmethod
     def _convert_model_definition_state(
-        value: Any,
+        value: ModelDefinition | Sentinel | None,
     ) -> TriState[ModelDefinition]:
         if value is SENTINEL:
             return TriState.nop()
         if value is None:
             return TriState.nullify()
-        return TriState.update(ModelDefinition.model_validate(value))
+        return TriState.update(value)
 
     @staticmethod
     def _convert_tri_state(value: Any) -> TriState[Any]:

--- a/src/ai/backend/manager/api/gql/common/types.py
+++ b/src/ai/backend/manager/api/gql/common/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.dto.manager.v2.common import EnvironmentVariableEntryInput
 from ai.backend.common.dto.manager.v2.resource_slot.types import (
     ResourceOptsDTOInput,
     ResourceOptsEntryDTO,
@@ -13,6 +14,7 @@ from ai.backend.common.dto.manager.v2.resource_slot.types import (
     ServicePortsInfoDTO,
 )
 from ai.backend.common.dto.manager.v2.streaming.types import ServiceProtocol
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_enum,
@@ -150,6 +152,23 @@ class ResourceOptsInput(PydanticInputMixin[ResourceOptsDTOInput]):
     entries: list[ResourceOptsEntryInput] = gql_field(
         description="List of resource option entries."
     )
+
+
+# ========== Environment Variable Input Types ==========
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A single environment variable entry with key and value.",
+    ),
+    name="EnvironEntryInput",
+)
+class EnvironEntryInputGQL(PydanticInputMixin[EnvironmentVariableEntryInput]):
+    """Single environment variable entry input with key and value."""
+
+    key: str = gql_field(description="Environment variable key (e.g., 'CUDA_VISIBLE_DEVICES').")
+    value: str = gql_field(description="Environment variable value.")
 
 
 # ========== Service Port Types ==========

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -26,6 +26,15 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
     DeploymentRevisionPresetOrder as OrderDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    EnvironEntryInput as EnvironEntryInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    PresetValueInput as PresetValueInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    ResourceOptsEntryInput as ResourceOptsEntryInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     UpdateDeploymentRevisionPresetInput as UpdateInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
@@ -58,8 +67,11 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     UpdateDeploymentRevisionPresetPayload as UpdatePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.common.types import ClusterModeGQL
 from ai.backend.manager.api.gql.common.types import ResourceOptsEntryGQL as ResourceOptsEntryInfoGQL
+from ai.backend.manager.api.gql.common_types import ResourceSlotEntryInputGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -87,6 +99,7 @@ from ai.backend.manager.api.gql.deployment.types.revision import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelDefinitionGQL,
+    ModelDefinitionInputGQL,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -364,6 +377,46 @@ class DeploymentRevisionPresetConnection(Connection[DeploymentRevisionPresetGQL]
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.",
+    ),
+    name="DeploymentRevisionPresetEnvironEntryInput",
+)
+class PresetEnvironEntryInputGQL(PydanticInputMixin[EnvironEntryInputDTO]):
+    key: str = gql_field(description="The environment variable name.")
+    value: str = gql_field(description="The value assigned to the environment variable.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A single additional resource option (e.g. shared memory size) for a deployment revision preset.",
+    ),
+    name="DeploymentRevisionPresetResourceOptsEntryInput",
+)
+class PresetResourceOptsEntryInputGQL(PydanticInputMixin[ResourceOptsEntryInputDTO]):
+    name: str = gql_field(description="Resource option name (e.g. 'shmem').")
+    value: str = gql_field(description="Resource option value (e.g. '1g').")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="A mapping of a runtime variant preset to a concrete value, used to auto-configure runtime parameters when this deployment preset is applied.",
+    ),
+    name="DeploymentRevisionPresetValueEntryInput",
+)
+class PresetValueEntryInputGQL(PydanticInputMixin[PresetValueInputDTO]):
+    preset_id: UUID = gql_field(
+        description="The runtime variant preset that this value applies to."
+    )
+    value: str = gql_field(
+        description="The concrete value to set for the referenced preset parameter."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
         added_version="26.4.2",
         description="Filter for deployment revision presets.",
     ),
@@ -433,6 +486,82 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
         default=None,
         description="Default deployment strategy for deployments created from this preset.",
     )
+    image_id: UUID = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Container image to run the inference server.",
+        ),
+    )
+    description: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Detailed explanation of when and why to use this preset configuration.",
+        ),
+        default=None,
+    )
+    model_definition: ModelDefinitionInputGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.",
+        ),
+        default=None,
+    )
+    resource_slots: list[ResourceSlotEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Resource slot allocations (e.g. cpu, mem, cuda.device).",
+        ),
+        default=None,
+    )
+    resource_opts: list[PresetResourceOptsEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Additional resource options such as shared memory (shmem) size.",
+        ),
+        default=None,
+    )
+    cluster_mode: ClusterModeGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Deployment topology mode (single-node or multi-node).",
+        ),
+        default=None,
+    )
+    cluster_size: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Number of worker nodes in the cluster.",
+        ),
+        default=None,
+    )
+    startup_command: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Command to start the inference server process inside the container.",
+        ),
+        default=None,
+    )
+    bootstrap_script: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Script executed before the main process starts (e.g. to download model weights).",
+        ),
+        default=None,
+    )
+    environ: list[PresetEnvironEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Environment variables injected into the inference container.",
+        ),
+        default=None,
+    )
+    preset_values: list[PresetValueEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Runtime variant preset values applied when using this deployment preset.",
+        ),
+        default=None,
+    )
 
 
 @gql_pydantic_input(
@@ -466,6 +595,76 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         default=UNSET,
         description="Default deployment strategy for deployments created from this "
         "preset. Set to null to clear.",
+    )
+    image_id: UUID | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Container image for the inference server. Set to null to clear.",
+        ),
+        default=UNSET,
+    )
+    model_definition: ModelDefinitionInputGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Parsed model definition. Set to null to clear.",
+        ),
+        default=UNSET,
+    )
+    startup_command: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Container startup command. Set to null to clear.",
+        ),
+        default=UNSET,
+    )
+    bootstrap_script: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Bootstrap script run before the main process. Set to null to clear.",
+        ),
+        default=UNSET,
+    )
+    resource_slots: list[ResourceSlotEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Replace resource slot allocations. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
+    resource_opts: list[PresetResourceOptsEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Replace additional resource options. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
+    cluster_mode: ClusterModeGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New cluster topology mode. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
+    cluster_size: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New cluster size. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
+    environ: list[PresetEnvironEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Replace environment variables. Omit to leave unchanged.",
+        ),
+        default=None,
+    )
+    preset_values: list[PresetValueEntryInputGQL] | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Replace runtime variant preset values. Omit to leave unchanged.",
+        ),
+        default=None,
     )
 
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -95,9 +95,6 @@ from ai.backend.manager.api.gql.deployment.types.resource_slot import (
     AllocatedResourceSlotOrderByGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.revision import (
-    EnvironmentVariableEntryGQL as EnvironEntryInfoGQL,
-)
-from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelDefinitionGQL,
     ModelDefinitionInputGQL,
 )
@@ -202,7 +199,7 @@ class PresetExecutionSpecGQL(PydanticOutputMixin[PresetExecutionSpecDTO]):
     bootstrap_script: str | None = gql_field(
         description="Script executed before the main process starts, used for setup tasks like downloading model weights."
     )
-    environ: list[EnvironEntryInfoGQL] = gql_field(
+    environ: list[EnvironEntryGQL] = gql_field(
         description="Environment variables injected into the inference container."
     )
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -26,13 +26,7 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
     DeploymentRevisionPresetOrder as OrderDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
-    EnvironEntryInput as EnvironEntryInputDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     PresetValueInput as PresetValueInputDTO,
-)
-from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
-    ResourceOptsEntryInput as ResourceOptsEntryInputDTO,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     UpdateDeploymentRevisionPresetInput as UpdateInputDTO,
@@ -69,7 +63,11 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 )
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
-from ai.backend.manager.api.gql.common.types import ClusterModeGQL
+from ai.backend.manager.api.gql.common.types import (
+    ClusterModeGQL,
+    EnvironEntryInputGQL,
+    ResourceOptsEntryInput,
+)
 from ai.backend.manager.api.gql.common.types import ResourceOptsEntryGQL as ResourceOptsEntryInfoGQL
 from ai.backend.manager.api.gql.common_types import ResourceSlotEntryInputGQL
 from ai.backend.manager.api.gql.decorators import (
@@ -375,30 +373,6 @@ class DeploymentRevisionPresetConnection(Connection[DeploymentRevisionPresetGQL]
 @gql_pydantic_input(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="A single environment variable key-value pair to inject into the inference container when a deployment revision preset is applied.",
-    ),
-    name="DeploymentRevisionPresetEnvironEntryInput",
-)
-class PresetEnvironEntryInputGQL(PydanticInputMixin[EnvironEntryInputDTO]):
-    key: str = gql_field(description="The environment variable name.")
-    value: str = gql_field(description="The value assigned to the environment variable.")
-
-
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description="A single additional resource option (e.g. shared memory size) for a deployment revision preset.",
-    ),
-    name="DeploymentRevisionPresetResourceOptsEntryInput",
-)
-class PresetResourceOptsEntryInputGQL(PydanticInputMixin[ResourceOptsEntryInputDTO]):
-    name: str = gql_field(description="Resource option name (e.g. 'shmem').")
-    value: str = gql_field(description="Resource option value (e.g. '1g').")
-
-
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
         description="A mapping of a runtime variant preset to a concrete value, used to auto-configure runtime parameters when this deployment preset is applied.",
     ),
     name="DeploymentRevisionPresetValueEntryInput",
@@ -510,7 +484,7 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
         ),
         default=None,
     )
-    resource_opts: list[PresetResourceOptsEntryInputGQL] | None = gql_added_field(
+    resource_opts: list[ResourceOptsEntryInput] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Additional resource options such as shared memory (shmem) size.",
@@ -545,7 +519,7 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
         ),
         default=None,
     )
-    environ: list[PresetEnvironEntryInputGQL] | None = gql_added_field(
+    environ: list[EnvironEntryInputGQL] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Environment variables injected into the inference container.",
@@ -628,7 +602,7 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         ),
         default=None,
     )
-    resource_opts: list[PresetResourceOptsEntryInputGQL] | None = gql_added_field(
+    resource_opts: list[ResourceOptsEntryInput] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Replace additional resource options. Omit to leave unchanged.",
@@ -649,7 +623,7 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         ),
         default=None,
     )
-    environ: list[PresetEnvironEntryInputGQL] | None = gql_added_field(
+    environ: list[EnvironEntryInputGQL] | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description="Replace environment variables. Omit to leave unchanged.",

--- a/src/ai/backend/manager/data/deployment_revision_preset/types.py
+++ b/src/ai/backend/manager/data/deployment_revision_preset/types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
@@ -42,7 +43,7 @@ class DeploymentRevisionPresetData:
     description: str | None
     rank: int
     image_id: ImageID
-    model_definition: dict[str, Any] | None
+    model_definition: ModelDefinition | None
     resource_opts: list[ResourceOptsEntryData]
     cluster_mode: str
     cluster_size: int

--- a/src/ai/backend/manager/models/deployment_revision_preset/row.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/row.py
@@ -126,11 +126,7 @@ class DeploymentRevisionPresetRow(Base):  # type: ignore[misc]
             description=self.description,
             rank=self.rank,
             image_id=self.image_id,
-            model_definition=(
-                self.model_definition.model_dump(by_alias=True, exclude_none=True)
-                if self.model_definition
-                else None
-            ),
+            model_definition=self.model_definition,
             resource_opts=[
                 ResourceOptsEntryData(name=e.name, value=e.value)
                 for e in (self.resource_opts or [])

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -24,10 +24,10 @@ from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
-    ResourceOptsEntryInput,
     SearchDeploymentRevisionPresetsInput,
     UpdateDeploymentRevisionPresetInput,
 )
+from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsEntryDTO
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
@@ -78,7 +78,7 @@ class TestDeploymentRevisionPresetCRUD:
                     ResourceSlotEntryInput(resource_type="cpu", quantity="4"),
                     ResourceSlotEntryInput(resource_type="mem", quantity="8g"),
                 ],
-                resource_opts=[ResourceOptsEntryInput(name="shmem", value="1g")],
+                resource_opts=[ResourceOptsEntryDTO(name="shmem", value="1g")],
                 cluster_mode="single-node",
                 cluster_size=1,
             )


### PR DESCRIPTION
## Summary
- Add missing fields (`image_id`, `description`, `model_definition`, `resource_slots`, `resource_opts`, `cluster_mode`, `cluster_size`, `startup_command`, `bootstrap_script`, `environ`, `preset_values`) to `CreateDeploymentRevisionPresetInput` and `UpdateDeploymentRevisionPresetInput` GQL inputs so WebUI can fully manage presets.
- Strong-type `model_definition` from `dict[str, Any]` to `ModelDefinition` across DTO request/response, Data, and adapter layers, removing redundant dump/validate round-trips.
- Add three new nested GQL input types (`PresetEnvironEntryInput`, `PresetResourceOptsEntryInput`, `PresetValueEntryInput`) wrapping their DTO counterparts.

## Test plan
- [x] `pants check` (mypy) on changed and adjacent modules
- [x] `pants lint` on changed files
- [x] `pants test tests/component/deployment_revision_preset::`
- [x] Live verification via `./bai admin deployment-revision-preset create/update` after `./dev restart mgr && ./dev restart web`

Resolves BA-5874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11354.org.readthedocs.build/en/11354/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11354.org.readthedocs.build/ko/11354/

<!-- readthedocs-preview sorna-ko end -->