### PR TITLE
fix(BA-5949): preserve raw PromQL label matchers in preset template render

### DIFF
--- a/changes/11478.fix.md
+++ b/changes/11478.fix.md
@@ -1,0 +1,1 @@
+Fix Prometheus query preset crash on raw PromQL label matchers and reject foreign template variables at preset save time

--- a/src/ai/backend/common/clients/prometheus/__init__.py
+++ b/src/ai/backend/common/clients/prometheus/__init__.py
@@ -1,5 +1,5 @@
 from .client import PrometheusClient
-from .preset import LabelMatcher, LabelOperator, MetricPreset
+from .preset import LabelMatcher, LabelOperator, MetricPreset, validate_query_template
 from .querier import ContainerMetricQuerier, MetricQuerier
 from .types import MetricValue, ValueType
 
@@ -12,4 +12,5 @@ __all__ = [
     "MetricQuerier",
     "ContainerMetricQuerier",
     "ValueType",
+    "validate_query_template",
 ]

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -1,7 +1,39 @@
+import re
 from collections.abc import Mapping, Set
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Self
+
+from ai.backend.common.exception import InvalidMetricPresetTemplate
+
+_PLACEHOLDER_NAMES = frozenset({"labels", "window", "group_by"})
+_BRACE_BLOCK_RE = re.compile(r"\{([^{}]*)\}")
+# Matches `$ident` / `${ident}` — foreign template syntax (Grafana, shell, etc.)
+# that Backend.AI does not substitute and Prometheus would reject.
+_UNSUPPORTED_TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
+
+
+def validate_query_template(template: str) -> None:
+    """Reject templates with foreign variables or malformed braces."""
+    unsupported_vars = _UNSUPPORTED_TEMPLATE_VAR_RE.findall(template)
+    if unsupported_vars:
+        raise InvalidMetricPresetTemplate(
+            f"Unsupported template variables: {unsupported_vars}. "
+            "Use placeholders {labels}, {window}, {group_by} or literal PromQL values."
+        )
+    # Check for malformed braces by attempting to render with dummy values.
+    MetricPreset(template=template).render()
+
+
+def _escape_non_placeholders(template: str) -> str:
+    # PromQL label matchers `{key=...}` collide with str.format placeholders;
+    # escape any non-placeholder `{...}` block so .format treats it as literal.
+    def repl(match: re.Match[str]) -> str:
+        if match.group(1) in _PLACEHOLDER_NAMES:
+            return match.group(0)
+        return "{{" + match.group(1) + "}}"
+
+    return _BRACE_BLOCK_RE.sub(repl, template)
 
 
 class LabelOperator(StrEnum):
@@ -34,7 +66,7 @@ def _escape_label_value(value: str) -> str:
 
 @dataclass(frozen=True)
 class MetricPreset:
-    """PromQL query preset with template and injectable values."""
+    """PromQL query preset with template (placeholders: {labels}, {window}, {group_by})."""
 
     # PromQL template (placeholders: {labels}, {window}, {group_by})
     template: str
@@ -54,8 +86,13 @@ class MetricPreset:
             f'{key}{value.operator}"{_escape_label_value(value.value)}"'
             for key, value in self.labels.items()
         )
-        return self.template.format(
-            labels=label_str,
-            window=self.window,
-            group_by=",".join(sorted(self.group_by)),  # sorted for consistency
-        )
+        try:
+            return _escape_non_placeholders(self.template).format(
+                labels=label_str,
+                window=self.window,
+                group_by=",".join(sorted(self.group_by)),
+            )
+        except (ValueError, KeyError, IndexError) as e:
+            raise InvalidMetricPresetTemplate(
+                f"Failed to render PromQL template ({type(e).__name__}: {e}): {self.template!r}"
+            ) from e

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -8,21 +8,24 @@ from ai.backend.common.exception import InvalidMetricPresetTemplate
 
 _PLACEHOLDER_NAMES = frozenset({"labels", "window", "group_by"})
 _BRACE_BLOCK_RE = re.compile(r"\{([^{}]*)\}")
-# Matches `$ident` / `${ident}` — foreign template syntax (Grafana, shell, etc.)
-# that Backend.AI does not substitute and Prometheus would reject.
+# `$ident` / `${ident}` — foreign templating syntax (Grafana, shell, etc.)
+# that Backend.AI does not substitute and is almost always unintended in PromQL.
 _UNSUPPORTED_TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
 
 
-def validate_query_template(template: str) -> None:
-    """Reject templates with foreign variables or malformed braces."""
+def validate_query_template(template: str) -> str:
+    """Reject templates with foreign variables or malformed braces.
+
+    Returns the dry-run rendered template (useful for inspection in tests).
+    """
     unsupported_vars = _UNSUPPORTED_TEMPLATE_VAR_RE.findall(template)
     if unsupported_vars:
