### PR TITLE
refactor(BA-5902): remove rowId field from Strawberry GQL Node types

### DIFF
--- a/changes/11411.breaking.md
+++ b/changes/11411.breaking.md
@@ -1,0 +1,1 @@
+Remove the `rowId` field from the Strawberry GQL Node types `RuntimeVariant`, `RuntimeVariantPreset`, and `DeploymentRevisionPreset`. Relay Node types now expose only the global `id` field; clients must derive the raw UUID by decoding `id` instead of selecting `rowId`.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5114,9 +5114,6 @@ type DeploymentRevisionPreset implements Node
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """The unique database identifier of this deployment preset."""
-  rowId: UUID!
-
   """The runtime variant this preset is designed for (e.g., vLLM, SGLang)."""
   runtimeVariantId: UUID!
 
@@ -15955,9 +15952,6 @@ type RuntimeVariant implements Node
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """The unique database identifier of this runtime variant."""
-  rowId: UUID!
-
   """
   Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang', 'nim', 'tgi').
   """
@@ -16042,9 +16036,6 @@ type RuntimeVariantPreset implements Node
 {
   """The Globally Unique ID of this object"""
   id: ID!
-
-  """The unique database identifier of this preset."""
-  rowId: UUID!
 
   """The runtime variant this preset belongs to."""
   runtimeVariantId: UUID!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3387,9 +3387,6 @@ type DeploymentRevisionPreset implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """The unique database identifier of this deployment preset."""
-  rowId: UUID!
-
   """The runtime variant this preset is designed for (e.g., vLLM, SGLang)."""
   runtimeVariantId: UUID!
 
@@ -10729,9 +10726,6 @@ type RuntimeVariant implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
 
-  """The unique database identifier of this runtime variant."""
-  rowId: UUID!
-
   """
   Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang', 'nim', 'tgi').
   """
@@ -10795,9 +10789,6 @@ Added in 26.4.2. Defines a configurable parameter for a runtime variant. Each pr
 type RuntimeVariantPreset implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
-
-  """The unique database identifier of this preset."""
-  rowId: UUID!
 
   """The runtime variant this preset belongs to."""
   runtimeVariantId: UUID!

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -244,9 +244,6 @@ class PresetDeploymentDefaultsGQL(PydanticOutputMixin[PresetDeploymentDefaultsDT
 )
 class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
     id: NodeID[str] = gql_field(description="Relay-style global node identifier.")
-    row_id: UUID = gql_field(
-        description="The unique database identifier of this deployment preset."
-    )
     runtime_variant_id: UUID = gql_field(
         description="The runtime variant this preset is designed for (e.g., vLLM, SGLang)."
     )
@@ -327,7 +324,7 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment_revision_preset.search_resource_slots(
-            preset_id=self.row_id,
+            preset_id=UUID(self.id),
             input=SearchAllocatedResourceSlotsInput(
                 filter=pydantic_filter,
                 order=pydantic_order,

--- a/src/ai/backend/manager/api/gql/runtime_variant/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant/types.py
@@ -68,7 +68,6 @@ class RuntimeVariantOrderFieldGQL(StrEnum):
 )
 class RuntimeVariantGQL(PydanticNodeMixin[RuntimeVariantNodeDTO]):
     id: NodeID[str] = gql_field(description="Relay-style global node identifier.")
-    row_id: UUID = gql_field(description="The unique database identifier of this runtime variant.")
     name: str = gql_field(
         description="Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang', 'nim', 'tgi')."
     )

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -199,7 +199,6 @@ class PresetTargetSpecGQL(PydanticOutputMixin[PresetTargetSpecDTO]):
 )
 class RuntimeVariantPresetGQL(PydanticNodeMixin[NodeDTO]):
     id: NodeID[str] = gql_field(description="Relay-style global node identifier.")
-    row_id: UUID = gql_field(description="The unique database identifier of this preset.")
     runtime_variant_id: UUID = gql_field(description="The runtime variant this preset belongs to.")
     name: str = gql_field(
         description="Human-readable name of the configurable parameter (e.g., 'Tensor Parallel Size', 'Quantization')."


### PR DESCRIPTION
resolve #11409 (BA-5902)

## Summary

Remove the `rowId` field from the three Strawberry-based Relay Node types:
- `RuntimeVariantGQL`
- `RuntimeVariantPresetGQL`
- `DeploymentRevisionPresetGQL`

GraphQL Relay Node types should expose only the global `id` field, not the raw DB UUID. The `rowId` field leaked the underlying primary key alongside the encoded relay ID.

The lone internal `self.row_id` use at `revision_preset.py:322` (`preset_id=self.row_id`) is replaced with `UUID(self.id)`, matching the established pattern across the `gql/` package (`object_storage.py`, `rbac/types/role.py`, `artifact/types.py`, `model_card/types.py`).

`gql_legacy/` types are intentionally out of scope for this task

## Breaking change

`rowId` is removed from `RuntimeVariant`, `RuntimeVariantPreset`, and `DeploymentRevisionPreset` in v2 schema. Clients (e.g. webui's `DeploymentLauncherPageRuntimeVariantsQuery`) using `rowId` must migrate to decoding the relay `id`.

## Test plan

- [ ] Existing GQL query selections without `rowId` continue to resolve
- [ ] `resource_slots` resolver on `DeploymentRevisionPreset` returns correct page (uses `UUID(self.id)`)
- [ ] webui consumers updated separately to use `id` instead of `rowId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5902]: https://lablup.atlassian.net/browse/BA-5902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11411.org.readthedocs.build/en/11411/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11411.org.readthedocs.build/ko/11411/

<!-- readthedocs-preview sorna-ko end -->