### PR TITLE
fix(BA-5894): bypass legacy permission check in vfolder REST middleware for UUID-based access

### DIFF
--- a/changes/11400.fix.md
+++ b/changes/11400.fix.md
@@ -1,0 +1,1 @@
+Allow project admins (and other RBAC-eligible roles) to update vfolder mount permission and other attributes by bypassing the legacy permission resolver in the vfolder REST middleware when the path parameter is a UUID; permission evaluation is delegated to the downstream RBAC validator on the action.

--- a/src/ai/backend/manager/api/rest/vfolder/registry.py
+++ b/src/ai/backend/manager/api/rest/vfolder/registry.py
@@ -21,6 +21,7 @@ from ai.backend.manager.models.vfolder import (
     VFolderStatusSet,
 )
 from ai.backend.manager.services.vfolder.actions.base import GetAccessibleVFolderAction
+from ai.backend.manager.services.vfolder.actions.get_row import GetVFolderRowAction
 
 from .handler import VFolderHandler
 
@@ -38,8 +39,15 @@ def _vfolder_resolver(
 ) -> RouteMiddleware:
     """Route middleware that resolves vfolder rows and checks status.
 
-    Uses the ``get_accessible_vfolder`` processor to resolve, validate
-    count (0 → NotFound, >1 → TooMany), and check status in a single call.
+    Branches on the path parameter type:
+
+    - When the path parameter is a UUID, fetch the row directly without
+      legacy permission filtering and without status validation. Permission
+      evaluation is delegated to the downstream RBAC validator on the action
+      invoked by the handler.
+    - When the path parameter is a name (str), use the legacy
+      ``get_accessible_vfolder`` flow, which scopes the lookup by the
+      requester's permissions to disambiguate folders sharing a name.
 
     Sets ``request["vfolder_row"]`` so that ``VFolderAuthContext`` can
     extract the row in handler methods.
@@ -49,24 +57,27 @@ def _vfolder_resolver(
         @functools.wraps(handler)
         async def wrapper(request: web.Request) -> web.StreamResponse:
             piece = request.match_info["name"]
-            folder_name_or_id: str | uuid.UUID
             try:
-                folder_name_or_id = uuid.UUID(piece)
+                vfolder_uuid = uuid.UUID(piece)
             except ValueError:
-                folder_name_or_id = piece
-            result = await vfolder_processors.get_accessible_vfolder.wait_for_complete(
-                GetAccessibleVFolderAction(
-                    user_uuid=request["user"]["uuid"],
-                    user_role=request["user"]["role"],
-                    domain_name=request["user"]["domain_name"],
-                    is_admin=request["is_admin"],
-                    perm=perm,
-                    folder_id_or_name=folder_name_or_id,
-                    required_status=status,
-                    allow_privileged_access=allow_privileged_access,
+                result = await vfolder_processors.get_accessible_vfolder.wait_for_complete(
+                    GetAccessibleVFolderAction(
+                        user_uuid=request["user"]["uuid"],
+                        user_role=request["user"]["role"],
+                        domain_name=request["user"]["domain_name"],
+                        is_admin=request["is_admin"],
+                        perm=perm,
+                        folder_id_or_name=piece,
+                        required_status=status,
+                        allow_privileged_access=allow_privileged_access,
+                    )
                 )
-            )
-            request["vfolder_row"] = result.row
+                request["vfolder_row"] = result.row
+            else:
+                row_result = await vfolder_processors.get_vfolder_row.wait_for_complete(
+                    GetVFolderRowAction(vfolder_uuid=vfolder_uuid)
+                )
+                request["vfolder_row"] = row_result.row
             return await handler(request)
 
         return wrapper

--- a/src/ai/backend/manager/api/rest/vfolder/registry.py
+++ b/src/ai/backend/manager/api/rest/vfolder/registry.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
+from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.manager.api.rest.middleware.auth import (
     admin_required,
     auth_required,
@@ -58,7 +59,7 @@ def _vfolder_resolver(
         async def wrapper(request: web.Request) -> web.StreamResponse:
             piece = request.match_info["name"]
             try:
-                vfolder_uuid = uuid.UUID(piece)
+                vfolder_uuid = VFolderUUID(uuid.UUID(piece))
             except ValueError:
                 result = await vfolder_processors.get_accessible_vfolder.wait_for_complete(
                     GetAccessibleVFolderAction(

--- a/src/ai/backend/manager/api/rest/vfolder/registry.py
+++ b/src/ai/backend/manager/api/rest/vfolder/registry.py
@@ -22,7 +22,7 @@ from ai.backend.manager.models.vfolder import (
     VFolderStatusSet,
 )
 from ai.backend.manager.services.vfolder.actions.base import GetAccessibleVFolderAction
-from ai.backend.manager.services.vfolder.actions.get_row import GetVFolderRowAction
+from ai.backend.manager.services.vfolder.actions.get_row import GetVFolderLegacyRowAction
 
 from .handler import VFolderHandler
 
@@ -76,7 +76,7 @@ def _vfolder_resolver(
                 request["vfolder_row"] = result.row
             else:
                 row_result = await vfolder_processors.get_vfolder_row.wait_for_complete(
-                    GetVFolderRowAction(vfolder_uuid=vfolder_uuid)
+                    GetVFolderLegacyRowAction(vfolder_uuid=vfolder_uuid)
                 )
                 request["vfolder_row"] = row_result.row
             return await handler(request)

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -205,7 +205,7 @@ class VfolderRepository:
             return self._vfolder_row_to_data(vfolder_row)
 
     @vfolder_repository_resilience.apply()
-    async def get_row_by_id(self, vfolder_id: uuid.UUID) -> Mapping[str, Any]:
+    async def get_row_by_id(self, vfolder_id: VFolderUUID) -> Mapping[str, Any]:
         """
         Fetch a vfolder row as a plain mapping by UUID, without permission filtering.
 

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -205,6 +205,43 @@ class VfolderRepository:
             return self._vfolder_row_to_data(vfolder_row)
 
     @vfolder_repository_resilience.apply()
