### PR TITLE
fix(BA-5918): use UUIDFilter/StringFilter for v2 filter DTO fields

### DIFF
--- a/changes/11438.fix.md
+++ b/changes/11438.fix.md
@@ -1,0 +1,1 @@
+Use UUIDFilter/StringFilter wrappers in model_card and preset filter DTOs

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5291,7 +5291,7 @@ input DeploymentRevisionPresetFilter
   name: StringFilter = null
 
   """Variant ID filter."""
-  runtimeVariantId: UUID = null
+  runtimeVariantId: UUIDFilter = null
 }
 
 """Added in 26.4.2. Order specification for deployment revision presets."""
@@ -9040,10 +9040,10 @@ input ModelCardV2Filter
   name: StringFilter = null
 
   """Domain filter."""
-  domainName: String = null
+  domainName: StringFilter = null
 
   """Project filter."""
-  projectId: UUID = null
+  projectId: UUIDFilter = null
 
   """
   Filter by the storage host backing the model card's VFolder. Matches via an EXISTS subquery against the VFolder host column.
@@ -16248,7 +16248,7 @@ input RuntimeVariantPresetFilter
   name: StringFilter = null
 
   """Variant ID filter."""
-  runtimeVariantId: UUID = null
+  runtimeVariantId: UUIDFilter = null
 }
 
 """Added in 26.4.2. Order specification."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3544,7 +3544,7 @@ input DeploymentRevisionPresetFilter {
   name: StringFilter = null
 
   """Variant ID filter."""
-  runtimeVariantId: UUID = null
+  runtimeVariantId: UUIDFilter = null
 }
 
 """Added in 26.4.2. Order specification for deployment revision presets."""
