### PR TITLE
fix(BA-5963): report current_revision_id correctly during rolling updates

### DIFF
--- a/changes/11494.fix.md
+++ b/changes/11494.fix.md
@@ -1,0 +1,1 @@
+Stop reporting the deploying revision id (or `null`) under `current_revision_id` on REST/GraphQL deployment responses during a rolling update.

--- a/changes/11494.fix.md
+++ b/changes/11494.fix.md
@@ -1,1 +1,1 @@
-Stop reporting the deploying revision id (or `null`) under `current_revision_id` on REST/GraphQL deployment responses during a rolling update.
+Report `current_revision_id` correctly on deployment responses during rolling updates.

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -2191,7 +2191,7 @@ class DeploymentAdapter(BaseAdapter):
             created_user_id=data.created_user_id,
             options=deployment_options_to_info(data.options),
             scaling_state=data.scaling_state,
-            current_revision_id=data.revision.id if data.revision is not None else None,
+            current_revision_id=data.current_revision_id,
             deploying_revision_id=data.deploying_revision_id,
             policy=policy_info,
         )

--- a/src/ai/backend/manager/api/rest/service/handler.py
+++ b/src/ai/backend/manager/api/rest/service/handler.py
@@ -68,6 +68,7 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentNetworkSpec,
     ExecutionSpec,
     ImageIdentifierDraft,
+    ModelRevisionSpec,
     ModelRevisionSpecDraft,
     MountMetadata,
     ReplicaSpec,
@@ -167,6 +168,14 @@ def _serve_info_from_dto(dto: ServiceInfo, runtime_variant_name: RuntimeVariant)
     )
 
 
