### PR TITLE
fix(BA-5940): expose category_id and AND/OR/NOT in prometheusQueryPresets filter

### DIFF
--- a/changes/11470.fix.md
+++ b/changes/11470.fix.md
@@ -1,0 +1,1 @@
+Expose `category_id` and `AND` / `OR` / `NOT` logical composition fields on the `prometheusQueryPresets` GraphQL filter (and the shared v2 search DTO), so callers can compose multi-condition queries and filter presets by category.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14172,6 +14172,24 @@ input QueryDefinitionFilter
 {
   """Filter by name."""
   name: StringFilter = null
+
+  """Added in UNRELEASED. Filter by category ID."""
+  categoryId: UUIDFilter = null
+
+  """
+  Added in UNRELEASED. Combine multiple filters with AND logic. All conditions must match.
+  """
+  AND: [QueryDefinitionFilter!] = null
+
+  """
+  Added in UNRELEASED. Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [QueryDefinitionFilter!] = null
+
+  """
+  Added in UNRELEASED. Negate the specified filters. Records matching these conditions will be excluded.
+  """
+  NOT: [QueryDefinitionFilter!] = null
 }
 
 """Added in 26.3.0. Single metric result from Prometheus query."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9305,6 +9305,24 @@ type QueryDefinitionExecuteResult {
 input QueryDefinitionFilter {
   """Filter by name."""
   name: StringFilter = null
+
+  """Added in UNRELEASED. Filter by category ID."""
+  categoryId: UUIDFilter = null
+
+  """
+  Added in UNRELEASED. Combine multiple filters with AND logic. All conditions must match.
+  """
+  AND: [QueryDefinitionFilter!] = null
+
+  """
+  Added in UNRELEASED. Combine multiple filters with OR logic. At least one condition must match.
+  """
+  OR: [QueryDefinitionFilter!] = null
+
+  """
+  Added in UNRELEASED. Negate the specified filters. Records matching these conditions will be excluded.
+  """
+  NOT: [QueryDefinitionFilter!] = null
 }
 
 """Added in 26.3.0. Single metric result from Prometheus query."""

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -12,7 +12,7 @@ from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.clients.prometheus.defs import PROMETHEUS_DURATION_PATTERN
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 
 from .types import OrderDirection, QueryDefinitionOrderField
 
@@ -154,7 +154,7 @@ class QueryDefinitionFilter(BaseRequestModel):
     """Filter for prometheus query definition search."""
 
     name: StringFilter | None = Field(default=None, description="Filter by name")
-    category_id: UUID | None = Field(default=None, description="Filter by category ID")
+    category_id: UUIDFilter | None = Field(default=None, description="Filter by category ID")
     AND: list[QueryDefinitionFilter] | None = Field(
         default=None, description="AND logical combinator."
     )

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -155,6 +155,18 @@ class QueryDefinitionFilter(BaseRequestModel):
 
     name: StringFilter | None = Field(default=None, description="Filter by name")
     category_id: UUID | None = Field(default=None, description="Filter by category ID")
+    AND: list[QueryDefinitionFilter] | None = Field(
+        default=None, description="AND logical combinator."
+    )
+    OR: list[QueryDefinitionFilter] | None = Field(
+        default=None, description="OR logical combinator."
+    )
+    NOT: list[QueryDefinitionFilter] | None = Field(
+        default=None, description="NOT logical combinator."
+    )
+
+
+QueryDefinitionFilter.model_rebuild()
 
 
 class QueryDefinitionOrder(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -260,7 +260,13 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
                 conditions.append(condition)
 
         if filter.category_id is not None:
-            conditions.append(PrometheusQueryPresetConditions.by_category_id(filter.category_id))
+            condition = self.convert_uuid_filter(
+                filter.category_id,
+                equals_factory=PrometheusQueryPresetConditions.by_category_id_equals,
+                in_factory=PrometheusQueryPresetConditions.by_category_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
 
         if filter.AND:
             for sub_filter in filter.AND:

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -53,6 +53,8 @@ from ai.backend.manager.repositories.base import (
     QueryCondition,
     QueryOrder,
     Updater,
+    combine_conditions_or,
+    negate_conditions,
 )
 from ai.backend.manager.repositories.prometheus_query_preset.creators import (
     PrometheusQueryPresetCreatorSpec,
@@ -259,6 +261,24 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
 
         if filter.category_id is not None:
             conditions.append(PrometheusQueryPresetConditions.by_category_id(filter.category_id))
+
+        if filter.AND:
+            for sub_filter in filter.AND:
+                conditions.extend(self._convert_filter(sub_filter))
+
+        if filter.OR:
+            or_sub_conditions: list[QueryCondition] = []
+            for sub_filter in filter.OR:
+                or_sub_conditions.extend(self._convert_filter(sub_filter))
+            if or_sub_conditions:
+                conditions.append(combine_conditions_or(or_sub_conditions))
+
+        if filter.NOT:
+            not_sub_conditions: list[QueryCondition] = []
+            for sub_filter in filter.NOT:
+                not_sub_conditions.extend(self._convert_filter(sub_filter))
+            if not_sub_conditions:
+                conditions.append(negate_conditions(not_sub_conditions))
 
         return conditions
 

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/filters.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/filters.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Self
+from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     QueryDefinitionFilter as QueryDefinitionFilterDTO,
@@ -10,12 +12,14 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     QueryDefinitionOrder as QueryDefinitionOrderDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     StringFilter,
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
@@ -31,6 +35,34 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
 )
 class QueryDefinitionFilter(PydanticInputMixin[QueryDefinitionFilterDTO]):
     name: StringFilter | None = gql_field(description="Filter by name.", default=None)
+    category_id: UUID | None = gql_added_field(
+        BackendAIGQLMeta(
+            description="Filter by category ID.",
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
+    AND: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            description="Combine multiple filters with AND logic. All conditions must match.",
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
+    OR: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            description="Combine multiple filters with OR logic. At least one condition must match.",
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
+    NOT: list[Self] | None = gql_added_field(
+        BackendAIGQLMeta(
+            description="Negate the specified filters. Records matching these conditions will be excluded.",
+            added_version=NEXT_RELEASE_VERSION,
+        ),
+        default=None,
+    )
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/filters.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/filters.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from enum import StrEnum
 from typing import Self
-from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     QueryDefinitionFilter as QueryDefinitionFilterDTO,
@@ -16,6 +15,7 @@ from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     OrderDirection,
     StringFilter,
+    UUIDFilter,
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -35,7 +35,7 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
 )
 class QueryDefinitionFilter(PydanticInputMixin[QueryDefinitionFilterDTO]):
     name: StringFilter | None = gql_field(description="Filter by name.", default=None)
-    category_id: UUID | None = gql_added_field(
+    category_id: UUIDFilter | None = gql_added_field(
         BackendAIGQLMeta(
             description="Filter by category ID.",
             added_version=NEXT_RELEASE_VERSION,

--- a/src/ai/backend/manager/models/prometheus_query_preset/conditions.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset/conditions.py
@@ -7,7 +7,11 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.filter_specs import StringMatchSpec
+from ai.backend.common.data.filter_specs import (
+    StringMatchSpec,
+    UUIDEqualMatchSpec,
+    UUIDInMatchSpec,
+)
 from ai.backend.manager.models.condition_utils import make_string_in_factory
 from ai.backend.manager.models.prometheus_query_preset import PrometheusQueryPresetRow
 from ai.backend.manager.repositories.base import QueryCondition
@@ -78,9 +82,22 @@ class PrometheusQueryPresetConditions:
     by_name_in = staticmethod(make_string_in_factory(PrometheusQueryPresetRow.name))
 
     @staticmethod
-    def by_category_id(category_id: uuid.UUID) -> QueryCondition:
+    def by_category_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
-            return PrometheusQueryPresetRow.category_id == category_id
+            condition = PrometheusQueryPresetRow.category_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_category_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.ColumnElement[bool]:
+            condition = PrometheusQueryPresetRow.category_id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
 
         return inner
 

--- a/tests/component/prometheus_query_preset/BUILD
+++ b/tests/component/prometheus_query_preset/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/prometheus_query_preset/conftest.py
+++ b/tests/component/prometheus_query_preset/conftest.py
@@ -1,0 +1,225 @@
+"""Component test fixtures for prometheus query preset v2 search filters."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.clients.prometheus.client import PrometheusClient
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.api.adapters.prometheus_query_preset.adapter import (
+    PrometheusQueryPresetAdapter,
+)
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.prometheus_query_preset.handler import (
+    V2PrometheusQueryPresetHandler,
+)
+from ai.backend.manager.api.rest.v2.prometheus_query_preset.registry import (
+    register_v2_prometheus_query_preset_routes,
+)
+from ai.backend.manager.models.prometheus_query_preset import PrometheusQueryPresetRow
+from ai.backend.manager.models.prometheus_query_preset.row import PresetOptions
+from ai.backend.manager.models.prometheus_query_preset_category import (
+    PrometheusQueryPresetCategoryRow,
+)
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.prometheus_query_preset import (
+    PrometheusQueryPresetRepository,
+)
+from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.prometheus_query_preset.processors import (
+    PrometheusQueryPresetProcessors,
+)
+from ai.backend.manager.services.prometheus_query_preset.service import (
+    PrometheusQueryPresetService,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+@dataclass(frozen=True)
+class PresetFilterDataset:
+    """Seeded preset/category IDs for filter tests."""
+
+    category_a_id: uuid.UUID
+    category_b_id: uuid.UUID
+    cpu_usage_id: uuid.UUID
+    cpu_usage_name: str
+    cpu_memory_id: uuid.UUID
+    cpu_memory_name: str
+    memory_usage_id: uuid.UUID
+    memory_usage_name: str
+
+
+@pytest.fixture()
+def prometheus_query_preset_processors(
+    database_engine: ExtendedAsyncSAEngine,
+) -> PrometheusQueryPresetProcessors:
+    repo = PrometheusQueryPresetRepository(database_engine)
+    service = PrometheusQueryPresetService(
+        repository=repo,
+        prometheus_client=MagicMock(spec=PrometheusClient),
+        default_timewindow="5m",
+    )
+    return PrometheusQueryPresetProcessors(
+        service=service,
+        action_monitors=[],
+        validators=MagicMock(spec=ActionValidators),
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    prometheus_query_preset_processors: PrometheusQueryPresetProcessors,
+) -> list[RouteRegistry]:
+    processors = MagicMock(spec=Processors)
+    processors.prometheus_query_preset = prometheus_query_preset_processors
+    adapter = PrometheusQueryPresetAdapter(processors)
+    handler = V2PrometheusQueryPresetHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_prometheus_query_preset_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def preset_filter_dataset(
+    db_engine: SAEngine,
+) -> AsyncIterator[PresetFilterDataset]:
+    """Seed two categories and three presets for filter regression tests.
+
+    Layout:
+      - category_a: cpu_usage_*, cpu_memory_*
+      - category_b: memory_usage_*
+
+    Names carry a per-run hex suffix so concurrent test runs do not collide
+    on the global preset table.
+    """
+    category_a_id = uuid.uuid4()
+    category_b_id = uuid.uuid4()
+    cpu_usage_id = uuid.uuid4()
+    cpu_memory_id = uuid.uuid4()
+    memory_usage_id = uuid.uuid4()
+    cpu_usage_name = f"cpu_usage_{cpu_usage_id.hex[:8]}"
+    cpu_memory_name = f"cpu_memory_{cpu_memory_id.hex[:8]}"
+    memory_usage_name = f"memory_usage_{memory_usage_id.hex[:8]}"
+    now = datetime.now(tz=UTC)
+    options_value = PresetOptions(filter_labels=[], group_labels=[])
+
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(PrometheusQueryPresetCategoryRow.__table__).values([
+                {
+                    "id": category_a_id,
+                    "name": f"cat-a-{category_a_id.hex[:8]}",
+                    "description": None,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+                {
+                    "id": category_b_id,
+                    "name": f"cat-b-{category_b_id.hex[:8]}",
+                    "description": None,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+            ])
+        )
+        await conn.execute(
+            sa.insert(PrometheusQueryPresetRow.__table__).values([
+                {
+                    "id": cpu_usage_id,
+                    "name": cpu_usage_name,
+                    "metric_name": "backendai_cpu",
+                    "query_template": "avg({metric_name})",
+                    "time_window": None,
+                    "description": None,
+                    "rank": 0,
+                    "category_id": category_a_id,
+                    "options": options_value,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+                {
+                    "id": cpu_memory_id,
+                    "name": cpu_memory_name,
+                    "metric_name": "backendai_cpu_memory",
+                    "query_template": "avg({metric_name})",
+                    "time_window": None,
+                    "description": None,
+                    "rank": 0,
+                    "category_id": category_a_id,
+                    "options": options_value,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+                {
+                    "id": memory_usage_id,
+                    "name": memory_usage_name,
+                    "metric_name": "backendai_memory",
+                    "query_template": "avg({metric_name})",
+                    "time_window": None,
+                    "description": None,
+                    "rank": 0,
+                    "category_id": category_b_id,
+                    "options": options_value,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+            ])
+        )
+
+    yield PresetFilterDataset(
+        category_a_id=category_a_id,
+        category_b_id=category_b_id,
+        cpu_usage_id=cpu_usage_id,
+        cpu_usage_name=cpu_usage_name,
+        cpu_memory_id=cpu_memory_id,
+        cpu_memory_name=cpu_memory_name,
+        memory_usage_id=memory_usage_id,
+        memory_usage_name=memory_usage_name,
+    )
+
+    preset_table = PrometheusQueryPresetRow.__table__
+    category_table = PrometheusQueryPresetCategoryRow.__table__
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.delete(preset_table).where(
+                preset_table.c.id.in_([cpu_usage_id, cpu_memory_id, memory_usage_id])
+            )
+        )
+        await conn.execute(
+            sa.delete(category_table).where(category_table.c.id.in_([category_a_id, category_b_id]))
+        )

--- a/tests/component/prometheus_query_preset/test_prometheus_query_preset_filter.py
+++ b/tests/component/prometheus_query_preset/test_prometheus_query_preset_filter.py
@@ -1,0 +1,110 @@
+"""Regression tests for QueryDefinitionFilter (BA-5940).
+
+Covers the v2 search filter fields that were previously missing or unexposed:
+``category_id`` and ``AND`` / ``OR`` / ``NOT`` logical composition.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
+    QueryDefinitionFilter,
+    SearchQueryDefinitionsInput,
+)
+
+if TYPE_CHECKING:
+    from tests.component.prometheus_query_preset.conftest import PresetFilterDataset
+
+
+class TestQueryPresetSearchFilter:
+    async def test_filter_by_category_id(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        preset_filter_dataset: PresetFilterDataset,
+    ) -> None:
+        """Filtering by category_id returns only presets in that category."""
+        result = await admin_v2_registry.prometheus_query_preset.search(
+            SearchQueryDefinitionsInput(
+                filter=QueryDefinitionFilter(category_id=preset_filter_dataset.category_a_id),
+                limit=100,
+            )
+        )
+        assert {item.id for item in result.items} == {
+            preset_filter_dataset.cpu_usage_id,
+            preset_filter_dataset.cpu_memory_id,
+        }
+
+    async def test_filter_and_combines_conditions(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        preset_filter_dataset: PresetFilterDataset,
+    ) -> None:
+        """AND yields the intersection of its sub-filters."""
+        result = await admin_v2_registry.prometheus_query_preset.search(
+            SearchQueryDefinitionsInput(
+                filter=QueryDefinitionFilter(
+                    AND=[
+                        QueryDefinitionFilter(category_id=preset_filter_dataset.category_a_id),
+                        QueryDefinitionFilter(
+                            name=StringFilter(equals=preset_filter_dataset.cpu_usage_name)
+                        ),
+                    ]
+                ),
+                limit=100,
+            )
+        )
+        assert {item.id for item in result.items} == {preset_filter_dataset.cpu_usage_id}
+
+    async def test_filter_or_combines_conditions(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        preset_filter_dataset: PresetFilterDataset,
+    ) -> None:
+        """OR yields the union of its sub-filters."""
+        result = await admin_v2_registry.prometheus_query_preset.search(
+            SearchQueryDefinitionsInput(
+                filter=QueryDefinitionFilter(
+                    OR=[
+                        QueryDefinitionFilter(
+                            name=StringFilter(equals=preset_filter_dataset.cpu_usage_name)
+                        ),
+                        QueryDefinitionFilter(
+                            name=StringFilter(equals=preset_filter_dataset.memory_usage_name)
+                        ),
+                    ]
+                ),
+                limit=100,
+            )
+        )
+        assert {item.id for item in result.items} == {
+            preset_filter_dataset.cpu_usage_id,
+            preset_filter_dataset.memory_usage_id,
+        }
+
+    async def test_filter_not_excludes_matching(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        preset_filter_dataset: PresetFilterDataset,
+    ) -> None:
+        """NOT excludes presets matching its sub-filters.
+
+        Scoped to the seeded category to avoid coupling to other rows that
+        may exist on the shared test database.
+        """
+        result = await admin_v2_registry.prometheus_query_preset.search(
+            SearchQueryDefinitionsInput(
+                filter=QueryDefinitionFilter(
+                    category_id=preset_filter_dataset.category_a_id,
+                    NOT=[
+                        QueryDefinitionFilter(
+                            name=StringFilter(equals=preset_filter_dataset.cpu_memory_name)
+                        ),
+                    ],
+                ),
+                limit=100,
+            )
+        )
+        assert {item.id for item in result.items} == {preset_filter_dataset.cpu_usage_id}

--- a/tests/component/prometheus_query_preset/test_prometheus_query_preset_filter.py
+++ b/tests/component/prometheus_query_preset/test_prometheus_query_preset_filter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     QueryDefinitionFilter,
     SearchQueryDefinitionsInput,
@@ -28,7 +28,9 @@ class TestQueryPresetSearchFilter:
         """Filtering by category_id returns only presets in that category."""
         result = await admin_v2_registry.prometheus_query_preset.search(
             SearchQueryDefinitionsInput(
-                filter=QueryDefinitionFilter(category_id=preset_filter_dataset.category_a_id),
+                filter=QueryDefinitionFilter(
+                    category_id=UUIDFilter(equals=preset_filter_dataset.category_a_id)
+                ),
                 limit=100,
             )
         )
@@ -47,7 +49,9 @@ class TestQueryPresetSearchFilter:
             SearchQueryDefinitionsInput(
                 filter=QueryDefinitionFilter(
                     AND=[
-                        QueryDefinitionFilter(category_id=preset_filter_dataset.category_a_id),
+                        QueryDefinitionFilter(
+                            category_id=UUIDFilter(equals=preset_filter_dataset.category_a_id)
+                        ),
                         QueryDefinitionFilter(
                             name=StringFilter(equals=preset_filter_dataset.cpu_usage_name)
                         ),
@@ -97,7 +101,7 @@ class TestQueryPresetSearchFilter:
         result = await admin_v2_registry.prometheus_query_preset.search(
             SearchQueryDefinitionsInput(
                 filter=QueryDefinitionFilter(
-                    category_id=preset_filter_dataset.category_a_id,
+                    category_id=UUIDFilter(equals=preset_filter_dataset.category_a_id),
                     NOT=[
                         QueryDefinitionFilter(
                             name=StringFilter(equals=preset_filter_dataset.cpu_memory_name)


### PR DESCRIPTION
## Summary
- Add `AND` / `OR` / `NOT` logical composition fields to the shared `QueryDefinitionFilter` DTO (also unblocks REST v2 callers).
- Expose `category_id` and `AND` / `OR` / `NOT` on the GQL `QueryDefinitionFilter` (DTO/adapter already supported `category_id`).
- Recurse over `AND` / `OR` / `NOT` in `PrometheusQueryPresetAdapter._convert_filter`, following the `DomainFilter` pattern.

## Test plan
- [x] `pants fmt/fix/lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main`
- [x] New regression tests `tests/component/prometheus_query_preset/test_prometheus_query_preset_filter.py` cover `category_id`, `AND`, `OR`, `NOT` against the v2 search endpoint
- [x] CI: `pants check ::` and `pants test ::`

Resolves BA-5940

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11470.org.readthedocs.build/en/11470/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11470.org.readthedocs.build/ko/11470/

<!-- readthedocs-preview sorna-ko end -->