### PR TITLE
feat(BA-5906): bulk add/remove/replace role permissions repository

### DIFF
--- a/changes/11422.feature.md
+++ b/changes/11422.feature.md
@@ -1,0 +1,1 @@
+Add bulk add/remove/replace operations for role permissions at the repository, service, and action layers, exposing per-row success/failure results via `BulkCreatorResultWithFailures` and `BulkPurgerResultWithFailures`.

--- a/changes/11422.feature.md
+++ b/changes/11422.feature.md
@@ -1,1 +1,1 @@
-Add bulk add/remove/replace operations for role permissions at the repository, service, and action layers, exposing per-row success/failure results via `BulkCreatorResultWithFailures` and `BulkPurgerResultWithFailures`.
+Add bulk add/remove/replace operations for role permissions at the repository, service, and action layers.

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -12,9 +12,16 @@ from .object_permission import (
     ObjectPermissionCreateInput,
     ObjectPermissionData,
 )
-from .permission import ScopedPermissionCreateInput
+from .permission import PermissionData, ScopedPermissionCreateInput
 from .status import RoleStatus
-from .types import EntityType, OperationType, RBACElementRef, RBACElementType, RoleSource
+from .types import (
+    EntityType,
+    OperationType,
+    RBACElementRef,
+    RBACElementType,
+    RoleSource,
+    ScopeType,
+)
 
 
 @dataclass(frozen=True)
@@ -251,6 +258,51 @@ class BulkRoleRevocationResultData:
 
     successes: list[UserRoleRevocationData] = field(default_factory=list)
     failures: list[BulkRoleRevocationFailure] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class BulkRolePermissionAddFailure:
+    """Failure information for a single permission entry in bulk add (or replace)."""
+
+    role_id: uuid.UUID
+    scope_type: ScopeType
+    scope_id: str
+    entity_type: EntityType
+    operation: OperationType
+    message: str
+
+
+@dataclass(frozen=True)
+class BulkRolePermissionRemoveFailure:
+    """Failure information for a single permission ID in bulk remove."""
+
+    permission_id: uuid.UUID
+    message: str
+
+
+@dataclass(frozen=True)
+class BulkRolePermissionAddResultData:
+    """Result of bulk inserting role-permission rows."""
+
+    successes: list[PermissionData] = field(default_factory=list)
+    failures: list[BulkRolePermissionAddFailure] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class BulkRolePermissionRemoveResultData:
+    """Result of bulk deleting role-permission rows."""
+
+    successes: list[PermissionData] = field(default_factory=list)
+    failures: list[BulkRolePermissionRemoveFailure] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class BulkRolePermissionReplaceResultData:
+    """Result of replacing a role's entire scoped-permission set."""
+
+    role_id: uuid.UUID
+    successes: list[PermissionData] = field(default_factory=list)
+    failures: list[BulkRolePermissionAddFailure] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -539,12 +539,7 @@ class PermissionDBSource:
         self,
         creator: BulkCreator[PermissionRow],
     ) -> BulkCreatorResultWithFailures[PermissionRow]:
-        """
-        Bulk-insert permission rows defined by ``creator.specs`` in a single
-        transaction. Each spec is processed individually inside a savepoint so
-        that one failing row (e.g. unique-violation) does not abort siblings;
-        successes and errors are reported via the returned result.
-        """
+        """Bulk-insert permission rows; per-row failures are reported separately."""
         async with self._db.begin_session_read_committed() as db_session:
             return await execute_bulk_creator_partial(db_session, creator)
 
@@ -552,12 +547,7 @@ class PermissionDBSource:
         self,
         purgers: list[Purger[PermissionRow]],
     ) -> BulkPurgerResultWithFailures[PermissionRow]:
-        """
-        Bulk-delete permission rows by primary key in a single transaction.
-        Each purger is executed inside a savepoint so that one failing delete
-        does not abort siblings; successes and errors are reported via the
-        returned result.
-        """
+        """Bulk-delete permission rows by primary key; per-row failures are reported separately."""
         async with self._db.begin_session_read_committed() as db_session:
             return await execute_bulk_purger_partial(db_session, purgers)
 

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -332,10 +332,9 @@ class PermissionDBSource:
     async def _get_role(self, db_session: SASession, role_id: uuid.UUID) -> RoleRow:
         stmt = sa.select(RoleRow).where(RoleRow.id == role_id)
         role_row = await db_session.scalar(stmt)
-        result = role_row
-        if result is None:
-            raise ObjectNotFound(f"Role with ID {role_id} does not exist.")
-        return result
+        if role_row is None:
+            raise RoleNotFound(f"Role with ID {role_id} does not exist.")
+        return role_row
 
     # ============================================================
     # Private Helper Functions (for use within transactions)
@@ -489,7 +488,7 @@ class PermissionDBSource:
             Updated role with refreshed relationships
 
         Raises:
-            ObjectNotFound: If role does not exist
+            RoleNotFound: If role does not exist
         """
         async with self._db.begin_session() as db_session:
             # 0. Verify role exists
@@ -562,7 +561,7 @@ class PermissionDBSource:
         defined by ``creator.specs``. Passing a creator with no specs clears
         the role's permissions.
 
-        - The role's existence is verified first; raises ``ObjectNotFound``
+        - The role's existence is verified first; raises ``RoleNotFound``
           if the role does not exist.
         - Each permission row in ``creator.specs`` is assumed to carry the
           same ``role_id`` as the one passed to this method; the caller is
@@ -579,7 +578,7 @@ class PermissionDBSource:
         async with self._db.begin_readonly_session_read_committed() as db_session:
             try:
                 result = await self._get_role(db_session, role_id)
-            except ObjectNotFound:
+            except RoleNotFound:
                 return None
             return result
 

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -90,7 +90,12 @@ from ai.backend.manager.repositories.base.creator import (
     execute_bulk_creator_partial,
     execute_creator,
 )
-from ai.backend.manager.repositories.base.purger import Purger, execute_purger
+from ai.backend.manager.repositories.base.purger import (
+    BulkPurgerResultWithFailures,
+    Purger,
+    execute_bulk_purger_partial,
+    execute_purger,
+)
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACEntityCreator,
@@ -529,6 +534,50 @@ class PermissionDBSource:
             # 5. Refresh and return
             await db_session.refresh(role_row)
             return role_row
+
+    async def bulk_add_role_permissions(
+        self,
+        creator: BulkCreator[PermissionRow],
+    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+        """
+        Bulk-insert permission rows defined by ``creator.specs`` in a single
+        transaction. Each spec is processed individually inside a savepoint so
+        that one failing row (e.g. unique-violation) does not abort siblings;
+        successes and errors are reported via the returned result.
+        """
+        async with self._db.begin_session() as db_session:
+            return await execute_bulk_creator_partial(db_session, creator)
+
+    async def bulk_remove_role_permissions(
+        self,
+        purgers: list[Purger[PermissionRow]],
+    ) -> BulkPurgerResultWithFailures[PermissionRow]:
+        """
+        Bulk-delete permission rows by primary key in a single transaction.
+        Each purger is executed inside a savepoint so that one failing delete
+        does not abort siblings; successes and errors are reported via the
+        returned result.
+        """
+        async with self._db.begin_session() as db_session:
+            return await execute_bulk_purger_partial(db_session, purgers)
+
+    async def replace_role_permissions(
+        self,
+        role_id: uuid.UUID,
+        creator: BulkCreator[PermissionRow],
+    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+        """
+        Replace the role's entire scoped-permission set in a single transaction:
+        delete all existing rows for ``role_id``, then bulk-insert the rows
+        defined by ``creator.specs``. Passing a creator with no specs clears
+        the role's permissions.
+        """
+        async with self._db.begin_session() as db_session:
+            await self._get_role(db_session, role_id)
+            await db_session.execute(
+                sa.delete(PermissionRow).where(PermissionRow.role_id == role_id)
+            )
+            return await execute_bulk_creator_partial(db_session, creator)
 
     async def get_role(self, role_id: uuid.UUID) -> RoleRow | None:
         async with self._db.begin_readonly_session_read_committed() as db_session:

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -545,7 +545,7 @@ class PermissionDBSource:
         that one failing row (e.g. unique-violation) does not abort siblings;
         successes and errors are reported via the returned result.
         """
-        async with self._db.begin_session() as db_session:
+        async with self._db.begin_session_read_committed() as db_session:
             return await execute_bulk_creator_partial(db_session, creator)
 
     async def bulk_remove_role_permissions(
@@ -558,7 +558,7 @@ class PermissionDBSource:
         does not abort siblings; successes and errors are reported via the
         returned result.
         """
-        async with self._db.begin_session() as db_session:
+        async with self._db.begin_session_read_committed() as db_session:
             return await execute_bulk_purger_partial(db_session, purgers)
 
     async def replace_role_permissions(
@@ -571,8 +571,14 @@ class PermissionDBSource:
         delete all existing rows for ``role_id``, then bulk-insert the rows
         defined by ``creator.specs``. Passing a creator with no specs clears
         the role's permissions.
+
+        - The role's existence is verified first; raises ``ObjectNotFound``
+          if the role does not exist.
+        - Each permission row in ``creator.specs`` is assumed to carry the
+          same ``role_id`` as the one passed to this method; the caller is
+          responsible for keeping them aligned.
         """
-        async with self._db.begin_session() as db_session:
+        async with self._db.begin_session_read_committed() as db_session:
             await self._get_role(db_session, role_id)
             await db_session.execute(
                 sa.delete(PermissionRow).where(PermissionRow.role_id == role_id)

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -58,7 +58,6 @@ from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.creator import (
     BulkCreator,
-    BulkCreatorError,
     Creator,
 )
 from ai.backend.manager.repositories.base.purger import Purger
@@ -98,23 +97,6 @@ permission_controller_repository_resilience = Resilience(
         ),
     ]
 )
-
-
-def _add_failure_from_creator_error(
-    err: BulkCreatorError[PermissionRow],
-) -> BulkRolePermissionAddFailure:
-    """Translate a generic BulkCreatorError into the domain failure type."""
-    spec = err.spec
-    if not isinstance(spec, PermissionCreatorSpec):
-        raise TypeError(f"Expected PermissionCreatorSpec, got {type(spec).__name__}")
-    return BulkRolePermissionAddFailure(
-        role_id=spec.role_id,
-        scope_type=ScopeType(spec.scope_type.value),
-        scope_id=spec.scope_id,
-        entity_type=EntityType(spec.entity_type.value),
-        operation=spec.operation,
-        message=str(err.exception),
-    )
 
 
 class PermissionControllerRepository:
@@ -196,11 +178,21 @@ class PermissionControllerRepository:
         self,
         creator: BulkCreator[PermissionRow],
     ) -> BulkRolePermissionAddResultData:
-        """Bulk-insert permission rows defined by the given creator."""
-        raw = await self._db_source.bulk_add_role_permissions(creator)
+        result = await self._db_source.bulk_add_role_permissions(creator)
+        failures = [
+            BulkRolePermissionAddFailure(
+                role_id=(spec := cast(PermissionCreatorSpec, error.spec)).role_id,
+                scope_type=ScopeType(spec.scope_type.value),
+                scope_id=spec.scope_id,
+                entity_type=EntityType(spec.entity_type.value),
+                operation=spec.operation,
+                message=str(error.exception),
+            )
+            for error in result.errors
+        ]
         return BulkRolePermissionAddResultData(
-            successes=[row.to_data() for row in raw.successes],
-            failures=[_add_failure_from_creator_error(err) for err in raw.errors],
+            successes=[row.to_data() for row in result.successes],
+            failures=failures,
         )
 
     @permission_controller_repository_resilience.apply()
@@ -208,17 +200,17 @@ class PermissionControllerRepository:
         self,
         purgers: list[Purger[PermissionRow]],
     ) -> BulkRolePermissionRemoveResultData:
