### PR TITLE
chore(BA-5879): auto-restart Apollo Router in refresh-graphql-gateway.sh

### DIFF
--- a/changes/11363.misc.md
+++ b/changes/11363.misc.md
@@ -1,0 +1,1 @@
+Always restart the Apollo Router halfstack container in `scripts/refresh-graphql-gateway.sh` instead of asking for an interactive `y/N` confirmation, so the script can be run unattended and never silently skips the restart.

--- a/scripts/refresh-graphql-gateway.sh
+++ b/scripts/refresh-graphql-gateway.sh
@@ -13,10 +13,6 @@ echo "==> 2. Copying schema and gateway config to project root..."
 cp docs/manager/graphql-reference/supergraph.graphql ./supergraph.graphql
 cp configs/graphql/gateway.config.ts ./gateway.config.ts
 
-read -rp "==> 3. Restart Apollo Router? [y/N] " answer
-if [[ "$answer" =~ ^[Yy]$ ]]; then
-  docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
-  echo "==> Done!"
-else
-  echo "==> Skipped Apollo Router restart."
-fi
+echo "==> 3. Restarting Apollo Router..."
+docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
+echo "==> Done!"


### PR DESCRIPTION
Resolves [BA-5879](https://lablup.atlassian.net/browse/BA-5879)

## Summary
- Drop the interactive `y/N` prompt in `scripts/refresh-graphql-gateway.sh` and always restart the `backendai-half-apollo-router` container after refreshing the schema and gateway config.
- The script's purpose is to refresh the gateway, so the prompt was friction that also broke non-interactive runs (default `N` skipped the restart).

## Test plan
- [ ] Run `./scripts/refresh-graphql-gateway.sh` and confirm Apollo Router restarts without prompting.

[BA-5879]: https://lablup.atlassian.net/browse/BA-5879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