### PR TITLE
fix(BA-5931): map deployment revision preset execution.image_id and model_definition

### DIFF
--- a/changes/11451.fix.md
+++ b/changes/11451.fix.md
@@ -1,0 +1,1 @@
+Fix `deploymentRevisionPreset` GraphQL query returning null for `execution.image` and `modelDefinition` by aligning GQL field name with the DTO `image_id` and converting the model definition type at the adapter boundary.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12029,10 +12029,8 @@ Added in 26.4.2. Container execution configuration for the deployment, including
 type PresetExecutionSpec
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Container image to run the inference server (e.g., 'cr.backend.ai/stable/vllm:latest').
-  """
-  image: String
+  """Container image UUID."""
+  imageId: UUID
 
   """Startup command."""
   startupCommand: String

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7806,10 +7806,8 @@ input PresetDeploymentStrategyInput {
 Added in 26.4.2. Container execution configuration for the deployment, including the inference server image, startup commands, and environment variables.
 """
 type PresetExecutionSpec {
-  """
-  Container image to run the inference server (e.g., 'cr.backend.ai/stable/vllm:latest').
-  """
-  image: String
+  """Container image UUID."""
+  imageId: UUID
 
   """Startup command."""
   startupCommand: String

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/response.py
@@ -7,8 +7,8 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.dto.manager.v2.deployment.types import ModelDefinitionInfoDTO
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
@@ -111,7 +111,7 @@ class DeploymentRevisionPresetNode(BaseResponseModel):
         default_factory=PresetDeploymentDefaults,
         description="Deployment-level default values provided by this preset.",
     )
-    model_definition: ModelDefinition | None = Field(
+    model_definition: ModelDefinitionInfoDTO | None = Field(
         default=None, description="Model definition configuration."
     )
     preset_values: list[PresetValueInfo] = Field(default_factory=list, description="Preset values.")

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -187,7 +187,11 @@ def _model_config_to_dto(config: ModelConfig) -> ModelConfigInfoDTO:
     )
 
 
-def _model_definition_to_dto(definition: ModelDefinition) -> ModelDefinitionInfoDTO:
+def _model_definition_to_dto(
+    definition: ModelDefinition | None,
+) -> ModelDefinitionInfoDTO | None:
+    if definition is None:
+        return None
     return ModelDefinitionInfoDTO(
         models=[_model_config_to_dto(m) for m in definition.models],
     )
@@ -632,11 +636,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 deployment_strategy=data.deployment_strategy,
                 deployment_strategy_spec=data.deployment_strategy_spec,
             ),
-            model_definition=(
-                _model_definition_to_dto(data.model_definition)
-                if data.model_definition is not None
-                else None
-            ),
+            model_definition=_model_definition_to_dto(data.model_definition),
             preset_values=preset_value_entries,
             created_at=data.created_at,
             updated_at=data.updated_at,

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -4,10 +4,24 @@ from typing import Any
 from uuid import UUID
 
 from ai.backend.common.api_handlers import SENTINEL, Sentinel
-from ai.backend.common.config import ModelDefinition
+from ai.backend.common.config import (
+    ModelConfig,
+    ModelDefinition,
+    ModelHealthCheck,
+    ModelMetadata,
+    ModelServiceConfig,
+    PreStartAction,
+)
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
-from ai.backend.common.dto.manager.v2.deployment.types import ModelDefinitionInfoDTO
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    ModelConfigInfoDTO,
+    ModelDefinitionInfoDTO,
+    ModelHealthCheckInfoDTO,
+    ModelMetadataInfoDTO,
+    ModelServiceConfigInfoDTO,
+    PreStartActionInfoDTO,
+)
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
@@ -112,6 +126,70 @@ def _preset_resource_slot_pagination_spec() -> PaginationSpec:
         forward_condition_factory=PresetResourceSlotConditions.by_cursor_forward,
         backward_condition_factory=PresetResourceSlotConditions.by_cursor_backward,
         tiebreaker_order=ALLOCATED_SLOT_PRESET_TIEBREAKER,