+    async def get_row_by_id(self, vfolder_id: uuid.UUID) -> Mapping[str, Any]:
+        """
+        Fetch a vfolder row as a plain mapping by UUID, without permission filtering.
+
+        For use only by the REST middleware; do not call from new code.
+        """
+        async with self._db.begin_readonly_session_read_committed() as session:
+            vfolder_row = await self._get_vfolder_by_id(session, vfolder_id)
+            if not vfolder_row:
+                raise VFolderNotFound(extra_data=str(vfolder_id))
+            return {
+                "name": vfolder_row.name,
+                "id": vfolder_row.id,
+                "host": vfolder_row.host,
+                "quota_scope_id": vfolder_row.quota_scope_id,
+                "domain_name": vfolder_row.domain_name,
+                "usage_mode": vfolder_row.usage_mode,
+                "created_at": vfolder_row.created_at,
+                "last_used": vfolder_row.last_used,
+                "max_size": vfolder_row.max_size,
+                "max_files": vfolder_row.max_files,
+                "ownership_type": vfolder_row.ownership_type,
+                "user": str(vfolder_row.user) if vfolder_row.user else None,
+                "group": str(vfolder_row.group) if vfolder_row.group else None,
+                "creator": vfolder_row.creator,
+                "creator_id": vfolder_row.creator_id,
+                "user_email": None,
+                "group_name": None,
+                "is_owner": False,
+                "permission": vfolder_row.permission,
+                "unmanaged_path": vfolder_row.unmanaged_path,
+                "cloneable": vfolder_row.cloneable,
+                "status": vfolder_row.status,
+                "cur_size": vfolder_row.cur_size,
+            }
+
+    @vfolder_repository_resilience.apply()
     async def batch_load_by_ids(self, ids: Sequence[uuid.UUID]) -> list[VFolderData | None]:
         """
         Batch fetch vfolders by IDs without permission validation.

--- a/src/ai/backend/manager/services/vfolder/actions/get_row.py
+++ b/src/ai/backend/manager/services/vfolder/actions/get_row.py
@@ -1,0 +1,38 @@
+"""Resolve a vfolder row by UUID without permission filtering.
+
+Used by the REST middleware when the path parameter is a UUID — permission
+evaluation is delegated to the downstream RBAC validator on the actual action
+(e.g., update_vfolder_attribute).
+"""
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.manager.actions.action.base import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.vfolder.actions.base import VFolderAction
+
+
+@dataclass
+class GetVFolderRowAction(VFolderAction):
+    vfolder_uuid: uuid.UUID
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.vfolder_uuid)
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class GetVFolderRowActionResult(BaseActionResult):
+    row: Mapping[str, Any]
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.row.get("id")) if self.row else None

--- a/src/ai/backend/manager/services/vfolder/actions/get_row.py
+++ b/src/ai/backend/manager/services/vfolder/actions/get_row.py
@@ -16,7 +16,7 @@ from ai.backend.manager.services.vfolder.actions.base import VFolderAction
 
 
 @dataclass
-class GetVFolderRowAction(VFolderAction):
+class GetVFolderLegacyRowAction(VFolderAction):
     vfolder_uuid: VFolderUUID
 
     @override
@@ -30,7 +30,7 @@ class GetVFolderRowAction(VFolderAction):
 
 
 @dataclass
-class GetVFolderRowActionResult(BaseActionResult):
+class GetVFolderLegacyRowActionResult(BaseActionResult):
     row: Mapping[str, Any]
 
     @override

--- a/src/ai/backend/manager/services/vfolder/actions/get_row.py
+++ b/src/ai/backend/manager/services/vfolder/actions/get_row.py
@@ -5,11 +5,11 @@ evaluation is delegated to the downstream RBAC validator on the actual action
 (e.g., update_vfolder_attribute).
 """
 