@@ -5871,10 +5871,10 @@ input ModelCardV2Filter {
   name: StringFilter = null
 
   """Domain filter."""
-  domainName: String = null
+  domainName: StringFilter = null
 
   """Project filter."""
-  projectId: UUID = null
+  projectId: UUIDFilter = null
 
   """
   Filter by the storage host backing the model card's VFolder. Matches via an EXISTS subquery against the VFolder host column.
@@ -10977,7 +10977,7 @@ input RuntimeVariantPresetFilter {
   name: StringFilter = null
 
   """Variant ID filter."""
-  runtimeVariantId: UUID = null
+  runtimeVariantId: UUIDFilter = null
 }
 
 """Added in 26.4.2. Order specification."""

--- a/src/ai/backend/client/cli/v2/admin/deployment_revision_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment_revision_preset.py
@@ -81,10 +81,12 @@ def search(
     else:
         filter_dto: DeploymentRevisionPresetFilter | None = None
         if runtime_variant_id is not None or name_contains is not None:
-            from ai.backend.common.dto.manager.query import StringFilter
+            from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
             filter_dto = DeploymentRevisionPresetFilter(
-                runtime_variant_id=runtime_variant_id,
+                runtime_variant_id=UUIDFilter(equals=runtime_variant_id)
+                if runtime_variant_id is not None
+                else None,
                 name=StringFilter(contains=name_contains) if name_contains is not None else None,
             )
         orders = (

--- a/src/ai/backend/client/cli/v2/admin/model_card.py
+++ b/src/ai/backend/client/cli/v2/admin/model_card.py
@@ -81,12 +81,12 @@ def search(
     else:
         filter_dto: ModelCardFilter | None = None
         if name_contains is not None or domain_name is not None or project_id is not None:
-            from ai.backend.common.dto.manager.query import StringFilter
+            from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
             filter_dto = ModelCardFilter(
                 name=StringFilter(contains=name_contains) if name_contains is not None else None,
-                domain_name=domain_name,
-                project_id=project_id,
+                domain_name=StringFilter(equals=domain_name) if domain_name is not None else None,
+                project_id=UUIDFilter(equals=project_id) if project_id is not None else None,
             )
         orders = (
             parse_order_options(order_by, ModelCardOrderField, ModelCardOrder) if order_by else None

--- a/src/ai/backend/client/cli/v2/admin/runtime_variant_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/runtime_variant_preset.py
@@ -81,10 +81,12 @@ def search(
     else:
         filter_dto: RuntimeVariantPresetFilter | None = None
         if runtime_variant_id is not None or name_contains is not None:
-            from ai.backend.common.dto.manager.query import StringFilter
+            from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
             filter_dto = RuntimeVariantPresetFilter(
-                runtime_variant_id=runtime_variant_id,
+                runtime_variant_id=UUIDFilter(equals=runtime_variant_id)
+                if runtime_variant_id is not None
+                else None,
                 name=StringFilter(contains=name_contains) if name_contains is not None else None,
             )
         orders = (

--- a/src/ai/backend/client/cli/v2/deployment/revision_preset.py
+++ b/src/ai/backend/client/cli/v2/deployment/revision_preset.py
@@ -62,10 +62,12 @@ def search(
 
     filter_dto: DeploymentRevisionPresetFilter | None = None
     if runtime_variant_id is not None or name_contains is not None:
-        from ai.backend.common.dto.manager.query import StringFilter
+        from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
         filter_dto = DeploymentRevisionPresetFilter(
-            runtime_variant_id=runtime_variant_id,
+            runtime_variant_id=UUIDFilter(equals=runtime_variant_id)
+            if runtime_variant_id is not None
+            else None,
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
         )
     orders = (

--- a/src/ai/backend/client/cli/v2/model_card/commands.py
+++ b/src/ai/backend/client/cli/v2/model_card/commands.py
@@ -86,7 +86,7 @@ def project_search(
 
             filter_dto = ModelCardFilter(
                 name=StringFilter(contains=name_contains) if name_contains is not None else None,
-                domain_name=domain_name,
+                domain_name=StringFilter(equals=domain_name) if domain_name is not None else None,
             )
         orders = (
             parse_order_options(order_by, ModelCardOrderField, ModelCardOrder) if order_by else None
@@ -218,10 +218,12 @@ def available_presets(
 
     filter_dto: DeploymentRevisionPresetFilter | None = None
     if runtime_variant_id is not None or name_contains is not None:
-        from ai.backend.common.dto.manager.query import StringFilter
+        from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
         filter_dto = DeploymentRevisionPresetFilter(
-            runtime_variant_id=runtime_variant_id,
+            runtime_variant_id=UUIDFilter(equals=runtime_variant_id)
+            if runtime_variant_id is not None
+            else None,
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
         )
     search_input = SearchDeploymentRevisionPresetsInput(

--- a/src/ai/backend/client/cli/v2/runtime_variant_preset/commands.py
+++ b/src/ai/backend/client/cli/v2/runtime_variant_preset/commands.py
@@ -62,10 +62,12 @@ def search(
 
     filter_dto: RuntimeVariantPresetFilter | None = None
     if runtime_variant_id is not None or name_contains is not None:
-        from ai.backend.common.dto.manager.query import StringFilter
+        from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
         filter_dto = RuntimeVariantPresetFilter(
-            runtime_variant_id=runtime_variant_id,
+            runtime_variant_id=UUIDFilter(equals=runtime_variant_id)
+            if runtime_variant_id is not None
+            else None,
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
         )
     orders = (

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -6,7 +6,7 @@ from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.config import ModelDefinition
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import (
     EnvironmentVariableEntryInput,
     OrderDirection,
@@ -96,7 +96,7 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
 
 class DeploymentRevisionPresetFilter(BaseRequestModel):
     name: StringFilter | None = Field(default=None)
-    runtime_variant_id: RuntimeVariantID | None = Field(default=None)
+    runtime_variant_id: UUIDFilter | None = Field(default=None)
     AND: list[DeploymentRevisionPresetFilter] | None = Field(default=None)
     OR: list[DeploymentRevisionPresetFilter] | None = Field(default=None)
     NOT: list[DeploymentRevisionPresetFilter] | None = Field(default=None)

--- a/src/ai/backend/common/dto/manager/v2/model_card/request.py
+++ b/src/ai/backend/common/dto/manager/v2/model_card/request.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
 from ai.backend.common.dto.manager.v2.model_card.types import (
@@ -74,8 +74,8 @@ class UpdateModelCardInput(BaseRequestModel):
 
 class ModelCardFilter(BaseRequestModel):
     name: StringFilter | None = Field(default=None)
-    domain_name: str | None = Field(default=None)
-    project_id: UUID | None = Field(default=None)
+    domain_name: StringFilter | None = Field(default=None)
+    project_id: UUIDFilter | None = Field(default=None)
     storage_host: StringFilter | None = Field(
         default=None,
         description=(

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
@@ -104,7 +104,7 @@ class UpdateRuntimeVariantPresetInput(BaseRequestModel):
 
 class RuntimeVariantPresetFilter(BaseRequestModel):
     name: StringFilter | None = Field(default=None)
-    runtime_variant_id: UUID | None = Field(default=None)
+    runtime_variant_id: UUIDFilter | None = Field(default=None)
     AND: list[RuntimeVariantPresetFilter] | None = Field(default=None)
     OR: list[RuntimeVariantPresetFilter] | None = Field(default=None)
     NOT: list[RuntimeVariantPresetFilter] | None = Field(default=None)

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -373,9 +373,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
     def _convert_filter(self, filter_: DeploymentRevisionPresetFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter_.runtime_variant_id is not None:
-            conditions.append(
-                DeploymentRevisionPresetConditions.by_runtime_variant_id(filter_.runtime_variant_id)
+            cond = self.convert_uuid_filter(
+                filter_.runtime_variant_id,
+                equals_factory=DeploymentRevisionPresetConditions.by_runtime_variant_id_equals,
+                in_factory=DeploymentRevisionPresetConditions.by_runtime_variant_id_in,
             )
+            if cond is not None:
+                conditions.append(cond)
         if filter_.name:
             cond = self.convert_string_filter(
                 filter_.name,

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -515,9 +515,24 @@ class ModelCardAdapter(BaseAdapter):
     def _convert_filter(self, filter_: ModelCardFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter_.domain_name is not None:
-            conditions.append(ModelCardConditions.by_domain(filter_.domain_name))
+            cond = self.convert_string_filter(
+                filter_.domain_name,
+                contains_factory=ModelCardConditions.by_domain_contains,
+                equals_factory=ModelCardConditions.by_domain_equals,
+                starts_with_factory=ModelCardConditions.by_domain_starts_with,
+                ends_with_factory=ModelCardConditions.by_domain_ends_with,
+                in_factory=ModelCardConditions.by_domain_in,
+            )
+            if cond:
+                conditions.append(cond)
         if filter_.project_id is not None:
-            conditions.append(ModelCardConditions.by_project(filter_.project_id))
+            cond = self.convert_uuid_filter(
+                filter_.project_id,
+                equals_factory=ModelCardConditions.by_project_equals,
+                in_factory=ModelCardConditions.by_project_in,
+            )
+            if cond:
+                conditions.append(cond)
         if filter_.name:
             cond = self.convert_string_filter(
                 filter_.name,

--- a/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
@@ -237,9 +237,13 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
     def _convert_filter(self, filter_: RuntimeVariantPresetFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter_.runtime_variant_id is not None:
-            conditions.append(
-                RuntimeVariantPresetConditions.by_runtime_variant_id(filter_.runtime_variant_id)
+            cond = self.convert_uuid_filter(
+                filter_.runtime_variant_id,
+                equals_factory=RuntimeVariantPresetConditions.by_runtime_variant_id_equals,
+                in_factory=RuntimeVariantPresetConditions.by_runtime_variant_id_in,
             )
+            if cond is not None:
+                conditions.append(cond)
         if filter_.name:
             cond = self.convert_string_filter(
                 filter_.name,

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -63,6 +63,7 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 )
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.common.types import (
     ClusterModeGQL,
     EnvironEntryInputGQL,
@@ -392,7 +393,9 @@ class PresetValueEntryInputGQL(PydanticInputMixin[PresetValueInputDTO]):
 )
 class DeploymentRevisionPresetFilterGQL(PydanticInputMixin[FilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
-    runtime_variant_id: UUID | None = gql_field(default=None, description="Variant ID filter.")
+    runtime_variant_id: UUIDFilterGQL | None = gql_field(
+        default=None, description="Variant ID filter."
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/api/gql/model_card/types.py
+++ b/src/ai/backend/manager/api/gql/model_card/types.py
@@ -70,6 +70,7 @@ from ai.backend.common.dto.manager.v2.model_card.types import (
     ProjectModelCardScope as ProjectModelCardScopeDTO,
 )
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -373,8 +374,8 @@ class ModelCardAvailablePresetsScopeGQL(PydanticInputMixin[AvailablePresetsScope
 )
 class ModelCardFilterGQL(PydanticInputMixin[FilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
-    domain_name: str | None = gql_field(default=None, description="Domain filter.")
-    project_id: UUID | None = gql_field(default=None, description="Project filter.")
+    domain_name: StringFilterGQL | None = gql_field(default=None, description="Domain filter.")
+    project_id: UUIDFilterGQL | None = gql_field(default=None, description="Project filter.")
     storage_host: StringFilterGQL | None = gql_field(
         default=None,
         description=(

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -52,6 +52,7 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     UIOption as UIOptionDTO,
 )
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
+from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -244,7 +245,9 @@ class RuntimeVariantPresetConnection(Connection[RuntimeVariantPresetGQL]):
 )
 class RuntimeVariantPresetFilterGQL(PydanticInputMixin[FilterDTO]):
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
-    runtime_variant_id: UUID | None = gql_field(default=None, description="Variant ID filter.")
+    runtime_variant_id: UUIDFilterGQL | None = gql_field(
+        default=None, description="Variant ID filter."
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
@@ -6,7 +6,11 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.repositories.base import QueryCondition
@@ -19,6 +23,26 @@ class DeploymentRevisionPresetConditions:
     def by_runtime_variant_id(variant_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return DeploymentRevisionPresetRow.runtime_variant == variant_id
+
+        return inner
+
+    @staticmethod
+    def by_runtime_variant_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = DeploymentRevisionPresetRow.runtime_variant == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_runtime_variant_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = DeploymentRevisionPresetRow.runtime_variant.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/src/ai/backend/manager/models/model_card/conditions.py
+++ b/src/ai/backend/manager/models/model_card/conditions.py
@@ -6,7 +6,11 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.manager.models.condition_utils import (
     make_nested_string_in_factory,
     make_string_in_factory,
@@ -30,6 +34,26 @@ class ModelCardConditions:
     def by_project(project_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ModelCardRow.project == project_id
+
+        return inner
+
+    @staticmethod
+    def by_project_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ModelCardRow.project == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_project_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ModelCardRow.project.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -93,6 +117,60 @@ class ModelCardConditions:
         return inner
 
     by_name_in = staticmethod(make_string_in_factory(ModelCardRow.name))
+
+    @staticmethod
+    def by_domain_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ModelCardRow.domain.ilike(f"%{spec.value}%")
+            else:
+                condition = ModelCardRow.domain.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(ModelCardRow.domain) == spec.value.lower()
+            else:
+                condition = ModelCardRow.domain == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ModelCardRow.domain.ilike(f"{spec.value}%")
+            else:
+                condition = ModelCardRow.domain.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_domain_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = ModelCardRow.domain.ilike(f"%{spec.value}")
+            else:
+                condition = ModelCardRow.domain.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_domain_in = staticmethod(make_string_in_factory(ModelCardRow.domain))
 
     # ==================== Storage Host Nested Filters ====================
 

--- a/src/ai/backend/manager/models/runtime_variant_preset/conditions.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/conditions.py
@@ -6,7 +6,11 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.runtime_variant_preset.row import RuntimeVariantPresetRow
 from ai.backend.manager.repositories.base import QueryCondition
@@ -19,6 +23,26 @@ class RuntimeVariantPresetConditions:
     def by_runtime_variant_id(variant_id: UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return RuntimeVariantPresetRow.runtime_variant == variant_id
+
+        return inner
+
+    @staticmethod
+    def by_runtime_variant_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = RuntimeVariantPresetRow.runtime_variant == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_runtime_variant_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = RuntimeVariantPresetRow.runtime_variant.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.query import UUIDFilter
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
@@ -111,7 +112,7 @@ class TestDeploymentRevisionPresetCRUD:
         result = await admin_v2_registry.deployment_revision_preset.search(
             SearchDeploymentRevisionPresetsInput(
                 filter=DeploymentRevisionPresetFilter(
-                    runtime_variant_id=runtime_variant_id,
+                    runtime_variant_id=UUIDFilter(equals=runtime_variant_id),
                 ),
                 limit=10,
             )


### PR DESCRIPTION
## Summary
- Replace raw `UUID` / `str` filter fields with `UUIDFilter` / `StringFilter` in `ModelCardFilter`, `RuntimeVariantPresetFilter`, and `DeploymentRevisionPresetFilter` so they support the same equals/in/contains options as other v2 filters.
- Add the corresponding `_equals` / `_in` / (for `domain_name`) `_contains` / `_starts_with` / `_ends_with` condition factories on each `models/conditions.py`.
- Propagate the typed wrappers through GQL filter inputs, REST adapters, SDK CLI call sites, and the affected component test.

## Test plan
- [x] `pants fmt --changed-since=origin/main`
- [x] `pants fix --changed-since=origin/main`
- [x] `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main`
- [x] Pre-push test suite (lint/check/test on origin/main..HEAD) — all green
- [ ] Manual verification via `./bai` CLI search commands for model_card / runtime_variant_preset / deployment_revision_preset

Resolves BA-5918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11438.org.readthedocs.build/en/11438/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11438.org.readthedocs.build/ko/11438/

<!-- readthedocs-preview sorna-ko end -->