### PR TITLE
fix(BA-5897): Allocate model_path with model_mount_destination when model_path is unset

### DIFF
--- a/changes/11408.fix.md
+++ b/changes/11408.fix.md
@@ -1,0 +1,1 @@
+Fix model serving deployment failure when model_path is omitted by defaulting it to the model mount destination.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -595,7 +595,7 @@ def _merge_config_draft(
         metadata = _pick(base.metadata, override.metadata, "metadata" in s)
     return ModelConfigDraft.model_construct(
         name=_pick(base.name, override.name, "name" in s),
-        model_path=_pick(base.model_path, override.model_path, "model_path" in s),
+        model_path=override.model_path if override.model_path is not None else base.model_path,
         service=service,
         metadata=metadata,
     )

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -372,11 +372,12 @@ class DeploymentController:
         merged RevisionDraft — mount identity is not a merge candidate.
 
         Merge order (low → high) is assembled by ``RevisionDraftReader``:
-            1. runtime-variant baseline model definition
-            2. revision preset (if ``preset_id`` is supplied)
-            3. deployment-config.yaml   (only when the variant reads vfolder files)
-            4. model-definition.yaml    (only when the variant reads vfolder files)
-            5. overrides (highest — explicit user input)
+            1. model mount destination as the ``model_path`` default
+            2. runtime-variant baseline model definition
+            3. revision preset (if ``preset_id`` is supplied)
+            4. deployment-config.yaml   (only when the variant reads vfolder files)
+            5. model-definition.yaml    (only when the variant reads vfolder files)
+            6. overrides (highest — explicit user input)
 
         ``runtime_variant_id`` is resolved before the draft chain runs because
         the runtime variant's baseline model definition is the first merge

--- a/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
@@ -47,7 +47,8 @@ class RevisionDraftReader:
 
     One public method per API path (legacy create, legacy modify, v2 add).
     Each returns the ordered list of drafts the controller feeds into
-    ``merge_revision_drafts`` — lowest priority first.
+    ``merge_revision_drafts`` — lowest priority first. The model mount
+    destination is added as the lowest-priority ``model_path`` default.
     """
 
     _deployment_repository: DeploymentRepository
@@ -69,17 +70,21 @@ class RevisionDraftReader:
         """Legacy model-serving create: no base revision.
 
         Merge order (low → high):
-          1. runtime-variant default model definition
-          2. revision preset (if supplied)
-          3. deployment-config.yaml  (only when the variant reads vfolder files)
-          4. model-definition.yaml   (only when the variant reads vfolder files)
-          5. request
+          1. model mount destination as model_path default
+          2. runtime-variant default model definition
+          3. revision preset (if supplied)
+          4. deployment-config.yaml  (only when the variant reads vfolder files)
+          5. model-definition.yaml   (only when the variant reads vfolder files)
+          6. request
         """
         bundle = await self._deployment_repository.load_legacy_model_service_deployment_read_bundle(
             runtime_variant_id=execution.runtime_variant_id,
             preset_id=preset_id,
         )
-        drafts: list[RevisionDraft] = [self._variant_baseline_to_draft(bundle.variant)]
+        drafts: list[RevisionDraft] = [
+            self._model_mount_path_default_draft(mounts),
+            self._variant_baseline_to_draft(bundle.variant),
+        ]
         if bundle.preset is not None:
             drafts.append(self._preset_to_draft(bundle.preset, bundle.preset_resource_slots or []))
         drafts.extend(await self._read_vfolder_drafts(mounts, bundle.variant))
@@ -101,7 +106,10 @@ class RevisionDraftReader:
             preset_id=preset_id,
             endpoint_id=endpoint_id,
         )
-        drafts: list[RevisionDraft] = [self._variant_baseline_to_draft(bundle.variant)]
+        drafts: list[RevisionDraft] = [
+            self._model_mount_path_default_draft(mounts),
+            self._variant_baseline_to_draft(bundle.variant),
+        ]
         if bundle.preset is not None:
             drafts.append(self._preset_to_draft(bundle.preset, bundle.preset_resource_slots or []))
         drafts.append(bundle.base.to_draft())
@@ -122,7 +130,10 @@ class RevisionDraftReader:
             runtime_variant_id=runtime_variant_id,
             preset_id=preset_id,
         )
-        drafts: list[RevisionDraft] = [self._variant_baseline_to_draft(bundle.variant)]
+        drafts: list[RevisionDraft] = [
+            self._model_mount_path_default_draft(mounts),
+            self._variant_baseline_to_draft(bundle.variant),
+        ]
         if bundle.preset is not None:
             drafts.append(self._preset_to_draft(bundle.preset, bundle.preset_resource_slots or []))
         drafts.extend(await self._read_vfolder_drafts(mounts, bundle.variant))
@@ -160,6 +171,16 @@ class RevisionDraftReader:
             model_definition=model_definition,
             preset_values=list(preset.preset_values) or None,
         )
+
+    def _model_mount_path_default_draft(
+        self,
+        mounts: MountMetadata,
+    ) -> RevisionDraft:
+        """Build the lowest-priority model_path default draft."""
+        model_definition = ModelDefinitionDraft(
+            models=[ModelConfigDraft(model_path=mounts.model_mount_destination)]
+        )
+        return RevisionDraft(model_definition=model_definition)
 
     async def _read_vfolder_drafts(
         self,

--- a/tests/unit/manager/data/deployment/test_revision_draft_merge.py
+++ b/tests/unit/manager/data/deployment/test_revision_draft_merge.py
@@ -105,3 +105,39 @@ class TestRevisionDraftMerge:
         later = RevisionDraft(preset_values=second)
         merged = earlier.merge(later)
         assert merged.preset_values == second
+
+    def test_model_definition_uses_lower_model_path_when_higher_omits_it(self) -> None:
+        base = RevisionDraft(
+            model_definition=ModelDefinitionDraft(
+                models=[ModelConfigDraft(name="base", model_path="/mnt/models")]
+            )
+        )
+        override = RevisionDraft(
+            model_definition=ModelDefinitionDraft(models=[ModelConfigDraft(name="override")])
+        )
+
+        merged = _merge_all(base, override)
+
+        assert merged.model_definition is not None
+        assert merged.model_definition.models is not None
+        assert merged.model_definition.models[0].name == "override"
+        assert merged.model_definition.models[0].model_path == "/mnt/models"
+
+    def test_model_definition_treats_null_model_path_as_missing(self) -> None:
+        base = RevisionDraft(
+            model_definition=ModelDefinitionDraft(
+                models=[ModelConfigDraft(name="base", model_path="/mnt/models")]
+            )
+        )
+        override = RevisionDraft(
+            model_definition=ModelDefinitionDraft(
+                models=[ModelConfigDraft(name="override", model_path=None)]
+            )
+        )
+
+        merged = _merge_all(base, override)
+
+        assert merged.model_definition is not None
+        assert merged.model_definition.models is not None
+        assert merged.model_definition.models[0].name == "override"
+        assert merged.model_definition.models[0].model_path == "/mnt/models"

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -1,0 +1,53 @@
+"""Unit tests for ``RevisionDraftReader``."""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, cast
+from uuid import uuid4
+
+from ai.backend.common.config import ModelConfigDraft, ModelDefinitionDraft
+from ai.backend.common.identifier.vfolder import VFolderUUID
+from ai.backend.manager.data.deployment.types import MountMetadata, RevisionDraft
+from ai.backend.manager.sokovan.deployment.revision_draft.reader import RevisionDraftReader
+
+
+def _reader() -> RevisionDraftReader:
+    return RevisionDraftReader(deployment_repository=cast(Any, object()))
+
+
+def _mounts(model_mount_destination: str = "/models") -> MountMetadata:
+    return MountMetadata(
+        model_vfolder_id=VFolderUUID(uuid4()),
+        model_definition_path=None,
+        model_mount_destination=model_mount_destination,
+        extra_mounts=[],
+    )
+
+
+def _merge_all(*drafts: RevisionDraft) -> RevisionDraft:
+    return functools.reduce(RevisionDraft.merge, drafts, RevisionDraft())
+
+
+class TestRevisionDraftReaderModelPathDefault:
+    def test_adds_lowest_priority_model_path_default(self) -> None:
+        drafts = [
+            _reader()._model_mount_path_default_draft(_mounts("/mnt/models")),
+            RevisionDraft(
+                model_definition=ModelDefinitionDraft(models=[ModelConfigDraft(name="base")])
+            ),
+            RevisionDraft(
+                model_definition=ModelDefinitionDraft(
+                    models=[
+                        ModelConfigDraft(name="override-0"),
+                    ]
+                )
+            ),
+        ]
+
+        merged = _merge_all(*drafts)
+
+        assert merged.model_definition is not None
+        assert merged.model_definition.models is not None
+        assert merged.model_definition.models[0].name == "override-0"
+        assert merged.model_definition.models[0].model_path == "/mnt/models"


### PR DESCRIPTION
resolves #11406 (BA-5897)

**Checklist:** (if applicable)

- [ ] Milestone metadata specifying the target backport version
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [ ] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations
