### PR TITLE
fix(BA-5927): flatten resourceSlots to plain list with filter/order_by

### DIFF
--- a/changes/11462.breaking.md
+++ b/changes/11462.breaking.md
@@ -1,0 +1,1 @@
+Change `resourceSlots` field on deployment revisions and presets from a Relay `Connection` to a plain list of `AllocatedResourceSlot`, since slot entries are not globally identifiable nodes. The field now accepts optional `filter` and `orderBy` arguments instead of cursor pagination.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -793,15 +793,11 @@ type AliasImage
 }
 
 """
-Added in 26.4.2. Represents a single allocated resource slot entry for a deployment revision or preset.
+Added in 26.4.2. An allocated resource slot entry on a deployment revision or preset.
 """
-type AllocatedResourceSlot implements Node
-  @join__implements(graph: STRAWBERRY, interface: "Node")
+type AllocatedResourceSlot
   @join__type(graph: STRAWBERRY)
 {
-  """The Globally Unique ID of this object"""
-  id: ID!
-
   """Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."""
   slotName: String!
 
@@ -809,40 +805,20 @@ type AllocatedResourceSlot implements Node
   quantity: Decimal!
 }
 
-"""
-Added in 26.4.2. Connection type for paginated allocated resource slot results.
-"""
-type AllocatedResourceSlotConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [AllocatedResourceSlotEdge!]!
-
-  """Total number of allocated resource slots matching the filter criteria."""
-  count: Int!
-}
-
-"""An edge in a connection."""
-type AllocatedResourceSlotEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: AllocatedResourceSlot!
-}
-
 """Added in 26.4.2. Filter for allocated resource slots."""
 input AllocatedResourceSlotFilter
   @join__type(graph: STRAWBERRY)
 {
+  """Filter by slot name."""
   slotName: StringFilter = null
+
+  """Logical AND of multiple filter conditions."""
   AND: [AllocatedResourceSlotFilter!] = null
+
+  """Logical OR of multiple filter conditions."""
   OR: [AllocatedResourceSlotFilter!] = null
+
+  """Logical NOT of filter conditions."""
   NOT: [AllocatedResourceSlotFilter!] = null
 }
 
@@ -850,7 +826,10 @@ input AllocatedResourceSlotFilter
 input AllocatedResourceSlotOrderBy
   @join__type(graph: STRAWBERRY)
 {
+  """Field to order by."""
   field: AllocatedResourceSlotOrderField!
+
+  """Order direction."""
   direction: OrderDirection! = ASC
 }
 
@@ -5244,7 +5223,7 @@ type DeploymentRevisionPreset implements Node
   runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
 }
 
 """Added in 26.4.2. Paginated list of deployment revision presets."""
@@ -9569,7 +9548,7 @@ type ModelRevision implements Node
   imageV2: ImageV2
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
 }
 
 """Added in 25.19.0. Connection for model revisions."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -537,12 +537,9 @@ type AgentV2Edge {
 }
 
 """