-import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, override
 
+from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.manager.actions.action.base import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.vfolder.actions.base import VFolderAction
@@ -17,7 +17,7 @@ from ai.backend.manager.services.vfolder.actions.base import VFolderAction
 
 @dataclass
 class GetVFolderRowAction(VFolderAction):
-    vfolder_uuid: uuid.UUID
+    vfolder_uuid: VFolderUUID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -48,6 +48,10 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     GetMyStorageHostPermissionsAction,
     GetMyStorageHostPermissionsActionResult,
 )
+from ai.backend.manager.services.vfolder.actions.get_row import (
+    GetVFolderRowAction,
+    GetVFolderRowActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.get_v2 import (
     GetVFolderV2Action,
     GetVFolderV2ActionResult,
@@ -156,6 +160,7 @@ class VFolderProcessors(AbstractProcessorPackage):
     get_accessible_vfolder: ActionProcessor[
         GetAccessibleVFolderAction, GetAccessibleVFolderActionResult
     ]
+    get_vfolder_row: ActionProcessor[GetVFolderRowAction, GetVFolderRowActionResult]
     batch_load_vfolders_by_ids: ActionProcessor[
         BatchLoadVFoldersByIdsAction, BatchLoadVFoldersByIdsActionResult
     ]
@@ -247,6 +252,7 @@ class VFolderProcessors(AbstractProcessorPackage):
         self.get_accessible_vfolder = ActionProcessor(
             service.get_accessible_vfolder, action_monitors
         )
+        self.get_vfolder_row = ActionProcessor(service.get_vfolder_row, action_monitors)
 
         # Cross-entity loaders (no RBAC validation; caller has parent access)
         self.batch_load_vfolders_by_ids = ActionProcessor(
@@ -305,6 +311,7 @@ class VFolderProcessors(AbstractProcessorPackage):
             UmountHostAction.spec(),
             GetFstabContentsAction.spec(),
             GetAccessibleVFolderAction.spec(),
+            GetVFolderRowAction.spec(),
             BatchLoadVFoldersByIdsAction.spec(),
             CreateVFolderV2Action.spec(),
             CreateUploadSessionV2Action.spec(),

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -49,8 +49,8 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     GetMyStorageHostPermissionsActionResult,
 )
 from ai.backend.manager.services.vfolder.actions.get_row import (
-    GetVFolderRowAction,
-    GetVFolderRowActionResult,
+    GetVFolderLegacyRowAction,
+    GetVFolderLegacyRowActionResult,
 )
 from ai.backend.manager.services.vfolder.actions.get_v2 import (
     GetVFolderV2Action,
@@ -160,7 +160,7 @@ class VFolderProcessors(AbstractProcessorPackage):
     get_accessible_vfolder: ActionProcessor[
         GetAccessibleVFolderAction, GetAccessibleVFolderActionResult
     ]
-    get_vfolder_row: ActionProcessor[GetVFolderRowAction, GetVFolderRowActionResult]
+    get_vfolder_row: ActionProcessor[GetVFolderLegacyRowAction, GetVFolderLegacyRowActionResult]
     batch_load_vfolders_by_ids: ActionProcessor[
         BatchLoadVFoldersByIdsAction, BatchLoadVFoldersByIdsActionResult
     ]
@@ -311,7 +311,7 @@ class VFolderProcessors(AbstractProcessorPackage):
             UmountHostAction.spec(),
             GetFstabContentsAction.spec(),
             GetAccessibleVFolderAction.spec(),
-            GetVFolderRowAction.spec(),
+            GetVFolderLegacyRowAction.spec(),
             BatchLoadVFoldersByIdsAction.spec(),
             CreateVFolderV2Action.spec(),
             CreateUploadSessionV2Action.spec(),

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1420,7 +1420,9 @@ class VFolderService:
         except Exception as e:
             raise InternalServerError from e
 
-    async def get_vfolder_row(self, action: GetVFolderLegacyRowAction) -> GetVFolderLegacyRowActionResult:
+    async def get_vfolder_row(
+        self, action: GetVFolderLegacyRowAction
+    ) -> GetVFolderLegacyRowActionResult:
         row = await self._vfolder_repository.get_row_by_id(action.vfolder_uuid)
         return GetVFolderLegacyRowActionResult(row=row)
 

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -115,6 +115,10 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     GetMyStorageHostPermissionsActionResult,
     StorageHostPermissionEntry,
 )
+from ai.backend.manager.services.vfolder.actions.get_row import (
+    GetVFolderRowAction,
+    GetVFolderRowActionResult,
+)
 from ai.backend.manager.services.vfolder.actions.get_v2 import (
     GetVFolderV2Action,
     GetVFolderV2ActionResult,
@@ -1415,6 +1419,10 @@ class VFolderService:
             raise BackendAgentError("TIMEOUT", "Could not fetch fstab data from agent") from e
         except Exception as e:
             raise InternalServerError from e
+
+    async def get_vfolder_row(self, action: GetVFolderRowAction) -> GetVFolderRowActionResult:
+        row = await self._vfolder_repository.get_row_by_id(action.vfolder_uuid)
+        return GetVFolderRowActionResult(row=row)
 
     async def get_accessible_vfolder(
         self, action: GetAccessibleVFolderAction

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -116,8 +116,8 @@ from ai.backend.manager.services.vfolder.actions.get_my_storage_host_permissions
     StorageHostPermissionEntry,
 )
 from ai.backend.manager.services.vfolder.actions.get_row import (
-    GetVFolderRowAction,
-    GetVFolderRowActionResult,
+    GetVFolderLegacyRowAction,
+    GetVFolderLegacyRowActionResult,
 )
 from ai.backend.manager.services.vfolder.actions.get_v2 import (
     GetVFolderV2Action,
@@ -1420,9 +1420,9 @@ class VFolderService:
         except Exception as e:
             raise InternalServerError from e
 
-    async def get_vfolder_row(self, action: GetVFolderRowAction) -> GetVFolderRowActionResult:
+    async def get_vfolder_row(self, action: GetVFolderLegacyRowAction) -> GetVFolderLegacyRowActionResult:
         row = await self._vfolder_repository.get_row_by_id(action.vfolder_uuid)
-        return GetVFolderRowActionResult(row=row)
+        return GetVFolderLegacyRowActionResult(row=row)
 
     async def get_accessible_vfolder(
         self, action: GetAccessibleVFolderAction


### PR DESCRIPTION
## Summary
- The legacy `_vfolder_resolver` middleware calls `get_accessible_vfolder` for every vfolder REST endpoint, which uses the pre-RBAC permission resolver. That resolver only recognizes domain-admin/superadmin special cases plus the static group default permission column, so a project admin granted update permission via the new RBAC association graph receives `VFolderNotFound` before the downstream RBAC validator on `update_vfolder_attribute` can run.
- Branch the resolver behavior on the path parameter type. UUID path: fetch the row via a new `get_vfolder_row` processor (no permission filter, no status check) — permission evaluation is delegated to the downstream RBAC validator on the action. Name path: keep the existing `get_accessible_vfolder` flow, since name-based resolution requires user context to disambiguate folders sharing a name.
- Handler signatures are unchanged. The injected `request["vfolder_row"]` mapping shape matches what `query_accessible_vfolders` returns.

## Test plan
- [x] As a project admin, `POST /folders/<UUID>/update-options` with a project-owned vfolder updates `cloneable` / `mount_permission` successfully (previously returned `VFolderNotFound`).
- [x] As a regular user without RBAC update permission, the same call is rejected by the RBAC validator (`NotEnoughPermission`).
- [x] Name-based access (`POST /folders/<NAME>/update-options`) preserves legacy behavior — a non-owner still receives `VFolderNotFound`.

Resolves BA-5894