+    )
+
+
+def _pre_start_action_to_dto(action: PreStartAction) -> PreStartActionInfoDTO:
+    return PreStartActionInfoDTO(action=action.action, args=action.args)
+
+
+def _model_health_check_to_dto(check: ModelHealthCheck) -> ModelHealthCheckInfoDTO:
+    return ModelHealthCheckInfoDTO(
+        interval=check.interval,
+        path=check.path,
+        max_retries=check.max_retries,
+        max_wait_time=check.max_wait_time,
+        expected_status_code=check.expected_status_code,
+        initial_delay=check.initial_delay,
+    )
+
+
+def _model_service_config_to_dto(service: ModelServiceConfig) -> ModelServiceConfigInfoDTO:
+    return ModelServiceConfigInfoDTO(
+        pre_start_actions=[_pre_start_action_to_dto(a) for a in service.pre_start_actions],
+        start_command=service.start_command,
+        shell=service.shell,
+        port=service.port,
+        health_check=(
+            _model_health_check_to_dto(service.health_check)
+            if service.health_check is not None
+            else None
+        ),
+    )
+
+
+def _model_metadata_to_dto(metadata: ModelMetadata) -> ModelMetadataInfoDTO:
+    return ModelMetadataInfoDTO(
+        author=metadata.author,
+        title=metadata.title,
+        version=metadata.version,
+        created=metadata.created,
+        last_modified=metadata.last_modified,
+        description=metadata.description,
+        task=metadata.task,
+        category=metadata.category,
+        architecture=metadata.architecture,
+        framework=metadata.framework,
+        label=metadata.label,
+        license=metadata.license,
+        min_resource=metadata.min_resource,
+    )
+
+
+def _model_config_to_dto(config: ModelConfig) -> ModelConfigInfoDTO:
+    return ModelConfigInfoDTO(
+        name=config.name,
+        model_path=config.model_path,
+        service=(
+            _model_service_config_to_dto(config.service) if config.service is not None else None
+        ),
+        metadata=(_model_metadata_to_dto(config.metadata) if config.metadata is not None else None),
+    )
+
+
+def _model_definition_to_dto(definition: ModelDefinition) -> ModelDefinitionInfoDTO:
+    return ModelDefinitionInfoDTO(
+        models=[_model_config_to_dto(m) for m in definition.models],
     )
 
 
@@ -555,9 +633,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 deployment_strategy_spec=data.deployment_strategy_spec,
             ),
             model_definition=(
-                ModelDefinitionInfoDTO.model_validate(
-                    data.model_definition.model_dump(by_alias=False)
-                )
+                _model_definition_to_dto(data.model_definition)
                 if data.model_definition is not None
                 else None
             ),

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -7,6 +7,7 @@ from ai.backend.common.api_handlers import SENTINEL, Sentinel
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
+from ai.backend.common.dto.manager.v2.deployment.types import ModelDefinitionInfoDTO
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
@@ -553,7 +554,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 deployment_strategy=data.deployment_strategy,
                 deployment_strategy_spec=data.deployment_strategy_spec,
             ),
