### PR TITLE
fix(BA-5919): remove revision mutation from update deployment mutation

### DIFF
--- a/changes/11445.fix.md
+++ b/changes/11445.fix.md
@@ -1,0 +1,1 @@
+Remove `active_revision_id` from the `updateDeployment` mutation; use the dedicated revision mutation to activate a revision.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -17906,7 +17906,6 @@ input UpdateDeploymentInput
   openToPublic: Boolean
   tags: [String!]
   defaultDeploymentStrategy: DeploymentStrategyInput
-  activeRevisionId: ID
   replicaCount: Int
   name: String
   preferredDomainName: String

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -12193,7 +12193,6 @@ input UpdateDeploymentInput {
   openToPublic: Boolean
   tags: [String!]
   defaultDeploymentStrategy: DeploymentStrategyInput
-  activeRevisionId: ID
   replicaCount: Int
   name: String
   preferredDomainName: String

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -437,9 +437,6 @@ class UpdateDeploymentInput(BaseRequestModel):
     preferred_domain_name: str | None = Field(
         default=None, description="Updated preferred domain name. None means no change."
     )
-    active_revision_id: UUID | None = Field(
-        default=None, description="ID of the revision to activate. None means no change."
-    )
     default_deployment_strategy: DeploymentStrategyInput | None = Field(
         default=None, description="Updated deployment strategy. None means no change."
     )

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -231,7 +231,6 @@ from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentNetworkSpecUpdaterSpec,
     DeploymentUpdaterSpec,
     ReplicaSpecUpdaterSpec,
-    RevisionStateUpdaterSpec,
 )
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
     BulkDeleteAccessTokensAction,
@@ -830,16 +829,10 @@ class DeploymentAdapter(BaseAdapter):
             network_spec = DeploymentNetworkSpecUpdaterSpec(
                 open_to_public=OptionalState.from_graphql(input.open_to_public),
             )
