### PR TITLE
fix(BA-5965): renormalize legacy hyphenated start-command in stored model definitions

### DIFF
--- a/changes/11497.fix.md
+++ b/changes/11497.fix.md
@@ -1,0 +1,1 @@
+Accept legacy whitespace-separated string values for `ModelMetadata.start_command` for backward compatibility with older model definitions.

--- a/changes/11497.fix.md
+++ b/changes/11497.fix.md
@@ -1,1 +1,1 @@
-Accept legacy whitespace-separated string values for `ModelMetadata.start_command` for backward compatibility with older model definitions.
+Renormalize legacy hyphenated `start-command` keys in stored deployment model definitions to the canonical `start_command` form, splitting string values into argv tokens.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -14,6 +14,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
 )
 
 from . import validators as tx
@@ -269,6 +270,14 @@ class ModelServiceConfig(BaseConfigModel):
         default=None,
         description="Health check configuration for the model service.",
     )
+
+    @field_validator("start_command", mode="before")
+    @classmethod
+    def _normalize_start_command(cls, value: Any) -> Any:
+        """Accept legacy string values by splitting."""
+        if isinstance(value, str):
+            return value.split()
+        return value
 
 
 class ModelMetadata(BaseConfigModel):

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -14,7 +14,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    field_validator,
 )
 
 from . import validators as tx
@@ -270,14 +269,6 @@ class ModelServiceConfig(BaseConfigModel):
         default=None,
         description="Health check configuration for the model service.",
     )
-
-    @field_validator("start_command", mode="before")
-    @classmethod
-    def _normalize_start_command(cls, value: Any) -> Any:
-        """Accept legacy string values by splitting."""
-        if isinstance(value, str):
-            return value.split()
-        return value
 
 
 class ModelMetadata(BaseConfigModel):

