### PR TITLE
fix: reject negative resource slot quantity

### DIFF
--- a/changes/11365.fix.md
+++ b/changes/11365.fix.md
@@ -1,0 +1,1 @@
+Reject negative resource slot quantities at `ResourceSlot._normalize_value` so that requests like `cpu: -1` fail fast with HTTP 400 (`InvalidResourceSlotQuantity`) at the API boundary instead of being deferred to the scheduler.

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -443,6 +443,18 @@ class InvalidAPIParameters(BackendAIError, web.HTTPBadRequest):
         )
 
 
+class InvalidResourceSlotQuantity(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/invalid-resource-slot-quantity"
+    error_title = "Invalid resource slot quantity."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.BACKENDAI,
+            operation=ErrorOperation.PARSING,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
 class ResourcePresetConflict(BackendAIError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-resource"
     error_title = "Duplicate Resource Preset"

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -53,7 +53,11 @@ from pydantic import (
 from redis.asyncio import Redis
 
 from .defs import UNKNOWN_CONTAINER_ID, RedisRole
-from .exception import GenericNotImplementedError, InvalidIpAddressValue
+from .exception import (
+    GenericNotImplementedError,
+    InvalidIpAddressValue,
+    InvalidResourceSlotQuantity,
+)
 
 # Deprecated re-export: new code should import ``ImageID`` from
 # ``ai.backend.common.identifier.image``. This line lets existing
@@ -1131,10 +1135,11 @@ class ResourceSlot(UserDict[str, Decimal]):
         try:
             if unit == SlotTypes.BYTES:
                 if isinstance(value, Decimal):
-                    return value
-                if isinstance(value, (int, float)):
-                    return Decimal(value)
-                value = Decimal(BinarySize.from_str(value))
+                    pass
+                elif isinstance(value, (int, float)):
+                    value = Decimal(value)
+                else:
+                    value = Decimal(BinarySize.from_str(value))
             else:
                 value = Decimal(value)
                 if value.is_finite():
@@ -1144,6 +1149,8 @@ class ResourceSlot(UserDict[str, Decimal]):
             ValueError,  # catch wrapped errors from BinarySize.from_str()
         ) as e:
             raise ValueError(f"Cannot convert the slot {key!r} to decimal: {value!r}") from e
+        if value.is_finite() and value < 0:
+            raise InvalidResourceSlotQuantity(f"Resource slot {key!r} cannot be negative: {value}")
         return value
 
     @classmethod

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 from typeguard import TypeCheckError
 
+from ai.backend.common.exception import InvalidResourceSlotQuantity
 from ai.backend.common.types import (
     BinarySize,
     DefaultForUnspecified,
@@ -312,6 +313,28 @@ def test_resource_slot_parsing_typeless_user_input_serialize_again_2() -> None:
                 SlotName("mem"): SlotTypes("bytes"),
                 # missing "shmem": should raise an unknown slot error
             },
+        )
+
+
+def test_resource_slot_rejects_negative_count() -> None:
+    with pytest.raises(InvalidResourceSlotQuantity, match="cannot be negative"):
+        ResourceSlot.from_user_input({"cpu": "-1"}, None)
+    with pytest.raises(InvalidResourceSlotQuantity, match="cannot be negative"):
+        ResourceSlot.from_user_input({"cpu": -1}, None)
+
+
+def test_resource_slot_rejects_negative_bytes() -> None:
+    with pytest.raises(InvalidResourceSlotQuantity, match="cannot be negative"):
+        ResourceSlot.from_user_input({"mem": Decimal(-1)}, None)
+    with pytest.raises(InvalidResourceSlotQuantity, match="cannot be negative"):
+        ResourceSlot.from_user_input({"mem": -1}, None)
+
+
+def test_resource_slot_rejects_negative_with_typed_slots() -> None:
+    with pytest.raises(InvalidResourceSlotQuantity, match="cannot be negative"):
+        ResourceSlot.from_user_input(
+            {"cpu": "-2"},
+            {SlotName("cpu"): SlotTypes("count")},
         )
 
 


### PR DESCRIPTION
## Summary
- Negative values for resource slots (e.g. `cpu: -1`) previously slipped past `ResourceSlot.from_user_input` / `from_policy` and were only rejected by the scheduler later in the pipeline.
- Add a finite-negative guard to `ResourceSlot._normalize_value` so the API boundary fails fast with HTTP 400 via the new `InvalidResourceSlotQuantity` exception (`BackendAIError` + `web.HTTPBadRequest`).
- `inf` ("unlimited") semantics preserved by gating the check on `is_finite()`.

## Test plan
- [x] `pants test tests/unit/common/test_types.py` (added 3 negative-rejection tests)
- [x] `pants test --changed-since=HEAD --changed-dependents=transitive` (all dependent tests pass)
- [x] `pants fmt / lint / check` clean
- [ ] Manually verify v2 deployment / legacy service create with `cpu: -1` returns HTTP 400 instead of being scheduled