### PR TITLE
fix(BA-5914): Record destroyed session IDs in audit log entity_id

### DIFF
--- a/changes/11430.fix.md
+++ b/changes/11430.fix.md
@@ -1,1 +1,1 @@
-Record the destroyed session UUID(s) in audit log entries for session `DELETE` events instead of the `(unknown)` placeholder.
+Session destroy audit log entries now record the destroyed session UUID(s) in `entity_id` instead of the `(unknown)` placeholder, so destroy events can be correlated with the affected session.

--- a/changes/11430.fix.md
+++ b/changes/11430.fix.md
@@ -1,0 +1,1 @@
+Record the destroyed session UUID(s) in audit log entries for session `DELETE` events instead of the `(unknown)` placeholder.

--- a/src/ai/backend/manager/services/session/actions/destroy_session.py
+++ b/src/ai/backend/manager/services/session/actions/destroy_session.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.types import AccessKey, SessionId
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
@@ -34,8 +34,13 @@ class DestroySessionAction(SessionAction):
 class DestroySessionActionResult(BaseActionResult):
     # TODO: Add proper type
     result: Any
+    session_ids: list[SessionId] = field(default_factory=list)
 
-    # TODO: Change this to `entity_ids`
+    # TODO: Change this to `entity_ids` once BaseActionResultMeta supports
+    # multiple ids; until then, comma-join so audit logs capture every
+    # affected session (recursive destroy can target several).
     @override
     def entity_id(self) -> str | None:
-        return None
+        if not self.session_ids:
+            return None
+        return ",".join(str(sid) for sid in self.session_ids)

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -812,7 +812,7 @@ class SessionService:
 
         # Return response - same format for both recursive and non-recursive
         resp = {"stats": last_stat}
-        return DestroySessionActionResult(result=resp)
+        return DestroySessionActionResult(result=resp, session_ids=list(session_ids))
 
     async def terminate_sessions(
         self, action: TerminateSessionsAction

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -502,6 +502,8 @@ class TestDestroySession:
         result = await session_service.destroy_session(action)
 
         assert result.result == {"stats": {"status": "cancelled"}}
+        assert result.session_ids == [sample_session_id]
+        assert result.entity_id() == str(sample_session_id)
         mock_session_repository.get_target_session_ids.assert_called_once_with(
             "test-session", sample_access_key, recursive=False
         )
@@ -609,6 +611,8 @@ class TestDestroySession:
             "test-session", sample_access_key, recursive=True
         )
         assert result.result == {"stats": {"status": "cancelled"}}
+        assert result.session_ids == session_ids
+        assert result.entity_id() == ",".join(str(sid) for sid in session_ids)
 
     async def test_no_sessions_to_destroy(
         self,
@@ -638,6 +642,8 @@ class TestDestroySession:
         result = await session_service.destroy_session(action)
 
         assert result.result == {"stats": {}}
+        assert result.session_ids == []
+        assert result.entity_id() is None
 
 
 # ==================== Complete Tests ====================


### PR DESCRIPTION
## Summary

- `DestroySessionActionResult` now carries the list of session ids resolved by the service and returns them (comma-joined for recursive destroys) from `entity_id()`.
- `AuditLogMonitor` therefore records the affected session UUID(s) for `DELETE` events, instead of the `(unknown)` blank-id sentinel.

Fixes #11429 (BA-5914)

## Background

`ActionProcessor` resolves the audit-log entity id via `action.entity_id() or result.entity_id()` (`manager/actions/processor/base.py`). For session create, the result returns `str(self.session_id)`; for session destroy, both the action and the result returned `None`, so `AuditLogMonitor` fell back to `_BLANK_ID = "(unknown)"`. The destroy service already resolves `session_name` to `list[SessionId]` via `SessionRepository.get_target_session_ids()` — those ids are now threaded into the result.

A proper multi-id audit-log model (`BaseActionResultMeta.entity_ids`, schema change) is left as a follow-up; comma-joined ids are a minimum-blast-radius fix that fits the existing `audit_logs.entity_id` (`sa.String`, no length cap).

## Test plan

- [x] Unit tests in `tests/unit/manager/services/session/test_session_service.py` updated to assert `result.session_ids` and `result.entity_id()` for the single-session, recursive (multi), and no-target cases.
- [x] `pants fmt`, `pants fix`, `pants lint`, `pants check`, `pants test` on the changed files all pass.
- [ ] Manual: create a session, destroy it, then verify the latest `audit_logs` row for `entity_type=session, operation=DELETE` carries the destroyed session's UUID instead of `(unknown)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)