### PR TITLE
fix(BA-5974): remove deployment name uniqueness constraint

### DIFF
--- a/changes/11507.fix.md
+++ b/changes/11507.fix.md
@@ -1,0 +1,1 @@
+Allow deployment names to be reused within a project so a hidden record from another user no longer blocks creation.

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -818,18 +818,6 @@ class ModelRevisionNotFound(BackendAIError, web.HTTPNotFound):
         )
 
 
-class DeploymentNameAlreadyExists(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/deployment-name-already-exists"
-    error_title = "Deployment name already exists."
-
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.ALREADY_EXISTS,
-        )
-
-
 class PassthroughError(BackendAIError):
     """
     Wraps and forwards errors from requests with original status code and message.

--- a/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
@@ -15,9 +15,16 @@ Drop the constraint so deployment names are no longer unique within
 session name template `f"{endpoint.name}-{route_id}"` already disambiguates
 on `route_id`, so the index is not load-bearing.
 
+Downgrade caveat: once the upgrade has been applied, users may legitimately
+create deployments with duplicate (name, domain, project) tuples. The
+downgrade re-creates the partial unique index and therefore fails if such
+duplicates exist among active rows. We do not silently mutate user data —
+the operator must delete or destroy the duplicate rows before retrying.
+
 """
 
 from alembic import op
+from sqlalchemy.exc import IntegrityError
 
 # revision identifiers, used by Alembic.
 revision = "c7d58e2a4f93"
@@ -36,8 +43,29 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME} "
-        f"ON endpoints (name, domain, project) "
-        f"WHERE {PREDICATE}"
-    )
+    """Recreate the partial unique index on (name, domain, project).
+
+    If duplicate active deployment names exist (which the dropped index
+    previously prevented but which the upgraded schema allows), the
+    `CREATE UNIQUE INDEX` raises a unique-violation. Re-raise with a
+    guided message instructing the operator to remove the duplicate
+    `endpoints` rows before retrying. We do not auto-resolve duplicates
+    because endpoint name may carry user-visible meaning and silent
+    mutation of user data during a downgrade is unsafe.
+    """
+    try:
+        op.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME} "
+            f"ON endpoints (name, domain, project) "
+            f"WHERE {PREDICATE}"
+        )
+    except IntegrityError as exc:
+        raise RuntimeError(
+            "Cannot recreate the unique index "
+            f"`{INDEX_NAME}` on `endpoints (name, domain, project)` "
+            "because two or more active deployments share the same name "
+            "within the same (domain, project). Delete or destroy the "
+            "duplicate `endpoints` rows (or move them to "
+            "`lifecycle_stage IN ('destroying', 'destroyed')`) before "
+            "retrying this downgrade."
+        ) from exc

--- a/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
@@ -1,0 +1,43 @@
+"""Drop endpoint name unique index
+
+Revision ID: c7d58e2a4f93
+Revises: 46e007d9b237
+Create Date: 2026-05-07 19:40:00.000000
+
+The partial unique index on (name, domain, project) restricted deployment
+name reuse to "active" rows. The list query `my_deployments` is scoped by
+`created_user`, so a deployment created by another user in the same project
+was invisible to the caller yet still blocked the create — leaving the user
+unable to choose the name and unable to locate the conflicting record.
+
+Drop the constraint so deployment names are no longer unique within
+(name, domain, project). Routing relies on `route_id`, and the inference
+session name template `f"{endpoint.name}-{route_id}"` already disambiguates
+on `route_id`, so the index is not load-bearing.
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7d58e2a4f93"
+down_revision = "46e007d9b237"
+# Part of: 26.5.0
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ix_endpoints_unique_name_when_active"
+PREDICATE = "lifecycle_stage NOT IN ('destroying', 'destroyed')"
+
+
+def upgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {INDEX_NAME}")
+
+
+def downgrade() -> None:
+    op.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME} "
+        f"ON endpoints (name, domain, project) "
+        f"WHERE {PREDICATE}"
+    )

--- a/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
@@ -1,7 +1,7 @@
 """Drop endpoint name unique index
 
 Revision ID: c7d58e2a4f93