-            model_definition=data.model_definition,
+            model_definition=(
+                ModelDefinitionInfoDTO.model_validate(
+                    data.model_definition.model_dump(by_alias=False)
+                )
+                if data.model_definition is not None
+                else None
+            ),
             preset_values=preset_value_entries,
             created_at=data.created_at,
             updated_at=data.updated_at,

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -189,8 +189,8 @@ class PresetResourceAllocationGQL(PydanticOutputMixin[PresetResourceAllocationDT
     name="PresetExecutionSpec",
 )
 class PresetExecutionSpecGQL(PydanticOutputMixin[PresetExecutionSpecDTO]):
-    image: str | None = gql_field(
-        description="Container image to run the inference server (e.g., 'cr.backend.ai/stable/vllm:latest')."
+    image_id: UUID | None = gql_field(
+        description="UUID of the container image used to run the inference server."
     )
     startup_command: str | None = gql_field(
         description="Command to start the inference server process inside the container."

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.config import ModelConfig, ModelDefinition
 from ai.backend.common.dto.manager.query import UUIDFilter
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
@@ -100,11 +101,16 @@ class TestDeploymentRevisionPresetCRUD:
         admin_v2_registry: V2ClientRegistry,
         runtime_variant_id: RuntimeVariantID,
     ) -> None:
+        image_id = ImageID(uuid.uuid4())
+        model_definition = ModelDefinition(
+            models=[ModelConfig(name="llama", model_path="/models/llama")],
+        )
         create_result = await admin_v2_registry.deployment_revision_preset.create(
             CreateDeploymentRevisionPresetInput(
                 runtime_variant_id=runtime_variant_id,
                 name="search-test-preset",
-                image_id=ImageID(uuid.uuid4()),
+                image_id=image_id,
+                model_definition=model_definition,
             )
         )
         preset_id = create_result.preset.id
@@ -118,8 +124,15 @@ class TestDeploymentRevisionPresetCRUD:
             )
         )
         assert result.total_count >= 1
-        ids = [item.id for item in result.items]
-        assert preset_id in ids
+        matched = [item for item in result.items if item.id == preset_id]
+        assert len(matched) == 1
+        # BA-5931: nested execution.image_id and model_definition must round-trip.
+        preset = matched[0]
+        assert preset.execution.image_id == image_id
+        assert preset.model_definition is not None
+        assert len(preset.model_definition.models) == 1
+        assert preset.model_definition.models[0].name == "llama"
+        assert preset.model_definition.models[0].model_path == "/models/llama"
 
         await admin_v2_registry.deployment_revision_preset.delete(preset_id)
 

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
@@ -1,10 +1,3 @@
-"""Regression tests for DeploymentRevisionPreset GraphQL type conversions.
-
-These tests pin down the Strawberry ``from_pydantic`` mapping for nested
-output types, guarding against silent field-name / type mismatches between
-the Pydantic DTO and the GraphQL type (BA-5931).
-"""
-
 from __future__ import annotations
 
 import uuid
@@ -29,7 +22,6 @@ from ai.backend.manager.api.adapters.deployment_revision_preset.adapter import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision_preset import (
     DeploymentRevisionPresetGQL,
-    PresetExecutionSpecGQL,
 )
 
 
