### PR TITLE
fix(BA-5957): clean up RBAC rows when purging projects and users

### DIFF
--- a/changes/11489.fix.md
+++ b/changes/11489.fix.md
@@ -1,0 +1,1 @@
+Clean up RBAC scope associations and permissions when purging projects or users so per-entity SYSTEM roles no longer report dangling `scope: null` references.

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -76,6 +76,10 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACEntityCreator,
     execute_rbac_entity_creator,
 )
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityBatchPurger,
+    execute_rbac_entity_batch_purger,
+)
 from ai.backend.manager.repositories.base.rbac.scope_binder import (
     RBACScopeBinder,
     RBACScopeBindingPair,
@@ -576,9 +580,11 @@ class GroupDBSource:
             await self._delete_group_kernels(session, group_id)
             await self._delete_group_sessions(session, group_id)
 
-            # Finally delete the group itself
-            result = await execute_batch_purger(
-                session, BatchPurger(spec=GroupBatchPurgerSpec(group_id=group_id), batch_size=1)
+            # Finally delete the group itself with RBAC scope/permission cleanup
+            # to avoid dangling association_scopes_entities and permission rows.
+            result = await execute_rbac_entity_batch_purger(
+                session,
+                RBACEntityBatchPurger(spec=GroupBatchPurgerSpec(group_id=group_id), batch_size=1),
             )
 
             if result.deleted_count > 0:

--- a/src/ai/backend/manager/repositories/group/purgers.py
+++ b/src/ai/backend/manager/repositories/group/purgers.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.permission.types import EntityType, ScopeType
+from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -16,6 +16,7 @@ from ai.backend.manager.models.rbac_models.association_scopes_entities import (
 )
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base.purger import BatchPurgerSpec
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityBatchPurgerSpec
 
 
 @dataclass
@@ -63,14 +64,18 @@ class GroupEndpointBatchPurgerSpec(BatchPurgerSpec[EndpointRow]):
 
 
 @dataclass
-class GroupBatchPurgerSpec(BatchPurgerSpec[GroupRow]):
-    """PurgerSpec for deleting a group."""
+class GroupBatchPurgerSpec(RBACEntityBatchPurgerSpec[GroupRow]):
+    """PurgerSpec for deleting a group with RBAC scope/permission cleanup."""
 
     group_id: UUID
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[GroupRow]]:
         return sa.select(GroupRow).where(GroupRow.id == self.group_id)
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.PROJECT
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -102,6 +102,10 @@ from ai.backend.manager.repositories.base.rbac.entity_creator import (
     RBACEntityCreator,
     execute_rbac_entity_creator,
 )
+from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityBatchPurger,
+    execute_rbac_entity_batch_purger,
+)
 from ai.backend.manager.repositories.base.rbac.scope_binder import (
     RBACScopeBinder,
     RBACScopeBindingPair,
@@ -119,10 +123,10 @@ from ai.backend.manager.repositories.permission_controller.creators import UserR
 from ai.backend.manager.repositories.permission_controller.role_manager import RoleManager
 from ai.backend.manager.repositories.user.creators import UserCreatorSpec
 from ai.backend.manager.repositories.user.purgers import (
+    UserBatchPurgerSpec,
     create_user_error_log_purger,
     create_user_group_association_purger,
     create_user_keypair_purger,
-    create_user_purger,
     create_user_vfolder_permission_purger,
 )
 from ai.backend.manager.repositories.user.types import (
@@ -632,8 +636,12 @@ class UserDBSource:
             await execute_batch_purger(session, create_user_vfolder_permission_purger(user_uuid))
             await execute_batch_purger(session, create_user_group_association_purger(user_uuid))
 
-            # Finally delete the user
-            await execute_batch_purger(session, create_user_purger(user_uuid))
+            # Finally delete the user itself with RBAC scope/permission cleanup
+            # to avoid dangling association_scopes_entities and permission rows.
+            await execute_rbac_entity_batch_purger(
+                session,
+                RBACEntityBatchPurger(spec=UserBatchPurgerSpec(user_uuid=user_uuid), batch_size=1),
+            )
 
     async def purge_user_by_uuid(self, user_uuid: UUID) -> None:
         """Completely purge user and all associated data by UUID."""
@@ -644,8 +652,12 @@ class UserDBSource:
             await execute_batch_purger(session, create_user_vfolder_permission_purger(user_uuid))
             await execute_batch_purger(session, create_user_group_association_purger(user_uuid))
 
-            # Finally delete the user
-            await execute_batch_purger(session, create_user_purger(user_uuid))
+            # Finally delete the user itself with RBAC scope/permission cleanup
+            # to avoid dangling association_scopes_entities and permission rows.
+            await execute_rbac_entity_batch_purger(
+                session,
+                RBACEntityBatchPurger(spec=UserBatchPurgerSpec(user_uuid=user_uuid), batch_size=1),
+            )
 
     async def check_user_vfolder_mounted_to_active_kernels(self, user_uuid: UUID) -> bool:
         """Check if user's vfolders are mounted to active kernels."""

--- a/src/ai/backend/manager/repositories/user/purgers.py
+++ b/src/ai/backend/manager/repositories/user/purgers.py
@@ -6,12 +6,14 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.models.error_logs import ErrorLogRow
 from ai.backend.manager.models.group import AssocGroupUserRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.vfolder import VFolderPermissionRow
 from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityBatchPurgerSpec
 
 
 @dataclass
@@ -59,14 +61,18 @@ class UserGroupAssociationBatchPurgerSpec(BatchPurgerSpec[AssocGroupUserRow]):
 
 
 @dataclass
-class UserBatchPurgerSpec(BatchPurgerSpec[UserRow]):
-    """PurgerSpec for deleting a user."""
+class UserBatchPurgerSpec(RBACEntityBatchPurgerSpec[UserRow]):
+    """PurgerSpec for deleting a user with RBAC scope/permission cleanup."""
 
     user_uuid: UUID
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[UserRow]]:
         return sa.select(UserRow).where(UserRow.uuid == self.user_uuid)
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.USER
 
 
 def create_user_error_log_purger(user_uuid: UUID) -> BatchPurger[ErrorLogRow]:

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -1,0 +1,187 @@
+"""Component tests for project purge endpoint.
+
+Tests: POST /v2/projects/purge
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
+
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.permission.types import RBACElementType, RelationType
+from ai.backend.common.dto.manager.v2.group.request import PurgeProjectInput
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.models.group.row import GroupRow
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+
+
+@pytest.fixture()
+async def project_with_rbac_rows(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    resource_policy_fixture: str,
+) -> AsyncIterator[tuple[uuid.UUID, str]]:
+    """Insert a project along with the RBAC rows that the create flow would
+    normally generate (two SYSTEM roles at the project's scope, scope-entity
+    associations binding them, and scope-bound permissions). The test then
+    exercises purge against this fully-controlled state.
+    """
+    project_id = uuid.uuid4()
+    scope_id = str(project_id)
+    admin_role_id = uuid.uuid4()
+    member_role_id = uuid.uuid4()
+    unique = secrets.token_hex(4)
+
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(GroupRow.__table__).values(
+                id=project_id,
+                name=f"rbac-purge-{unique}",
+                description="Test project for RBAC purge cleanup",
+                is_active=True,
+                domain_name=domain_fixture,
+                resource_policy=resource_policy_fixture,
+            )
+        )
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values([
+                {
+                    "id": admin_role_id,
+                    "name": f"project-{scope_id[:8]}-admin",
+                    "status": RoleStatus.ACTIVE,
+                },
+                {
+                    "id": member_role_id,
+                    "name": f"project-{scope_id[:8]}-member",
+                    "status": RoleStatus.ACTIVE,
+                },
+            ])
+        )
+        # Both per-project SYSTEM roles are registered in the project's own scope.
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values([
+                {
+                    "scope_type": ScopeType.PROJECT,
+                    "scope_id": scope_id,
+                    "entity_type": EntityType.ROLE,
+                    "entity_id": str(admin_role_id),
+                    "relation_type": RelationType.AUTO,
+                },
+                {
+                    "scope_type": ScopeType.PROJECT,
+                    "scope_id": scope_id,
+                    "entity_type": EntityType.ROLE,
+                    "entity_id": str(member_role_id),
+                    "relation_type": RelationType.AUTO,
+                },
+                # Project registered as an entity in the domain scope.
+                {
+                    "scope_type": ScopeType.DOMAIN,
+                    "scope_id": domain_fixture,
+                    "entity_type": EntityType.PROJECT,
+                    "entity_id": scope_id,
+                    "relation_type": RelationType.AUTO,
+                },
+            ])
+        )
+        await conn.execute(
+            sa.insert(PermissionRow.__table__).values([
+                {
+                    "role_id": admin_role_id,
+                    "scope_type": ScopeType.PROJECT,
+                    "scope_id": scope_id,
+                    "entity_type": EntityType.PROJECT,
+                    "operation": OperationType.UPDATE,
+                },
+                {
+                    "role_id": member_role_id,
+                    "scope_type": ScopeType.PROJECT,
+                    "scope_id": scope_id,
+                    "entity_type": EntityType.PROJECT,
+                    "operation": OperationType.READ,
+                },
+            ])
+        )
+
+    yield project_id, scope_id
+
+    async with db_engine.begin() as conn:
+        # Permissions cascade-delete with the role; explicit delete is a safety net.
+        await conn.execute(
+            PermissionRow.__table__.delete().where(
+                PermissionRow.__table__.c.role_id.in_([admin_role_id, member_role_id])
+            )
+        )
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                sa.or_(
+                    AssociationScopesEntitiesRow.__table__.c.scope_id == scope_id,
+                    AssociationScopesEntitiesRow.__table__.c.entity_id == scope_id,
+                )
+            )
+        )
+        await conn.execute(
+            RoleRow.__table__.delete().where(
+                RoleRow.__table__.c.id.in_([admin_role_id, member_role_id])
+            )
+        )
+        await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == project_id))
+
+
+class TestProjectPurgeRBACCleanup:
+    async def test_admin_purge_cleans_up_rbac_rows(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        project_with_rbac_rows: tuple[uuid.UUID, str],
+        db_engine: SAEngine,
+    ) -> None:
+        """Purge must remove scope-entity associations and scope-bound permissions
+        for the project, so the per-project SYSTEM roles do not end up with
+        dangling scope references that resolve to NULL via GraphQL.
+        """
+        project_id, scope_id = project_with_rbac_rows
+
+        await admin_v2_registry.project.admin_purge(PurgeProjectInput(group_id=project_id))
+
+        async with db_engine.connect() as conn:
+            group_row = await conn.scalar(
+                sa.select(sa.func.count()).select_from(GroupRow).where(GroupRow.id == project_id)
+            )
+            ase_after = await conn.scalar(
+                sa.select(sa.func.count())
+                .select_from(AssociationScopesEntitiesRow)
+                .where(
+                    sa.or_(
+                        sa.and_(
+                            AssociationScopesEntitiesRow.scope_type == RBACElementType.PROJECT,
+                            AssociationScopesEntitiesRow.scope_id == scope_id,
+                        ),
+                        sa.and_(
+                            AssociationScopesEntitiesRow.entity_type == RBACElementType.PROJECT,
+                            AssociationScopesEntitiesRow.entity_id == scope_id,
+                        ),
+                    )
+                )
+            )
+            permissions_after = await conn.scalar(
+                sa.select(sa.func.count())
+                .select_from(PermissionRow)
+                .where(
+                    PermissionRow.scope_type == RBACElementType.PROJECT,
+                    PermissionRow.scope_id == scope_id,
+                )
+            )
+        assert group_row == 0, "Group row should be removed after purge"
+        assert ase_after == 0, "association_scopes_entities rows should be cleaned up after purge"
+        assert permissions_after == 0, "scope-bound permissions should be cleaned up after purge"

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import secrets
 import uuid
+from collections.abc import AsyncIterator
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.exceptions import NotFoundError, PermissionDeniedError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.common.data.permission.types import RBACElementType, RelationType
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.user import (
     CreateUserRequest,
@@ -27,6 +31,16 @@ from ai.backend.common.dto.manager.user import (
     UserRole,
     UserStatus,
 )
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.user import users
 
 from .conftest import UserFactory
 
@@ -343,6 +357,100 @@ class TestUserDelete:
             await user_registry.user.delete(DeleteUserRequest(user_id=target_user.user.id))
 
 
+@pytest.fixture()
+async def user_with_rbac_rows(
+    db_engine: SAEngine,
+    domain_fixture: str,
+    resource_policy_fixture: str,
+) -> AsyncIterator[tuple[uuid.UUID, str]]:
+    """Insert a user along with the RBAC rows that the create flow would
+    normally generate (a SYSTEM role at the user's scope, two scope-entity
+    associations, and a scope-bound permission). The test then exercises
+    purge against this fully-controlled state.
+    """
+    user_id = uuid.uuid4()
+    scope_id = str(user_id)
+    role_id = uuid.uuid4()
+    unique = secrets.token_hex(4)
+    email = f"rbac-purge-{unique}@test.local"
+    async with db_engine.begin() as conn:
+        await conn.execute(
+            sa.insert(users).values(
+                uuid=str(user_id),
+                username=f"rbac-purge-{unique}",
+                email=email,
+                password=PasswordInfo(
+                    password=secrets.token_urlsafe(8),
+                    algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                    rounds=600_000,
+                    salt_size=32,
+                ),
+                need_password_change=False,
+                full_name=f"RBAC Purge {unique}",
+                description="Test user for RBAC purge cleanup",
+                status=UserStatus.ACTIVE,
+                status_info="admin-requested",
+                domain_name=domain_fixture,
+                resource_policy=resource_policy_fixture,
+                role=UserRole.USER,
+            )
+        )
+        await conn.execute(
+            sa.insert(RoleRow.__table__).values(
+                id=role_id,
+                name=f"user-{scope_id[:8]}",
+                status=RoleStatus.ACTIVE,
+            )
+        )
+        # Role registered in the user's own scope (the per-user SYSTEM role binding).
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.USER,
+                scope_id=scope_id,
+                entity_type=EntityType.ROLE,
+                entity_id=str(role_id),
+                relation_type=RelationType.AUTO,
+            )
+        )
+        # User registered as an entity in the domain scope.
+        await conn.execute(
+            sa.insert(AssociationScopesEntitiesRow.__table__).values(
+                scope_type=ScopeType.DOMAIN,
+                scope_id=domain_fixture,
+                entity_type=EntityType.USER,
+                entity_id=scope_id,
+                relation_type=RelationType.AUTO,
+            )
+        )
+        await conn.execute(
+            sa.insert(PermissionRow.__table__).values(
+                role_id=role_id,
+                scope_type=ScopeType.USER,
+                scope_id=scope_id,
+                entity_type=EntityType.USER,
+                operation=OperationType.READ,
+            )
+        )
+
+    yield user_id, scope_id
+
+    async with db_engine.begin() as conn:
+        # Permissions cascade-delete with the role; explicit delete is a safety net.
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                sa.or_(
+                    AssociationScopesEntitiesRow.__table__.c.scope_id == scope_id,
+                    AssociationScopesEntitiesRow.__table__.c.entity_id == scope_id,
+                )
+            )
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+        await conn.execute(users.delete().where(users.c.uuid == str(user_id)))
+
+
 class TestUserPurge:
     async def test_admin_purges_user(
         self,
@@ -363,6 +471,48 @@ class TestUserPurge:
     ) -> None:
         with pytest.raises(PermissionDeniedError):
             await user_registry.user.purge(PurgeUserRequest(user_id=target_user.user.id))
+
+    async def test_admin_purge_cleans_up_rbac_rows(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        user_with_rbac_rows: tuple[uuid.UUID, str],
+        db_engine: SAEngine,
+    ) -> None:
+        """Purge must remove scope-entity associations and scope-bound permissions
+        for the user, so the per-user SYSTEM role does not end up with dangling
+        scope references that resolve to NULL via GraphQL.
+        """
+        user_id, scope_id = user_with_rbac_rows
+
+        await admin_registry.user.purge(PurgeUserRequest(user_id=user_id))
+
+        async with db_engine.connect() as conn:
+            ase_after = await conn.scalar(
+                sa.select(sa.func.count())
+                .select_from(AssociationScopesEntitiesRow)
+                .where(
+                    sa.or_(
+                        sa.and_(
+                            AssociationScopesEntitiesRow.scope_type == RBACElementType.USER,
+                            AssociationScopesEntitiesRow.scope_id == scope_id,
+                        ),
+                        sa.and_(
+                            AssociationScopesEntitiesRow.entity_type == RBACElementType.USER,
+                            AssociationScopesEntitiesRow.entity_id == scope_id,
+                        ),
+                    )
+                )
+            )
+            permissions_after = await conn.scalar(
+                sa.select(sa.func.count())
+                .select_from(PermissionRow)
+                .where(
+                    PermissionRow.scope_type == RBACElementType.USER,
+                    PermissionRow.scope_id == scope_id,
+                )
+            )
+        assert ase_after == 0, "association_scopes_entities rows should be cleaned up after purge"
+        assert permissions_after == 0, "scope-bound permissions should be cleaned up after purge"
 
 
 class TestUserBulkOperations:


### PR DESCRIPTION
## Summary
- Project and user purges left dangling `association_scopes_entities` and scope-bound `permissions` rows, causing GraphQL `role.scopes.edges[].node.scope` to resolve to NULL on the per-entity SYSTEM roles (`project-{id}-admin/member`, `user-{id}`).
- Switch the final group/user delete step to `RBACEntityBatchPurger` so scope-entity associations and scope-bound permissions are cleaned up alongside the row deletion.
- SYSTEM `roles` rows are intentionally retained (audit history); their `scopes` connection naturally returns an empty list once the underlying ASE rows are gone — no more dangling `scope: null`.

## Test plan
- [x] Verified end-to-end against a live manager: project create → delete → purge, and user create → delete → purge via `adminPurgeUserV2`.
- [x] Confirmed DB rows after purge: `groups`/`users` = 0, `association_scopes_entities` (both directions) = 0, `permissions` (scope=entity) = 0, SYSTEM `roles` retained as orphan.
- [x] Confirmed GraphQL `adminRoles` returns `scopes.edges = []` (no `scope: null`) for purged entities.
- [x] Existing unit tests pass (`tests/unit/manager/repositories/{group,user}/test_*_purgers.py`).

Resolves BA-5957