-Added in 26.4.2. Represents a single allocated resource slot entry for a deployment revision or preset.
+Added in 26.4.2. An allocated resource slot entry on a deployment revision or preset.
 """
-type AllocatedResourceSlot implements Node {
-  """The Globally Unique ID of this object"""
-  id: ID!
-
+type AllocatedResourceSlot {
   """Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."""
   slotName: String!
 
@@ -550,40 +547,27 @@ type AllocatedResourceSlot implements Node {
   quantity: Decimal!
 }
 
-"""
-Added in 26.4.2. Connection type for paginated allocated resource slot results.
-"""
-type AllocatedResourceSlotConnection {
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [AllocatedResourceSlotEdge!]!
-
-  """Total number of allocated resource slots matching the filter criteria."""
-  count: Int!
-}
-
-"""An edge in a connection."""
-type AllocatedResourceSlotEdge {
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: AllocatedResourceSlot!
-}
-
 """Added in 26.4.2. Filter for allocated resource slots."""
 input AllocatedResourceSlotFilter {
+  """Filter by slot name."""
   slotName: StringFilter = null
+
+  """Logical AND of multiple filter conditions."""
   AND: [AllocatedResourceSlotFilter!] = null
+
+  """Logical OR of multiple filter conditions."""
   OR: [AllocatedResourceSlotFilter!] = null
+
+  """Logical NOT of filter conditions."""
   NOT: [AllocatedResourceSlotFilter!] = null
 }
 
 """Added in 26.4.2. Order by specification for allocated resource slots."""
 input AllocatedResourceSlotOrderBy {
+  """Field to order by."""
   field: AllocatedResourceSlotOrderField!
+
+  """Order direction."""
   direction: OrderDirection! = ASC
 }
 
@@ -3505,7 +3489,7 @@ type DeploymentRevisionPreset implements Node {
   runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
 }
 
 """Added in 26.4.2. Paginated list of deployment revision presets."""
@@ -6347,7 +6331,7 @@ type ModelRevision implements Node {
   imageV2: ImageV2
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AllocatedResourceSlotConnection!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
 }
 
 """Added in 25.19.0. Connection for model revisions."""

--- a/src/ai/backend/manager/api/gql/deployment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/__init__.py
@@ -89,7 +89,12 @@ from .replica import (
     TrafficStatus,
     TrafficStatusFilter,
 )
-from .resource_slot import AllocatedResourceSlotGQL
+from .resource_slot import (
+    AllocatedResourceSlotFilterGQL,
+    AllocatedResourceSlotGQL,
+    AllocatedResourceSlotOrderByGQL,
+    AllocatedResourceSlotOrderFieldGQL,
+)
 from .revision import (
     ActivateRevisionInputGQL,
     ActivateRevisionPayloadGQL,
@@ -251,7 +256,10 @@ __all__ = [
     "ResourceConfigInput",
     "ResourceGroupInput",
     # Allocated Resource Slot
+    "AllocatedResourceSlotFilterGQL",
     "AllocatedResourceSlotGQL",
+    "AllocatedResourceSlotOrderByGQL",
+    "AllocatedResourceSlotOrderFieldGQL",
     # Route
     "Route",
     "RouteConnection",

--- a/src/ai/backend/manager/api/gql/deployment/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/__init__.py
@@ -89,14 +89,7 @@ from .replica import (
     TrafficStatus,
     TrafficStatusFilter,
 )
-from .resource_slot import (
-    AllocatedResourceSlotConnection,
-    AllocatedResourceSlotEdge,
-    AllocatedResourceSlotFilterGQL,
-    AllocatedResourceSlotNodeGQL,
-    AllocatedResourceSlotOrderByGQL,
-    AllocatedResourceSlotOrderFieldGQL,
-)
+from .resource_slot import AllocatedResourceSlotGQL
 from .revision import (
     ActivateRevisionInputGQL,
     ActivateRevisionPayloadGQL,
@@ -258,12 +251,7 @@ __all__ = [
     "ResourceConfigInput",
     "ResourceGroupInput",
     # Allocated Resource Slot
-    "AllocatedResourceSlotConnection",
-    "AllocatedResourceSlotEdge",
-    "AllocatedResourceSlotFilterGQL",
-    "AllocatedResourceSlotNodeGQL",
-    "AllocatedResourceSlotOrderByGQL",
-    "AllocatedResourceSlotOrderFieldGQL",
+    "AllocatedResourceSlotGQL",
     # Route
     "Route",
     "RouteConnection",

--- a/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
@@ -2,120 +2,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from decimal import Decimal
-from enum import StrEnum
-from typing import Any, Self
 
-from strawberry import Info
-from strawberry.relay import Connection, Edge, NodeID
-
-from ai.backend.common.dto.manager.v2.resource_slot.request import (
-    AllocatedResourceSlotFilter as AllocatedResourceSlotFilterDTO,
-)
-from ai.backend.common.dto.manager.v2.resource_slot.request import (
-    AllocatedResourceSlotOrder as AllocatedResourceSlotOrderDTO,
-)
 from ai.backend.common.dto.manager.v2.resource_slot.response import (
     AllocatedResourceSlotNode as AllocatedResourceSlotNodeDTO,
 )
-from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
-    PydanticInputMixin,
-    gql_connection_type,
-    gql_enum,
     gql_field,
-    gql_node_type,
-    gql_pydantic_input,
+    gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
-from ai.backend.manager.api.gql.types import StrawberryGQLContext
-from ai.backend.manager.errors.api import UnsupportedOperation
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
 
 
-@gql_node_type(
+@gql_pydantic_type(
     BackendAIGQLMeta(
         added_version="26.4.2",
-        description="Represents a single allocated resource slot entry for a deployment revision or preset.",
+        description="An allocated resource slot entry on a deployment revision or preset.",
     ),
+    model=AllocatedResourceSlotNodeDTO,
     name="AllocatedResourceSlot",
 )
-class AllocatedResourceSlotNodeGQL(PydanticNodeMixin[AllocatedResourceSlotNodeDTO]):
-    id: NodeID[str]
+class AllocatedResourceSlotGQL(PydanticOutputMixin[AllocatedResourceSlotNodeDTO]):
     slot_name: str = gql_field(
         description="Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."
     )
     quantity: Decimal = gql_field(description="Allocated quantity for this resource slot.")
-
-    @classmethod
-    async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def
-        cls,
-        *,
-        info: Info[StrawberryGQLContext],
-        node_ids: Iterable[str],
-        required: bool = False,
-    ) -> Iterable[Self | None]:
-        raise UnsupportedOperation(
-            "AllocatedResourceSlotNodeGQL does not support root-level node resolution. "
-            "Access resource slots through the parent revision or preset."
-        )
-
-
-AllocatedResourceSlotEdge = Edge[AllocatedResourceSlotNodeGQL]
-
-
-@gql_connection_type(
-    BackendAIGQLMeta(
-        added_version="26.4.2",
-        description="Connection type for paginated allocated resource slot results.",
-    )
-)
-class AllocatedResourceSlotConnection(Connection[AllocatedResourceSlotNodeGQL]):
-    count: int = gql_field(
-        description="Total number of allocated resource slots matching the filter criteria."
-    )
-
-    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.count = count
-
-
-@gql_enum(
-    BackendAIGQLMeta(
-        added_version="26.4.2",
-        description="Fields available for ordering allocated resource slots.",
-    ),
-    name="AllocatedResourceSlotOrderField",
-)
-class AllocatedResourceSlotOrderFieldGQL(StrEnum):
-    SLOT_NAME = "slot_name"
-    QUANTITY = "quantity"
-    RANK = "rank"
-
-
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        description="Filter for allocated resource slots.",
-        added_version="26.4.2",
-    ),
-    name="AllocatedResourceSlotFilter",
-)
-class AllocatedResourceSlotFilterGQL(PydanticInputMixin[AllocatedResourceSlotFilterDTO]):
-    slot_name: StringFilter | None = None
-
-    AND: list[Self] | None = None
-    OR: list[Self] | None = None
-    NOT: list[Self] | None = None
-
-
-@gql_pydantic_input(
-    BackendAIGQLMeta(
-        description="Order by specification for allocated resource slots.",
-        added_version="26.4.2",
-    ),
-    name="AllocatedResourceSlotOrderBy",
-)
-class AllocatedResourceSlotOrderByGQL(PydanticInputMixin[AllocatedResourceSlotOrderDTO]):
-    field: AllocatedResourceSlotOrderFieldGQL
-    direction: OrderDirection = OrderDirection.ASC

--- a/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
@@ -3,13 +3,25 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from enum import StrEnum
+from typing import Self
 
+from ai.backend.common.dto.manager.v2.resource_slot.request import (
+    AllocatedResourceSlotFilter as AllocatedResourceSlotFilterDTO,
+)
+from ai.backend.common.dto.manager.v2.resource_slot.request import (
+    AllocatedResourceSlotOrder as AllocatedResourceSlotOrderDTO,
+)
 from ai.backend.common.dto.manager.v2.resource_slot.response import (
     AllocatedResourceSlotNode as AllocatedResourceSlotNodeDTO,
 )
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    PydanticInputMixin,
+    gql_enum,
     gql_field,
+    gql_pydantic_input,
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
@@ -28,3 +40,51 @@ class AllocatedResourceSlotGQL(PydanticOutputMixin[AllocatedResourceSlotNodeDTO]
         description="Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."
     )
     quantity: Decimal = gql_field(description="Allocated quantity for this resource slot.")
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version="26.4.2",
+        description="Fields available for ordering allocated resource slots.",
+    ),
+    name="AllocatedResourceSlotOrderField",
+)
+class AllocatedResourceSlotOrderFieldGQL(StrEnum):
+    SLOT_NAME = "slot_name"
+    QUANTITY = "quantity"
+    RANK = "rank"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Filter for allocated resource slots.",
+        added_version="26.4.2",
+    ),
+    name="AllocatedResourceSlotFilter",
+)
+class AllocatedResourceSlotFilterGQL(PydanticInputMixin[AllocatedResourceSlotFilterDTO]):
+    slot_name: StringFilter | None = gql_field(default=None, description="Filter by slot name.")
+
+    AND: list[Self] | None = gql_field(
+        default=None, description="Logical AND of multiple filter conditions."
+    )
+    OR: list[Self] | None = gql_field(
+        default=None, description="Logical OR of multiple filter conditions."
+    )
+    NOT: list[Self] | None = gql_field(
+        default=None, description="Logical NOT of filter conditions."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Order by specification for allocated resource slots.",
+        added_version="26.4.2",
+    ),
+    name="AllocatedResourceSlotOrderBy",
+)
+class AllocatedResourceSlotOrderByGQL(PydanticInputMixin[AllocatedResourceSlotOrderDTO]):
+    field: AllocatedResourceSlotOrderFieldGQL = gql_field(description="Field to order by.")
+    direction: OrderDirection = gql_field(
+        default=OrderDirection.ASC, description="Order direction."
+    )

--- a/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/resource_slot.py
@@ -26,6 +26,12 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
 
+# A resource slot row is bound to a single revision/preset and the slot count
+# per parent is bounded by the number of declared resource slot types
+# (CPU, MEM, GPU SKUs, …), which is small in practice. This limit effectively
+# returns all rows without exposing cursor pagination on the field.
+RESOURCE_SLOTS_FETCH_LIMIT = 10000
+
 
 @gql_pydantic_type(
     BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -138,6 +138,7 @@ from ai.backend.manager.api.gql_legacy.scaling_group import ScalingGroupNode
 from ai.backend.manager.api.gql_legacy.vfolder import VirtualFolderNode
 
 from .resource_slot import (
+    RESOURCE_SLOTS_FETCH_LIMIT,
     AllocatedResourceSlotFilterGQL,
     AllocatedResourceSlotGQL,
     AllocatedResourceSlotOrderByGQL,
@@ -523,7 +524,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
             input=SearchAllocatedResourceSlotsInput(
                 filter=filter.to_pydantic() if filter else None,
                 order=[o.to_pydantic() for o in order_by] if order_by else None,
-                limit=10000,
+                limit=RESOURCE_SLOTS_FETCH_LIMIT,
             ),
         )
         return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import strawberry
 from strawberry import ID, Info
-from strawberry.relay import Connection, Edge, NodeID, PageInfo
+from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
 from ai.backend.common.config import (
@@ -137,13 +137,7 @@ from ai.backend.manager.api.gql_legacy.image import ImageNode
 from ai.backend.manager.api.gql_legacy.scaling_group import ScalingGroupNode
 from ai.backend.manager.api.gql_legacy.vfolder import VirtualFolderNode
 
-from .resource_slot import (
-    AllocatedResourceSlotConnection,
-    AllocatedResourceSlotEdge,
-    AllocatedResourceSlotFilterGQL,
-    AllocatedResourceSlotNodeGQL,
-    AllocatedResourceSlotOrderByGQL,
-)
+from .resource_slot import AllocatedResourceSlotGQL
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.gql.image.types import ImageV2GQL
@@ -513,46 +507,16 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     async def resource_slots(
         self,
         info: Info[StrawberryGQLContext],
-        filter: AllocatedResourceSlotFilterGQL | None = None,
-        order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
-        before: str | None = None,
-        after: str | None = None,
-        first: int | None = None,
-        last: int | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> AllocatedResourceSlotConnection:
+    ) -> list[AllocatedResourceSlotGQL]:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
         )
 
-        pydantic_filter = filter.to_pydantic() if filter else None
-        pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment.search_revision_resource_slots(
             revision_id=UUID(str(self.id)),
-            input=SearchAllocatedResourceSlotsInput(
-                filter=pydantic_filter,
-                order=pydantic_order,
-                first=first,
-                after=after,
-                last=last,
-                before=before,
-                limit=limit,
-                offset=offset,
-            ),
+            input=SearchAllocatedResourceSlotsInput(limit=10000),
         )
-        nodes = [AllocatedResourceSlotNodeGQL.from_pydantic(item) for item in payload.items]
-        edges = [AllocatedResourceSlotEdge(node=node, cursor=node.slot_name) for node in nodes]
-        return AllocatedResourceSlotConnection(
-            count=payload.total_count,
-            edges=edges,
-            page_info=PageInfo(
-                has_next_page=payload.has_next_page,
-                has_previous_page=payload.has_previous_page,
-                start_cursor=edges[0].cursor if edges else None,
-                end_cursor=edges[-1].cursor if edges else None,
-            ),
-        )
+        return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]
 
     @classmethod
     async def resolve_nodes(  # type: ignore[override]  # Strawberry Node uses AwaitableOrValue overloads incompatible with async def

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -137,7 +137,11 @@ from ai.backend.manager.api.gql_legacy.image import ImageNode
 from ai.backend.manager.api.gql_legacy.scaling_group import ScalingGroupNode
 from ai.backend.manager.api.gql_legacy.vfolder import VirtualFolderNode
 
-from .resource_slot import AllocatedResourceSlotGQL
+from .resource_slot import (
+    AllocatedResourceSlotFilterGQL,
+    AllocatedResourceSlotGQL,
+    AllocatedResourceSlotOrderByGQL,
+)
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.gql.image.types import ImageV2GQL
@@ -507,6 +511,8 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     async def resource_slots(
         self,
         info: Info[StrawberryGQLContext],
+        filter: AllocatedResourceSlotFilterGQL | None = None,
+        order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
     ) -> list[AllocatedResourceSlotGQL]:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
@@ -514,7 +520,11 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
 
         payload = await info.context.adapters.deployment.search_revision_resource_slots(
             revision_id=UUID(str(self.id)),
-            input=SearchAllocatedResourceSlotsInput(limit=10000),
+            input=SearchAllocatedResourceSlotsInput(
+                filter=filter.to_pydantic() if filter else None,
+                order=[o.to_pydantic() for o in order_by] if order_by else None,
+                limit=10000,
+            ),
         )
         return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -87,7 +87,9 @@ from ai.backend.manager.api.gql.deployment.types.policy import (
     RollingUpdateConfigInputGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.resource_slot import (
+    AllocatedResourceSlotFilterGQL,
     AllocatedResourceSlotGQL,
+    AllocatedResourceSlotOrderByGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelDefinitionGQL,
@@ -305,6 +307,8 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
     async def resource_slots(
         self,
         info: Info[StrawberryGQLContext],
+        filter: AllocatedResourceSlotFilterGQL | None = None,
+        order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
     ) -> list[AllocatedResourceSlotGQL]:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
@@ -312,7 +316,11 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
 
         payload = await info.context.adapters.deployment_revision_preset.search_resource_slots(
             preset_id=UUID(self.id),
-            input=SearchAllocatedResourceSlotsInput(limit=10000),
+            input=SearchAllocatedResourceSlotsInput(
+                filter=filter.to_pydantic() if filter else None,
+                order=[o.to_pydantic() for o in order_by] if order_by else None,
+                limit=10000,
+            ),
         )
         return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 import strawberry
 from strawberry import UNSET, Info
-from strawberry.relay import Connection, Edge, NodeID, PageInfo
+from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
@@ -87,11 +87,7 @@ from ai.backend.manager.api.gql.deployment.types.policy import (
     RollingUpdateConfigInputGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.resource_slot import (
-    AllocatedResourceSlotConnection,
-    AllocatedResourceSlotEdge,
-    AllocatedResourceSlotFilterGQL,
-    AllocatedResourceSlotNodeGQL,
-    AllocatedResourceSlotOrderByGQL,
+    AllocatedResourceSlotGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelDefinitionGQL,
@@ -309,46 +305,16 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
     async def resource_slots(
         self,
         info: Info[StrawberryGQLContext],
-        filter: AllocatedResourceSlotFilterGQL | None = None,
-        order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
-        before: str | None = None,
-        after: str | None = None,
-        first: int | None = None,
-        last: int | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> AllocatedResourceSlotConnection:
+    ) -> list[AllocatedResourceSlotGQL]:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
         )
 
-        pydantic_filter = filter.to_pydantic() if filter else None
-        pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment_revision_preset.search_resource_slots(
             preset_id=UUID(self.id),
-            input=SearchAllocatedResourceSlotsInput(
-                filter=pydantic_filter,
-                order=pydantic_order,
-                first=first,
-                after=after,
-                last=last,
-                before=before,
-                limit=limit,
-                offset=offset,
-            ),
+            input=SearchAllocatedResourceSlotsInput(limit=10000),
         )
-        nodes = [AllocatedResourceSlotNodeGQL.from_pydantic(item) for item in payload.items]
-        edges = [AllocatedResourceSlotEdge(node=node, cursor=node.slot_name) for node in nodes]
-        return AllocatedResourceSlotConnection(
-            count=payload.total_count,
-            edges=edges,
-            page_info=PageInfo(
-                has_next_page=payload.has_next_page,
-                has_previous_page=payload.has_previous_page,
-                start_cursor=edges[0].cursor if edges else None,
-                end_cursor=edges[-1].cursor if edges else None,
-            ),
-        )
+        return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]
 
 
 DeploymentRevisionPresetEdge = Edge[DeploymentRevisionPresetGQL]

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -87,6 +87,7 @@ from ai.backend.manager.api.gql.deployment.types.policy import (
     RollingUpdateConfigInputGQL,
 )
 from ai.backend.manager.api.gql.deployment.types.resource_slot import (
+    RESOURCE_SLOTS_FETCH_LIMIT,
     AllocatedResourceSlotFilterGQL,
     AllocatedResourceSlotGQL,
     AllocatedResourceSlotOrderByGQL,
@@ -319,7 +320,7 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
             input=SearchAllocatedResourceSlotsInput(
                 filter=filter.to_pydantic() if filter else None,
                 order=[o.to_pydantic() for o in order_by] if order_by else None,
-                limit=10000,
+                limit=RESOURCE_SLOTS_FETCH_LIMIT,
             ),
         )
         return [AllocatedResourceSlotGQL.from_pydantic(item) for item in payload.items]


### PR DESCRIPTION
## Summary

- Querying `resourceSlots` on `DeploymentRevision` or `DeploymentRevisionPreset` failed with `'AllocatedResourceSlotNode' object has no attribute 'id'`. The DTO carries only `slot_name` and `quantity` — there is no `id` for `PydanticNodeMixin.from_pydantic` to read.
- Root cause: `AllocatedResourceSlot` was modeled as a Relay Node, but Relay Node IDs must be globally unique and slot names are not.
- Fix: convert `AllocatedResourceSlotGQL` to a plain `@gql_pydantic_type` and have `resourceSlots` return `list[AllocatedResourceSlotGQL]` directly. Drop the unused Edge / Connection / `resolve_nodes`.
- Re-expose `filter` and `orderBy` arguments on the field (the lower layers already support them) — only cursor pagination is dropped, since slot count per parent is bounded.
- Extract the fetch limit (`10000`) to a named constant `RESOURCE_SLOTS_FETCH_LIMIT` so it is no longer a magic number duplicated across resolvers.

## Schema change (breaking)

`resourceSlots` on `DeploymentRevision` and `DeploymentRevisionPreset` is now `[AllocatedResourceSlot!]!` instead of an `AllocatedResourceSlotConnection`. Existing client queries that wrap it in `edges { node { ... } }` must drop that wrapping. The field accepts optional `filter: AllocatedResourceSlotFilter` and `orderBy: [AllocatedResourceSlotOrderBy!]` arguments. Announced via `changes/11462.breaking.md`.

## Test plan

- [x] `pants fmt`, `pants fix`, `pants lint` clean.
- [x] Schema import smoke test (`schema OK`).
- [x] Existing unit test `tests/unit/manager/api/gql/deployment/test_revision_preset_types.py` still passes.
- [x] Live verification on the running server — preset side, end-to-end:
  - baseline (no args) returns the flat list with no `id`-attribute error
  - `orderBy` on `SLOT_NAME` and `QUANTITY` (ASC/DESC) all sort correctly
  - `filter` with `equals`, `contains`, `in`, `endsWith`, plus `AND` / `OR` composition all match
  - `filter + orderBy` combined produces the filtered, ordered subset
- [x] Revision side schema accepts the new `filter` / `orderBy` arguments (Strawberry validation passes); the adapter helpers (`_convert_allocated_slot_filter`, the order resolvers) are shared with the preset path.

Resolves BA-5927