### PR TITLE
refactor(BA-5877): migrate group user-project membership to ASE

### DIFF
--- a/changes/11364.misc.md
+++ b/changes/11364.misc.md
@@ -1,0 +1,1 @@
+Migrate group user-project membership reads and writes from `association_groups_users` to `association_scopes_entities` (PROJECT scope, USER entity).

--- a/src/ai/backend/manager/api/gql_legacy/group.py
+++ b/src/ai/backend/manager/api/gql_legacy/group.py
@@ -17,6 +17,8 @@ from graphene.types.datetime import DateTime as GQLDateTime
 from graphql import Undefined
 from sqlalchemy.engine.row import Row
 
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.common.data.permission.types import ScopeType as RBACScopeType
 from ai.backend.common.exception import (
     GroupNotFound,
     InvalidAPIParameters,
@@ -24,10 +26,8 @@ from ai.backend.common.exception import (
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.group.types import GroupData
 from ai.backend.manager.models.group import (
-    AssocGroupUserRow,
     GroupRow,
     ProjectType,
-    association_groups_users,
     get_permission_ctx,
     groups,
 )
@@ -37,6 +37,9 @@ from ai.backend.manager.models.minilang.queryfilter import QueryFilterParser
 from ai.backend.manager.models.rbac import ProjectScope
 from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.rbac.permission_defs import ProjectPermission
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
@@ -213,11 +216,21 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
             before=before,
             last=last,
         )
-        j = sa.join(UserRow, AssocGroupUserRow)
-        user_query = query.select_from(j).where(AssocGroupUserRow.group_id == self.id)
-        cnt_query = (
-            sa.select(sa.func.count()).select_from(j).where(AssocGroupUserRow.group_id == self.id)
+        # Project membership comes from association_scopes_entities (PROJECT/USER).
+        # Cast UserRow.uuid (GUID) to String to match the non-UUID String(64)
+        # entity_id column safely.
+        j = sa.join(
+            UserRow,
+            AssociationScopesEntitiesRow,
+            sa.cast(UserRow.uuid, sa.String) == AssociationScopesEntitiesRow.entity_id,
         )
+        membership_filter = sa.and_(
+            AssociationScopesEntitiesRow.scope_type == RBACScopeType.PROJECT,
+            AssociationScopesEntitiesRow.scope_id == str(self.id),
+            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+        )
+        user_query = query.select_from(j).where(membership_filter)
+        cnt_query = sa.select(sa.func.count()).select_from(j).where(membership_filter)
         for cond in conditions:
             cnt_query = cnt_query.where(cond)
         async with graph_ctx.db.begin_readonly_session() as db_session:
@@ -496,15 +509,21 @@ class Group(graphene.ObjectType):  # type: ignore[misc]
             _type = [ProjectType.GENERAL]
         else:
             _type = type
+        ase = AssociationScopesEntitiesRow.__table__
+        user_id_strs = [str(uid) for uid in user_ids]
         j = sa.join(
             groups,
-            association_groups_users,
-            groups.c.id == association_groups_users.c.group_id,
+            ase,
+            sa.and_(
+                sa.cast(groups.c.id, sa.String) == ase.c.scope_id,
+                ase.c.scope_type == RBACScopeType.PROJECT,
+                ase.c.entity_type == EntityType.USER,
+            ),
         )
         query = (
-            sa.select(groups, association_groups_users.c.user_id)
+            sa.select(groups, ase.c.entity_id.label("user_id_str"))
             .select_from(j)
-            .where(association_groups_users.c.user_id.in_(user_ids) & (groups.c.type.in_(_type)))
+            .where(ase.c.entity_id.in_(user_id_strs) & (groups.c.type.in_(_type)))
         )
         if is_active is not None:
             query = query.where(groups.c.is_active == is_active)
@@ -515,7 +534,7 @@ class Group(graphene.ObjectType):  # type: ignore[misc]
                 query,
                 cls,
                 user_ids,
-                lambda row: row.user_id,
+                lambda row: uuid.UUID(row.user_id_str),
             )
 
     @classmethod
@@ -524,14 +543,17 @@ class Group(graphene.ObjectType):  # type: ignore[misc]
         graph_ctx: GraphQueryContext,
         user_id: uuid.UUID,
     ) -> Sequence[Group]:
+        ase = AssociationScopesEntitiesRow.__table__
         j = sa.join(
             groups,
-            association_groups_users,
-            groups.c.id == association_groups_users.c.group_id,
+            ase,
+            sa.and_(
+                sa.cast(groups.c.id, sa.String) == ase.c.scope_id,
+                ase.c.scope_type == RBACScopeType.PROJECT,
+                ase.c.entity_type == EntityType.USER,
+            ),
         )
