### PR TITLE
fix: evict orphan-revision routes through RouteEvictionHandler

### DIFF
--- a/changes/11370.fix.md
+++ b/changes/11370.fix.md
@@ -1,0 +1,1 @@
+Evict orphan-revision routes (active routes whose `revision_id` is neither the endpoint's `current_revision` nor its `deploying_revision`) through `RouteEvictionHandler` alongside the existing scaling-group health-policy eviction, so a preempted rollout no longer leaves behind PROVISIONING / RUNNING routes pointing at a stale revision.

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -20,6 +20,7 @@ from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.types import (
 from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.service_discovery import ServiceDiscovery
 from ai.backend.common.service_discovery.service_discovery import ModelServiceMetadata
 from ai.backend.common.types import SessionId
@@ -598,11 +599,15 @@ class RouteExecutor:
 
     async def cleanup_routes_by_config(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
         """
-        Filter routes for cleanup based on scaling group configuration.
+        Filter routes that should be terminated.
 
-        Checks if each route's status (unhealthy/degraded) is in the scaling group's
-        cleanup_target_statuses. Routes that should be cleaned up are returned as successes,
-        others are filtered out.
+        A route is flagged when at least one of the following holds:
+
+        - **Orphan revision**: ``route.revision_id`` matches neither the
+          endpoint's ``current_revision_id`` nor its ``deploying_revision_id``.
+          Catches leftovers from a preempted rollout.
+        - **Health policy**: ``route.health_status`` is listed in the
+          scaling group's ``cleanup_target_statuses`` (default: UNHEALTHY).
 
         Args:
             routes: Routes to check for cleanup eligibility
@@ -629,18 +634,27 @@ class RouteExecutor:
 
         # Create mapping of deployment_id -> cleanup config (no phase - transformation only)
         deployment_cleanup_config: dict[DeploymentID, set[RouteHealthStatus]] = {}
+        deployment_valid_revisions: dict[DeploymentID, set[DeploymentRevisionID]] = {}
         for deployment in deployments:
             config = cleanup_configs.get(deployment.metadata.resource_group, None)
             if config:
                 deployment_cleanup_config[deployment.id] = set(config.cleanup_target_statuses)
             else:
                 deployment_cleanup_config[deployment.id] = set()
+            valid_revisions: set[DeploymentRevisionID] = set()
+            if deployment.current_revision_id is not None:
+                valid_revisions.add(deployment.current_revision_id)
+            if deployment.deploying_revision_id is not None:
+                valid_revisions.add(deployment.deploying_revision_id)
+            deployment_valid_revisions[deployment.id] = valid_revisions
 
         successes: list[RouteData] = []
 
         # Phase 2: Identify cleanup targets (per-route)
         for route in routes:
-            should_cleanup = self._check_route_cleanup_eligibility(route, deployment_cleanup_config)
+            should_cleanup = self._check_route_cleanup_eligibility(
+                route, deployment_cleanup_config, deployment_valid_revisions
+            )
             if should_cleanup:
                 successes.append(route)
                 log.info(
@@ -725,12 +739,28 @@ class RouteExecutor:
         self,
         route: RouteData,
         deployment_cleanup_config: Mapping[DeploymentID, set[RouteHealthStatus]],
+        deployment_valid_revisions: Mapping[DeploymentID, set[DeploymentRevisionID]],
     ) -> bool:
-        """Check if route should be cleaned up based on cleanup config."""
+        """Return True if the route should be evicted.
+
+        Checked reasons (OR-combined):
+
+        1. Orphan revision: ``route.revision_id`` is not the endpoint's
+           current or deploying revision. The check is skipped when the
+           endpoint has no revisions known yet (transient bootstrap state)
+           to avoid wiping freshly-created routes.
+        2. Scaling-group health policy: ``route.health_status`` is in
+           ``cleanup_target_statuses`` for the route's scaling group.
+        """
         pool = RouteRecorderContext.current_pool()
         recorder = pool.recorder(route.route_id)
 
         with recorder.phase("identify_cleanup_target"):
+            with recorder.step("check_orphan_revision"):
+                valid_revisions = deployment_valid_revisions.get(route.deployment_id, set())
+                if valid_revisions and route.revision_id not in valid_revisions:
+                    return True
+
             with recorder.step("check_cleanup_eligibility"):
                 cleanup_targets = deployment_cleanup_config.get(route.deployment_id, set())
                 return route.health_status in cleanup_targets

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/route_eviction.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/route_eviction.py
@@ -25,10 +25,16 @@ log = BraceStyleAdapter(logging.getLogger(__name__))
 
 class RouteEvictionHandler(RouteHandler):
     """
-    Handler for evicting unhealthy routes based on scaling group configuration.
+    Handler for evicting routes that are no longer needed.
 
-    This handler checks routes in UNHEALTHY state and marks them for
-    termination if their status is in the scaling group's cleanup_target_statuses.
+    Two eviction reasons are checked together:
+
+    - **Health-based**: a RUNNING route whose health status is listed in
+      the scaling group's ``cleanup_target_statuses`` (default: UNHEALTHY).
+    - **Orphan revision**: an active (PROVISIONING / RUNNING) route whose
+      ``revision_id`` belongs to neither the endpoint's ``current_revision``
+      nor its ``deploying_revision``. This catches leftovers from a
+      preempted rollout, regardless of endpoint lifecycle.
     """
 
     def __init__(
@@ -55,9 +61,13 @@ class RouteEvictionHandler(RouteHandler):
 
     @classmethod
     def target_statuses(cls) -> RouteTargetStatuses:
+        # The handler runs over every active route (PROVISIONING / RUNNING)
+        # regardless of health, because the orphan-revision check applies
+        # to both lifecycle states. The scaling-group health policy still
+        # filters to UNHEALTHY internally inside the executor.
         return RouteTargetStatuses(
-            lifecycle=[RouteStatus.RUNNING],
-            health=[RouteHealthStatus.UNHEALTHY],
+            lifecycle=[RouteStatus.PROVISIONING, RouteStatus.RUNNING],
+            health=list(RouteHealthStatus),
         )
 
     @classmethod
@@ -71,10 +81,10 @@ class RouteEvictionHandler(RouteHandler):
 
     async def execute(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
         """
-        Execute eviction for unhealthy routes based on scaling group configuration.
+        Execute eviction for routes flagged by either eviction reason.
 
-        For each route, checks if its endpoint's scaling group has the route's current status
-        in cleanup_target_statuses. If so, marks the route for termination.
+        Delegates to the executor, which combines the orphan-revision
+        check with the scaling-group health policy in a single pass.
         """
         log.debug("Checking {} routes for eviction", len(routes))
 

--- a/tests/unit/manager/sokovan/deployment/route/executor/conftest.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/conftest.py
@@ -183,6 +183,7 @@ def _create_route_data(
     session_id: SessionId | None = None,
     status: RouteStatus = RouteStatus.PROVISIONING,
     health_status: RouteHealthStatus = RouteHealthStatus.NOT_CHECKED,
+    revision_id: DeploymentRevisionID | None = None,
 ) -> RouteData:
     """Create RouteData for tests."""
     return RouteData(
@@ -193,7 +194,7 @@ def _create_route_data(
         health_status=health_status,
         traffic_ratio=1.0,
         created_at=datetime.now(tzutc()),
-        revision_id=DeploymentRevisionID(uuid4()),
+        revision_id=revision_id or DeploymentRevisionID(uuid4()),
     )
 
 

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
@@ -490,6 +490,8 @@ class TestCleanupRoutesByConfig:
         deployment.id = unhealthy_route.deployment_id
         deployment.metadata = MagicMock()
         deployment.metadata.resource_group = "default"
+        deployment.current_revision_id = unhealthy_route.revision_id
+        deployment.deploying_revision_id = None
         mock_deployment_repo.get_deployments_by_ids.return_value = [deployment]
         mock_deployment_repo.get_scaling_group_cleanup_configs.return_value = {
             "default": cleanup_config_unhealthy_only
@@ -521,6 +523,8 @@ class TestCleanupRoutesByConfig:
         deployment.id = healthy_route.deployment_id
         deployment.metadata = MagicMock()
         deployment.metadata.resource_group = "default"
+        deployment.current_revision_id = healthy_route.revision_id
+        deployment.deploying_revision_id = None
         mock_deployment_repo.get_deployments_by_ids.return_value = [deployment]
         mock_deployment_repo.get_scaling_group_cleanup_configs.return_value = {
             "default": cleanup_config_unhealthy_only
@@ -550,6 +554,137 @@ class TestCleanupRoutesByConfig:
         # Assert
         assert len(result.successes) == 0
         assert len(result.errors) == 0
+
+    async def test_orphan_revision_route_marked_for_cleanup(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        cleanup_config_unhealthy_only: MagicMock,
+    ) -> None:
+        """RE-004: Route whose revision is neither current nor deploying is evicted.
+
+        Given: HEALTHY RUNNING route whose revision_id matches neither
+            ``current_revision_id`` nor ``deploying_revision_id`` of its
+            endpoint (e.g. leftover from a preempted rollout)
+        When: Cleanup routes by config
+        Then: Route is in successes (orphan eviction), independent of
+            the scaling group's health policy.
+        """
+        deployment_id = DeploymentID(uuid4())
+        current_revision_id = DeploymentRevisionID(uuid4())
+        deploying_revision_id = DeploymentRevisionID(uuid4())
+        orphan_route = RouteData(
+            route_id=uuid4(),
+            deployment_id=deployment_id,
+            session_id=SessionId(uuid4()),
+            status=RouteStatus.RUNNING,
+            health_status=RouteHealthStatus.HEALTHY,
+            traffic_ratio=1.0,
+            created_at=datetime.now(tzutc()),
+            revision_id=DeploymentRevisionID(uuid4()),  # neither current nor deploying
+        )
+
+        deployment = MagicMock()
+        deployment.id = deployment_id
+        deployment.metadata = MagicMock()
+        deployment.metadata.resource_group = "default"
+        deployment.current_revision_id = current_revision_id
+        deployment.deploying_revision_id = deploying_revision_id
+        mock_deployment_repo.get_deployments_by_ids.return_value = [deployment]
+        mock_deployment_repo.get_scaling_group_cleanup_configs.return_value = {
+            "default": cleanup_config_unhealthy_only
+        }
+
+        with RouteRecorderContext.scope("test", entity_ids=[orphan_route.route_id]):
+            result = await route_executor.cleanup_routes_by_config([orphan_route])
+
+        assert len(result.successes) == 1
+        assert result.successes[0].route_id == orphan_route.route_id
+
+    async def test_provisioning_route_for_deploying_revision_kept(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        cleanup_config_unhealthy_only: MagicMock,
+    ) -> None:
+        """RE-005: PROVISIONING route on the deploying revision is not orphan.
+
+        Given: PROVISIONING route whose ``revision_id`` matches the
+            endpoint's ``deploying_revision_id`` (active rollout)
+        When: Cleanup routes by config
+        Then: Route is not flagged — neither orphan nor health-policy match.
+        """
+        deployment_id = DeploymentID(uuid4())
+        deploying_revision_id = DeploymentRevisionID(uuid4())
+        provisioning_route = RouteData(
+            route_id=uuid4(),
+            deployment_id=deployment_id,
+            session_id=None,
+            status=RouteStatus.PROVISIONING,
+            health_status=RouteHealthStatus.NOT_CHECKED,
+            traffic_ratio=1.0,
+            created_at=datetime.now(tzutc()),
+            revision_id=deploying_revision_id,
+        )
+
+        deployment = MagicMock()
+        deployment.id = deployment_id
+        deployment.metadata = MagicMock()
+        deployment.metadata.resource_group = "default"
+        deployment.current_revision_id = None
+        deployment.deploying_revision_id = deploying_revision_id
+        mock_deployment_repo.get_deployments_by_ids.return_value = [deployment]
+        mock_deployment_repo.get_scaling_group_cleanup_configs.return_value = {
+            "default": cleanup_config_unhealthy_only
+        }
+
+        with RouteRecorderContext.scope("test", entity_ids=[provisioning_route.route_id]):
+            result = await route_executor.cleanup_routes_by_config([provisioning_route])
+
+        assert len(result.successes) == 0
+
+    async def test_orphan_check_skipped_when_no_known_revisions(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        cleanup_config_unhealthy_only: MagicMock,
+    ) -> None:
+        """RE-006: Endpoint with no current/deploying revisions skips orphan check.
+
+        Given: An endpoint that has no ``current_revision_id`` and no
+            ``deploying_revision_id`` yet (transient bootstrap state)
+            with a HEALTHY RUNNING route attached
+        When: Cleanup routes by config
+        Then: The route is not evicted — the orphan check needs at least
+            one known valid revision before it can declare orphans.
+        """
+        deployment_id = DeploymentID(uuid4())
+        bootstrap_route = RouteData(
+            route_id=uuid4(),
+            deployment_id=deployment_id,
+            session_id=SessionId(uuid4()),
+            status=RouteStatus.RUNNING,
+            health_status=RouteHealthStatus.HEALTHY,
+            traffic_ratio=1.0,
+            created_at=datetime.now(tzutc()),
+            revision_id=DeploymentRevisionID(uuid4()),
+        )
+
+        deployment = MagicMock()
+        deployment.id = deployment_id
+        deployment.metadata = MagicMock()
+        deployment.metadata.resource_group = "default"
+        deployment.current_revision_id = None
+        deployment.deploying_revision_id = None
+        mock_deployment_repo.get_deployments_by_ids.return_value = [deployment]
+        mock_deployment_repo.get_scaling_group_cleanup_configs.return_value = {
+            "default": cleanup_config_unhealthy_only
+        }
+
+        with RouteRecorderContext.scope("test", entity_ids=[bootstrap_route.route_id]):
+            result = await route_executor.cleanup_routes_by_config([bootstrap_route])
+
+        assert len(result.successes) == 0
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- ``RouteEvictionHandler`` previously fired only on RUNNING routes whose health was flagged by the scaling group's ``cleanup_target_statuses`` (default UNHEALTHY). Active routes whose ``revision_id`` matched neither the endpoint's ``current_revision`` nor its ``deploying_revision`` (e.g. leftovers from a preempted rollout) were never cleaned up.
- Broaden the handler's target to every active route (``lifecycle=[PROVISIONING, RUNNING]``, all health statuses) and combine two eviction reasons inside ``RouteExecutor.cleanup_routes_by_config``:
  1. **Orphan revision**: ``route.revision_id`` is not the endpoint's current or deploying revision. Skipped when the endpoint has no revisions known yet (bootstrap state) so freshly created routes are not wiped.
  2. **Existing scaling-group health policy**: route's ``health_status`` is in the resource group's ``cleanup_target_statuses``.
- A route matched by either reason is marked TERMINATING — same outgoing behaviour as before.

## Test plan
- [x] New unit tests:
  - ``test_orphan_revision_route_marked_for_cleanup`` — preempted leftover gets evicted regardless of health
  - ``test_provisioning_route_for_deploying_revision_kept`` — active rollout PROVISIONING route is kept
  - ``test_orphan_check_skipped_when_no_known_revisions`` — bootstrap endpoint without current/deploying never wipes routes
- [x] Existing ``RE-001 / RE-002 / RE-003`` continue to pass (now explicitly stub ``current_revision_id``)
- [x] ``pants test --changed-since=origin/main --changed-dependents=transitive`` (all pass)
- [x] ``pants fmt / lint / check`` clean

## Note
- History ``from_status`` is recorded as the first lifecycle in ``target.lifecycle`` (PROVISIONING after this change). Cosmetic limitation — the actual UPDATE is still gated by ``RouteConditions.by_lifecycle_statuses(target.lifecycle)`` so routes only transition out of their real prior status. Worth a follow-up if richer history matters.
- Sets up the ground for the next PR (issue #2: allow ``set_deploying_revision`` to override an active deploying revision) — orphan leftovers will be picked up by this handler in the very next route-handler tick.