### PR TITLE
feat(BA-5950): admin preview endpoint for prometheus query preset templates

### DIFF
--- a/changes/11482.feature.md
+++ b/changes/11482.feature.md
@@ -1,0 +1,1 @@
+Add admin preview endpoint to validate prometheus query preset templates before saving (REST v2, GraphQL, CLI)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12114,6 +12114,16 @@ input PreStartActionInput
 }
 
 """
+Added in UNRELEASED. Input for previewing a prometheus query template (admin only).
+"""
+input PreviewQueryDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """PromQL template to validate."""
+  queryTemplate: String!
+}
+
+"""
 Added in 26.2.0. Basic project information. Contains identity and descriptive fields for the project.
 """
 type ProjectBasicInfo
@@ -13688,6 +13698,11 @@ type Query
   Added in 26.4.2. Execute a prometheus query preset by ID and return the result. Available to any authenticated user; the underlying preset query is the same regardless of who runs it.
   """
   prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
+  """
+  adminPrometheusQueryPresetPreview(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13702,7 +13702,7 @@ type Query
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
   """
-  adminPrometheusQueryPresetPreview(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -7860,6 +7860,14 @@ enum PresetValueType {
 }
 
 """
+Added in UNRELEASED. Input for previewing a prometheus query template (admin only).
+"""
+input PreviewQueryDefinitionInput {
+  """PromQL template to validate."""
+  queryTemplate: String!
+}
+
+"""
 Added in 26.2.0. Basic project information. Contains identity and descriptive fields for the project.
 """
 type ProjectBasicInfo {
@@ -8830,6 +8838,11 @@ type Query {
   Added in 26.4.2. Execute a prometheus query preset by ID and return the result. Available to any authenticated user; the underlying preset query is the same regardless of who runs it.
   """
   prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult!
+
+  """
+  Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
+  """
+  adminPrometheusQueryPresetPreview(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult!
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8842,7 +8842,7 @@ type Query {
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
   """
-  adminPrometheusQueryPresetPreview(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult!
+  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult!
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/src/ai/backend/client/cli/v2/admin/prometheus_query_preset.py
+++ b/src/ai/backend/client/cli/v2/admin/prometheus_query_preset.py
@@ -1,7 +1,7 @@
 """Admin CLI commands for the v2 prometheus query definition resource.
 
-Only write operations (create, update, delete) live here. Read operations
-(search, get, execute) are user-facing and live under
+Write operations (create, update, delete) and template preview live here.
+Read operations (search, get, execute) are user-facing and live under
 ``cli/v2/prometheus_query_preset/commands.py``.
 """
 
@@ -145,6 +145,32 @@ def delete(preset_id: UUID) -> None:
         try:
             result = await registry.prometheus_query_preset.delete(
                 DeleteQueryDefinitionInput(id=preset_id),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@prometheus_query_preset.command()
+@click.option(
+    "--query-template",
+    required=True,
+    type=str,
+    help="PromQL template to validate.",
+)
+def preview(query_template: str) -> None:
+    """Preview a prometheus query template before saving (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
+        PreviewQueryDefinitionInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.prometheus_query_preset.admin_preview(
+                PreviewQueryDefinitionInput(query_template=query_template),
             )
             print_result(result)
         finally:

--- a/src/ai/backend/client/v2/domains_v2/prometheus_query_preset.py
+++ b/src/ai/backend/client/v2/domains_v2/prometheus_query_preset.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     DeleteQueryDefinitionInput,
     ExecuteQueryDefinitionInput,
     ModifyQueryDefinitionInput,
+    PreviewQueryDefinitionInput,
     SearchQueryDefinitionsInput,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.response import (
@@ -80,6 +81,17 @@ class V2PrometheusQueryPresetClient(BaseDomainClient):
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/{preset_id}/execute",
+            request=request,
+            response_model=ExecuteQueryDefinitionPayload,
+        )
+
+    async def admin_preview(
+        self, request: PreviewQueryDefinitionInput
+    ) -> ExecuteQueryDefinitionPayload:
+        """Preview a prometheus query template (superadmin only)."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/preview",
             request=request,
             response_model=ExecuteQueryDefinitionPayload,
         )

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -14,10 +14,12 @@ _UNSUPPORTED_TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*
 
 
 def validate_query_template(template: str) -> str:
-    """Reject templates with foreign variables or malformed braces.
+    """Reject empty templates, foreign variables, or malformed braces.
 
     Returns the dry-run rendered template (useful for inspection in tests).
     """
+    if not template:
+        raise InvalidMetricPresetTemplate("Template must not be empty.")
     unsupported_vars = _UNSUPPORTED_TEMPLATE_VAR_RE.findall(template)
     if unsupported_vars:
         placeholders = ", ".join(f"{{{name}}}" for name in sorted(_PLACEHOLDER_NAMES))

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -18,7 +18,7 @@ def validate_query_template(template: str) -> str:
 
     Returns the dry-run rendered template (useful for inspection in tests).
     """
-    if not template or not template.strip():
+    if not template.strip():
         raise InvalidMetricPresetTemplate("Template must not be empty.")
     unsupported_vars = _UNSUPPORTED_TEMPLATE_VAR_RE.findall(template)
     if unsupported_vars:

--- a/src/ai/backend/common/clients/prometheus/preset.py
+++ b/src/ai/backend/common/clients/prometheus/preset.py
@@ -18,7 +18,7 @@ def validate_query_template(template: str) -> str:
 
     Returns the dry-run rendered template (useful for inspection in tests).
     """
-    if not template:
+    if not template or not template.strip():
         raise InvalidMetricPresetTemplate("Template must not be empty.")
     unsupported_vars = _UNSUPPORTED_TEMPLATE_VAR_RE.findall(template)
     if unsupported_vars:

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/__init__.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     MetricLabelEntry,
     ModifyQueryDefinitionInput,
     ModifyQueryDefinitionOptionsInput,
+    PreviewQueryDefinitionInput,
     QueryDefinitionFilter,
     QueryDefinitionOrder,
     SearchQueryDefinitionsInput,
@@ -57,6 +58,8 @@ __all__ = (
     # Request (execute supporting)
     "MetricLabelEntry",
     "ExecuteQueryDefinitionInput",
+    # Request (preview)
+    "PreviewQueryDefinitionInput",
     # Response (node)
     "QueryDefinitionNode",
     # Response (CRUD payloads)

--- a/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/prometheus_query_preset/request.py
@@ -33,6 +33,8 @@ __all__ = (
     # Execute supporting
     "MetricLabelEntry",
     "ExecuteQueryDefinitionInput",
+    # Preview
+    "PreviewQueryDefinitionInput",
     # Query time range
     "QueryTimeRangeInputDTO",
 )
@@ -230,6 +232,18 @@ class ExecuteQueryDefinitionOptionsInput(BaseRequestModel):
         default_factory=list,
         description="Group-by labels",
     )
+
+
+class PreviewQueryDefinitionInput(BaseRequestModel):
+    """Input for previewing a prometheus query template before saving (admin only)."""
+
+    query_template: str = Field(description="PromQL template to validate")
+
+    @field_validator("query_template")
+    @classmethod
+    def _validate_query_template(cls, v: str) -> str:
+        validate_query_template(v)
+        return v
 
 
 class ExecuteQueryDefinitionInput(BaseRequestModel):

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1083,6 +1083,25 @@ class InvalidMetricPresetTemplate(BackendAIError, web.HTTPBadRequest):
         )
 
 
+class PrometheusQueryEvaluationFailed(BackendAIError, web.HTTPBadRequest):
+    """Raised when Prometheus rejects a rendered PromQL query.
+
+    Used by user-facing flows (e.g., preset preview) to attribute query
+    rejection to the caller's input rather than treating it as a downstream
+    gateway failure (502).
+    """
+
+    error_type = "https://api.backend.ai/probs/prometheus-query-evaluation-failed"
+    error_title = "Prometheus rejected the query."
+
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.METRIC,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
 # JWT Errors
 class JWTError(BackendAIError, web.HTTPUnauthorized):
     """

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1041,7 +1041,7 @@ class InvalidNotificationChannelSpec(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class PrometheusConnectionError(BackendAIError):
+class PrometheusConnectionError(BackendAIError, web.HTTPServiceUnavailable):
     """Exception raised when a connection to Prometheus fails."""
 
     error_type = "https://api.backend.ai/probs/prometheus-connection-error"
@@ -1055,7 +1055,7 @@ class PrometheusConnectionError(BackendAIError):
         )
 
 
-class FailedToGetMetric(BackendAIError):
+class FailedToGetMetric(BackendAIError, web.HTTPBadGateway):
     """Exception raised when a metric cannot be retrieved."""
 
     error_type = "https://api.backend.ai/probs/failed-to-get-metric"

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -164,7 +164,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
 
         return ModifyQueryDefinitionPayload(item=self._data_to_dto(action_result.preset))
 
-    async def preview(self, input: PreviewQueryDefinitionInput) -> QueryDefinitionResultInfo:
+    async def admin_preview(self, input: PreviewQueryDefinitionInput) -> QueryDefinitionResultInfo:
         """Preview a prometheus query template (admin only)."""
         action_result = (
             await self._processors.prometheus_query_preset.preview_preset.wait_for_complete(

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     CreateQueryDefinitionInput,
     DeleteQueryDefinitionInput,
     ModifyQueryDefinitionInput,
+    PreviewQueryDefinitionInput,
     QueryDefinitionFilter,
     QueryDefinitionOrder,
     QueryTimeRangeInputDTO,
@@ -68,6 +69,7 @@ from ai.backend.manager.services.prometheus_query_preset.actions import (
     ExecutePresetAction,
     GetPresetAction,
     ModifyPresetAction,
+    PreviewPresetAction,
     SearchPresetsAction,
 )
 from ai.backend.manager.types import OptionalState, TriState
@@ -160,6 +162,29 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
         )
 
         return ModifyQueryDefinitionPayload(item=self._data_to_dto(action_result.preset))
+
+    async def preview(self, input: PreviewQueryDefinitionInput) -> QueryDefinitionResultInfo:
+        """Preview a prometheus query template (admin only)."""
+        action_result = (
+            await self._processors.prometheus_query_preset.preview_preset.wait_for_complete(
+                PreviewPresetAction(query_template=input.query_template)
+            )
+        )
+        response = action_result.response
+        return QueryDefinitionResultInfo(
+            status=response.status,
+            result_type=response.data.result_type,
+            result=[
+                QueryDefinitionMetricResultInfo(
+                    metric=[
+                        MetricLabelEntryInfo(key=k, value=v)
+                        for k, v in mr.metric.model_dump(exclude_none=True).items()
+                    ],
+                    values=[MetricValueInfo(timestamp=ts, value=val) for ts, val in mr.values],
+                )
+                for mr in response.data.result
+            ],
+        )
 
     async def execute_preset(
         self,

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.dto.clients.prometheus.request import QueryTimeRange
+from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     CreateQueryDefinitionInput,
     DeleteQueryDefinitionInput,
@@ -170,21 +171,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
                 PreviewPresetAction(query_template=input.query_template)
             )
         )
-        response = action_result.response
-        return QueryDefinitionResultInfo(
-            status=response.status,
-            result_type=response.data.result_type,
-            result=[
-                QueryDefinitionMetricResultInfo(
-                    metric=[
-                        MetricLabelEntryInfo(key=k, value=v)
-                        for k, v in mr.metric.model_dump(exclude_none=True).items()
-                    ],
-                    values=[MetricValueInfo(timestamp=ts, value=val) for ts, val in mr.values],
-                )
-                for mr in response.data.result
-            ],
-        )
+        return self._prometheus_response_to_result_info(action_result.response)
 
     async def execute_preset(
         self,
@@ -219,7 +206,13 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
                 )
             )
         )
-        response = action_result.response
+        return self._prometheus_response_to_result_info(action_result.response)
+
+    def _prometheus_response_to_result_info(
+        self,
+        response: PrometheusResponse,
+    ) -> QueryDefinitionResultInfo:
+        """Convert a raw Prometheus response into the manager-layer DTO."""
         return QueryDefinitionResultInfo(
             status=response.status,
             result_type=response.data.result_type,

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
@@ -6,7 +6,7 @@ from .resolver import (
     admin_delete_prometheus_query_preset,
     admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
-    admin_prometheus_query_preset_preview,
+    admin_preview_prometheus_query_preset,
     prometheus_query_preset,
     prometheus_query_preset_categories,
     prometheus_query_preset_category,
@@ -47,7 +47,7 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
-    "admin_prometheus_query_preset_preview",
+    "admin_preview_prometheus_query_preset",
     # Category Queries
     "prometheus_query_preset_category",
     "prometheus_query_preset_categories",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/__init__.py
@@ -6,6 +6,7 @@ from .resolver import (
     admin_delete_prometheus_query_preset,
     admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
+    admin_prometheus_query_preset_preview,
     prometheus_query_preset,
     prometheus_query_preset_categories,
     prometheus_query_preset_category,
@@ -46,6 +47,7 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
+    "admin_prometheus_query_preset_preview",
     # Category Queries
     "prometheus_query_preset_category",
     "prometheus_query_preset_categories",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
@@ -14,7 +14,7 @@ from .mutation import (
     admin_modify_prometheus_query_preset,
 )
 from .query import (
-    admin_prometheus_query_preset_preview,
+    admin_preview_prometheus_query_preset,
     prometheus_query_preset,
     prometheus_query_preset_result,
     prometheus_query_presets,
@@ -25,7 +25,7 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
-    "admin_prometheus_query_preset_preview",
+    "admin_preview_prometheus_query_preset",
     # Category Queries
     "prometheus_query_preset_category",
     "prometheus_query_preset_categories",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/__init__.py
@@ -14,6 +14,7 @@ from .mutation import (
     admin_modify_prometheus_query_preset,
 )
 from .query import (
+    admin_prometheus_query_preset_preview,
     prometheus_query_preset,
     prometheus_query_preset_result,
     prometheus_query_presets,
@@ -24,6 +25,7 @@ __all__ = [
     "prometheus_query_preset",
     "prometheus_query_presets",
     "prometheus_query_preset_result",
+    "admin_prometheus_query_preset_preview",
     # Category Queries
     "prometheus_query_preset_category",
     "prometheus_query_preset_categories",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
@@ -10,6 +10,7 @@ from strawberry.relay import PageInfo
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     SearchQueryDefinitionsInput,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -17,6 +18,7 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.prometheus_query_preset.types import (
     ExecuteQueryDefinitionOptionsInput,
+    PreviewQueryDefinitionInput,
     QueryDefinitionConnection,
     QueryDefinitionEdge,
     QueryDefinitionFilter,
@@ -26,6 +28,7 @@ from ai.backend.manager.api.gql.prometheus_query_preset.types import (
     QueryTimeRangeInput,
 )
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
 
 
 @gql_root_field(
@@ -104,4 +107,19 @@ async def prometheus_query_preset_result(
         time_range=time_range.to_pydantic() if time_range is not None else None,
     )
 
+    return QueryDefinitionResultGQL.from_pydantic(dto)
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Preview a prometheus query template before saving it as a preset (admin only).",
+    )
+)  # type: ignore[misc]
+async def admin_prometheus_query_preset_preview(
+    info: Info[StrawberryGQLContext],
+    input: PreviewQueryDefinitionInput,
+) -> QueryDefinitionResultGQL:
+    check_admin_only()
+    dto = await info.context.adapters.prometheus_query_preset.preview(input.to_pydantic())
     return QueryDefinitionResultGQL.from_pydantic(dto)

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
@@ -18,7 +18,7 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.prometheus_query_preset.types import (
     ExecuteQueryDefinitionOptionsInput,
-    PreviewQueryDefinitionInput,
+    PreviewQueryDefinitionInputGQL,
     QueryDefinitionConnection,
     QueryDefinitionEdge,
     QueryDefinitionFilter,
@@ -116,10 +116,10 @@ async def prometheus_query_preset_result(
         description="Preview a prometheus query template before saving it as a preset (admin only).",
     )
 )  # type: ignore[misc]
-async def admin_prometheus_query_preset_preview(
+async def admin_preview_prometheus_query_preset(
     info: Info[StrawberryGQLContext],
-    input: PreviewQueryDefinitionInput,
+    input: PreviewQueryDefinitionInputGQL,
 ) -> QueryDefinitionResultGQL:
     check_admin_only()
-    dto = await info.context.adapters.prometheus_query_preset.preview(input.to_pydantic())
+    dto = await info.context.adapters.prometheus_query_preset.admin_preview(input.to_pydantic())
     return QueryDefinitionResultGQL.from_pydantic(dto)

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
@@ -19,6 +19,7 @@ from .inputs import (
     ExecuteQueryDefinitionOptionsInput,
     MetricLabelEntryInput,
     ModifyQueryDefinitionInput,
+    PreviewQueryDefinitionInput,
     QueryTimeRangeInput,
 )
 from .node import (
@@ -60,6 +61,7 @@ __all__ = [
     "QueryTimeRangeInput",
     "MetricLabelEntryInput",
     "ExecuteQueryDefinitionOptionsInput",
+    "PreviewQueryDefinitionInput",
     # Payload and result types
     "QueryDefinitionOptionsGQL",
     "MetricLabelEntryGQL",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/__init__.py
@@ -19,7 +19,7 @@ from .inputs import (
     ExecuteQueryDefinitionOptionsInput,
     MetricLabelEntryInput,
     ModifyQueryDefinitionInput,
-    PreviewQueryDefinitionInput,
+    PreviewQueryDefinitionInputGQL,
     QueryTimeRangeInput,
 )
 from .node import (
@@ -61,7 +61,7 @@ __all__ = [
     "QueryTimeRangeInput",
     "MetricLabelEntryInput",
     "ExecuteQueryDefinitionOptionsInput",
-    "PreviewQueryDefinitionInput",
+    "PreviewQueryDefinitionInputGQL",
     # Payload and result types
     "QueryDefinitionOptionsGQL",
     "MetricLabelEntryGQL",

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
@@ -147,5 +147,5 @@ class ExecuteQueryDefinitionOptionsInput(PydanticInputMixin[ExecuteQueryDefiniti
     ),
     name="PreviewQueryDefinitionInput",
 )
-class PreviewQueryDefinitionInput(PydanticInputMixin[PreviewQueryDefinitionInputDTO]):
+class PreviewQueryDefinitionInputGQL(PydanticInputMixin[PreviewQueryDefinitionInputDTO]):
     query_template: str = gql_field(description="PromQL template to validate.")

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/types/inputs.py
@@ -26,8 +26,12 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     ModifyQueryDefinitionOptionsInput as ModifyQueryDefinitionOptionsInputDTO,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
+    PreviewQueryDefinitionInput as PreviewQueryDefinitionInputDTO,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     QueryTimeRangeInputDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_field,
@@ -134,3 +138,14 @@ class ExecuteQueryDefinitionOptionsInput(PydanticInputMixin[ExecuteQueryDefiniti
     group_labels: list[str] | None = gql_field(
         description="Label keys to group results by.", default=None
     )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Input for previewing a prometheus query template (admin only).",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="PreviewQueryDefinitionInput",
+)
+class PreviewQueryDefinitionInput(PydanticInputMixin[PreviewQueryDefinitionInputDTO]):
+    query_template: str = gql_field(description="PromQL template to validate.")

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -251,7 +251,7 @@ from .prometheus_query_preset import (
     admin_delete_prometheus_query_preset,
     admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
-    admin_prometheus_query_preset_preview,
+    admin_preview_prometheus_query_preset,
     prometheus_query_preset,
     prometheus_query_preset_categories,
     prometheus_query_preset_category,
@@ -529,7 +529,7 @@ class Query:
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
     prometheus_query_preset_result = prometheus_query_preset_result
-    admin_prometheus_query_preset_preview = admin_prometheus_query_preset_preview
+    admin_preview_prometheus_query_preset = admin_preview_prometheus_query_preset
     # Prometheus Query Preset Category APIs (read available to any authenticated user)
     prometheus_query_preset_category = prometheus_query_preset_category
     prometheus_query_preset_categories = prometheus_query_preset_categories

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -251,6 +251,7 @@ from .prometheus_query_preset import (
     admin_delete_prometheus_query_preset,
     admin_delete_prometheus_query_preset_category,
     admin_modify_prometheus_query_preset,
+    admin_prometheus_query_preset_preview,
     prometheus_query_preset,
     prometheus_query_preset_categories,
     prometheus_query_preset_category,
@@ -528,6 +529,7 @@ class Query:
     prometheus_query_preset = prometheus_query_preset
     prometheus_query_presets = prometheus_query_presets
     prometheus_query_preset_result = prometheus_query_preset_result
+    admin_prometheus_query_preset_preview = admin_prometheus_query_preset_preview
     # Prometheus Query Preset Category APIs (read available to any authenticated user)
     prometheus_query_preset_category = prometheus_query_preset_category
     prometheus_query_preset_categories = prometheus_query_preset_categories

--- a/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/handler.py
@@ -12,6 +12,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     DeleteQueryDefinitionInput,
     ExecuteQueryDefinitionInput,
     ModifyQueryDefinitionInput,
+    PreviewQueryDefinitionInput,
     SearchQueryDefinitionsInput,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.response import (
@@ -100,3 +101,18 @@ class V2PrometheusQueryPresetHandler:
         """Delete a query definition by ID."""
         result = await self._adapter.delete(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_preview(
+        self,
+        body: BodyParam[PreviewQueryDefinitionInput],
+    ) -> APIResponse:
+        """Preview a prometheus query template before saving (superadmin only)."""
+        result = await self._adapter.preview(body.parsed)
+        payload = ExecuteQueryDefinitionPayload(
+            status=result.status,
+            data=QueryDefinitionExecuteDataInfo(
+                result_type=result.result_type,
+                result=result.result,
+            ),
+        )
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=payload)

--- a/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/handler.py
@@ -107,7 +107,7 @@ class V2PrometheusQueryPresetHandler:
         body: BodyParam[PreviewQueryDefinitionInput],
     ) -> APIResponse:
         """Preview a prometheus query template before saving (superadmin only)."""
-        result = await self._adapter.preview(body.parsed)
+        result = await self._adapter.admin_preview(body.parsed)
         payload = ExecuteQueryDefinitionPayload(
             status=result.status,
             data=QueryDefinitionExecuteDataInfo(

--- a/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/prometheus_query_preset/registry.py
@@ -28,6 +28,7 @@ def register_v2_prometheus_query_preset_routes(
 
     reg.add("POST", "", handler.create, middlewares=[superadmin_required])
     reg.add("POST", "/search", handler.search, middlewares=[auth_required])
+    reg.add("POST", "/preview", handler.admin_preview, middlewares=[superadmin_required])
     reg.add("GET", "/{preset_id}", handler.get, middlewares=[auth_required])
     reg.add("PATCH", "/{preset_id}", handler.update, middlewares=[superadmin_required])
     reg.add("POST", "/{preset_id}/execute", handler.execute, middlewares=[auth_required])

--- a/src/ai/backend/manager/repositories/prometheus_query_preset/repositories.py
+++ b/src/ai/backend/manager/repositories/prometheus_query_preset/repositories.py
@@ -13,7 +13,7 @@ class PrometheusQueryPresetRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
-        repository = PrometheusQueryPresetRepository(args.db)
+        repository = PrometheusQueryPresetRepository(args.db, args.prometheus_client)
 
         return cls(
             repository=repository,

--- a/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
+++ b/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from ai.backend.common.clients.prometheus.client import PrometheusClient
+from ai.backend.common.clients.prometheus.preset import MetricPreset
+from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     MetricArgs,
@@ -53,9 +56,15 @@ class PrometheusQueryPresetRepository:
     """Repository for prometheus query preset data access."""
 
     _db_source: PrometheusQueryPresetDBSource
+    _prometheus_client: PrometheusClient
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(
+        self,
+        db: ExtendedAsyncSAEngine,
+        prometheus_client: PrometheusClient,
+    ) -> None:
         self._db_source = PrometheusQueryPresetDBSource(db)
+        self._prometheus_client = prometheus_client
 
     @prometheus_query_preset_repository_resilience.apply()
     async def create(
@@ -90,3 +99,17 @@ class PrometheusQueryPresetRepository:
     ) -> PrometheusQueryPresetListResult:
         """Searches prometheus query presets with total count."""
         return await self._db_source.search(querier=querier)
+
+    async def preview_query_template(
+        self,
+        query_template: str,
+        default_window: str,
+    ) -> PrometheusResponse:
+        """Render the template with empty matchers and run an instant query."""
+        metric_preset = MetricPreset(
+            template=query_template,
+            labels={},
+            group_by=frozenset(),
+            window=default_window,
+        )
+        return await self._prometheus_client.query_instant(preset=metric_preset)

--- a/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
+++ b/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.clients.prometheus.preset import MetricPreset
 from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
+from ai.backend.common.exception import BackendAIError
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     MetricArgs,
@@ -46,6 +47,7 @@ prometheus_query_preset_repository_resilience = Resilience(
                 max_retries=10,
                 retry_delay=0.1,
                 backoff_strategy=BackoffStrategy.FIXED,
+                non_retryable_exceptions=(BackendAIError,),
             )
         ),
     ]
@@ -100,6 +102,7 @@ class PrometheusQueryPresetRepository:
         """Searches prometheus query presets with total count."""
         return await self._db_source.search(querier=querier)
 
+    @prometheus_query_preset_repository_resilience.apply()
     async def preview_query_template(
         self,
         query_template: str,

--- a/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
+++ b/src/ai/backend/manager/repositories/prometheus_query_preset/repository.py
@@ -6,7 +6,11 @@ from uuid import UUID
 from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.clients.prometheus.preset import MetricPreset
 from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
-from ai.backend.common.exception import BackendAIError
+from ai.backend.common.exception import (
+    BackendAIError,
+    FailedToGetMetric,
+    PrometheusQueryEvaluationFailed,
+)
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     MetricArgs,
@@ -115,4 +119,7 @@ class PrometheusQueryPresetRepository:
             group_by=frozenset(),
             window=default_window,
         )
-        return await self._prometheus_client.query_instant(preset=metric_preset)
+        try:
+            return await self._prometheus_client.query_instant(preset=metric_preset)
+        except FailedToGetMetric as e:
+            raise PrometheusQueryEvaluationFailed(str(e)) from e

--- a/src/ai/backend/manager/services/prometheus_query_preset/actions/__init__.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/actions/__init__.py
@@ -3,6 +3,7 @@ from .delete import DeletePresetAction, DeletePresetActionResult
 from .execute_preset import ExecutePresetAction, ExecutePresetActionResult
 from .get import GetPresetAction, GetPresetActionResult
 from .modify import ModifyPresetAction, ModifyPresetActionResult
+from .preview import PreviewPresetAction, PreviewPresetActionResult
 from .search import SearchPresetsAction, SearchPresetsActionResult
 
 __all__ = [
@@ -16,6 +17,8 @@ __all__ = [
     "GetPresetActionResult",
     "ModifyPresetAction",
     "ModifyPresetActionResult",
+    "PreviewPresetAction",
+    "PreviewPresetActionResult",
     "SearchPresetsAction",
     "SearchPresetsActionResult",
 ]

--- a/src/ai/backend/manager/services/prometheus_query_preset/actions/preview.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/actions/preview.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dto.clients.prometheus.response import PrometheusResponse
+from ai.backend.manager.actions.action import BaseActionResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.services.prometheus_query_preset.actions.base import (
+    PrometheusQueryPresetAction,
+)
+
+
+@dataclass
+class PreviewPresetAction(PrometheusQueryPresetAction):
+    query_template: str
+
+    @override
+    def entity_id(self) -> str | None:
+        return None
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class PreviewPresetActionResult(BaseActionResult):
+    response: PrometheusResponse
+
+    @override
+    def entity_id(self) -> str | None:
+        return None

--- a/src/ai/backend/manager/services/prometheus_query_preset/processors.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/processors.py
@@ -15,6 +15,8 @@ from ai.backend.manager.services.prometheus_query_preset.actions import (
     GetPresetActionResult,
     ModifyPresetAction,
     ModifyPresetActionResult,
+    PreviewPresetAction,
+    PreviewPresetActionResult,
     SearchPresetsAction,
     SearchPresetsActionResult,
 )
@@ -30,6 +32,7 @@ class PrometheusQueryPresetProcessors(AbstractProcessorPackage):
     modify_preset: ActionProcessor[ModifyPresetAction, ModifyPresetActionResult]
     delete_preset: ActionProcessor[DeletePresetAction, DeletePresetActionResult]
     execute_preset: ActionProcessor[ExecutePresetAction, ExecutePresetActionResult]
+    preview_preset: ActionProcessor[PreviewPresetAction, PreviewPresetActionResult]
 
     def __init__(
         self,
@@ -43,6 +46,7 @@ class PrometheusQueryPresetProcessors(AbstractProcessorPackage):
         self.modify_preset = ActionProcessor(service.modify_preset, action_monitors)
         self.delete_preset = ActionProcessor(service.delete_preset, action_monitors)
         self.execute_preset = ActionProcessor(service.execute_preset, action_monitors)
+        self.preview_preset = ActionProcessor(service.preview_preset, action_monitors)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:
@@ -53,4 +57,5 @@ class PrometheusQueryPresetProcessors(AbstractProcessorPackage):
             ModifyPresetAction.spec(),
             DeletePresetAction.spec(),
             ExecutePresetAction.spec(),
+            PreviewPresetAction.spec(),
         ]

--- a/src/ai/backend/manager/services/prometheus_query_preset/service.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/service.py
@@ -23,6 +23,8 @@ from ai.backend.manager.services.prometheus_query_preset.actions import (
     GetPresetActionResult,
     ModifyPresetAction,
     ModifyPresetActionResult,
+    PreviewPresetAction,
+    PreviewPresetActionResult,
     SearchPresetsAction,
     SearchPresetsActionResult,
 )
@@ -95,6 +97,13 @@ class PrometheusQueryPresetService:
         filter_labels: dict[str, str],
     ) -> dict[str, LabelMatcher]:
         return {key: LabelMatcher.exact(value) for key, value in filter_labels.items()}
+
+    async def preview_preset(self, action: PreviewPresetAction) -> PreviewPresetActionResult:
+        response = await self._repository.preview_query_template(
+            query_template=action.query_template,
+            default_window=self._default_timewindow,
+        )
+        return PreviewPresetActionResult(response=response)
 
     async def execute_preset(self, action: ExecutePresetAction) -> ExecutePresetActionResult:
         preset_data = await self._repository.get_by_id(action.preset_id)

--- a/tests/component/prometheus_query_preset/conftest.py
+++ b/tests/component/prometheus_query_preset/conftest.py
@@ -66,13 +66,20 @@ class PresetFilterDataset:
 
 
 @pytest.fixture()
+def prometheus_client_mock() -> MagicMock:
+    """Shared MagicMock(spec=PrometheusClient) — tests can stub query methods on it."""
+    return MagicMock(spec=PrometheusClient)
+
+
+@pytest.fixture()
 def prometheus_query_preset_processors(
     database_engine: ExtendedAsyncSAEngine,
+    prometheus_client_mock: MagicMock,
 ) -> PrometheusQueryPresetProcessors:
-    repo = PrometheusQueryPresetRepository(database_engine)
+    repo = PrometheusQueryPresetRepository(database_engine, prometheus_client_mock)
     service = PrometheusQueryPresetService(
         repository=repo,
-        prometheus_client=MagicMock(spec=PrometheusClient),
+        prometheus_client=prometheus_client_mock,
         default_timewindow="5m",
     )
     return PrometheusQueryPresetProcessors(

--- a/tests/component/prometheus_query_preset/test_prometheus_query_preset_preview.py
+++ b/tests/component/prometheus_query_preset/test_prometheus_query_preset_preview.py
@@ -1,0 +1,68 @@
+"""Component tests for the v2 prometheus query preset preview endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.client.exceptions import BackendAPIError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.clients.prometheus.response import (
+    PrometheusQueryData,
+    PrometheusResponse,
+)
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
+    PreviewQueryDefinitionInput,
+)
+from ai.backend.common.exception import FailedToGetMetric
+
+
+class TestPrometheusQueryPresetPreview:
+    @pytest.mark.parametrize(
+        ("query_template", "result_type"),
+        [
+            # Instant vector wrapping a range vector (typical preset shape).
+            ("sum(rate(metric{{{labels}}}[{window}]))", "vector"),
+            # Plain instant vector.
+            ("metric{{{labels}}}", "vector"),
+            # Raw range vector — accepted by query_instant, returns matrix.
+            ("metric{{{labels}}}[{window}]", "matrix"),
+        ],
+    )
+    async def test_returns_prometheus_response(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        prometheus_client_mock: MagicMock,
+        query_template: str,
+        result_type: str,
+    ) -> None:
+        prometheus_client_mock.query_instant = AsyncMock(
+            return_value=PrometheusResponse(
+                status="success",
+                data=PrometheusQueryData(result_type=result_type, result=[]),
+            )
+        )
+
+        result = await admin_v2_registry.prometheus_query_preset.admin_preview(
+            PreviewQueryDefinitionInput(query_template=query_template),
+        )
+
+        assert result.status == "success"
+        assert result.data.result_type == result_type
+        prometheus_client_mock.query_instant.assert_called_once()
+
+    async def test_propagates_prometheus_error(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        prometheus_client_mock: MagicMock,
+    ) -> None:
+        prometheus_client_mock.query_instant = AsyncMock(
+            side_effect=FailedToGetMetric('parse error: unexpected "}" (status=400, path=query)'),
+        )
+
+        with pytest.raises(BackendAPIError) as exc_info:
+            await admin_v2_registry.prometheus_query_preset.admin_preview(
+                PreviewQueryDefinitionInput(query_template="sum({invalid_placeholder})"),
+            )
+        assert exc_info.value.data["type"] == FailedToGetMetric.error_type

--- a/tests/component/prometheus_query_preset/test_prometheus_query_preset_preview.py
+++ b/tests/component/prometheus_query_preset/test_prometheus_query_preset_preview.py
@@ -15,7 +15,7 @@ from ai.backend.common.dto.clients.prometheus.response import (
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     PreviewQueryDefinitionInput,
 )
-from ai.backend.common.exception import FailedToGetMetric
+from ai.backend.common.exception import FailedToGetMetric, PrometheusQueryEvaluationFailed
 
 
 class TestPrometheusQueryPresetPreview:
@@ -65,4 +65,4 @@ class TestPrometheusQueryPresetPreview:
             await admin_v2_registry.prometheus_query_preset.admin_preview(
                 PreviewQueryDefinitionInput(query_template="sum({invalid_placeholder})"),
             )
-        assert exc_info.value.data["type"] == FailedToGetMetric.error_type
+        assert exc_info.value.data["type"] == PrometheusQueryEvaluationFailed.error_type

--- a/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/prometheus_query_preset/test_request.py
@@ -17,6 +17,7 @@ from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import (
     MetricLabelEntry,
     ModifyQueryDefinitionInput,
     ModifyQueryDefinitionOptionsInput,
+    PreviewQueryDefinitionInput,
     QueryDefinitionFilter,
     QueryDefinitionOrder,
     SearchQueryDefinitionsInput,
@@ -440,3 +441,15 @@ class TestExecuteQueryDefinitionInput:
         json_str = inp.model_dump_json()
         restored = ExecuteQueryDefinitionInput.model_validate_json(json_str)
         assert restored.time_window == "1h"
+
+
+class TestPreviewQueryDefinitionInput:
+    """Tests for PreviewQueryDefinitionInput field validation."""
+
+    def test_rejects_empty_template(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate, match="empty"):
+            PreviewQueryDefinitionInput(query_template="")
+
+    def test_rejects_foreign_var(self) -> None:
+        with pytest.raises(InvalidMetricPresetTemplate, match="Unsupported"):
+            PreviewQueryDefinitionInput(query_template="rate(metric[$range])")

--- a/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_options.py
+++ b/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_options.py
@@ -7,9 +7,11 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
+from ai.backend.common.clients.prometheus.client import PrometheusClient
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.models.prometheus_query_preset import PrometheusQueryPresetRow
 from ai.backend.manager.models.prometheus_query_preset.conditions import (
@@ -99,7 +101,10 @@ class TestPrometheusQueryPresetOptions:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> PrometheusQueryPresetRepository:
-        return PrometheusQueryPresetRepository(db=db_with_cleanup)
+        return PrometheusQueryPresetRepository(
+            db=db_with_cleanup,
+            prometheus_client=MagicMock(spec=PrometheusClient),
+        )
 
     async def _seed_presets(
         self,

--- a/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
+++ b/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
@@ -15,7 +15,11 @@ from ai.backend.common.dto.clients.prometheus.response import (
     PrometheusQueryData,
     PrometheusResponse,
 )
-from ai.backend.common.exception import PrometheusQueryPresetNotFound
+from ai.backend.common.exception import (
+    FailedToGetMetric,
+    PrometheusQueryEvaluationFailed,
+    PrometheusQueryPresetNotFound,
+)
 from ai.backend.manager.data.prometheus_query_preset import (
     PrometheusQueryPresetData,
 )
@@ -310,3 +314,18 @@ class TestPrometheusQueryPresetRepositoryPreview:
         assert passed_preset.group_by == frozenset()
         assert passed_preset.window == "5m"
         assert result is canned_response
+
+    async def test_converts_failed_to_get_metric_to_evaluation_failed(
+        self,
+        repository: PrometheusQueryPresetRepository,
+        prometheus_client: MagicMock,
+    ) -> None:
+        prometheus_client.query_instant = AsyncMock(
+            side_effect=FailedToGetMetric('parse error: unexpected "}" (status=400, path=query)'),
+        )
+
+        with pytest.raises(PrometheusQueryEvaluationFailed):
+            await repository.preview_query_template(
+                query_template="sum({invalid",
+                default_window="5m",
+            )

--- a/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
+++ b/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.clients.prometheus.client import PrometheusClient
+from ai.backend.common.clients.prometheus.preset import MetricPreset
+from ai.backend.common.dto.clients.prometheus.response import (
+    PrometheusQueryData,
+    PrometheusResponse,
+)
 from ai.backend.common.exception import PrometheusQueryPresetNotFound
 from ai.backend.manager.data.prometheus_query_preset import (
     PrometheusQueryPresetData,
@@ -54,7 +61,10 @@ class TestPrometheusQueryPresetRepository:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> PrometheusQueryPresetRepository:
-        return PrometheusQueryPresetRepository(db=db_with_cleanup)
+        return PrometheusQueryPresetRepository(
+            db=db_with_cleanup,
+            prometheus_client=MagicMock(spec=PrometheusClient),
+        )
 
     @pytest.fixture
     async def sample_preset_id(
@@ -254,3 +264,49 @@ class TestPrometheusQueryPresetRepository:
     ) -> None:
         with pytest.raises(PrometheusQueryPresetNotFound):
             await preset_repository.delete(uuid.uuid4())
+
+
+class TestPrometheusQueryPresetRepositoryPreview:
+    """Tests for preview_query_template — does not touch DB."""
+
+    @pytest.fixture
+    def canned_response(self) -> PrometheusResponse:
+        return PrometheusResponse(
+            status="success",
+            data=PrometheusQueryData(result_type="vector", result=[]),
+        )
+
+    @pytest.fixture
+    def prometheus_client(self, canned_response: PrometheusResponse) -> MagicMock:
+        client = MagicMock(spec=PrometheusClient)
+        client.query_instant = AsyncMock(return_value=canned_response)
+        return client
+
+    @pytest.fixture
+    def repository(
+        self,
+        prometheus_client: MagicMock,
+    ) -> PrometheusQueryPresetRepository:
+        return PrometheusQueryPresetRepository(
+            db=MagicMock(),
+            prometheus_client=prometheus_client,
+        )
+
+    async def test_renders_empty_matchers_and_default_window(
+        self,
+        repository: PrometheusQueryPresetRepository,
+        prometheus_client: MagicMock,
+        canned_response: PrometheusResponse,
+    ) -> None:
+        result = await repository.preview_query_template(
+            query_template="sum(rate(metric{{{labels}}}[{window}]))",
+            default_window="5m",
+        )
+
+        passed_preset = prometheus_client.query_instant.call_args.kwargs["preset"]
+        assert isinstance(passed_preset, MetricPreset)
+        assert passed_preset.template == "sum(rate(metric{{{labels}}}[{window}]))"
+        assert passed_preset.labels == {}
+        assert passed_preset.group_by == frozenset()
+        assert passed_preset.window == "5m"
+        assert result is canned_response

--- a/tests/unit/manager/services/prometheus_query_preset/test_prometheus_query_preset_service.py
+++ b/tests/unit/manager/services/prometheus_query_preset/test_prometheus_query_preset_service.py
@@ -39,6 +39,7 @@ from ai.backend.manager.services.prometheus_query_preset.actions import (
     ExecutePresetAction,
     GetPresetAction,
     ModifyPresetAction,
+    PreviewPresetAction,
     SearchPresetsAction,
 )
 from ai.backend.manager.services.prometheus_query_preset.service import (
@@ -465,3 +466,25 @@ class TestPrometheusQueryPresetService:
         assert result.response == prometheus_response
         mock_prometheus_client.query_range.assert_called_once()
         mock_prometheus_client.query_instant.assert_not_called()
+
+    async def test_preview_uses_server_default_window(
+        self,
+        service: PrometheusQueryPresetService,
+        mock_repository: MagicMock,
+    ) -> None:
+        """preview_preset must pass the service's default window to the repository."""
+        mock_repository.preview_query_template = AsyncMock(
+            return_value=PrometheusResponse(
+                status="success",
+                data=PrometheusQueryData(result_type="vector", result=[]),
+            )
+        )
+
+        await service.preview_preset(
+            PreviewPresetAction(query_template="sum(rate(metric{{{labels}}}[{window}]))")
+        )
+
+        mock_repository.preview_query_template.assert_called_once_with(
+            query_template="sum(rate(metric{{{labels}}}[{window}]))",
+            default_window="1m",
+        )


### PR DESCRIPTION
resolve #11481 (BA-5950)

## Summary

Lets superadmins validate a PromQL template against Prometheus before saving it as a preset. Spans REST v2, GraphQL, SDK v2, and CLI.

- **REST**: `POST /v2/prometheus-query-presets/preview` (superadmin)
- **GQL**: Query field `adminPrometheusQueryPresetPreview(input)` (admin only)
- **CLI**: `./bai admin prometheus-query-definition preview --query-template "..."`

The repository owns the Prometheus call (`preview_query_template`): builds an empty `MetricPreset(labels={}, group_by=frozenset(), window=server_default)` and runs `query_instant`. Template validation is consolidated through the shared `validate_query_template`, which now also rejects empty templates so all template-validation failures surface a single domain exception (`InvalidMetricPresetTemplate`, 400).

### Drive-by fix
`PrometheusConnectionError` and `FailedToGetMetric` previously inherited only `BackendAIError` without a concrete `web.HTTPException` mixin, so `status_code` defaulted to the abstract sentinel `-1` and aiohttp emitted a malformed `HTTP/1.1 -1` response on Prometheus failures. Added `web.HTTPServiceUnavailable` (503) and `web.HTTPBadGateway` (502) respectively.

## Test plan

- [x] `pants fmt / lint / check` clean
- [x] Unit tests — DTO validator, Repository preview, Service preview
- [x] Component test (live aiohttp + DB) — three template shapes and Prometheus error mapping
- [x] Live verification via `./bai admin prometheus-query-definition preview` and GraphQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11482.org.readthedocs.build/en/11482/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11482.org.readthedocs.build/ko/11482/

<!-- readthedocs-preview sorna-ko end -->