### PR TITLE
fix: delete endpoint access tokens when destroying a deployment

### DIFF
--- a/changes/11369.fix.md
+++ b/changes/11369.fix.md
@@ -1,0 +1,1 @@
+Wipe a deployment's access tokens (`endpoint_tokens`) in the same transaction that flips the endpoint to `DESTROYING`, so destroyed deployments no longer leave behind never-expiring token rows that were still resolvable through direct lookups.

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -621,7 +621,13 @@ class DeploymentDBSource:
         endpoint_id: uuid.UUID,
         lifecycle: EndpointLifecycle,
     ) -> bool:
-        """Update endpoint lifecycle status."""
+        """Update endpoint lifecycle status.
+
+        Transitioning to ``DESTROYING`` also wipes any access tokens
+        bound to the endpoint in the same transaction, so a destroyed
+        deployment cannot be re-authenticated against once the routes
+        are torn down.
+        """
         async with self._begin_session_read_committed() as db_sess:
             query = (
                 sa.update(EndpointRow)
@@ -629,7 +635,12 @@ class DeploymentDBSource:
                 .values(lifecycle_stage=lifecycle)
             )
             result = await db_sess.execute(query)
-            return cast(CursorResult[Any], result).rowcount > 0
+            updated = cast(CursorResult[Any], result).rowcount > 0
+            if updated and lifecycle == EndpointLifecycle.DESTROYING:
+                await db_sess.execute(
+                    sa.delete(EndpointTokenRow).where(EndpointTokenRow.endpoint == endpoint_id)
+                )
+            return updated
 
     async def get_modified_endpoint(
         self,

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -61,7 +61,7 @@ from ai.backend.manager.models.deployment_policy import (
 )
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.domain import DomainRow
-from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
@@ -3548,6 +3548,7 @@ class TestDeploymentRepositoryDuplicateName:
                 ImageRow,
                 ResourceSlotTypeRow,
                 EndpointRow,
+                EndpointTokenRow,
                 RuntimeVariantRow,
                 DeploymentRevisionRow,
                 DeploymentRevisionResourceSlotRow,
@@ -3957,3 +3958,109 @@ class TestDeploymentRepositoryDuplicateName:
                 )
             ).scalar_one()
             assert target_stage == EndpointLifecycle.DESTROYING
+
+    async def test_destroy_endpoint_deletes_associated_tokens(
+        self,
+        deployment_repository: DeploymentRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_group: GroupRow,
+        test_scaling_group: ScalingGroupRow,
+    ) -> None:
+        """Destroying an endpoint also wipes its access tokens in the same
+        transaction so the destroyed endpoint cannot be re-authenticated.
+        Tokens for unrelated endpoints are left untouched."""
+        endpoint_id = DeploymentID(uuid.uuid4())
+        sibling_id = DeploymentID(uuid.uuid4())
+        user_id = uuid.uuid4()
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add_all([
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"with-tokens-{uuid.uuid4().hex[:8]}",
+                    created_user=user_id,
+                    session_owner=user_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    resource_group=test_scaling_group.name,
+                    replicas=1,
+                    desired_replicas=1,
+                    url=None,
+                    open_to_public=False,
+                    lifecycle_stage=EndpointLifecycle.CREATED,
+                ),
+                EndpointRow(
+                    id=sibling_id,
+                    name=f"sibling-{uuid.uuid4().hex[:8]}",
+                    created_user=user_id,
+                    session_owner=user_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    resource_group=test_scaling_group.name,
+                    replicas=1,
+                    desired_replicas=1,
+                    url=None,
+                    open_to_public=False,
+                    lifecycle_stage=EndpointLifecycle.CREATED,
+                ),
+            ])
+            target_token_ids = [uuid.uuid4(), uuid.uuid4()]
+            sibling_token_id = uuid.uuid4()
+            db_sess.add_all([
+                EndpointTokenRow(
+                    id=target_token_ids[0],
+                    token=f"tok-{uuid.uuid4().hex}",
+                    endpoint=endpoint_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    session_owner=user_id,
+                ),
+                EndpointTokenRow(
+                    id=target_token_ids[1],
+                    token=f"tok-{uuid.uuid4().hex}",
+                    endpoint=endpoint_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    session_owner=user_id,
+                ),
+                EndpointTokenRow(
+                    id=sibling_token_id,
+                    token=f"tok-{uuid.uuid4().hex}",
+                    endpoint=sibling_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    session_owner=user_id,
+                ),
+            ])
+            await db_sess.commit()
+
+        succeeded = await deployment_repository.destroy_endpoint(endpoint_id)
+        assert succeeded is True
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            remaining_target_tokens = (
+                (
+                    await db_sess.execute(
+                        sa.select(EndpointTokenRow.id).where(
+                            EndpointTokenRow.endpoint == endpoint_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert remaining_target_tokens == []
+
+            remaining_sibling_tokens = (
+                (
+                    await db_sess.execute(
+                        sa.select(EndpointTokenRow.id).where(
+                            EndpointTokenRow.endpoint == sibling_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert set(remaining_sibling_tokens) == {sibling_token_id}


### PR DESCRIPTION
## Summary
- Destroying a deployment used to flip the endpoint to ``DESTROYING`` but leave every ``endpoint_tokens`` row behind, typically with ``expires_at = NULL`` (never-expires). Tokens for a destroyed deployment then remained resolvable by anything that looked them up directly.
- Wipe the deployment's access tokens in the same transaction as the lifecycle transition inside ``DeploymentDBSource.update_endpoint_lifecycle``, so the single path that puts an endpoint into ``DESTROYING`` also clears its tokens atomically.
- Tokens for unrelated endpoints are untouched.

## Test plan
- [x] New unit test `test_destroy_endpoint_deletes_associated_tokens` (real DB) verifies target tokens are gone and a sibling endpoint's tokens survive
- [x] Existing `test_destroy_endpoint_with_destroying_sibling_does_not_conflict` still passes
- [x] `pants test --changed-since=origin/main --changed-dependents=transitive` (all pass)
- [x] `pants fmt / lint / check` clean
- [ ] Manually verify via `./bai deployment destroy <id>` that ``endpoint_tokens`` rows for that endpoint are gone afterwards

## Note
- ``update_endpoint_lifecycle_bulk`` and ``update_endpoint_lifecycle_bulk_with_history`` are intentionally **not** changed in this PR. Those bulk paths transition between non-DESTROYING states (e.g. DESTROYING → DESTROYED, history-driven recoveries); the user-initiated Destroy is the only entry point that puts an endpoint into ``DESTROYING`` and so is the only one that needs to drop tokens.