### PR TITLE
chore(BA-5904): drop unused credentials.toml read/write from CLI v2 config

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -114,12 +114,13 @@ For direct manager access without webserver (HMAC signature auth):
 ```bash
 ./bai config set endpoint http://127.0.0.1:8091
 ./bai config set endpoint-type api
-./bai config set access-key AKIAIOSFODNN7EXAMPLE
-./bai config set secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export BACKEND_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+export BACKEND_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ./bai config show
 ```
 
-Config stored in `~/.backend.ai/config.toml` and `credentials.toml`.
+Endpoint config stored in `~/.backend.ai/config.toml`. HMAC credentials are read
+from `BACKEND_ACCESS_KEY` / `BACKEND_SECRET_KEY` env vars only — no on-disk storage.
 
 ## Command Pattern
 

--- a/.claude/skills/cli-sdk-guide/SKILL.md
+++ b/.claude/skills/cli-sdk-guide/SKILL.md
@@ -303,8 +303,8 @@ When implementing new CLI/SDK feature:
 ### V2 Config (`~/.backend.ai/`)
 
 - `config.toml` — endpoint, endpoint_type, api_version
-- `credentials.toml` — access_key, secret_key
 - `session/cookie.dat` — webserver session cookie (login/logout)
+- `BACKEND_ACCESS_KEY` / `BACKEND_SECRET_KEY` env vars — HMAC credentials (no on-disk storage)
 
 **Related skills:**
 - `/api-guide` - REST API implementation (prerequisite)

--- a/changes/11414.misc.md
+++ b/changes/11414.misc.md
@@ -1,0 +1,1 @@
+Drop unused `credentials.toml` read/write from the v2 client CLI; environment variables remain the only credential input.

--- a/src/ai/backend/client/cli/v2/config_cmd.py
+++ b/src/ai/backend/client/cli/v2/config_cmd.py
@@ -6,15 +6,13 @@ from typing import Any
 
 import click
 
-from .helpers import CONFIG_DIR, CONFIG_FILE, CREDENTIALS_FILE
+from .helpers import CONFIG_DIR, CONFIG_FILE
 
 CONFIGURABLE_KEYS = {
-    "endpoint": ("config", "endpoint"),
-    "endpoint-type": ("config", "endpoint_type"),
-    "api-version": ("config", "api_version"),
-    "skip-ssl-verification": ("config", "skip_ssl_verification"),
-    "access-key": ("credentials", "access_key"),
-    "secret-key": ("credentials", "secret_key"),
+    "endpoint": "endpoint",
+    "endpoint-type": "endpoint_type",
+    "api-version": "api_version",
+    "skip-ssl-verification": "skip_ssl_verification",
 }
 
 
@@ -75,17 +73,11 @@ def show() -> None:
 def set_value(key: str, value: str) -> None:
     """Set a configuration value.
 
-    KEY is one of: endpoint, endpoint-type, api-version, skip-ssl-verification,
-    access-key, secret-key.
+    KEY is one of: endpoint, endpoint-type, api-version, skip-ssl-verification.
     """
-    file_type, toml_key = CONFIGURABLE_KEYS[key]
+    toml_key = CONFIGURABLE_KEYS[key]
 
-    if file_type == "config":
-        path = CONFIG_FILE
-    else:
-        path = CREDENTIALS_FILE
-
-    data = _load_toml(path)
+    data = _load_toml(CONFIG_FILE)
     section = data.setdefault("backend-ai", {})
 
     if key == "skip-ssl-verification":
@@ -93,7 +85,7 @@ def set_value(key: str, value: str) -> None:
     else:
         section[toml_key] = value
 
-    _save_toml(path, data)
+    _save_toml(CONFIG_FILE, data)
     click.echo(f"Set {key} = {value}")
 
 
@@ -109,7 +101,5 @@ def get_value(key: str) -> None:
         "endpoint-type": cfg.endpoint_type,
         "api-version": cfg.api_version,
         "skip-ssl-verification": str(cfg.skip_ssl_verification),
