### PR TITLE
fix(BA-5916): route v1 CLI `-v <uuid>` mounts into `mount_ids`

### DIFF
--- a/changes/BA-5916.fix.md
+++ b/changes/BA-5916.fix.md
@@ -1,0 +1,1 @@
+Route UUID-shaped vfolder sources from the v1 CLI `-v` flag into `mount_ids` / `mount_id_map` so the manager actually mounts them; previously they landed silently in the legacy name-keyed `mounts` field that the new sokovan path skips.

--- a/src/ai/backend/client/cli/service.py
+++ b/src/ai/backend/client/cli/service.py
@@ -321,7 +321,15 @@ def create(
 
     """
     envs = prepare_env_arg(env)
-    mount, mount_map, mount_options = prepare_mount_arg(mount, escape=True)
+    mount, mount_map, mount_options, _mount_ids, _mount_id_map = prepare_mount_arg(
+        mount, escape=True
+    )
+    # Service.create handles UUID resolution itself via /folders lookup, so
+    # merge UUID-shaped sources back into the name-keyed list.
+    if _mount_ids:
+        mount = [*mount, *(str(mid) for mid in _mount_ids)]
+        for mid, dst in _mount_id_map.items():
+            mount_map[str(mid)] = dst
     parsed_resources = prepare_resource_arg(resources)
     parsed_resource_opts = prepare_resource_arg(resource_opts)
     body = {

--- a/src/ai/backend/client/cli/session/execute.py
+++ b/src/ai/backend/client/cli/session/execute.py
@@ -264,11 +264,21 @@ def prepare_mount_arg(
     mount_args: Sequence[str] | None = None,
     *,
     escape: bool = True,
-) -> tuple[Sequence[str], Mapping[str, str], Mapping[str, Mapping[str, str]]]:
+) -> tuple[
+    list[str],
+    dict[str, str],
+    dict[str, Mapping[str, str]],
+    list[uuid.UUID],
+    dict[uuid.UUID, str],
+]:
     """
-    Parse the list of mount arguments into a list of
-    vfolder name and in-container mount path pairs,
-    followed by extra options.
+    Parse the list of mount arguments and split them into
+    name-keyed and UUID-keyed buckets.
+
+    UUID-shaped sources are routed to ``mount_ids`` /
+    ``mount_id_map`` so they reach the manager's UUID-based
+    mount resolver. Non-UUID sources stay in ``mounts`` /
+    ``mount_map`` for the legacy name-based path.
 
     :param mount_args: A list of mount arguments such as
         [
@@ -276,20 +286,35 @@ def prepare_mount_arg(
             "type=bind,source=/colon:path/abcd,target=/zxcv,readonly",
             # simple formats are still supported
             "vf-abcd:/home/work/zxcv",
+            # UUID-shaped sources are split out into mount_ids
+            "d2b0f974-80d0-4988-8e99-0347c2f45965",
+            "d2b0f974-80d0-4988-8e99-0347c2f45965:/home/work/data",
         ]
     """
-    mounts = set()
-    mount_map = {}
-    mount_options = {}
+    mounts: set[str] = set()
+    mount_map: dict[str, str] = {}
+    mount_options: dict[str, Mapping[str, str]] = {}
+    mount_ids: set[uuid.UUID] = set()
+    mount_id_map: dict[uuid.UUID, str] = {}
     if mount_args is not None:
         for mount_arg in mount_args:
             mountpoint = {**MountExpression(mount_arg).parse(escape=escape)}
-            mount = str(mountpoint.pop("source"))
-            mounts.add(mount)
-            if target := mountpoint.pop("target", None):
-                mount_map[mount] = str(target)
-            mount_options[mount] = mountpoint
-    return list(mounts), mount_map, mount_options
+            source = str(mountpoint.pop("source"))
+            target = mountpoint.pop("target", None)
+            try:
+                vfolder_uuid = uuid.UUID(source)
+            except (ValueError, AttributeError):
+                vfolder_uuid = None
+            if vfolder_uuid is not None:
+                mount_ids.add(vfolder_uuid)
+                if target:
+                    mount_id_map[vfolder_uuid] = str(target)
+            else:
+                mounts.add(source)
+                if target:
+                    mount_map[source] = str(target)
+                mount_options[source] = mountpoint
+    return list(mounts), mount_map, mount_options, list(mount_ids), mount_id_map
 
 
 @main.command()
@@ -474,7 +499,7 @@ def run(
     envs = prepare_env_arg(env)
     resources = prepare_resource_arg(resources)
     resource_opts = prepare_resource_arg(resource_opts)
-    mount, mount_map, mount_options = prepare_mount_arg(mount, escape=True)
+    mount, mount_map, mount_options, mount_ids, mount_id_map = prepare_mount_arg(mount, escape=True)
 
     env_ranges: dict[str, Any] = {v: r for v, r in env_range}  # type: ignore[has-type]
     build_ranges: dict[str, Any] = {v: r for v, r in build_range}  # type: ignore[has-type]
@@ -554,6 +579,8 @@ def run(
                 cluster_mode=cluster_mode,
                 mounts=mount,
                 mount_map=mount_map,
+                mount_ids=mount_ids,
+                mount_id_map=mount_id_map,
                 envs=envs,
                 resources=resources,
                 domain_name=domain,
@@ -685,6 +712,8 @@ def run(
                 mounts=mount,
                 mount_map=mount_map,
                 mount_options=mount_options,
+                mount_ids=mount_ids,
+                mount_id_map=mount_id_map,
                 envs=envs,
                 resources=resources,
                 resource_opts=resource_opts,

--- a/src/ai/backend/client/cli/session/lifecycle.py
+++ b/src/ai/backend/client/cli/session/lifecycle.py
@@ -196,7 +196,9 @@ def _create_cmd(docs: str | None = None) -> Callable[..., None]:
         envs = prepare_env_arg(env)
         parsed_resources = prepare_resource_arg(resources)
         parsed_resource_opts = prepare_resource_arg(resource_opts)
-        mount, mount_map, mount_options = prepare_mount_arg(mount, escape=True)
+        mount, mount_map, mount_options, mount_ids, mount_id_map = prepare_mount_arg(
+            mount, escape=True
+        )
 
         preopen_ports = preopen
         assigned_agent_list = assign_agent
@@ -239,6 +241,8 @@ def _create_cmd(docs: str | None = None) -> Callable[..., None]:
                     mounts=mount,
                     mount_map=mount_map,
                     mount_options=mount_options,
+                    mount_ids=mount_ids,
+                    mount_id_map=mount_id_map,
                     envs=envs,
                     startup_command=startup_command,
                     batch_timeout=timeout,
@@ -490,10 +494,10 @@ def _create_from_template_cmd(docs: str | None = None) -> Callable[..., None]:
             if len(resource_opts) > 0 or no_resource
             else undefined
         )
-        prepared_mount, prepared_mount_map, _ = (
+        prepared_mount, prepared_mount_map, _, prepared_mount_ids, prepared_mount_id_map = (
             prepare_mount_arg(mount)
             if len(mount) > 0 or no_mount
-            else (undefined, undefined, undefined)
+            else (undefined, undefined, undefined, undefined, undefined)
         )
         kwargs = {
             "name": name,
@@ -508,6 +512,8 @@ def _create_from_template_cmd(docs: str | None = None) -> Callable[..., None]:
             "cluster_size": cluster_size,
             "mounts": prepared_mount,
             "mount_map": prepared_mount_map,
+            "mount_ids": prepared_mount_ids,
+            "mount_id_map": prepared_mount_id_map,
             "envs": envs,
             "startup_command": startup_command,
             "batch_timeout": timeout,

--- a/tests/unit/client/cli/test_mount.py
+++ b/tests/unit/client/cli/test_mount.py
@@ -1,3 +1,5 @@
+import uuid
+
 from ai.backend.client.cli.session.execute import prepare_mount_arg
 from ai.backend.common.types import MountPermission, MountTypes
 
@@ -12,7 +14,7 @@ def test_vfolder_mount() -> None:
     ]
 
     # when
-    mount, mount_map, mount_options = prepare_mount_arg(mount)
+    mount, mount_map, mount_options, mount_ids, mount_id_map = prepare_mount_arg(mount)
 
     # then
     assert set(mount) == {"/colon:path/test", "/usr/abcd", "/usr/lorem", "/src/hello"}
@@ -42,6 +44,35 @@ def test_vfolder_mount() -> None:
     }
 
 
+def test_vfolder_mount_uuid_routes_to_mount_ids() -> None:
+    # given
+    # UUIDs that start with a letter — the MountExpression parser's
+    # underlying lark grammar requires a CNAME (letter/underscore) at the
+    # start of a token, so digit-starting UUIDs fail to parse upstream
+    # regardless of this fix.
+    vfid_a = "d2b0f974-80d0-4988-8e99-0347c2f45965"
+    vfid_b = "abcd1234-2222-3333-4444-555555555555"
+    mount = [
+        # plain UUID (no target)
+        vfid_a,
+        # UUID with target
+        f"{vfid_b}:/home/work/data",
+        # mixed: a name-keyed entry stays in the name bucket
+        "vf-name-only:/home/work/keep",
+    ]
+
+    # when
+    names, name_map, name_opts, ids, id_map = prepare_mount_arg(mount)
+
+    # then
+    assert set(ids) == {uuid.UUID(vfid_a), uuid.UUID(vfid_b)}
+    assert id_map == {uuid.UUID(vfid_b): "/home/work/data"}
+    assert names == ["vf-name-only"]
+    assert name_map == {"vf-name-only": "/home/work/keep"}
+    # UUID entries do not pollute the name-keyed options dict
+    assert set(name_opts) == {"vf-name-only"}
+
+
 def test_vfolder_mount_without_target() -> None:
     # given
     mount = [
@@ -49,7 +80,7 @@ def test_vfolder_mount_without_target() -> None:
     ]
 
     # when
-    mount, mount_map, mount_options = prepare_mount_arg(mount)
+    mount, mount_map, mount_options, mount_ids, mount_id_map = prepare_mount_arg(mount)
 
     # then
     assert set(mount) == {"vf-dd244f7f"}


### PR DESCRIPTION
## Summary
- v1 CLI `-v <vfolder-uuid>` was silently dropped: `prepare_mount_arg` put every source into the legacy name-keyed `mounts` config field, but the new sokovan path on the manager (`registry.py:_mount_entries_from_creation_config`) only consumes UUID-keyed `mount_ids` / `mount_id_map` and explicitly skips string-keyed `mounts`. The session was created without ever mounting the vfolder, with no warning anywhere.
- `prepare_mount_arg` now detects UUID-shaped sources and routes them to `mount_ids` / `mount_id_map`, leaving non-UUID names in the legacy buckets. Both v1 CLI session create/start callsites forward the new buckets to `ComputeSession.get_or_create`.
- The model-serving create callsite keeps merging UUIDs back into the name list because `Service.create` does its own `/folders` lookup to resolve names↔ids — no behavior change there.
- Unit tests cover the UUID-bucket / name-bucket split.

Verified e2e: `./backend.ai session create python -v <uuid> --scaling-group default --enqueue-only` now produces a session with `vfolder_mounts = [<uuid>]` instead of an empty list.

Out of scope: digit-leading UUIDs still fail at the `MountExpression` lark grammar (CNAME-first rule), tracked separately. Server-side resolution of name-keyed `mounts` to UUIDs in the new sokovan path is also a separate issue.

Resolves BA-5916.