### PR TITLE
fix(BA-5880): backfill association_scopes_entities rows in seed JSON fixtures

### DIFF
--- a/changes/11368.fix.md
+++ b/changes/11368.fix.md
@@ -1,0 +1,1 @@
+Fix superadmin session creation in `model-store` after the RBAC scope-binding migration by backfilling `association_scopes_entities` rows in seed fixtures.

--- a/fixtures/manager/example-users.json
+++ b/fixtures/manager/example-users.json
@@ -189,5 +189,77 @@
             "group_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "user_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6"
         }
+    ],
+    "association_scopes_entities": [
+        {
+            "scope_type": "project",
+            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
+            "entity_type": "user",
+            "entity_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
+            "entity_type": "user",
+            "entity_id": "4f13d193-f646-425a-a340-270c4d2b9860",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
+            "entity_type": "user",
+            "entity_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
+            "entity_type": "user",
+            "entity_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
+            "entity_type": "user",
+            "entity_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
+            "entity_type": "user",
+            "entity_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
+            "entity_type": "user",
+            "entity_id": "4f13d193-f646-425a-a340-270c4d2b9860",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
+            "entity_type": "user",
+            "entity_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
+            "entity_type": "user",
+            "entity_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
+            "relation_type": "auto"
+        },
+        {
+            "scope_type": "project",
+            "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
+            "entity_type": "user",
+            "entity_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
+            "relation_type": "auto"
+        }
     ]
 }


### PR DESCRIPTION
## Summary

- After BA-5818, `query_userinfo()` reads project membership from `association_scopes_entities` (ASE) instead of `association_groups_users` (agus); seed-installed users were missing the corresponding ASE rows, so superadmin/monitor failed to create sessions in `model-store` with `Invalid group ... user is not a member`.
- `fixtures/manager/example-users.json`: add 10 ASE rows (`relation_type=auto`) mirroring every `(user_id, group_id)` entry in `association_groups_users` 1:1.
- `fixtures/manager/example-roles.json`: drop 6 stale PROJECT→USER rows with `relation_type=ref`; they overlapped with the new `auto` rows (loaded later, so `ON CONFLICT DO NOTHING` would skip them anyway) and disagreed with the BA-5684 migration semantics.

## Test plan

- [x] Fresh DB: `./bai mgr fixture populate fixtures/manager/example-users.json` then `example-roles.json` succeed without conflict.
- [x] `SELECT count(*) FROM association_scopes_entities WHERE scope_type='project' AND entity_type='user'` matches `SELECT count(*) FROM association_groups_users` (10 vs 10) on a clean install.
- [x] As `admin@lablup.com` (superadmin), creating a session in the `model-store` project no longer raises `Invalid group (model-store): the group does not exist, is inactive, or the user is not a member.`

Resolves BA-5880

🤖 Generated with [Claude Code](https://claude.com/claude-code)