### PR TITLE
fix(BA-5889): Add default value in mount_destination

### DIFF
--- a/changes/11392.fix.md
+++ b/changes/11392.fix.md
@@ -1,0 +1,1 @@
+Add missing default value to MountInfoEntry.mount_destination to allow construction without the field

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -674,6 +674,7 @@ class MountInfoEntry(BaseModel):
     vfolder_id: VFolderUUID
     mount_destination: str | None = Field(
         validation_alias=AliasChoices("mount_destination", "kernel_path"),
+        default=None,
     )
     mount_perm: MountPermission | None = Field(default=None)
 


### PR DESCRIPTION
resolves #11391 (BA-5889)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [ ] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
