### PR TITLE
fix(BA-5954): make `adminPreviewPrometheusQueryPreset` nullable

### DIFF
--- a/changes/11485.fix.md
+++ b/changes/11485.fix.md
@@ -1,0 +1,1 @@
+Fix `adminPreviewPrometheusQueryPreset` GraphQL query to return `null` for the failed field on invalid template input instead of nulling the entire response `data`, so sibling fields like `viewer` continue to resolve.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -13702,7 +13702,7 @@ type Query
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
   """
-  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8842,7 +8842,7 @@ type Query {
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
   """
-  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult!
+  adminPreviewPrometheusQueryPreset(input: PreviewQueryDefinitionInput!): QueryDefinitionExecuteResult
 
   """
   Added in 26.4.2. Get a single query preset category by ID. Available to any authenticated user.

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
@@ -119,7 +119,7 @@ async def prometheus_query_preset_result(
 async def admin_preview_prometheus_query_preset(
     info: Info[StrawberryGQLContext],
     input: PreviewQueryDefinitionInputGQL,
-) -> QueryDefinitionResultGQL:
+) -> QueryDefinitionResultGQL | None:
     check_admin_only()
     dto = await info.context.adapters.prometheus_query_preset.admin_preview(input.to_pydantic())
     return QueryDefinitionResultGQL.from_pydantic(dto)


### PR DESCRIPTION
## Summary
- Declared the resolver return type of `admin_preview_prometheus_query_preset` as `QueryDefinitionResultGQL | None` so the GraphQL field is nullable.
- Previously a non-null return caused GraphQL nullability propagation to bubble template-validation failures up to the root `data` field, nulling sibling fields (e.g. `viewer`) and making Relay treat the response as a network error.
- The exception is still surfaced in `errors`, but the failure now stays scoped to the field while siblings continue to resolve.

Resolves BA-5954.