+        placeholders = ", ".join(f"{{{name}}}" for name in sorted(_PLACEHOLDER_NAMES))
         raise InvalidMetricPresetTemplate(
             f"Unsupported template variables: {unsupported_vars}. "
-            "Use placeholders {labels}, {window}, {group_by} or literal PromQL values."
+            f"Use placeholders {placeholders} or literal PromQL values."
         )
-    # Check for malformed braces by attempting to render with dummy values.
-    MetricPreset(template=template).render()
+    return MetricPreset(template=template).render()
 
 
 def _escape_non_placeholders(template: str) -> str:

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -26,12 +26,20 @@ def validate_query_template(template: str) -> None:
 
 
 def _escape_non_placeholders(template: str) -> str:
-    # PromQL label matchers `{key=...}` collide with str.format placeholders;
-    # escape any non-placeholder `{...}` block so .format treats it as literal.
+    # Normalize each `{X}` so str.format produces a single PromQL `{value}`
+    # regardless of how many braces the user wrote.
     def repl(match: re.Match[str]) -> str:
-        if match.group(1) in _PLACEHOLDER_NAMES:
+        name = match.group(1)
+        start, end = match.span()
+        text = match.string
+        already_wrapped = (
+            start > 0 and text[start - 1] == "{" and end < len(text) and text[end] == "}"
+        )
+        if name not in _PLACEHOLDER_NAMES:
+            return match.group(0) if already_wrapped else "{{" + name + "}}"
+        if name != "labels":
             return match.group(0)
-        return "{{" + match.group(1) + "}}"
+        return match.group(0) if already_wrapped else "{{" + match.group(0) + "}}"
 
     return _BRACE_BLOCK_RE.sub(repl, template)
 

--- a/src/ai/backend/common/dto/manager/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/prometheus_query_preset/request.py
@@ -10,6 +10,7 @@ import re
 from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.clients.prometheus.preset import validate_query_template
 from ai.backend.common.dto.clients.prometheus.defs import PROMETHEUS_DURATION_PATTERN
 from ai.backend.common.dto.clients.prometheus.request import QueryTimeRange
 from ai.backend.common.dto.manager.defs import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
@@ -48,6 +49,12 @@ class CreateQueryDefinitionRequest(BaseRequestModel):
     )
     options: CreateQueryDefinitionOptionsRequest = Field(description="Query definition options")
 
+    @field_validator("query_template")
+    @classmethod
+    def _validate_query_template(cls, v: str) -> str:
+        validate_query_template(v)
+        return v
+
 
 class ModifyQueryDefinitionOptionsRequest(BaseRequestModel):
     """Options for modifying a prometheus query definition.
@@ -81,6 +88,13 @@ class ModifyQueryDefinitionRequest(BaseRequestModel):
     def _validate_time_window(cls, v: str | Sentinel | None) -> str | Sentinel | None:
         if isinstance(v, str) and not re.match(PROMETHEUS_DURATION_PATTERN, v):
             raise ValueError(f"Invalid Prometheus duration format: {v!r}")
+        return v
+
+    @field_validator("query_template")
+    @classmethod
+    def _validate_query_template(cls, v: str | None) -> str | None:
+        if v is not None:
+            validate_query_template(v)
         return v
 
 

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from pydantic import Field, field_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.clients.prometheus.preset import validate_query_template
 from ai.backend.common.dto.clients.prometheus.defs import PROMETHEUS_DURATION_PATTERN
 from ai.backend.common.dto.manager.query import StringFilter
 
@@ -78,6 +79,12 @@ class CreateQueryDefinitionInput(BaseRequestModel):
             raise ValueError("name must not be blank or whitespace-only")
         return stripped
 
+    @field_validator("query_template")
+    @classmethod
+    def _validate_query_template(cls, v: str) -> str:
+        validate_query_template(v)
+        return v
+
 
 class ModifyQueryDefinitionOptionsInput(BaseRequestModel):
     """Options for modifying a prometheus query definition.
@@ -141,6 +148,13 @@ class ModifyQueryDefinitionInput(BaseRequestModel):
     def _validate_time_window(cls, v: str | Sentinel | None) -> str | Sentinel | None:
         if isinstance(v, str) and not re.match(PROMETHEUS_DURATION_PATTERN, v):
             raise ValueError(f"Invalid Prometheus duration format: {v!r}")
