### PR TITLE
fix(BA-5955): add shmem to image_min_mem when filling default resources

### DIFF
--- a/changes/11488.fix.md
+++ b/changes/11488.fix.md
@@ -1,0 +1,1 @@
+Fix session creation rejecting server-filled resource defaults by adding shmem to the image memory minimum during default fill, matching the validator's accounting.

--- a/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/preparers/compute_kernel_resources_rule.py
@@ -79,8 +79,9 @@ class ComputeKernelResourcesRule(SessionSpecDraftRule):
         draft: KernelExecutionSpecDraft,
         image_info: ImageInfo,
     ) -> KernelExecutionSpecDraft:
-        min_slots = image_min_slots(image_info)
+        raw_min_slots = image_min_slots(image_info)
         resolved_opts = cls._resolve_resource_opts(draft.resource_opts, image_info.labels)
+        min_slots = cls._apply_shmem_to_mem_min(raw_min_slots, resolved_opts.shmem)
         resolved_resources = cls._fill_intrinsic_slots(draft.resources, min_slots)
         return draft.model_copy(
             update={
@@ -88,6 +89,23 @@ class ComputeKernelResourcesRule(SessionSpecDraftRule):
                 "resource_opts": resolved_opts,
             }
         )
+
+    @staticmethod
+    def _apply_shmem_to_mem_min(
+        min_slots: Mapping[str, Decimal],
+        shmem: BinarySize | None,
+    ) -> dict[str, Decimal]:
+        """Inflate ``mem`` minimum by ``shmem``.
+
+        Mirrors ``ResourceLimitRule._validate_kernel`` which adds shmem to
+        ``min_slots["mem"]`` before comparing against the requested memory.
+        Without this adjustment, defaults filled from the raw image minimum
+        would be rejected by the validator.
+        """
+        adjusted: dict[str, Decimal] = dict(min_slots)
+        if shmem is not None:
+            adjusted["mem"] = adjusted.get("mem", Decimal(0)) + Decimal(int(shmem))
+        return adjusted
 
     @classmethod
     def _resolve_resource_opts(

--- a/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
+++ b/tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py
@@ -77,7 +77,7 @@ class TestComputeKernelResourcesRule:
     async def test_fills_intrinsic_slots_from_image_min(
         self, rule: ComputeKernelResourcesRule
     ) -> None:
-        """Zero/missing cpu and mem fall back to image minimums."""
+        """Zero/missing cpu and mem fall back to image minimums (with shmem added to mem)."""
         image_id = ImageID(uuid.uuid4())
         draft = _draft(
             KernelGroupDraft(
@@ -86,14 +86,56 @@ class TestComputeKernelResourcesRule:
                 execution_spec=KernelExecutionSpecDraft(image_id=image_id),
             ),
         )
-        ctx = _context({image_id: _image(image_id, cpu_min="2", mem_min="512m")})
+        ctx = _context({
+            image_id: _image(
+                image_id,
+                cpu_min="2",
+                mem_min="512m",
+                labels={"ai.backend.resource.preferred.shmem": "64m"},
+            )
+        })
         result = await rule.prepare(draft, ctx)
 
         assert result.options.kernel_groups is not None
         resources = result.options.kernel_groups[0].execution_spec.resources
         resource_map = {entry.resource_type: Decimal(entry.quantity) for entry in resources}
         assert resource_map["cpu"] == Decimal("2")
-        assert resource_map["mem"] >= Decimal("512") * Decimal(1024 * 1024)
+        # mem must include shmem so the result clears ResourceLimitRule's
+        # `mem >= image_min_mem + shmem` check.
+        expected_mem = Decimal(512 * 1024 * 1024) + Decimal(64 * 1024 * 1024)
+        assert resource_map["mem"] == expected_mem
+
+    async def test_default_fill_passes_validator_minimum(
+        self, rule: ComputeKernelResourcesRule
+    ) -> None:
+        """Default-filled mem must satisfy `image_min + shmem`."""
+        image_id = ImageID(uuid.uuid4())
+        draft = _draft(
+            KernelGroupDraft(
+                role="main",
+                replica_count=1,
+                execution_spec=KernelExecutionSpecDraft(image_id=image_id),
+            ),
+        )
+        ctx = _context({
+            image_id: _image(
+                image_id,
+                mem_min="256m",
+                labels={"ai.backend.resource.preferred.shmem": "64m"},
+            )
+        })
+        result = await rule.prepare(draft, ctx)
+
+        assert result.options.kernel_groups is not None
+        exec_spec = result.options.kernel_groups[0].execution_spec
+        resource_map = {
+            entry.resource_type: Decimal(entry.quantity) for entry in exec_spec.resources
+        }
+        assert exec_spec.resource_opts is not None
+        shmem = exec_spec.resource_opts.shmem
+        assert shmem is not None
+        image_min_mem = Decimal(256 * 1024 * 1024)
+        assert resource_map["mem"] >= image_min_mem + Decimal(int(shmem))
 
     async def test_preserves_caller_slot_values(self, rule: ComputeKernelResourcesRule) -> None:
         """Caller-set cpu / mem slots win over image minimums."""


### PR DESCRIPTION
## Summary
- `ComputeKernelResourcesRule` filled missing `mem` from the raw image minimum, but `ResourceLimitRule` validates against `image_min_mem + shmem`. Sessions created without explicit resources were rejected with `kernel_specs[0] resource request is smaller than the image minimum`.
- Mirror the validator's shmem accounting in the preparer via a new `_apply_shmem_to_mem_min` helper so default-filled `mem` clears the validator.
- Add a regression test that asserts default-filled `mem` is at least `image_min_mem + shmem`, and tighten the existing fill test to check the exact value.

## Test plan
- [x] `pants test tests/unit/manager/sokovan/scheduling_controller/preparers/test_compute_kernel_resources_rule.py`
- [x] `pants test tests/unit/manager/sokovan/scheduling_controller/validators/test_session_spec_rules.py`

Resolves BA-5955