### PR TITLE
refactor(BA-5820): migrate image entity code from agus to ASE

### DIFF
--- a/changes/11357.feature.md
+++ b/changes/11357.feature.md
@@ -1,0 +1,1 @@
+Migrate image project membership check from `association_groups_users` to `association_scopes_entities` (ASE).

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -63,6 +63,8 @@ from ai.backend.manager.data.image.types import (
     RescanImagesResult,
     ResourceLimit,
 )
+from ai.backend.manager.data.permission.types import EntityType
+from ai.backend.manager.data.permission.types import ScopeType as PermissionScopeType
 from ai.backend.manager.defs import INTRINSIC_SLOTS, INTRINSIC_SLOTS_MIN
 from ai.backend.manager.errors.image import ImageNotFound
 from ai.backend.manager.models.base import (
@@ -72,6 +74,7 @@ from ai.backend.manager.models.base import (
     StructuredJSONColumn,
 )
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.rbac import (
     AbstractPermissionContext,
     AbstractPermissionContextBuilder,
@@ -84,6 +87,9 @@ from ai.backend.manager.models.rbac import (
 from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.rbac.exceptions import InvalidScope
 from ai.backend.manager.models.rbac.permission_defs import ImagePermission
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.user import UserRole, UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
@@ -1341,13 +1347,6 @@ class ImagePermissionContextBuilder(
         _ctx: ClientContext,
         scope: UserScope,
     ) -> list[ProjectScope]:
-        from ai.backend.manager.data.permission.types import EntityType
-        from ai.backend.manager.data.permission.types import ScopeType as PermissionScopeType
-        from ai.backend.manager.models.group import GroupRow
-        from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-            AssociationScopesEntitiesRow,
-        )
-
         project_ids_stmt = (
             sa.select(GroupRow.id)
             .join(

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -1341,19 +1341,28 @@ class ImagePermissionContextBuilder(
         _ctx: ClientContext,
         scope: UserScope,
     ) -> list[ProjectScope]:
-        from ai.backend.manager.data.permission.types import EntityType, ScopeType
+        from ai.backend.manager.data.permission.types import EntityType
+        from ai.backend.manager.data.permission.types import ScopeType as PermissionScopeType
+        from ai.backend.manager.models.group import GroupRow
         from ai.backend.manager.models.rbac_models.association_scopes_entities import (
             AssociationScopesEntitiesRow,
         )
 
-        get_assoc_group_ids_stmt = sa.select(AssociationScopesEntitiesRow.scope_id).where(
-            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
-            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
-            AssociationScopesEntitiesRow.entity_id == str(scope.user_id),
+        project_ids_stmt = (
+            sa.select(GroupRow.id)
+            .join(
+                AssociationScopesEntitiesRow,
+                sa.cast(GroupRow.id, sa.String) == AssociationScopesEntitiesRow.scope_id,
+            )
+            .where(
+                AssociationScopesEntitiesRow.scope_type == PermissionScopeType.PROJECT,
+                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.entity_id == str(scope.user_id),
+            )
         )
-        group_ids = await self.db_session.scalars(get_assoc_group_ids_stmt)
+        project_ids = await self.db_session.scalars(project_ids_stmt)
 
-        return [ProjectScope(project_id=UUID(group_id)) for group_id in group_ids]
+        return [ProjectScope(project_id=project_id) for project_id in project_ids]
 
     async def _get_domain_accessible_project_scopes(
         self,

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -1341,14 +1341,19 @@ class ImagePermissionContextBuilder(
         _ctx: ClientContext,
         scope: UserScope,
     ) -> list[ProjectScope]:
-        from ai.backend.manager.models.group import AssocGroupUserRow
+        from ai.backend.manager.data.permission.types import EntityType, ScopeType
+        from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+            AssociationScopesEntitiesRow,
+        )
 
-        get_assoc_group_ids_stmt = sa.select(AssocGroupUserRow.group_id).where(
-            AssocGroupUserRow.user_id == scope.user_id
+        get_assoc_group_ids_stmt = sa.select(AssociationScopesEntitiesRow.scope_id).where(
+            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+            AssociationScopesEntitiesRow.entity_id == str(scope.user_id),
         )
         group_ids = await self.db_session.scalars(get_assoc_group_ids_stmt)
 
-        return [ProjectScope(project_id=group_id) for group_id in group_ids]
+        return [ProjectScope(project_id=UUID(group_id)) for group_id in group_ids]
 
     async def _get_domain_accessible_project_scopes(
         self,


### PR DESCRIPTION
## Summary
- Replace `AssocGroupUserRow` lookup in `ImagePermissionContextBuilder._get_user_accessible_project_scopes` with an `association_scopes_entities` query filtered by `scope_type=PROJECT, entity_type=USER`.
- Cast the user UUID to `str` on the filter side to avoid runtime errors from non-UUID `scope_id`/`entity_id` values in ASE; convert the returned `scope_id` back to `UUID` for `ProjectScope`.
- Sole agus reference in the image domain (verified across `models/image`, `repositories/image`, `services/image`, `data/image`, `api/gql`, `api/gql_legacy/image.py`, `api/rest`, `api/adapters`).

## Test plan
- [x] `pants fmt/fix/lint/check` on `src/ai/backend/manager/models/image/row.py` — passed (mypy clean).
- [x] Image domain unit tests passed (`tests/unit/manager/models/image`, `repositories/image`, `services/image`, `api/image`).
- [x] CI green.

Resolves BA-5820