### PR TITLE
ci: exclude release-time dockerfiles from OSV-Scanner container matrix

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -48,7 +48,7 @@ jobs:
       id: set-matrix
       run: |
         echo "Scanning all Dockerfiles"
-        DOCKERFILES=$(find docker -type f -name "*.dockerfile")
+        DOCKERFILES=$(find docker -type f -name "*.dockerfile" ! -name "backend.ai-*.dockerfile")
 
         # Build JSON matrix
         MATRIX_JSON=$(echo "$DOCKERFILES" | jq -R -s -c '

--- a/changes/11389.fix.md
+++ b/changes/11389.fix.md
@@ -1,0 +1,1 @@
+Re-enable the OSV-Scanner CI workflow by skipping release-time dockerfiles that require pre-built wheels.


### PR DESCRIPTION
## Summary
- Apply the same `! -name "backend.ai-*.dockerfile"` exclude to `.github/workflows/osv-scanner.yml:51` that `.github/workflows/sbom.yml:40` already uses, so the `scan-containers` matrix stops trying to build release-time dockerfiles that require pre-built wheels (`COPY dist /dist`, `--find-links=/dist`, `PKGVER` build-arg) which CI cannot produce without `pants package`.

## Test plan
- [ ] Trigger the OSV-Scanner workflow on this branch via `workflow_dispatch`
- [ ] Confirm `scan-containers` matrix expands to exactly 3 entries (the non-`backend.ai-*` dockerfiles)
- [ ] Confirm all 3 matrix entries pass
- [ ] Confirm SARIF results upload to the Security tab

Closes #11386
Refs #11379

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>