### PR TITLE
fix(BA-5953): expose `revisionPresetId` on `ModelRevision`

### DIFF
--- a/changes/11486.fix.md
+++ b/changes/11486.fix.md
@@ -1,0 +1,1 @@
+Expose `revisionPresetId` on the `ModelRevision` GraphQL type so clients can recover the deployment-level preset selection used to create a revision without back-tracing through resource slot values.

--- a/changes/11486.fix.md
+++ b/changes/11486.fix.md
@@ -1,1 +1,1 @@
-Expose `revisionPresetId` on the `ModelRevision` GraphQL type so clients can recover the deployment-level preset selection used to create a revision without back-tracing through resource slot values.
+Expose `revisionPresetId` and a `revisionPreset` Node link on the `ModelRevision` GraphQL type so clients can recover the deployment-level preset selection used to create a revision without back-tracing through resource slot values.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5279,6 +5279,9 @@ type DeploymentRevisionPresetEnvironEntry
 input DeploymentRevisionPresetFilter
   @join__type(graph: STRAWBERRY)
 {
+  """Added in UNRELEASED. Filter by preset ID."""
+  id: UUIDFilter = null
+
   """Name filter."""
   name: StringFilter = null
 
@@ -9567,6 +9570,11 @@ type ModelRevision implements Node
   Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
   """
   imageV2: ImageV2
+
+  """
+  Added in UNRELEASED. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  """
+  revisionPreset: DeploymentRevisionPreset
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9552,6 +9552,11 @@ type ModelRevision implements Node
   """Additional volume folder mounts."""
   extraMounts: [ExtraVFolderMountInfoGQL!]!
 
+  """
+  Added in UNRELEASED. ID of the deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  """
+  revisionPresetId: UUID
+
   """Timestamp when the revision was created."""
   createdAt: DateTime!
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3535,6 +3535,9 @@ type DeploymentRevisionPresetEnvironEntry {
 
 """Added in 26.4.2. Filter for deployment revision presets."""
 input DeploymentRevisionPresetFilter {
+  """Added in UNRELEASED. Filter by preset ID."""
+  id: UUIDFilter = null
+
   """Name filter."""
   name: StringFilter = null
 
@@ -6348,6 +6351,11 @@ type ModelRevision implements Node {
   Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
   """
   imageV2: ImageV2
+
+  """
+  Added in UNRELEASED. The deployment-level preset that produced this revision, resolved via DataLoader. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  """
+  revisionPreset: DeploymentRevisionPreset
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
   resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6333,6 +6333,11 @@ type ModelRevision implements Node {
   """Additional volume folder mounts."""
   extraMounts: [ExtraVFolderMountInfoGQL!]!
 
+  """
+  Added in UNRELEASED. ID of the deployment-level preset that produced this revision. ``None`` when the revision was created without a preset, when the originating preset row has since been deleted (SET NULL FK), or for legacy rows that predate this field.
+  """
+  revisionPresetId: UUID
+
   """Timestamp when the revision was created."""
   createdAt: DateTime!
 

--- a/src/ai/backend/common/dto/manager/v2/deployment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/response.py
@@ -118,6 +118,15 @@ class RevisionNode(BaseResponseModel):
     extra_mounts: list[ExtraVFolderMountGQLDTO] = Field(
         default_factory=list, description="Extra vfolder mounts"
     )
+    revision_preset_id: UUID | None = Field(
+        default=None,
+        description=(
+            "ID of the deployment-level preset that produced this revision. "
+            "``None`` when the revision was created without a preset, when "
+            "the originating preset row has since been deleted (SET NULL FK), "
+            "or for legacy rows that predate this field."
+        ),
+    )
 
 
 class DeploymentNode(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -93,6 +93,7 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
 
 
 class DeploymentRevisionPresetFilter(BaseRequestModel):
+    id: UUIDFilter | None = Field(default=None, description="Filter by preset ID.")
     name: StringFilter | None = Field(default=None)
     runtime_variant_id: UUIDFilter | None = Field(default=None)
     AND: list[DeploymentRevisionPresetFilter] | None = Field(default=None)

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -2370,6 +2370,7 @@ class DeploymentAdapter(BaseAdapter):
                 )
                 for m in data.extra_vfolder_mounts
             ],
+            revision_preset_id=data.revision_preset_id,
         )
 
     @staticmethod

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -455,6 +455,14 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
 
     def _convert_filter(self, filter_: DeploymentRevisionPresetFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
+        if filter_.id is not None:
+            cond = self.convert_uuid_filter(
+                filter_.id,
+                equals_factory=DeploymentRevisionPresetConditions.by_id_equals,
+                in_factory=DeploymentRevisionPresetConditions.by_id_in,
+            )
+            if cond is not None:
+                conditions.append(cond)
         if filter_.runtime_variant_id is not None:
             cond = self.convert_uuid_filter(
                 filter_.runtime_variant_id,

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
     from ai.backend.manager.api.gql.deployment.types.revision import (  # pants: no-infer-dep
         ModelRevision,
     )
+    from ai.backend.manager.api.gql.deployment.types.revision_preset import (  # pants: no-infer-dep
+        DeploymentRevisionPresetGQL,
+    )
     from ai.backend.manager.api.gql.deployment.types.route import Route  # pants: no-infer-dep
     from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL  # pants: no-infer-dep
     from ai.backend.manager.api.gql.huggingface_registry import (  # pants: no-infer-dep
@@ -378,6 +381,39 @@ class DataLoaders:
 
             dtos = await adapter.batch_load_revisions_by_ids(ids)
             return [MRev.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def revision_preset_loader(
+        self,
+    ) -> DataLoader[uuid.UUID, DeploymentRevisionPresetGQL | None]:
+        adapter = self._adapters.deployment_revision_preset
+
+        async def load_fn(ids: list[uuid.UUID]) -> list[DeploymentRevisionPresetGQL | None]:
+            from ai.backend.common.dto.manager.query import UUIDFilter
+            from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (  # pants: no-infer-dep
+                DeploymentRevisionPresetFilter,
+                SearchDeploymentRevisionPresetsInput,
+            )
+            from ai.backend.common.identifier.deployment_preset import (  # pants: no-infer-dep
+                DeploymentPresetID,
+            )
+            from ai.backend.manager.api.gql.deployment.types.revision_preset import (  # pants: no-infer-dep
+                DeploymentRevisionPresetGQL as DRP,
+            )
+
+            payload = await adapter.search(
+                SearchDeploymentRevisionPresetsInput(
+                    filter=DeploymentRevisionPresetFilter(id=UUIDFilter(in_=list(ids))),
+                    limit=len(ids),
+                )
+            )
+            node_map = {item.id: item for item in payload.items}
+            return [
+                DRP.from_pydantic(node) if (node := node_map.get(DeploymentPresetID(pid))) else None
+                for pid in ids
+            ]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -396,8 +396,8 @@ class DataLoaders:
                 DeploymentRevisionPresetFilter,
                 SearchDeploymentRevisionPresetsInput,
             )
-            from ai.backend.common.identifier.deployment_preset import (  # pants: no-infer-dep
-                DeploymentPresetID,
+            from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (  # pants: no-infer-dep
+                DeploymentRevisionPresetNode,
             )
             from ai.backend.manager.api.gql.deployment.types.revision_preset import (  # pants: no-infer-dep
                 DeploymentRevisionPresetGQL as DRP,
@@ -409,11 +409,10 @@ class DataLoaders:
                     limit=len(ids),
                 )
             )
-            node_map = {item.id: item for item in payload.items}
-            return [
-                DRP.from_pydantic(node) if (node := node_map.get(DeploymentPresetID(pid))) else None
-                for pid in ids
-            ]
+            node_map: dict[uuid.UUID, DeploymentRevisionPresetNode] = {
+                item.id: item for item in payload.items
+            }
+            return [DRP.from_pydantic(node) if (node := node_map.get(pid)) else None for pid in ids]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -150,6 +150,7 @@ if TYPE_CHECKING:
 
     from .deployment import ModelDeployment
     from .policy import DeploymentPolicyGQL
+    from .revision_preset import DeploymentRevisionPresetGQL
 
 MountPermission: type[CommonMountPermission] = gql_enum(
     BackendAIGQLMeta(
@@ -515,6 +516,31 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         from ai.backend.common.types import ImageID
 
         return await info.context.data_loaders.image_loader.load(ImageID(UUID(str(self.image_id))))
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "The deployment-level preset that produced this revision, "
+                "resolved via DataLoader. ``None`` when the revision was "
+                "created without a preset, when the originating preset row "
+                "has since been deleted (SET NULL FK), or for legacy rows "
+                "that predate this field."
+            ),
+        )
+    )  # type: ignore[misc]
+    async def revision_preset(
+        self, info: Info[StrawberryGQLContext]
+    ) -> (
+        Annotated[
+            DeploymentRevisionPresetGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.deployment.types.revision_preset"),
+        ]
+        | None
+    ):
+        if self.revision_preset_id is None:
+            return None
+        return await info.context.data_loaders.revision_preset_loader.load(self.revision_preset_id)
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -472,6 +472,19 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
     extra_mounts: list[ExtraVFolderMountInfoGQL] = gql_field(
         description="Additional volume folder mounts."
     )
+    revision_preset_id: UUID | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "ID of the deployment-level preset that produced this "
+                "revision. ``None`` when the revision was created without a "
+                "preset, when the originating preset row has since been "
+                "deleted (SET NULL FK), or for legacy rows that predate "
+                "this field."
+            ),
+        ),
+        default=None,
+    )
     created_at: datetime = gql_field(description="Timestamp when the revision was created.")
 
     @gql_field(

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -367,6 +367,10 @@ class PresetValueEntryInputGQL(PydanticInputMixin[PresetValueInputDTO]):
     name="DeploymentRevisionPresetFilter",
 )
 class DeploymentRevisionPresetFilterGQL(PydanticInputMixin[FilterDTO]):
