### PR TITLE
fix(BA-5975): honor AND/OR/NOT in deployment my/project search

### DIFF
--- a/changes/11506.fix.md
+++ b/changes/11506.fix.md
@@ -1,0 +1,1 @@
+Honor `AND`/`OR`/`NOT` clauses in `myDeployments` and `projectDeployments` GraphQL filters, which were previously ignored and caused multi-condition deployment queries to return unfiltered results.

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -223,6 +223,7 @@ from ai.backend.manager.repositories.base import (
     QueryCondition,
     QueryOrder,
     Updater,
+    combine_conditions_and,
     combine_conditions_or,
     negate_conditions,
 )
@@ -1550,17 +1551,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_deployment_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_deployment_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_deployment_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_deployment_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_deployment_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_deployment_querier(self, input: AdminSearchDeploymentsInput) -> BatchQuerier:
@@ -1641,17 +1643,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_revision_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_revision_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_revision_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_revision_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_revision_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_revision_querier(
@@ -1702,17 +1705,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_route_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_route_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_route_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_route_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_route_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_route_querier(
@@ -1774,17 +1778,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_access_token_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_access_token_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_access_token_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_access_token_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_access_token_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_access_token_querier(
@@ -1843,17 +1848,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_auto_scaling_rule_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_auto_scaling_rule_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_auto_scaling_rule_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_auto_scaling_rule_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_auto_scaling_rule_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_auto_scaling_rule_querier(
@@ -1956,17 +1962,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in f.AND:
                 conditions.extend(self._convert_replica_filter(sub))
         if f.OR:
-            or_conditions: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in f.OR:
-                or_conditions.extend(self._convert_replica_filter(sub))
-            if or_conditions:
-                conditions.append(combine_conditions_or(or_conditions))
+                sub_conditions = self._convert_replica_filter(sub)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if f.NOT:
-            not_conditions: list[QueryCondition] = []
             for sub in f.NOT:
-                not_conditions.extend(self._convert_replica_filter(sub))
-            if not_conditions:
-                conditions.append(negate_conditions(not_conditions))
+                sub_conditions = self._convert_replica_filter(sub)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     def _build_replica_querier(
@@ -2048,17 +2055,18 @@ class DeploymentAdapter(BaseAdapter):
             for sub in filter_.AND:
                 conditions.extend(self._convert_allocated_slot_filter(sub, conditions_cls))
         if filter_.OR:
-            or_conds: list[QueryCondition] = []
+            or_groups: list[QueryCondition] = []
             for sub in filter_.OR:
-                or_conds.extend(self._convert_allocated_slot_filter(sub, conditions_cls))
-            if or_conds:
-                conditions.append(combine_conditions_or(or_conds))
+                sub_conditions = self._convert_allocated_slot_filter(sub, conditions_cls)
+                if sub_conditions:
+                    or_groups.append(combine_conditions_and(sub_conditions))
+            if or_groups:
+                conditions.append(combine_conditions_or(or_groups))
         if filter_.NOT:
-            not_conds: list[QueryCondition] = []
             for sub in filter_.NOT:
-                not_conds.extend(self._convert_allocated_slot_filter(sub, conditions_cls))
-            if not_conds:
-                conditions.append(negate_conditions(not_conds))
+                sub_conditions = self._convert_allocated_slot_filter(sub, conditions_cls)
+                if sub_conditions:
+                    conditions.append(negate_conditions(sub_conditions))
         return conditions
 
     # ------------------------------------------------------------------

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -597,63 +597,7 @@ class DeploymentAdapter(BaseAdapter):
             raise RuntimeError("No authenticated user in context")
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.status is not None:
-                if f.status.equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.in_ is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.in_
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.not_equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.not_equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-                if f.status.not_in is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.not_in
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
-            if f.tags is not None:
-                condition = self.convert_string_filter(
-                    f.tags,
-                    contains_factory=DeploymentConditions.by_tag_contains,
-                    equals_factory=DeploymentConditions.by_tag_equals,
-                    starts_with_factory=DeploymentConditions.by_tag_starts_with,
-                    ends_with_factory=DeploymentConditions.by_tag_ends_with,
-                    in_factory=DeploymentConditions.by_tag_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.endpoint_url is not None:
-                condition = self.convert_string_filter(
-                    f.endpoint_url,
-                    contains_factory=DeploymentConditions.by_url_contains,
-                    equals_factory=DeploymentConditions.by_url_equals,
-                    starts_with_factory=DeploymentConditions.by_url_starts_with,
-                    ends_with_factory=DeploymentConditions.by_url_ends_with,
-                    in_factory=DeploymentConditions.by_url_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )
@@ -691,63 +635,7 @@ class DeploymentAdapter(BaseAdapter):
         """Search deployments within a specific project."""
         conditions: list[QueryCondition] = []
         if input.filter:
-            f = input.filter
-            if f.name is not None:
-                condition = self.convert_string_filter(
-                    f.name,
-                    contains_factory=DeploymentConditions.by_name_contains,
-                    equals_factory=DeploymentConditions.by_name_equals,
-                    starts_with_factory=DeploymentConditions.by_name_starts_with,
-                    ends_with_factory=DeploymentConditions.by_name_ends_with,
-                    in_factory=DeploymentConditions.by_name_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.status is not None:
-                if f.status.equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.in_ is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.in_
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_in(lifecycles))
-                if f.status.not_equals is not None:
-                    lifecycles = _status_to_lifecycles(ModelDeploymentStatus(f.status.not_equals))
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-                if f.status.not_in is not None:
-                    lifecycles = _statuses_to_lifecycles([
-                        ModelDeploymentStatus(s) for s in f.status.not_in
-                    ])
-                    if lifecycles:
-                        conditions.append(DeploymentConditions.by_status_not_in(lifecycles))
-            if f.open_to_public is not None:
-                conditions.append(DeploymentConditions.by_open_to_public(f.open_to_public))
-            if f.tags is not None:
-                condition = self.convert_string_filter(
-                    f.tags,
-                    contains_factory=DeploymentConditions.by_tag_contains,
-                    equals_factory=DeploymentConditions.by_tag_equals,
-                    starts_with_factory=DeploymentConditions.by_tag_starts_with,
-                    ends_with_factory=DeploymentConditions.by_tag_ends_with,
-                    in_factory=DeploymentConditions.by_tag_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
-            if f.endpoint_url is not None:
-                condition = self.convert_string_filter(
-                    f.endpoint_url,
-                    contains_factory=DeploymentConditions.by_url_contains,
-                    equals_factory=DeploymentConditions.by_url_equals,
-                    starts_with_factory=DeploymentConditions.by_url_starts_with,
-                    ends_with_factory=DeploymentConditions.by_url_ends_with,
-                    in_factory=DeploymentConditions.by_url_in,
-                )
-                if condition is not None:
-                    conditions.append(condition)
+            conditions.extend(self._convert_deployment_filter(input.filter))
         orders: list[QueryOrder] = (
             self._convert_deployment_orders(input.order) if input.order else []
         )

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -87,6 +87,7 @@ from .upserter import (
     execute_upserter,
 )
 from .utils import (
+    combine_conditions_and,
     combine_conditions_or,
     negate_conditions,
 )
@@ -174,6 +175,7 @@ __all__ = [
     "BatchPurgerResult",
     "execute_batch_purger",
     # Utils
+    "combine_conditions_and",
     "combine_conditions_or",
     "negate_conditions",
 ]

--- a/src/ai/backend/manager/repositories/base/utils.py
+++ b/src/ai/backend/manager/repositories/base/utils.py
@@ -24,6 +24,23 @@ def combine_conditions_or(conditions: list[QueryCondition]) -> QueryCondition:
     return inner
 
 
+def combine_conditions_and(conditions: list[QueryCondition]) -> QueryCondition:
+    """Combine multiple QueryConditions with AND logic.
+
+    Args:
+        conditions: List of QueryCondition callables to combine
+
+    Returns:
+        A single QueryCondition that applies all conditions with AND logic
+    """
+
+    def inner() -> sa.sql.expression.ColumnElement[bool]:
+        clauses = [cond() for cond in conditions]
+        return sa.and_(*clauses)
+
+    return inner
+
+
 def negate_conditions(conditions: list[QueryCondition]) -> QueryCondition:
     """Negate multiple QueryConditions with NOT logic.
 

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -368,13 +368,14 @@ class TestDeploymentAdapterFilter:
         scaling_group: str,
         seed_data: tuple[ImageID, VFolderUUID],
         tags: list[str],
+        name: str | None = None,
     ) -> uuid.UUID:
         image_id, vfolder_id = seed_data
         request = CreateDeploymentRequest(
             metadata=DeploymentMetadataInput(
                 project_id=project_id,
                 domain_name=domain,
-                name=f"test-deployment-{secrets.token_hex(4)}",
+                name=name or f"test-deployment-{secrets.token_hex(4)}",
                 tags=tags,
             ),
             network_access=NetworkAccessInput(open_to_public=False),
@@ -501,6 +502,81 @@ class TestDeploymentAdapterFilter:
 
         assert payload.total_count == 2
         assert {item.id for item in payload.items} == {alpha_id, beta_id}
+
+    async def test_my_search_or_filter_groups_multi_field_subfilters(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        admin_user_fixture: UserFixtureData,
+        deployment_adapter: DeploymentAdapter,
+        group_fixture: uuid.UUID,
+        domain_fixture: str,
+        scaling_group_fixture: str,
+        deployment_seed_data: tuple[ImageID, VFolderUUID],
+    ) -> None:
+        """OR with multi-field sub-filters must AND fields within each branch.
+
+        Pins ``(A AND B) OR (C AND D)`` semantics: each OR sub-filter is an AND
+        of its own fields, then the sub-filters are OR'd. A regression that
+        flattens sub-conditions would degenerate into ``A OR B OR C OR D`` and
+        return rows that match neither full branch.
+        """
+        suffix = secrets.token_hex(4)
+        branch1_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha"],
+            name=f"bar-x-{suffix}",
+        )
+        branch2_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["beta"],
+            name=f"foo-x-{suffix}",
+        )
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["beta"],
+            name=f"bar-y-{suffix}",
+        )
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha"],
+            name=f"foo-y-{suffix}",
+        )
+
+        filter_input = DeploymentFilterV2(
+            OR=[
+                DeploymentFilterV2(
+                    name=StringFilter(i_contains="bar"),
+                    tags=StringFilter(i_contains="alpha"),
+                ),
+                DeploymentFilterV2(
+                    name=StringFilter(i_contains="foo"),
+                    tags=StringFilter(i_contains="beta"),
+                ),
+            ],
+        )
+        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+            payload = await deployment_adapter.my_search(
+                AdminSearchDeploymentsInput(filter=filter_input, limit=50),
+            )
+
+        assert payload.total_count == 2
+        assert {item.id for item in payload.items} == {branch1_id, branch2_id}
 
     async def test_project_search_and_filter_returns_intersection(
         self,

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -9,14 +9,18 @@ from __future__ import annotations
 
 import secrets
 import uuid
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
 from ai.backend.client.v2.exceptions import NotFoundError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy, ModelDeploymentStatus
+from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.dto.manager.deployment import (
     CreateDeploymentRequest,
     DeactivateRevisionResponse,
@@ -38,10 +42,22 @@ from ai.backend.common.dto.manager.deployment import (
 )
 from ai.backend.common.dto.manager.deployment.request import ClusterConfigInput
 from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    AdminSearchDeploymentsInput,
+)
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    DeploymentFilter as DeploymentFilterV2,
+)
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import ClusterMode
+from ai.backend.manager.api.adapters.deployment.adapter import DeploymentAdapter
+from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import _map_lifecycle_to_status
+from ai.backend.manager.services.processors import Processors
+
+if TYPE_CHECKING:
+    from tests.component.conftest import UserFixtureData
 
 
 class TestSearchDeployments:
@@ -313,6 +329,221 @@ class TestDeactivateRevision:
         )
         assert isinstance(result, DeactivateRevisionResponse)
         assert result.success is True
+
+
+class TestDeploymentAdapterFilter:
+    """Verify the GQL adapter honors AND/OR/NOT in DeploymentFilter.
+
+    The adapter's ``my_search`` and ``project_search`` previously inlined
+    the filter conversion and silently dropped nested ``AND``/``OR``/``NOT``
+    clauses, so multi-condition filters degenerated into "no filter at all".
+    These tests pin the corrected behavior.
+    """
+
+    @pytest.fixture
+    def deployment_adapter(
+        self,
+        deployment_processors: DeploymentProcessors,
+    ) -> DeploymentAdapter:
+        processors_mock = MagicMock(spec=Processors)
+        processors_mock.deployment = deployment_processors
+        return DeploymentAdapter(processors_mock, deployment_coordinator=MagicMock())
+
+    @staticmethod
+    def _admin_user_data(user_uuid: uuid.UUID, domain: str) -> UserData:
+        return UserData(
+            user_id=user_uuid,
+            is_authorized=True,
+            is_admin=True,
+            is_superadmin=True,
+            role=UserRole.SUPERADMIN,
+            domain_name=domain,
+        )
+
+    @staticmethod
+    async def _create_deployment_with_tags(
+        admin_registry: BackendAIClientRegistry,
+        project_id: uuid.UUID,
+        domain: str,
+        scaling_group: str,
+        seed_data: tuple[ImageID, VFolderUUID],
+        tags: list[str],
+    ) -> uuid.UUID:
+        image_id, vfolder_id = seed_data
+        request = CreateDeploymentRequest(
+            metadata=DeploymentMetadataInput(
+                project_id=project_id,
+                domain_name=domain,
+                name=f"test-deployment-{secrets.token_hex(4)}",
+                tags=tags,
+            ),
+            network_access=NetworkAccessInput(open_to_public=False),
+            default_deployment_strategy=DeploymentStrategyInput(
+                type=DeploymentStrategy.ROLLING,
+            ),
+            replica_count=1,
+            initial_revision=RevisionInput(
+                name="v1",
+                cluster_config=ClusterConfigInput(mode=ClusterMode.SINGLE_NODE, size=1),
+                resource_config=ResourceConfigInput(
+                    resource_group=scaling_group,
+                    resource_slots={"cpu": "2", "mem": "2147483648"},
+                ),
+                image=ImageInput(id=image_id),
+                model_runtime_config=ModelRuntimeConfigInput(),
+                model_mount_config=ModelMountConfigInput(
+                    vfolder_id=vfolder_id,
+                    mount_destination="/models",
+                    definition_path="model-definition.yaml",
+                ),
+                model_definition=ModelDefinitionDraft(),
+            ),
+        )
+        response = await admin_registry.deployment.create_deployment(request)
+        return response.deployment.id
+
+    async def test_my_search_and_filter_returns_intersection(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        admin_user_fixture: UserFixtureData,
+        deployment_adapter: DeploymentAdapter,
+        group_fixture: uuid.UUID,
+        domain_fixture: str,
+        scaling_group_fixture: str,
+        deployment_seed_data: tuple[ImageID, VFolderUUID],
+    ) -> None:
+        """AND clause must narrow results to deployments matching every nested filter."""
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha", "production"],
+        )
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["beta", "production"],
+        )
+        target_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha", "beta"],
+        )
+
+        filter_input = DeploymentFilterV2(
+            AND=[
+                DeploymentFilterV2(tags=StringFilter(i_contains="alpha")),
+                DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
+            ],
+        )
+        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+            payload = await deployment_adapter.my_search(
+                AdminSearchDeploymentsInput(filter=filter_input, limit=50),
+            )
+
+        assert payload.total_count == 1
+        assert [item.id for item in payload.items] == [target_id]
+
+    async def test_my_search_or_filter_returns_union(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        admin_user_fixture: UserFixtureData,
+        deployment_adapter: DeploymentAdapter,
+        group_fixture: uuid.UUID,
+        domain_fixture: str,
+        scaling_group_fixture: str,
+        deployment_seed_data: tuple[ImageID, VFolderUUID],
+    ) -> None:
+        """OR clause must widen results to deployments matching any nested filter."""
+        alpha_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha"],
+        )
+        beta_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["beta"],
+        )
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["gamma"],
+        )
+
+        filter_input = DeploymentFilterV2(
+            OR=[
+                DeploymentFilterV2(tags=StringFilter(i_contains="alpha")),
+                DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
+            ],
+        )
+        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+            payload = await deployment_adapter.my_search(
+                AdminSearchDeploymentsInput(filter=filter_input, limit=50),
+            )
+
+        assert payload.total_count == 2
+        assert {item.id for item in payload.items} == {alpha_id, beta_id}
+
+    async def test_project_search_and_filter_returns_intersection(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        admin_user_fixture: UserFixtureData,
+        deployment_adapter: DeploymentAdapter,
+        group_fixture: uuid.UUID,
+        domain_fixture: str,
+        scaling_group_fixture: str,
+        deployment_seed_data: tuple[ImageID, VFolderUUID],
+    ) -> None:
+        """project_search must also honor AND across nested filters."""
+        await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha"],
+        )
+        target_id = await self._create_deployment_with_tags(
+            admin_registry,
+            group_fixture,
+            domain_fixture,
+            scaling_group_fixture,
+            deployment_seed_data,
+            ["alpha", "beta"],
+        )
+
+        filter_input = DeploymentFilterV2(
+            AND=[
+                DeploymentFilterV2(tags=StringFilter(i_contains="alpha")),
+                DeploymentFilterV2(tags=StringFilter(i_contains="beta")),
+            ],
+        )
+        with with_user(self._admin_user_data(admin_user_fixture.user_uuid, domain_fixture)):
+            payload = await deployment_adapter.project_search(
+                group_fixture,
+                AdminSearchDeploymentsInput(filter=filter_input, limit=50),
+            )
+
+        assert payload.total_count == 1
+        assert [item.id for item in payload.items] == [target_id]
 
 
 class TestStatusMapping:


### PR DESCRIPTION
## Summary
- `my_search` and `project_search` in the deployment GQL adapter inlined the filter conversion and silently dropped `DeploymentFilter.AND` / `OR` / `NOT`, so multi-condition queries degenerated into "no filter applied" (e.g. `myDeployments` with `AND: [{tags:{iContains:"4123"}}, {tags:{iContains:"1"}}]` returned every non-stopped deployment).
- Both methods now delegate to the existing `_convert_deployment_filter` helper that `admin_search` already uses, so all three variants share one correct path. As a side effect, the previously dropped `domain_name`, `project_id`, `resource_group`, `created_user_id`, `created_at`, and `destroyed_at` fields are now honored on `my_search` / `project_search` as well.
- Adds component tests covering AND on `my_search` and `project_search` plus OR on `my_search` to pin the regression.

## Test plan
- [x] `pants fmt fix lint check` on the changed files
- [x] `pants test tests/component/deployment/test_deployment.py` (15/15 pass, including the 3 new `TestDeploymentAdapterFilter` cases)

Resolves BA-5975