-Revises: 46e007d9b237
+Revises: 3632aad9d5d9
 Create Date: 2026-05-07 19:40:00.000000
 
 Drop the partial unique index on (name, domain, project). The previous
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 
 # revision identifiers, used by Alembic.
 revision = "c7d58e2a4f93"
-down_revision = "46e007d9b237"
+down_revision = "3632aad9d5d9"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7d58e2a4f93_drop_endpoint_name_unique_index.py
@@ -4,22 +4,13 @@ Revision ID: c7d58e2a4f93
 Revises: 46e007d9b237
 Create Date: 2026-05-07 19:40:00.000000
 
-The partial unique index on (name, domain, project) restricted deployment
-name reuse to "active" rows. The list query `my_deployments` is scoped by
-`created_user`, so a deployment created by another user in the same project
-was invisible to the caller yet still blocked the create — leaving the user
-unable to choose the name and unable to locate the conflicting record.
+Drop the partial unique index on (name, domain, project). The previous
+scope did not match `my_deployments` (which is scoped by `created_user`),
+so a deployment by another user in the same project blocked creates while
+staying invisible to the caller.
 
-Drop the constraint so deployment names are no longer unique within
-(name, domain, project). Routing relies on `route_id`, and the inference
-session name template `f"{endpoint.name}-{route_id}"` already disambiguates
-on `route_id`, so the index is not load-bearing.
-
-Downgrade caveat: once the upgrade has been applied, users may legitimately
-create deployments with duplicate (name, domain, project) tuples. The
-downgrade re-creates the partial unique index and therefore fails if such
-duplicates exist among active rows. We do not silently mutate user data —
-the operator must delete or destroy the duplicate rows before retrying.
+Downgrade fails if active rows now hold duplicate (name, domain, project);
+operator must dedupe first.
 
 """
 
@@ -43,16 +34,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Recreate the partial unique index on (name, domain, project).
-
-    If duplicate active deployment names exist (which the dropped index
-    previously prevented but which the upgraded schema allows), the
-    `CREATE UNIQUE INDEX` raises a unique-violation. Re-raise with a
-    guided message instructing the operator to remove the duplicate
-    `endpoints` rows before retrying. We do not auto-resolve duplicates
-    because endpoint name may carry user-visible meaning and silent
-    mutation of user data during a downgrade is unsafe.
-    """
     try:
         op.execute(
             f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME} "
