### PR TITLE
fix(BA-5891): allow optional start_command in model service config

### DIFF
--- a/changes/11402.fix.md
+++ b/changes/11402.fix.md
@@ -1,0 +1,1 @@
+Allow `start_command` to be omitted in model service definitions and fall back to the container image's default command.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9600,7 +9600,7 @@ type ModelServiceConfig
   """Command to start the model service."""
   startCommand: [String!]
 
-  """Shell used to wrap a string-form start_command at parse time."""
+  """Shell configured for the model service."""
   shell: String!
 
   """Port number for the model service."""
@@ -9624,7 +9624,7 @@ input ModelServiceConfigInput
   """Command to start the model service."""
   startCommand: [String!] = null
 
-  """Shell used to wrap a string-form start_command at parse time."""
+  """Shell configured for the model service."""
   shell: String! = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9598,9 +9598,9 @@ type ModelServiceConfig
   preStartActions: [PreStartAction!]!
 
   """Command to start the model service."""
-  startCommand: JSON!
+  startCommand: [String!]
 
-  """Shell to use if start_command is a string."""
+  """Shell used to wrap a string-form start_command at parse time."""
   shell: String!
 
   """Port number for the model service."""
@@ -9622,9 +9622,9 @@ input ModelServiceConfigInput
   preStartActions: [PreStartActionInput!]!
 
   """Command to start the model service."""
-  startCommand: JSON!
+  startCommand: [String!] = null
 