-        query = (
-            sa.select(groups).select_from(j).where(association_groups_users.c.user_id == user_id)
-        )
+        query = sa.select(groups).select_from(j).where(ase.c.entity_id == str(user_id))
         async with graph_ctx.db.begin_readonly() as conn:
             return [
                 obj

--- a/src/ai/backend/manager/repositories/group/creators.py
+++ b/src/ai/backend/manager/repositories/group/creators.py
@@ -49,17 +49,17 @@ class GroupCreatorSpec(CreatorSpec[GroupRow]):
 
 
 @dataclass
-class AssocGroupUserCreatorSpec(CreatorSpec[AssociationScopesEntitiesRow]):
+class ProjectUserMembershipCreatorSpec(CreatorSpec[AssociationScopesEntitiesRow]):
     """CreatorSpec for user-project membership (PROJECT/USER ASE row)."""
 
     user_id: UUID
-    group_id: UUID
+    project_id: UUID
 
     @override
     def build_row(self) -> AssociationScopesEntitiesRow:
         return AssociationScopesEntitiesRow(
             scope_type=ScopeType.PROJECT,
-            scope_id=str(self.group_id),
+            scope_id=str(self.project_id),
             entity_type=EntityType.USER,
             entity_id=str(self.user_id),
             relation_type=RelationType.AUTO,

--- a/src/ai/backend/manager/repositories/group/creators.py
+++ b/src/ai/backend/manager/repositories/group/creators.py
@@ -6,9 +6,12 @@ from dataclasses import dataclass
 from typing import override
 from uuid import UUID
 
+from ai.backend.common.data.permission.types import EntityType, RelationType, ScopeType
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.models.group import GroupRow, ProjectType
-from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.repositories.base import CreatorSpec
 
 
@@ -46,15 +49,18 @@ class GroupCreatorSpec(CreatorSpec[GroupRow]):
 
 
 @dataclass
-class AssocGroupUserCreatorSpec(CreatorSpec[AssocGroupUserRow]):
-    """CreatorSpec for user-project association."""
+class AssocGroupUserCreatorSpec(CreatorSpec[AssociationScopesEntitiesRow]):
+    """CreatorSpec for user-project membership (PROJECT/USER ASE row)."""
 
     user_id: UUID
     group_id: UUID
 
     @override
-    def build_row(self) -> AssocGroupUserRow:
-        return AssocGroupUserRow(
-            user_id=self.user_id,
-            group_id=self.group_id,
+    def build_row(self) -> AssociationScopesEntitiesRow:
+        return AssociationScopesEntitiesRow(
+            scope_type=ScopeType.PROJECT,
+            scope_id=str(self.group_id),
+            entity_type=EntityType.USER,
+            entity_id=str(self.user_id),
+            relation_type=RelationType.AUTO,
         )

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -86,8 +86,8 @@ from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
 )
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
 from ai.backend.manager.repositories.group.creators import (
-    AssocGroupUserCreatorSpec,
     GroupCreatorSpec,
+    ProjectUserMembershipCreatorSpec,
 )
 from ai.backend.manager.repositories.group.purgers import (
     GroupBatchPurgerSpec,
@@ -250,7 +250,7 @@ class GroupDBSource:
         project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
         pairs = [
             RBACScopeBindingPair(
-                spec=AssocGroupUserCreatorSpec(user_id=row.uuid, group_id=project_id),
+                spec=ProjectUserMembershipCreatorSpec(user_id=row.uuid, project_id=project_id),
                 entity_ref=RBACElementRef(RBACElementType.USER, str(row.uuid)),
                 scope_ref=project_scope_ref,
             )
@@ -786,7 +786,7 @@ class GroupDBSource:
             project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
             pairs = [
                 RBACScopeBindingPair(
-                    spec=AssocGroupUserCreatorSpec(user_id=row.uuid, group_id=project_id),
+                    spec=ProjectUserMembershipCreatorSpec(user_id=row.uuid, project_id=project_id),
                     entity_ref=RBACElementRef(RBACElementType.USER, str(row.uuid)),
                     scope_ref=project_scope_ref,
                 )
@@ -888,7 +888,7 @@ class GroupDBSource:
 
             project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
             pair = RBACScopeBindingPair(
-                spec=AssocGroupUserCreatorSpec(user_id=user_id, group_id=project_id),
+                spec=ProjectUserMembershipCreatorSpec(user_id=user_id, project_id=project_id),
                 entity_ref=RBACElementRef(RBACElementType.USER, str(user_id)),
                 scope_ref=project_scope_ref,
             )

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -41,7 +41,6 @@ from ai.backend.manager.models.domain import domains
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
 from ai.backend.manager.models.group import groups
 from ai.backend.manager.models.group.row import (
-    AssocGroupUserRow,
     GroupRow,
 )
 from ai.backend.manager.models.kernel import (
@@ -216,12 +215,12 @@ class GroupDBSource:
     ) -> None:
         """Add users to a project within an existing session.
 
-        Creates the business association (association_groups_users), the RBAC
-        scope binding, and a user-role mapping to the project's member role.
-        Admin roles are intentionally NOT granted here; the modifyGroup
-        add path represents "make this user a project member", not
-        "make this user a project admin". Already-assigned users are
-        filtered out to avoid unique-constraint conflicts.
+        Creates the RBAC scope binding (association_scopes_entities) via
+        ``RBACScopeBinder`` and a user-role mapping to the project's member
+        role. Admin roles are intentionally NOT granted here; the modifyGroup
+        add path represents "make this user a project member", not "make this
+        user a project admin". Already-assigned users are filtered out to
+        avoid unique-constraint conflicts.
         """
         project_domain_subq = (
             sa.select(GroupRow.domain_name).where(GroupRow.id == project_id).scalar_subquery()
@@ -230,14 +229,18 @@ class GroupDBSource:
             await session.scalars(
                 sa.select(UserRow)
                 .outerjoin(
-                    AssocGroupUserRow,
-                    (UserRow.uuid == AssocGroupUserRow.user_id)
-                    & (AssocGroupUserRow.group_id == project_id),
+                    AssociationScopesEntitiesRow,
+                    sa.and_(
+                        sa.cast(UserRow.uuid, sa.String) == AssociationScopesEntitiesRow.entity_id,
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(project_id),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    ),
                 )
                 .where(
                     UserRow.uuid.in_(user_uuids)
                     & (UserRow.domain_name == project_domain_subq)
-                    & AssocGroupUserRow.user_id.is_(None)
+                    & AssociationScopesEntitiesRow.entity_id.is_(None)
                 )
             )
         ).all()
@@ -296,23 +299,27 @@ class GroupDBSource:
     ) -> None:
         """Remove users from a project within an existing session.
 
-        Deletes the business N:N association, the RBAC scope binding, and any
+        Deletes the RBAC scope binding (association_scopes_entities) and any
         user-role mappings for roles scoped to this project, mirroring
         `unassign_users_from_project`.
         """
-        assigned_user_ids = (
+        target_entity_ids = [str(uid) for uid in user_uuids]
+        assigned_entity_ids = (
             await session.scalars(
-                sa.select(AssocGroupUserRow.user_id).where(
-                    AssocGroupUserRow.user_id.in_(user_uuids),
-                    AssocGroupUserRow.group_id == project_id,
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id.in_(target_entity_ids),
                 )
             )
         ).all()
-        if not assigned_user_ids:
+        if not assigned_entity_ids:
             return
 
+        assigned_user_uuids = [uuid.UUID(eid) for eid in assigned_entity_ids]
         unbinder = UserProjectEntityUnbinder(
-            user_uuids=list(assigned_user_ids),
+            user_uuids=assigned_user_uuids,
             project_id=project_id,
         )
         await execute_rbac_scope_entity_unbinder(session, unbinder)
@@ -326,7 +333,7 @@ class GroupDBSource:
         )
         await session.execute(
             sa.delete(UserRoleRow).where(
-                UserRoleRow.user_id.in_(assigned_user_ids),
+                UserRoleRow.user_id.in_(assigned_user_uuids),
                 sa.cast(UserRoleRow.role_id, sa.String).in_(project_role_ids_subq),
             )
         )
@@ -725,9 +732,9 @@ class GroupDBSource:
         """Assign users to a project with domain validation and RBAC scope binding.
 
         Validates that the project exists, users are in the same domain and active,
-        and filters out already-assigned users. Creates both the business association
-        (association_groups_users) and the RBAC scope association atomically.
-        Also creates user-role mappings for the specified role.
+        and filters out already-assigned users. Inserts the RBAC scope association
+        (association_scopes_entities) and creates user-role mappings for the
+        specified role.
 
         Returns the list of newly assigned users.
         """
@@ -742,7 +749,7 @@ class GroupDBSource:
                 raise InvalidAPIParameters(f"Role not found: {role_id}")
 
             # Find assignable users in a single query:
-            # same domain as the project and not already assigned
+            # same domain as the project and not already assigned (per ASE).
             # TODO: This pre-filtering can be removed once execute_rbac_scope_binder_partial
             # is implemented (BA-5488), which handles unique constraint conflicts via
             # per-row savepoints instead of requiring callers to filter duplicates.
@@ -753,14 +760,19 @@ class GroupDBSource:
                 await session.scalars(
                     sa.select(UserRow)
                     .outerjoin(
-                        AssocGroupUserRow,
-                        (UserRow.uuid == AssocGroupUserRow.user_id)
-                        & (AssocGroupUserRow.group_id == project_id),
+                        AssociationScopesEntitiesRow,
+                        sa.and_(
+                            sa.cast(UserRow.uuid, sa.String)
+                            == AssociationScopesEntitiesRow.entity_id,
+                            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                            AssociationScopesEntitiesRow.scope_id == str(project_id),
+                            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        ),
                     )
                     .where(
                         UserRow.uuid.in_(user_ids)
                         & (UserRow.domain_name == project_domain_subq)
-                        & AssocGroupUserRow.user_id.is_(None)
+                        & AssociationScopesEntitiesRow.entity_id.is_(None)
                     )
                 )
             ).all()
@@ -768,7 +780,9 @@ class GroupDBSource:
             if not new_user_rows:
                 return []
 
-            # Build scope binder pairs for atomic business + RBAC association
+            # Build scope binder pairs for atomic ASE write via the binder API.
+            # Both the spec and the binder's own ASE insert target ASE; the
+            # latter is an ON CONFLICT DO NOTHING no-op for project-user.
             project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
             pairs = [
                 RBACScopeBindingPair(
@@ -793,12 +807,13 @@ class GroupDBSource:
     ) -> UnassignUsersResult:
         """Remove users from a project and return unassigned users and failures.
 
-        Deletes both the business N:N mapping (association_groups_users) and
-        RBAC scope associations (AssociationScopesEntitiesRow) atomically.
-        Also reports which requested user IDs could not be unassigned and why.
+        Deletes RBAC scope associations (AssociationScopesEntitiesRow) and any
+        project-scoped user-role mappings. Reports which requested user IDs
+        could not be unassigned and why.
         """
         async with self._db.begin_session_read_committed() as session:
             requested_ids = set(unbinder.user_uuids)
+            target_entity_ids = [str(uid) for uid in unbinder.user_uuids]
 
             # Find which requested UUIDs actually exist in the system
             existing_query = sa.select(UserRow.uuid).where(UserRow.uuid.in_(unbinder.user_uuids))
@@ -806,15 +821,14 @@ class GroupDBSource:
             existing_ids = set(existing_result.all())
 
             # Fetch users that are actually associated before removing
-            actual_assoc_query = (
-                sa.select(UserRow)
-                .join(
-                    AssocGroupUserRow,
-                    UserRow.uuid == AssocGroupUserRow.user_id,
-                )
-                .where(
-                    AssocGroupUserRow.user_id.in_(unbinder.user_uuids)
-                    & (AssocGroupUserRow.group_id == unbinder.project_id),
+            actual_assoc_query = sa.select(UserRow).where(
+                sa.cast(UserRow.uuid, sa.String).in_(
+                    sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(unbinder.project_id),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id.in_(target_entity_ids),
+                    )
                 )
             )
             result = await session.scalars(actual_assoc_query)
@@ -822,11 +836,11 @@ class GroupDBSource:
             assigned_ids = {row.uuid for row in assigned_rows}
             unassigned_users = [row.to_data() for row in assigned_rows]
 
-            # Delete business N:N rows and RBAC scope associations
+            # Delete RBAC scope associations via the unbinder API
             await execute_rbac_scope_entity_unbinder(session, unbinder)
 
-            # Delete user-role mappings for project-scoped roles
             if assigned_rows:
+                # Delete user-role mappings for project-scoped roles
                 project_role_ids_subq = sa.select(
                     AssociationScopesEntitiesRow.entity_id,
                 ).where(
@@ -856,18 +870,17 @@ class GroupDBSource:
             )
 
     async def bind_user_to_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Add a user to a project (business association + RBAC scope binding).
+        """Add a user to a project via the RBAC scope binding (ASE).
 
         Skips if the user is already a member of the project.
-
-        TODO: Remove once association_groups_users is fully migrated to
-        association_scopes_entities.
         """
         async with self._db.begin_session() as session:
             already_bound = await session.scalar(
-                sa.select(AssocGroupUserRow.user_id).where(
-                    AssocGroupUserRow.user_id == user_id,
-                    AssocGroupUserRow.group_id == project_id,
+                sa.select(AssociationScopesEntitiesRow.id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_id),
                 )
             )
             if already_bound is not None:
@@ -882,18 +895,8 @@ class GroupDBSource:
             await execute_rbac_scope_binder(session, RBACScopeBinder(pairs=[pair]))
 
     async def unbind_user_from_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Remove a user from a project (business association + RBAC scope binding).
-
-        TODO: Remove once association_groups_users is fully migrated to
-        association_scopes_entities.
-        """
+        """Remove a user from a project (RBAC scope binding only)."""
         async with self._db.begin_session() as session:
-            await session.execute(
-                sa.delete(AssocGroupUserRow).where(
-                    AssocGroupUserRow.user_id == user_id,
-                    AssocGroupUserRow.group_id == project_id,
-                )
-            )
             await session.execute(
                 sa.delete(AssociationScopesEntitiesRow).where(
                     AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
@@ -1007,7 +1010,9 @@ class GroupDBSource:
     ) -> GroupSearchResult:
         """Search projects a user is member of.
 
-        Joins with association_groups_users to find user's projects.
+        Joins with association_scopes_entities (PROJECT/USER) to find user's
+        projects. Casts GroupRow.id to String for the JOIN since ASE.scope_id
+        is a non-UUID String column.
 
         Args:
             scope: UserProjectSearchScope defining the user to search for.
@@ -1020,7 +1025,14 @@ class GroupDBSource:
             query = (
                 sa.select(GroupRow)
                 .select_from(GroupRow)
-                .join(AssocGroupUserRow, GroupRow.id == AssocGroupUserRow.group_id)
+                .join(
+                    AssociationScopesEntitiesRow,
+                    sa.and_(
+                        sa.cast(GroupRow.id, sa.String) == AssociationScopesEntitiesRow.scope_id,
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    ),
+                )
             )
             result = await execute_batch_querier(db_sess, query, querier, scope=scope)
 

--- a/src/ai/backend/manager/repositories/group/purgers.py
+++ b/src/ai/backend/manager/repositories/group/purgers.py
@@ -7,10 +7,13 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.group.row import AssocGroupUserRow
 from ai.backend.manager.models.kernel import KernelRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 
@@ -71,17 +74,18 @@ class GroupBatchPurgerSpec(BatchPurgerSpec[GroupRow]):
 
 
 @dataclass
-class UsersForProjectPurgerSpec(BatchPurgerSpec[AssocGroupUserRow]):
-    """PurgerSpec for removing specific users from a project."""
+class UsersForProjectPurgerSpec(BatchPurgerSpec[AssociationScopesEntitiesRow]):
+    """PurgerSpec for removing user-project memberships (PROJECT/USER ASE rows)."""
 
     user_uuids: list[UUID]
     project_id: UUID
 
     @override
-    def build_subquery(self) -> sa.sql.Select[tuple[AssocGroupUserRow]]:
-        return sa.select(AssocGroupUserRow).where(
-            sa.and_(
-                AssocGroupUserRow.user_id.in_(self.user_uuids),
-                AssocGroupUserRow.group_id == self.project_id,
-            )
+    def build_subquery(self) -> sa.sql.Select[tuple[AssociationScopesEntitiesRow]]:
+        entity_ids = [str(uid) for uid in self.user_uuids]
+        return sa.select(AssociationScopesEntitiesRow).where(
+            AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+            AssociationScopesEntitiesRow.scope_id == str(self.project_id),
+            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+            AssociationScopesEntitiesRow.entity_id.in_(entity_ids),
         )

--- a/src/ai/backend/manager/repositories/group/repository.py
+++ b/src/ai/backend/manager/repositories/group/repository.py
@@ -142,22 +142,15 @@ class GroupRepository:
 
     @group_repository_resilience.apply()
     async def bind_user_to_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Add a user to a project (business association + RBAC scope binding).
+        """Add a user to a project via the RBAC scope binding (ASE).
 
-        Skips if the user is already a member of the project.
-
-        TODO: Remove once association_groups_users is fully migrated to
-        association_scopes_entities.
+        Idempotent: re-binding an existing member is a no-op.
         """
         await self._db_source.bind_user_to_project(user_id, project_id)
 
     @group_repository_resilience.apply()
     async def unbind_user_from_project(self, user_id: UUID, project_id: UUID) -> None:
-        """Remove a user from a project (business association + RBAC scope binding).
-
-        TODO: Remove once association_groups_users is fully migrated to
-        association_scopes_entities.
-        """
+        """Remove a user from a project (RBAC scope binding only)."""
         await self._db_source.unbind_user_from_project(user_id, project_id)
 
     @group_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/group/scope_binders.py
+++ b/src/ai/backend/manager/repositories/group/scope_binders.py
@@ -7,7 +7,9 @@ from uuid import UUID
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
 from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
     RBACScopeEntityUnbinder,
@@ -16,18 +18,14 @@ from ai.backend.manager.repositories.group.purgers import UsersForProjectPurgerS
 
 
 @dataclass
-class UserProjectEntityUnbinder(RBACScopeEntityUnbinder[AssocGroupUserRow]):
-    """Unbind users from a project.
-
-    Deletes association_groups_users rows and corresponding
-    AssociationScopesEntitiesRow entries for the given users in the project scope.
-    """
+class UserProjectEntityUnbinder(RBACScopeEntityUnbinder[AssociationScopesEntitiesRow]):
+    """Unbind users from a project (PROJECT/USER ASE rows)."""
 
     user_uuids: list[UUID]
     project_id: UUID
 
     @override
-    def build_purger_spec(self) -> BatchPurgerSpec[AssocGroupUserRow]:
+    def build_purger_spec(self) -> BatchPurgerSpec[AssociationScopesEntitiesRow]:
         return UsersForProjectPurgerSpec(
             user_uuids=self.user_uuids,
             project_id=self.project_id,

--- a/src/ai/backend/manager/repositories/group/types.py
+++ b/src/ai/backend/manager/repositories/group/types.py
@@ -8,10 +8,14 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.data.group.types import GroupData
 from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.domain import DomainRow
-from ai.backend.manager.models.group.row import AssocGroupUserRow, GroupRow
+from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.repositories.base import ExistenceCheck, QueryCondition, SearchScope
 
 __all__ = (
@@ -67,21 +71,28 @@ class UserProjectSearchScope(SearchScope):
     """Required scope for searching projects a user is member of.
 
     Used for user-scoped project search (any authenticated user).
-    Requires checking association_groups_users table.
+    Filters via the association_scopes_entities table (PROJECT scope, USER
+    entity).
     """
 
     user_uuid: UUID
     """Required. The user UUID to search projects for."""
 
     def to_condition(self) -> QueryCondition:
-        """Convert scope to a query condition for AssocGroupUserRow.
+        """Convert scope to a query condition on AssociationScopesEntitiesRow.
 
-        This will be used in a JOIN query with GroupRow.
+        This will be used in a JOIN query with GroupRow. The caller is
+        responsible for joining ASE with the correct ``scope_type`` and
+        ``entity_type`` filters; this condition only narrows ``entity_id``.
         """
-        user_uuid = self.user_uuid
+        user_uuid_str = str(self.user_uuid)
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return AssocGroupUserRow.user_id == user_uuid
+            return sa.and_(
+                AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.entity_id == user_uuid_str,
+            )
 
         return inner
 

--- a/src/ai/backend/manager/repositories/group/types.py
+++ b/src/ai/backend/manager/repositories/group/types.py
@@ -81,9 +81,10 @@ class UserProjectSearchScope(SearchScope):
     def to_condition(self) -> QueryCondition:
         """Convert scope to a query condition on AssociationScopesEntitiesRow.
 
-        This will be used in a JOIN query with GroupRow. The caller is
-        responsible for joining ASE with the correct ``scope_type`` and
-        ``entity_type`` filters; this condition only narrows ``entity_id``.
+        Used as a WHERE predicate in a JOIN query with GroupRow. Applies the
+        ``scope_type=PROJECT`` / ``entity_type=USER`` filters and narrows
+        ``entity_id`` to this user; the JOIN side may also re-state the
+        scope/entity-type filters for redundancy without affecting results.
         """
         user_uuid_str = str(self.user_uuid)
 

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -1009,12 +1009,16 @@ class UserDBSource:
             )
         )
 
-        current_rows = (
+        current_entity_ids = (
             await session.scalars(
-                sa.select(AssocGroupUserRow.group_id).where(AssocGroupUserRow.user_id == user_uuid)
+                sa.select(AssociationScopesEntitiesRow.scope_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_uuid),
+                )
             )
         ).all()
-        current_project_ids = set(current_rows)
+        current_project_ids = {UUID(sid) for sid in current_entity_ids}
 
         to_remove = current_project_ids - target_project_ids
         to_add = target_project_ids - current_project_ids
@@ -1042,8 +1046,9 @@ class UserDBSource:
         """Add a user to a project within an existing session.
 
         Mirrors GroupDBSource._add_users_to_project_in_session for the
-        single-user case: inserts the business association, creates the RBAC
-        scope binding, and maps the user to the project's member role (only).
+        single-user case: inserts the RBAC scope binding (ASE) via
+        ``RBACScopeBinder`` and maps the user to the project's member role
+        (only).
         """
         project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
         pair = RBACScopeBindingPair(
@@ -1095,8 +1100,8 @@ class UserDBSource:
         """Remove a user from a project within an existing session.
 
         Mirrors GroupDBSource._remove_users_from_project_in_session for the
-        single-user case: deletes the business association, removes the RBAC
-        scope binding, and unmaps the user from any project-scoped roles.
+        single-user case: deletes the RBAC scope binding (ASE) via the
+        unbinder API and unmaps the user from any project-scoped roles.
         """
         unbinder = UserProjectEntityUnbinder(
             user_uuids=[user_uuid],

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -113,7 +113,7 @@ from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
     execute_rbac_scope_entity_unbinder,
 )
 from ai.backend.manager.repositories.base.updater import BulkUpdaterError, Updater, execute_updater
-from ai.backend.manager.repositories.group.creators import AssocGroupUserCreatorSpec
+from ai.backend.manager.repositories.group.creators import ProjectUserMembershipCreatorSpec
 from ai.backend.manager.repositories.group.scope_binders import UserProjectEntityUnbinder
 from ai.backend.manager.repositories.keypair.creators import KeyPairCreatorSpec
 from ai.backend.manager.repositories.keypair.types import UserKeypairSearchScope
@@ -1052,7 +1052,7 @@ class UserDBSource:
         """
         project_scope_ref = RBACElementRef(RBACElementType.PROJECT, str(project_id))
         pair = RBACScopeBindingPair(
-            spec=AssocGroupUserCreatorSpec(user_id=user_uuid, group_id=project_id),
+            spec=ProjectUserMembershipCreatorSpec(user_id=user_uuid, project_id=project_id),
             entity_ref=RBACElementRef(RBACElementType.USER, str(user_uuid)),
             scope_ref=project_scope_ref,
         )

--- a/src/ai/backend/manager/services/group/service.py
+++ b/src/ai/backend/manager/services/group/service.py
@@ -230,7 +230,7 @@ class GroupService:
     ) -> ScopedSearchProjectsActionResult:
         """Search projects a user is member of.
 
-        Filters by association_groups_users table.
+        Filters by association_scopes_entities (PROJECT scope, USER entity).
 
         Args:
             action: SearchProjectsByUserAction with scope and querier.

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -20,6 +20,7 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
+from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
@@ -34,9 +35,11 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
 from ai.backend.manager.data.user.types import UserStatus
-from ai.backend.manager.models.group import association_groups_users
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import keypairs
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
@@ -228,9 +231,12 @@ async def assigned_users(
                 )
             )
             await conn.execute(
-                sa.insert(association_groups_users).values(
-                    group_id=str(group_fixture),
-                    user_id=str(uid),
+                sa.insert(AssociationScopesEntitiesRow).values(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(group_fixture),
+                    entity_type=EntityType.USER,
+                    entity_id=str(uid),
+                    relation_type=RelationType.AUTO,
                 )
             )
             user_ids.append(uid)
@@ -242,8 +248,11 @@ async def assigned_users(
     async with db_engine.begin() as conn:
         for uid in reversed(user_ids):
             await conn.execute(
-                association_groups_users.delete().where(
-                    association_groups_users.c.user_id == str(uid)
+                sa.delete(AssociationScopesEntitiesRow).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(group_fixture),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(uid),
                 )
             )
         for ak in reversed(access_keys):

--- a/tests/component/project/test_project_unassign_users.py
+++ b/tests/component/project/test_project_unassign_users.py
@@ -11,8 +11,11 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.dto.manager.v2.group.request import UnassignUsersFromProjectInput
-from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 
 
 class TestUnassignUsersFromProject:
@@ -36,13 +39,17 @@ class TestUnassignUsersFromProject:
         assert returned_ids == set(assigned_users)
         assert result.failed == []
 
-        # Verify rows removed from association_groups_users
+        # Verify ASE rows removed (PROJECT scope, USER entity)
         async with db_engine.begin() as conn:
             rows = (
                 await conn.execute(
-                    sa.select(AssocGroupUserRow.user_id).where(
-                        (AssocGroupUserRow.group_id == group_fixture)
-                        & (AssocGroupUserRow.user_id.in_(assigned_users))
+                    sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(group_fixture),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id.in_([
+                            str(uid) for uid in assigned_users
+                        ]),
                     )
                 )
             ).all()
@@ -89,13 +96,17 @@ class TestUnassignUsersFromProject:
         assert len(result.failed) == 1
         assert result.failed[0].user_id == fake_id
 
-        # The other assigned users should still be in the association
+        # The other assigned users should still be bound (ASE)
         async with db_engine.begin() as conn:
             remaining = (
                 await conn.execute(
-                    sa.select(AssocGroupUserRow.user_id).where(
-                        (AssocGroupUserRow.group_id == group_fixture)
-                        & (AssocGroupUserRow.user_id.in_(assigned_users[1:]))
+                    sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(group_fixture),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        AssociationScopesEntitiesRow.entity_id.in_([
+                            str(uid) for uid in assigned_users[1:]
+                        ]),
                     )
                 )
             ).all()

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -15,8 +15,7 @@ from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.group import GroupRow, association_groups_users
-from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -73,7 +72,6 @@ class TestAssignUsersToProject:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
-                AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
                 ImageRow,
                 VFolderRow,
@@ -291,11 +289,13 @@ class TestAssignUsersToProject:
         result_uuids = {u.uuid for u in result}
         assert result_uuids == {same_domain_user_1, same_domain_user_2}
 
-        # Verify association rows created
+        # Verify ASE rows created (PROJECT scope, USER entity)
         async with db_with_cleanup.begin_readonly_session() as session:
             assoc_result = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.group_id == test_project
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_project),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                 )
             )
             assert len(assoc_result.fetchall()) == 2
@@ -331,11 +331,13 @@ class TestAssignUsersToProject:
         assert len(result) == 1
         assert result[0].uuid == same_domain_user_2
 
-        # Verify total 2 associations
+        # Verify total 2 ASE associations
         async with db_with_cleanup.begin_readonly_session() as session:
             assoc_result = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.group_id == test_project
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_project),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                 )
             )
             assert len(assoc_result.fetchall()) == 2
@@ -459,7 +461,6 @@ class TestUnassignUsersFromProject:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
-                AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
                 ImageRow,
                 VFolderRow,
@@ -644,33 +645,6 @@ class TestUnassignUsersFromProject:
         return GroupDBSource(db=db_with_cleanup)
 
     # --- Test cases ---
-
-    async def test_unassign_deletes_business_association(
-        self,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        group_db_source: GroupDBSource,
-        project_with_role_registered: uuid.UUID,
-        test_role: uuid.UUID,
-        same_domain_user_1: uuid.UUID,
-    ) -> None:
-        """Unassign removes AssocGroupUserRow records."""
-        project_id = project_with_role_registered
-        await group_db_source.assign_users_to_project(project_id, [same_domain_user_1], test_role)
-
-        result = await group_db_source.unassign_users_from_project(
-            UserProjectEntityUnbinder(user_uuids=[same_domain_user_1], project_id=project_id)
-        )
-        assert len(result.unassigned_users) == 1
-
-        async with db_with_cleanup.begin_readonly_session() as session:
-            assoc_rows = (
-                await session.execute(
-                    sa.select(association_groups_users).where(
-                        association_groups_users.c.group_id == project_id
-                    )
-                )
-            ).fetchall()
-            assert len(assoc_rows) == 0
 
     async def test_unassign_deletes_scope_entity_rows(
         self,

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -44,7 +44,7 @@ from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow, association_groups_users
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -255,7 +255,6 @@ class TestGroupRepository:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
-                AssocGroupUserRow,  # User-Group association table
                 AssociationScopesEntitiesRow,  # RBAC scopes-entities association
                 ImageRow,
                 VFolderRow,
@@ -1019,13 +1018,15 @@ class TestGroupRepository:
 
         async with db_with_cleanup.begin_session() as session:
             assoc_result = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.group_id == test_group
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_group),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                 )
             )
             associations = assoc_result.fetchall()
             assert len(associations) == 2
-            added_user_ids = {a.user_id for a in associations}
+            added_user_ids = {uuid.UUID(a.entity_id) for a in associations}
             assert test_users_for_group[0] in added_user_ids
             assert test_users_for_group[1] in added_user_ids
 
@@ -1101,13 +1102,15 @@ class TestGroupRepository:
 
         async with db_with_cleanup.begin_session() as session:
             assoc_result = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.group_id == test_group
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_group),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                 )
             )
             associations = assoc_result.fetchall()
             assert len(associations) == 2  # 3 added - 1 removed = 2
-            remaining_user_ids = {a.user_id for a in associations}
+            remaining_user_ids = {uuid.UUID(a.entity_id) for a in associations}
             assert test_users_for_group[0] not in remaining_user_ids
             assert test_users_for_group[1] in remaining_user_ids
             assert test_users_for_group[2] in remaining_user_ids

--- a/tests/unit/manager/repositories/group/test_unassign_users_from_project.py
+++ b/tests/unit/manager/repositories/group/test_unassign_users_from_project.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import EntityType, RelationType, ScopeType
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.group.types import ProjectType
@@ -15,7 +16,6 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
-from ai.backend.manager.models.group.row import AssocGroupUserRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -71,7 +71,6 @@ class TestUnassignUsersFromProject:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
-                AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
                 ImageRow,
                 VFolderRow,
@@ -196,7 +195,13 @@ class TestUnassignUsersFromProject:
     ) -> None:
         async with db.begin_session() as session:
             session.add(
-                AssocGroupUserRow(user_id=user_id, group_id=project_id),
+                AssociationScopesEntitiesRow(
+                    scope_type=ScopeType.PROJECT,
+                    scope_id=str(project_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(user_id),
+                    relation_type=RelationType.AUTO,
+                ),
             )
             await session.commit()
 
@@ -251,7 +256,11 @@ class TestUnassignUsersFromProject:
         async with db_with_cleanup.begin_readonly_session() as session:
             remaining = (
                 await session.execute(
-                    sa.select(AssocGroupUserRow).where(AssocGroupUserRow.group_id == test_project)
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(test_project),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    )
                 )
             ).all()
             assert len(remaining) == 0
@@ -282,7 +291,11 @@ class TestUnassignUsersFromProject:
         async with db_with_cleanup.begin_readonly_session() as session:
             remaining = (
                 await session.execute(
-                    sa.select(AssocGroupUserRow).where(AssocGroupUserRow.group_id == test_project)
+                    sa.select(AssociationScopesEntitiesRow).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(test_project),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    )
                 )
             ).all()
             assert len(remaining) == 3

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -19,8 +19,7 @@ from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.group import GroupRow, association_groups_users
-from ai.backend.manager.models.group.row import AssocGroupUserRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -79,7 +78,6 @@ class TestRoleAssignment:
                 UserRow,
                 KeyPairRow,
                 GroupRow,
-                AssocGroupUserRow,
                 AssociationScopesEntitiesRow,
                 ImageRow,
                 VFolderRow,
@@ -324,14 +322,16 @@ class TestRoleAssignment:
         user_1: uuid.UUID,
         test_project: uuid.UUID,
     ) -> None:
-        """bind_user_to_project creates business + RBAC associations."""
+        """bind_user_to_project creates the ASE row (PROJECT/USER)."""
         await group_db_source.bind_user_to_project(user_1, test_project)
 
         async with db_with_cleanup.begin_readonly_session() as session:
             assoc = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.user_id == user_1,
-                    association_groups_users.c.group_id == test_project,
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_project),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_1),
                 )
             )
             assert len(assoc.fetchall()) == 1
@@ -349,9 +349,11 @@ class TestRoleAssignment:
 
         async with db_with_cleanup.begin_readonly_session() as session:
             assoc = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.user_id == user_1,
-                    association_groups_users.c.group_id == test_project,
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_project),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_1),
                 )
             )
             assert len(assoc.fetchall()) == 1
@@ -363,14 +365,16 @@ class TestRoleAssignment:
         user_1: uuid.UUID,
         test_project: uuid.UUID,
     ) -> None:
-        """unbind_user_from_project removes business + RBAC associations."""
+        """unbind_user_from_project removes the ASE row."""
         await group_db_source.bind_user_to_project(user_1, test_project)
         await group_db_source.unbind_user_from_project(user_1, test_project)
 
         async with db_with_cleanup.begin_readonly_session() as session:
             assoc = await session.execute(
-                sa.select(association_groups_users).where(
-                    association_groups_users.c.group_id == test_project,
+                sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(test_project),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                 )
             )
             assert len(assoc.fetchall()) == 0

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -763,9 +763,9 @@ class TestUserRepository:
         sample_group_id: str,
     ) -> None:
         """Assigning a user to a new project via update_user_validated must
-        produce the same RBAC state as the modifyGroup path: business
-        association, (PROJECT, user) scope binding, and a user-role mapping
-        to the project member role (not the admin role).
+        produce the same RBAC state as the modifyGroup path: a (PROJECT, user)
+        scope binding and a user-role mapping to the project member role
+        (not the admin role).
         """
         updater_spec = UserUpdaterSpec(
             group_ids=OptionalState.update([sample_group_id]),
@@ -784,14 +784,6 @@ class TestUserRepository:
                 sa.select(UserRow.uuid).where(UserRow.email == sample_user_email)
             )
             assert user_uuid is not None
-
-            business_assoc = await session.scalar(
-                sa.select(AssocGroupUserRow).where(
-                    AssocGroupUserRow.user_id == user_uuid,
-                    AssocGroupUserRow.group_id == project_id,
-                )
-            )
-            assert business_assoc is not None
 
             scope_binding = await session.scalar(
                 sa.select(AssociationScopesEntitiesRow).where(
@@ -870,16 +862,6 @@ class TestUserRepository:
                 sa.select(UserRow.uuid).where(UserRow.email == sample_user_email)
             )
             assert user_uuid is not None
-
-            business_assocs = (
-                await session.scalars(
-                    sa.select(AssocGroupUserRow).where(
-                        AssocGroupUserRow.user_id == user_uuid,
-                        AssocGroupUserRow.group_id == project_id,
-                    )
-                )
-            ).all()
-            assert len(business_assocs) == 0
 
             scope_bindings = (
                 await session.scalars(


### PR DESCRIPTION
## Summary
- Switches all group-domain reads/writes off the legacy `association_groups_users` table to `association_scopes_entities` (PROJECT scope, USER entity).
- Reads use cast-safe `LEFT JOIN` predicates (`sa.cast(uuid, sa.String) == ase.entity_id`) per the BA-5877 cast-safety guidance; writes keep the `RBACScopeBinder` / `RBACScopeEntityUnbinder` symmetry, with the spec/purger retyped to ASE.
- Mirrors the change in `repositories/user/db_source` (`_add/_remove_user_to_project_in_session`, `_sync_user_groups`) so the user repo doesn't drift from the group repo's source-of-truth.

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main`
- [x] `tests/unit/manager/repositories/group/{test_assign_users_to_project,test_unassign_users_from_project,test_group_repository,test_group_db_source,test_group_purgers}.py`
- [x] `tests/unit/manager/repositories/user/{test_user_repository,test_user_purgers,test_user_updaters}.py`
- [x] `tests/unit/manager/repositories/permission_controller/test_role_assignment.py`
- [x] `tests/component/project/test_project_unassign_users.py`
- [x] `tests/component/model_card/{test_model_card_project_assign,test_model_card_role_assign}.py` (reference component tests)
- [x] CI `pants check` / full `pants test`

Resolves BA-5877

🤖 Generated with [Claude Code](https://claude.com/claude-code)