### PR TITLE
feat(BA-5903): persist deployment chat history and replay as request context

### DIFF
--- a/changes/11412.feature.md
+++ b/changes/11412.feature.md
@@ -1,0 +1,1 @@
+Persist multi-turn `./bai deployment chat` history per deployment and replay recent turns as request context, with new `./bai deployment chat-history show / clear` subcommands.

--- a/src/ai/backend/client/cli/v2/deployment/__init__.py
+++ b/src/ai/backend/client/cli/v2/deployment/__init__.py
@@ -1,6 +1,6 @@
 from .access_token import access_token
 from .auto_scaling_rule import auto_scaling_rule
-from .chat import chat, chat_cache, chat_config
+from .chat import chat, chat_cache, chat_config, chat_history
 from .commands import deployment as deployment
 from .options import options
 from .policy import policy
@@ -19,5 +19,6 @@ deployment.add_command(options)
 deployment.add_command(chat)
 deployment.add_command(chat_config)
 deployment.add_command(chat_cache)
+deployment.add_command(chat_history)
 
 __all__ = ("deployment",)

--- a/src/ai/backend/client/cli/v2/deployment/chat/__init__.py
+++ b/src/ai/backend/client/cli/v2/deployment/chat/__init__.py
@@ -1,8 +1,8 @@
-"""``./bai deployment chat``, ``chat-config``, and ``chat-cache`` CLI commands.
+"""``./bai deployment chat``, ``chat-config``, ``chat-cache``, and ``chat-history`` CLI commands.
 
 Submodules:
 - :mod:`commands` — Click command/group definitions.