-        revision_state_spec: RevisionStateUpdaterSpec | None = None
-        if input.active_revision_id is not None:
-            revision_state_spec = RevisionStateUpdaterSpec(
-                current_revision=TriState[UUID].from_graphql(input.active_revision_id),
-            )
         spec = DeploymentUpdaterSpec(
             metadata=metadata_spec,
             replica_spec=replica_spec,
             network=network_spec,
-            revision_state=revision_state_spec,
         )
         updater: Updater[EndpointRow] = Updater(spec=spec, pk_value=deployment_id)
         action_result = await self._processors.deployment.update_deployment.wait_for_complete(

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -749,7 +749,6 @@ class UpdateDeploymentInput(PydanticInputMixin[UpdateDeploymentInputDTO]):
     open_to_public: bool | None = UNSET
     tags: list[str] | None = UNSET
     default_deployment_strategy: DeploymentStrategyInputGQL | None = UNSET
-    active_revision_id: ID | None = UNSET
     replica_count: int | None = UNSET
     name: str | None = UNSET
     preferred_domain_name: str | None = UNSET

--- a/src/ai/backend/manager/repositories/deployment/updaters.py
+++ b/src/ai/backend/manager/repositories/deployment/updaters.py
@@ -108,42 +108,16 @@ class MountUpdaterSpec(UpdaterSpec[EndpointRow]):
 
 
 @dataclass
-class RevisionStateUpdaterSpec(UpdaterSpec[EndpointRow]):
-    """UpdaterSpec for deployment revision state updates.
-
-    Manages which revision is currently active and which is being deployed.
-    """
-
-    current_revision: TriState[UUID] = field(default_factory=TriState[UUID].nop)
-    deploying_revision: TriState[UUID] = field(default_factory=TriState[UUID].nop)
-    revision_history_limit: OptionalState[int] = field(default_factory=OptionalState[int].nop)
-
-    @property
-    @override
-    def row_class(self) -> type[EndpointRow]:
-        return EndpointRow
-
-    @override
-    def build_values(self) -> dict[str, Any]:
-        to_update: dict[str, Any] = {}
-        self.current_revision.update_dict(to_update, "current_revision")
-        self.deploying_revision.update_dict(to_update, "deploying_revision")
-        self.revision_history_limit.update_dict(to_update, "revision_history_limit")
-        return to_update
-
-
-@dataclass
 class DeploymentUpdaterSpec(UpdaterSpec[EndpointRow]):
     """Composite UpdaterSpec for deployment updates.
 
-    Combines metadata, replica_spec, network, mount, and revision_state updates.
+    Combines metadata, replica_spec, network, and mount updates.
     """
 
     metadata: DeploymentMetadataUpdaterSpec | None = None
     replica_spec: ReplicaSpecUpdaterSpec | None = None
     network: DeploymentNetworkSpecUpdaterSpec | None = None
     mount: MountUpdaterSpec | None = None
-    revision_state: RevisionStateUpdaterSpec | None = None
 
     @property
     @override
@@ -161,8 +135,6 @@ class DeploymentUpdaterSpec(UpdaterSpec[EndpointRow]):
             to_update.update(self.network.build_values())
         if self.mount:
             to_update.update(self.mount.build_values())
-        if self.revision_state:
-            to_update.update(self.revision_state.build_values())
         return to_update
 
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -116,7 +116,6 @@ from ai.backend.manager.repositories.deployment.updaters import (
     DeploymentMetadataUpdaterSpec,
     DeploymentUpdaterSpec,
     ReplicaSpecUpdaterSpec,
-    RevisionStateUpdaterSpec,
     RouteStatusUpdaterSpec,
     RouteUpdaterSpec,
 )
@@ -1929,94 +1928,6 @@ class TestDeploymentRevisionOperations:
         assert result.has_next_page is True
         assert result.has_previous_page is True
 
-    async def test_update_endpoint_deploying_revision(
-        self,
-        deployment_repository: DeploymentRepository,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        test_endpoint_id: DeploymentID,
-        test_revision_data: ModelRevisionData,
-    ) -> None:
-        """Test updating endpoint deploying_revision using Updater."""
-        updater = Updater(
-            spec=RevisionStateUpdaterSpec(
-                deploying_revision=TriState.update(test_revision_data.id),
-            ),
-            pk_value=test_endpoint_id,
-        )
-        deployment_info = await deployment_repository.update_endpoint(updater)
-
-        # Verify returned DeploymentInfo
-        assert deployment_info.id == test_endpoint_id
-
-        # Verify database state (deploying_revision is not part of DeploymentInfo)
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            query = sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
-            result = await db_sess.execute(query)
-            endpoint = result.scalar_one()
-            assert endpoint.deploying_revision == test_revision_data.id
-
-    async def test_update_endpoint_current_revision(
-        self,
-        deployment_repository: DeploymentRepository,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        test_endpoint_id: DeploymentID,
-        test_revision_data: ModelRevisionData,
-    ) -> None:
-        """Test updating endpoint current_revision using Updater."""
-        updater = Updater(
-            spec=RevisionStateUpdaterSpec(
-                current_revision=TriState.update(test_revision_data.id),
-            ),
-            pk_value=test_endpoint_id,
-        )
-        deployment_info = await deployment_repository.update_endpoint(updater)
-
-        # Verify returned DeploymentInfo
-        assert deployment_info.id == test_endpoint_id
-        assert deployment_info.current_revision_id == test_revision_data.id
-
-        # Verify database state
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            query = sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
-            result = await db_sess.execute(query)
-            endpoint = result.scalar_one()
-            assert endpoint.current_revision == test_revision_data.id
-
-    async def test_update_endpoint_nullify_deploying_revision(
-        self,
-        deployment_repository: DeploymentRepository,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        test_endpoint_id: DeploymentID,
-        test_revision_data: ModelRevisionData,
-    ) -> None:
-        """Test nullifying endpoint deploying_revision using TriState.nullify()."""
-        # First set deploying_revision
-        updater = Updater(
-            spec=RevisionStateUpdaterSpec(
-                deploying_revision=TriState.update(test_revision_data.id),
-            ),
-            pk_value=test_endpoint_id,
-        )
-        deployment_info = await deployment_repository.update_endpoint(updater)
-        assert deployment_info.id == test_endpoint_id
-
-        # Then nullify it
-        updater = Updater(
-            spec=RevisionStateUpdaterSpec(
-                deploying_revision=TriState.nullify(),
-            ),
-            pk_value=test_endpoint_id,
-        )
-        deployment_info = await deployment_repository.update_endpoint(updater)
-        assert deployment_info.id == test_endpoint_id
-
-        # Verify database state (deploying_revision is not part of DeploymentInfo)
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            query = sa.select(EndpointRow).where(EndpointRow.id == test_endpoint_id)
-            result = await db_sess.execute(query)
-            endpoint = result.scalar_one()
-            assert endpoint.deploying_revision is None
-
     async def test_update_endpoint_returns_updated_deployment_info(
         self,
         deployment_repository: DeploymentRepository,
@@ -2036,9 +1947,6 @@ class TestDeploymentRevisionOperations:
                 replica_spec=ReplicaSpecUpdaterSpec(
                     replica_count=OptionalState.update(new_replica_count),
                 ),
-                revision_state=RevisionStateUpdaterSpec(
-                    current_revision=TriState.update(test_revision_data.id),
-                ),
             ),
             pk_value=test_endpoint_id,
         )
@@ -2048,7 +1956,6 @@ class TestDeploymentRevisionOperations:
         assert deployment_info.id == test_endpoint_id
         assert deployment_info.metadata.name == new_name
         assert deployment_info.replica_spec.replica_count == new_replica_count
-        assert deployment_info.current_revision_id == test_revision_data.id
 
         # Verify database state matches returned values
         async with db_with_cleanup.begin_readonly_session() as db_sess:
@@ -2057,7 +1964,6 @@ class TestDeploymentRevisionOperations:
             endpoint = result.scalar_one()
             assert endpoint.name == new_name
             assert endpoint.replicas == new_replica_count
-            assert endpoint.current_revision == test_revision_data.id
 
 
 class TestDeploymentAutoScalingPolicyOperations:


### PR DESCRIPTION
## Summary
- Drop `active_revision_id` from `UpdateDeploymentInput` (REST v2 DTO and GraphQL input) so `updateDeployment` no longer doubles as a revision activation API.
- Remove `RevisionStateUpdaterSpec` and its wiring in `DeploymentAdapter` / `DeploymentUpdaterSpec`; revision state changes should go through their dedicated revision mutations instead.
- Drop the now-unused revision-state tests from the deployment repository test suite.

## Test plan
- [x] `pants fmt --changed-since=origin/main`
- [x] `pants fix --changed-since=origin/main`
- [x] `pants lint --changed-since=origin/main`
- [ ] CI: `pants check` / `pants test`
- [ ] Manual smoke: call `updateDeployment` mutation and confirm `active_revision_id` is no longer accepted; revision activation continues to work via the dedicated revision mutation.

Resolves BA-5919