### PR TITLE
fix: allow re-activating a revision while another rollout is in progress

### DIFF
--- a/changes/11371.fix.md
+++ b/changes/11371.fix.md
@@ -1,0 +1,1 @@
+Allow re-activating a deployment revision while another rollout is still in progress: `set_deploying_revision` now overrides any in-flight `deploying_revision` and `activate_revision` no longer raises `DeploymentAlreadyInProgress`. Routes belonging to the preempted rollout are cleaned up on the next route tick by `RouteEvictionHandler`'s orphan-revision branch.

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -2684,20 +2684,18 @@ class DeploymentDBSource:
     ) -> tuple[uuid.UUID | None, bool]:
         """Set deploying_revision and transition lifecycle to DEPLOYING.
 
-        Uses ``deploying_revision IS NULL`` as an atomic guard against
-        concurrent activations.
+        Overrides any previous ``deploying_revision`` unconditionally;
+        leftover routes from the previous rollout are picked up by
+        ``RouteEvictionHandler``'s orphan-revision branch.
 
         Returns:
             Tuple of (previous_current_revision_id, updated).
-            ``updated=False`` means the guard fired (another deployment in progress).
+            ``updated=False`` means the endpoint row was not found.
         """
         async with self._begin_session_read_committed() as db_sess:
             update_query = (
                 sa.update(EndpointRow)
-                .where(
-                    EndpointRow.id == endpoint_id,
-                    EndpointRow.deploying_revision.is_(None),
-                )
+                .where(EndpointRow.id == endpoint_id)
                 .values(
                     deploying_revision=revision_id,
                     lifecycle_stage=EndpointLifecycle.DEPLOYING,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -1311,12 +1311,13 @@ class DeploymentRepository:
     ) -> tuple[uuid.UUID | None, bool]:
         """Set deploying_revision and transition lifecycle to DEPLOYING.
 
-        Uses ``deploying_revision IS NULL`` as an atomic guard against
-        concurrent activations.
+        Overrides any previous ``deploying_revision`` unconditionally;
+        leftover routes from the preempted rollout are picked up by
+        ``RouteEvictionHandler``'s orphan-revision branch.
 
         Returns:
             Tuple of (previous_current_revision_id, updated).
-            ``updated=False`` means the guard fired (another deployment in progress).
+            ``updated=False`` means the endpoint row was not found.
         """
         return await self._db_source.set_deploying_revision(endpoint_id, revision_id)
 

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -51,6 +51,7 @@ from ai.backend.manager.data.deployment_revision_preset.types import (
 from ai.backend.manager.data.image.types import ImageIdentifier
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.errors.deployment import EndpointNotFound
 from ai.backend.manager.models.deployment_policy import BlueGreenSpec, RollingUpdateSpec
 from ai.backend.manager.models.deployment_revision_preset.types import PresetValueEntry
 from ai.backend.manager.models.endpoint import EndpointRow
@@ -75,7 +76,6 @@ from ai.backend.manager.repositories.deployment.updaters import (
     RouteUpdaterSpec,
 )
 from ai.backend.manager.sokovan.deployment.exceptions import (
-    DeploymentAlreadyInProgress,
     InvalidEndpointState,
 )
 from ai.backend.manager.sokovan.deployment.revision_draft import RevisionDraftReader
@@ -521,8 +521,12 @@ class DeploymentController:
         update, blue-green, etc.) and swap deploying_revision → current_revision
         on completion.
 
+        If a previous rollout is still in progress, its ``deploying_revision`` is
+        overwritten; routes belonging to the preempted revision are picked up by
+        ``RouteEvictionHandler``'s orphan-revision branch on the next route tick.
+
         Raises:
-            DeploymentAlreadyInProgress: If another revision is currently deploying.
+            EndpointNotFound: If the deployment does not exist.
             InvalidEndpointState: If the revision is already current.
         """
         # 1. Validate revision exists
@@ -530,26 +534,18 @@ class DeploymentController:
 
         # 2. Validate deployment state
         deployment_info = await self._deployment_repository.get_endpoint_info(deployment_id)
-        if deployment_info.deploying_revision_id is not None:
-            raise DeploymentAlreadyInProgress(
-                f"Deployment {deployment_id} already has deploying_revision "
-                f"{deployment_info.deploying_revision_id} in progress."
-            )
         if deployment_info.current_revision_id == revision_id:
             raise InvalidEndpointState(
                 f"Revision {revision_id} is already the current revision "
                 f"of deployment {deployment_id}."
             )
 
-        # 3. Set deploying_revision atomically (WHERE deploying_revision IS NULL)
+        # 3. Set deploying_revision (override any in-flight rollout)
         previous_revision_id, updated = await self._deployment_repository.set_deploying_revision(
             deployment_id, revision_id
         )
         if not updated:
-            raise DeploymentAlreadyInProgress(
-                f"Deployment {deployment_id} already has a deploying revision in progress "
-                f"(concurrent activation detected)."
-            )
+            raise EndpointNotFound(f"Endpoint {deployment_id} not found")
 
         # 4. Trigger DEPLOYING lifecycle
         await self.mark_lifecycle_needed(

--- a/src/ai/backend/manager/sokovan/deployment/exceptions.py
+++ b/src/ai/backend/manager/sokovan/deployment/exceptions.py
@@ -79,17 +79,3 @@ class ServiceInfoRetrievalFailed(DeploymentError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
-
-
-class DeploymentAlreadyInProgress(DeploymentError):
-    """Raised when trying to activate a revision while another deployment is in progress."""
-
-    error_type = "https://api.backend.ai/probs/deployment-already-in-progress"
-    error_title = "Another deployment is already in progress."
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.BAD_REQUEST,
-        )

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -3959,6 +3959,75 @@ class TestDeploymentRepositoryDuplicateName:
             ).scalar_one()
             assert target_stage == EndpointLifecycle.DESTROYING
 
+    async def test_set_deploying_revision_overrides_in_flight(
+        self,
+        deployment_repository: DeploymentRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainRow,
+        test_group: GroupRow,
+        test_scaling_group: ScalingGroupRow,
+    ) -> None:
+        """``set_deploying_revision`` overwrites a non-NULL deploying_revision.
+
+        A previous rollout's ``deploying_revision`` no longer guards
+        against re-activation; orphan routes from the preempted rollout
+        are cleaned up by ``RouteEvictionHandler``'s orphan branch.
+        """
+        endpoint_id = uuid.uuid4()
+        previous_deploying = uuid.uuid4()
+        new_deploying = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                EndpointRow(
+                    id=endpoint_id,
+                    name=f"override-{uuid.uuid4().hex[:8]}",
+                    created_user=user_id,
+                    session_owner=user_id,
+                    domain=test_domain.name,
+                    project=test_group.id,
+                    resource_group=test_scaling_group.name,
+                    replicas=1,
+                    desired_replicas=1,
+                    url=None,
+                    open_to_public=False,
+                    lifecycle_stage=EndpointLifecycle.DEPLOYING,
+                    deploying_revision=previous_deploying,
+                )
+            )
+            await db_sess.commit()
+
+        previous_current, updated = await deployment_repository.set_deploying_revision(
+            endpoint_id, new_deploying
+        )
+
+        assert updated is True
+        assert previous_current is None  # current_revision was not set on this fixture
+
+        async with db_with_cleanup.begin_readonly_session() as db_sess:
+            row = (
+                await db_sess.execute(
+                    sa.select(EndpointRow.deploying_revision, EndpointRow.lifecycle_stage).where(
+                        EndpointRow.id == endpoint_id
+                    )
+                )
+            ).one()
+            assert row.deploying_revision == new_deploying
+            assert row.lifecycle_stage == EndpointLifecycle.DEPLOYING
+
+    async def test_set_deploying_revision_returns_false_for_missing_endpoint(
+        self,
+        deployment_repository: DeploymentRepository,
+    ) -> None:
+        """``set_deploying_revision`` returns updated=False when the endpoint id
+        does not match any row, instead of raising."""
+        previous_current, updated = await deployment_repository.set_deploying_revision(
+            uuid.uuid4(), uuid.uuid4()
+        )
+        assert updated is False
+        assert previous_current is None
+
     async def test_destroy_endpoint_deletes_associated_tokens(
         self,
         deployment_repository: DeploymentRepository,


### PR DESCRIPTION
## Summary
- ``DeploymentController.activate_revision`` previously rejected an activation request whenever ``deploying_revision`` was non-NULL, both via an early ``DeploymentAlreadyInProgress`` raise and via the ``WHERE deploying_revision IS NULL`` guard inside ``set_deploying_revision``. An in-flight rollout (or a stuck one) blocked the operator from rolling forward without manual DB intervention.
- Drop both guards. ``set_deploying_revision`` now overrides ``deploying_revision`` unconditionally; ``updated=False`` collapses to "endpoint row not found" and the controller maps that to ``EndpointNotFound``.
- Leftover routes pointing at the preempted revision are cleaned up on the next route tick by ``RouteEvictionHandler``'s orphan-revision branch ([#11370](https://github.com/lablup/backend.ai/pull/11370)). This PR depends on that orphan eviction landing first to avoid leaving stale routes around when an override happens.
- The ``InvalidEndpointState`` check for "revision is already current" stays — re-activating the live revision remains a no-op.
- ``DeploymentAlreadyInProgress`` is removed since nothing raises it anymore.

## Test plan
- [x] New unit tests:
  - ``test_set_deploying_revision_overrides_in_flight`` — verifies a non-NULL ``deploying_revision`` is overwritten and lifecycle stays DEPLOYING
  - ``test_set_deploying_revision_returns_false_for_missing_endpoint`` — verifies the unknown-endpoint case returns ``updated=False``
- [x] ``pants test --changed-since=origin/main --changed-dependents=transitive`` (all pass)
- [x] ``pants fmt / fix / lint / check`` clean
- [ ] Manual verify: while a deployment is mid-rollout, ``./bai deployment revision activate`` for a different revision succeeds and the previous deploying revision's leftover routes get evicted.

## Note
Order of merge matters: this PR should land **after** [#11370](https://github.com/lablup/backend.ai/pull/11370) (orphan-route eviction). Merging this alone leaves preempted-rollout routes around indefinitely.