--- a/src/ai/backend/manager/models/alembic/versions/46e007d9b237_renormalize_legacy_start_command.py
+++ b/src/ai/backend/manager/models/alembic/versions/46e007d9b237_renormalize_legacy_start_command.py
@@ -1,0 +1,79 @@
+"""renormalize legacy hyphenated ``start-command`` key
+
+``service`` entries written with the legacy hyphenated key
+``start-command`` were not matched by 8c1f7d3a9e2b (it only looked
+up ``start_command`` with an underscore), so the key was left
+untouched and Pydantic validation now rejects them. Move the value
+under ``start_command`` and drop the hyphenated key. If the value
+is a string, split it on whitespace into argv tokens before
+storing.
+
+Existing ``start_command`` values (already under the underscored
+key) are left untouched even if a stray ``start-command`` key
+also exists — the underscored value wins and the hyphenated key
+is dropped.
+
+Revision ID: 46e007d9b237
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-06
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+# revision identifiers, used by Alembic.
+# Part of: 26.4.6 (main)
+revision = "46e007d9b237"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def _renormalize_model_definition(conn: Connection, table: str, column: str) -> None:
+    rows = conn.execute(
+        sa.text(f"SELECT id, {column} FROM {table} WHERE {column} IS NOT NULL")
+    ).fetchall()
+
+    for row_id, model_definition in rows:
+        if not isinstance(model_definition, dict):
+            continue
+        changed = False
+        for model in model_definition.get("models") or []:
+            if not isinstance(model, dict):
+                continue
+            service = model.get("service")
+            if not isinstance(service, dict):
+                continue
+
+            if "start-command" not in service:
+                continue
+            hyphen_value = service.pop("start-command")
+            changed = True
+            if "start_command" in service:
+                continue
+            if isinstance(hyphen_value, str):
+                hyphen_value = hyphen_value.split()
+            service["start_command"] = hyphen_value
+
+        if changed:
+            conn.execute(
+                sa.text(f"UPDATE {table} SET {column} = CAST(:definition AS JSONB) WHERE id = :id"),
+                {"definition": json.dumps(model_definition), "id": row_id},
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _renormalize_model_definition(conn, "deployment_revisions", "model_definition")
+    _renormalize_model_definition(conn, "deployment_revision_presets", "model_definition")
+    _renormalize_model_definition(conn, "runtime_variants", "default_model_definition")
+
+
+def downgrade() -> None:
+    # No-op: argv-list form is valid under any prior schema, and the
+    # hyphenated legacy key was never officially supported.
+    pass

--- a/tests/unit/manager/api/gql/deployment/test_access_token_filter.py
+++ b/tests/unit/manager/api/gql/deployment/test_access_token_filter.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.group import GroupRow
@@ -55,6 +56,7 @@ _MAPPER_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/api/gql/rbac/test_role_filter.py
+++ b/tests/unit/manager/api/gql/rbac/test_role_filter.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -56,6 +57,7 @@ _MAPPER_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/api/gql/resource_group/test_filters.py
+++ b/tests/unit/manager/api/gql/resource_group/test_filters.py
@@ -28,6 +28,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -65,6 +66,7 @@ _MAPPER_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/api/gql/scheduling_history/test_filters.py
+++ b/tests/unit/manager/api/gql/scheduling_history/test_filters.py
@@ -15,6 +15,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -53,6 +54,7 @@ _MAPPER_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/api/gql/user/types/test_filters.py
+++ b/tests/unit/manager/api/gql/user/types/test_filters.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
@@ -58,6 +59,7 @@ _MAPPER_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/models/domain/test_conditions.py
+++ b/tests/unit/manager/models/domain/test_conditions.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.domain.conditions import DomainConditions
 from ai.backend.manager.models.domain.orders import DomainOrders
@@ -75,6 +76,7 @@ _WITH_TABLES = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/models/group/test_conditions.py
+++ b/tests/unit/manager/models/group/test_conditions.py
@@ -21,6 +21,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
@@ -67,6 +68,7 @@ _WITH_TABLES = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/models/scaling_group/test_conditions.py
+++ b/tests/unit/manager/models/scaling_group/test_conditions.py
@@ -11,6 +11,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -52,6 +53,7 @@ _WITH_TABLES = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
+++ b/tests/unit/manager/models/test_deployment_auto_scaling_policy.py
@@ -26,6 +26,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -96,6 +97,7 @@ class TestDeploymentAutoScalingPolicyRow:
                 EndpointRow,
                 DeploymentPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentAutoScalingPolicyRow,
             ],

--- a/tests/unit/manager/models/test_session.py
+++ b/tests/unit/manager/models/test_session.py
@@ -13,6 +13,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -83,6 +84,7 @@ class TestSessionUniqueNamePerUser:
                 ResourcePresetRow,
                 EndpointRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentAutoScalingPolicyRow,
                 DeploymentPolicyRow,

--- a/tests/unit/manager/models/test_vfolder_quota_scope.py
+++ b/tests/unit/manager/models/test_vfolder_quota_scope.py
@@ -16,6 +16,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow, ProjectType
@@ -77,6 +78,7 @@ class TestEnsureQuotaScopeAccessibleByUser:
                 ResourcePresetRow,
                 EndpointRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentAutoScalingPolicyRow,
                 DeploymentPolicyRow,

--- a/tests/unit/manager/models/user/test_conditions.py
+++ b/tests/unit/manager/models/user/test_conditions.py
@@ -19,6 +19,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
@@ -65,6 +66,7 @@ _WITH_TABLES = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -43,6 +43,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -115,6 +116,7 @@ class TestAgentRepositoryDB:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -624,6 +626,7 @@ class TestAgentDBSourceKernelFiltering:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/agent/test_sync_installed_images.py
+++ b/tests/unit/manager/repositories/agent/test_sync_installed_images.py
@@ -22,6 +22,7 @@ from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -176,6 +177,7 @@ class TestSyncInstalledImagesIntegration:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/app_config/test_app_config.py
+++ b/tests/unit/manager/repositories/app_config/test_app_config.py
@@ -18,6 +18,7 @@ from ai.backend.manager.models.app_config import AppConfigRow, AppConfigScopeTyp
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -89,6 +90,7 @@ class TestAppConfigRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/artifact/test_artifact_repository.py
+++ b/tests/unit/manager/repositories/artifact/test_artifact_repository.py
@@ -26,6 +26,7 @@ from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -87,6 +88,7 @@ class TestArtifactRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
+++ b/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -92,6 +93,7 @@ class TestArtifactRevisionRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/auth/test_auth_repository.py
+++ b/tests/unit/manager/repositories/auth/test_auth_repository.py
@@ -25,6 +25,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow
@@ -105,6 +106,7 @@ class TestAuthRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
+++ b/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
@@ -28,6 +28,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -130,6 +131,7 @@ class TestContainerRegistryRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -1331,6 +1333,7 @@ class TestSearchContainerRegistries:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/domain/test_domain_repository.py
+++ b/tests/unit/manager/repositories/domain/test_domain_repository.py
@@ -30,6 +30,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow, domains, row_to_data
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow, ProjectType, groups
@@ -87,6 +88,7 @@ class TestDomainRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/error_log/test_error_log_repository.py
+++ b/tests/unit/manager/repositories/error_log/test_error_log_repository.py
@@ -19,6 +19,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.error_logs import ErrorLogRow, error_logs
@@ -83,6 +84,7 @@ class TestErrorLogRepository:
                 ResourcePresetRow,
                 EndpointRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 DeploymentAutoScalingPolicyRow,
                 DeploymentPolicyRow,

--- a/tests/unit/manager/repositories/group/test_group_db_source.py
+++ b/tests/unit/manager/repositories/group/test_group_db_source.py
@@ -19,6 +19,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -95,6 +96,7 @@ class TestGroupDBSourceDeleteEndpoints:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -42,6 +42,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -49,7 +50,7 @@ from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
-from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models import PermissionRow, RoleRow, UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
@@ -252,6 +253,7 @@ class TestGroupRepository:
                 KeyPairResourcePolicyRow,
                 RoleRow,
                 UserRoleRow,
+                PermissionRow,
                 UserRow,
                 KeyPairRow,
                 GroupRow,
@@ -262,6 +264,7 @@ class TestGroupRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
+++ b/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -81,6 +82,7 @@ class TestKeypairResourcePolicyRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
@@ -30,6 +30,7 @@ from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.data.model_serving.types import EndpointData, EndpointLifecycle
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -77,6 +78,7 @@ async def db_with_cleanup(
             VFolderRow,
             EndpointRow,
             RuntimeVariantRow,
+            DeploymentRevisionPresetRow,
             DeploymentRevisionRow,
             ResourceSlotTypeRow,
             DeploymentRevisionResourceSlotRow,

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -24,6 +24,7 @@ from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.data.model_serving.types import EndpointLifecycle
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -89,6 +90,7 @@ class TestModifyEndpointModelDefinitionRefresh:
                 EndpointRow,
                 RoutingRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 ResourceSlotTypeRow,
                 DeploymentRevisionResourceSlotRow,

--- a/tests/unit/manager/repositories/model_serving/test_search_auto_scaling_rule_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_search_auto_scaling_rule_validated.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy import (
 )
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import (
     AutoScalingMetricSource,
@@ -97,6 +98,7 @@ class TestSearchAutoScalingRulesValidated:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
+++ b/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
@@ -28,6 +28,7 @@ from ai.backend.manager.data.image.types import ImageType
 from ai.backend.manager.data.model_serving.types import EndpointData, EndpointLifecycle
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -75,6 +76,7 @@ async def db_with_cleanup(
             VFolderRow,
             EndpointRow,
             RuntimeVariantRow,
+            DeploymentRevisionPresetRow,
             DeploymentRevisionRow,
             ResourceSlotTypeRow,
             DeploymentRevisionResourceSlotRow,

--- a/tests/unit/manager/repositories/notification/test_notification_options.py
+++ b/tests/unit/manager/repositories/notification/test_notification_options.py
@@ -23,6 +23,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -102,6 +103,7 @@ class TestNotificationOptions:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -988,6 +990,7 @@ class TestNotificationCursorPagination:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/notification/test_notification_repository.py
+++ b/tests/unit/manager/repositories/notification/test_notification_repository.py
@@ -27,6 +27,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -110,6 +111,7 @@ class TestNotificationRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_scopes.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group.row import GroupRow
@@ -93,6 +94,7 @@ class TestSearchDomainScopes:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -346,6 +348,7 @@ class TestSearchProjectScopes:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -559,6 +562,7 @@ class TestSearchUserScopes:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -772,6 +776,7 @@ class TestSearchGlobalScope:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -820,6 +825,7 @@ class TestSearchScopesEmptyResult:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/project_resource_policy/test_project_resource_policy.py
+++ b/tests/unit/manager/repositories/project_resource_policy/test_project_resource_policy.py
@@ -20,6 +20,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -88,6 +89,7 @@ class TestProjectResourcePolicyRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/resource_preset/test_check_presets.py
+++ b/tests/unit/manager/repositories/resource_preset/test_check_presets.py
@@ -42,6 +42,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow, association_groups_users
@@ -123,6 +124,7 @@ class TestCheckPresetsOccupiedSlots:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,
@@ -1200,6 +1202,7 @@ class TestCheckPresetsZeroValues:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/resource_preset/test_resource_preset_cache_invalidation.py
+++ b/tests/unit/manager/repositories/resource_preset/test_resource_preset_cache_invalidation.py
@@ -19,6 +19,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow, association_groups_users
@@ -80,6 +81,7 @@ class TestResourcePresetCacheInvalidation:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -19,6 +19,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointLifecycle, EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -113,6 +114,7 @@ class TestScalingGroupRepositoryDB:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/scheduler/test_termination.py
+++ b/tests/unit/manager/repositories/scheduler/test_termination.py
@@ -33,6 +33,7 @@ from ai.backend.manager.models.deployment_auto_scaling_policy.row import (
 )
 from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint.row import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -84,6 +85,7 @@ class TestKernelTermination:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/test_utils.py
+++ b/tests/unit/manager/repositories/test_utils.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -81,6 +82,7 @@ async def db_with_cleanup(
             DeploymentPolicyRow,
             DeploymentAutoScalingPolicyRow,
             RuntimeVariantRow,
+            DeploymentRevisionPresetRow,
             DeploymentRevisionRow,
             SessionRow,
             AgentRow,

--- a/tests/unit/manager/repositories/user/test_user_repository.py
+++ b/tests/unit/manager/repositories/user/test_user_repository.py
@@ -21,6 +21,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import AssocGroupUserRow, GroupRow, ProjectType
@@ -106,6 +107,7 @@ class TestUserRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/repositories/user_resource_policy/test_user_resource_policy_repository.py
+++ b/tests/unit/manager/repositories/user_resource_policy/test_user_resource_policy_repository.py
@@ -10,6 +10,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -74,6 +75,7 @@ class TestUserResourcePolicyRepository:
                 DeploymentPolicyRow,
                 DeploymentAutoScalingPolicyRow,
                 RuntimeVariantRow,
+                DeploymentRevisionPresetRow,
                 DeploymentRevisionRow,
                 SessionRow,
                 AgentRow,

--- a/tests/unit/manager/test_query_userinfo.py
+++ b/tests/unit/manager/test_query_userinfo.py
@@ -23,6 +23,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
 from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
@@ -67,6 +68,7 @@ ALL_ROWS = [
     DeploymentPolicyRow,
     DeploymentAutoScalingPolicyRow,
     RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
     DeploymentRevisionRow,
     SessionRow,
     AgentRow,


### PR DESCRIPTION
## Summary
- Add alembic migration `46e007d9b237` that renormalizes the legacy hyphenated `start-command` key in stored model definitions (`deployment_revisions.model_definition`, `deployment_revision_presets.model_definition`, `runtime_variants.default_model_definition`). The previous migration `8c1f7d3a9e2b` looked up only the underscored `start_command`, so rows storing the YAML-style hyphenated key were silently skipped and remained rejected by current Pydantic validation. The new migration moves the value under `start_command`, drops the hyphenated key, and splits string values into argv tokens. Existing `start_command` entries are preserved unchanged.
- Fix 40 test fixtures that listed `DeploymentRevisionRow` in `with_tables` without its FK target `DeploymentRevisionPresetRow`, which caused SQLAlchemy table creation to fail with `UndefinedTableError`. Also add `PermissionRow` to `test_group_repository`'s purge fixture, broken after RBAC purge cleanup began touching the `permissions` table.

## Test plan
- [x] Migration moves `start-command` (hyphen) value to `start_command` and splits strings on whitespace
- [x] Existing `start_command` entries are preserved unchanged when both keys are present
- [x] All 32 originally-failing unit tests pass
- [x] `pants lint --changed-since=origin/main` clean

Resolves BA-5965