-        """Bulk-delete permission rows by primary key."""
-        raw = await self._db_source.bulk_remove_role_permissions(purgers)
+        result = await self._db_source.bulk_remove_role_permissions(purgers)
+        failures = [
+            BulkRolePermissionRemoveFailure(
+                permission_id=cast(uuid.UUID, error.purger.pk_value),
+                message=str(error.exception),
+            )
+            for error in result.errors
+        ]
         return BulkRolePermissionRemoveResultData(
-            successes=[row.to_data() for row in raw.successes],
-            failures=[
-                BulkRolePermissionRemoveFailure(
-                    permission_id=cast(uuid.UUID, err.purger.pk_value),
-                    message=str(err.exception),
-                )
-                for err in raw.errors
-            ],
+            successes=[row.to_data() for row in result.successes],
+            failures=failures,
         )
 
     @permission_controller_repository_resilience.apply()
@@ -227,12 +219,22 @@ class PermissionControllerRepository:
         role_id: uuid.UUID,
         creator: BulkCreator[PermissionRow],
     ) -> BulkRolePermissionReplaceResultData:
-        """Replace the role's entire scoped-permission set in one transaction."""
-        raw = await self._db_source.replace_role_permissions(role_id=role_id, creator=creator)
+        result = await self._db_source.replace_role_permissions(role_id=role_id, creator=creator)
+        failures = [
+            BulkRolePermissionAddFailure(
+                role_id=(spec := cast(PermissionCreatorSpec, error.spec)).role_id,
+                scope_type=ScopeType(spec.scope_type.value),
+                scope_id=spec.scope_id,
+                entity_type=EntityType(spec.entity_type.value),
+                operation=spec.operation,
+                message=str(error.exception),
+            )
+            for error in result.errors
+        ]
         return BulkRolePermissionReplaceResultData(
             role_id=role_id,
-            successes=[row.to_data() for row in raw.successes],
-            failures=[_add_failure_from_creator_error(err) for err in raw.errors],
+            successes=[row.to_data() for row in result.successes],
+            failures=failures,
         )
 
     @permission_controller_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -25,6 +25,11 @@ from ai.backend.manager.data.permission.role import (
     BulkPermissionCheckInput,
     BulkRoleAssignmentFailure,
     BulkRoleAssignmentResultData,
+    BulkRolePermissionAddFailure,
+    BulkRolePermissionAddResultData,
+    BulkRolePermissionRemoveFailure,
+    BulkRolePermissionRemoveResultData,
+    BulkRolePermissionReplaceResultData,
     BulkRoleRevocationResultData,
     BulkUserRoleRevocationInput,
     EffectivePermissionsInput,
@@ -42,7 +47,9 @@ from ai.backend.manager.data.permission.role import (
     UserRoleRevocationInput,
 )
 from ai.backend.manager.data.permission.types import (
+    EntityType,
     ScopeListResult,
+    ScopeType,
 )
 from ai.backend.manager.data.role_invitation.types import RoleInvitationData
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -51,13 +58,16 @@ from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.creator import (
     BulkCreator,
-    BulkCreatorResultWithFailures,
+    BulkCreatorError,
     Creator,
 )
-from ai.backend.manager.repositories.base.purger import BulkPurgerResultWithFailures, Purger
+from ai.backend.manager.repositories.base.purger import Purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater
-from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
+from ai.backend.manager.repositories.permission_controller.creators import (
+    PermissionCreatorSpec,
+    UserRoleCreatorSpec,
+)
 from ai.backend.manager.repositories.permission_controller.types import (
     PermissionSearchScope,
     ScopedRoleSearchScope,
@@ -88,6 +98,23 @@ permission_controller_repository_resilience = Resilience(
         ),
     ]
 )
+
+
+def _add_failure_from_creator_error(
+    err: BulkCreatorError[PermissionRow],
+) -> BulkRolePermissionAddFailure:
+    """Translate a generic BulkCreatorError into the domain failure type."""
+    spec = err.spec
+    if not isinstance(spec, PermissionCreatorSpec):
+        raise TypeError(f"Expected PermissionCreatorSpec, got {type(spec).__name__}")
+    return BulkRolePermissionAddFailure(
+        role_id=spec.role_id,
+        scope_type=ScopeType(spec.scope_type.value),
+        scope_id=spec.scope_id,
+        entity_type=EntityType(spec.entity_type.value),
+        operation=spec.operation,
+        message=str(err.exception),
+    )
 
 
 class PermissionControllerRepository:
@@ -168,26 +195,45 @@ class PermissionControllerRepository:
     async def bulk_add_role_permissions(
         self,
         creator: BulkCreator[PermissionRow],
-    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+    ) -> BulkRolePermissionAddResultData:
         """Bulk-insert permission rows defined by the given creator."""
-        return await self._db_source.bulk_add_role_permissions(creator)
+        raw = await self._db_source.bulk_add_role_permissions(creator)
+        return BulkRolePermissionAddResultData(
+            successes=[row.to_data() for row in raw.successes],
+            failures=[_add_failure_from_creator_error(err) for err in raw.errors],
+        )
 
     @permission_controller_repository_resilience.apply()
     async def bulk_remove_role_permissions(
         self,
         purgers: list[Purger[PermissionRow]],
-    ) -> BulkPurgerResultWithFailures[PermissionRow]:
+    ) -> BulkRolePermissionRemoveResultData:
         """Bulk-delete permission rows by primary key."""
-        return await self._db_source.bulk_remove_role_permissions(purgers)
+        raw = await self._db_source.bulk_remove_role_permissions(purgers)
+        return BulkRolePermissionRemoveResultData(
+            successes=[row.to_data() for row in raw.successes],
+            failures=[
+                BulkRolePermissionRemoveFailure(
+                    permission_id=cast(uuid.UUID, err.purger.pk_value),
+                    message=str(err.exception),
+                )
+                for err in raw.errors
+            ],
+        )
 
     @permission_controller_repository_resilience.apply()
     async def replace_role_permissions(
         self,
         role_id: uuid.UUID,
         creator: BulkCreator[PermissionRow],
-    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+    ) -> BulkRolePermissionReplaceResultData:
         """Replace the role's entire scoped-permission set in one transaction."""