-- :mod:`types` — Pydantic models for the on-disk cache and config,
+- :mod:`types` — Pydantic models for the on-disk cache, config, and history,
   including the ``.load()``/``.save()`` classmethods that wire them to
   ``~/.backend.ai/deployment_chat/*.json``.
 - :mod:`utils` — file paths and shared JSON I/O helpers.
@@ -12,6 +12,6 @@ OpenAI-compat wire DTOs live in :mod:`ai.backend.common.dto.clients.openai_compa
 so they can be reused by any backend.ai component.
 """
 
-from .commands import chat, chat_cache, chat_config
+from .commands import chat, chat_cache, chat_config, chat_history
 
-__all__ = ("chat", "chat_cache", "chat_config")
+__all__ = ("chat", "chat_cache", "chat_config", "chat_history")

--- a/src/ai/backend/client/cli/v2/deployment/chat/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/chat/commands.py
@@ -1,4 +1,4 @@
-"""User-facing CLI: ``./bai deployment chat``, ``chat-config``, ``chat-cache``."""
+"""User-facing CLI: ``./bai deployment chat``, ``chat-config``, ``chat-cache``, ``chat-history``."""
 
 from __future__ import annotations
 
@@ -15,9 +15,11 @@ from ai.backend.client.cli.v2.deployment.chat.formatter import (
     mask_token,
 )
 from ai.backend.client.cli.v2.deployment.chat.types import (
+    DEFAULT_CHAT_HISTORY_LIMIT,
     DeploymentChatCache,
     DeploymentChatCacheEntry,
     DeploymentChatConfig,
+    DeploymentChatHistory,
 )
 from ai.backend.client.cli.v2.helpers import create_v2_registry, load_v2_config
 from ai.backend.common.dto.clients.openai_compat import ChatCompletionRequest
@@ -67,11 +69,24 @@ def _run_async(coro_fn: Callable[[], Coroutine[Any, Any, None]]) -> None:
         "The 'model' and 'messages' fields are always overridden by --model and MESSAGE."
     ),
 )
+@click.option(
+    "--history-limit",
+    default=DEFAULT_CHAT_HISTORY_LIMIT,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help=(
+        "Maximum number of past messages from this deployment's persisted "
+        "history to replay as context. Set to 0 to skip context for this "
+        "turn (the round is still recorded; use `chat-history clear` to "
+        "wipe the persisted transcript)."
+    ),
+)
 def chat(
     deployment_id: DeploymentID,
     message: str,
     model: str | None,
     params: Any,
+    history_limit: int,
 ) -> None:
     """Send a one-shot chat completion request to a deployed model.
 
@@ -81,8 +96,6 @@ def chat(
     temperature and top_p differ between runtime variants — pass them
     through ``--params``.
     """
-    import json
-
     from ai.backend.client.v2.config import ClientConfig
     from ai.backend.client.v2.deployment_chat import DeploymentChatClient
     from ai.backend.client.v2.exceptions import DeploymentAuthError
@@ -91,6 +104,7 @@ def chat(
 
     cache = DeploymentChatCache.load()
     chat_config = DeploymentChatConfig.load()
+    history = DeploymentChatHistory.load()
 
     if not isinstance(params, dict):
         raise click.ClickException("--params must be a JSON object.")
@@ -159,10 +173,15 @@ def chat(
                     cache.set(deployment_id, endpoint_entry)
                     cache.save()
 
+                past_messages = history.slice(deployment_id, history_limit)
+                request_messages: list[dict[str, str]] = [
+                    *({"role": past.role, "content": past.content} for past in past_messages),
+                    {"role": "user", "content": message},
+                ]
                 request = ChatCompletionRequest.model_validate({
                     **extra_body,
                     "model": request_model,
-                    "messages": [{"role": "user", "content": message}],
+                    "messages": request_messages,
                 })
                 body = request.model_dump(mode="json")
                 response = await client.chat_completion(endpoint_entry.endpoint_url, token, body)
@@ -180,7 +199,15 @@ def chat(
                     f"re-register with:\n"
                     f"  ./bai deployment chat-config set {deployment_id} --token <token>"
                 ) from e
-        print(json.dumps(response, indent=2, ensure_ascii=False, default=str))
+        # Only persist when both sides of the round are present, so the file
+        # never carries half-conversations that would skew future context.
+        assistant_message = response.assistant_message
+        if assistant_message is not None:
+            now = datetime.now(UTC)
+            history.append(deployment_id, "user", message, created_at=now)
+            history.append(deployment_id, "assistant", assistant_message, created_at=now)
+            history.save()
+        print(response.model_dump_json(indent=2))
 
     _run_async(_run)
 
@@ -330,4 +357,58 @@ def cache_clear(deployment_id: DeploymentID) -> None:
         print(f"No cache entry for deployment {deployment_id}.")
 
 
-__all__ = ("chat", "chat_cache", "chat_config")
+# ---------------------------------------------------------------------------
+# chat-history
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="chat-history")
+def chat_history() -> None:
+    """Manage per-deployment chat transcripts.
+
+    The ``chat`` command auto-records each user/assistant round into
+    ``~/.backend.ai/deployment_chat/history.json`` so subsequent calls
+    can replay recent turns as context. Use this group to inspect or
+    wipe what has been persisted.
+    """
+
+
+@chat_history.command(name="show")
+@click.argument("deployment_id", type=click.UUID)
+@click.option(
+    "--limit",
+    default=None,
+    type=click.IntRange(min=1),
+    help="Print only the most recent N messages (default: all persisted).",
+)
+def history_show(deployment_id: DeploymentID, limit: int | None) -> None:
+    """Print the persisted transcript for a deployment."""
+    history = DeploymentChatHistory.load()
+    messages = history.get(deployment_id)
+    if not messages:
+        print(f"No chat history for deployment {deployment_id}.")
+        return
+    visible = messages if limit is None else messages[-limit:]
+    print(f"deployment_id : {deployment_id}")
+    print(f"messages      : {len(messages)} persisted (showing {len(visible)})")
+    for message in visible:
+        print(f"  [{message.created_at.isoformat()}] {message.role}: {message.content}")
+
+
+@chat_history.command(name="clear")
+@click.argument("deployment_id", type=click.UUID)
+def history_clear(deployment_id: DeploymentID) -> None:
+    """Drop the persisted transcript for a deployment.
+
+    The next ``chat`` call starts a fresh context. Cache and config
+    entries are unaffected.
+    """
+    history = DeploymentChatHistory.load()
+    if history.clear(deployment_id):
+        history.save()
+        print(f"Cleared chat history for deployment {deployment_id}.")
+    else:
+        print(f"No chat history for deployment {deployment_id}.")
+
+
+__all__ = ("chat", "chat_cache", "chat_config", "chat_history")

--- a/src/ai/backend/client/cli/v2/deployment/chat/types.py
+++ b/src/ai/backend/client/cli/v2/deployment/chat/types.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, ValidationError
 from ai.backend.client.cli.v2.deployment.chat.utils import (
     CHAT_CACHE_FILE,
     CHAT_CONFIG_FILE,
+    CHAT_HISTORY_FILE,
     read_json_file,
     write_json_file,
 )
@@ -19,6 +20,20 @@ from ai.backend.common.identifier.deployment import DeploymentID
 
 CACHE_ENTRY_TTL = timedelta(hours=24)
 """Endpoint cache entries older than this are treated as a cache miss."""
+
+DEFAULT_CHAT_HISTORY_LIMIT = 10
+"""Default number of past messages forwarded as context on each ``chat`` call.
+
+Mirrors the typical 5-turn rolling window of OpenAI-compatible chat UIs.
+Override per-call with ``--history-limit``; setting it to 0 disables context.
+"""
+
+MAX_PERSISTED_HISTORY_MESSAGES = 100
+"""Hard cap on messages kept in ``history.json`` per deployment.
+
+The file holds plain text; capping it keeps disk usage bounded even when the
+user never runs ``chat-history clear``. Older messages are dropped FIFO.
+"""
 
 
 class DeploymentChatCacheEntry(BaseModel):
@@ -151,3 +166,80 @@ class DeploymentChatConfig(BaseModel):
         storage convention; see ``client/cli/v2/config_cmd.py``).
         """
         write_json_file(CHAT_CONFIG_FILE, self.model_dump_json(indent=2))
+
+
+class ChatMessage(BaseModel):
+    """One persisted user/assistant turn.
+
+    ``created_at`` is local-only metadata for ``chat-history show``; it is
+    stripped before the message is replayed into the chat-completions request
+    body (the wire format is just ``{role, content}``).
+    """
+
+    role: str
+    content: str
+    created_at: datetime
+
+
+class DeploymentChatHistory(BaseModel):
+    """Per-deployment rolling chat transcripts.
+
+    Stored separately from the cache (auto-managed endpoint metadata) and
+    config (user-managed token/model) so that clearing one does not affect
+    the others. The transcripts are FIFO-truncated at
+    :data:`MAX_PERSISTED_HISTORY_MESSAGES` to bound disk usage.
+    """
+
+    deployments: dict[DeploymentID, list[ChatMessage]] = Field(default_factory=dict)
+
+    def get(self, deployment_id: DeploymentID) -> list[ChatMessage] | None:
+        return self.deployments.get(deployment_id)
+
+    def slice(self, deployment_id: DeploymentID, limit: int) -> list[ChatMessage]:
+        """Return the last ``limit`` turns of the transcript for replay as request context."""
+        if limit <= 0:
+            return []
+        messages = self.deployments.get(deployment_id)
+        if not messages:
+            return []
+        return messages[-limit:]
+
+    def append(
+        self,
+        deployment_id: DeploymentID,
+        role: str,
+        content: str,
+        *,
+        created_at: datetime,
+        max_persisted: int = MAX_PERSISTED_HISTORY_MESSAGES,
+    ) -> None:
+        """Append one turn and FIFO-truncate to keep the file bounded."""
+        messages = self.deployments.setdefault(deployment_id, [])
+        messages.append(ChatMessage(role=role, content=content, created_at=created_at))
+        overflow = len(messages) - max_persisted
+        if overflow > 0:
+            del messages[:overflow]
+
+    def clear(self, deployment_id: DeploymentID) -> bool:
+        return self.deployments.pop(deployment_id, None) is not None
+
+    @classmethod
+    def load(cls) -> Self:
+        """Load the chat history; return an empty history when the file is absent or unreadable."""
+        raw = read_json_file(CHAT_HISTORY_FILE)
+        if raw is None:
+            return cls()
+        try:
+            return cls.model_validate(raw)
+        except ValidationError:
+            print(
+                f"WARNING: {CHAT_HISTORY_FILE} is in an invalid format and was ignored.",
+                file=sys.stderr,
+            )
+            return cls()
+
+    def save(self) -> None:
+        """Persist the history as a plain JSON file (matches existing CLI credential
+        storage convention; see ``client/cli/v2/config_cmd.py``).
+        """
+        write_json_file(CHAT_HISTORY_FILE, self.model_dump_json(indent=2))

--- a/src/ai/backend/client/cli/v2/deployment/chat/utils.py
+++ b/src/ai/backend/client/cli/v2/deployment/chat/utils.py
@@ -1,12 +1,13 @@
 """Filesystem helpers for ``./bai deployment chat`` storage.
 
-Two on-disk JSON files live under ``~/.backend.ai/deployment_chat/`` —
-``cache.json`` for the auto-managed endpoint cache and ``config.json``
-for user-supplied tokens. The per-feature subdirectory matches the
-existing ``session/`` layout used by ``./bai login``.
+Three on-disk JSON files live under ``~/.backend.ai/deployment_chat/`` —
+``cache.json`` for the auto-managed endpoint cache, ``config.json`` for
+user-supplied tokens, and ``history.json`` for per-deployment chat
+transcripts. The per-feature subdirectory matches the existing
+``session/`` layout used by ``./bai login``.
 
-Both files are written as plain JSON (no atomic-rename, no special POSIX
-permissions) to stay aligned with the existing CLI credential-storage
+All three files are written as plain JSON (no atomic-rename, no special
+POSIX permissions) to stay aligned with the existing CLI credential-storage
 convention in :mod:`ai.backend.client.cli.v2.config_cmd`.
 """
 
@@ -21,6 +22,7 @@ from ai.backend.common.json import load_json
 CHAT_DIR = CONFIG_DIR / "deployment_chat"
 CHAT_CACHE_FILE = CHAT_DIR / "cache.json"
 CHAT_CONFIG_FILE = CHAT_DIR / "config.json"
+CHAT_HISTORY_FILE = CHAT_DIR / "history.json"
 
 
 def read_json_file(path: Path) -> dict[str, Any] | None:

--- a/src/ai/backend/client/v2/deployment_chat.py
+++ b/src/ai/backend/client/v2/deployment_chat.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 from typing import Any
 
 from ai.backend.client.v2.base_client import BackendAIAppProxyClient
-from ai.backend.common.dto.clients.openai_compat import ListModelsResponse
+from ai.backend.common.dto.clients.openai_compat import (
+    ChatCompletionResponse,
+    ListModelsResponse,
+)
 
 _OPENAI_COMPATIBLE_CHAT_PATH = "/v1/chat/completions"
 _OPENAI_COMPATIBLE_MODELS_PATH = "/v1/models"
@@ -38,10 +41,11 @@ class DeploymentChatClient(BackendAIAppProxyClient):
         endpoint_url: str,
         token: str | None,
         body: dict[str, Any],
-    ) -> dict[str, Any]:
-        return await self._request(
+    ) -> ChatCompletionResponse:
+        payload = await self._request(
             "POST", endpoint_url, _OPENAI_COMPATIBLE_CHAT_PATH, token, body=body
         )
+        return ChatCompletionResponse.model_validate(payload)
 
     async def list_models(
         self,

--- a/src/ai/backend/common/dto/clients/openai_compat/__init__.py
+++ b/src/ai/backend/common/dto/clients/openai_compat/__init__.py
@@ -7,11 +7,20 @@ agent tomorrow) can consume the same types when talking to a deployed model.
 """
 
 from .request import ChatCompletionMessage, ChatCompletionRequest
-from .response import ListModelsResponse, ModelEntry
+from .response import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseMessage,
+    ListModelsResponse,
+    ModelEntry,
+)
 
 __all__ = (
     "ChatCompletionMessage",
     "ChatCompletionRequest",
+    "ChatCompletionResponse",
+    "ChatCompletionResponseChoice",
+    "ChatCompletionResponseMessage",
     "ListModelsResponse",
     "ModelEntry",
 )

--- a/src/ai/backend/common/dto/clients/openai_compat/response.py
+++ b/src/ai/backend/common/dto/clients/openai_compat/response.py
@@ -26,3 +26,63 @@ class ListModelsResponse(BaseModel):
 
     object: str = "list"
     data: list[ModelEntry]
+
+
+class ChatCompletionResponseMessage(BaseModel):
+    """The ``message`` payload inside one OpenAI-compat choice.
+
+    Only ``content`` is consumed by the CLI (for chat-history persistence);
+    ``extra="allow"`` keeps runtime-specific fields like ``tool_calls`` or
+    ``reasoning_content`` (DeepSeek-R1, Qwen-QwQ) on the model so they pass
+    through to the JSON pretty-printed output.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    role: str | None = None
+    content: str | None = None
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    """One entry in ``choices[]`` on a non-streaming chat-completion response.
+
+    Streaming responses use ``delta`` instead of ``message``; this model
+    intentionally requires ``message`` so a streaming chunk that slips
+    through (the SDK never sets ``stream=true`` itself) fails loudly via
+    ``ValidationError`` rather than corrupting persisted history.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    message: ChatCompletionResponseMessage
+
+
+class ChatCompletionResponse(BaseModel):
+    """Body of ``POST /v1/chat/completions`` (OpenAI-compatible).
+
+    Only the path used by chat-history bookkeeping
+    (``choices[0].message.content``) is typed here. The remaining
+    top-level fields (``id``, ``object``, ``created``, ``model``,
+    ``usage``, ``system_fingerprint``, runtime-specific extras) ride
+    through via ``extra="allow"`` so they survive the round-trip back
+    to the user's stdout when the CLI pretty-prints the response.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    choices: list[ChatCompletionResponseChoice]
+
+    @property
+    def assistant_message(self) -> str | None:
+        """Text emitted by the model in the first choice, if any.
+
+        Returns ``None`` when the response advertised no choices or when
+        the assistant emitted only a tool-call (``message.content`` is
+        ``null`` in that case). The CLI uses this to gate chat-history
+        persistence: a half-recorded round (user logged but assistant
+        missing) would skew future context, so we skip the save in that
+        case.
+        """
+        if not self.choices:
+            return None
+        return self.choices[0].message.content

--- a/tests/unit/client/cli/test_deployment_chat_types.py
+++ b/tests/unit/client/cli/test_deployment_chat_types.py
@@ -10,6 +10,7 @@ from ai.backend.client.cli.v2.deployment.chat.types import (
     DeploymentChatCacheEntry,
     DeploymentChatConfig,
     DeploymentChatConfigEntry,
+    DeploymentChatHistory,
 )
 
 
@@ -21,6 +22,16 @@ def cache() -> DeploymentChatCache:
 @pytest.fixture
 def chat_config() -> DeploymentChatConfig:
     return DeploymentChatConfig()
+
+
+@pytest.fixture
+def chat_history() -> DeploymentChatHistory:
+    return DeploymentChatHistory()
+
+
+@pytest.fixture
+def history_now() -> datetime:
+    return datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -158,3 +169,88 @@ class TestConfigPop:
         self, chat_config: DeploymentChatConfig, deployment_id: UUID
     ) -> None:
         assert chat_config.pop(deployment_id) is False
+
+
+class TestHistoryAppendSlice:
+    def test_slice_returns_empty_when_no_entry(
+        self, chat_history: DeploymentChatHistory, deployment_id: UUID
+    ) -> None:
+        assert chat_history.slice(deployment_id, 5) == []
+
+    def test_slice_zero_limit_returns_empty_even_when_populated(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+        history_now: datetime,
+    ) -> None:
+        chat_history.append(deployment_id, "user", "hi", created_at=history_now)
+        chat_history.append(deployment_id, "assistant", "hello", created_at=history_now)
+        # Limit 0 lets callers send a turn without context but still record it.
+        assert chat_history.slice(deployment_id, 0) == []
+
+    def test_slice_returns_in_insertion_order(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+        history_now: datetime,
+    ) -> None:
+        for index in range(6):
+            chat_history.append(
+                deployment_id,
+                "user" if index % 2 == 0 else "assistant",
+                f"msg-{index}",
+                created_at=history_now,
+            )
+        recent = chat_history.slice(deployment_id, 3)
+        assert [m.content for m in recent] == ["msg-3", "msg-4", "msg-5"]
+
+    def test_slice_caps_to_available_length(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+        history_now: datetime,
+    ) -> None:
+        chat_history.append(deployment_id, "user", "only", created_at=history_now)
+        # Asking for more than exists must not error out and must not pad.
+        assert [m.content for m in chat_history.slice(deployment_id, 10)] == ["only"]
+
+
+class TestHistoryTruncation:
+    def test_append_drops_oldest_when_max_persisted_exceeded(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+        history_now: datetime,
+    ) -> None:
+        # FIFO truncation: oldest is dropped first so the most recent
+        # context survives across long sessions.
+        for index in range(5):
+            chat_history.append(
+                deployment_id,
+                "user",
+                f"msg-{index}",
+                created_at=history_now,
+                max_persisted=3,
+            )
+        stored = chat_history.get(deployment_id)
+        assert stored is not None
+        assert [m.content for m in stored] == ["msg-2", "msg-3", "msg-4"]
+
+
+class TestHistoryClear:
+    def test_clear_returns_true_when_present(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+        history_now: datetime,
+    ) -> None:
+        chat_history.append(deployment_id, "user", "hi", created_at=history_now)
+        assert chat_history.clear(deployment_id) is True
+        assert chat_history.get(deployment_id) is None
+
+    def test_clear_returns_false_when_absent(
+        self,
+        chat_history: DeploymentChatHistory,
+        deployment_id: UUID,
+    ) -> None:
+        assert chat_history.clear(deployment_id) is False

--- a/tests/unit/client/cli/test_deployment_chat_utils.py
+++ b/tests/unit/client/cli/test_deployment_chat_utils.py
@@ -13,6 +13,7 @@ from ai.backend.client.cli.v2.deployment.chat.types import (
     DeploymentChatCache,
     DeploymentChatCacheEntry,
     DeploymentChatConfig,
+    DeploymentChatHistory,
 )
 
 
@@ -33,6 +34,15 @@ def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(chat_utils, "CHAT_CONFIG_FILE", path)
     monkeypatch.setattr(chat_types, "CHAT_CONFIG_FILE", path)
+    return path
+
+
+@pytest.fixture
+def history_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "deployment_chat" / "history.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(chat_utils, "CHAT_HISTORY_FILE", path)
+    monkeypatch.setattr(chat_types, "CHAT_HISTORY_FILE", path)
     return path
 
 
@@ -131,3 +141,63 @@ class TestConfigLoaderResilience:
             encoding="utf-8",
         )
         assert DeploymentChatConfig.load().deployments == {}
+
+
+class TestHistoryLoadSaveRoundTrip:
+    def test_load_returns_empty_when_file_missing(self, history_path: Path) -> None:
+        assert DeploymentChatHistory.load().deployments == {}
+
+    def test_save_then_load_preserves_messages(self, history_path: Path) -> None:
+        history = DeploymentChatHistory()
+        dep_id = uuid4()
+        now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+        history.append(dep_id, "user", "hello", created_at=now)
+        history.append(dep_id, "assistant", "world", created_at=now)
+        history.save()
+
+        loaded = DeploymentChatHistory.load()
+        messages = loaded.get(dep_id)
+        assert messages is not None
+        assert [(m.role, m.content) for m in messages] == [
+            ("user", "hello"),
+            ("assistant", "world"),
+        ]
+        assert messages[0].created_at == now
+
+
+class TestHistoryLoaderResilience:
+    def test_load_returns_empty_on_corrupt_json(self, history_path: Path) -> None:
+        history_path.write_text("not-json{", encoding="utf-8")
+        assert DeploymentChatHistory.load().deployments == {}
+
+    def test_load_returns_empty_when_top_level_not_object(self, history_path: Path) -> None:
+        history_path.write_text("[]", encoding="utf-8")
+        assert DeploymentChatHistory.load().deployments == {}
+
+    def test_load_returns_empty_on_invalid_uuid_key(self, history_path: Path) -> None:
+        history_path.write_text(
+            json.dumps({
+                "deployments": {
+                    "not-a-uuid": [
+                        {
+                            "role": "user",
+                            "content": "hi",
+                            "created_at": "2026-04-27T12:00:00+00:00",
+                        },
+                    ],
+                },
+            }),
+            encoding="utf-8",
+        )
+        assert DeploymentChatHistory.load().deployments == {}
+
+    def test_load_returns_empty_on_malformed_message_payload(self, history_path: Path) -> None:
+        history_path.write_text(
+            json.dumps({
+                "deployments": {
+                    "12345678-1234-5678-1234-567812345678": [{"role": "user"}],
+                },
+            }),
+            encoding="utf-8",
+        )
+        assert DeploymentChatHistory.load().deployments == {}

--- a/tests/unit/client/v2/test_deployment_chat_client.py
+++ b/tests/unit/client/v2/test_deployment_chat_client.py
@@ -5,12 +5,14 @@ from typing import Any
 
 import pytest
 from aioresponses import aioresponses
+from pydantic import ValidationError
 from yarl import URL
 
 from ai.backend.client.exceptions import BackendAPIError, BackendClientError
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.deployment_chat import DeploymentChatClient
 from ai.backend.client.v2.exceptions import DeploymentAuthError
+from ai.backend.common.dto.clients.openai_compat import ChatCompletionResponse
 
 BASE_URL = "http://infer.test.local"
 CHAT_URL = f"{BASE_URL}/v1/chat/completions"
@@ -66,7 +68,9 @@ class TestChatCompletionSuccess:
         assert call.kwargs["headers"]["Authorization"] == "Bearer sk-test-token"
         assert call.kwargs["headers"]["Content-Type"] == "application/json"
         assert call.kwargs["json"] == _make_body()
-        assert resp["choices"][0]["message"]["content"] == "hi"
+        assert isinstance(resp, ChatCompletionResponse)
+        assert resp.choices[0].message.content == "hi"
+        assert resp.assistant_message == "hi"
 
     async def test_endpoint_url_already_ending_in_chat_completions(
         self, chat_client: DeploymentChatClient
@@ -147,3 +151,79 @@ class TestNonJsonResponse:
                 await chat_client.chat_completion(BASE_URL, "sk", _make_body())
         assert exc_info.value.status == 502
         assert "Bad Gateway" in exc_info.value.data["detail"]
+
+
+class TestChatCompletionResponseModel:
+    """Direct coverage for the response Pydantic model.
+
+    ``DeploymentChatClient.chat_completion`` runs ``model_validate`` on the
+    payload, so failures here surface as ``ValidationError`` at the SDK
+    boundary instead of corrupting persisted chat history downstream.
+    """
+
+    def test_assistant_message_returns_first_choice_text(self) -> None:
+        resp = ChatCompletionResponse.model_validate({
+            "choices": [
+                {"message": {"role": "assistant", "content": "hi 길동"}},
+                {"message": {"role": "assistant", "content": "ignored"}},
+            ],
+        })
+        assert resp.assistant_message == "hi 길동"
+
+    def test_assistant_message_none_when_choices_empty(self) -> None:
+        # vLLM emits choices=[] on certain error paths; the CLI uses this
+        # to skip half-recorded history rounds.
+        resp = ChatCompletionResponse.model_validate({"choices": []})
+        assert resp.assistant_message is None
+
+    def test_assistant_message_none_for_tool_call_only_response(self) -> None:
+        # Function-calling responses leave message.content as null and put
+        # the call in tool_calls; nothing text-shaped to persist.
+        resp = ChatCompletionResponse.model_validate({
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            },
+                        ],
+                    },
+                },
+            ],
+        })
+        assert resp.assistant_message is None
+
+    def test_extra_top_level_fields_round_trip(self) -> None:
+        # Runtime-specific telemetry (usage, system_fingerprint, vLLM
+        # prompt_logprobs, NIM extras) must survive parsing so the CLI's
+        # JSON pretty-print still shows them to the user.
+        payload: dict[str, Any] = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1741569952,
+            "model": "vllm/test",
+            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5},
+            "system_fingerprint": "fp_xyz",
+        }
+        resp = ChatCompletionResponse.model_validate(payload)
+        dumped = resp.model_dump(mode="json")
+        assert dumped["usage"]["total_tokens"] == 5
+        assert dumped["system_fingerprint"] == "fp_xyz"
+        assert dumped["model"] == "vllm/test"
+
+    def test_streaming_chunk_shape_fails_validation(self) -> None:
+        # ``delta`` is the streaming-chunk shape; the SDK never sets
+        # stream=true, so its arrival means the server misbehaved.
+        # Failing loudly is preferable to silently dropping the round.
+        with pytest.raises(ValidationError):
+            ChatCompletionResponse.model_validate({
+                "choices": [
+                    {"delta": {"role": "assistant", "content": "partial"}},
+                ],
+            })


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 2-PR stack. **Merge in order:**

1. ⬇️ #11344 — `feat(BA-5528): add deployment chat CLI for vLLM-backed model services`
2. 👉 **#11412** — `feat(BA-5903): persist deployment chat history and replay as request context` ← you are here

## Summary

Builds on top of [BA-5528](https://github.com/lablup/backend.ai/pull/11344) to add **client-side chat history** so multi-turn conversations against an OpenAI-compatible deployment endpoint keep their state across `./bai deployment chat` invocations. Also tightens the SDK boundary by typing the chat-completion response as a Pydantic model.

Resolves [BA-5903](https://lablup.atlassian.net/browse/BA-5903).

## What's added

- `~/.backend.ai/deployment_chat/history.json` — per-deployment rolling transcript, isolated from the existing `cache.json` (auto endpoint metadata) and `config.json` (user token/model).
- `chat` command auto-injects the most recent K user/assistant turns into the request `messages[]` array, then records the round on success.
  - `--history-limit N` (default 10) controls the context window. `0` skips context for the turn but still records the round.
  - Persisted history per deployment is FIFO-capped at 100 messages so disk usage stays bounded.
  - Half-recorded rounds are never written: if assistant `content` is missing (tool-call only / empty `choices`), the user side is dropped too.
- New `chat-history show / clear` subcommands for inspection and reset.
- `DeploymentChatClient.chat_completion()` now returns a Pydantic `ChatCompletionResponse` with strict validation on `choices[0].message.content` (the path the CLI consumes) and `extra="allow"` everywhere else, so vLLM `prompt_logprobs` / `usage` / `system_fingerprint` / NIM extras still survive the JSON pretty-print.

## Why prefix-cache-friendly

vLLM/SGLang/NIM all advertise OpenAI-compat `/v1/chat/completions`, which is stateless by spec — the client must re-send full message history each turn. Prefix caching on the inference server reuses the KV cache for the unchanged prefix, so the GPU cost only grows with the new tokens, not the whole conversation. Storing history client-side and replaying it is the conventional pattern.

## Test plan

- [x] `pants fmt/lint/check` clean
- [x] Unit tests:
  - History storage round-trip and FIFO truncation (`test_deployment_chat_types.py`, `test_deployment_chat_utils.py`)
  - Loader resilience against corrupt / schema-mismatched `history.json`
  - `ChatCompletionResponse.assistant_message` extraction across OpenAI-compat edge cases (empty `choices`, tool-call only, streaming `delta` shape) (`test_deployment_chat_client.py`)
- [ ] Smoke test against a live vLLM deployment: two-turn conversation where the second turn references the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BA-5528]: https://lablup.atlassian.net/browse/BA-5528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BA-5903]: https://lablup.atlassian.net/browse/BA-5903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
