### PR TITLE
fix(BA-5939): add UUID filter to ImageV2Filter

### DIFF
--- a/changes/11469.fix.md
+++ b/changes/11469.fix.md
@@ -1,0 +1,1 @@
+Add a UUID filter (`id`) to `ImageV2Filter` so callers can locate a specific image by UUID via the v2 image search APIs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7349,6 +7349,9 @@ input ImageV2Filter
   name: StringFilter = null
   architecture: StringFilter = null
 
+  """Added in UNRELEASED. Filter by image UUID."""
+  id: UUIDFilter = null
+
   """Added in 26.4.0. Filter by container registry ID."""
   registryId: UUIDFilter = null
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4710,6 +4710,9 @@ input ImageV2Filter {
   name: StringFilter = null
   architecture: StringFilter = null
 
+  """Added in UNRELEASED. Filter by image UUID."""
+  id: UUIDFilter = null
+
   """Added in 26.4.0. Filter by container registry ID."""
   registryId: UUIDFilter = null
 

--- a/src/ai/backend/common/dto/manager/v2/image/request.py
+++ b/src/ai/backend/common/dto/manager/v2/image/request.py
@@ -76,6 +76,7 @@ class ImageAliasNestedFilterInputDTO(BaseRequestModel):
 class ImageFilterInputDTO(BaseRequestModel):
     """Filter options for images."""
 
+    id: UUIDFilter | None = Field(default=None, description="Filter by image UUID.")
     status: ImageStatusFilterInputDTO | None = Field(default=None, description="Filter by status.")
     name: StringFilter | None = Field(default=None, description="Filter by name.")
     architecture: StringFilter | None = Field(default=None, description="Filter by architecture.")

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -349,11 +349,13 @@ class ImageAdapter(BaseAdapter):
         conditions: list[QueryCondition] = list(base_conditions) if base_conditions else []
 
         if filter.id is not None:
-            iid = filter.id
-            if iid.equals is not None:
-                conditions.append(ImageConditions.by_ids([ImageID(iid.equals)]))
-            elif iid.in_ is not None:
-                conditions.append(ImageConditions.by_ids([ImageID(uid) for uid in iid.in_]))
+            condition = self.convert_uuid_filter(
+                filter.id,
+                equals_factory=ImageConditions.by_id_equals,
+                in_factory=ImageConditions.by_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
 
         if filter.name is not None:
             condition = self.convert_string_filter(
@@ -397,13 +399,13 @@ class ImageAdapter(BaseAdapter):
                 )
 
         if filter.registry_id is not None:
-            rid = filter.registry_id
-            if rid.equals is not None:
-                conditions.append(ImageConditions.by_registry_id(rid.equals))
-            elif rid.in_ is not None:
-                # Multiple registry IDs: combine with OR
-                sub: list[QueryCondition] = [ImageConditions.by_registry_id(r) for r in rid.in_]
-                conditions.append(combine_conditions_or(sub))
+            condition = self.convert_uuid_filter(
+                filter.registry_id,
+                equals_factory=ImageConditions.by_registry_id_equals,
+                in_factory=ImageConditions.by_registry_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
 
         if filter.alias is not None:
             alias_f = filter.alias

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -348,6 +348,13 @@ class ImageAdapter(BaseAdapter):
     ) -> list[QueryCondition]:
         conditions: list[QueryCondition] = list(base_conditions) if base_conditions else []
 
+        if filter.id is not None:
+            iid = filter.id
+            if iid.equals is not None:
+                conditions.append(ImageConditions.by_ids([ImageID(iid.equals)]))
+            elif iid.in_ is not None:
+                conditions.append(ImageConditions.by_ids([ImageID(uid) for uid in iid.in_]))
+
         if filter.name is not None:
             condition = self.convert_string_filter(
                 filter.name,

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -41,6 +41,7 @@ from ai.backend.common.dto.manager.v2.image.types import (
     ImageResourceLimitGQLInfo,
     ImageTagInfo,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import ImageID
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
@@ -445,6 +446,10 @@ class ImageV2FilterGQL(PydanticInputMixin[ImageFilterInputDTO], GQLFilter):
     status: ImageV2StatusFilterGQL | None = None
     name: StringFilter | None = None
     architecture: StringFilter | None = None
+    id: UUIDFilter | None = gql_added_field(
+        BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Filter by image UUID."),
+        default=None,
+    )
     registry_id: UUIDFilter | None = gql_added_field(
         BackendAIGQLMeta(added_version="26.4.0", description="Filter by container registry ID."),
         default=None,

--- a/src/ai/backend/manager/models/image/conditions.py
+++ b/src/ai/backend/manager/models/image/conditions.py
@@ -8,7 +8,12 @@ from datetime import datetime
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringInMatchSpec, StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringInMatchSpec,
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.common.types import ImageID
 from ai.backend.manager.data.image.types import ImageStatus
 from ai.backend.manager.models.condition_utils import make_string_in_factory
@@ -23,6 +28,26 @@ class ImageConditions:
     def by_ids(image_ids: Collection[ImageID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ImageRow.id.in_(image_ids)
+
+        return inner
+
+    @staticmethod
+    def by_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ImageRow.id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ImageRow.id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 
@@ -72,6 +97,26 @@ class ImageConditions:
     def by_registry_id(registry_id: uuid.UUID) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ImageRow.registry_id == registry_id
+
+        return inner
+
+    @staticmethod
+    def by_registry_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ImageRow.registry_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_registry_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = ImageRow.registry_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/tests/component/image/conftest.py
+++ b/tests/component/image/conftest.py
@@ -15,12 +15,15 @@ from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACVali
 from ai.backend.manager.actions.validators.rbac.single_entity import (
     SingleEntityActionRBACValidator,
 )
+from ai.backend.manager.api.adapters.image.adapter import ImageAdapter
 from ai.backend.manager.api.rest.admin.handler import AdminHandler
 from ai.backend.manager.api.rest.admin.registry import register_admin_routes
 from ai.backend.manager.api.rest.image.handler import ImageHandler
 from ai.backend.manager.api.rest.image.registry import register_image_routes
 from ai.backend.manager.api.rest.routing import RouteRegistry
 from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.image.handler import V2ImageHandler
+from ai.backend.manager.api.rest.v2.image.registry import register_v2_image_routes
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.image.types import ImageStatus, ImageType
 from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
@@ -53,22 +56,36 @@ def image_processors(
 
 
 @pytest.fixture()
+def image_adapter(image_processors: ImageProcessors) -> ImageAdapter:
+    """Build an ImageAdapter wired only with image processors.
+
+    Other adapter call sites in ImageAdapter use ``self._processors.image`` exclusively,
+    so a MagicMock backing object with ``.image`` set to the real ImageProcessors is sufficient.
+    """
+    processors = MagicMock()
+    processors.image = image_processors
+    return ImageAdapter(processors)
+
+
+@pytest.fixture()
 def server_module_registries(
     route_deps: RouteDeps,
     image_processors: ImageProcessors,
+    image_adapter: ImageAdapter,
 ) -> list[RouteRegistry]:
-    """Load only the modules required for image-domain tests."""
+    """Load both v1 and v2 image route trees for image-domain tests."""
     image_registry = register_image_routes(ImageHandler(image=image_processors), route_deps)
-    return [
-        register_admin_routes(
-            AdminHandler(
-                gql_schema=MagicMock(), gql_deps=MagicMock(), strawberry_schema=MagicMock()
-            ),
-            route_deps,
-            sub_registries=[image_registry],
-            gql_ws_handler=MagicMock(),
-        ),
-    ]
+    admin_registry = register_admin_routes(
+        AdminHandler(gql_schema=MagicMock(), gql_deps=MagicMock(), strawberry_schema=MagicMock()),
+        route_deps,
+        sub_registries=[image_registry],
+        gql_ws_handler=MagicMock(),
+    )
+    v2_registry = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_registry.add_subregistry(
+        register_v2_image_routes(V2ImageHandler(adapter=image_adapter), route_deps)
+    )
+    return [admin_registry, v2_registry]
 
 
 @pytest.fixture()

--- a/tests/component/image/test_image_v2_search.py
+++ b/tests/component/image/test_image_v2_search.py
@@ -1,0 +1,147 @@
+"""Component tests for the v2 admin image search REST endpoint (POST /v2/images/search).
+
+Exercises the v2 SDK ``V2ImageClient.admin_search`` against a real aiohttp server,
+covering the ``ImageFilterInputDTO`` fields surfaced through ``ImageV2FilterGQL``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+import pytest
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.exceptions import PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.query import UUIDFilter
+from ai.backend.common.dto.manager.v2.image.request import (
+    AdminSearchImagesInput,
+    ImageFilterInputDTO,
+)
+from ai.backend.common.dto.manager.v2.image.response import AdminSearchImagesPayload
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+    from tests.component.image.conftest import ImageFactoryHelper
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+class TestV2AdminSearchImages:
+    """Sanity coverage for the v2 admin_search endpoint."""
+
+    async def test_no_filter_returns_seeded_image(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """Calling admin_search without a filter returns the pre-seeded image."""
+        image_id, _ = image_fixture
+        result = await admin_v2_registry.image.admin_search(AdminSearchImagesInput())
+        assert isinstance(result, AdminSearchImagesPayload)
+        assert result.total_count >= 1
+        assert image_id in [item.id for item in result.items]
+
+
+class TestV2AdminSearchImagesByID:
+    """Filter ``ImageV2Filter.id`` (the BA-5939 fix)."""
+
+    async def test_filter_id_equals_returns_only_target(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """``id.equals`` returns exactly the matching image and no others."""
+        image_id, helper = image_fixture
+        await helper.create(name_suffix="other-image")
+
+        result = await admin_v2_registry.image.admin_search(
+            AdminSearchImagesInput(filter=ImageFilterInputDTO(id=UUIDFilter(equals=image_id))),
+        )
+        assert isinstance(result, AdminSearchImagesPayload)
+        assert result.total_count == 1
+        assert [item.id for item in result.items] == [image_id]
+
+    async def test_filter_id_in_returns_all_matches(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """``id.in_`` returns every image whose id is in the list."""
+        image_id, helper = image_fixture
+        second_id = await helper.create(name_suffix="second-image")
+        third_id = await helper.create(name_suffix="third-image")
+
+        result = await admin_v2_registry.image.admin_search(
+            AdminSearchImagesInput(
+                filter=ImageFilterInputDTO(id=UUIDFilter(in_=[image_id, second_id])),
+            ),
+        )
+        assert isinstance(result, AdminSearchImagesPayload)
+        found_ids = {item.id for item in result.items}
+        assert found_ids == {image_id, second_id}
+        assert third_id not in found_ids
+
+    async def test_filter_id_no_match_returns_empty(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """``id.equals`` with a random UUID returns no items."""
+        result = await admin_v2_registry.image.admin_search(
+            AdminSearchImagesInput(filter=ImageFilterInputDTO(id=UUIDFilter(equals=uuid.uuid4()))),
+        )
+        assert isinstance(result, AdminSearchImagesPayload)
+        assert result.total_count == 0
+        assert result.items == []
+
+
+class TestV2AdminSearchImagesPermissions:
+    """Endpoint is mounted under ``superadmin_required`` middleware."""
+
+    async def test_regular_user_cannot_admin_search(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """A non-admin keypair receives PermissionDeniedError (403)."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.image.admin_search(AdminSearchImagesInput())

--- a/tests/component/image/test_image_v2_search.py
+++ b/tests/component/image/test_image_v2_search.py
@@ -133,6 +133,46 @@ class TestV2AdminSearchImagesByID:
         assert result.total_count == 0
         assert result.items == []
 
+    async def test_filter_id_not_equals_excludes_target(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """``id.not_equals`` returns every image except the excluded one."""
+        image_id, helper = image_fixture
+        other_id = await helper.create(name_suffix="other-image")
+
+        result = await admin_v2_registry.image.admin_search(
+            AdminSearchImagesInput(
+                filter=ImageFilterInputDTO(id=UUIDFilter(not_equals=image_id)),
+            ),
+        )
+        assert isinstance(result, AdminSearchImagesPayload)
+        found_ids = {item.id for item in result.items}
+        assert image_id not in found_ids
+        assert other_id in found_ids
+
+    async def test_filter_id_not_in_excludes_targets(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        image_fixture: tuple[uuid.UUID, ImageFactoryHelper],
+    ) -> None:
+        """``id.not_in`` returns every image whose id is outside the list."""
+        image_id, helper = image_fixture
+        excluded_id = await helper.create(name_suffix="excluded-image")
+        kept_id = await helper.create(name_suffix="kept-image")
+
+        result = await admin_v2_registry.image.admin_search(
+            AdminSearchImagesInput(
+                filter=ImageFilterInputDTO(id=UUIDFilter(not_in=[image_id, excluded_id])),
+            ),
+        )
+        assert isinstance(result, AdminSearchImagesPayload)
+        found_ids = {item.id for item in result.items}
+        assert image_id not in found_ids
+        assert excluded_id not in found_ids
+        assert kept_id in found_ids
+
 
 class TestV2AdminSearchImagesPermissions:
     """Endpoint is mounted under ``superadmin_required`` middleware."""


### PR DESCRIPTION
## Summary
- Add `id: UUIDFilter` to `ImageFilterInputDTO` and the `ImageV2FilterGQL` input so callers can locate a specific image by UUID via the v2 GraphQL/REST search APIs.
- Wire the new field into `ImageAdapter._convert_filter`, reusing the existing `ImageConditions.by_ids` for both `equals` and `in_` paths.
- Add v2 admin search component tests (the v2 path was previously uncovered) — tests register `V2ImageHandler` alongside the existing v1 routes and assert `id.equals` / `id.in_` filtering plus the superadmin-required permission gate.

## Test plan
- [x] `pants test tests/component/image::` (covers new `test_image_v2_search.py`)
- [x] Manual verification via `./bai admin image search` once GraphQL schema docs are regenerated (separate environment due to local Strawberry/Federation issue)

Resolves BA-5939

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11469.org.readthedocs.build/en/11469/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11469.org.readthedocs.build/ko/11469/

<!-- readthedocs-preview sorna-ko end -->