-  """Shell to use if start_command is a string."""
+  """Shell used to wrap a string-form start_command at parse time."""
   shell: String! = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6374,7 +6374,7 @@ type ModelServiceConfig {
   """Command to start the model service."""
   startCommand: [String!]
 
-  """Shell used to wrap a string-form start_command at parse time."""
+  """Shell configured for the model service."""
   shell: String!
 
   """Port number for the model service."""
@@ -6396,7 +6396,7 @@ input ModelServiceConfigInput {
   """Command to start the model service."""
   startCommand: [String!] = null
 
-  """Shell used to wrap a string-form start_command at parse time."""
+  """Shell configured for the model service."""
   shell: String! = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6372,9 +6372,9 @@ type ModelServiceConfig {
   preStartActions: [PreStartAction!]!
 
   """Command to start the model service."""
-  startCommand: JSON!
+  startCommand: [String!]
 
-  """Shell to use if start_command is a string."""
+  """Shell used to wrap a string-form start_command at parse time."""
   shell: String!
 
   """Port number for the model service."""
@@ -6394,9 +6394,9 @@ input ModelServiceConfigInput {
   preStartActions: [PreStartActionInput!]!
 
   """Command to start the model service."""
-  startCommand: JSON!
+  startCommand: [String!] = null
 
-  """Shell to use if start_command is a string."""
+  """Shell used to wrap a string-form start_command at parse time."""
   shell: String! = "/bin/bash"
 
   """Port number for the model service. Must be greater than 1."""

--- a/scripts/e2e-model-store/01-setup-presets.sh
+++ b/scripts/e2e-model-store/01-setup-presets.sh
@@ -76,7 +76,7 @@ CPU_PRESET=$(./bai admin deployment revision-preset create "{
       \"name\": \"test-model\",
       \"model_path\": \"/models\",
       \"service\": {
-        \"start_command\": \"python /models/serve.py\",
+        \"start_command\": [\"python\", \"/models/serve.py\"],
         \"port\": 8000,
         \"health_check\": {
           \"path\": \"/health\",

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -3182,7 +3182,16 @@ class AbstractAgent[
                             )
                         )
                         for model in populated_models:
-                            service = model.get("service") or {}
+                            service = model.get("service")
+                            if not isinstance(service, dict):
+                                log.warning(
+                                    "create_kernel(kernel:{}, session:{}) skipping model"
+                                    " '{}': no service definition",
+                                    kernel_id,
+                                    session_id,
+                                    model.get("name", "<unknown>"),
+                                )
+                                continue
                             if not service.get("start_command"):
                                 log.warning(
                                     "create_kernel(kernel:{}, session:{}) cannot start model"

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2469,8 +2469,8 @@ class AbstractAgent[
         image_command_loaded = False
         image_command: str | list[str] | None = None
         for model in models:
-            service = model.get("service") or {}
-            if not isinstance(service, MutableMapping):
+            service = model.get("service")
+            if not isinstance(service, dict):
                 continue
             if service.get("start_command"):
                 continue

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2461,6 +2461,28 @@ class AbstractAgent[
             ),
         )
 
+    async def _populate_missing_model_service_start_commands(
+        self,
+        models: list[dict[str, Any]],
+        image: str,
+    ) -> list[dict[str, Any]]:
+        image_command_loaded = False
+        image_command: str | list[str] | None = None
+        for model in models:
+            service = model.get("service") or {}
+            if not isinstance(service, MutableMapping):
+                continue
+            if service.get("start_command"):
+                continue
+            if not image_command_loaded:
+                image_command = await self.extract_image_command(image)
+                image_command_loaded = True
+            if not image_command:
+                continue
+            service["start_command"] = image_command
+            model["service"] = service
+        return models
+
     async def create_kernel(
         self,
         ownership_data: KernelOwnershipData,
@@ -3149,7 +3171,25 @@ class AbstractAgent[
                     }
 
                     if ctx.kernel_config["cluster_role"] in ("main", "master") and model_definition:
-                        for model in model_definition["models"]:
+                        populated_models = (
+                            await self._populate_missing_model_service_start_commands(
+                                model_definition["models"],
+                                ctx.image_ref.canonical,
+                            )
+                        )
+                        for model in populated_models:
+                            service = model.get("service") or {}
+                            if not service.get("start_command"):
+                                log.warning(
+                                    "create_kernel(kernel:{}, session:{}) cannot start model"
+                                    " service '{}': no start_command and image {} has no"
+                                    " Config.Cmd",
+                                    kernel_id,
+                                    session_id,
+                                    model.get("name", "<unknown>"),
+                                    ctx.image_ref.canonical,
+                                )
+                                continue
                             asyncio.create_task(
                                 self.start_and_monitor_model_service_health(kernel_obj, model)
                             )
@@ -3283,7 +3323,7 @@ class AbstractAgent[
         return [port for port in service_ports if port["protocol"] != ServicePortProtocols.INTERNAL]
 
     @abstractmethod
-    async def extract_image_command(self, image: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | list[str] | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2479,7 +2479,11 @@ class AbstractAgent[
                 image_command_loaded = True
             if not image_command:
                 continue
-            service["start_command"] = image_command
+            if isinstance(image_command, str):
+                shell = service.get("shell") or "/bin/bash"
+                service["start_command"] = [shell, "-c", image_command]
+            else:
+                service["start_command"] = list(image_command)
             model["service"] = service
         return models
 

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2467,7 +2467,7 @@ class AbstractAgent[
         image: str,
     ) -> list[dict[str, Any]]:
         image_command_loaded = False
-        image_command: str | list[str] | None = None
+        image_command: list[str] | None = None
         for model in models:
             service = model.get("service")
             if not isinstance(service, dict):
@@ -2479,11 +2479,7 @@ class AbstractAgent[
                 image_command_loaded = True
             if not image_command:
                 continue
-            if isinstance(image_command, str):
-                shell = service.get("shell") or "/bin/bash"
-                service["start_command"] = [shell, "-c", image_command]
-            else:
-                service["start_command"] = list(image_command)
+            service["start_command"] = list(image_command)
             model["service"] = service
         return models
 
@@ -3336,7 +3332,7 @@ class AbstractAgent[
         return [port for port in service_ports if port["protocol"] != ServicePortProtocols.INTERNAL]
 
     @abstractmethod
-    async def extract_image_command(self, image: str) -> str | list[str] | None:
+    async def extract_image_command(self, image: str) -> list[str] | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1662,8 +1662,9 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 return None
             if isinstance(command, str):
                 return [command]
-            if isinstance(command, Sequence):
-                return cast(list[str], list(command))
+
+            if isinstance(command, list):
+                return cast(list[str], command)
             return None
 
     @override

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1654,10 +1654,10 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         return cast(str, self.docker_info["CgroupVersion"])
 
     @override
-    async def extract_image_command(self, image: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | list[str] | None:
         async with closing_async(Docker()) as docker:
             result = await docker.images.get(image)
-            return cast(str | None, result["Config"].get("Cmd"))
+            return cast(str | list[str] | None, result["Config"].get("Cmd"))
 
     @override
     async def enumerate_containers(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1654,10 +1654,17 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         return cast(str, self.docker_info["CgroupVersion"])
 
     @override
-    async def extract_image_command(self, image: str) -> str | list[str] | None:
+    async def extract_image_command(self, image: str) -> list[str] | None:
         async with closing_async(Docker()) as docker:
             result = await docker.images.get(image)
-            return cast(str | list[str] | None, result["Config"].get("Cmd"))
+            command = result["Config"].get("Cmd")
+            if command is None:
+                return None
+            if isinstance(command, str):
+                return [command]
+            if isinstance(command, Sequence):
+                return cast(list[str], list(command))
+            return None
 
     @override
     async def enumerate_containers(

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -308,7 +308,7 @@ class DummyAgent(
         return ""
 
     @override
-    async def extract_image_command(self, image: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | list[str] | None:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
         return "cr.backend.ai/stable/python:3.9-ubuntu20.04"

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -311,7 +311,7 @@ class DummyAgent(
     async def extract_image_command(self, image: str) -> str | list[str] | None:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
-        return "cr.backend.ai/stable/python:3.9-ubuntu20.04"
+        return ["cr.backend.ai/stable/python:3.9-ubuntu20.04"]
 
     @override
     async def scan_images(self) -> ScanImagesResult:

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -308,7 +308,7 @@ class DummyAgent(
         return ""
 
     @override
-    async def extract_image_command(self, image: str) -> str | list[str] | None:
+    async def extract_image_command(self, image: str) -> list[str] | None:
         delay = self.dummy_agent_cfg["delay"]["scan-image"]
         await asyncio.sleep(delay)
         return ["cr.backend.ai/stable/python:3.9-ubuntu20.04"]

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -1030,7 +1030,7 @@ class KubernetesAgent(
         return ""
 
     @override
-    async def extract_image_command(self, image: str) -> str | None:
+    async def extract_image_command(self, image: str) -> str | list[str] | None:
         raise NotImplementedError
 
     @override

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -1030,7 +1030,7 @@ class KubernetesAgent(
         return ""
 
     @override
-    async def extract_image_command(self, image: str) -> str | list[str] | None:
+    async def extract_image_command(self, image: str) -> list[str] | None:
         raise NotImplementedError
 
     @override

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -14,7 +14,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    model_validator,
 )
 
 from . import validators as tx
@@ -144,54 +143,35 @@ agent_selector_globalconfig_iv = t.Dict({}).allow_extra("*")
 agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 
 
-def _normalize_service_start_command(service: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Wrap a string ``start_command`` as ``[shell, "-c", string]`` so downstream
-    consumers always see ``list[str] | None``."""
-    if service is None:
-        return service
-    return _wrap_string_start_command_dict(service)
-
-
-def _wrap_string_start_command_dict(data: dict[str, Any]) -> dict[str, Any]:
-    cmd = data.get("start_command")
-    if isinstance(cmd, str):
-        shell = data.get("shell") or "/bin/bash"
-        data["start_command"] = [shell, "-c", cmd]
-    return data
-
-
 model_definition_iv = t.Dict({
     t.Key("models"): t.List(
         t.Dict({
             t.Key("name"): t.String,
             t.Key("model_path"): t.String,
-            t.Key("service", default=None): (
-                t.Null
+            t.Key("service", default=None): t.Null
+            | t.Dict({
+                # ai.backend.kernel.service.ServiceParser.start_service()
+                # ai.backend.kernel.service_actions
+                t.Key("pre_start_actions", default=[]): t.Null
+                | t.List(
+                    t.Dict({
+                        t.Key("action"): t.String,
+                        t.Key("args"): t.Dict().allow_extra("*"),
+                    })
+                ),
+                t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
+                t.Key("shell", default="/bin/bash"): t.String,  # used if start_command is a string
+                t.Key("port"): t.ToInt[1:],
+                t.Key("health_check", default=None): t.Null
                 | t.Dict({
-                    # ai.backend.kernel.service.ServiceParser.start_service()
-                    # ai.backend.kernel.service_actions
-                    t.Key("pre_start_actions", default=[]): t.Null
-                    | t.List(
-                        t.Dict({
-                            t.Key("action"): t.String,
-                            t.Key("args"): t.Dict().allow_extra("*"),
-                        })
-                    ),
-                    t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
-                    t.Key("shell", default="/bin/bash"): t.String,
-                    t.Key("port"): t.ToInt[1:],
-                    t.Key("health_check", default=None): t.Null
-                    | t.Dict({
-                        t.Key("interval", default=10): t.Null | t.ToFloat[0:],
-                        t.Key("path"): t.String,
-                        t.Key("max_retries", default=10): t.Null | t.ToInt[1:],
-                        t.Key("max_wait_time", default=15): t.Null | t.ToFloat[0:],
-                        t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
-                        t.Key("initial_delay", default=60): t.Null | t.ToFloat[0:],
-                    }),
-                })
-            )
-            >> _normalize_service_start_command,
+                    t.Key("interval", default=10): t.Null | t.ToFloat[0:],
+                    t.Key("path"): t.String,
+                    t.Key("max_retries", default=10): t.Null | t.ToInt[1:],
+                    t.Key("max_wait_time", default=15): t.Null | t.ToFloat[0:],
+                    t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
+                    t.Key("initial_delay", default=60): t.Null | t.ToFloat[0:],
+                }),
+            }),
             t.Key("metadata", default=None): t.Null
             | t.Dict({
                 t.Key("author", default=None): t.Null | t.String(allow_blank=True),
@@ -266,14 +246,14 @@ class ModelServiceConfig(BaseConfigModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: list[str] | None = Field(
+    start_command: str | list[str] | None = Field(
         default=None,
         description="Command to start the model service.",
-        examples=[["python", "service.py"]],
+        examples=["python service.py", ["python", "service.py"]],
     )
     shell: str = Field(
         default="/bin/bash",
-        description="Shell used to wrap a string-form start_command at parse time.",
+        description="Shell to use if start_command is a string.",
         examples=["/bin/bash"],
     )
     port: int = Field(
@@ -285,13 +265,6 @@ class ModelServiceConfig(BaseConfigModel):
         default=None,
         description="Health check configuration for the model service.",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _wrap_string_start_command(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            return _wrap_string_start_command_dict(data)
-        return data
 
 
 class ModelMetadata(BaseConfigModel):
@@ -530,17 +503,10 @@ class ModelHealthCheckDraft(BaseConfigModel):
 
 class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
-    start_command: list[str] | None = None
+    start_command: str | list[str] | None = None
     shell: str | None = None
     port: int | None = None
     health_check: ModelHealthCheckDraft | None = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def _wrap_string_start_command(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            return _wrap_string_start_command_dict(data)
-        return data
 
     def to_resolved(self) -> ModelServiceConfig:
         if self.port is None:

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -159,8 +159,8 @@ model_definition_iv = t.Dict({
                         t.Key("args"): t.Dict().allow_extra("*"),
                     })
                 ),
-                t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
-                t.Key("shell", default="/bin/bash"): t.String,  # used if start_command is a string
+                t.Key("start_command", default=None): t.Null | t.List(t.String),
+                t.Key("shell", default="/bin/bash"): t.String,
                 t.Key("port"): t.ToInt[1:],
                 t.Key("health_check", default=None): t.Null
                 | t.Dict({
@@ -246,14 +246,14 @@ class ModelServiceConfig(BaseConfigModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: str | list[str] | None = Field(
+    start_command: list[str] | None = Field(
         default=None,
         description="Command to start the model service.",
-        examples=["python service.py", ["python", "service.py"]],
+        examples=[["python", "service.py"]],
     )
     shell: str = Field(
         default="/bin/bash",
-        description="Shell to use if start_command is a string.",
+        description="Shell configured for the model service.",
         examples=["/bin/bash"],
     )
     port: int = Field(
@@ -503,7 +503,7 @@ class ModelHealthCheckDraft(BaseConfigModel):
 
 class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
-    start_command: str | list[str] | None = None
+    start_command: list[str] | None = None
     shell: str | None = None
     port: int | None = None
     health_check: ModelHealthCheckDraft | None = None

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -14,6 +14,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    model_validator,
 )
 
 from . import validators as tx
@@ -143,35 +144,54 @@ agent_selector_globalconfig_iv = t.Dict({}).allow_extra("*")
 agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 
 
+def _normalize_service_start_command(service: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Wrap a string ``start_command`` as ``[shell, "-c", string]`` so downstream
+    consumers always see ``list[str] | None``."""
+    if service is None:
+        return service
+    return _wrap_string_start_command_dict(service)
+
+
+def _wrap_string_start_command_dict(data: dict[str, Any]) -> dict[str, Any]:
+    cmd = data.get("start_command")
+    if isinstance(cmd, str):
+        shell = data.get("shell") or "/bin/bash"
+        data["start_command"] = [shell, "-c", cmd]
+    return data
+
+
 model_definition_iv = t.Dict({
     t.Key("models"): t.List(
         t.Dict({
             t.Key("name"): t.String,
             t.Key("model_path"): t.String,
-            t.Key("service", default=None): t.Null
-            | t.Dict({
-                # ai.backend.kernel.service.ServiceParser.start_service()
-                # ai.backend.kernel.service_actions
-                t.Key("pre_start_actions", default=[]): t.Null
-                | t.List(
-                    t.Dict({
-                        t.Key("action"): t.String,
-                        t.Key("args"): t.Dict().allow_extra("*"),
-                    })
-                ),
-                t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
-                t.Key("shell", default="/bin/bash"): t.String,  # used if start_command is a string
-                t.Key("port"): t.ToInt[1:],
-                t.Key("health_check", default=None): t.Null
+            t.Key("service", default=None): (
+                t.Null
                 | t.Dict({
-                    t.Key("interval", default=10): t.Null | t.ToFloat[0:],
-                    t.Key("path"): t.String,
-                    t.Key("max_retries", default=10): t.Null | t.ToInt[1:],
-                    t.Key("max_wait_time", default=15): t.Null | t.ToFloat[0:],
-                    t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
-                    t.Key("initial_delay", default=60): t.Null | t.ToFloat[0:],
-                }),
-            }),
+                    # ai.backend.kernel.service.ServiceParser.start_service()
+                    # ai.backend.kernel.service_actions
+                    t.Key("pre_start_actions", default=[]): t.Null
+                    | t.List(
+                        t.Dict({
+                            t.Key("action"): t.String,
+                            t.Key("args"): t.Dict().allow_extra("*"),
+                        })
+                    ),
+                    t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
+                    t.Key("shell", default="/bin/bash"): t.String,
+                    t.Key("port"): t.ToInt[1:],
+                    t.Key("health_check", default=None): t.Null
+                    | t.Dict({
+                        t.Key("interval", default=10): t.Null | t.ToFloat[0:],
+                        t.Key("path"): t.String,
+                        t.Key("max_retries", default=10): t.Null | t.ToInt[1:],
+                        t.Key("max_wait_time", default=15): t.Null | t.ToFloat[0:],
+                        t.Key("expected_status_code", default=200): t.Null | t.ToInt[100:],
+                        t.Key("initial_delay", default=60): t.Null | t.ToFloat[0:],
+                    }),
+                })
+            )
+            >> _normalize_service_start_command,
             t.Key("metadata", default=None): t.Null
             | t.Dict({
                 t.Key("author", default=None): t.Null | t.String(allow_blank=True),
@@ -246,14 +266,14 @@ class ModelServiceConfig(BaseConfigModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: str | list[str] | None = Field(
+    start_command: list[str] | None = Field(
         default=None,
         description="Command to start the model service.",
-        examples=["python service.py", ["python", "service.py"]],
+        examples=[["python", "service.py"]],
     )
     shell: str = Field(
         default="/bin/bash",
-        description="Shell to use if start_command is a string.",
+        description="Shell used to wrap a string-form start_command at parse time.",
         examples=["/bin/bash"],
     )
     port: int = Field(
@@ -265,6 +285,13 @@ class ModelServiceConfig(BaseConfigModel):
         default=None,
         description="Health check configuration for the model service.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_string_start_command(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return _wrap_string_start_command_dict(data)
+        return data
 
 
 class ModelMetadata(BaseConfigModel):
@@ -503,10 +530,17 @@ class ModelHealthCheckDraft(BaseConfigModel):
 
 class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
-    start_command: str | list[str] | None = None
+    start_command: list[str] | None = None
     shell: str | None = None
     port: int | None = None
     health_check: ModelHealthCheckDraft | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_string_start_command(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return _wrap_string_start_command_dict(data)
+        return data
 
     def to_resolved(self) -> ModelServiceConfig:
         if self.port is None:

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -159,7 +159,7 @@ model_definition_iv = t.Dict({
                         t.Key("args"): t.Dict().allow_extra("*"),
                     })
                 ),
-                t.Key("start_command"): t.String | t.List(t.String),
+                t.Key("start_command", default=None): t.Null | t.String | t.List(t.String),
                 t.Key("shell", default="/bin/bash"): t.String,  # used if start_command is a string
                 t.Key("port"): t.ToInt[1:],
                 t.Key("health_check", default=None): t.Null
@@ -246,7 +246,8 @@ class ModelServiceConfig(BaseConfigModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: str | list[str] = Field(
+    start_command: str | list[str] | None = Field(
+        default=None,
         description="Command to start the model service.",
         examples=["python service.py", ["python", "service.py"]],
     )
@@ -508,8 +509,6 @@ class ModelServiceConfigDraft(BaseConfigModel):
     health_check: ModelHealthCheckDraft | None = None
 
     def to_resolved(self) -> ModelServiceConfig:
-        if self.start_command is None:
-            raise ValueError("ModelServiceConfig.start_command is required")
         if self.port is None:
             raise ValueError("ModelServiceConfig.port is required")
         return ModelServiceConfig(

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -23,7 +23,11 @@ from ai.backend.common.data.model_deployment.types import (
 from ai.backend.common.dto.manager.v2.common import OrderDirection, ResourceSlotInfo
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsInfoDTO
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
-from ai.backend.common.types import ClusterMode, MountPermission, RuntimeVariant
+from ai.backend.common.types import (
+    ClusterMode,
+    MountPermission,
+    RuntimeVariant,
+)
 
 __all__ = (
     "AccessTokenOrderField",
@@ -293,7 +297,9 @@ class ModelServiceConfigInfoDTO(BaseResponseModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: str | list[str] = Field(description="Command to start the model service.")
+    start_command: str | list[str] | None = Field(
+        default=None, description="Command to start the model service."
+    )
     shell: str = Field(
         default="/bin/bash", description="Shell to use if start_command is a string."
     )

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -302,22 +302,12 @@ class ModelServiceConfigInfoDTO(BaseResponseModel):
     )
     shell: str = Field(
         default="/bin/bash",
-        description="Shell used to wrap a string-form start_command at parse time.",
+        description="Shell configured for the model service.",
     )
     port: int = Field(description="Port number for the model service.")
     health_check: ModelHealthCheckInfoDTO | None = Field(
         default=None, description="Health check configuration for the model service."
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _wrap_string_start_command(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            cmd = data.get("start_command")
-            if isinstance(cmd, str):
-                shell = data.get("shell") or "/bin/bash"
-                data["start_command"] = [shell, "-c", cmd]
-        return data
 
 
 class ModelMetadataInfoDTO(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/types.py
@@ -297,16 +297,27 @@ class ModelServiceConfigInfoDTO(BaseResponseModel):
         default_factory=list,
         description="List of pre-start actions to execute before starting the model service.",
     )
-    start_command: str | list[str] | None = Field(
+    start_command: list[str] | None = Field(
         default=None, description="Command to start the model service."
     )
     shell: str = Field(
-        default="/bin/bash", description="Shell to use if start_command is a string."
+        default="/bin/bash",
+        description="Shell used to wrap a string-form start_command at parse time.",
     )
     port: int = Field(description="Port number for the model service.")
     health_check: ModelHealthCheckInfoDTO | None = Field(
         default=None, description="Health check configuration for the model service."
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_string_start_command(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            cmd = data.get("start_command")
+            if isinstance(cmd, str):
+                shell = data.get("shell") or "/bin/bash"
+                data["start_command"] = [shell, "-c", cmd]
+        return data
 
 
 class ModelMetadataInfoDTO(BaseResponseModel):

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -369,7 +369,7 @@ class ModelServiceConfigGQL:
     pre_start_actions: list[PreStartActionGQL] = gql_field(
         description="List of pre-start actions to execute before starting the model service."
     )
-    start_command: JSON | None = gql_field(
+    start_command: str | list[str] | None = gql_field(
         description="Command to start the model service.", default=None
     )
     shell: str = gql_field(description="Shell to use if start_command is a string.")
@@ -826,7 +826,7 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigDTO]):
         description="List of pre-start actions to execute before starting the model service.",
         default=strawberry.UNSET,
     )
-    start_command: JSON | None = gql_field(
+    start_command: str | list[str] | None = gql_field(
         description="Command to start the model service.", default=None
     )
     shell: str = gql_field(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -369,7 +369,9 @@ class ModelServiceConfigGQL:
     pre_start_actions: list[PreStartActionGQL] = gql_field(
         description="List of pre-start actions to execute before starting the model service."
     )
-    start_command: JSON = gql_field(description="Command to start the model service.")
+    start_command: JSON | None = gql_field(
+        description="Command to start the model service.", default=None
+    )
     shell: str = gql_field(description="Shell to use if start_command is a string.")
     port: int = gql_field(description="Port number for the model service.")
     health_check: ModelHealthCheckGQL | None = gql_field(
@@ -824,7 +826,9 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigDTO]):
         description="List of pre-start actions to execute before starting the model service.",
         default=strawberry.UNSET,
     )
-    start_command: JSON = gql_field(description="Command to start the model service.")
+    start_command: JSON | None = gql_field(
+        description="Command to start the model service.", default=None
+    )
     shell: str = gql_field(
         description="Shell to use if start_command is a string.", default="/bin/bash"
     )

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -372,9 +372,7 @@ class ModelServiceConfigGQL:
     start_command: list[str] | None = gql_field(
         description="Command to start the model service.", default=None
     )
-    shell: str = gql_field(
-        description="Shell used to wrap a string-form start_command at parse time."
-    )
+    shell: str = gql_field(description="Shell configured for the model service.")
     port: int = gql_field(description="Port number for the model service.")
     health_check: ModelHealthCheckGQL | None = gql_field(
         description="Health check configuration for the model service.",
@@ -832,7 +830,7 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigDTO]):
         description="Command to start the model service.", default=None
     )
     shell: str = gql_field(
-        description="Shell used to wrap a string-form start_command at parse time.",
+        description="Shell configured for the model service.",
         default="/bin/bash",
     )
     port: int = gql_field(description="Port number for the model service. Must be greater than 1.")

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -369,10 +369,12 @@ class ModelServiceConfigGQL:
     pre_start_actions: list[PreStartActionGQL] = gql_field(
         description="List of pre-start actions to execute before starting the model service."
     )
-    start_command: str | list[str] | None = gql_field(
+    start_command: list[str] | None = gql_field(
         description="Command to start the model service.", default=None
     )
-    shell: str = gql_field(description="Shell to use if start_command is a string.")
+    shell: str = gql_field(
+        description="Shell used to wrap a string-form start_command at parse time."
+    )
     port: int = gql_field(description="Port number for the model service.")
     health_check: ModelHealthCheckGQL | None = gql_field(
         description="Health check configuration for the model service.",
@@ -826,11 +828,12 @@ class ModelServiceConfigInputGQL(PydanticInputMixin[ModelServiceConfigDTO]):
         description="List of pre-start actions to execute before starting the model service.",
         default=strawberry.UNSET,
     )
-    start_command: str | list[str] | None = gql_field(
+    start_command: list[str] | None = gql_field(
         description="Command to start the model service.", default=None
     )
     shell: str = gql_field(
-        description="Shell to use if start_command is a string.", default="/bin/bash"
+        description="Shell used to wrap a string-form start_command at parse time.",
+        default="/bin/bash",
     )
     port: int = gql_field(description="Port number for the model service. Must be greater than 1.")
     health_check: ModelHealthCheckInputGQL | None = gql_field(

--- a/src/ai/backend/web/static/resources/model-definition.schema.json
+++ b/src/ai/backend/web/static/resources/model-definition.schema.json
@@ -85,11 +85,8 @@
           }
         },
         "start_command": {
-          "description": "Command to start the model service. Can be a string (executed via shell) or an array of arguments.",
+          "description": "Command to start the model service as an array of arguments.",
           "oneOf": [
-            {
-              "type": "string"
-            },
             {
               "type": "array",
               "items": {
@@ -102,7 +99,6 @@
           ],
           "default": null,
           "examples": [
-            "python service.py",
             [
               "python",
               "service.py"
@@ -111,7 +107,7 @@
         },
         "shell": {
           "type": "string",
-          "description": "Shell to use when start_command is a string.",
+          "description": "Shell used to wrap a legacy string-form start_command at parse time.",
           "default": "/bin/bash",
           "examples": [
             "/bin/bash",

--- a/src/ai/backend/web/static/resources/model-definition.schema.json
+++ b/src/ai/backend/web/static/resources/model-definition.schema.json
@@ -72,7 +72,6 @@
       "type": "object",
       "description": "Service configuration that defines how to start and monitor the model service.",
       "required": [
-        "start_command",
         "port"
       ],
       "additionalProperties": true,
@@ -96,8 +95,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            {
+              "type": "null"
             }
           ],
+          "default": null,
           "examples": [
             "python service.py",
             [

--- a/src/ai/backend/web/static/resources/model-definition.schema.json
+++ b/src/ai/backend/web/static/resources/model-definition.schema.json
@@ -85,16 +85,13 @@
           }
         },
         "start_command": {
-          "description": "Command to start the model service. Accepts an array of arguments, or a legacy shell string which will be wrapped with the configured shell at parse time.",
+          "description": "Command arguments to start the model service.",
           "oneOf": [
             {
               "type": "array",
               "items": {
                 "type": "string"
               }
-            },
-            {
-              "type": "string"
             },
             {
               "type": "null"
@@ -105,13 +102,12 @@
             [
               "python",
               "service.py"
-            ],
-            "python service.py"
+            ]
           ]
         },
         "shell": {
           "type": "string",
-          "description": "Shell used to wrap a legacy string-form start_command at parse time.",
+          "description": "Shell configured for the model service.",
           "default": "/bin/bash",
           "examples": [
             "/bin/bash",

--- a/src/ai/backend/web/static/resources/model-definition.schema.json
+++ b/src/ai/backend/web/static/resources/model-definition.schema.json
@@ -85,13 +85,16 @@
           }
         },
         "start_command": {
-          "description": "Command to start the model service as an array of arguments.",
+          "description": "Command to start the model service. Accepts an array of arguments, or a legacy shell string which will be wrapped with the configured shell at parse time.",
           "oneOf": [
             {
               "type": "array",
               "items": {
                 "type": "string"
               }
+            },
+            {
+              "type": "string"
             },
             {
               "type": "null"
@@ -102,7 +105,8 @@
             [
               "python",
               "service.py"
-            ]
+            ],
+            "python service.py"
           ]
         },
         "shell": {

--- a/tests/unit/agent/test_model_service_start_command.py
+++ b/tests/unit/agent/test_model_service_start_command.py
@@ -14,7 +14,7 @@ TEST_IMAGE = "example.com/custom-vllm:latest"
 @dataclass(frozen=True)
 class ModelServiceStartCommandScenario:
     id: str
-    image_command: str | list[str] | None
+    image_command: list[str] | None
     models: list[dict[str, Any]]
     expected_start_commands: dict[str, list[str]]
     expected_image_command_calls: int = 1
@@ -24,7 +24,7 @@ class ModelServiceStartCommandScenario:
 class _ModelServiceCommandAgent:
     def __init__(
         self,
-        image_command: str | list[str] | None,
+        image_command: list[str] | None,
         *,
         raise_not_implemented: bool = False,
     ) -> None:
@@ -32,7 +32,7 @@ class _ModelServiceCommandAgent:
         self._image_command = image_command
         self._raise_not_implemented = raise_not_implemented
 
-    async def extract_image_command(self, image: str) -> str | list[str] | None:
+    async def extract_image_command(self, image: str) -> list[str] | None:
         self.calls.append(image)
         if self._raise_not_implemented:
             raise NotImplementedError
@@ -88,26 +88,6 @@ class TestPopulateMissingModelServiceStartCommands:
                 expected_start_commands={
                     "vllm": ["/etc/container/start-vllm.sh"],
                     "explicit": ["python", "serve.py"],
-                },
-            ),
-            ModelServiceStartCommandScenario(
-                id="wraps_string_command_with_shell_for_multiple_models",
-                image_command="python -m vllm.entrypoints.openai.api_server",
-                models=[
-                    _model("model-a", 8000),
-                    _model("model-b", 8001),
-                ],
-                expected_start_commands={
-                    "model-a": [
-                        "/bin/bash",
-                        "-c",
-                        "python -m vllm.entrypoints.openai.api_server",
-                    ],
-                    "model-b": [
-                        "/bin/bash",
-                        "-c",
-                        "python -m vllm.entrypoints.openai.api_server",
-                    ],
                 },
             ),
             ModelServiceStartCommandScenario(

--- a/tests/unit/agent/test_model_service_start_command.py
+++ b/tests/unit/agent/test_model_service_start_command.py
@@ -16,7 +16,7 @@ class ModelServiceStartCommandScenario:
     id: str
     image_command: str | list[str] | None
     models: list[dict[str, Any]]
-    expected_start_commands: dict[str, str | list[str]]
+    expected_start_commands: dict[str, list[str]]
     expected_image_command_calls: int = 1
     expected_unset_models: set[str] = field(default_factory=set)
 
@@ -42,13 +42,15 @@ class _ModelServiceCommandAgent:
 def _model(
     name: str,
     port: int,
-    start_command: str | list[str] | None = None,
+    start_command: list[str] | None = None,
+    shell: str = "/bin/bash",
 ) -> dict[str, Any]:
     return {
         "name": name,
         "model_path": f"/models/{name}",
         "service": {
             "port": port,
+            "shell": shell,
             "start_command": start_command if start_command is not None else None,
         },
     }
@@ -81,23 +83,31 @@ class TestPopulateMissingModelServiceStartCommands:
                 image_command=["/etc/container/start-vllm.sh"],
                 models=[
                     _model("vllm", 8000),
-                    _model("explicit", 8001, "python serve.py"),
+                    _model("explicit", 8001, ["python", "serve.py"]),
                 ],
                 expected_start_commands={
                     "vllm": ["/etc/container/start-vllm.sh"],
-                    "explicit": "python serve.py",
+                    "explicit": ["python", "serve.py"],
                 },
             ),
             ModelServiceStartCommandScenario(
-                id="reuses_string_command_for_multiple_models",
+                id="wraps_string_command_with_shell_for_multiple_models",
                 image_command="python -m vllm.entrypoints.openai.api_server",
                 models=[
                     _model("model-a", 8000),
                     _model("model-b", 8001),
                 ],
                 expected_start_commands={
-                    "model-a": "python -m vllm.entrypoints.openai.api_server",
-                    "model-b": "python -m vllm.entrypoints.openai.api_server",
+                    "model-a": [
+                        "/bin/bash",
+                        "-c",
+                        "python -m vllm.entrypoints.openai.api_server",
+                    ],
+                    "model-b": [
+                        "/bin/bash",
+                        "-c",
+                        "python -m vllm.entrypoints.openai.api_server",
+                    ],
                 },
             ),
             ModelServiceStartCommandScenario(
@@ -113,11 +123,11 @@ class TestPopulateMissingModelServiceStartCommands:
                 id="skips_image_command_lookup_when_all_commands_are_explicit",
                 image_command=["/etc/container/start-vllm.sh"],
                 models=[
-                    _model("explicit-a", 8000, "python serve-a.py"),
+                    _model("explicit-a", 8000, ["python", "serve-a.py"]),
                     _model("explicit-b", 8001, ["python", "serve-b.py"]),
                 ],
                 expected_start_commands={
-                    "explicit-a": "python serve-a.py",
+                    "explicit-a": ["python", "serve-a.py"],
                     "explicit-b": ["python", "serve-b.py"],
                 },
                 expected_image_command_calls=0,

--- a/tests/unit/agent/test_model_service_start_command.py
+++ b/tests/unit/agent/test_model_service_start_command.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import pytest
+
+from ai.backend.agent.agent import AbstractAgent
+
+TEST_IMAGE = "example.com/custom-vllm:latest"
+
+
+@dataclass(frozen=True)
+class ModelServiceStartCommandScenario:
+    id: str
+    image_command: str | list[str] | None
+    models: list[dict[str, Any]]
+    expected_start_commands: dict[str, str | list[str]]
+    expected_image_command_calls: int = 1
+    expected_unset_models: set[str] = field(default_factory=set)
+
+
+class _ModelServiceCommandAgent:
+    def __init__(
+        self,
+        image_command: str | list[str] | None,
+        *,
+        raise_not_implemented: bool = False,
+    ) -> None:
+        self.calls: list[str] = []
+        self._image_command = image_command
+        self._raise_not_implemented = raise_not_implemented
+
+    async def extract_image_command(self, image: str) -> str | list[str] | None:
+        self.calls.append(image)
+        if self._raise_not_implemented:
+            raise NotImplementedError
+        return self._image_command
+
+
+def _model(
+    name: str,
+    port: int,
+    start_command: str | list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "model_path": f"/models/{name}",
+        "service": {
+            "port": port,
+            "start_command": start_command if start_command is not None else None,
+        },
+    }
+
+
+class TestPopulateMissingModelServiceStartCommands:
+    @pytest.fixture
+    def image(self) -> str:
+        return TEST_IMAGE
+
+    @pytest.fixture
+    def agent(
+        self,
+        scenario: ModelServiceStartCommandScenario,
+    ) -> _ModelServiceCommandAgent:
+        return _ModelServiceCommandAgent(scenario.image_command)
+
+    @pytest.fixture
+    def models(
+        self,
+        scenario: ModelServiceStartCommandScenario,
+    ) -> list[dict[str, Any]]:
+        return deepcopy(scenario.models)
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            ModelServiceStartCommandScenario(
+                id="uses_list_command_from_image",
+                image_command=["/etc/container/start-vllm.sh"],
+                models=[
+                    _model("vllm", 8000),
+                    _model("explicit", 8001, "python serve.py"),
+                ],
+                expected_start_commands={
+                    "vllm": ["/etc/container/start-vllm.sh"],
+                    "explicit": "python serve.py",
+                },
+            ),
+            ModelServiceStartCommandScenario(
+                id="reuses_string_command_for_multiple_models",
+                image_command="python -m vllm.entrypoints.openai.api_server",
+                models=[
+                    _model("model-a", 8000),
+                    _model("model-b", 8001),
+                ],
+                expected_start_commands={
+                    "model-a": "python -m vllm.entrypoints.openai.api_server",
+                    "model-b": "python -m vllm.entrypoints.openai.api_server",
+                },
+            ),
+            ModelServiceStartCommandScenario(
+                id="leaves_missing_command_unset_without_image_command",
+                image_command=None,
+                models=[
+                    _model("vllm", 8000),
+                ],
+                expected_start_commands={},
+                expected_unset_models={"vllm"},
+            ),
+            ModelServiceStartCommandScenario(
+                id="skips_image_command_lookup_when_all_commands_are_explicit",
+                image_command=["/etc/container/start-vllm.sh"],
+                models=[
+                    _model("explicit-a", 8000, "python serve-a.py"),
+                    _model("explicit-b", 8001, ["python", "serve-b.py"]),
+                ],
+                expected_start_commands={
+                    "explicit-a": "python serve-a.py",
+                    "explicit-b": ["python", "serve-b.py"],
+                },
+                expected_image_command_calls=0,
+            ),
+        ],
+        ids=lambda scenario: scenario.id,
+    )
+    async def test_populates_missing_commands_from_image_command(
+        self,
+        scenario: ModelServiceStartCommandScenario,
+        agent: _ModelServiceCommandAgent,
+        models: list[dict[str, Any]],
+        image: str,
+    ) -> None:
+        populated_models = await AbstractAgent._populate_missing_model_service_start_commands(
+            cast(AbstractAgent[Any, Any], agent),
+            models,
+            image,
+        )
+
+        assert populated_models is models
+        assert agent.calls == [image] * scenario.expected_image_command_calls
+        services = {model["name"]: model["service"] for model in populated_models}
+        for model_name, expected_start_command in scenario.expected_start_commands.items():
+            assert services[model_name]["start_command"] == expected_start_command
+        for model_name in scenario.expected_unset_models:
+            assert not services[model_name].get("start_command")
+
+    @pytest.fixture
+    def raise_not_implemented_agent(
+        self,
+    ) -> _ModelServiceCommandAgent:
+        return _ModelServiceCommandAgent(None, raise_not_implemented=True)
+
+    async def test_reraises_not_implemented_error(
+        self,
+        image: str,
+        raise_not_implemented_agent: _ModelServiceCommandAgent,
+    ) -> None:
+        models = [_model("vllm", 8000)]
+
+        with pytest.raises(NotImplementedError):
+            await AbstractAgent._populate_missing_model_service_start_commands(
+                cast(AbstractAgent[Any, Any], raise_not_implemented_agent),
+                models,
+                image,
+            )
+
+        assert raise_not_implemented_agent.calls == [image]
+        assert not models[0]["service"].get("start_command")

--- a/tests/unit/common/dto/manager/v2/deployment/test_response.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_response.py
@@ -39,7 +39,6 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
     IntOrPercent,
     ModelMountConfigInfoDTO,
     ModelRuntimeConfigInfoDTO,
-    ModelServiceConfigInfoDTO,
     ReplicaStateInfo,
     ResourceConfigInfoDTO,
     RollingUpdateConfigInfo,
@@ -199,19 +198,6 @@ class TestExtraVFolderMountNode:
         restored = ExtraVFolderMountNode.model_validate_json(json_str)
         assert restored.vfolder_id == vfolder_id
         assert restored.mount_destination == "/data"
-
-
-class TestModelServiceConfigInfoDTO:
-    """Tests for ModelServiceConfigInfoDTO model."""
-
-    def test_wraps_legacy_string_start_command_with_shell(self) -> None:
-        service = ModelServiceConfigInfoDTO.model_validate({
-            "start_command": "python serve.py",
-            "shell": "/bin/sh",
-            "port": 8000,
-        })
-
-        assert service.start_command == ["/bin/sh", "-c", "python serve.py"]
 
 
 class TestRevisionNode:

--- a/tests/unit/common/dto/manager/v2/deployment/test_response.py
+++ b/tests/unit/common/dto/manager/v2/deployment/test_response.py
@@ -39,6 +39,7 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
     IntOrPercent,
     ModelMountConfigInfoDTO,
     ModelRuntimeConfigInfoDTO,
+    ModelServiceConfigInfoDTO,
     ReplicaStateInfo,
     ResourceConfigInfoDTO,
     RollingUpdateConfigInfo,
@@ -200,6 +201,19 @@ class TestExtraVFolderMountNode:
         assert restored.mount_destination == "/data"
 
 
+class TestModelServiceConfigInfoDTO:
+    """Tests for ModelServiceConfigInfoDTO model."""
+
+    def test_wraps_legacy_string_start_command_with_shell(self) -> None:
+        service = ModelServiceConfigInfoDTO.model_validate({
+            "start_command": "python serve.py",
+            "shell": "/bin/sh",
+            "port": 8000,
+        })
+
+        assert service.start_command == ["/bin/sh", "-c", "python serve.py"]
+
+
 class TestRevisionNode:
     """Tests for RevisionNode model."""
 
@@ -261,7 +275,7 @@ class TestRevisionNode:
                     "name": "sample-model",
                     "model_path": "/models/sample",
                     "service": {
-                        "start_command": "python serve.py",
+                        "start_command": ["python", "serve.py"],
                         "port": 8000,
                     },
                 }
@@ -272,6 +286,7 @@ class TestRevisionNode:
         assert node.model_definition is not None
         assert node.model_definition.models[0].name == "sample-model"
         assert node.model_definition.models[0].service is not None
+        assert node.model_definition.models[0].service.start_command == ["python", "serve.py"]
         assert node.model_definition.models[0].service.port == 8000
 
     def test_round_trip(self) -> None:

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -1,11 +1,13 @@
 import pickle
 from typing import Any
 
+import pytest
 import tomli
 
 from ai.backend.common.config import (
     ModelConfig,
     ModelDefinition,
+    ModelDefinitionDraft,
     ModelHealthCheck,
     ModelMetadata,
     ModelServiceConfig,
@@ -177,24 +179,50 @@ class TestMergeFieldCoverage:
         assert not missing, f"_merge_definition() does not handle: {missing}"
 
 
-def test_sanitize_inline_dicts() -> None:
-    sample = """
-    [section]
-    a = { x = 1, y = 1 }
-    b = { x = 1, y = { t = 2, u = 2 } }
-    """
+class TestModelConfigs:
+    def test_sanitize_inline_dicts(self) -> None:
+        sample = """
+        [section]
+        a = { x = 1, y = 1 }
+        b = { x = 1, y = { t = 2, u = 2 } }
+        """
 
-    result = tomli.loads(sample)
-    assert isinstance(result["section"]["a"], dict)
-    assert isinstance(result["section"]["b"], dict)
-    assert isinstance(result["section"]["b"]["y"], dict)
+        result = tomli.loads(sample)
+        assert isinstance(result["section"]["a"], dict)
+        assert isinstance(result["section"]["b"], dict)
+        assert isinstance(result["section"]["b"]["y"], dict)
 
-    # Also ensure the result is picklable.
-    data = pickle.dumps(result)
-    result = pickle.loads(data)
-    assert result == {
-        "section": {
-            "a": {"x": 1, "y": 1},
-            "b": {"x": 1, "y": {"t": 2, "u": 2}},
-        },
-    }
+        # Also ensure the result is picklable.
+        data = pickle.dumps(result)
+        result = pickle.loads(data)
+        assert result == {
+            "section": {
+                "a": {"x": 1, "y": 1},
+                "b": {"x": 1, "y": {"t": 2, "u": 2}},
+            },
+        }
+
+    @pytest.fixture
+    def model_definition_draft_with_minimal_service(self) -> ModelDefinitionDraft:
+        return ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "demo",
+                    "model_path": "/models/demo",
+                    "service": {
+                        "port": 8000,
+                    },
+                }
+            ]
+        })
+
+    def test_model_service_config_draft_allows_missing_start_command(
+        self, model_definition_draft_with_minimal_service: ModelDefinitionDraft
+    ) -> None:
+        model_definition = model_definition_draft_with_minimal_service
+        resolved = model_definition.to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.start_command is None
+        assert service.port == 8000

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -103,7 +103,7 @@ class TestMergeFieldCoverage:
         base = ModelServiceConfig.model_construct(
             _fields_set=set(ModelServiceConfig.model_fields),
             pre_start_actions=[],
-            start_command="base-cmd",
+            start_command=["base-cmd"],
             shell="/bin/base",
             port=9999,
             health_check=None,
@@ -111,7 +111,7 @@ class TestMergeFieldCoverage:
         override = ModelServiceConfig.model_construct(
             _fields_set=set(),
             pre_start_actions=[],
-            start_command="",
+            start_command=[],
             shell="",
             port=2,
             health_check=None,
@@ -136,13 +136,13 @@ class TestMergeFieldCoverage:
         )
         base = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command="",
+            start_command=[],
             port=2,
             health_check=base_hc,
         )
         override = ModelServiceConfig.model_construct(
             _fields_set={"health_check"},
-            start_command="",
+            start_command=[],
             port=2,
             health_check=override_hc,
         )

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -226,3 +226,18 @@ class TestModelConfigs:
         assert service is not None
         assert service.start_command is None
         assert service.port == 8000
+
+    def test_model_service_config_draft_rejects_string_start_command(self) -> None:
+        with pytest.raises(ValueError):
+            ModelDefinitionDraft.model_validate({
+                "models": [
+                    {
+                        "name": "demo",
+                        "model_path": "/models/demo",
+                        "service": {
+                            "start_command": "python serve.py",
+                            "port": 8000,
+                        },
+                    }
+                ]
+            })

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -70,8 +70,10 @@ class TestRevisionDataToDTO:
 
         assert dto.model_definition is not None
         assert dto.model_definition.models[0].name == "demo-model"
-        assert dto.model_definition.models[0].service is not None
-        assert dto.model_definition.models[0].service.port == 8000
+        service = dto.model_definition.models[0].service
+        assert service is not None
+        assert service.port == 8000
+        assert service.start_command == ["python", "serve.py"]
 
 
 class TestTriStateFromInput:

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -55,7 +55,7 @@ class TestRevisionDataToDTO:
                         name="demo-model",
                         model_path="/models/demo",
                         service=ModelServiceConfig(
-                            start_command="python serve.py",
+                            start_command=["python", "serve.py"],
                             port=8000,
                         ),
                     ),


### PR DESCRIPTION
## Summary
- Make `start_command` optional in model service configs and fall back to the container image's `Config.Cmd` when omitted.
- Update trafaret schema, Pydantic config models, v2 DTOs, GraphQL types, and `model-definition.schema.json` to allow `null` / missing `start_command`.
- Resolve the missing command in `AbstractAgent` at kernel-creation time via `extract_image_command()`; log a warning and skip the model service when neither source provides a command.

## Test plan
- [x] `pants fmt / fix / lint --changed-since=origin/main`
- [x] Unit tests: `tests/unit/agent/test_model_service_start_command.py`, updated `tests/unit/common/test_config.py`
- [ ] Manual: deploy a model with no `start_command` and verify the agent uses the image's default Cmd
- [ ] Manual: deploy with an image that has no `Config.Cmd` and verify a warning is logged and the service is skipped

Resolves BA-5891

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11402.org.readthedocs.build/en/11402/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11402.org.readthedocs.build/ko/11402/

<!-- readthedocs-preview sorna-ko end -->