+        return v
+
+    @field_validator("query_template")
+    @classmethod
+    def _validate_query_template(cls, v: str | None) -> str | None:
+        if v is not None:
+            validate_query_template(v)
         return v
 
 

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1069,6 +1069,20 @@ class FailedToGetMetric(BackendAIError):
         )
 
 
+class InvalidMetricPresetTemplate(BackendAIError):
+    """Exception raised when a metric preset template cannot be rendered."""
+
+    error_type = "https://api.backend.ai/probs/invalid-metric-preset-template"
+    error_title = "Invalid metric preset template."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.METRIC,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
 # JWT Errors
 class JWTError(BackendAIError, web.HTTPUnauthorized):
     """

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1069,7 +1069,7 @@ class FailedToGetMetric(BackendAIError):
         )
 
 
-class InvalidMetricPresetTemplate(BackendAIError):
+class InvalidMetricPresetTemplate(BackendAIError, web.HTTPBadRequest):
     """Exception raised when a metric preset template cannot be rendered."""
 
     error_type = "https://api.backend.ai/probs/invalid-metric-preset-template"

--- a/tests/unit/common/clients/prometheus/test_preset.py
+++ b/tests/unit/common/clients/prometheus/test_preset.py
@@ -131,6 +131,40 @@ class TestMetricPresetRender:
                 window="5m",
                 expected='rate(node_cpu_seconds_total{mode!="idle"}[5m])',
             ),
+            # Bare `{labels}` (single-brace) auto-wraps into PromQL `{value}`.
+            RenderTestCase(
+                id="bare_labels_placeholder_auto_wraps",
+                template='sum by ({group_by})(rate(metric{mode!="idle"}{labels}[{window}]))',
+                labels={"job": LabelMatcher.exact("api")},
+                group_by=frozenset({"instance"}),
+                window="5m",
+                expected='sum by (instance)(rate(metric{mode!="idle"}{job="api"}[5m]))',
+            ),
+            RenderTestCase(
+                id="bare_labels_with_empty_labels",
+                template="metric{labels}",
+                labels={},
+                group_by=frozenset(),
+                window="",
+                expected="metric{}",
+            ),
+            # User pre-escaped a raw matcher with `{{...}}` — must not be re-escaped.
+            RenderTestCase(
+                id="user_escaped_double_brace_matcher",
+                template='metric{{job="api"}}',
+                labels={},
+                group_by=frozenset(),
+                window="",
+                expected='metric{job="api"}',
+            ),
+            RenderTestCase(
+                id="user_escaped_empty_braces",
+                template="metric{{}}",
+                labels={},
+                group_by=frozenset(),
+                window="",
+                expected="metric{}",
+            ),
         ],
         ids=lambda c: c.id,
     )

--- a/tests/unit/common/clients/prometheus/test_preset.py
+++ b/tests/unit/common/clients/prometheus/test_preset.py
@@ -199,17 +199,27 @@ class TestValidateQueryTemplate:
     """Tests for validate_query_template() called from Pydantic field validators."""
 
     @pytest.mark.parametrize(
-        "template",
+        ("template", "expected_dry_run"),
         [
-            pytest.param('rate(node_cpu_seconds_total{mode!="idle"}[5m])', id="raw_promql"),
             pytest.param(
-                "sum by ({group_by})(metric{{{labels}}}[{window}])", id="with_placeholders"
+                'rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+                'rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+                id="raw_promql",
             ),
-            pytest.param('count(metric{a="1",b=~"x|y"})', id="multiple_matchers"),
+            pytest.param(
+                "sum by ({group_by})(metric{{{labels}}}[{window}])",
+                "sum by ()(metric{}[])",
+                id="with_placeholders",
+            ),
+            pytest.param(
+                'count(metric{a="1",b=~"x|y"})',
+                'count(metric{a="1",b=~"x|y"})',
+                id="multiple_matchers",
+            ),
         ],
     )
-    def test_accepts_valid_template(self, template: str) -> None:
-        validate_query_template(template)
+    def test_accepts_valid_template(self, template: str, expected_dry_run: str) -> None:
+        assert validate_query_template(template) == expected_dry_run
 
     @pytest.mark.parametrize(
         "template",

--- a/tests/unit/common/clients/prometheus/test_preset.py
+++ b/tests/unit/common/clients/prometheus/test_preset.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 
 import pytest
 
-from ai.backend.common.clients.prometheus import LabelMatcher, MetricPreset
+from ai.backend.common.clients.prometheus import (
+    LabelMatcher,
+    MetricPreset,
+    validate_query_template,
+)
+from ai.backend.common.exception import InvalidMetricPresetTemplate
 
 
 @dataclass
@@ -97,6 +102,35 @@ class TestMetricPresetRender:
                 window="",
                 expected='my_metric{kernel_id=~"kernel-1|kernel-2"}',
             ),
+            # Regression: original bug — `!=` in label matcher was parsed as
+            # str.format conversion specifier and raised ValueError.
+            RenderTestCase(
+                id="raw_label_matcher_passes_through",
+                template='rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+                labels={},
+                group_by=frozenset(),
+                window="",
+                expected='rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+            ),
+            # Raw matcher coexists with all placeholders + label injection.
+            RenderTestCase(
+                id="raw_matcher_with_all_placeholders",
+                template='sum by ({group_by})(rate(metric{mode!="idle"}{{{labels}}}[{window}]))',
+                labels={"job": LabelMatcher.exact("api")},
+                group_by=frozenset({"instance"}),
+                window="5m",
+                expected='sum by (instance)(rate(metric{mode!="idle"}{job="api"}[5m]))',
+            ),
+            # Grafana paste with no {labels} placeholder — provided labels must
+            # be silently ignored, raw matcher must survive.
+            RenderTestCase(
+                id="raw_template_ignores_provided_labels",
+                template='rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+                labels={"job": LabelMatcher.exact("api")},
+                group_by=frozenset({"instance"}),
+                window="5m",
+                expected='rate(node_cpu_seconds_total{mode!="idle"}[5m])',
+            ),
         ],
         ids=lambda c: c.id,
     )
@@ -111,3 +145,58 @@ class TestMetricPresetRender:
         result = preset.render()
 
         assert result == case.expected
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("metric}", id="orphan_close_brace"),
+            pytest.param("metric{", id="orphan_open_brace"),
+            pytest.param("metric{a{b}c}", id="nested_braces"),
+        ],
+    )
+    async def test_render_raises_on_malformed_template(self, template: str) -> None:
+        preset = MetricPreset(template=template)
+
+        with pytest.raises(InvalidMetricPresetTemplate):
+            preset.render()
+
+
+class TestValidateQueryTemplate:
+    """Tests for validate_query_template() called from Pydantic field validators."""
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param('rate(node_cpu_seconds_total{mode!="idle"}[5m])', id="raw_promql"),
+            pytest.param(
+                "sum by ({group_by})(metric{{{labels}}}[{window}])", id="with_placeholders"
+            ),
+            pytest.param('count(metric{a="1",b=~"x|y"})', id="multiple_matchers"),
+        ],
+    )
+    def test_accepts_valid_template(self, template: str) -> None:
+        validate_query_template(template)
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param('rate(metric{mode!="idle"}[$__rate_interval])', id="grafana_builtin"),
+            pytest.param('metric{job="$service"}', id="dollar_identifier"),
+            pytest.param('metric{region="${region}"}', id="braced_dollar_var"),
+        ],
+    )
+    def test_rejects_unsupported_template_variables(self, template: str) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate, match="Unsupported"):
+            validate_query_template(template)
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("metric}", id="orphan_close_brace"),
+            pytest.param("metric{", id="orphan_open_brace"),
+            pytest.param("metric{a{b}c}", id="nested_braces"),
+        ],
+    )
+    def test_rejects_malformed_template(self, template: str) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate):
+            validate_query_template(template)

--- a/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
@@ -25,6 +25,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import (
     OrderDirection,
     QueryDefinitionOrderField,
 )
+from ai.backend.common.exception import InvalidMetricPresetTemplate
 
 _SAMPLE_UUID = UUID("550e8400-e29b-41d4-a716-446655440000")
 
@@ -164,6 +165,24 @@ class TestCreateQueryDefinitionInput:
         assert restored.name == "cpu_usage"
         assert restored.time_window == "5m"
 
+    def test_unsupported_template_var_in_query_template_raises(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate, match="Unsupported"):
+            CreateQueryDefinitionInput(
+                name="test",
+                metric_name="metric",
+                query_template='rate(metric{mode!="idle"}[$__rate_interval])',
+                options=_make_create_options(),
+            )
+
+    def test_malformed_query_template_raises(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate):
+            CreateQueryDefinitionInput(
+                name="test",
+                metric_name="metric",
+                query_template="metric{",
+                options=_make_create_options(),
+            )
+
 
 class TestModifyQueryDefinitionOptionsInput:
     """Tests for ModifyQueryDefinitionOptionsInput model."""
@@ -237,6 +256,20 @@ class TestModifyQueryDefinitionInput:
         assert inp.name == "new_name"
         assert inp.metric_name == "new_metric"
         assert inp.query_template is None
+
+    def test_query_template_none_skips_validation(self) -> None:
+        inp = ModifyQueryDefinitionInput(query_template=None)
+        assert inp.query_template is None
+
+    def test_unsupported_template_var_in_query_template_raises(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate, match="Unsupported"):
+            ModifyQueryDefinitionInput(
+                query_template='rate(metric{mode!="idle"}[$__rate_interval])',
+            )
+
+    def test_malformed_query_template_raises(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate):
+            ModifyQueryDefinitionInput(query_template="metric{")
 
     def test_round_trip_serialization(self) -> None:
         inp = ModifyQueryDefinitionInput(


### PR DESCRIPTION
## Summary

`MetricPreset.render()` calls `template.format(...)` on the user-supplied PromQL template. PromQL label matchers (`{job="api"}`, `{mode!="idle"}`, ...) share the `{...}` delimiter with Python `str.format`, so any preset whose template was pasted from Grafana — or simply contains literal label matchers — crashes at execute time with `ValueError: expected ':' after conversion specifier` or similar cryptic errors.

This PR makes the render path tolerate raw PromQL pastes regardless of how the user wrote braces, wraps remaining failures in a domain exception, and adds save-time validation for foreign template variables.

## Changes

### Render path — symmetric brace handling

`MetricPreset.render()` runs each `{X}` block of the template through a context-aware preprocessor before `.format()`. The preprocessor inspects the original characters around the match (`already_wrapped` = preceded by `{` AND followed by `}`) and decides:

| `{X}` content | already wrapped | Action |
|---|---|---|
| Raw matcher (e.g. `job="api"`) | No (1-brace `{X}`) | Escape to `{{X}}` so `.format` keeps it literal |
| Raw matcher | Yes (2-brace `{{X}}`) | Leave alone — already user-escaped |
| `{window}` / `{group_by}` | — | Leave alone (no PromQL braces required) |
| `{labels}` | No (bare 1-brace) | Auto-wrap to `{{{labels}}}` so `.format` produces `{value}` |
| `{labels}` | Yes (3-brace `{{{labels}}}`) | Leave alone — seeded convention |

Net effect: all of `metric{job="api"}`, `metric{{job="api"}}`, `metric{labels}`, and `metric{{{labels}}}` render to a single PromQL `{value}` matcher. No DB migration; the existing `{{{labels}}}` seeded convention keeps working.

### Failure path

`.format()`'s `ValueError`/`KeyError`/`IndexError` are wrapped into a new `InvalidMetricPresetTemplate` domain exception so the manager never leaks raw stdlib errors to the API layer.

### Save path

New `validate_query_template()` helper, wired into Pydantic `field_validator` on `query_template` for both v1 and v2 create/update DTOs. Rejects:
- Foreign template variables (`$ident`, `${ident}` — typically Grafana `$__rate_interval`, `$service`)
- Templates that fail a dry-run render (orphan/nested braces)

## Test plan

Unit tests added/updated:
- [x] `tests/unit/common/clients/prometheus/test_preset.py` — raw matcher pass-through (1-brace), user-escaped 2-brace pass-through, bare `{labels}` auto-wrap, render error wrap, `validate_query_template` accepts/rejects.
- [x] `tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py` — DTO validator rejects foreign vars and malformed braces, skips when `query_template=None` on modify.

Manual verification against local manager (`./bai prometheus-query-definition ...`):
- [x] **A. Create reject** — `$__rate_interval`, `$service`, `${region}`, orphan `{`, nested `{a{b}c}` all rejected with `InvalidMetricPresetTemplate`.
- [x] **B. Create accept** — raw `{mode!="idle"}` (1-brace), user-escaped `{{mode!="idle"}}` (2-brace), classic `{{{labels}}}`, multi-matcher + regex, bare `{labels}` all saved.
- [x] **C. Execute regression** — preset with raw `{mode!="idle"}` no longer crashes; query reaches Prometheus. 2-brace user-escaped form returns 200. Bare `{labels}` substitutes with `{key="value"}`. Seeded `container_gauge` still works.
- [x] **D. Modify** — Grafana var rejected on update; non-template field updates skip validation; raw matcher update accepted.
- [x] **E. DB-injected bypass** — manually `UPDATE`-ed templates with orphan/nested braces surface as `InvalidMetricPresetTemplate` server-side rather than raw `ValueError`. Empty `{}` and unknown `{wrong}` placeholders pass render and are evaluated by Prometheus as expected.

## Out of scope

- During E2E verification, the v2 REST endpoint was observed to serialize `BackendAIError` responses with status `HTTP/1.1 -1`, which causes clients to surface a transport-level parse error instead of the structured domain error. The exception is raised correctly server-side; only the HTTP response mapping is broken. Will file as a separate issue.