### PR TITLE
feat(BA-5921): launch model service from runtime-variant defaults and preset args

### DIFF
--- a/changes/11463.feature.md
+++ b/changes/11463.feature.md
@@ -1,0 +1,1 @@
+Launch model services from runtime-variant default start_command and deployment preset ARGS in inference deployments

--- a/fixtures/manager/example-runtime-variants.json
+++ b/fixtures/manager/example-runtime-variants.json
@@ -8,6 +8,7 @@
           {
             "name": "vllm-model",
             "service": {
+              "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
                 "path": "/health",
@@ -62,6 +63,7 @@
           {
             "name": "tgi-model",
             "service": {
+              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
                 "path": "/info",
@@ -82,6 +84,13 @@
           {
             "name": "sglang-model",
             "service": {
+              "start_command": [
+                "python",
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                "{model_path}"
+              ],
               "port": 9001,
               "health_check": {
                 "path": "/health",
@@ -102,6 +111,7 @@
           {
             "name": "max-model",
             "service": {
+              "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
                 "path": "/health",

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -3171,11 +3171,9 @@ class AbstractAgent[
                     }
 
                     if ctx.kernel_config["cluster_role"] in ("main", "master") and model_definition:
-                        populated_models = (
-                            await self._apply_image_cmd_fallback(
-                                model_definition["models"],
-                                ctx.image_ref.canonical,
-                            )
+                        populated_models = await self._apply_image_cmd_fallback(
+                            model_definition["models"],
+                            ctx.image_ref.canonical,
                         )
                         for model in populated_models:
                             service = model.get("service")

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2461,7 +2461,7 @@ class AbstractAgent[
             ),
         )
 
-    async def _populate_missing_model_service_start_commands(
+    async def _apply_image_cmd_fallback(
         self,
         models: list[dict[str, Any]],
         image: str,
@@ -3172,7 +3172,7 @@ class AbstractAgent[
 
                     if ctx.kernel_config["cluster_role"] in ("main", "master") and model_definition:
                         populated_models = (
-                            await self._populate_missing_model_service_start_commands(
+                            await self._apply_image_cmd_fallback(
                                 model_definition["models"],
                                 ctx.image_ref.canonical,
                             )

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -248,8 +248,12 @@ class ModelServiceConfig(BaseConfigModel):
     )
     start_command: list[str] | None = Field(
         default=None,
-        description="Command to start the model service.",
-        examples=[["python", "service.py"]],
+        description=(
+            "Argv list to start the model service. ``{model_path}`` in any "
+            "token is replaced per-token with the resolved ``model_path`` "
+            "before launch. ``None`` falls back to the image's default CMD."
+        ),
+        examples=[["python", "service.py"], ["vllm", "serve", "{model_path}"]],
     )
     shell: str = Field(
         default="/bin/bash",

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -467,6 +467,29 @@ class ModelDefinition(BaseConfigModel):
                     return model.service.health_check
         return None
 
+    def with_args_appended(self, args: list[str]) -> ModelDefinition:
+        """Return a copy with ``args`` appended to each model's
+        ``service.start_command`` as separate argv tokens.
+
+        Models with ``service is None`` are passed through unchanged;
+        a model whose ``start_command`` is ``None`` receives ``args``
+        as its initial ``start_command`` (the agent's image-CMD fallback
+        is responsible for prepending a launcher when this happens).
+        """
+        if not args:
+            return self
+        new_models: list[ModelConfig] = []
+        for model in self.models:
+            if model.service is None:
+                new_models.append(model)
+                continue
+            existing = model.service.start_command or []
+            new_service = model.service.model_copy(
+                update={"start_command": existing + args},
+            )
+            new_models.append(model.model_copy(update={"service": new_service}))
+        return self.model_copy(update={"models": new_models})
+
 
 # ============================================================================
 # ModelDefinition draft types — partial-input variants used by source layers

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -531,10 +531,19 @@ class ModelConfigDraft(BaseConfigModel):
             raise ValueError("ModelConfig.name is required")
         if self.model_path is None:
             raise ValueError("ModelConfig.model_path is required")
+        service = self.service.to_resolved() if self.service else None
+        if service is not None and service.start_command:
+            # ``{model_path}`` placeholders in the variant baseline's
+            # ``start_command`` are resolved here, at the same moment the
+            # draft becomes a strict ``ModelConfig`` and ``model_path`` is
+            # finalized. Placeholders therefore never propagate downstream.
+            service.start_command = [
+                token.replace("{model_path}", self.model_path) for token in service.start_command
+            ]
         return ModelConfig(
             name=self.name,
             model_path=self.model_path,
-            service=self.service.to_resolved() if self.service else None,
+            service=service,
             metadata=self.metadata,
         )
 

--- a/src/ai/backend/install/fixtures/example-runtime-variants.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variants.json
@@ -8,6 +8,7 @@
           {
             "name": "vllm-model",
             "service": {
+              "start_command": ["vllm", "serve", "{model_path}"],
               "port": 8000,
               "health_check": {
                 "path": "/health",
@@ -62,6 +63,7 @@
           {
             "name": "tgi-model",
             "service": {
+              "start_command": ["text-generation-launcher", "--model-id", "{model_path}"],
               "port": 3000,
               "health_check": {
                 "path": "/info",
@@ -82,6 +84,13 @@
           {
             "name": "sglang-model",
             "service": {
+              "start_command": [
+                "python",
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                "{model_path}"
+              ],
               "port": 9001,
               "health_check": {
                 "path": "/health",
@@ -102,6 +111,7 @@
           {
             "name": "max-model",
             "service": {
+              "start_command": ["max", "serve", "--model", "{model_path}"],
               "port": 8000,
               "health_check": {
                 "path": "/health",

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -2047,7 +2047,8 @@ class DeploymentDBSource:
                             if (pv.value or "").strip().lower() in ("true", "1"):
                                 resolved_args.append(vp.key)
                         else:
-                            resolved_args.append(f"{vp.key} {pv.value}")
+                            resolved_args.append(vp.key)
+                            resolved_args.append(pv.value)
                 resolved_presets = ResolvedPresetValues(
                     environ=resolved_environ, args=resolved_args
                 )

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -67,13 +67,13 @@ class DeploymentSessionDraftBuilder:
         target_revision: ModelRevisionSpec,
     ) -> SessionSpecDraft:
         environ = cls._resolve_environ(deployment_info, target_revision, context)
-        startup_command = cls._resolve_startup_command(target_revision, context)
+        startup_command = target_revision.execution.startup_command
         mounts = cls._resolve_mounts(target_revision)
         resource_entries = cls._resource_entries(target_revision)
         resource_opts = ResourceOpts.model_validate(
             target_revision.resource_spec.resource_opts or {}
         )
-        model_definition_payload = cls._model_definition_payload(target_revision)
+        model_definition_payload = cls._model_definition_payload(target_revision, context)
 
         return SessionSpecDraft(
             identity=SessionIdentityDraft(
@@ -138,17 +138,6 @@ class DeploymentSessionDraftBuilder:
         return environ
 
     @staticmethod
-    def _resolve_startup_command(
-        target_revision: ModelRevisionSpec,
-        context: DeploymentContext,
-    ) -> str | None:
-        startup_command = target_revision.execution.startup_command
-        if context.resolved_presets and context.resolved_presets.args:
-            args_str = " ".join(context.resolved_presets.args)
-            startup_command = f"{startup_command} {args_str}" if startup_command else args_str
-        return startup_command
-
-    @staticmethod
     def _resolve_mounts(
         target_revision: ModelRevisionSpec,
     ) -> tuple[MountInfoEntry, ...]:
@@ -177,7 +166,24 @@ class DeploymentSessionDraftBuilder:
     @staticmethod
     def _model_definition_payload(
         target_revision: ModelRevisionSpec,
+        context: DeploymentContext,
     ) -> dict[str, Any] | None:
+        """Materialize ``model_definition`` into the kernel payload.
+
+        ``service.start_command`` is taken as-is from the revision snapshot
+        (the controller has already resolved any ``{model_path}`` placeholder
+        against ``models[0].model_path`` at revision creation time). Preset
+        ARGS are appended as separate argv tokens.
+        """
         if target_revision.model_definition is None:
             return None
-        return target_revision.model_definition.model_dump(mode="json")
+        payload = target_revision.model_definition.model_dump(mode="json")
+        args = (context.resolved_presets.args if context.resolved_presets else None) or []
+        if args and payload.get("models"):
+            for model in payload["models"]:
+                service = model.get("service")
+                if service is None:
+                    continue
+                existing = list(service.get("start_command") or [])
+                service["start_command"] = existing + list(args)
+        return payload

--- a/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_draft_builder.py
@@ -173,17 +173,14 @@ class DeploymentSessionDraftBuilder:
         ``service.start_command`` is taken as-is from the revision snapshot
         (the controller has already resolved any ``{model_path}`` placeholder
         against ``models[0].model_path`` at revision creation time). Preset
-        ARGS are appended as separate argv tokens.
+        ARGS are appended as separate argv tokens via
+        :meth:`ModelDefinition.with_args_appended` so the merge stays on
+        typed objects up to the final ``model_dump``.
         """
-        if target_revision.model_definition is None:
+        model_definition = target_revision.model_definition
+        if model_definition is None:
             return None
-        payload = target_revision.model_definition.model_dump(mode="json")
         args = (context.resolved_presets.args if context.resolved_presets else None) or []
-        if args and payload.get("models"):
-            for model in payload["models"]:
-                service = model.get("service")
-                if service is None:
-                    continue
-                existing = list(service.get("start_command") or [])
-                service["start_command"] = existing + list(args)
-        return payload
+        if args:
+            model_definition = model_definition.with_args_appended(args)
+        return model_definition.model_dump(mode="json")

--- a/tests/unit/agent/test_model_service_start_command.py
+++ b/tests/unit/agent/test_model_service_start_command.py
@@ -122,7 +122,7 @@ class TestPopulateMissingModelServiceStartCommands:
         models: list[dict[str, Any]],
         image: str,
     ) -> None:
-        populated_models = await AbstractAgent._populate_missing_model_service_start_commands(
+        populated_models = await AbstractAgent._apply_image_cmd_fallback(
             cast(AbstractAgent[Any, Any], agent),
             models,
             image,
@@ -150,7 +150,7 @@ class TestPopulateMissingModelServiceStartCommands:
         models = [_model("vllm", 8000)]
 
         with pytest.raises(NotImplementedError):
-            await AbstractAgent._populate_missing_model_service_start_commands(
+            await AbstractAgent._apply_image_cmd_fallback(
                 cast(AbstractAgent[Any, Any], raise_not_implemented_agent),
                 models,
                 image,

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -318,3 +318,138 @@ class TestModelConfigs:
         service = resolved.models[0].service
         assert service is not None
         assert service.start_command == ["my-server", "--bind", "0.0.0.0"]
+
+
+class TestModelDefinitionWithArgsAppended:
+    @pytest.fixture
+    def vllm_definition(self) -> ModelDefinition:
+        return ModelDefinition(
+            models=[
+                ModelConfig(
+                    name="demo",
+                    model_path="/models",
+                    service=ModelServiceConfig(
+                        port=8000,
+                        start_command=["vllm", "serve", "/models"],
+                    ),
+                )
+            ]
+        )
+
+    @pytest.fixture
+    def definition_without_start_command(self) -> ModelDefinition:
+        return ModelDefinition(
+            models=[
+                ModelConfig(
+                    name="demo",
+                    model_path="/models",
+                    service=ModelServiceConfig(port=8000, start_command=None),
+                )
+            ]
+        )
+
+    @pytest.fixture
+    def definition_without_service(self) -> ModelDefinition:
+        return ModelDefinition(
+            models=[ModelConfig(name="demo", model_path="/models", service=None)],
+        )
+
+    @pytest.fixture
+    def multi_model_definition(self) -> ModelDefinition:
+        return ModelDefinition(
+            models=[
+                ModelConfig(
+                    name="a",
+                    model_path="/models/a",
+                    service=ModelServiceConfig(port=8001, start_command=["a"]),
+                ),
+                ModelConfig(
+                    name="b",
+                    model_path="/models/b",
+                    service=ModelServiceConfig(port=8002, start_command=["b"]),
+                ),
+            ]
+        )
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            pytest.param(
+                ["--max-model-len", "4096"],
+                ["vllm", "serve", "/models", "--max-model-len", "4096"],
+                id="single-flag-pair",
+            ),
+            pytest.param(
+                ["--port", "8000", "--max-model-len", "4096"],
+                ["vllm", "serve", "/models", "--port", "8000", "--max-model-len", "4096"],
+                id="multiple-flag-pairs",
+            ),
+            pytest.param(
+                ["--trust-remote-code"],
+                ["vllm", "serve", "/models", "--trust-remote-code"],
+                id="bare-flag",
+            ),
+        ],
+    )
+    async def test_appends_args_as_separate_tokens(
+        self,
+        vllm_definition: ModelDefinition,
+        args: list[str],
+        expected: list[str],
+    ) -> None:
+        result = vllm_definition.with_args_appended(args)
+
+        service = result.models[0].service
+        assert service is not None
+        assert service.start_command == expected
+
+    async def test_empty_args_returns_self(
+        self,
+        vllm_definition: ModelDefinition,
+    ) -> None:
+        # Identity (``is``) is the contract for the no-op shortcut — no
+        # copy is taken when there is nothing to append.
+        assert vllm_definition.with_args_appended([]) is vllm_definition
+
+    async def test_does_not_mutate_input(
+        self,
+        vllm_definition: ModelDefinition,
+    ) -> None:
+        # The same ``ModelDefinition`` may be re-used across deployments
+        # with different presets; mutation here would cross-contaminate
+        # later builds.
+        vllm_definition.with_args_appended(["--port", "8000"])
+
+        service = vllm_definition.models[0].service
+        assert service is not None
+        assert service.start_command == ["vllm", "serve", "/models"]
+
+    async def test_args_become_start_command_when_none(
+        self,
+        definition_without_start_command: ModelDefinition,
+    ) -> None:
+        result = definition_without_start_command.with_args_appended(["--port", "8000"])
+
+        service = result.models[0].service
+        assert service is not None
+        assert service.start_command == ["--port", "8000"]
+
+    async def test_passes_through_models_without_service(
+        self,
+        definition_without_service: ModelDefinition,
+    ) -> None:
+        result = definition_without_service.with_args_appended(["--port", "8000"])
+
+        assert result.models[0].service is None
+
+    async def test_each_model_receives_args(
+        self,
+        multi_model_definition: ModelDefinition,
+    ) -> None:
+        result = multi_model_definition.with_args_appended(["--shared", "true"])
+
+        first = result.models[0].service
+        second = result.models[1].service
+        assert first is not None and second is not None
+        assert first.start_command == ["a", "--shared", "true"]
+        assert second.start_command == ["b", "--shared", "true"]

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -241,3 +241,80 @@ class TestModelConfigs:
                     }
                 ]
             })
+
+    def test_to_resolved_substitutes_model_path_placeholder(self) -> None:
+        # The variant baseline keeps ``{model_path}`` so a single fixture
+        # entry covers any mount destination; the placeholder is resolved
+        # once, at the boundary between draft merge and persistence.
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "demo",
+                    "model_path": "/custom-mount",
+                    "service": {
+                        "start_command": ["vllm", "serve", "{model_path}"],
+                        "port": 8000,
+                    },
+                }
+            ]
+        })
+
+        resolved = draft.to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.start_command == ["vllm", "serve", "/custom-mount"]
+
+    def test_to_resolved_substitutes_placeholder_with_named_flag(self) -> None:
+        # SGLang-style: ``{model_path}`` lands after a flag; the
+        # substitution touches the placeholder token only, not the flag.
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "demo",
+                    "model_path": "/data",
+                    "service": {
+                        "start_command": [
+                            "python",
+                            "-m",
+                            "sglang.launch_server",
+                            "--model-path",
+                            "{model_path}",
+                        ],
+                        "port": 9001,
+                    },
+                }
+            ]
+        })
+
+        resolved = draft.to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.start_command == [
+            "python",
+            "-m",
+            "sglang.launch_server",
+            "--model-path",
+            "/data",
+        ]
+
+    def test_to_resolved_leaves_start_command_with_no_placeholder_unchanged(self) -> None:
+        draft = ModelDefinitionDraft.model_validate({
+            "models": [
+                {
+                    "name": "demo",
+                    "model_path": "/models",
+                    "service": {
+                        "start_command": ["my-server", "--bind", "0.0.0.0"],
+                        "port": 8000,
+                    },
+                }
+            ]
+        })
+
+        resolved = draft.to_resolved()
+
+        service = resolved.models[0].service
+        assert service is not None
+        assert service.start_command == ["my-server", "--bind", "0.0.0.0"]

--- a/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
+++ b/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
@@ -1,16 +1,9 @@
-"""Unit tests for ``DeploymentSessionDraftBuilder`` helpers.
-
-The builder appends ``ResolvedPresetValues.args`` onto each model's
-``service.start_command`` as separate argv tokens. Resolution of
-``{model_path}`` placeholders happens earlier (at
-``ModelConfigDraft.to_resolved`` during revision creation), so the
-snapshot the builder reads here already carries fully-resolved argv.
-"""
-
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 from unittest.mock import MagicMock
+
+import pytest
 
 from ai.backend.common.config import (
     ModelConfig,
@@ -27,21 +20,6 @@ from ai.backend.manager.sokovan.deployment.deployment_draft_builder import (
 )
 
 
-def _model_definition(start_command: list[str] | None) -> ModelDefinition:
-    return ModelDefinition(
-        models=[
-            ModelConfig(
-                name="vllm-model",
-                model_path="/models",
-                service=ModelServiceConfig(
-                    port=8000,
-                    start_command=start_command,
-                ),
-            )
-        ]
-    )
-
-
 def _revision_spec(model_definition: ModelDefinition | None) -> ModelRevisionSpec:
     revision = MagicMock(spec=ModelRevisionSpec)
     revision.model_definition = model_definition
@@ -49,19 +27,42 @@ def _revision_spec(model_definition: ModelDefinition | None) -> ModelRevisionSpe
 
 
 def _context(args: list[str] | None) -> DeploymentContext:
+    """Build a ``DeploymentContext`` with only the preset-args slice the
+    builder method touches; everything else stays a ``MagicMock`` because
+    ``_model_definition_payload`` does not read it."""
     context = MagicMock(spec=DeploymentContext)
     context.resolved_presets = (
-        ResolvedPresetValues(environ={}, args=list(args)) if args is not None else None
+        ResolvedPresetValues(environ={}, args=args) if args is not None else None
     )
     return cast(DeploymentContext, context)
 
 
 class TestModelDefinitionPayload:
-    """``_model_definition_payload`` appends preset ARGS onto the snapshot
-    ``service.start_command`` as separate argv tokens. Without args it is
-    a pass-through ``model_dump`` of the resolved ``ModelDefinition``."""
+    """Tests scoped to the builder method only — the merge invariants
+    themselves (identity on empty args, immutability, multi-model fan-out,
+    ``service=None`` pass-through, ``start_command=None`` handling) are
+    covered by ``TestModelDefinitionWithArgsAppended`` in
+    ``tests/unit/common/test_config.py`` and not duplicated here.
+    """
 
-    def test_returns_none_when_revision_has_no_definition(self) -> None:
+    @pytest.fixture
+    def vllm_revision(self) -> ModelRevisionSpec:
+        return _revision_spec(
+            ModelDefinition(
+                models=[
+                    ModelConfig(
+                        name="vllm-model",
+                        model_path="/models",
+                        service=ModelServiceConfig(
+                            port=8000,
+                            start_command=["vllm", "serve", "/models"],
+                        ),
+                    )
+                ]
+            )
+        )
+
+    async def test_returns_none_when_revision_has_no_definition(self) -> None:
         payload = DeploymentSessionDraftBuilder._model_definition_payload(
             _revision_spec(None),
             _context(None),
@@ -69,107 +70,51 @@ class TestModelDefinitionPayload:
 
         assert payload is None
 
-    def test_no_presets_passes_through_unchanged(self) -> None:
-        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
-
-        payload = DeploymentSessionDraftBuilder._model_definition_payload(revision, _context(None))
-
-        assert payload is not None
-        assert payload["models"][0]["service"]["start_command"] == [
-            "vllm",
-            "serve",
-            "/models",
-        ]
-
-    def test_appends_args_to_existing_start_command(self) -> None:
-        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
-
+    @pytest.mark.parametrize(
+        ("args", "expected_start_command"),
+        [
+            pytest.param(None, ["vllm", "serve", "/models"], id="presets-absent"),
+            pytest.param([], ["vllm", "serve", "/models"], id="presets-empty"),
+            pytest.param(
+                ["--max-model-len", "4096"],
+                ["vllm", "serve", "/models", "--max-model-len", "4096"],
+                id="presets-with-args",
+            ),
+        ],
+    )
+    async def test_reads_args_from_context_into_dict_payload(
+        self,
+        vllm_revision: ModelRevisionSpec,
+        args: list[str] | None,
+        expected_start_command: list[str],
+    ) -> None:
+        # Builder wiring contract: pulls args from ``context.resolved_presets``
+        # (handling both ``None`` and empty-list shapes) and returns a dict
+        # ready for the kernel — i.e., ``model_dump`` has been called.
         payload = DeploymentSessionDraftBuilder._model_definition_payload(
-            revision, _context(["--max-model-len", "4096"])
+            vllm_revision, _context(args)
         )
 
         assert payload is not None
-        assert payload["models"][0]["service"]["start_command"] == [
-            "vllm",
-            "serve",
-            "/models",
-            "--max-model-len",
-            "4096",
-        ]
+        assert isinstance(payload, dict)
+        assert payload["models"][0]["service"]["start_command"] == expected_start_command
 
-    def test_args_become_start_command_when_definition_has_none(self) -> None:
-        # Snapshot with no start_command (e.g. cmd/custom variants) still
-        # accepts preset args, but the agent's image-CMD fallback has to
-        # provide the launcher prefix.
-        revision = _revision_spec(_model_definition(start_command=None))
-
-        payload = DeploymentSessionDraftBuilder._model_definition_payload(
-            revision, _context(["--port", "8000"])
-        )
-
-        assert payload is not None
-        assert payload["models"][0]["service"]["start_command"] == ["--port", "8000"]
-
-    def test_empty_args_leaves_start_command_unchanged(self) -> None:
-        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
-
-        payload = DeploymentSessionDraftBuilder._model_definition_payload(revision, _context([]))
-
-        assert payload is not None
-        assert payload["models"][0]["service"]["start_command"] == [
-            "vllm",
-            "serve",
-            "/models",
-        ]
-
-    def test_args_tokenized_per_token_not_concatenated(self) -> None:
-        # Regression guard for BA-5891: tokens must arrive split, so each
-        # value lands as its own argv entry rather than ``"--port 8000"``.
-        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
+    async def test_args_tokenized_per_token_not_concatenated(
+        self,
+        vllm_revision: ModelRevisionSpec,
+    ) -> None:
+        # Regression guard for BA-5891 at the highest layer where the bug
+        # surfaced: tokens must arrive split, so each value lands as its
+        # own argv entry rather than ``"--port 8000"``. The same invariant
+        # is implied by the parametrized expected lists above, but this
+        # test makes it an explicit assertion at the kernel-payload boundary.
         tokens = ["--port", "8000", "--max-model-len", "4096"]
 
         payload = DeploymentSessionDraftBuilder._model_definition_payload(
-            revision, _context(tokens)
+            vllm_revision, _context(tokens)
         )
 
         assert payload is not None
         cmd = payload["models"][0]["service"]["start_command"]
         assert cmd == ["vllm", "serve", "/models", *tokens]
         assert all(" " not in token for token in cmd)
-
-    def test_each_model_in_payload_receives_args(self) -> None:
-        # Multi-model definitions are rare but supported; the merge applies
-        # to every entry uniformly.
-        definition = ModelDefinition(
-            models=[
-                ModelConfig(
-                    name="model-a",
-                    model_path="/models/a",
-                    service=ModelServiceConfig(port=8001, start_command=["a"]),
-                ),
-                ModelConfig(
-                    name="model-b",
-                    model_path="/models/b",
-                    service=ModelServiceConfig(port=8002, start_command=["b"]),
-                ),
-            ]
-        )
-        revision = _revision_spec(definition)
-
-        payload = cast(
-            dict[str, Any],
-            DeploymentSessionDraftBuilder._model_definition_payload(
-                revision, _context(["--shared", "true"])
-            ),
-        )
-
-        assert payload["models"][0]["service"]["start_command"] == [
-            "a",
-            "--shared",
-            "true",
-        ]
-        assert payload["models"][1]["service"]["start_command"] == [
-            "b",
-            "--shared",
-            "true",
-        ]

--- a/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
+++ b/tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py
@@ -1,0 +1,175 @@
+"""Unit tests for ``DeploymentSessionDraftBuilder`` helpers.
+
+The builder appends ``ResolvedPresetValues.args`` onto each model's
+``service.start_command`` as separate argv tokens. Resolution of
+``{model_path}`` placeholders happens earlier (at
+``ModelConfigDraft.to_resolved`` during revision creation), so the
+snapshot the builder reads here already carries fully-resolved argv.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from ai.backend.common.config import (
+    ModelConfig,
+    ModelDefinition,
+    ModelServiceConfig,
+)
+from ai.backend.manager.data.deployment.types import ModelRevisionSpec
+from ai.backend.manager.repositories.scheduler.types.session_creation import (
+    DeploymentContext,
+    ResolvedPresetValues,
+)
+from ai.backend.manager.sokovan.deployment.deployment_draft_builder import (
+    DeploymentSessionDraftBuilder,
+)
+
+
+def _model_definition(start_command: list[str] | None) -> ModelDefinition:
+    return ModelDefinition(
+        models=[
+            ModelConfig(
+                name="vllm-model",
+                model_path="/models",
+                service=ModelServiceConfig(
+                    port=8000,
+                    start_command=start_command,
+                ),
+            )
+        ]
+    )
+
+
+def _revision_spec(model_definition: ModelDefinition | None) -> ModelRevisionSpec:
+    revision = MagicMock(spec=ModelRevisionSpec)
+    revision.model_definition = model_definition
+    return cast(ModelRevisionSpec, revision)
+
+
+def _context(args: list[str] | None) -> DeploymentContext:
+    context = MagicMock(spec=DeploymentContext)
+    context.resolved_presets = (
+        ResolvedPresetValues(environ={}, args=list(args)) if args is not None else None
+    )
+    return cast(DeploymentContext, context)
+
+
+class TestModelDefinitionPayload:
+    """``_model_definition_payload`` appends preset ARGS onto the snapshot
+    ``service.start_command`` as separate argv tokens. Without args it is
+    a pass-through ``model_dump`` of the resolved ``ModelDefinition``."""
+
+    def test_returns_none_when_revision_has_no_definition(self) -> None:
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(
+            _revision_spec(None),
+            _context(None),
+        )
+
+        assert payload is None
+
+    def test_no_presets_passes_through_unchanged(self) -> None:
+        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
+
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(revision, _context(None))
+
+        assert payload is not None
+        assert payload["models"][0]["service"]["start_command"] == [
+            "vllm",
+            "serve",
+            "/models",
+        ]
+
+    def test_appends_args_to_existing_start_command(self) -> None:
+        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
+
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(
+            revision, _context(["--max-model-len", "4096"])
+        )
+
+        assert payload is not None
+        assert payload["models"][0]["service"]["start_command"] == [
+            "vllm",
+            "serve",
+            "/models",
+            "--max-model-len",
+            "4096",
+        ]
+
+    def test_args_become_start_command_when_definition_has_none(self) -> None:
+        # Snapshot with no start_command (e.g. cmd/custom variants) still
+        # accepts preset args, but the agent's image-CMD fallback has to
+        # provide the launcher prefix.
+        revision = _revision_spec(_model_definition(start_command=None))
+
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(
+            revision, _context(["--port", "8000"])
+        )
+
+        assert payload is not None
+        assert payload["models"][0]["service"]["start_command"] == ["--port", "8000"]
+
+    def test_empty_args_leaves_start_command_unchanged(self) -> None:
+        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
+
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(revision, _context([]))
+
+        assert payload is not None
+        assert payload["models"][0]["service"]["start_command"] == [
+            "vllm",
+            "serve",
+            "/models",
+        ]
+
+    def test_args_tokenized_per_token_not_concatenated(self) -> None:
+        # Regression guard for BA-5891: tokens must arrive split, so each
+        # value lands as its own argv entry rather than ``"--port 8000"``.
+        revision = _revision_spec(_model_definition(start_command=["vllm", "serve", "/models"]))
+        tokens = ["--port", "8000", "--max-model-len", "4096"]
+
+        payload = DeploymentSessionDraftBuilder._model_definition_payload(
+            revision, _context(tokens)
+        )
+
+        assert payload is not None
+        cmd = payload["models"][0]["service"]["start_command"]
+        assert cmd == ["vllm", "serve", "/models", *tokens]
+        assert all(" " not in token for token in cmd)
+
+    def test_each_model_in_payload_receives_args(self) -> None:
+        # Multi-model definitions are rare but supported; the merge applies
+        # to every entry uniformly.
+        definition = ModelDefinition(
+            models=[
+                ModelConfig(
+                    name="model-a",
+                    model_path="/models/a",
+                    service=ModelServiceConfig(port=8001, start_command=["a"]),
+                ),
+                ModelConfig(
+                    name="model-b",
+                    model_path="/models/b",
+                    service=ModelServiceConfig(port=8002, start_command=["b"]),
+                ),
+            ]
+        )
+        revision = _revision_spec(definition)
+
+        payload = cast(
+            dict[str, Any],
+            DeploymentSessionDraftBuilder._model_definition_payload(
+                revision, _context(["--shared", "true"])
+            ),
+        )
+
+        assert payload["models"][0]["service"]["start_command"] == [
+            "a",
+            "--shared",
+            "true",
+        ]
+        assert payload["models"][1]["service"]["start_command"] == [
+            "b",
+            "--shared",
+            "true",
+        ]


### PR DESCRIPTION
## Summary
- Tokenize runtime-variant preset ARGS values so each flag and value lands as its own argv token instead of a single `"key value"` string.
- Append resolved preset ARGS to `service.start_command` in the deployment draft builder; the kernel-level `startup_command` no longer absorbs them.
- Resolve `{model_path}` placeholders inside `ModelConfigDraft.to_resolved` so the revision snapshot carries fully-resolved argv with no template syntax reaching the kernel.
- Seed runtime-variant baselines (vllm, sglang, huggingface-tgi, modular-max) with their canonical launcher `start_command` using the `{model_path}` placeholder.
- Rename the agent's `_populate_missing_model_service_start_commands` to `_apply_image_cmd_fallback`; behavior unchanged, used only by the `cmd` variant which intentionally inherits from the image's `Config.Cmd`.

## Test plan
- [x] Unit: `pants test tests/unit/common/test_config.py tests/unit/manager/sokovan/deployment/test_deployment_draft_builder.py tests/unit/agent/test_model_service_start_command.py`
- [x] Live e2e — vllm placeholder substitution: container ran `vllm serve /models` and reached healthy
- [x] Live e2e — sglang named flag substitution: container received `python -m sglang.launch_server --model-path /models`
- [x] Live e2e — custom variant + vfolder `model-definition.yaml`: snapshot pass-through, kernel ran user-supplied command
- [x] Image CMD fallback (`cmd` variant) preserved by `_apply_image_cmd_fallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)