-        "access-key": cfg.access_key or "(not set)",
-        "secret-key": cfg.secret_key or "(not set)",
     }
     click.echo(field_map[key])

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 CONFIG_DIR = Path.home() / ".backend.ai"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
-CREDENTIALS_FILE = CONFIG_DIR / "credentials.toml"
 SESSION_DIR = CONFIG_DIR / "session"
 COOKIE_FILE = SESSION_DIR / "cookie.dat"
 
@@ -47,9 +46,8 @@ def load_v2_config() -> V2ConnectionConfig:
 
     Precedence (highest to lowest):
     1. Environment variables (``BACKEND_ENDPOINT``, ``BACKEND_ACCESS_KEY``, etc.)
-    2. ``~/.backend.ai/credentials.toml``
-    3. ``~/.backend.ai/config.toml``
-    4. Built-in defaults
+    2. ``~/.backend.ai/config.toml``
+    3. Built-in defaults
     """
     import tomllib
 
@@ -62,12 +60,6 @@ def load_v2_config() -> V2ConnectionConfig:
 
     access_key: str | None = None
     secret_key: str | None = None
-
-    if CREDENTIALS_FILE.exists():
-        with CREDENTIALS_FILE.open("rb") as f:
-            creds = tomllib.load(f).get("backend-ai", {})
-        access_key = creds.get("access_key")
-        secret_key = creds.get("secret_key")
 
     # Environment variables override file settings
     if env_endpoint := os.environ.get("BACKEND_ENDPOINT"):

--- a/tests/unit/client/cli/test_v2_dotenv.py
+++ b/tests/unit/client/cli/test_v2_dotenv.py
@@ -17,7 +17,7 @@ def dotenv_environment(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> Iterator[Path]:
-    """Place a ``.env`` in an isolated cwd with no fallback config/credentials."""
+    """Place a ``.env`` in an isolated cwd with no fallback config."""
     monkeypatch.chdir(tmp_path)
     for key in (
         "BACKEND_ENDPOINT",
@@ -27,7 +27,6 @@ def dotenv_environment(
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setattr(helpers, "CONFIG_FILE", tmp_path / "missing-config.toml")
-    monkeypatch.setattr(helpers, "CREDENTIALS_FILE", tmp_path / "missing-creds.toml")
     (tmp_path / ".env").write_text(
         "BACKEND_ENDPOINT=https://from-dotenv.example\nBACKEND_ACCESS_KEY=ak-from-dotenv\n",
     )


### PR DESCRIPTION
## Summary
- `config set access-key` / `secret-key` in `cli/v2/config_cmd.py` writes credentials to `~/.backend.ai/credentials.toml`, but nothing outside the v2 CLI itself reads that file. In practice, v2 authentication only uses the `BACKEND_ACCESS_KEY` / `BACKEND_SECRET_KEY` environment variables.
- `credentials.toml` support was added a month ago in #10504 (2026-03-25) as part of the initial v2 CLI scaffolding, so there is no legacy compatibility cost in removing both the read and write sides.
- `config show` continues to surface access/secret keys sourced from environment variables, so display behavior is unaffected.

## Changes
- `helpers.py`: drop the `CREDENTIALS_FILE` constant and the `credentials.toml` parsing block in `load_v2_config()`; update the precedence docstring.
- `config_cmd.py`: remove `access-key` / `secret-key` from `CONFIGURABLE_KEYS` and collapse the value mapping; simplify `set_value` / `get_value` accordingly.
- `tests/unit/client/cli/test_v2_dotenv.py`: drop the now-stale `CREDENTIALS_FILE` monkeypatch.

## Test plan
- [x] `pants fmt/fix/lint` on changed files — passed
- [x] `pants test tests/unit/client/cli/test_v2_dotenv.py` — passed
- [ ] `./bai v2 config show` with env vars set — credentials still visible
- [ ] `./bai v2 config set access-key foo` — should fail with a click choice error

Resolves BA-5904

🤖 Generated with [Claude Code](https://claude.com/claude-code)