### PR TITLE
fix(BA-5846): write association_scopes_entities for OpenID/SSO group auto-mapping

### DIFF
--- a/changes/11396.fix.md
+++ b/changes/11396.fix.md
@@ -1,0 +1,1 @@
+Write an `association_scopes_entities` row in the OpenID/SSO group auto-mapping flow so SSO-provisioned users can create sessions, deployments, and model-servings in their mapped group after the ASE-only `query_userinfo` migration.

--- a/changes/11396.fix.md
+++ b/changes/11396.fix.md
@@ -1,1 +1,1 @@
-Write an `association_scopes_entities` row in the OpenID/SSO group auto-mapping flow so SSO-provisioned users can create sessions, deployments, and model-servings in their mapped group after the ASE-only `query_userinfo` migration.
+Replace `association_groups_users` reference with the RBAC `association_scopes_entities` table in the OpenID plugin.

--- a/src/ai/backend/manager/plugin/openid/webapp.py
+++ b/src/ai/backend/manager/plugin/openid/webapp.py
@@ -22,13 +22,18 @@ from authlib.common.security import generate_token  # pants: no-infer-dep
 from authlib.integrations.httpx_client import AsyncOAuth2Client  # pants: no-infer-dep
 from authlib.jose import jwt as joseJWT  # pants: no-infer-dep
 from authlib.oidc.core import CodeIDToken  # pants: no-infer-dep
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.types import CORSOptions, WebMiddleware
-from ai.backend.manager.models.group import association_groups_users, groups
+from ai.backend.manager.data.permission.types import EntityType, RelationType, ScopeType
+from ai.backend.manager.models.group import groups
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import KeyPairRow, generate_keypair, generate_ssh_keypair
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.webapp import WebappPlugin
@@ -150,11 +155,17 @@ async def associate_user_with_group(
     )
     group_id = await conn.scalar(query)
     if group_id:
-        query = association_groups_users.insert().values({
-            "user_id": user.uuid,
-            "group_id": group_id,
-        })
-        await conn.execute(query)
+        await conn.execute(
+            pg_insert(AssociationScopesEntitiesRow.__table__)
+            .values(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(group_id),
+                entity_type=EntityType.USER,
+                entity_id=str(user.uuid),
+                relation_type=RelationType.AUTO,
+            )
+            .on_conflict_do_nothing()
+        )
 
 
 async def create_user_if_not_exists(


### PR DESCRIPTION
## Summary
- `associate_user_with_group()` in the OpenID/SSO plugin previously inserted only into `association_groups_users` (agus). After BA-5818 migrated `query_userinfo` / `query_userinfo_from_session` to read `association_scopes_entities` (ASE) only, SSO-provisioned users failed the USER-role membership check on session/deployment/model-serving creation.
- Replace the agus INSERT with a single ASE INSERT keyed on `(scope_type=PROJECT, scope_id=group_id, entity_type=USER, entity_id=user.uuid, relation_type=AUTO)`, using `pg_insert(...).on_conflict_do_nothing()`. The `association_groups_users` import is removed from the plugin.

Resolves BA-5846