+def _resolve_active_revision_spec(info: DeploymentInfo) -> ModelRevisionSpec | None:
+    """Resolve the active revision spec by id (current first, then deploying)."""
+    target_id = info.current_revision_id or info.deploying_revision_id
+    if target_id is None:
+        return None
+    return next((r for r in info.model_revisions if r.revision_id == target_id), None)
+
+
 def _serve_info_from_deployment_info(
     deployment_info: DeploymentInfo,
     runtime_variant_name: RuntimeVariant,
@@ -177,7 +186,7 @@ def _serve_info_from_deployment_info(
     active revision's ``runtime_variant_id`` (internal data types are
     id-only; the legacy REST response still exposes the name string).
     """
-    model_revision = deployment_info.model_revisions[0] if deployment_info.model_revisions else None
+    model_revision = _resolve_active_revision_spec(deployment_info)
 
     return ServeInfoModel(
         endpoint_id=deployment_info.id,
@@ -378,9 +387,7 @@ class ServiceHandler:
             await self._deployment.create_legacy_deployment.wait_for_complete(deployment_action)
         )
         deployment_info = deployment_result.data
-        model_revision = (
-            deployment_info.model_revisions[0] if deployment_info.model_revisions else None
-        )
+        model_revision = _resolve_active_revision_spec(deployment_info)
         if model_revision is None:
             raise RuntimeVariantNotFound()
         runtime_variant_name = await self._resolve_runtime_variant_name(

--- a/src/ai/backend/manager/api/rest/service/handler.py
+++ b/src/ai/backend/manager/api/rest/service/handler.py
@@ -168,8 +168,8 @@ def _serve_info_from_dto(dto: ServiceInfo, runtime_variant_name: RuntimeVariant)
     )
 
 
-def _resolve_active_revision_spec(info: DeploymentInfo) -> ModelRevisionSpec | None:
-    """Resolve the active revision spec by id (current first, then deploying)."""
+def _resolve_target_revision_spec(info: DeploymentInfo) -> ModelRevisionSpec | None:
+    """Resolve the target revision spec by id (current first, then deploying)."""
     target_id = info.current_revision_id or info.deploying_revision_id
     if target_id is None:
         return None
@@ -186,7 +186,7 @@ def _serve_info_from_deployment_info(
     active revision's ``runtime_variant_id`` (internal data types are
     id-only; the legacy REST response still exposes the name string).
     """
-    model_revision = _resolve_active_revision_spec(deployment_info)
+    model_revision = _resolve_target_revision_spec(deployment_info)
 
     return ServeInfoModel(
         endpoint_id=deployment_info.id,
@@ -387,7 +387,7 @@ class ServiceHandler:
             await self._deployment.create_legacy_deployment.wait_for_complete(deployment_action)
         )
         deployment_info = deployment_result.data
-        model_revision = _resolve_active_revision_spec(deployment_info)
+        model_revision = _resolve_target_revision_spec(deployment_info)
         if model_revision is None:
             raise RuntimeVariantNotFound()
         runtime_variant_name = await self._resolve_runtime_variant_name(

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -959,6 +959,11 @@ class ModelDeploymentData:
     metadata: ModelDeploymentMetadataInfo
     network_access: DeploymentNetworkSpec
     revision: ModelRevisionData | None
+    # Identity of the active revision, mirrored directly from
+    # ``endpoints.current_revision``. Decoupled from ``revision`` so the API
+    # can surface the DB-truth ID even if the matching ``ModelRevisionSpec``
+    # is missing (e.g. dangling reference after a revision row was removed).
+    current_revision_id: DeploymentRevisionID | None
     deploying_revision_id: DeploymentRevisionID | None
     revision_history_ids: list[DeploymentRevisionID]
     scaling_rule_ids: list[UUID]

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -959,10 +959,6 @@ class ModelDeploymentData:
     metadata: ModelDeploymentMetadataInfo
     network_access: DeploymentNetworkSpec
     revision: ModelRevisionData | None
-    # Identity of the active revision, mirrored directly from
-    # ``endpoints.current_revision``. Decoupled from ``revision`` so the API
-    # can surface the DB-truth ID even if the matching ``ModelRevisionSpec``
-    # is missing (e.g. dangling reference after a revision row was removed).
     current_revision_id: DeploymentRevisionID | None
     deploying_revision_id: DeploymentRevisionID | None
     revision_history_ids: list[DeploymentRevisionID]

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -291,7 +291,7 @@ class EndpointRow(Base):  # type: ignore[misc]
         "DeploymentRevisionRow",
         back_populates="endpoint_row",
         primaryjoin=_get_endpoint_revisions_join_condition,
-        order_by="DeploymentRevisionRow.revision_number",
+        order_by="DeploymentRevisionRow.revision_number.desc()",
     )
 
     auto_scaling_policy: Mapped[DeploymentAutoScalingPolicyRow | None] = relationship(

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -291,6 +291,7 @@ class EndpointRow(Base):  # type: ignore[misc]
         "DeploymentRevisionRow",
         back_populates="endpoint_row",
         primaryjoin=_get_endpoint_revisions_join_condition,
+        order_by="DeploymentRevisionRow.revision_number",
     )
 
     auto_scaling_policy: Mapped[DeploymentAutoScalingPolicyRow | None] = relationship(

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -233,10 +233,28 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
 
     Note: Some fields are set to defaults as DeploymentInfo doesn't have all the data.
     """
-    # Map revision if available
+    # Resolve the revision spec for the *current* revision specifically.
+    # ``info.model_revisions`` may also contain the deploying revision during a
+    # rolling update, and PostgreSQL returns those rows in undefined order, so
+    # picking ``model_revisions[0]`` would non-deterministically expose the
+    # deploying revision under ``current_revision_id``.
     revision: ModelRevisionData | None = None
-    if info.model_revisions:
-        rev = info.model_revisions[0]
+    rev: ModelRevisionSpec | None = None
+    if info.current_revision_id is not None:
+        rev = next(
+            (r for r in info.model_revisions if r.revision_id == info.current_revision_id),
+            None,
+        )
+        if rev is None:
+            log.warning(
+                "Deployment {} has current_revision_id {} but no matching "
+                "ModelRevisionSpec was found in DeploymentInfo.model_revisions; "
+                "current_revision will be reported as null. This usually means "
+                "EndpointRow.revisions was not eagerly loaded by the caller.",
+                info.id,
+                info.current_revision_id,
+            )
+    if rev is not None:
         if rev.revision_id is None:
             raise ValueError(f"ModelRevisionSpec has no revision_id for deployment {info.id}")
         revision = ModelRevisionData(

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -233,11 +233,6 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
 
     Note: Some fields are set to defaults as DeploymentInfo doesn't have all the data.
     """
-    # Resolve the revision spec for the *current* revision specifically.
-    # ``info.model_revisions`` may also contain the deploying revision during a
-    # rolling update, and PostgreSQL returns those rows in undefined order, so
-    # picking ``model_revisions[0]`` would non-deterministically expose the
-    # deploying revision under ``current_revision_id``.
     revision: ModelRevisionData | None = None
     rev: ModelRevisionSpec | None = None
     if info.current_revision_id is not None:

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -301,6 +301,7 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
         network_access=info.network,
         revision_history_ids=[info.current_revision_id] if info.current_revision_id else [],
         revision=revision,
+        current_revision_id=info.current_revision_id,
         deploying_revision_id=info.deploying_revision_id,
         scaling_rule_ids=[],  # Not available in DeploymentInfo
         replica_state=ReplicaStateData(

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -246,7 +246,7 @@ def _convert_deployment_info_to_data(info: DeploymentInfo) -> ModelDeploymentDat
             None,
         )
         if rev is None:
-            log.warning(
+            log.error(
                 "Deployment {} has current_revision_id {} but no matching "
                 "ModelRevisionSpec was found in DeploymentInfo.model_revisions; "
                 "current_revision will be reported as null. This usually means "

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -7,6 +7,7 @@ Tests verify service layer business logic using mocked repositories.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -645,20 +646,11 @@ class TestCreateAccessToken(DeploymentServiceBaseFixtures):
 class TestConvertDeploymentInfoToData:
     """Regression test for ``_convert_deployment_info_to_data`` (BA-5963)."""
 
-    def test_current_revision_resolved_by_id_match_not_list_order(self) -> None:
-        """During a rolling update, ``DeploymentInfo.model_revisions`` may carry
-        both the current and deploying revisions. PostgreSQL returns those rows
-        in undefined order, so the conversion must resolve the current revision
-        by an explicit ``current_revision_id`` match — picking
-        ``model_revisions[0]`` non-deterministically leaks the deploying
-        revision into ``current_revision_id`` on the public response (BA-5963).
-        """
-        deploying_revision_id = DeploymentRevisionID(uuid.uuid4())
-        current_revision_id = DeploymentRevisionID(uuid.uuid4())
-
-        def make_spec(revision_id: DeploymentRevisionID) -> ModelRevisionSpec:
+    @pytest.fixture
+    def make_revision_spec(self) -> Callable[[], ModelRevisionSpec]:
+        def make() -> ModelRevisionSpec:
             return ModelRevisionSpec(
-                revision_id=revision_id,
+                revision_id=DeploymentRevisionID(uuid.uuid4()),
                 image_id=ImageID(uuid.uuid4()),
                 resource_spec=ResourceSpec(
                     cluster_mode=ClusterMode.SINGLE_NODE,
@@ -676,10 +668,16 @@ class TestConvertDeploymentInfoToData:
                 ),
             )
 
-        deploying_spec = make_spec(deploying_revision_id)
-        current_spec = make_spec(current_revision_id)
+        return make
 
-        # Adversarial ordering: deploying revision listed first.
+    def test_current_revision_resolved_by_id_match_not_list_order(
+        self,
+        make_revision_spec: Callable[[], ModelRevisionSpec],
+    ) -> None:
+        """Pin: revision lookup must use explicit ``current_revision_id``, not list[0]."""
+        deploying_spec = make_revision_spec()
+        current_spec = make_revision_spec()
+
         deployment_info = DeploymentInfo(
             id=DeploymentID(uuid.uuid4()),
             metadata=DeploymentMetadata(
@@ -701,14 +699,14 @@ class TestConvertDeploymentInfoToData:
             network=DeploymentNetworkSpec(open_to_public=False),
             model_revisions=[deploying_spec, current_spec],
             options=DeploymentOptions(),
-            current_revision_id=current_revision_id,
-            deploying_revision_id=deploying_revision_id,
+            current_revision_id=current_spec.revision_id,
+            deploying_revision_id=deploying_spec.revision_id,
         )
 
         deployment_data = _convert_deployment_info_to_data(deployment_info)
 
-        assert deployment_data.current_revision_id == current_revision_id
-        assert deployment_data.deploying_revision_id == deploying_revision_id
+        assert deployment_data.current_revision_id == current_spec.revision_id
+        assert deployment_data.deploying_revision_id == deploying_spec.revision_id
         assert deployment_data.current_revision_id != deployment_data.deploying_revision_id
         assert deployment_data.revision is not None
-        assert deployment_data.revision.id == current_revision_id
+        assert deployment_data.revision.id == current_spec.revision_id

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -21,6 +21,7 @@ from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.response import (
 )
 from ai.backend.common.dto.manager.v2.deployment.types import IntOrPercent
 from ai.backend.common.identifier.deployment import DeploymentID
+from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -50,7 +51,9 @@ from ai.backend.manager.data.deployment.types import (
     ExecutionSpec,
     ModelMountConfigData,
     ModelRevisionData,
+    ModelRevisionSpec,
     ModelRuntimeConfigData,
+    MountMetadata,
     ReplicaSpec,
     ResourceConfigData,
     ResourceSpec,
@@ -76,7 +79,10 @@ from ai.backend.manager.services.deployment.actions.model_revision.add_model_rev
     AddModelRevisionAction,
 )
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
-from ai.backend.manager.services.deployment.service import DeploymentService
+from ai.backend.manager.services.deployment.service import (
+    DeploymentService,
+    _convert_deployment_info_to_data,
+)
 from ai.backend.manager.sokovan.deployment import DeploymentController
 
 
@@ -634,3 +640,75 @@ class TestCreateAccessToken(DeploymentServiceBaseFixtures):
         creator = cast(RBACEntityCreator[object], repo_call.args[0])
         spec = cast(EndpointTokenCreatorSpec, creator.spec)
         assert spec.token == sample_coordinator_jwt
+
+
+class TestConvertDeploymentInfoToData:
+    """Regression test for ``_convert_deployment_info_to_data`` (BA-5963)."""
+
+    def test_current_revision_resolved_by_id_match_not_list_order(self) -> None:
+        """During a rolling update, ``DeploymentInfo.model_revisions`` may carry
+        both the current and deploying revisions. PostgreSQL returns those rows
+        in undefined order, so the conversion must resolve the current revision
+        by an explicit ``current_revision_id`` match — picking
+        ``model_revisions[0]`` non-deterministically leaks the deploying
+        revision into ``current_revision_id`` on the public response (BA-5963).
+        """
+        deploying_revision_id = DeploymentRevisionID(uuid.uuid4())
+        current_revision_id = DeploymentRevisionID(uuid.uuid4())
+
+        def make_spec(revision_id: DeploymentRevisionID) -> ModelRevisionSpec:
+            return ModelRevisionSpec(
+                revision_id=revision_id,
+                image_id=ImageID(uuid.uuid4()),
+                resource_spec=ResourceSpec(
+                    cluster_mode=ClusterMode.SINGLE_NODE,
+                    cluster_size=1,
+                    resource_slots={"cpu": "1"},
+                ),
+                mounts=MountMetadata(
+                    model_vfolder_id=VFolderUUID(uuid.uuid4()),
+                    model_definition_path="model-definition.yaml",
+                    model_mount_destination="/models",
+                    extra_mounts=[],
+                ),
+                execution=ExecutionSpec(
+                    runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+                ),
+            )
+
+        deploying_spec = make_spec(deploying_revision_id)
+        current_spec = make_spec(current_revision_id)
+
+        # Adversarial ordering: deploying revision listed first.
+        deployment_info = DeploymentInfo(
+            id=DeploymentID(uuid.uuid4()),
+            metadata=DeploymentMetadata(
+                name="ba5963-test",
+                domain="default",
+                project=uuid.uuid4(),
+                resource_group="default",
+                created_user=uuid.uuid4(),
+                session_owner=uuid.uuid4(),
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                revision_history_limit=10,
+            ),
+            state=DeploymentState(
+                lifecycle=EndpointLifecycle.DEPLOYING,
+                scaling_state=ScalingState.STABLE,
+                retry_count=0,
+            ),
+            replica_spec=ReplicaSpec(replica_count=1),
+            network=DeploymentNetworkSpec(open_to_public=False),
+            model_revisions=[deploying_spec, current_spec],
+            options=DeploymentOptions(),
+            current_revision_id=current_revision_id,
+            deploying_revision_id=deploying_revision_id,
+        )
+
+        deployment_data = _convert_deployment_info_to_data(deployment_info)
+
+        assert deployment_data.current_revision_id == current_revision_id
+        assert deployment_data.deploying_revision_id == deploying_revision_id
+        assert deployment_data.current_revision_id != deployment_data.deploying_revision_id
+        assert deployment_data.revision is not None
+        assert deployment_data.revision.id == current_revision_id


### PR DESCRIPTION
## Summary
- `_convert_deployment_info_to_data` picked `info.model_revisions[0]` as the current revision spec. During a rolling update the list also contains the deploying revision, and PostgreSQL returned them in undefined order, so the API could expose the deploying revision id under `current_revision_id` (or `null` when downstream adapters derived the id from `data.revision.id`).
- Match the spec by `info.current_revision_id` directly in `services/deployment/service.py`; add `order_by="DeploymentRevisionRow.revision_number"` on `EndpointRow.revisions` for deterministic iteration in any other caller.
- Carry `current_revision_id` through the data layer (`ModelDeploymentData.current_revision_id`) and read it from there in the GraphQL/REST v2 adapter, instead of recomputing it from `data.revision.id`. This stops the API from collapsing to `null` when the matching `ModelRevisionSpec` can't be resolved (e.g. dangling `endpoints.current_revision` after a revision row was removed) — the column value now flows straight through.

Resolves BA-5963.