### PR TITLE
fix(BA-5924): correct inverted enabled check in CreateNetwork legacy mutation (#11448)

### DIFF
--- a/changes/11448.fix.md
+++ b/changes/11448.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy `CreateNetwork` GraphQL mutation so it no longer rejects requests when inter-container networking is enabled (the `enabled` flag was being checked with an inverted condition).

--- a/src/ai/backend/manager/models/network.py
+++ b/src/ai/backend/manager/models/network.py
@@ -320,7 +320,7 @@ class CreateNetwork(graphene.Mutation):
     ) -> "CreateNetwork":
         graph_ctx: GraphQueryContext = info.context
         network_config = graph_ctx.config_provider.config.network.inter_container
-        if network_config.enabled:
+        if not network_config.enabled:
             return CreateNetwork(
                 ok=False, msg="Inter-container networking disabled on this cluster", network=None
             )


### PR DESCRIPTION
This is an auto-generated backport PR of #11448 to the 25.15 release.