@@ -49,8 +41,8 @@ def _make_preset_node(
         resource=PresetResourceAllocation(resource_opts=[]),
         execution=PresetExecutionSpec(
             image_id=image_id,
-            startup_command=None,
-            bootstrap_script=None,
+            startup_command="serve",
+            bootstrap_script="setup.sh",
             environ=[],
         ),
         deployment_defaults=PresetDeploymentDefaults(),
@@ -61,77 +53,46 @@ def _make_preset_node(
     )
 
 
-class TestPresetExecutionSpecGQL:
-    def test_image_id_is_mapped_from_dto(self) -> None:
-        """BA-5931: GQL must expose ``image_id`` matching the DTO field name."""
-        image_id = ImageID(uuid.uuid4())
-        dto = PresetExecutionSpec(
-            image_id=image_id,
-            startup_command="serve",
-            bootstrap_script="setup.sh",
-            environ=[],
-        )
+def test_deployment_revision_preset_gql_from_pydantic() -> None:
+    image_id = ImageID(uuid.uuid4())
+    model_def = ModelDefinitionInfoDTO(
+        models=[
+            ModelConfigInfoDTO(
+                name="llama",
+                model_path="/models/llama",
+                service=None,
+                metadata=None,
+            ),
+        ],
+    )
 
-        gql = PresetExecutionSpecGQL.from_pydantic(dto)
+    populated = DeploymentRevisionPresetGQL.from_pydantic(
+        _make_preset_node(image_id=image_id, model_definition=model_def),
+    )
 
-        assert gql.image_id == uuid.UUID(str(image_id))
-        assert gql.startup_command == "serve"
-        assert gql.bootstrap_script == "setup.sh"
+    assert populated.execution.image_id == uuid.UUID(str(image_id))
+    assert populated.execution.startup_command == "serve"
+    assert populated.execution.bootstrap_script == "setup.sh"
+    assert populated.model_definition is not None
+    assert len(populated.model_definition.models) == 1
+    assert populated.model_definition.models[0].name == "llama"
+    assert populated.model_definition.models[0].model_path == "/models/llama"
 
-    def test_image_id_none_when_dto_image_id_is_none(self) -> None:
-        dto = PresetExecutionSpec(image_id=None)
+    empty = DeploymentRevisionPresetGQL.from_pydantic(_make_preset_node())
 
-        gql = PresetExecutionSpecGQL.from_pydantic(dto)
-
-        assert gql.image_id is None
+    assert empty.execution.image_id is None
+    assert empty.model_definition is None
 
 
-class TestDeploymentRevisionPresetGQL:
-    def test_execution_image_id_round_trips_through_node(self) -> None:
-        """BA-5931: nested ``execution.image_id`` must survive node-level conversion."""
-        image_id = ImageID(uuid.uuid4())
-        node = _make_preset_node(image_id=image_id)
+def test_model_definition_to_dto_converts_config_to_info_dto() -> None:
+    config_model_def = ModelDefinition(
+        models=[ModelConfig(name="llama", model_path="/models/llama")],
+    )
 
-        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
+    info_dto = _model_definition_to_dto(config_model_def)
 
-        assert gql.execution.image_id == uuid.UUID(str(image_id))
-
-    def test_model_definition_is_mapped_from_dto(self) -> None:
-        """BA-5931: nested ``model_definition`` must convert via ModelDefinitionInfoDTO."""
-        model_def = ModelDefinitionInfoDTO(
-            models=[
-                ModelConfigInfoDTO(
-                    name="llama",
-                    model_path="/models/llama",
-                    service=None,
-                    metadata=None,
-                ),
-            ],
-        )
-        node = _make_preset_node(model_definition=model_def)
-
-        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
-
-        assert gql.model_definition is not None
-        assert len(gql.model_definition.models) == 1
-        assert gql.model_definition.models[0].name == "llama"
-        assert gql.model_definition.models[0].model_path == "/models/llama"
-
-    def test_model_definition_none_when_absent(self) -> None:
-        node = _make_preset_node(model_definition=None)
-
-        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
-
-        assert gql.model_definition is None
-
-    def test_adapter_converts_config_model_definition_to_dto(self) -> None:
-        """Adapter helper must bridge ``ModelDefinition`` (config) to ``ModelDefinitionInfoDTO``."""
-        config_model_def = ModelDefinition(
-            models=[ModelConfig(name="llama", model_path="/models/llama")],
-        )
-
-        info_dto = _model_definition_to_dto(config_model_def)
-
-        assert len(info_dto.models) == 1
-        assert info_dto.models[0].name == "llama"
-        assert info_dto.models[0].model_path == "/models/llama"
+    assert info_dto is not None
+    assert len(info_dto.models) == 1
+    assert info_dto.models[0].name == "llama"
+    assert info_dto.models[0].model_path == "/models/llama"
+    assert _model_definition_to_dto(None) is None

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
@@ -1,0 +1,142 @@
+"""Regression tests for DeploymentRevisionPreset GraphQL type conversions.
+
+These tests pin down the Strawberry ``from_pydantic`` mapping for nested
+output types, guarding against silent field-name / type mismatches between
+the Pydantic DTO and the GraphQL type (BA-5931).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from ai.backend.common.config import ModelConfig, ModelDefinition
+from ai.backend.common.dto.manager.v2.deployment.types import (
+    ModelConfigInfoDTO,
+    ModelDefinitionInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
+    DeploymentRevisionPresetNode,
+    PresetClusterSpec,
+    PresetDeploymentDefaults,
+    PresetExecutionSpec,
+    PresetResourceAllocation,
+)
+from ai.backend.common.identifier.image import ImageID
+from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.manager.api.gql.deployment.types.revision_preset import (
+    DeploymentRevisionPresetGQL,
+    PresetExecutionSpecGQL,
+)
+
+
+def _make_preset_node(
+    *,
+    image_id: ImageID | None = None,
+    model_definition: ModelDefinitionInfoDTO | None = None,
+) -> DeploymentRevisionPresetNode:
+    now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    return DeploymentRevisionPresetNode(
+        id=uuid.uuid4(),
+        runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+        name="preset",
+        description=None,
+        rank=100,
+        cluster=PresetClusterSpec(cluster_mode="single-node", cluster_size=1),
+        resource=PresetResourceAllocation(resource_opts=[]),
+        execution=PresetExecutionSpec(
+            image_id=image_id,
+            startup_command=None,
+            bootstrap_script=None,
+            environ=[],
+        ),
+        deployment_defaults=PresetDeploymentDefaults(),
+        model_definition=model_definition,
+        preset_values=[],
+        created_at=now,
+        updated_at=None,
+    )
+
+
+class TestPresetExecutionSpecGQL:
+    def test_image_id_is_mapped_from_dto(self) -> None:
+        """BA-5931: GQL must expose ``image_id`` matching the DTO field name."""
+        image_id = ImageID(uuid.uuid4())
+        dto = PresetExecutionSpec(
+            image_id=image_id,
+            startup_command="serve",
+            bootstrap_script="setup.sh",
+            environ=[],
+        )
+
+        gql = PresetExecutionSpecGQL.from_pydantic(dto)
+
+        assert gql.image_id == uuid.UUID(str(image_id))
+        assert gql.startup_command == "serve"
+        assert gql.bootstrap_script == "setup.sh"
+
+    def test_image_id_none_when_dto_image_id_is_none(self) -> None:
+        dto = PresetExecutionSpec(image_id=None)
+
+        gql = PresetExecutionSpecGQL.from_pydantic(dto)
+
+        assert gql.image_id is None
+
+
+class TestDeploymentRevisionPresetGQL:
+    def test_execution_image_id_round_trips_through_node(self) -> None:
+        """BA-5931: nested ``execution.image_id`` must survive node-level conversion."""
+        image_id = ImageID(uuid.uuid4())
+        node = _make_preset_node(image_id=image_id)
+
+        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
+
+        assert gql.execution.image_id == uuid.UUID(str(image_id))
+
+    def test_model_definition_is_mapped_from_dto(self) -> None:
+        """BA-5931: nested ``model_definition`` must convert via ModelDefinitionInfoDTO."""
+        model_def = ModelDefinitionInfoDTO(
+            models=[
+                ModelConfigInfoDTO(
+                    name="llama",
+                    model_path="/models/llama",
+                    service=None,
+                    metadata=None,
+                ),
+            ],
+        )
+        node = _make_preset_node(model_definition=model_def)
+
+        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
+
+        assert gql.model_definition is not None
+        assert len(gql.model_definition.models) == 1
+        assert gql.model_definition.models[0].name == "llama"
+        assert gql.model_definition.models[0].model_path == "/models/llama"
+
+    def test_model_definition_none_when_absent(self) -> None:
+        node = _make_preset_node(model_definition=None)
+
+        gql = DeploymentRevisionPresetGQL.from_pydantic(node)
+
+        assert gql.model_definition is None
+
+    def test_adapter_converts_config_model_definition_to_dto(self) -> None:
+        """Adapter must bridge ``ModelDefinition`` (config) to ``ModelDefinitionInfoDTO``.
+
+        The data layer holds ``ModelDefinition`` from ``ai.backend.common.config``,
+        but the response DTO is typed as ``ModelDefinitionInfoDTO``. The adapter
+        converts via ``model_validate(model_dump(...))``; this test pins down the
+        round-trip so future regressions (e.g. dropping the conversion) fail loudly.
+        """
+        config_model_def = ModelDefinition(
+            models=[ModelConfig(name="llama", model_path="/models/llama")],
+        )
+
+        info_dto = ModelDefinitionInfoDTO.model_validate(
+            config_model_def.model_dump(by_alias=False)
+        )
+
+        assert len(info_dto.models) == 1
+        assert info_dto.models[0].name == "llama"
+        assert info_dto.models[0].model_path == "/models/llama"

--- a/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
+++ b/tests/unit/manager/api/gql/deployment/test_revision_preset_types.py
@@ -24,6 +24,9 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import
 )
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
+from ai.backend.manager.api.adapters.deployment_revision_preset.adapter import (
+    _model_definition_to_dto,
+)
 from ai.backend.manager.api.gql.deployment.types.revision_preset import (
     DeploymentRevisionPresetGQL,
     PresetExecutionSpecGQL,
@@ -122,20 +125,12 @@ class TestDeploymentRevisionPresetGQL:
         assert gql.model_definition is None
 
     def test_adapter_converts_config_model_definition_to_dto(self) -> None:
-        """Adapter must bridge ``ModelDefinition`` (config) to ``ModelDefinitionInfoDTO``.
-
-        The data layer holds ``ModelDefinition`` from ``ai.backend.common.config``,
-        but the response DTO is typed as ``ModelDefinitionInfoDTO``. The adapter
-        converts via ``model_validate(model_dump(...))``; this test pins down the
-        round-trip so future regressions (e.g. dropping the conversion) fail loudly.
-        """
+        """Adapter helper must bridge ``ModelDefinition`` (config) to ``ModelDefinitionInfoDTO``."""
         config_model_def = ModelDefinition(
             models=[ModelConfig(name="llama", model_path="/models/llama")],
         )
 
-        info_dto = ModelDefinitionInfoDTO.model_validate(
-            config_model_def.model_dump(by_alias=False)
-        )
+        info_dto = _model_definition_to_dto(config_model_def)
 
         assert len(info_dto.models) == 1
         assert info_dto.models[0].name == "llama"


### PR DESCRIPTION
## Summary
- Rename `PresetExecutionSpecGQL.image: str | None` to `image_id: UUID | None` so Strawberry's `from_pydantic` correctly maps the DTO `image_id` field. Previously every `deploymentRevisionPreset.execution.image` came back `null` despite the DB row carrying a valid image UUID.
- Switch the preset response DTO's `model_definition` from `ModelDefinition` (config class) to `ModelDefinitionInfoDTO` so the GQL `ModelDefinitionGQL` (bound to `ModelDefinitionInfoDTO`) can convert it. Add the same `model_validate(model_dump(...))` bridge in the adapter that the parent deployment revision adapter already uses.

## Test plan
- [x] `pants test tests/unit/manager/api/gql/deployment/test_revision_preset_types.py` — new unit tests assert `from_pydantic` mapping for `execution.image_id`, nested `model_definition`, and the adapter's config→DTO conversion.
- [x] `pants test tests/component/deployment_revision_preset::` — `test_search_with_filter` extended to assert `execution.image_id` and `model_definition` round-trip through SDK/REST.
- [ ] Verify against live server via GraphiQL: `deploymentRevisionPreset(id: ...) { execution { imageId } modelDefinition { models { name modelPath } } }` returns populated values.

Resolves BA-5931

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11451.org.readthedocs.build/en/11451/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11451.org.readthedocs.build/ko/11451/

<!-- readthedocs-preview sorna-ko end -->