@@ -61,11 +42,6 @@ def downgrade() -> None:
         )
     except IntegrityError as exc:
         raise RuntimeError(
-            "Cannot recreate the unique index "
-            f"`{INDEX_NAME}` on `endpoints (name, domain, project)` "
-            "because two or more active deployments share the same name "
-            "within the same (domain, project). Delete or destroy the "
-            "duplicate `endpoints` rows (or move them to "
-            "`lifecycle_stage IN ('destroying', 'destroyed')`) before "
-            "retrying this downgrade."
+            f"Duplicate (name, domain, project) among active `endpoints` rows; "
+            f"delete duplicates before retrying downgrade to recreate `{INDEX_NAME}`."
         ) from exc

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -167,17 +167,6 @@ class EndpointRow(Base):  # type: ignore[misc]
 
     __table_args__ = (
         sa.Index(
-            "ix_endpoints_unique_name_when_active",
-            "name",
-            "domain",
-            "project",
-            unique=True,
-            postgresql_where=sa.column("lifecycle_stage").notin_([
-                EndpointLifecycle.DESTROYING.value,
-                EndpointLifecycle.DESTROYED.value,
-            ]),
-        ),
-        sa.Index(
             "ix_endpoints_lifecycle_sub_step",
             "lifecycle_stage",
             "sub_step",

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -25,7 +25,6 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
 )
-from ai.backend.common.exception import DeploymentNameAlreadyExists
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_preset import DeploymentPresetID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
@@ -301,9 +300,6 @@ class DeploymentDBSource:
         spec = cast(DeploymentCreatorSpec, creator.spec)
         async with self._begin_session_read_committed() as db_sess:
             await self._check_group_exists(db_sess, spec.metadata.domain, spec.metadata.project_id)
-            await self._check_endpoint_name_exists(
-                db_sess, spec.metadata.domain, spec.metadata.project_id, spec.metadata.name
-            )
 
             # Create endpoint with RBAC scope association
             rbac_result = await execute_rbac_entity_creator(db_sess, creator)
@@ -366,36 +362,6 @@ class DeploymentDBSource:
         result = await db_sess.execute(query)
         if result.first() is None:
             raise ProjectNotFound(f"Project {group_id} not found in domain {domain_name}")
-
-    async def _check_endpoint_name_exists(
-        self,
-        db_sess: SASession,
-        domain_name: str,
-        project_id: uuid.UUID,
-        name: str,
-    ) -> None:
-        """Check if endpoint name already exists in the project.
-
-        Raises:
-            DeploymentNameAlreadyExists: If an endpoint with the same name exists.
-        """
-        query = (
-            sa.select(EndpointRow.id)
-            .where(
-                sa.and_(
-                    EndpointRow.domain == domain_name,
-                    EndpointRow.project == project_id,
-                    EndpointRow.name == name,
-                    EndpointRow.lifecycle_stage != EndpointLifecycle.DESTROYED,
-                )
-            )
-            .limit(1)
-        )
-        result = await db_sess.execute(query)
-        if result.first() is not None:
-            raise DeploymentNameAlreadyExists(
-                f"Deployment with name '{name}' already exists in this project"
-            )
 
     async def get_image_id(self, image: ImageIdentifier) -> ImageID:
         """Get image ID from ImageIdentifier.

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -18,7 +18,6 @@ from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.dto.manager.v2.deployment.types import IntOrPercent
-from ai.backend.common.exception import DeploymentNameAlreadyExists
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
@@ -3651,37 +3650,6 @@ class TestDeploymentRepositoryDuplicateName:
                 element_type=RBACElementType.PROJECT, element_id=str(group.id)
             ),
         )
-
-    async def test_create_endpoint_raises_when_duplicate_name(
-        self,
-        deployment_repository: DeploymentRepository,
-        test_domain: DomainRow,
-        test_group: GroupRow,
-        test_scaling_group: ScalingGroupRow,
-        test_image_id: uuid.UUID,
-    ) -> None:
-        """Test that create_endpoint raises DeploymentNameAlreadyExists for duplicate name."""
-        # Create first endpoint with specific name
-        first_creator = self._create_endpoint_creator(
-            name="duplicate-test-endpoint",
-            domain=test_domain,
-            group=test_group,
-            scaling_group=test_scaling_group,
-            image_id=test_image_id,
-        )
-        await deployment_repository.create_endpoint(first_creator)
-
-        # Attempt to create second endpoint with same name should fail
-        second_creator = self._create_endpoint_creator(
-            name="duplicate-test-endpoint",
-            domain=test_domain,
-            group=test_group,
-            scaling_group=test_scaling_group,
-            image_id=test_image_id,
-        )
-
-        with pytest.raises(DeploymentNameAlreadyExists):
-            await deployment_repository.create_endpoint(second_creator)
 
     async def test_create_endpoint_succeeds_with_different_name(
         self,


### PR DESCRIPTION
## Summary
- Drop the partial unique index `ix_endpoints_unique_name_when_active` on `(name, domain, project)` and the application-level `_check_endpoint_name_exists` pre-check, so deployment names are no longer unique within a project.
- The previous constraint scope (`domain, project`) did not match the `my_deployments` list scope (`created_user`), so a deployment created by another user in the same project blocked the create yet stayed invisible to the caller — leaving the user unable to choose the name and unable to locate the conflicting record.
- Remove the now-unused `DeploymentNameAlreadyExists` exception and the duplicate-name test. Routing keys on `route_id`, and the inference session name template `f"{endpoint.name}-{route_id}"` already disambiguates downstream.

## Test plan
- [x] Apply the new alembic migration on a database that holds the existing index and verify `\d endpoints` no longer lists `ix_endpoints_unique_name_when_active`.
- [x] Create two deployments with the same name in the same project (different and same `created_user`) and confirm both succeed.
- [x] Confirm `my_deployments` and project-scoped list queries return both rows as expected.
- [x] Downgrade the migration and verify the index is recreated with predicate `lifecycle_stage NOT IN ('destroying', 'destroyed')`.

Resolves BA-5974