### PR TITLE
fix(BA-5973): Map EndpointLifecycle.CREATED to ModelDeploymentStatus PENDING instead of READY

### DIFF
--- a/changes/11516.fix.md
+++ b/changes/11516.fix.md
@@ -1,0 +1,1 @@
+Fix model deployment status incorrectly reported as READY for endpoints that have never been deployed

--- a/src/ai/backend/common/data/model_deployment/types.py
+++ b/src/ai/backend/common/data/model_deployment/types.py
@@ -28,7 +28,7 @@ class ActivenessStatus(CIStrEnum):
 _LIFECYCLE_TO_DEPLOYMENT_STATUS_ALIASES: dict[str, str] = {
     "destroying": "STOPPING",
     "destroyed": "STOPPED",
-    "created": "READY",  # EndpointLifecycle deprecated alias of READY
+    "created": "PENDING",  # never-deployed initial state
 }
 
 

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -423,10 +423,10 @@ def _get_revision_resource_slot_pagination_spec() -> PaginationSpec:
 
 
 _STATUS_TO_LIFECYCLE: dict[ModelDeploymentStatus, list[EndpointLifecycle]] = {
-    ModelDeploymentStatus.PENDING: [EndpointLifecycle.PENDING],
+    ModelDeploymentStatus.PENDING: [EndpointLifecycle.PENDING, EndpointLifecycle.CREATED],
     ModelDeploymentStatus.SCALING: [EndpointLifecycle.SCALING],
     ModelDeploymentStatus.DEPLOYING: [EndpointLifecycle.DEPLOYING],
-    ModelDeploymentStatus.READY: [EndpointLifecycle.READY, EndpointLifecycle.CREATED],
+    ModelDeploymentStatus.READY: [EndpointLifecycle.READY],
     ModelDeploymentStatus.STOPPING: [EndpointLifecycle.DESTROYING],
     ModelDeploymentStatus.STOPPED: [EndpointLifecycle.DESTROYED],
 }

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -213,12 +213,12 @@ def _map_lifecycle_to_status(lifecycle: EndpointLifecycle) -> ModelDeploymentSta
     no longer surfaced through ``ModelDeploymentStatus`` — a legacy
     ``lifecycle=SCALING`` row folds into ``READY`` so clients only have to
     consult ``scaling_state`` to decide whether a replica reconcile is in
-    flight.
+    flight. Legacy ``CREATED`` (never-deployed) folds into ``PENDING``.
     """
     match lifecycle:
-        case EndpointLifecycle.PENDING:
+        case EndpointLifecycle.PENDING | EndpointLifecycle.CREATED:
             return ModelDeploymentStatus.PENDING
-        case EndpointLifecycle.CREATED | EndpointLifecycle.READY | EndpointLifecycle.SCALING:
+        case EndpointLifecycle.READY | EndpointLifecycle.SCALING:
             return ModelDeploymentStatus.READY
         case EndpointLifecycle.DEPLOYING:
             return ModelDeploymentStatus.DEPLOYING

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -628,13 +628,14 @@ class TestStatusMapping:
 
         After the scaling_state split, the lifecycle axis is monotonic and
         SCALING is no longer surfaced through ModelDeploymentStatus — legacy
-        ``lifecycle=SCALING`` rows (and the deprecated CREATED) fold into
-        READY. Replica reconciliation is exposed via the orthogonal
-        ``scaling_state`` field on the deployment node instead.
+        ``lifecycle=SCALING`` rows fold into READY. Replica reconciliation is
+        exposed via the orthogonal ``scaling_state`` field on the deployment
+        node instead. The deprecated ``lifecycle=CREATED`` (never-deployed)
+        folds into PENDING.
         """
         mapping = {
             EndpointLifecycle.PENDING: ModelDeploymentStatus.PENDING,
-            EndpointLifecycle.CREATED: ModelDeploymentStatus.READY,
+            EndpointLifecycle.CREATED: ModelDeploymentStatus.PENDING,
             EndpointLifecycle.READY: ModelDeploymentStatus.READY,
             EndpointLifecycle.SCALING: ModelDeploymentStatus.READY,
             EndpointLifecycle.DEPLOYING: ModelDeploymentStatus.DEPLOYING,

--- a/tests/unit/common/data/model_deployment/test_status_aliases.py
+++ b/tests/unit/common/data/model_deployment/test_status_aliases.py
@@ -25,8 +25,8 @@ class TestModelDeploymentStatusLegacyAliases:
             ("DESTROYING", ModelDeploymentStatus.STOPPING),
             ("destroyed", ModelDeploymentStatus.STOPPED),
             ("DESTROYED", ModelDeploymentStatus.STOPPED),
-            ("created", ModelDeploymentStatus.READY),
-            ("CREATED", ModelDeploymentStatus.READY),
+            ("created", ModelDeploymentStatus.PENDING),
+            ("CREATED", ModelDeploymentStatus.PENDING),
         ],
     )
     def test_lifecycle_value_resolves_to_v2_status(


### PR DESCRIPTION
## Summary
- A never-deployed endpoint with `lifecycle=CREATED` (legacy initial state, no `current_revision`) was being surfaced as `ModelDeploymentStatus.READY`, making it impossible for clients/UI to tell whether the deployment is actually serving traffic.
- Fold `CREATED` into `PENDING` in the forward map (`_map_lifecycle_to_status` in `services/deployment/service.py`), the inverse filter map (`_STATUS_TO_LIFECYCLE` in `api/adapters/deployment/adapter.py`), and the `deployment_history` alias resolver (`_LIFECYCLE_TO_DEPLOYMENT_STATUS_ALIASES` in `common/data/model_deployment/types.py`).
- Tests updated to assert the new mapping.

## Test plan
- [x] `pants check` on changed files
- [x] `pants test tests/unit/common/data/model_deployment/test_status_aliases.py tests/component/deployment/test_deployment.py`
- [ ] Manual: GQL `deployment.metadata.status` returns `PENDING` for an endpoint with `lifecycle=CREATED` / `current_revision=null`

Resolves BA-5973