-        return await self._db_source.replace_role_permissions(role_id=role_id, creator=creator)
+        raw = await self._db_source.replace_role_permissions(role_id=role_id, creator=creator)
+        return BulkRolePermissionReplaceResultData(
+            role_id=role_id,
+            successes=[row.to_data() for row in raw.successes],
+            failures=[_add_failure_from_creator_error(err) for err in raw.errors],
+        )
 
     @permission_controller_repository_resilience.apply()
     async def delete_role(self, updater: Updater[RoleRow]) -> RoleData:

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -49,8 +49,12 @@ from ai.backend.manager.models.rbac_models.permission.permission import Permissi
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
-from ai.backend.manager.repositories.base.creator import BulkCreator, Creator
-from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.base.creator import (
+    BulkCreator,
+    BulkCreatorResultWithFailures,
+    Creator,
+)
+from ai.backend.manager.repositories.base.purger import BulkPurgerResultWithFailures, Purger
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
@@ -159,6 +163,31 @@ class PermissionControllerRepository:
         """Update role permissions using batch update."""
         result = await self._db_source.update_role_permissions(input_data=input_data)
         return result.to_detail_data_without_users()
+
+    @permission_controller_repository_resilience.apply()
+    async def bulk_add_role_permissions(
+        self,
+        creator: BulkCreator[PermissionRow],
+    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+        """Bulk-insert permission rows defined by the given creator."""
+        return await self._db_source.bulk_add_role_permissions(creator)
+
+    @permission_controller_repository_resilience.apply()
+    async def bulk_remove_role_permissions(
+        self,
+        purgers: list[Purger[PermissionRow]],
+    ) -> BulkPurgerResultWithFailures[PermissionRow]:
+        """Bulk-delete permission rows by primary key."""
+        return await self._db_source.bulk_remove_role_permissions(purgers)
+
+    @permission_controller_repository_resilience.apply()
+    async def replace_role_permissions(
+        self,
+        role_id: uuid.UUID,
+        creator: BulkCreator[PermissionRow],
+    ) -> BulkCreatorResultWithFailures[PermissionRow]:
+        """Replace the role's entire scoped-permission set in one transaction."""
+        return await self._db_source.replace_role_permissions(role_id=role_id, creator=creator)
 
     @permission_controller_repository_resilience.apply()
     async def delete_role(self, updater: Updater[RoleRow]) -> RoleData:

--- a/src/ai/backend/manager/services/permission_contoller/actions/__init__.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/__init__.py
@@ -1,5 +1,13 @@
 from .assign_role import AssignRoleAction, AssignRoleActionResult
+from .bulk_add_role_permissions import (
+    BulkAddRolePermissionsAction,
+    BulkAddRolePermissionsActionResult,
+)
 from .bulk_assign_role import BulkAssignRoleAction, BulkAssignRoleActionResult
+from .bulk_remove_role_permissions import (
+    BulkRemoveRolePermissionsAction,
+    BulkRemoveRolePermissionsActionResult,
+)
 from .bulk_revoke_role import BulkRevokeRoleAction, BulkRevokeRoleActionResult
 from .check_permission import CheckPermissionAction, CheckPermissionActionResult
 from .create_role import CreateRoleAction, CreateRoleActionResult
@@ -7,6 +15,10 @@ from .delete_role import DeleteRoleAction, DeleteRoleActionResult
 from .get_permission_matrix import GetPermissionMatrixAction, GetPermissionMatrixActionResult
 from .get_role_detail import GetRoleDetailAction, GetRoleDetailActionResult
 from .purge_role import PurgeRoleAction, PurgeRoleActionResult
+from .replace_role_permissions import (
+    ReplaceRolePermissionsAction,
+    ReplaceRolePermissionsActionResult,
+)
 from .resolve_effective_permissions import (
     ResolveEffectivePermissionsAction,
     ResolveEffectivePermissionsActionResult,
@@ -35,8 +47,12 @@ from .update_role_permissions import (
 __all__ = [
     "AssignRoleAction",
     "AssignRoleActionResult",
+    "BulkAddRolePermissionsAction",
+    "BulkAddRolePermissionsActionResult",
     "BulkAssignRoleAction",
     "BulkAssignRoleActionResult",
+    "BulkRemoveRolePermissionsAction",
+    "BulkRemoveRolePermissionsActionResult",
     "BulkRevokeRoleAction",
     "BulkRevokeRoleActionResult",
     "CheckPermissionAction",
@@ -51,6 +67,8 @@ __all__ = [
     "GetRoleDetailActionResult",
     "PurgeRoleAction",
     "PurgeRoleActionResult",
+    "ReplaceRolePermissionsAction",
+    "ReplaceRolePermissionsActionResult",
     "ResolveEffectivePermissionsAction",
     "ResolveEffectivePermissionsActionResult",
     "RevokeRoleAction",

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.repositories.base.creator import (
+    BulkCreator,
+    BulkCreatorResultWithFailures,
+)
+from ai.backend.manager.repositories.permission_controller.creators import (
+    PermissionCreatorSpec,
+)
+
+
+@dataclass
+class BulkAddRolePermissionsAction(BaseAction):
+    creator: BulkCreator[PermissionRow]
+
+    @override
+    def entity_id(self) -> str | None:
+        for spec in self.creator.specs:
+            if isinstance(spec, PermissionCreatorSpec):
+                return str(spec.role_id)
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_PERMISSION
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class BulkAddRolePermissionsActionResult(BaseActionResult):
+    result: BulkCreatorResultWithFailures[PermissionRow]
+
+    @override
+    def entity_id(self) -> str | None:
+        for row in self.result.successes:
+            return str(row.role_id)
+        return None

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
@@ -6,11 +6,9 @@ from typing import override
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.role import BulkRolePermissionAddResultData
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.repositories.base.creator import (
-    BulkCreator,
-    BulkCreatorResultWithFailures,
-)
+from ai.backend.manager.repositories.base.creator import BulkCreator
 from ai.backend.manager.repositories.permission_controller.creators import (
     PermissionCreatorSpec,
 )
@@ -40,10 +38,12 @@ class BulkAddRolePermissionsAction(BaseAction):
 
 @dataclass
 class BulkAddRolePermissionsActionResult(BaseActionResult):
-    result: BulkCreatorResultWithFailures[PermissionRow]
+    data: BulkRolePermissionAddResultData
 
     @override
     def entity_id(self) -> str | None:
-        for row in self.result.successes:
+        for row in self.data.successes:
             return str(row.role_id)
+        for failure in self.data.failures:
+            return str(failure.role_id)
         return None

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
@@ -28,7 +28,7 @@ class BulkAddRolePermissionsAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.ROLE_PERMISSION
+        return EntityType.ROLE
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_add_role_permissions.py
@@ -9,9 +9,6 @@ from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.role import BulkRolePermissionAddResultData
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.repositories.base.creator import BulkCreator
-from ai.backend.manager.repositories.permission_controller.creators import (
-    PermissionCreatorSpec,
-)
 
 
 @dataclass
@@ -20,9 +17,6 @@ class BulkAddRolePermissionsAction(BaseAction):
 
     @override
     def entity_id(self) -> str | None:
-        for spec in self.creator.specs:
-            if isinstance(spec, PermissionCreatorSpec):
-                return str(spec.role_id)
         return None
 
     @override
@@ -42,8 +36,4 @@ class BulkAddRolePermissionsActionResult(BaseActionResult):
 
     @override
     def entity_id(self) -> str | None:
-        for row in self.data.successes:
-            return str(row.role_id)
-        for failure in self.data.failures:
-            return str(failure.role_id)
         return None

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
@@ -22,7 +22,7 @@ class BulkRemoveRolePermissionsAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.ROLE_PERMISSION
+        return EntityType.ROLE
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.repositories.base.purger import (
+    BulkPurgerResultWithFailures,
+    Purger,
+)
+
+
+@dataclass
+class BulkRemoveRolePermissionsAction(BaseAction):
+    purgers: list[Purger[PermissionRow]]
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_PERMISSION
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class BulkRemoveRolePermissionsActionResult(BaseActionResult):
+    result: BulkPurgerResultWithFailures[PermissionRow]
+
+    @override
+    def entity_id(self) -> str | None:
+        for row in self.result.successes:
+            return str(row.role_id)
+        return None

--- a/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/bulk_remove_role_permissions.py
@@ -6,11 +6,9 @@ from typing import override
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.role import BulkRolePermissionRemoveResultData
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.repositories.base.purger import (
-    BulkPurgerResultWithFailures,
-    Purger,
-)
+from ai.backend.manager.repositories.base.purger import Purger
 
 
 @dataclass
@@ -34,10 +32,10 @@ class BulkRemoveRolePermissionsAction(BaseAction):
 
 @dataclass
 class BulkRemoveRolePermissionsActionResult(BaseActionResult):
-    result: BulkPurgerResultWithFailures[PermissionRow]
+    data: BulkRolePermissionRemoveResultData
 
     @override
     def entity_id(self) -> str | None:
-        for row in self.result.successes:
+        for row in self.data.successes:
             return str(row.role_id)
         return None

--- a/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
@@ -7,11 +7,9 @@ from typing import override
 from ai.backend.common.data.permission.types import EntityType
 from ai.backend.manager.actions.action import BaseAction, BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.permission.role import BulkRolePermissionReplaceResultData
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.repositories.base.creator import (
-    BulkCreator,
-    BulkCreatorResultWithFailures,
-)
+from ai.backend.manager.repositories.base.creator import BulkCreator
 
 
 @dataclass
@@ -36,9 +34,8 @@ class ReplaceRolePermissionsAction(BaseAction):
 
 @dataclass
 class ReplaceRolePermissionsActionResult(BaseActionResult):
-    role_id: uuid.UUID
-    result: BulkCreatorResultWithFailures[PermissionRow]
+    data: BulkRolePermissionReplaceResultData
 
     @override
     def entity_id(self) -> str | None:
-        return str(self.role_id)
+        return str(self.data.role_id)

--- a/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import EntityType
+from ai.backend.manager.actions.action import BaseAction, BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.repositories.base.creator import (
+    BulkCreator,
+    BulkCreatorResultWithFailures,
+)
+
+
+@dataclass
+class ReplaceRolePermissionsAction(BaseAction):
+    role_id: uuid.UUID
+    creator: BulkCreator[PermissionRow]
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.role_id)
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return EntityType.ROLE_PERMISSION
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPDATE
+
+
+@dataclass
+class ReplaceRolePermissionsActionResult(BaseActionResult):
+    role_id: uuid.UUID
+    result: BulkCreatorResultWithFailures[PermissionRow]
+
+    @override
+    def entity_id(self) -> str | None:
+        return str(self.role_id)

--- a/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/replace_role_permissions.py
@@ -24,7 +24,7 @@ class ReplaceRolePermissionsAction(BaseAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.ROLE_PERMISSION
+        return EntityType.ROLE
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -10,8 +10,12 @@ from ai.backend.manager.actions.validators import ActionValidators
 from .actions import (
     AssignRoleAction,
     AssignRoleActionResult,
+    BulkAddRolePermissionsAction,
+    BulkAddRolePermissionsActionResult,
     BulkAssignRoleAction,
     BulkAssignRoleActionResult,
+    BulkRemoveRolePermissionsAction,
+    BulkRemoveRolePermissionsActionResult,
     BulkRevokeRoleAction,
     BulkRevokeRoleActionResult,
     CreateRoleAction,
@@ -21,6 +25,8 @@ from .actions import (
     GetRoleDetailAction,
     GetRoleDetailActionResult,
     PurgeRoleAction,
+    ReplaceRolePermissionsAction,
+    ReplaceRolePermissionsActionResult,
     RevokeRoleAction,
     RevokeRoleActionResult,
     SearchRolesAction,
@@ -118,6 +124,15 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     update_role_permissions: ActionProcessor[
         UpdateRolePermissionsAction, UpdateRolePermissionsActionResult
     ]
+    bulk_add_role_permissions: ActionProcessor[
+        BulkAddRolePermissionsAction, BulkAddRolePermissionsActionResult
+    ]
+    bulk_remove_role_permissions: ActionProcessor[
+        BulkRemoveRolePermissionsAction, BulkRemoveRolePermissionsActionResult
+    ]
+    replace_role_permissions: ActionProcessor[
+        ReplaceRolePermissionsAction, ReplaceRolePermissionsActionResult
+    ]
     search_scopes: ActionProcessor[SearchScopesAction, SearchScopesActionResult]
     get_scope_types: ActionProcessor[GetScopeTypesAction, GetScopeTypesActionResult]
     get_entity_types: ActionProcessor[GetEntityTypesAction, GetEntityTypesActionResult]
@@ -183,6 +198,15 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
         self.update_role_permissions = ActionProcessor(
             service.update_role_permissions, action_monitors
         )
+        self.bulk_add_role_permissions = ActionProcessor(
+            service.bulk_add_role_permissions, action_monitors
+        )
+        self.bulk_remove_role_permissions = ActionProcessor(
+            service.bulk_remove_role_permissions, action_monitors
+        )
+        self.replace_role_permissions = ActionProcessor(
+            service.replace_role_permissions, action_monitors
+        )
         self.search_scopes = ActionProcessor(service.search_scopes, action_monitors)
         self.get_scope_types = ActionProcessor(service.get_scope_types, action_monitors)
         self.get_entity_types = ActionProcessor(service.get_entity_types, action_monitors)
@@ -244,6 +268,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             SearchRolesInScopeAction.spec(),
             SearchUsersAssignedToRoleAction.spec(),
             UpdateRolePermissionsAction.spec(),
+            BulkAddRolePermissionsAction.spec(),
+            BulkRemoveRolePermissionsAction.spec(),
+            ReplaceRolePermissionsAction.spec(),
             SearchScopesAction.spec(),
             GetScopeTypesAction.spec(),
             GetEntityTypesAction.spec(),

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -337,14 +337,14 @@ class PermissionControllerService:
     ) -> BulkAddRolePermissionsActionResult:
         """Bulk-insert permission rows defined by the action's creator."""
         result = await self._repository.bulk_add_role_permissions(action.creator)
-        return BulkAddRolePermissionsActionResult(result=result)
+        return BulkAddRolePermissionsActionResult(data=result)
 
     async def bulk_remove_role_permissions(
         self, action: BulkRemoveRolePermissionsAction
     ) -> BulkRemoveRolePermissionsActionResult:
         """Bulk-delete permission rows for the given purgers."""
         result = await self._repository.bulk_remove_role_permissions(action.purgers)
-        return BulkRemoveRolePermissionsActionResult(result=result)
+        return BulkRemoveRolePermissionsActionResult(data=result)
 
     async def replace_role_permissions(
         self, action: ReplaceRolePermissionsAction
@@ -354,7 +354,7 @@ class PermissionControllerService:
             role_id=action.role_id,
             creator=action.creator,
         )
-        return ReplaceRolePermissionsActionResult(role_id=action.role_id, result=result)
+        return ReplaceRolePermissionsActionResult(data=result)
 
     async def search_scopes(self, action: SearchScopesAction) -> SearchScopesActionResult:
         """Search scopes based on element type."""

--- a/src/ai/backend/manager/services/permission_contoller/service.py
+++ b/src/ai/backend/manager/services/permission_contoller/service.py
@@ -26,9 +26,17 @@ from ai.backend.manager.services.permission_contoller.actions.assign_role import
     AssignRoleAction,
     AssignRoleActionResult,
 )
+from ai.backend.manager.services.permission_contoller.actions.bulk_add_role_permissions import (
+    BulkAddRolePermissionsAction,
+    BulkAddRolePermissionsActionResult,
+)
 from ai.backend.manager.services.permission_contoller.actions.bulk_assign_role import (
     BulkAssignRoleAction,
     BulkAssignRoleActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.bulk_remove_role_permissions import (
+    BulkRemoveRolePermissionsAction,
+    BulkRemoveRolePermissionsActionResult,
 )
 from ai.backend.manager.services.permission_contoller.actions.bulk_revoke_role import (
     BulkRevokeRoleAction,
@@ -67,6 +75,10 @@ from ai.backend.manager.services.permission_contoller.actions.permission import 
 from ai.backend.manager.services.permission_contoller.actions.purge_role import (
     PurgeRoleAction,
     PurgeRoleActionResult,
+)
+from ai.backend.manager.services.permission_contoller.actions.replace_role_permissions import (
+    ReplaceRolePermissionsAction,
+    ReplaceRolePermissionsActionResult,
 )
 from ai.backend.manager.services.permission_contoller.actions.resolve_effective_permissions import (
     ResolveEffectivePermissionsAction,
@@ -319,6 +331,30 @@ class PermissionControllerService:
             input_data=action.input_data,
         )
         return UpdateRolePermissionsActionResult(role=result)
+
+    async def bulk_add_role_permissions(
+        self, action: BulkAddRolePermissionsAction
+    ) -> BulkAddRolePermissionsActionResult:
+        """Bulk-insert permission rows defined by the action's creator."""
+        result = await self._repository.bulk_add_role_permissions(action.creator)
+        return BulkAddRolePermissionsActionResult(result=result)
+
+    async def bulk_remove_role_permissions(
+        self, action: BulkRemoveRolePermissionsAction
+    ) -> BulkRemoveRolePermissionsActionResult:
+        """Bulk-delete permission rows for the given purgers."""
+        result = await self._repository.bulk_remove_role_permissions(action.purgers)
+        return BulkRemoveRolePermissionsActionResult(result=result)
+
+    async def replace_role_permissions(
+        self, action: ReplaceRolePermissionsAction
+    ) -> ReplaceRolePermissionsActionResult:
+        """Replace the role's entire scoped-permission set."""
+        result = await self._repository.replace_role_permissions(
+            role_id=action.role_id,
+            creator=action.creator,
+        )
+        return ReplaceRolePermissionsActionResult(role_id=action.role_id, result=result)
 
     async def search_scopes(self, action: SearchScopesAction) -> SearchScopesActionResult:
         """Search scopes based on element type."""

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
-from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.errors.permission import RoleNotFound
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.repositories.base.creator import BulkCreator
@@ -309,7 +309,7 @@ class TestBulkRolePermissions:
     async def test_replace_against_missing_role_raises(
         self, perm_db_source: PermissionDBSource
     ) -> None:
-        with pytest.raises(ObjectNotFound):
+        with pytest.raises(RoleNotFound):
             await perm_db_source.replace_role_permissions(
                 role_id=uuid.uuid4(), creator=BulkCreator(specs=[])
             )

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -1,0 +1,315 @@
+"""
+Tests for PermissionDBSource bulk role-permission methods:
+bulk_add_role_permissions, bulk_remove_role_permissions, replace_role_permissions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Sequence
+from typing import TYPE_CHECKING
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.errors.common import ObjectNotFound
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.repositories.base.creator import BulkCreator
+from ai.backend.manager.repositories.base.purger import Purger
+from ai.backend.manager.repositories.permission_controller.creators import (
+    PermissionCreatorSpec,
+)
+from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
+    PermissionDBSource,
+)
+from ai.backend.testutils.db import TableOrORM, with_tables
+
+if TYPE_CHECKING:
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+BULK_PERMISSION_TABLES: Sequence[TableOrORM] = [
+    RoleRow,
+    PermissionRow,
+]
+
+USER_SCOPE_ID = "test-user-uuid"
+
+ALL_OWNER_OPS = (
+    OperationType.CREATE,
+    OperationType.READ,
+    OperationType.UPDATE,
+    OperationType.SOFT_DELETE,
+    OperationType.HARD_DELETE,
+)
+
+
+def _spec(
+    role_id: uuid.UUID,
+    entity_type: RBACElementType,
+    operation: OperationType,
+    scope_type: RBACElementType = RBACElementType.USER,
+    scope_id: str = USER_SCOPE_ID,
+) -> PermissionCreatorSpec:
+    return PermissionCreatorSpec(
+        role_id=role_id,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        entity_type=entity_type,
+        operation=operation,
+    )
+
+
+def _owner_specs(role_id: uuid.UUID, entity_type: RBACElementType) -> list[PermissionCreatorSpec]:
+    return [_spec(role_id, entity_type, op) for op in ALL_OWNER_OPS]
+
+
+class TestBulkRolePermissions:
+    """Tests for bulk add/remove/replace operations on PermissionDBSource."""
+
+    @pytest.fixture
+    async def db_with_cleanup(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, BULK_PERMISSION_TABLES):
+            yield database_connection
+
+    @pytest.fixture
+    def perm_db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> PermissionDBSource:
+        return PermissionDBSource(db=db_with_cleanup)
+
+    async def _seed_role(
+        self,
+        db: ExtendedAsyncSAEngine,
+        role_name: str = "role_user_test",
+        seed_permission: PermissionCreatorSpec | None = None,
+    ) -> uuid.UUID:
+        role_id = uuid.uuid4()
+        async with db.begin_session() as session:
+            session.add(RoleRow(id=role_id, name=role_name))
+            await session.flush()
+            if seed_permission is not None:
+                session.add(
+                    PermissionRow(
+                        role_id=role_id,
+                        scope_type=ScopeType(seed_permission.scope_type.value),
+                        scope_id=seed_permission.scope_id,
+                        entity_type=EntityType(seed_permission.entity_type.value),
+                        operation=seed_permission.operation,
+                    )
+                )
+            await session.commit()
+        return role_id
+
+    async def _seed_permission(
+        self,
+        db: ExtendedAsyncSAEngine,
+        spec: PermissionCreatorSpec,
+    ) -> uuid.UUID:
+        permission_id = uuid.uuid4()
+        async with db.begin_session() as session:
+            session.add(
+                PermissionRow(
+                    id=permission_id,
+                    role_id=spec.role_id,
+                    scope_type=ScopeType(spec.scope_type.value),
+                    scope_id=spec.scope_id,
+                    entity_type=EntityType(spec.entity_type.value),
+                    operation=spec.operation,
+                )
+            )
+            await session.commit()
+        return permission_id
+
+    async def _count_permissions(
+        self,
+        db: ExtendedAsyncSAEngine,
+        role_id: uuid.UUID,
+        entity_type: EntityType | None = None,
+    ) -> int:
+        stmt = (
+            sa.select(sa.func.count())
+            .select_from(PermissionRow)
+            .where(PermissionRow.role_id == role_id)
+        )
+        if entity_type is not None:
+            stmt = stmt.where(PermissionRow.entity_type == entity_type)
+        async with db.begin_readonly_session() as session:
+            return (await session.execute(stmt)).scalar_one()
+
+    async def _list_operations(
+        self,
+        db: ExtendedAsyncSAEngine,
+        role_id: uuid.UUID,
+        entity_type: EntityType,
+    ) -> set[OperationType]:
+        stmt = sa.select(PermissionRow.operation).where(
+            PermissionRow.role_id == role_id,
+            PermissionRow.entity_type == entity_type,
+        )
+        async with db.begin_readonly_session() as session:
+            rows = (await session.execute(stmt)).scalars().all()
+        return set(rows)
+
+    # ---------- bulk_add_role_permissions ----------
+
+    async def test_bulk_add_against_missing_role_records_failures(
+        self, perm_db_source: PermissionDBSource
+    ) -> None:
+        ghost_role_id = uuid.uuid4()
+        creator = BulkCreator(
+            specs=[_spec(ghost_role_id, RBACElementType.SESSION, OperationType.READ)]
+        )
+        result = await perm_db_source.bulk_add_role_permissions(creator)
+        assert result.success_count() == 0
+        assert result.has_failures()
+
+    async def test_bulk_add_inserts_given_rows(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        creator = BulkCreator(specs=_owner_specs(role_id, RBACElementType.SESSION))
+        result = await perm_db_source.bulk_add_role_permissions(creator)
+        assert result.success_count() == len(ALL_OWNER_OPS)
+        assert not result.has_failures()
+        assert await self._list_operations(db_with_cleanup, role_id, EntityType.SESSION) == set(
+            ALL_OWNER_OPS
+        )
+
+    async def test_bulk_add_duplicate_rows_are_recorded_as_failures(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        creator = BulkCreator(specs=_owner_specs(role_id, RBACElementType.SESSION))
+        first = await perm_db_source.bulk_add_role_permissions(creator)
+        assert first.success_count() == len(ALL_OWNER_OPS)
+        second = await perm_db_source.bulk_add_role_permissions(creator)
+        assert second.success_count() == 0
+        assert len(second.errors) == len(ALL_OWNER_OPS)
+        assert await self._count_permissions(db_with_cleanup, role_id, EntityType.SESSION) == len(
+            ALL_OWNER_OPS
+        )
+
+    async def test_bulk_add_with_empty_creator_is_noop(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        before = await self._count_permissions(db_with_cleanup, role_id)
+        result = await perm_db_source.bulk_add_role_permissions(BulkCreator(specs=[]))
+        after = await self._count_permissions(db_with_cleanup, role_id)
+        assert before == after
+        assert result.success_count() == 0
+        assert not result.has_failures()
+
+    # ---------- bulk_remove_role_permissions ----------
+
+    async def test_bulk_remove_unknown_pk_returns_no_success(
+        self, perm_db_source: PermissionDBSource
+    ) -> None:
+        purgers = [Purger(row_class=PermissionRow, pk_value=uuid.uuid4())]
+        result = await perm_db_source.bulk_remove_role_permissions(purgers)
+        assert result.success_count() == 0
+        assert not result.has_failures()
+
+    async def test_bulk_remove_drops_only_specified_rows(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        keep_id = await self._seed_permission(
+            db_with_cleanup,
+            _spec(role_id, RBACElementType.SESSION, OperationType.READ),
+        )
+        drop_id = await self._seed_permission(
+            db_with_cleanup,
+            _spec(role_id, RBACElementType.SESSION, OperationType.HARD_DELETE),
+        )
+        result = await perm_db_source.bulk_remove_role_permissions([
+            Purger(row_class=PermissionRow, pk_value=drop_id)
+        ])
+        assert result.success_count() == 1
+        remaining_ids = {keep_id}
+        async with db_with_cleanup.begin_readonly_session() as session:
+            rows = (
+                (
+                    await session.execute(
+                        sa.select(PermissionRow.id).where(PermissionRow.role_id == role_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert set(rows) == remaining_ids
+
+    async def test_bulk_remove_with_empty_list_is_noop(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        await self._seed_permission(
+            db_with_cleanup,
+            _spec(role_id, RBACElementType.SESSION, OperationType.READ),
+        )
+        before = await self._count_permissions(db_with_cleanup, role_id)
+        result = await perm_db_source.bulk_remove_role_permissions([])
+        after = await self._count_permissions(db_with_cleanup, role_id)
+        assert before == after
+        assert result.success_count() == 0
+        assert not result.has_failures()
+
+    # ---------- replace_role_permissions ----------
+
+    async def test_replace_swaps_full_permission_set(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        await self._seed_permission(
+            db_with_cleanup,
+            _spec(role_id, RBACElementType.USER, OperationType.READ),
+        )
+        new_specs = _owner_specs(role_id, RBACElementType.SESSION)
+        result = await perm_db_source.replace_role_permissions(
+            role_id=role_id, creator=BulkCreator(specs=new_specs)
+        )
+        assert result.success_count() == len(new_specs)
+        assert await self._count_permissions(db_with_cleanup, role_id) == len(new_specs)
+        assert await self._list_operations(db_with_cleanup, role_id, EntityType.SESSION) == set(
+            ALL_OWNER_OPS
+        )
+
+    async def test_replace_with_empty_creator_clears_role(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        perm_db_source: PermissionDBSource,
+    ) -> None:
+        role_id = await self._seed_role(db_with_cleanup)
+        await self._seed_permission(
+            db_with_cleanup,
+            _spec(role_id, RBACElementType.USER, OperationType.READ),
+        )
+        await perm_db_source.replace_role_permissions(
+            role_id=role_id, creator=BulkCreator(specs=[])
+        )
+        assert await self._count_permissions(db_with_cleanup, role_id) == 0
+
+    async def test_replace_against_missing_role_raises(
+        self, perm_db_source: PermissionDBSource
+    ) -> None:
+        with pytest.raises(ObjectNotFound):
+            await perm_db_source.replace_role_permissions(
+                role_id=uuid.uuid4(), creator=BulkCreator(specs=[])
+            )


### PR DESCRIPTION
## Summary
- New repository / service / action triplet for managing role permissions in bulk, layered on top of the existing `permission_controller` domain.
- Repository methods (`bulk_add_role_permissions`, `bulk_remove_role_permissions`, `replace_role_permissions`) delegate to `execute_bulk_creator_partial` / `execute_bulk_purger_partial`, exposing per-row success/failure breakdown via `BulkCreatorResultWithFailures` / `BulkPurgerResultWithFailures`.
- Each Action carries a single bulk-helper field (`creator: BulkCreator[PermissionRow]` or `purgers: list[Purger[PermissionRow]]`) so the input shape mirrors the helper contract.


## Test plan
- [x] DB-backed unit tests in `tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py` — 11 tests cover:
  - bulk_add: missing role → failures recorded; happy-path inserts; duplicate inserts → ON CONFLICT-equivalent failures recorded with existing rows preserved; empty creator → no-op.
  - bulk_remove: unknown PK → no success; partial-target removal preserves siblings; empty list → no-op.
  - replace: full swap (wipe + insert); empty creator clears role; missing role → `ObjectNotFound`.
- [x] `pants fmt fix lint check` — all green.

Resolves BA-5906