+    id: UUIDFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Filter by preset ID."),
+        default=None,
+    )
     name: StringFilterGQL | None = gql_field(default=None, description="Name filter.")
     runtime_variant_id: UUIDFilterGQL | None = gql_field(
         default=None, description="Variant ID filter."

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -432,6 +432,11 @@ class ModelRevisionSpec(ConfiguredModel):
     execution: ExecutionSpec
     model_definition: ModelDefinition | None = None
     preset_values: list[PresetValueSpec] = Field(default_factory=list)
+    # Original deployment-level preset selection used to build this revision.
+    # ``None`` for legacy rows and revisions created without a preset; the
+    # materialised effects still live on ``preset_values`` and the resolved
+    # configuration columns.
+    revision_preset_id: DeploymentPresetID | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -913,6 +918,10 @@ class ModelRevisionData:
     # this data-layer projection — keeps ``mount_perm`` visible end-to-end
     # so modify flows can carry it over without information loss.
     extra_vfolder_mounts: list[MountInfoEntry] = field(default_factory=list)
+    # Original deployment-level preset selection used to build this
+    # revision; ``None`` for legacy rows and revisions created without a
+    # preset.
+    revision_preset_id: DeploymentPresetID | None = None
 
     def to_draft(self) -> RevisionDraft:
         """Project this persisted revision onto a ``RevisionDraft`` layer.

--- a/src/ai/backend/manager/models/alembic/versions/c4d5e6f7a8b9_add_revision_preset_id_to_deployment_revisions.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4d5e6f7a8b9_add_revision_preset_id_to_deployment_revisions.py
@@ -1,0 +1,44 @@
+"""add revision_preset_id to deployment_revisions
+
+Revision ID: c4d5e6f7a8b9
+Revises: ba5923b1f4a7
+Create Date: 2026-05-06
+
+Persist the deployment-level preset selection on the revision row so the
+preset that produced a revision can be recovered after creation. The
+column is nullable because revisions created without a preset (legacy
+rows and ad-hoc revisions) carry no preset reference.
+
+A SET NULL FK is used so a preset deletion does not cascade-delete
+historical revisions; revisions are retained for history but lose the
+preset back-reference.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+# Part of: 26.4.6 (main)
+revision = "c4d5e6f7a8b9"
+down_revision = "ba5923b1f4a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "deployment_revisions",
+        sa.Column(
+            "revision_preset_id",
+            GUID,
+            sa.ForeignKey("deployment_revision_presets.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("deployment_revisions", "revision_preset_id")

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
@@ -203,6 +204,19 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
         server_default="[]",
     )
 
+    # Deployment-level preset reference. ``NULL`` after the referenced
+    # preset row is deleted (SET NULL FK), and on legacy rows that
+    # predate this column. The materialised effects of the preset live
+    # on ``preset_values`` and the resolved configuration columns; this
+    # field exists so the original preset selection can be recovered
+    # when the client edits the revision.
+    revision_preset_id: Mapped[DeploymentPresetID | None] = mapped_column(
+        "revision_preset_id",
+        GUID(DeploymentPresetID),
+        sa.ForeignKey("deployment_revision_presets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     # Metadata
     created_at: Mapped[datetime] = mapped_column(
         "created_at",
@@ -286,6 +300,7 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
                 PresetValueSpec(preset_id=pv.preset_id, value=pv.value)
                 for pv in (self.preset_values or [])
             ],
+            revision_preset_id=self.revision_preset_id,
         )
 
     def to_data(self) -> ModelRevisionData:
@@ -317,4 +332,5 @@ class DeploymentRevisionRow(Base):  # type: ignore[misc]
             image_id=self.image,
             model_definition=self.model_definition,
             extra_vfolder_mounts=list(self.extra_mounts),
+            revision_preset_id=self.revision_preset_id,
         )

--- a/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/conditions.py
@@ -101,6 +101,26 @@ class DeploymentRevisionPresetConditions:
     by_name_in = staticmethod(make_string_in_factory(DeploymentRevisionPresetRow.name))
 
     @staticmethod
+    def by_id_equals(spec: UUIDEqualMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = DeploymentRevisionPresetRow.id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_id_in(spec: UUIDInMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            condition = DeploymentRevisionPresetRow.id.in_(spec.values)
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
     def by_cursor_forward(cursor_id: str) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return DeploymentRevisionPresetRow.id < sa.text(f"'{cursor_id}'::uuid")

--- a/src/ai/backend/manager/repositories/deployment/creators/revision.py
+++ b/src/ai/backend/manager/repositories/deployment/creators/revision.py
@@ -8,6 +8,7 @@ from typing import Any, override
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -53,6 +54,7 @@ class DeploymentRevisionCreatorSpec(CreatorSpec[DeploymentRevisionRow]):
     runtime_variant_id: RuntimeVariantID
     extra_mounts: Sequence[MountInfoEntry]
     preset_values: Sequence[PresetValueEntry] = field(default_factory=list)
+    revision_preset_id: DeploymentPresetID | None = None
     revision_number: int | None = None
 
     def with_revision_number(self, revision_number: int) -> DeploymentRevisionCreatorSpec:
@@ -82,6 +84,7 @@ class DeploymentRevisionCreatorSpec(CreatorSpec[DeploymentRevisionRow]):
             runtime_variant_id=self.runtime_variant_id,
             extra_mounts=list(self.extra_mounts),
             preset_values=list(self.preset_values),
+            revision_preset_id=self.revision_preset_id,
         )
         row.resource_slot_rows = [
             DeploymentRevisionResourceSlotRow(

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -266,6 +266,7 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
             image_id=rev.image_id,
             created_at=info.metadata.created_at or datetime.now(UTC),
             model_definition=rev.model_definition,
+            revision_preset_id=rev.revision_preset_id,
         )
 
     desired_count = info.replica_spec.desired_replica_count
@@ -358,11 +359,12 @@ def _build_creator_from_revision_spec(spec: ModelRevisionSpec) -> ModelRevisionC
     """Rebuild a ``ModelRevisionCreator`` from an existing revision's spec.
 
     ``model_definition`` is reset to ``None`` so ``DeploymentController.add_revision``
-    re-resolves it from the vfolder. ``revision_preset_id`` is left ``None`` since
-    it is not persisted on the revision row; the materialized ``preset_values``
-    carry forward the preset effect without requiring re-application.
-    ``extra_mounts`` is left empty because ``add_revision`` does not propagate
-    this field to the new revision spec (see ``DeploymentController.add_revision``).
+    re-resolves it from the vfolder. ``revision_preset_id`` is carried over from the
+    persisted spec so the new revision keeps the same preset attribution; the
+    materialised ``preset_values`` are also propagated to preserve the preset
+    effect without requiring re-application. ``extra_mounts`` is left empty
+    because ``add_revision`` does not propagate this field to the new revision
+    spec (see ``DeploymentController.add_revision``).
     """
     return ModelRevisionCreator(
         image_id=spec.image_id,
@@ -375,7 +377,7 @@ def _build_creator_from_revision_spec(spec: ModelRevisionSpec) -> ModelRevisionC
         ),
         execution=spec.execution,
         model_definition=None,
-        revision_preset_id=None,
+        revision_preset_id=spec.revision_preset_id,
         preset_values=[
             PresetValueData(preset_id=pv.preset_id, value=pv.value) for pv in spec.preset_values
         ],

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -442,6 +442,7 @@ class DeploymentController:
                 PresetValueEntry(preset_id=pv.preset_id, value=pv.value)
                 for pv in (merged.preset_values or [])
             ],
+            revision_preset_id=preset_id,
         )
         rbac_creator = RBACEntityCreator(
             spec=spec,

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -415,64 +415,6 @@ class TestDeploymentRevisionRow:
             assert data.model_runtime_config.runtime_variant_id is not None
             assert data.model_runtime_config.environ == {"DEBUG": "true"}
             assert data.image_id == test_image.id
-            assert data.revision_preset_id is None
-
-    async def test_revision_preset_id_round_trips(
-        self,
-        db_with_cleanup: ExtendedAsyncSAEngine,
-        test_endpoint: EndpointRow,
-        test_image: ImageRow,
-        test_runtime_variant: RuntimeVariantRow,
-    ) -> None:
-        """``revision_preset_id`` must survive both ``to_data()`` and
-        ``to_model_revision_spec()`` projections so clients can recover the
-        originating preset selection."""
-        model_id = uuid.uuid4()
-        async with db_with_cleanup.begin_session() as db_sess:
-            preset = DeploymentRevisionPresetRow(
-                id=uuid.uuid4(),
-                runtime_variant=test_runtime_variant.id,
-                name=f"test-preset-{uuid.uuid4().hex[:8]}",
-                rank=1,
-                image_id=test_image.id,
-            )
-            db_sess.add(preset)
-            vfolder = VFolderRow(
-                id=model_id,
-                host="local:volume1",
-                domain_name=test_endpoint.domain,
-                quota_scope_id=QuotaScopeID.parse("user:00000000-0000-0000-0000-000000000001"),
-                name=f"model-vfolder-{uuid.uuid4().hex[:8]}",
-                creator="test@example.com",
-            )
-            db_sess.add(vfolder)
-            await db_sess.flush()
-
-            revision = DeploymentRevisionRow(
-                endpoint=test_endpoint.id,
-                revision_number=1,
-                image=test_image.id,
-                model=model_id,
-                model_mount_destination="/models",
-                resource_group="default",
-                resource_opts={},
-                cluster_mode=ClusterMode.SINGLE_NODE.name,
-                cluster_size=1,
-                runtime_variant_id=test_runtime_variant.id,
-                environ={},
-                extra_mounts=[],
-                revision_preset_id=preset.id,
-            )
-            revision.resource_slot_rows = [
-                DeploymentRevisionResourceSlotRow(slot_name="cpu", quantity=Decimal("1")),
-                DeploymentRevisionResourceSlotRow(slot_name="mem", quantity=Decimal("1024")),
-            ]
-            db_sess.add(revision)
-            await db_sess.flush()
-            await db_sess.refresh(revision)
-
-            assert revision.to_data().revision_preset_id == preset.id
-            assert revision.to_model_revision_spec().revision_preset_id == preset.id
 
     async def test_unique_constraint_endpoint_revision_number(
         self,

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -91,6 +92,7 @@ class TestDeploymentRevisionRow:
                 ResourceSlotTypeRow,
                 RuntimeVariantRow,
                 EndpointRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentRevisionResourceSlotRow,
                 DeploymentAutoScalingPolicyRow,

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -415,6 +415,64 @@ class TestDeploymentRevisionRow:
             assert data.model_runtime_config.runtime_variant_id is not None
             assert data.model_runtime_config.environ == {"DEBUG": "true"}
             assert data.image_id == test_image.id
+            assert data.revision_preset_id is None
+
+    async def test_revision_preset_id_round_trips(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_endpoint: EndpointRow,
+        test_image: ImageRow,
+        test_runtime_variant: RuntimeVariantRow,
+    ) -> None:
+        """``revision_preset_id`` must survive both ``to_data()`` and
+        ``to_model_revision_spec()`` projections so clients can recover the
+        originating preset selection."""
+        model_id = uuid.uuid4()
+        async with db_with_cleanup.begin_session() as db_sess:
+            preset = DeploymentRevisionPresetRow(
+                id=uuid.uuid4(),
+                runtime_variant=test_runtime_variant.id,
+                name=f"test-preset-{uuid.uuid4().hex[:8]}",
+                rank=1,
+                image_id=test_image.id,
+            )
+            db_sess.add(preset)
+            vfolder = VFolderRow(
+                id=model_id,
+                host="local:volume1",
+                domain_name=test_endpoint.domain,
+                quota_scope_id=QuotaScopeID.parse("user:00000000-0000-0000-0000-000000000001"),
+                name=f"model-vfolder-{uuid.uuid4().hex[:8]}",
+                creator="test@example.com",
+            )
+            db_sess.add(vfolder)
+            await db_sess.flush()
+
+            revision = DeploymentRevisionRow(
+                endpoint=test_endpoint.id,
+                revision_number=1,
+                image=test_image.id,
+                model=model_id,
+                model_mount_destination="/models",
+                resource_group="default",
+                resource_opts={},
+                cluster_mode=ClusterMode.SINGLE_NODE.name,
+                cluster_size=1,
+                runtime_variant_id=test_runtime_variant.id,
+                environ={},
+                extra_mounts=[],
+                revision_preset_id=preset.id,
+            )
+            revision.resource_slot_rows = [
+                DeploymentRevisionResourceSlotRow(slot_name="cpu", quantity=Decimal("1")),
+                DeploymentRevisionResourceSlotRow(slot_name="mem", quantity=Decimal("1024")),
+            ]
+            db_sess.add(revision)
+            await db_sess.flush()
+            await db_sess.refresh(revision)
+
+            assert revision.to_data().revision_preset_id == preset.id
+            assert revision.to_model_revision_spec().revision_preset_id == preset.id
 
     async def test_unique_constraint_endpoint_revision_number(
         self,

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -60,6 +60,7 @@ from ai.backend.manager.models.deployment_policy import (
     RollingUpdateSpec,
 )
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.group import GroupRow
@@ -166,6 +167,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                 KernelRow,
                 EndpointRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentRevisionResourceSlotRow,
                 RoutingRow,
@@ -1363,6 +1365,7 @@ class TestDeploymentRevisionOperations:
                 EntityFieldRow,  # DeploymentRevisionRow relationship dependency
                 AssociationScopesEntitiesRow,  # RBACEntityCreator dependency
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentRevisionResourceSlotRow,
                 DeploymentPolicyRow,
@@ -3456,6 +3459,7 @@ class TestDeploymentRepositoryDuplicateName:
                 EndpointRow,
                 EndpointTokenRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentRevisionResourceSlotRow,
                 AssociationScopesEntitiesRow,

--- a/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
@@ -23,6 +23,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -86,6 +87,7 @@ class TestEndpointSearchInProject:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/scheduling_history/test_scheduling_history_repository.py
+++ b/tests/unit/manager/repositories/scheduling_history/test_scheduling_history_repository.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -101,6 +102,7 @@ class TestSchedulingHistoryRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,


### PR DESCRIPTION
## Summary
- Persist the deployment-level preset selection on the `deployment_revisions` row (new nullable `revision_preset_id` column with SET NULL FK to `deployment_revision_presets`).
- Expose the value through `RevisionNode` (v2 DTO) and `ModelRevision` GraphQL type as `revisionPresetId`, so clients can recover the preset that produced a revision instead of back-tracing through resource slot values.
- Carry the value through revision rebuild (`_build_creator_from_revision_spec`) and creation (`DeploymentRevisionCreatorSpec` + `DeploymentController.add_revision`).

Resolves BA-5953.

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11486.org.readthedocs.build/en/11486/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11486.org.readthedocs.build/ko/11486/

<!-- readthedocs-preview sorna-ko end -->