### PR TITLE
feat(BA-5840): add effective-permissions DataLoader for batched RBAC resolution

### DIFF
--- a/changes/11499.feature.md
+++ b/changes/11499.feature.md
@@ -1,0 +1,1 @@
+Add a request-scoped GraphQL DataLoader for batched per-entity effective permission resolution.

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from datetime import UTC, datetime
 from functools import lru_cache
 from uuid import UUID
@@ -175,6 +175,7 @@ from ai.backend.manager.data.permission.role import (
     BulkRolePermissionReplaceResultData,
     BulkRoleRevocationResultData,
     BulkUserRoleRevocationInput,
+    PermissionResolutionKey,
     RoleData,
     RoleDetailData,
     UserRoleAssignmentData,
@@ -267,6 +268,9 @@ from ai.backend.manager.services.permission_contoller.actions.permission import 
 from ai.backend.manager.services.permission_contoller.actions.purge_role import PurgeRoleAction
 from ai.backend.manager.services.permission_contoller.actions.replace_role_permissions import (
     ReplaceRolePermissionsAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.resolve_effective_permissions import (
+    ResolveEffectivePermissionsAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.revoke_role import RevokeRoleAction
 from ai.backend.manager.services.permission_contoller.actions.search_element_associations import (
@@ -634,6 +638,18 @@ class RBACAdapter(BaseAdapter):
             )
             for scope, entity_map in sorted(matrix.items(), key=lambda e: e[0].value)
         ]
+
+    # ------------------------------------------------------------------ effective permissions
+
+    async def batch_resolve_effective_permissions(
+        self,
+        keys: Sequence[PermissionResolutionKey],
+    ) -> Mapping[PermissionResolutionKey, frozenset[InternalOperationType]]:
+        """Resolve granted operations for each input key; missing keys map to an empty frozenset."""
+        action_result = await self._processors.permission_controller.resolve_effective_permissions.wait_for_complete(
+            ResolveEffectivePermissionsAction(keys=list(keys))
+        )
+        return action_result.permissions
 
     # ------------------------------------------------------------------ create
 

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 
 from strawberry.dataloader import DataLoader
 
+from ai.backend.common.data.permission.types import OperationType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import AgentId, ImageID, KernelId, SessionId
 from ai.backend.manager.data.permission.id import ObjectId
+from ai.backend.manager.data.permission.role import PermissionResolutionKey
 
 if TYPE_CHECKING:
     from ai.backend.common.dto.manager.v2.rbac.response import EntityNode  # pants: no-infer-dep
@@ -681,6 +683,20 @@ class DataLoaders:
 
             dtos = await adapter.batch_load_roles_by_ids(ids)
             return [RG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+
+        return DataLoader(load_fn=load_fn)
+
+    @cached_property
+    def effective_permissions_loader(
+        self,
+    ) -> DataLoader[PermissionResolutionKey, frozenset[OperationType]]:
+        adapter = self._adapters.rbac
+
+        async def load_fn(
+            keys: list[PermissionResolutionKey],
+        ) -> list[frozenset[OperationType]]:
+            result = await adapter.batch_resolve_effective_permissions(keys)
+            return [result.get(key, frozenset()) for key in keys]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -27,6 +27,8 @@ from .actions import (
     PurgeRoleAction,
     ReplaceRolePermissionsAction,
     ReplaceRolePermissionsActionResult,
+    ResolveEffectivePermissionsAction,
+    ResolveEffectivePermissionsActionResult,
     RevokeRoleAction,
     RevokeRoleActionResult,
     SearchRolesAction,
@@ -139,6 +141,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
     get_permission_matrix: ActionProcessor[
         GetPermissionMatrixAction, GetPermissionMatrixActionResult
     ]
+    resolve_effective_permissions: ActionProcessor[
+        ResolveEffectivePermissionsAction, ResolveEffectivePermissionsActionResult
+    ]
     search_entities: ActionProcessor[SearchEntitiesAction, SearchEntitiesActionResult]
     search_element_associations: ActionProcessor[
         SearchElementAssociationsAction, SearchElementAssociationsActionResult
@@ -211,6 +216,9 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
         self.get_scope_types = ActionProcessor(service.get_scope_types, action_monitors)
         self.get_entity_types = ActionProcessor(service.get_entity_types, action_monitors)
         self.get_permission_matrix = ActionProcessor(service.get_permission_matrix, action_monitors)
+        self.resolve_effective_permissions = ActionProcessor(
+            service.resolve_effective_permissions, action_monitors
+        )
         self.search_entities = ActionProcessor(service.search_entities, action_monitors)
         self.search_element_associations = ActionProcessor(
             service.search_element_associations, action_monitors
@@ -275,6 +283,7 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
             GetScopeTypesAction.spec(),
             GetEntityTypesAction.spec(),
             GetPermissionMatrixAction.spec(),
+            ResolveEffectivePermissionsAction.spec(),
             SearchEntitiesAction.spec(),
             SearchElementAssociationsAction.spec(),
             SearchPermissionsAction.spec(),


### PR DESCRIPTION
## Summary
- Register `resolve_effective_permissions` ActionProcessor on `PermissionControllerProcessors` (the action and service method already existed but were not wired through a processor).
- Add `RBACAdapter.batch_resolve_effective_permissions` as a thin wrapper over the processor.
- Add `DataLoaders.effective_permissions_loader` keyed by `PermissionResolutionKey`; keys with no grant map to an empty `frozenset[OperationType]`. Repository-level grouping by `(user_id, element_type, subject_entity_type)` already collapses to one SQL round-trip per group, so a single page of same-typed nodes resolves in one query.

This enables BA-5841 (shared per-node `permissions` GraphQL field) to resolve per-row permissions in list views without N+1 round-trips.

## Test plan
- [ ] CI runs `pants check` / `pants test` on impacted targets.
- [ ] Smoke-test the loader against a real DB once BA-5841 wires it into a node type (e.g. `vfolder_node`).

Resolves BA-5840