### PR TITLE
fix(BA-5924): correct inverted enabled check in CreateNetwork legacy mutation

### DIFF
--- a/changes/11448.fix.md
+++ b/changes/11448.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy `CreateNetwork` GraphQL mutation so it no longer rejects requests when inter-container networking is enabled (the `enabled` flag was being checked with an inverted condition).

--- a/src/ai/backend/manager/api/gql_legacy/network.py
+++ b/src/ai/backend/manager/api/gql_legacy/network.py
@@ -236,7 +236,7 @@ class CreateNetwork(graphene.Mutation):  # type: ignore[misc]
     ) -> CreateNetwork:
         graph_ctx: GraphQueryContext = info.context
         network_config = graph_ctx.config_provider.config.network.inter_container
-        if network_config.enabled:
+        if not network_config.enabled:
             return CreateNetwork(
                 ok=False, msg="Inter-container networking disabled on this cluster", network=None
             )


### PR DESCRIPTION
## Summary
- Negate the `network_config.enabled` check in the legacy `CreateNetwork` GraphQL mutation so the "Inter-container networking disabled on this cluster" error is returned only when the feature is actually disabled.
- Previously the condition was inverted: enabled clusters were rejected and disabled clusters silently fell through to the plugin/driver checks.

Resolves BA-5924.