### PR TITLE
fix(BA-5956): make v2 GraphQL Query/Mutation/computed-field returns nullable

### DIFF
--- a/changes/11517.breaking.md
+++ b/changes/11517.breaking.md
@@ -1,0 +1,1 @@
+v2 GraphQL Query/Mutation root fields and computed nested resolver fields are now nullable in the schema. Clients with strict-typed code generation (Relay, Apollo, etc.) must regenerate types and add null-handling around fields that previously came back as non-null.

--- a/changes/11517.fix.md
+++ b/changes/11517.fix.md
@@ -1,0 +1,1 @@
+Make every v2 GraphQL field that runs through a resolver — Query, Mutation, and computed nested fields — nullable by default, so partial resolver failures and permission denials no longer abort the whole query.

--- a/changes/11517.fix.md
+++ b/changes/11517.fix.md
@@ -1,1 +1,0 @@
-Make every v2 GraphQL field that runs through a resolver — Query, Mutation, and computed nested fields — nullable by default, so partial resolver failures and permission denials no longer abort the whole query.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -744,20 +744,20 @@ type AgentV2 implements Node
   scalingGroup: String!
 
   """Added in 26.1.0. Load the container count for this agent."""
-  containerCount: Int!
+  containerCount: Int
 
   """
   Added in 26.2.0. List of kernels running on this agent with pagination support.
   """
-  kernels(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection!
+  kernels(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection
 
   """
   Added in 26.3.0. List of sessions running on this agent with pagination support.
   """
-  sessions(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection!
+  sessions(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection
 
   """Added in 26.3.0. Per-slot resource capacity and usage for this agent."""
-  resourceSlots(filter: AgentResourceSlotFilter = null, orderBy: [AgentResourceSlotOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AgentResourceConnection!
+  resourceSlots(filter: AgentResourceSlotFilter = null, orderBy: [AgentResourceSlotOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AgentResourceConnection
 }
 
 """
@@ -929,7 +929,7 @@ type Artifact implements Node
   availability: ArtifactAvailability!
 
   """The revisions of this entity."""
-  revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection!
+  revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection
 }
 
 enum ArtifactAvailability
@@ -1123,7 +1123,7 @@ type ArtifactRevision implements Node
   verificationResult: ArtifactVerificationResult
 
   """The artifact of this entity."""
-  artifact: Artifact!
+  artifact: Artifact
 }
 
 """
@@ -5273,7 +5273,7 @@ type DeploymentRevisionPreset implements Node
   runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }
 
 """Added in 26.4.2. Paginated list of deployment revision presets."""
@@ -5966,17 +5966,17 @@ type DomainUsageBucket implements Node
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 
   """
   Added in 26.1.0. Project usage buckets belonging to this domain. Returns paginated project-level usage history for all projects in this domain within the same scaling group.
   """
-  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection
 }
 
 """
@@ -6114,23 +6114,23 @@ type DomainV2 implements Node
   """
   Fair share record for this domain in the specified resource group. Returns the scheduling priority configuration for this domain. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: DomainFairShareScope!): DomainFairShare!
+  fairShare(scope: DomainFairShareScope!): DomainFairShare
 
   """
   Added in 26.4.0. Active resource usage overview for this domain. Returns the currently occupied resource slots and the number of active sessions.
   """
-  activeResourceOverview: ActiveResourceOverview!
+  activeResourceOverview: ActiveResourceOverview
 
   """
   Usage buckets for this domain, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: DomainUsageScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection!
+  usageBuckets(scope: DomainUsageScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection
 
   """Projects belonging to this domain."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection
 
   """Users belonging to this domain."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection
 }
 
 """
@@ -6733,7 +6733,7 @@ type ExtraVFolderMountInfoGQL
   @join__type(graph: STRAWBERRY)
 {
   """The vfolder of this entity."""
-  vfolder: VirtualFolderNode!
+  vfolder: VirtualFolderNode
   vfolderId: ID!
   mountDestination: String
 
@@ -6760,7 +6760,7 @@ type FairShareCalculationSnapshot
   """
   Added in 26.2.0. Average daily decayed resource usage during the lookback period. Calculated as total_decayed_usage divided by lookback duration in days. For each resource type, this represents the average decayed amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyDecayedUsage: ResourceSlot!
+  averageDailyDecayedUsage: ResourceSlot
 
   """Computed fair share factor (0-1 range)"""
   fairShareFactor: Decimal!
@@ -7054,7 +7054,7 @@ type HuggingFaceRegistryConnection
   edges: [HuggingFaceRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -7268,7 +7268,7 @@ type ImageV2 implements Node
   lastUsed: DateTime
 
   """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection!
+  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
 }
 
 """
@@ -7880,7 +7880,7 @@ type KernelV2 implements Node
   session: SessionV2
 
   """Added in 26.3.0. Per-slot resource allocation for this kernel."""
-  resourceAllocations(filter: KernelResourceAllocationFilter = null, orderBy: [KernelResourceAllocationOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): ResourceAllocationConnection!
+  resourceAllocations(filter: KernelResourceAllocationFilter = null, orderBy: [KernelResourceAllocationOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): ResourceAllocationConnection
 }
 
 """
@@ -9245,16 +9245,16 @@ type ModelDeployment implements Node
   deploymentPolicy: DeploymentPolicy
 
   """The revision history of this entity."""
-  revisionHistory(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection!
+  revisionHistory(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection
 
   """The replicas of this entity."""
-  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection!
+  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection
 
   """The auto scaling rules of this entity."""
-  autoScalingRules(filter: AutoScalingRuleFilter = null, orderBy: [AutoScalingRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AutoScalingRuleConnection!
+  autoScalingRules(filter: AutoScalingRuleFilter = null, orderBy: [AutoScalingRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AutoScalingRuleConnection
 
   """The access tokens of this entity."""
-  accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection!
+  accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection
 }
 
 """Added in 25.19.0. Connection for model deployments."""
@@ -9287,7 +9287,7 @@ type ModelDeploymentMetadata
   @join__type(graph: STRAWBERRY)
 {
   """The project of this entity."""
-  project: GroupNode! @deprecated(reason: "Use project_v2 instead.")
+  project: GroupNode @deprecated(reason: "Use project_v2 instead.")
 
   """
   Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
@@ -9295,7 +9295,7 @@ type ModelDeploymentMetadata
   projectV2: ProjectV2
 
   """The domain of this entity."""
-  domain: DomainNode! @deprecated(reason: "Use domain_v2 instead.")
+  domain: DomainNode @deprecated(reason: "Use domain_v2 instead.")
 
   """
   Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
@@ -9482,7 +9482,7 @@ type ModelMountConfig
   @join__type(graph: STRAWBERRY)
 {
   """The vfolder of this entity."""
-  vfolder: VirtualFolderNode!
+  vfolder: VirtualFolderNode
   vfolderId: ID!
   mountDestination: String!
   definitionPath: String!
@@ -9532,7 +9532,7 @@ type ModelReplica implements Node
   sessionV2: SessionV2
 
   """The revision of this entity."""
-  revision: ModelRevision!
+  revision: ModelRevision
 }
 
 """
@@ -9598,7 +9598,7 @@ type ModelRevision implements Node
   createdAt: DateTime!
 
   """The image of this entity."""
-  image: ImageNode! @deprecated(reason: "Use image_v2 instead.")
+  image: ImageNode @deprecated(reason: "Use image_v2 instead.")
 
   """
   Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
@@ -9611,7 +9611,7 @@ type ModelRevision implements Node
   revisionPreset: DeploymentRevisionPreset
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }
 
 """Added in 25.19.0. Connection for model revisions."""
@@ -10676,670 +10676,670 @@ type Mutation
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
-  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload! @join__field(graph: STRAWBERRY)
+  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Perform detailed scanning of specific models. Unlike the general scan_artifacts operation, this performs immediate detailed scanning of specified models including README content and file sizes. Returns artifact revisions with complete metadata ready for use
   """
-  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload! @join__field(graph: STRAWBERRY)
+  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Import scanned artifact revisions from external registries. Downloads the actual files for the specified artifact revisions, transitioning them from SCANNED → PULLING → VERIFYING → AVAILABLE status. Returns background tasks that can be monitored for import progress. Once AVAILABLE, artifacts can be used by users in their sessions
   """
-  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload! @join__field(graph: STRAWBERRY)
+  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Create or update user-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. These settings will override domain-level settings when configurations are merged for this user. If user_id is not provided, the current user's configuration will be updated. Users can only modify their own configuration, but admins can modify any user's configuration
   """
-  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload! @join__field(graph: STRAWBERRY)
+  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Delete user-level app configuration. After deletion, the user will still receive domain-level configuration values when configurations are merged, as domain settings remain unaffected. If user_id is not provided, the current user's configuration will be deleted. Users can only delete their own configuration, but admins can delete any user's configuration
   """
-  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload! @join__field(graph: STRAWBERRY)
+  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Triggers artifact scanning on a remote reservoir registry. This mutation instructs a reservoir-type registry to initiate a scan of artifacts from its associated remote reservoir registry source. The scan process will discover and catalog artifacts available in the remote reservoir, making them accessible through the local reservoir registry. Requirements: - The delegator registry must be of type 'reservoir' - The delegator reservoir registry must have a valid remote registry configuration
   """
-  delegateScanArtifacts(input: DelegateScanArtifactsInput!): DelegateScanArtifactsPayload! @join__field(graph: STRAWBERRY)
+  delegateScanArtifacts(input: DelegateScanArtifactsInput!): DelegateScanArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Trigger import of artifact revisions from a remote reservoir registry. This mutation instructs a reservoir-type registry to import specific artifact revisions that were previously discovered during a scan from its remote registry. Note that this operation does not import the artifacts directly into the local registry, but only into the delegator reservoir's storage. Requirements: - The delegator registry must be of type 'reservoir' - The delegator registry must have a valid remote registry configuration
   """
-  delegateImportArtifacts(input: DelegateImportArtifactsInput!): DelegateImportArtifactsPayload! @join__field(graph: STRAWBERRY)
+  delegateImportArtifacts(input: DelegateImportArtifactsInput!): DelegateImportArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Update artifact metadata properties. Modifies artifact metadata such as readonly status and description. This operation does not affect the actual artifact files or revisions
   """
-  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload! @join__field(graph: STRAWBERRY)
+  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Soft-delete artifacts from the system. Marks artifacts as deleted without permanently removing them. Deleted artifacts can be restored using the restore_artifacts mutation
   """
-  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload! @join__field(graph: STRAWBERRY)
+  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Restore previously deleted artifacts. Reverses the soft-delete operation, making the artifacts available again for use in the system
   """
-  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload! @join__field(graph: STRAWBERRY)
+  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Clean up stored artifact revision data to free storage space. Removes the downloaded files for the specified artifact revisions and transitions them back to SCANNED status. The metadata remains, allowing the artifacts to be re-imported later if needed. Use this operation to manage storage usage by removing unused artifacts
   """
-  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload! @join__field(graph: STRAWBERRY)
+  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Cancel an in-progress artifact import operation. Stops the download process for the specified artifact revision and reverts its status back to SCANNED. The partially downloaded data is cleaned up
   """
-  cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload! @join__field(graph: STRAWBERRY)
+  cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create model deployment."""
-  createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload! @join__field(graph: STRAWBERRY)
+  createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Update model deployment."""
-  updateModelDeployment(input: UpdateDeploymentInput!): UpdateDeploymentPayload! @join__field(graph: STRAWBERRY)
+  updateModelDeployment(input: UpdateDeploymentInput!): UpdateDeploymentPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Delete model deployment."""
-  deleteModelDeployment(input: DeleteDeploymentInput!): DeleteDeploymentPayload! @join__field(graph: STRAWBERRY)
+  deleteModelDeployment(input: DeleteDeploymentInput!): DeleteDeploymentPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Force syncs up-to-date replica information. In normal situations this will be automatically handled by Backend.AI schedulers.
   """
-  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload! @join__field(graph: STRAWBERRY)
+  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Add model revision."""
-  addModelRevision(input: AddRevisionInput!): AddRevisionPayload! @join__field(graph: STRAWBERRY)
+  addModelRevision(input: AddRevisionInput!): AddRevisionPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.3. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
   """
-  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload! @join__field(graph: STRAWBERRY)
+  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Create or update the deployment policy for a given deployment (upsert semantics). If the deployment already has a policy, it is replaced entirely with the new configuration
   """
-  updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload! @join__field(graph: STRAWBERRY)
+  updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new notification channel (admin only)"""
-  adminCreateNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  adminCreateNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a notification channel (admin only)"""
-  adminUpdateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a notification channel (admin only)"""
-  adminDeleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Validate a notification channel (admin only)"""
-  adminValidateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  adminValidateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new notification rule (admin only)"""
-  adminCreateNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  adminCreateNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a notification rule (admin only)"""
-  adminUpdateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  adminUpdateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a notification rule (admin only)"""
-  adminDeleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  adminDeleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Validate a notification rule (admin only)"""
-  adminValidateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  adminValidateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create or update domain-level app configuration (admin only). The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys
   """
-  adminUpsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Delete domain-level app configuration (admin only). All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults
   """
-  adminDeleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new notification channel"""
-  createNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  createNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Update a notification channel"""
-  updateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Delete a notification channel"""
-  deleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Validate a notification channel"""
-  validateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  validateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Create a new notification rule"""
-  createNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  createNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Update a notification rule"""
-  updateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Delete a notification rule"""
-  deleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Validate a notification rule"""
-  validateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  validateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 25.16.0. Create or update domain-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys. Requires admin privileges
   """
-  upsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 25.16.0. Delete domain-level app configuration. All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults. Requires admin privileges
   """
-  deleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 25.14.0. Create an object storage."""
-  createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Update an object storage."""
-  updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create auto scaling rule."""
-  createAutoScalingRule(input: CreateAutoScalingRuleInput!): CreateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  createAutoScalingRule(input: CreateAutoScalingRuleInput!): CreateAutoScalingRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Update auto scaling rule."""
-  updateAutoScalingRule(input: UpdateAutoScalingRuleInput!): UpdateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  updateAutoScalingRule(input: UpdateAutoScalingRuleInput!): UpdateAutoScalingRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Delete auto scaling rule."""
-  deleteAutoScalingRule(input: DeleteAutoScalingRuleInput!): DeleteAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  deleteAutoScalingRule(input: DeleteAutoScalingRuleInput!): DeleteAutoScalingRulePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Delete an object storage."""
-  deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create a new VFS storage"""
-  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Update an existing VFS storage"""
-  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Delete a VFS storage"""
-  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.15.0. Registers a new namespace within a storage"""
-  registerStorageNamespace(input: RegisterStorageNamespaceInput!): RegisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
+  registerStorageNamespace(input: RegisterStorageNamespaceInput!): RegisterStorageNamespacePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.15.0. Unregisters an existing namespace from a storage"""
-  unregisterStorageNamespace(input: UnregisterStorageNamespaceInput!): UnregisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
+  unregisterStorageNamespace(input: UnregisterStorageNamespaceInput!): UnregisterStorageNamespacePayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Create huggingface registry."""
-  createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Update huggingface registry."""
-  updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Delete huggingface registry."""
-  deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Create reservoir registry."""
-  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Update reservoir registry."""
-  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Delete reservoir registry."""
-  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Get a presigned download URL."""
-  getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload! @join__field(graph: STRAWBERRY)
+  getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Get a presigned upload URL."""
-  getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload! @join__field(graph: STRAWBERRY)
+  getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Approve an artifact revision for general use. Admin-only operation to approve artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload! @join__field(graph: STRAWBERRY)
+  approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Reject an artifact revision, preventing its use. Admin-only operation to reject artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload! @join__field(graph: STRAWBERRY)
+  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Create access token."""
-  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload! @join__field(graph: STRAWBERRY)
+  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Delete access token."""
-  deleteAccessToken(input: DeleteAccessTokenInput!): DeleteAccessTokenPayload! @join__field(graph: STRAWBERRY)
+  deleteAccessToken(input: DeleteAccessTokenInput!): DeleteAccessTokenPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.19.0. Activate a specific revision to be the current revision
   """
-  activateDeploymentRevision(input: ActivateRevisionInput!): ActivateRevisionPayload! @join__field(graph: STRAWBERRY)
+  activateDeploymentRevision(input: ActivateRevisionInput!): ActivateRevisionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 25.19.0. Update the traffic status of a route"""
-  updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload! @join__field(graph: STRAWBERRY)
+  updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert domain fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert project fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert user fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert domain fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert project fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert user fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.1.0. Upsert domain fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Upsert project fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Upsert user fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert domain fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert project fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert user fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (admin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  adminUpdateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update resource group configuration (admin only). Only provided fields are updated; others retain their existing values. Supports all configuration fields except fair_share (use separate mutation).
   """
-  adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed resource groups for a domain (admin only).
   """
-  adminUpdateAllowedResourceGroupsForDomainV2(input: UpdateAllowedResourceGroupsForDomainInput!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedResourceGroupsForDomainV2(input: UpdateAllowedResourceGroupsForDomainInput!): AllowedResourceGroupsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed resource groups for a project (admin only).
   """
-  adminUpdateAllowedResourceGroupsForProjectV2(input: UpdateAllowedResourceGroupsForProjectInput!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedResourceGroupsForProjectV2(input: UpdateAllowedResourceGroupsForProjectInput!): AllowedResourceGroupsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed domains for a resource group (admin only).
   """
-  adminUpdateAllowedDomainsForResourceGroupV2(input: UpdateAllowedDomainsForResourceGroupInput!): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedDomainsForResourceGroupV2(input: UpdateAllowedDomainsForResourceGroupInput!): AllowedDomainsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update allowed projects for a resource group (admin only).
   """
-  adminUpdateAllowedProjectsForResourceGroupV2(input: UpdateAllowedProjectsForResourceGroupInput!): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedProjectsForResourceGroupV2(input: UpdateAllowedProjectsForResourceGroupInput!): AllowedProjectsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Fully replace a resource group's ``default_deployment_options`` (admin only). Replace semantics — the supplied payload is the complete new value. New deployments created in this resource group snapshot the new default; existing deployments are not affected.
   """
-  replaceResourceGroupDefaultDeploymentOptions(input: ReplaceResourceGroupDefaultDeploymentOptionsInput!): ReplaceResourceGroupDefaultDeploymentOptionsPayload! @join__field(graph: STRAWBERRY)
+  replaceResourceGroupDefaultDeploymentOptions(input: ReplaceResourceGroupDefaultDeploymentOptionsInput!): ReplaceResourceGroupDefaultDeploymentOptionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Fully replace a resource group's ``default_session_options`` (admin only). Replace semantics — the supplied payload is the complete new value. New sessions created in this resource group consult the new default via the scheduling controller's options resolver at enqueue time; already-enqueued sessions keep the frozen options they were enqueued with.
   """
-  replaceResourceGroupDefaultSessionOptions(input: ReplaceResourceGroupDefaultSessionOptionsInput!): ReplaceResourceGroupDefaultSessionOptionsPayload! @join__field(graph: STRAWBERRY)
+  replaceResourceGroupDefaultSessionOptions(input: ReplaceResourceGroupDefaultSessionOptionsInput!): ReplaceResourceGroupDefaultSessionOptionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (superadmin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.4.2. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Unassign users from a project. RBAC validates project admin permission.
   """
-  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload! @join__field(graph: STRAWBERRY)
+  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create a new user (admin only). Requires superadmin privileges. Automatically creates a default keypair for the user
   """
-  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual specifications
   """
-  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Update multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual update specifications
   """
-  adminBulkUpdateUsersV2(input: BulkUpdateUserV2Input!): BulkUpdateUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkUpdateUsersV2(input: BulkUpdateUserV2Input!): BulkUpdateUsersV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Update a user's information (admin only). Requires superadmin privileges. Only provided fields will be updated
   """
-  adminUpdateUserV2(userId: UUID!, input: UpdateUserV2Input!): UpdateUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminUpdateUserV2(userId: UUID!, input: UpdateUserV2Input!): UpdateUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update the current user's information. Users can only update their own profile. Some fields may be restricted based on user role
   """
-  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload! @join__field(graph: STRAWBERRY)
+  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Soft-delete a user (admin only). Requires superadmin privileges. Sets the user status to DELETED but preserves data
   """
-  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Soft-delete multiple users (admin only). Requires superadmin privileges. Sets user status to DELETED but preserves data
   """
-  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Permanently delete a user and all associated data (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data, sessions, and resources will be deleted
   """
-  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Permanently delete multiple users in bulk (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data will be deleted
   """
-  adminBulkPurgeUsersV2(input: BulkPurgeUsersV2Input!): BulkPurgeUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkPurgeUsersV2(input: BulkPurgeUsersV2Input!): BulkPurgeUsersV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Issue a new keypair for the current user. Settings (resource_policy, rate_limit, is_admin) are inherited from the main keypair. The secret_key is only returned at creation time.
   """
-  issueMyKeypair: IssueMyKeypairPayload! @join__field(graph: STRAWBERRY)
+  issueMyKeypair: IssueMyKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Revoke a keypair owned by the current user. The main access key cannot be revoked — switch it first.
   """
-  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload! @join__field(graph: STRAWBERRY)
+  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Switch the main access key for the current user. The target keypair must be active and owned by the user.
   """
-  switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload! @join__field(graph: STRAWBERRY)
+  switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a keypair owned by the current user (e.g. toggle active state). The keypair must be owned by the current user.
   """
-  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload! @join__field(graph: STRAWBERRY)
+  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Admin creates a keypair for a specified user. The secret_key is only returned at creation time.
   """
-  adminCreateKeypairV2(input: AdminCreateKeypairInput!): AdminCreateKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminCreateKeypairV2(input: AdminCreateKeypairInput!): AdminCreateKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Admin updates a keypair (e.g. toggle active state, change resource policy).
   """
-  adminUpdateKeypairV2(input: AdminUpdateKeypairInput!): AdminUpdateKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairV2(input: AdminUpdateKeypairInput!): AdminUpdateKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Admin deletes a keypair by access key. Cannot delete a main access key.
   """
-  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Admin registers (overwrites) a user's SSH keypair."""
-  adminRegisterSshKeypairV2(input: AdminRegisterSSHKeypairInput!): AdminRegisterSSHKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminRegisterSshKeypairV2(input: AdminRegisterSSHKeypairInput!): AdminRegisterSSHKeypairPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Admin clears a user's SSH keypair."""
-  adminDeleteSshKeypairV2(accessKey: String!): AdminDeleteSSHKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteSshKeypairV2(accessKey: String!): AdminDeleteSSHKeypairPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Revoke a login session. (admin only)"""
-  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload! @join__field(graph: STRAWBERRY)
+  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Revoke a login session owned by the current user."""
-  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload! @join__field(graph: STRAWBERRY)
+  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Clear the failed-login rate limit block for a user. (admin only)
   """
-  adminUnblockUser(username: String!): UnblockUserPayload! @join__field(graph: STRAWBERRY)
+  adminUnblockUser(username: String!): UnblockUserPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention)
   """
-  updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload! @join__field(graph: STRAWBERRY)
+  updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a new query definition (admin only)"""
-  adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Modify an existing query definition (admin only)."""
-  adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!): ModifyQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!): ModifyQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Delete a query definition (admin only)"""
-  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a new query preset category (admin only)."""
-  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload! @join__field(graph: STRAWBERRY)
+  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Delete a query preset category (admin only)."""
-  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload! @join__field(graph: STRAWBERRY)
+  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a new role (admin only)."""
-  adminCreateRole(input: CreateRoleInput!): Role! @join__field(graph: STRAWBERRY)
+  adminCreateRole(input: CreateRoleInput!): Role @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Update an existing role (admin only)."""
-  adminUpdateRole(input: UpdateRoleInput!): Role! @join__field(graph: STRAWBERRY)
+  adminUpdateRole(input: UpdateRoleInput!): Role @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Soft-delete a role (admin only)."""
-  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload! @join__field(graph: STRAWBERRY)
+  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Permanently remove a role (admin only)."""
-  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload! @join__field(graph: STRAWBERRY)
+  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Create a scoped permission (admin only)."""
-  adminCreatePermission(input: CreatePermissionInput!): Permission! @join__field(graph: STRAWBERRY)
+  adminCreatePermission(input: CreatePermissionInput!): Permission @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Update a scoped permission (admin only)."""
-  adminUpdatePermission(input: UpdatePermissionInput!): Permission! @join__field(graph: STRAWBERRY)
+  adminUpdatePermission(input: UpdatePermissionInput!): Permission @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Delete a scoped permission (admin only)."""
-  adminDeletePermission(input: DeletePermissionInput!): DeletePermissionPayload! @join__field(graph: STRAWBERRY)
+  adminDeletePermission(input: DeletePermissionInput!): DeletePermissionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Assign a role to a user (admin only)."""
-  adminAssignRole(input: AssignRoleInput!): RoleAssignment! @join__field(graph: STRAWBERRY)
+  adminAssignRole(input: AssignRoleInput!): RoleAssignment @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Revoke a role from a user (admin only)."""
-  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment! @join__field(graph: STRAWBERRY)
+  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Bulk assign a role to multiple users (admin only)."""
-  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload! @join__field(graph: STRAWBERRY)
+  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
-  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload! @join__field(graph: STRAWBERRY)
+  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-insert scoped permission rows across one or more roles (admin only).
   """
-  adminBulkAddRolePermissions(input: BulkAddRolePermissionsInput!): BulkAddRolePermissionsPayload! @join__field(graph: STRAWBERRY)
+  adminBulkAddRolePermissions(input: BulkAddRolePermissionsInput!): BulkAddRolePermissionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-delete permission rows by primary key (admin only).
   """
-  adminBulkRemoveRolePermissions(input: BulkRemoveRolePermissionsInput!): BulkRemoveRolePermissionsPayload! @join__field(graph: STRAWBERRY)
+  adminBulkRemoveRolePermissions(input: BulkRemoveRolePermissionsInput!): BulkRemoveRolePermissionsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Replace one role's entire scoped-permission set (admin only).
   """
-  adminReplaceRolePermissions(input: ReplaceRolePermissionsInput!): ReplaceRolePermissionsPayload! @join__field(graph: STRAWBERRY)
+  adminReplaceRolePermissions(input: ReplaceRolePermissionsInput!): ReplaceRolePermissionsPayload @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Create role invitations by email."""
-  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload! @join__field(graph: STRAWBERRY)
+  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Accept a pending role invitation."""
-  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Reject a pending role invitation."""
-  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
-  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation! @join__field(graph: STRAWBERRY)
+  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new project resource policy (admin only)."""
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new login client type (super admin only)."""
-  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a login client type (super admin only)."""
-  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a login client type (super admin only)."""
-  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload! @join__field(graph: STRAWBERRY)
+  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
-  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a runtime variant preset (superadmin only)."""
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a runtime variant preset (superadmin only)."""
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a runtime variant preset (superadmin only)."""
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a deployment revision preset (admin only)."""
-  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a deployment revision preset (admin only)."""
-  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a deployment revision preset (admin only)."""
-  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Bulk-delete model cards (admin only) with per-card partial-failure reporting.
@@ -11349,67 +11349,67 @@ type Mutation
   """
   Added in 26.4.2. Scan a MODEL_STORE project and upsert model cards from vfolder model-definition.yaml files.
   """
-  scanProjectModelCardsV2(projectId: UUID!): ScanProjectModelCardsV2Payload! @join__field(graph: STRAWBERRY)
+  scanProjectModelCardsV2(projectId: UUID!): ScanProjectModelCardsV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Deploy a model card by creating a deployment with a revision preset.
   """
-  deployModelCardV2(cardId: UUID!, input: DeployModelCardV2Input!): DeployModelCardV2Payload! @join__field(graph: STRAWBERRY)
+  deployModelCardV2(cardId: UUID!, input: DeployModelCardV2Input!): DeployModelCardV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a new virtual folder."""
-  createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
-  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
-  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload! @join__field(graph: STRAWBERRY)
+  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
-  deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Soft-delete multiple virtual folders."""
-  bulkDeleteVfoldersV2(input: BulkDeleteVFoldersV2Input!): BulkDeleteVFoldersV2Payload! @join__field(graph: STRAWBERRY)
+  bulkDeleteVfoldersV2(input: BulkDeleteVFoldersV2Input!): BulkDeleteVFoldersV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Permanently purge multiple virtual folders."""
-  bulkPurgeVfoldersV2(input: BulkPurgeVFoldersV2Input!): BulkPurgeVFoldersV2Payload! @join__field(graph: STRAWBERRY)
+  bulkPurgeVfoldersV2(input: BulkPurgeVFoldersV2Input!): BulkPurgeVFoldersV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Clone a virtual folder."""
-  cloneVfolderV2(vfolderId: UUID!, input: CloneVFolderV2Input!): CloneVFolderV2Payload! @join__field(graph: STRAWBERRY)
+  cloneVfolderV2(vfolderId: UUID!, input: CloneVFolderV2Input!): CloneVFolderV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List files in a virtual folder."""
-  vfolderListFilesV2(vfolderId: UUID!, input: ListFilesV2Input!): ListFilesV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderListFilesV2(vfolderId: UUID!, input: ListFilesV2Input!): ListFilesV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create directories inside a virtual folder."""
-  vfolderMkdirV2(vfolderId: UUID!, input: MkdirV2Input!): MkdirV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderMkdirV2(vfolderId: UUID!, input: MkdirV2Input!): MkdirV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Move a file within a virtual folder."""
-  vfolderMoveFileV2(vfolderId: UUID!, input: MoveFileV2Input!): MoveFileV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderMoveFileV2(vfolderId: UUID!, input: MoveFileV2Input!): MoveFileV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Delete files inside a virtual folder."""
-  vfolderDeleteFilesV2(vfolderId: UUID!, input: DeleteFilesV2Input!): DeleteFilesV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderDeleteFilesV2(vfolderId: UUID!, input: DeleteFilesV2Input!): DeleteFilesV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create an upload session for a virtual folder."""
-  vfolderCreateUploadSessionV2(vfolderId: UUID!, input: CreateUploadSessionV2Input!): CreateUploadSessionV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderCreateUploadSessionV2(vfolderId: UUID!, input: CreateUploadSessionV2Input!): CreateUploadSessionV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Create a download session for a virtual folder."""
-  vfolderCreateDownloadSessionV2(vfolderId: UUID!, input: CreateDownloadSessionV2Input!): CreateDownloadSessionV2Payload! @join__field(graph: STRAWBERRY)
+  vfolderCreateDownloadSessionV2(vfolderId: UUID!, input: CreateDownloadSessionV2Input!): CreateDownloadSessionV2Payload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Enqueue a new compute session."""
-  enqueueSession(input: EnqueueSessionInput!): EnqueueSessionPayload! @join__field(graph: STRAWBERRY)
+  enqueueSession(input: EnqueueSessionInput!): EnqueueSessionPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Terminate sessions within a project scope."""
-  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload! @join__field(graph: STRAWBERRY)
+  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload @join__field(graph: STRAWBERRY)
 }
 
 """
@@ -11745,7 +11745,7 @@ type ObjectStorage implements Node
   region: String!
 
   """The namespaces of this entity."""
-  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): StorageNamespaceConnection!
+  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): StorageNamespaceConnection
 }
 
 """
@@ -11761,7 +11761,7 @@ type ObjectStorageConnection
   edges: [ObjectStorageEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -12673,17 +12673,17 @@ type ProjectUsageBucket implements Node
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 
   """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
-  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection
 }
 
 """
@@ -12834,23 +12834,23 @@ type ProjectV2 implements Node
   """
   Fair share record for this project in the specified resource group. Returns the scheduling priority configuration for this project. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: ProjectFairShareScope!): ProjectFairShare!
+  fairShare(scope: ProjectFairShareScope!): ProjectFairShare
 
   """
   Added in 26.4.0. Active resource usage overview for this project. Returns the currently occupied resource slots and the number of active sessions.
   """
-  activeResourceOverview: ActiveResourceOverview!
+  activeResourceOverview: ActiveResourceOverview
 
   """
   Usage buckets for this project, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: ProjectUsageScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  usageBuckets(scope: ProjectUsageScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection
 
   """The domain this project belongs to."""
-  domain: DomainV2!
+  domain: DomainV2
 
   """Users who are members of this project."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection
 }
 
 """
@@ -13543,7 +13543,7 @@ type Query
   """
   Added in 25.16.0. Retrieve merged app configuration for the current user. The result combines domain-level and user-level configurations, where user settings override domain settings for the same keys. This query should be used when working with user app configurations to get the actual configuration values that will be applied.
   """
-  mergedAppConfig: AppConfig! @join__field(graph: STRAWBERRY)
+  mergedAppConfig: AppConfig @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Get a specific deployment by ID."""
   deployment(id: ID!): ModelDeployment @join__field(graph: STRAWBERRY)
@@ -13570,7 +13570,7 @@ type Query
   """
   Added in 26.4.2. Get JSON schema for a notification rule type's message format
   """
-  notificationRuleTypeSchema(ruleType: NotificationRuleType!): JSON! @join__field(graph: STRAWBERRY)
+  notificationRuleTypeSchema(ruleType: NotificationRuleType!): JSON @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0. Get an object storage by ID"""
   objectStorage(id: ID!): ObjectStorage @join__field(graph: STRAWBERRY)
@@ -13618,30 +13618,30 @@ type Query
   """
   Added in UNRELEASED. List all registered deployment scheduling handlers (superadmin only). The returned ``name`` values are valid keys for ``DeploymentOptions.timeouts.by_handler``.
   """
-  schedulingHandlers: [SchedulingHandlerNode!]! @join__field(graph: STRAWBERRY)
+  schedulingHandlers: [SchedulingHandlerNode!] @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
   """
-  adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed resource groups for a project (admin only).
   """
-  adminAllowedResourceGroupsForProjectV2(projectId: UUID!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedResourceGroupsForProjectV2(projectId: UUID!): AllowedResourceGroupsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed domains for a resource group (admin only).
   """
-  adminAllowedDomainsForResourceGroupV2(resourceGroupName: String!): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedDomainsForResourceGroupV2(resourceGroupName: String!): AllowedDomainsPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get allowed projects for a resource group (admin only).
   """
-  adminAllowedProjectsForResourceGroupV2(resourceGroupName: String!): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedProjectsForResourceGroupV2(resourceGroupName: String!): AllowedProjectsPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Query service catalog entries. Admin only."""
-  adminServiceCatalogs(filter: ServiceCatalogFilter = null, orderBy: [ServiceCatalogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): [ServiceCatalog!]! @join__field(graph: STRAWBERRY)
+  adminServiceCatalogs(filter: ServiceCatalogFilter = null, orderBy: [ServiceCatalogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): [ServiceCatalog!] @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List session scheduling history (admin only)"""
   adminSessionSchedulingHistories(filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
@@ -13712,7 +13712,7 @@ type Query
   """
   Added in 26.3.0. Query audit logs with pagination and filtering. (admin only)
   """
-  adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection! @join__field(graph: STRAWBERRY)
+  adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -13722,22 +13722,22 @@ type Query
   """
   Added in 26.4.2. Query login sessions with pagination and filtering. (admin only)
   """
-  adminLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
+  adminLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Query login history with pagination and filtering. (admin only)
   """
-  adminLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
+  adminLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Query sessions with pagination and filtering. (admin only)
   """
-  adminSessionsV2(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection! @join__field(graph: STRAWBERRY)
+  adminSessionsV2(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List sessions within a specific project. Requires project membership or higher privileges.
   """
-  projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection! @join__field(graph: STRAWBERRY)
+  projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.3. Query a single session by ID. Returns an error if not found.
@@ -13758,7 +13758,7 @@ type Query
   """
   Added in 26.3.0. Returns resource slot types with pagination and filtering.
   """
-  resourceSlotTypes(filter: ResourceSlotTypeFilter = null, orderBy: [ResourceSlotTypeOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceSlotTypeConnection! @join__field(graph: STRAWBERRY)
+  resourceSlotTypes(filter: ResourceSlotTypeFilter = null, orderBy: [ResourceSlotTypeOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceSlotTypeConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
@@ -13778,7 +13778,7 @@ type Query
   """
   Added in 26.4.2. Execute a prometheus query preset by ID and return the result. Available to any authenticated user; the underlying preset query is the same regardless of who runs it.
   """
-  prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+  prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
@@ -13793,7 +13793,7 @@ type Query
   """
   Added in 26.4.2. List query preset categories with filtering and pagination. Available to any authenticated user.
   """
-  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]! @join__field(graph: STRAWBERRY)
+  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!] @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role @join__field(graph: STRAWBERRY)
@@ -13801,27 +13801,27 @@ type Query
   """
   Added in 26.3.0. List roles with filtering and pagination (admin only).
   """
-  adminRoles(filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
+  adminRoles(filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List scoped permissions with filtering and pagination (admin only).
   """
-  adminPermissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection! @join__field(graph: STRAWBERRY)
+  adminPermissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List role assignments with filtering and pagination (admin only).
   """
-  adminRoleAssignments(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
+  adminRoleAssignments(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Search entity associations (admin only). Optionally filter by entity_type and entity_id.
   """
-  adminEntities(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection! @join__field(graph: STRAWBERRY)
+  adminEntities(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List keypairs owned by the current authenticated user. Supports filtering, ordering, and both cursor-based and offset-based pagination.
   """
-  myKeypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection! @join__field(graph: STRAWBERRY)
+  myKeypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a single keypair by access key (admin only). Requires superadmin privileges.
@@ -13831,55 +13831,55 @@ type Query
   """
   Added in 26.4.2. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminKeypairsV2(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection! @join__field(graph: STRAWBERRY)
+  adminKeypairsV2(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get a user's SSH public key (admin only). The private key is never returned.
   """
-  adminSshKeypairV2(accessKey: String!): AdminGetSSHKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminSshKeypairV2(accessKey: String!): AdminGetSSHKeypairPayload @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Query login sessions of the current user with pagination and filtering.
   """
-  myLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
+  myLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Query login history of the current user with pagination and filtering.
   """
-  myLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
+  myLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List roles assigned to the current authenticated user.
   """
-  myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
+  myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List role invitations sent by the current user."""
-  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """
-  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List roles registered in a project scope."""
-  projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
+  projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List invitations for a specific role."""
-  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection! @join__field(graph: STRAWBERRY)
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.3.0. List valid RBAC scope-entity type combinations."""
-  rbacScopeEntityCombinations: [ScopeEntityCombination!]! @join__field(graph: STRAWBERRY)
+  rbacScopeEntityCombinations: [ScopeEntityCombination!] @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List valid RBAC entity-operation combinations."""
-  rbacEntityOperationCombinations: [EntityOperationCombination!]! @join__field(graph: STRAWBERRY)
+  rbacEntityOperationCombinations: [EntityOperationCombination!] @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List complete RBAC scope-entity-operation combinations (permission matrix).
   """
-  rbacPermissionMatrix: [ScopeEntityOperationCombination!]! @join__field(graph: STRAWBERRY)
+  rbacPermissionMatrix: [ScopeEntityOperationCombination!] @join__field(graph: STRAWBERRY)
 
   """Added in 26.2.0. Query kernels within a specific session."""
   sessionKernelsV2(scope: SessionScope!, filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection @join__field(graph: STRAWBERRY)
@@ -13980,10 +13980,10 @@ type Query
   """
   Added in 25.16.0. Get configuration JSON Schemas for all inference runtimes.
   """
-  inferenceRuntimeConfigs: JSON! @join__field(graph: STRAWBERRY)
+  inferenceRuntimeConfigs: JSON @join__field(graph: STRAWBERRY)
 
   """Added in 25.16.0. Get JSON Schema for inference runtime configuration"""
-  inferenceRuntimeConfig(name: String!): JSON! @join__field(graph: STRAWBERRY)
+  inferenceRuntimeConfig(name: String!): JSON @join__field(graph: STRAWBERRY)
 
   """Added in 25.19.0. Get a specific route by ID."""
   route(id: ID!): Route @join__field(graph: STRAWBERRY)
@@ -14018,7 +14018,7 @@ type Query
   """
   Added in 26.4.2. Get the current client's IP address as seen by the server. Useful for configuring IP allowlists.
   """
-  myClientIp: MyClientIp! @join__field(graph: STRAWBERRY)
+  myClientIp: MyClientIp @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get the current authenticated user's information. Returns the user associated with the current session. Returns an error if not authenticated.
@@ -14102,7 +14102,7 @@ type Query
   """
   Added in 26.4.2. List storage hosts the current user is allowed to mount, with the union of permissions inherited from domain, project, and keypair resource policies.
   """
-  myStorageHostPermissions: MyStorageHostPermissionsPayload! @join__field(graph: STRAWBERRY)
+  myStorageHostPermissions: MyStorageHostPermissionsPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List resource presets (admin only)."""
   adminResourcePresetsV2(filter: ResourcePresetFilter = null, orderBy: [ResourcePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourcePresetConnection @join__field(graph: STRAWBERRY)
@@ -14151,45 +14151,45 @@ type Query
   modelCardAvailablePresets(scope: ModelCardAvailablePresetsScope!, filter: DeploymentRevisionPresetFilter = null, orderBy: [DeploymentRevisionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentRevisionPresetConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Get my keypair resource allocation (current user)."""
-  myKeypairResourceAllocationV2: KeypairResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  myKeypairResourceAllocationV2: KeypairResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Get project resource allocation (project usage)."""
-  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Get domain resource allocation (admin only)."""
-  adminDomainResourceAllocationV2(domainName: String!): DomainResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  adminDomainResourceAllocationV2(domainName: String!): DomainResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Get resource group resource allocation."""
-  resourceGroupResourceAllocationV2(resourceGroupName: String!): ResourceGroupResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  resourceGroupResourceAllocationV2(resourceGroupName: String!): ResourceGroupResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get effective resource allocation for the current user.
   """
-  effectiveResourceAllocationV2(input: EffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  effectiveResourceAllocationV2(input: EffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Get effective resource allocation for a specific user (admin only).
   """
-  adminEffectiveResourceAllocationV2(input: AdminEffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  adminEffectiveResourceAllocationV2(input: AdminEffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Check which resource presets are available for session creation.
   """
-  checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2! @join__field(graph: STRAWBERRY)
+  checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2 @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Search all virtual folders (superadmin only)."""
-  adminVfoldersV2(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  adminVfoldersV2(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. Get a single virtual folder by ID."""
   vfolderV2(vfolderId: UUID!): VFolder @join__field(graph: STRAWBERRY)
 
   """Added in 26.4.2. List virtual folders within a specific project."""
-  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. Search virtual folders accessible to the current user with pagination and filtering.
   """
-  myVfolders(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  myVfolders(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection @join__field(graph: STRAWBERRY)
 }
 
 """
@@ -14749,7 +14749,7 @@ type ReservoirRegistry implements Node
   apiVersion: String!
 
   """The remote artifact registries of this entity."""
-  remoteArtifactRegistries: ArtifactRegistryMetaConnection!
+  remoteArtifactRegistries: ArtifactRegistryMetaConnection
 }
 
 """
@@ -14765,7 +14765,7 @@ type ReservoirRegistryConnection
   edges: [ReservoirRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -14815,7 +14815,7 @@ type ResourceConfig
   @join__type(graph: STRAWBERRY)
 {
   """The resource group of this entity."""
-  resourceGroup: ScalingGroupNode!
+  resourceGroup: ScalingGroupNode
   resourceGroupName: String!
   resourceOpts: ResourceOpts
 }
@@ -14877,12 +14877,12 @@ type ResourceGroup implements Node
   """
   Added in 26.1.0. Fair share calculation configuration for this resource group. Defines decay parameters and resource weights for fair share factor computation. Resource weights are merged with capacity and include default indicators.
   """
-  fairShareSpec: FairShareScalingGroupSpec!
+  fairShareSpec: FairShareScalingGroupSpec
 
   """
   Added in 26.1.0. Resource usage information for this resource group. Provides aggregated metrics for capacity, used, and free resources. This is a lazy-loaded field that queries agent and kernel data on demand.
   """
-  resourceInfo: ResourceInfo!
+  resourceInfo: ResourceInfo
 }
 
 """Added in 26.2.0. Resource group connection"""
@@ -15596,13 +15596,13 @@ type Role implements Node
   deletedAt: DateTime
 
   """Added in 26.3.0. Permissions associated with this role."""
-  permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection!
+  permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
   """Added in 26.3.0. Users assigned to this role."""
-  users(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
+  users(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection
 
   """Added in 26.4.2. Scopes this role is registered in."""
-  scopes(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection!
+  scopes(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection
 }
 
 """Added in 26.3.0. RBAC role assignment (user-role association)."""
@@ -15988,7 +15988,7 @@ type Route implements Node
   errorData: JSON
 
   """The deployment this route belongs to."""
-  deployment: ModelDeployment!
+  deployment: ModelDeployment
 
   """
   The session associated with the route. Can be null if the route is still provisioning.
@@ -16591,7 +16591,7 @@ type SchedulingBroadcastEventPayload
   """
   The session ID associated with the replica. This can be null right after replica creation.
   """
-  session: ComputeSessionNode!
+  session: ComputeSessionNode
 
   """UUID of the session being scheduled."""
   sessionId: ID!
@@ -17199,10 +17199,10 @@ type SessionV2 implements Node
   """
   Added in 26.4.3. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
   """
-  images: ImageV2Connection!
+  images: ImageV2Connection
 
   """Added in 26.3.0. The kernels belonging to this session."""
-  kernels: KernelV2Connection!
+  kernels: KernelV2Connection
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""
@@ -17524,7 +17524,7 @@ type StorageNamespaceConnection
   edges: [StorageNamespaceEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -19603,12 +19603,12 @@ type UserUsageBucket implements Node
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 }
 
 """
@@ -19773,18 +19773,18 @@ type UserV2 implements Node
   """
   Fair share record for this user in the specified resource group and project. Returns the scheduling priority configuration for this user. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: UserFairShareScope!): UserFairShare!
+  fairShare(scope: UserFairShareScope!): UserFairShare
 
   """
   Usage buckets for this user, filtered by resource group and project. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: UserUsageScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  usageBuckets(scope: UserUsageScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection
 
   """The domain this user belongs to."""
   domain: DomainV2
 
   """Projects this user is a member of."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection
 }
 
 """
@@ -20364,7 +20364,7 @@ type VFSStorageConnection
   edges: [VFSStorageEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7054,7 +7054,7 @@ type HuggingFaceRegistryConnection
   edges: [HuggingFaceRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -11761,7 +11761,7 @@ type ObjectStorageConnection
   edges: [ObjectStorageEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -14765,7 +14765,7 @@ type ReservoirRegistryConnection
   edges: [ReservoirRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -17524,7 +17524,7 @@ type StorageNamespaceConnection
   edges: [StorageNamespaceEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -20364,7 +20364,7 @@ type VFSStorageConnection
   edges: [VFSStorageEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -499,20 +499,20 @@ type AgentV2 implements Node {
   scalingGroup: String!
 
   """Added in 26.1.0. Load the container count for this agent."""
-  containerCount: Int!
+  containerCount: Int
 
   """
   Added in 26.2.0. List of kernels running on this agent with pagination support.
   """
-  kernels(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection!
+  kernels(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection
 
   """
   Added in 26.3.0. List of sessions running on this agent with pagination support.
   """
-  sessions(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection!
+  sessions(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection
 
   """Added in 26.3.0. Per-slot resource capacity and usage for this agent."""
-  resourceSlots(filter: AgentResourceSlotFilter = null, orderBy: [AgentResourceSlotOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AgentResourceConnection!
+  resourceSlots(filter: AgentResourceSlotFilter = null, orderBy: [AgentResourceSlotOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AgentResourceConnection
 }
 
 """
@@ -639,7 +639,7 @@ type Artifact implements Node {
   availability: ArtifactAvailability!
 
   """The revisions of this entity."""
-  revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection!
+  revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection
 }
 
 enum ArtifactAvailability {
@@ -803,7 +803,7 @@ type ArtifactRevision implements Node {
   verificationResult: ArtifactVerificationResult
 
   """The artifact of this entity."""
-  artifact: Artifact!
+  artifact: Artifact
 }
 
 """
@@ -3533,7 +3533,7 @@ type DeploymentRevisionPreset implements Node {
   runtimeVariant: RuntimeVariant
 
   """Added in 26.4.2. Resource slot allocations for this preset."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }
 
 """Added in 26.4.2. Paginated list of deployment revision presets."""
@@ -3933,17 +3933,17 @@ type DomainUsageBucket implements Node {
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 
   """
   Added in 26.1.0. Project usage buckets belonging to this domain. Returns paginated project-level usage history for all projects in this domain within the same scaling group.
   """
-  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection
 }
 
 """
@@ -4064,23 +4064,23 @@ type DomainV2 implements Node @key(fields: "id") {
   """
   Fair share record for this domain in the specified resource group. Returns the scheduling priority configuration for this domain. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: DomainFairShareScope!): DomainFairShare!
+  fairShare(scope: DomainFairShareScope!): DomainFairShare
 
   """
   Added in 26.4.0. Active resource usage overview for this domain. Returns the currently occupied resource slots and the number of active sessions.
   """
-  activeResourceOverview: ActiveResourceOverview!
+  activeResourceOverview: ActiveResourceOverview
 
   """
   Usage buckets for this domain, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: DomainUsageScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection!
+  usageBuckets(scope: DomainUsageScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection
 
   """Projects belonging to this domain."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection
 
   """Users belonging to this domain."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection
 }
 
 """
@@ -4426,7 +4426,7 @@ Added in 25.19.0. An extra virtual folder mount attached to a model revision.
 """
 type ExtraVFolderMountInfoGQL {
   """The vfolder of this entity."""
-  vfolder: VirtualFolderNode!
+  vfolder: VirtualFolderNode
   vfolderId: ID!
   mountDestination: String
 
@@ -4449,7 +4449,7 @@ type FairShareCalculationSnapshot {
   """
   Added in 26.2.0. Average daily decayed resource usage during the lookback period. Calculated as total_decayed_usage divided by lookback duration in days. For each resource type, this represents the average decayed amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyDecayedUsage: ResourceSlot!
+  averageDailyDecayedUsage: ResourceSlot
 
   """Computed fair share factor (0-1 range)"""
   fairShareFactor: Decimal!
@@ -4588,7 +4588,7 @@ type HuggingFaceRegistryConnection {
   edges: [HuggingFaceRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -4647,7 +4647,7 @@ type ImageV2 implements Node {
   lastUsed: DateTime
 
   """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection!
+  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection
 }
 
 """
@@ -5080,7 +5080,7 @@ type KernelV2 implements Node {
   session: SessionV2
 
   """Added in 26.3.0. Per-slot resource allocation for this kernel."""
-  resourceAllocations(filter: KernelResourceAllocationFilter = null, orderBy: [KernelResourceAllocationOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): ResourceAllocationConnection!
+  resourceAllocations(filter: KernelResourceAllocationFilter = null, orderBy: [KernelResourceAllocationOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): ResourceAllocationConnection
 }
 
 """
@@ -6056,16 +6056,16 @@ type ModelDeployment implements Node {
   deploymentPolicy: DeploymentPolicy
 
   """The revision history of this entity."""
-  revisionHistory(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection!
+  revisionHistory(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection
 
   """The replicas of this entity."""
-  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection!
+  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection
 
   """The auto scaling rules of this entity."""
-  autoScalingRules(filter: AutoScalingRuleFilter = null, orderBy: [AutoScalingRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AutoScalingRuleConnection!
+  autoScalingRules(filter: AutoScalingRuleFilter = null, orderBy: [AutoScalingRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AutoScalingRuleConnection
 
   """The access tokens of this entity."""
-  accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection!
+  accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection
 }
 
 """Added in 25.19.0. Connection for model deployments."""
@@ -6092,7 +6092,7 @@ Added in 25.19.0. Contains metadata information for a model deployment including
 """
 type ModelDeploymentMetadata {
   """The project of this entity."""
-  project: GroupNode! @deprecated(reason: "Use project_v2 instead.")
+  project: GroupNode @deprecated(reason: "Use project_v2 instead.")
 
   """
   Added in 26.4.3. The project this deployment belongs to, resolved via DataLoader.
@@ -6100,7 +6100,7 @@ type ModelDeploymentMetadata {
   projectV2: ProjectV2
 
   """The domain of this entity."""
-  domain: DomainNode! @deprecated(reason: "Use domain_v2 instead.")
+  domain: DomainNode @deprecated(reason: "Use domain_v2 instead.")
 
   """
   Added in 26.4.3. The domain this deployment belongs to, resolved via DataLoader.
@@ -6271,7 +6271,7 @@ Added in 25.19.0. Configuration for mounting the model data into the inference c
 """
 type ModelMountConfig {
   """The vfolder of this entity."""
-  vfolder: VirtualFolderNode!
+  vfolder: VirtualFolderNode
   vfolderId: ID!
   mountDestination: String!
   definitionPath: String!
@@ -6316,7 +6316,7 @@ type ModelReplica implements Node {
   sessionV2: SessionV2
 
   """The revision of this entity."""
-  revision: ModelRevision!
+  revision: ModelRevision
 }
 
 """
@@ -6375,7 +6375,7 @@ type ModelRevision implements Node {
   createdAt: DateTime!
 
   """The image of this entity."""
-  image: ImageNode! @deprecated(reason: "Use image_v2 instead.")
+  image: ImageNode @deprecated(reason: "Use image_v2 instead.")
 
   """
   Added in 26.4.3. The container image used by this revision, resolved via DataLoader.
@@ -6388,7 +6388,7 @@ type ModelRevision implements Node {
   revisionPreset: DeploymentRevisionPreset
 
   """Added in 26.4.2. Resource slot allocations for this revision."""
-  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]!
+  resourceSlots(filter: AllocatedResourceSlotFilter = null, orderBy: [AllocatedResourceSlotOrderBy!] = null): [AllocatedResourceSlot!]
 }
 
 """Added in 25.19.0. Connection for model revisions."""
@@ -6599,670 +6599,670 @@ type Mutation {
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
-  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload!
+  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload
 
   """
   Added in 25.14.0. Perform detailed scanning of specific models. Unlike the general scan_artifacts operation, this performs immediate detailed scanning of specified models including README content and file sizes. Returns artifact revisions with complete metadata ready for use
   """
-  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload!
+  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload
 
   """
   Added in 25.14.0. Import scanned artifact revisions from external registries. Downloads the actual files for the specified artifact revisions, transitioning them from SCANNED → PULLING → VERIFYING → AVAILABLE status. Returns background tasks that can be monitored for import progress. Once AVAILABLE, artifacts can be used by users in their sessions
   """
-  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload!
+  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload
 
   """
   Added in 25.16.0. Create or update user-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. These settings will override domain-level settings when configurations are merged for this user. If user_id is not provided, the current user's configuration will be updated. Users can only modify their own configuration, but admins can modify any user's configuration
   """
-  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload!
+  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload
 
   """
   Added in 25.16.0. Delete user-level app configuration. After deletion, the user will still receive domain-level configuration values when configurations are merged, as domain settings remain unaffected. If user_id is not provided, the current user's configuration will be deleted. Users can only delete their own configuration, but admins can delete any user's configuration
   """
-  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload!
+  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload
 
   """
   Added in 25.15.0. Triggers artifact scanning on a remote reservoir registry. This mutation instructs a reservoir-type registry to initiate a scan of artifacts from its associated remote reservoir registry source. The scan process will discover and catalog artifacts available in the remote reservoir, making them accessible through the local reservoir registry. Requirements: - The delegator registry must be of type 'reservoir' - The delegator reservoir registry must have a valid remote registry configuration
   """
-  delegateScanArtifacts(input: DelegateScanArtifactsInput!): DelegateScanArtifactsPayload!
+  delegateScanArtifacts(input: DelegateScanArtifactsInput!): DelegateScanArtifactsPayload
 
   """
   Added in 25.15.0. Trigger import of artifact revisions from a remote reservoir registry. This mutation instructs a reservoir-type registry to import specific artifact revisions that were previously discovered during a scan from its remote registry. Note that this operation does not import the artifacts directly into the local registry, but only into the delegator reservoir's storage. Requirements: - The delegator registry must be of type 'reservoir' - The delegator registry must have a valid remote registry configuration
   """
-  delegateImportArtifacts(input: DelegateImportArtifactsInput!): DelegateImportArtifactsPayload!
+  delegateImportArtifacts(input: DelegateImportArtifactsInput!): DelegateImportArtifactsPayload
 
   """
   Added in 25.14.0. Update artifact metadata properties. Modifies artifact metadata such as readonly status and description. This operation does not affect the actual artifact files or revisions
   """
-  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload!
+  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload
 
   """
   Added in 25.15.0. Soft-delete artifacts from the system. Marks artifacts as deleted without permanently removing them. Deleted artifacts can be restored using the restore_artifacts mutation
   """
-  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload!
+  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload
 
   """
   Added in 25.15.0. Restore previously deleted artifacts. Reverses the soft-delete operation, making the artifacts available again for use in the system
   """
-  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload!
+  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload
 
   """
   Added in 25.14.0. Clean up stored artifact revision data to free storage space. Removes the downloaded files for the specified artifact revisions and transitions them back to SCANNED status. The metadata remains, allowing the artifacts to be re-imported later if needed. Use this operation to manage storage usage by removing unused artifacts
   """
-  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload!
+  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload
 
   """
   Added in 25.14.0. Cancel an in-progress artifact import operation. Stops the download process for the specified artifact revision and reverts its status back to SCANNED. The partially downloaded data is cleaned up
   """
-  cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload!
+  cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload
 
   """Added in 26.4.2. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL!
+  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL
 
   """Added in 26.4.2. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL!
+  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL
 
   """Added in 26.4.2. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL!
+  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL
 
   """Added in 25.16.0. Create model deployment."""
-  createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload!
+  createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload
 
   """Added in 25.16.0. Update model deployment."""
-  updateModelDeployment(input: UpdateDeploymentInput!): UpdateDeploymentPayload!
+  updateModelDeployment(input: UpdateDeploymentInput!): UpdateDeploymentPayload
 
   """Added in 25.16.0. Delete model deployment."""
-  deleteModelDeployment(input: DeleteDeploymentInput!): DeleteDeploymentPayload!
+  deleteModelDeployment(input: DeleteDeploymentInput!): DeleteDeploymentPayload
 
   """
   Added in 25.16.0. Force syncs up-to-date replica information. In normal situations this will be automatically handled by Backend.AI schedulers.
   """
-  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload!
+  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload
 
   """Added in 25.16.0. Add model revision."""
-  addModelRevision(input: AddRevisionInput!): AddRevisionPayload!
+  addModelRevision(input: AddRevisionInput!): AddRevisionPayload
 
   """
   Added in 26.4.3. Rebuild and activate a fresh revision for every active deployment (superadmin). Used to repair deployments whose current revision has stale or missing model_definition after backing store migrations.
   """
-  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload!
+  adminRefreshDeploymentRevisions: AdminRefreshDeploymentRevisionsPayload
 
   """
   Added in 26.4.2. Create or update the deployment policy for a given deployment (upsert semantics). If the deployment already has a policy, it is replaced entirely with the new configuration
   """
-  updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload!
+  updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload
 
   """Added in 26.4.2. Create a new notification channel (admin only)"""
-  adminCreateNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload!
+  adminCreateNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload
 
   """Added in 26.4.2. Update a notification channel (admin only)"""
-  adminUpdateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload!
+  adminUpdateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload
 
   """Added in 26.4.2. Delete a notification channel (admin only)"""
-  adminDeleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload!
+  adminDeleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload
 
   """Added in 26.4.2. Validate a notification channel (admin only)"""
-  adminValidateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload!
+  adminValidateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload
 
   """Added in 26.4.2. Create a new notification rule (admin only)"""
-  adminCreateNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload!
+  adminCreateNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload
 
   """Added in 26.4.2. Update a notification rule (admin only)"""
-  adminUpdateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload!
+  adminUpdateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload
 
   """Added in 26.4.2. Delete a notification rule (admin only)"""
-  adminDeleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload!
+  adminDeleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload
 
   """Added in 26.4.2. Validate a notification rule (admin only)"""
-  adminValidateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload!
+  adminValidateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload
 
   """
   Added in 26.2.0. Create or update domain-level app configuration (admin only). The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys
   """
-  adminUpsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload!
+  adminUpsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload
 
   """
   Added in 26.2.0. Delete domain-level app configuration (admin only). All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults
   """
-  adminDeleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload!
+  adminDeleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload
 
   """Added in 26.4.2. Create a new notification channel"""
-  createNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload! @deprecated(reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  createNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload @deprecated(reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Update a notification channel"""
-  updateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload! @deprecated(reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload @deprecated(reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Delete a notification channel"""
-  deleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload! @deprecated(reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload @deprecated(reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Validate a notification channel"""
-  validateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload! @deprecated(reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  validateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload @deprecated(reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Create a new notification rule"""
-  createNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload! @deprecated(reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  createNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload @deprecated(reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Update a notification rule"""
-  updateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload! @deprecated(reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload @deprecated(reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Delete a notification rule"""
-  deleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload! @deprecated(reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload @deprecated(reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 26.4.2. Validate a notification rule"""
-  validateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload! @deprecated(reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  validateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload @deprecated(reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 25.16.0. Create or update domain-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys. Requires admin privileges
   """
-  upsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload! @deprecated(reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload @deprecated(reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 25.16.0. Delete domain-level app configuration. All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults. Requires admin privileges
   """
-  deleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload! @deprecated(reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload @deprecated(reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """Added in 25.14.0. Create an object storage."""
-  createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload!
+  createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload
 
   """Added in 25.14.0. Update an object storage."""
-  updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload!
+  updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload
 
   """Added in 25.16.0. Create auto scaling rule."""
-  createAutoScalingRule(input: CreateAutoScalingRuleInput!): CreateAutoScalingRulePayload!
+  createAutoScalingRule(input: CreateAutoScalingRuleInput!): CreateAutoScalingRulePayload
 
   """Added in 25.16.0. Update auto scaling rule."""
-  updateAutoScalingRule(input: UpdateAutoScalingRuleInput!): UpdateAutoScalingRulePayload!
+  updateAutoScalingRule(input: UpdateAutoScalingRuleInput!): UpdateAutoScalingRulePayload
 
   """Added in 25.16.0. Delete auto scaling rule."""
-  deleteAutoScalingRule(input: DeleteAutoScalingRuleInput!): DeleteAutoScalingRulePayload!
+  deleteAutoScalingRule(input: DeleteAutoScalingRuleInput!): DeleteAutoScalingRulePayload
 
   """Added in 25.14.0. Delete an object storage."""
-  deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload!
+  deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload
 
   """Added in 25.16.0. Create a new VFS storage"""
-  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload!
+  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload
 
   """Added in 25.16.0. Update an existing VFS storage"""
-  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload!
+  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload
 
   """Added in 25.16.0. Delete a VFS storage"""
-  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload!
+  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload
 
   """Added in 25.15.0. Registers a new namespace within a storage"""
-  registerStorageNamespace(input: RegisterStorageNamespaceInput!): RegisterStorageNamespacePayload!
+  registerStorageNamespace(input: RegisterStorageNamespaceInput!): RegisterStorageNamespacePayload
 
   """Added in 25.15.0. Unregisters an existing namespace from a storage"""
-  unregisterStorageNamespace(input: UnregisterStorageNamespaceInput!): UnregisterStorageNamespacePayload!
+  unregisterStorageNamespace(input: UnregisterStorageNamespaceInput!): UnregisterStorageNamespacePayload
 
   """Added in 25.14.0. Create huggingface registry."""
-  createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload!
+  createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload
 
   """Added in 25.14.0. Update huggingface registry."""
-  updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload!
+  updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload
 
   """Added in 25.14.0. Delete huggingface registry."""
-  deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload!
+  deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload
 
   """Added in 25.14.0. Create reservoir registry."""
-  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload!
+  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload
 
   """Added in 25.14.0. Update reservoir registry."""
-  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload!
+  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload
 
   """Added in 25.14.0. Delete reservoir registry."""
-  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload!
+  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload
 
   """Added in 25.14.0. Get a presigned download URL."""
-  getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload!
+  getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload
 
   """Added in 25.14.0. Get a presigned upload URL."""
-  getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload!
+  getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload
 
   """
   Added in 25.14.0. Approve an artifact revision for general use. Admin-only operation to approve artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload!
+  approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload
 
   """
   Added in 25.14.0. Reject an artifact revision, preventing its use. Admin-only operation to reject artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload!
+  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload
 
   """Added in 25.16.0. Create access token."""
-  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload!
+  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload
 
   """Added in UNRELEASED. Delete access token."""
-  deleteAccessToken(input: DeleteAccessTokenInput!): DeleteAccessTokenPayload!
+  deleteAccessToken(input: DeleteAccessTokenInput!): DeleteAccessTokenPayload
 
   """
   Added in 25.19.0. Activate a specific revision to be the current revision
   """
-  activateDeploymentRevision(input: ActivateRevisionInput!): ActivateRevisionPayload!
+  activateDeploymentRevision(input: ActivateRevisionInput!): ActivateRevisionPayload
 
   """Added in 25.19.0. Update the traffic status of a route"""
-  updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload!
+  updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload
 
   """
   Added in 26.2.0. Upsert domain fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload!
+  adminUpsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload
 
   """
   Added in 26.2.0. Upsert project fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload!
+  adminUpsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload
 
   """
   Added in 26.2.0. Upsert user fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload!
+  adminUpsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload
 
   """
   Added in 26.2.0. Bulk upsert domain fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload!
+  adminBulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload
 
   """
   Added in 26.2.0. Bulk upsert project fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload!
+  adminBulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload
 
   """
   Added in 26.2.0. Bulk upsert user fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload!
+  adminBulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload
 
   """
   Added in 26.1.0. Upsert domain fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @deprecated(reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload @deprecated(reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Upsert project fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @deprecated(reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload @deprecated(reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Upsert user fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @deprecated(reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload @deprecated(reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert domain fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload! @deprecated(reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload @deprecated(reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert project fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload! @deprecated(reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload @deprecated(reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.1.0. Bulk upsert user fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload! @deprecated(reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload @deprecated(reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (admin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  adminUpdateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload!
+  adminUpdateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload
 
   """
   Added in 26.2.0. Update resource group configuration (admin only). Only provided fields are updated; others retain their existing values. Supports all configuration fields except fair_share (use separate mutation).
   """
-  adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload!
+  adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload
 
   """Added in 26.4.2. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL!
+  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL
 
   """Added in 26.4.2. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL!
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL
 
   """
   Added in 26.4.2. Update allowed resource groups for a domain (admin only).
   """
-  adminUpdateAllowedResourceGroupsForDomainV2(input: UpdateAllowedResourceGroupsForDomainInput!): AllowedResourceGroupsPayload!
+  adminUpdateAllowedResourceGroupsForDomainV2(input: UpdateAllowedResourceGroupsForDomainInput!): AllowedResourceGroupsPayload
 
   """
   Added in 26.4.2. Update allowed resource groups for a project (admin only).
   """
-  adminUpdateAllowedResourceGroupsForProjectV2(input: UpdateAllowedResourceGroupsForProjectInput!): AllowedResourceGroupsPayload!
+  adminUpdateAllowedResourceGroupsForProjectV2(input: UpdateAllowedResourceGroupsForProjectInput!): AllowedResourceGroupsPayload
 
   """
   Added in 26.4.2. Update allowed domains for a resource group (admin only).
   """
-  adminUpdateAllowedDomainsForResourceGroupV2(input: UpdateAllowedDomainsForResourceGroupInput!): AllowedDomainsPayload!
+  adminUpdateAllowedDomainsForResourceGroupV2(input: UpdateAllowedDomainsForResourceGroupInput!): AllowedDomainsPayload
 
   """
   Added in 26.4.2. Update allowed projects for a resource group (admin only).
   """
-  adminUpdateAllowedProjectsForResourceGroupV2(input: UpdateAllowedProjectsForResourceGroupInput!): AllowedProjectsPayload!
+  adminUpdateAllowedProjectsForResourceGroupV2(input: UpdateAllowedProjectsForResourceGroupInput!): AllowedProjectsPayload
 
   """
   Added in UNRELEASED. Fully replace a resource group's ``default_deployment_options`` (admin only). Replace semantics — the supplied payload is the complete new value. New deployments created in this resource group snapshot the new default; existing deployments are not affected.
   """
-  replaceResourceGroupDefaultDeploymentOptions(input: ReplaceResourceGroupDefaultDeploymentOptionsInput!): ReplaceResourceGroupDefaultDeploymentOptionsPayload!
+  replaceResourceGroupDefaultDeploymentOptions(input: ReplaceResourceGroupDefaultDeploymentOptionsInput!): ReplaceResourceGroupDefaultDeploymentOptionsPayload
 
   """
   Added in UNRELEASED. Fully replace a resource group's ``default_session_options`` (admin only). Replace semantics — the supplied payload is the complete new value. New sessions created in this resource group consult the new default via the scheduling controller's options resolver at enqueue time; already-enqueued sessions keep the frozen options they were enqueued with.
   """
-  replaceResourceGroupDefaultSessionOptions(input: ReplaceResourceGroupDefaultSessionOptionsInput!): ReplaceResourceGroupDefaultSessionOptionsPayload!
+  replaceResourceGroupDefaultSessionOptions(input: ReplaceResourceGroupDefaultSessionOptionsInput!): ReplaceResourceGroupDefaultSessionOptionsPayload
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (superadmin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @deprecated(reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload @deprecated(reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
 
   """
   Added in 26.4.2. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL!
+  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL
 
   """
   Added in 26.4.2. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL!
+  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL
 
   """
   Added in 26.4.2. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL!
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL
 
   """
   Added in 26.4.2. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL!
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL
 
   """
   Added in 26.4.2. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL!
+  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL
 
   """
   Added in 26.4.2. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL!
+  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL
 
   """
   Added in 26.4.2. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL!
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL
 
   """
   Added in 26.4.2. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL!
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL
 
   """
   Added in 26.4.2. Unassign users from a project. RBAC validates project admin permission.
   """
-  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload!
+  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload
 
   """
   Added in 26.2.0. Create a new user (admin only). Requires superadmin privileges. Automatically creates a default keypair for the user
   """
-  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload!
+  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload
 
   """
   Added in 26.2.0. Create multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual specifications
   """
-  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload!
+  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload
 
   """
   Added in 26.3.0. Update multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual update specifications
   """
-  adminBulkUpdateUsersV2(input: BulkUpdateUserV2Input!): BulkUpdateUsersV2Payload!
+  adminBulkUpdateUsersV2(input: BulkUpdateUserV2Input!): BulkUpdateUsersV2Payload
 
   """
   Added in 26.3.0. Update a user's information (admin only). Requires superadmin privileges. Only provided fields will be updated
   """
-  adminUpdateUserV2(userId: UUID!, input: UpdateUserV2Input!): UpdateUserV2Payload!
+  adminUpdateUserV2(userId: UUID!, input: UpdateUserV2Input!): UpdateUserV2Payload
 
   """
   Added in 26.2.0. Update the current user's information. Users can only update their own profile. Some fields may be restricted based on user role
   """
-  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload!
+  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload
 
   """
   Added in 26.2.0. Soft-delete a user (admin only). Requires superadmin privileges. Sets the user status to DELETED but preserves data
   """
-  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload!
+  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload
 
   """
   Added in 26.2.0. Soft-delete multiple users (admin only). Requires superadmin privileges. Sets user status to DELETED but preserves data
   """
-  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload!
+  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload
 
   """
   Added in 26.2.0. Permanently delete a user and all associated data (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data, sessions, and resources will be deleted
   """
-  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload!
+  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload
 
   """
   Added in 26.3.0. Permanently delete multiple users in bulk (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data will be deleted
   """
-  adminBulkPurgeUsersV2(input: BulkPurgeUsersV2Input!): BulkPurgeUsersV2Payload!
+  adminBulkPurgeUsersV2(input: BulkPurgeUsersV2Input!): BulkPurgeUsersV2Payload
 
   """
   Added in 26.4.2. Issue a new keypair for the current user. Settings (resource_policy, rate_limit, is_admin) are inherited from the main keypair. The secret_key is only returned at creation time.
   """
-  issueMyKeypair: IssueMyKeypairPayload!
+  issueMyKeypair: IssueMyKeypairPayload
 
   """
   Added in 26.4.2. Revoke a keypair owned by the current user. The main access key cannot be revoked — switch it first.
   """
-  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload!
+  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload
 
   """
   Added in 26.4.2. Switch the main access key for the current user. The target keypair must be active and owned by the user.
   """
-  switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload!
+  switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload
 
   """
   Added in 26.4.2. Update a keypair owned by the current user (e.g. toggle active state). The keypair must be owned by the current user.
   """
-  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload!
+  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload
 
   """
   Added in 26.4.2. Admin creates a keypair for a specified user. The secret_key is only returned at creation time.
   """
-  adminCreateKeypairV2(input: AdminCreateKeypairInput!): AdminCreateKeypairPayload!
+  adminCreateKeypairV2(input: AdminCreateKeypairInput!): AdminCreateKeypairPayload
 
   """
   Added in 26.4.2. Admin updates a keypair (e.g. toggle active state, change resource policy).
   """
-  adminUpdateKeypairV2(input: AdminUpdateKeypairInput!): AdminUpdateKeypairPayload!
+  adminUpdateKeypairV2(input: AdminUpdateKeypairInput!): AdminUpdateKeypairPayload
 
   """
   Added in 26.4.2. Admin deletes a keypair by access key. Cannot delete a main access key.
   """
-  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload!
+  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload
 
   """Added in 26.4.2. Admin registers (overwrites) a user's SSH keypair."""
-  adminRegisterSshKeypairV2(input: AdminRegisterSSHKeypairInput!): AdminRegisterSSHKeypairPayload!
+  adminRegisterSshKeypairV2(input: AdminRegisterSSHKeypairInput!): AdminRegisterSSHKeypairPayload
 
   """Added in 26.4.2. Admin clears a user's SSH keypair."""
-  adminDeleteSshKeypairV2(accessKey: String!): AdminDeleteSSHKeypairPayload!
+  adminDeleteSshKeypairV2(accessKey: String!): AdminDeleteSSHKeypairPayload
 
   """Added in 26.4.2. Revoke a login session. (admin only)"""
-  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload!
+  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload
 
   """Added in 26.4.2. Revoke a login session owned by the current user."""
-  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload!
+  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload
 
   """
   Added in 26.4.2. Clear the failed-login rate limit block for a user. (admin only)
   """
-  adminUnblockUser(username: String!): UnblockUserPayload!
+  adminUnblockUser(username: String!): UnblockUserPayload
 
   """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention)
   """
-  updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload!
+  updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload
 
   """Added in 26.3.0. Create a new query definition (admin only)"""
-  adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload!
+  adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload
 
   """Added in 26.3.0. Modify an existing query definition (admin only)."""
-  adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!): ModifyQueryDefinitionPayload!
+  adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!): ModifyQueryDefinitionPayload
 
   """Added in 26.3.0. Delete a query definition (admin only)"""
-  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload!
+  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload
 
   """Added in 26.3.0. Create a new query preset category (admin only)."""
-  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload!
+  adminCreatePrometheusQueryPresetCategory(input: CreateCategoryInput!): CreateCategoryPayload
 
   """Added in 26.3.0. Delete a query preset category (admin only)."""
-  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload!
+  adminDeletePrometheusQueryPresetCategory(id: ID!): DeleteCategoryPayload
 
   """Added in 26.3.0. Create a new role (admin only)."""
-  adminCreateRole(input: CreateRoleInput!): Role!
+  adminCreateRole(input: CreateRoleInput!): Role
 
   """Added in 26.3.0. Update an existing role (admin only)."""
-  adminUpdateRole(input: UpdateRoleInput!): Role!
+  adminUpdateRole(input: UpdateRoleInput!): Role
 
   """Added in 26.3.0. Soft-delete a role (admin only)."""
-  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload!
+  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload
 
   """Added in 26.3.0. Permanently remove a role (admin only)."""
-  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload!
+  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload
 
   """Added in 26.3.0. Create a scoped permission (admin only)."""
-  adminCreatePermission(input: CreatePermissionInput!): Permission!
+  adminCreatePermission(input: CreatePermissionInput!): Permission
 
   """Added in 26.3.0. Update a scoped permission (admin only)."""
-  adminUpdatePermission(input: UpdatePermissionInput!): Permission!
+  adminUpdatePermission(input: UpdatePermissionInput!): Permission
 
   """Added in 26.3.0. Delete a scoped permission (admin only)."""
-  adminDeletePermission(input: DeletePermissionInput!): DeletePermissionPayload!
+  adminDeletePermission(input: DeletePermissionInput!): DeletePermissionPayload
 
   """Added in 26.3.0. Assign a role to a user (admin only)."""
-  adminAssignRole(input: AssignRoleInput!): RoleAssignment!
+  adminAssignRole(input: AssignRoleInput!): RoleAssignment
 
   """Added in 26.3.0. Revoke a role from a user (admin only)."""
-  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment!
+  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment
 
   """Added in 26.3.0. Bulk assign a role to multiple users (admin only)."""
-  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload!
+  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload
 
   """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
-  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload!
+  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload
 
   """
   Added in UNRELEASED. Bulk-insert scoped permission rows across one or more roles (admin only).
   """
-  adminBulkAddRolePermissions(input: BulkAddRolePermissionsInput!): BulkAddRolePermissionsPayload!
+  adminBulkAddRolePermissions(input: BulkAddRolePermissionsInput!): BulkAddRolePermissionsPayload
 
   """
   Added in UNRELEASED. Bulk-delete permission rows by primary key (admin only).
   """
-  adminBulkRemoveRolePermissions(input: BulkRemoveRolePermissionsInput!): BulkRemoveRolePermissionsPayload!
+  adminBulkRemoveRolePermissions(input: BulkRemoveRolePermissionsInput!): BulkRemoveRolePermissionsPayload
 
   """
   Added in UNRELEASED. Replace one role's entire scoped-permission set (admin only).
   """
-  adminReplaceRolePermissions(input: ReplaceRolePermissionsInput!): ReplaceRolePermissionsPayload!
+  adminReplaceRolePermissions(input: ReplaceRolePermissionsInput!): ReplaceRolePermissionsPayload
 
   """Added in UNRELEASED. Create role invitations by email."""
-  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload!
+  createRoleInvitation(input: CreateRoleInvitationInput!): CreateRoleInvitationPayload
 
   """Added in UNRELEASED. Accept a pending role invitation."""
-  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation!
+  acceptRoleInvitation(input: AcceptRoleInvitationInput!): RoleInvitation
 
   """Added in UNRELEASED. Reject a pending role invitation."""
-  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation!
+  rejectRoleInvitation(input: RejectRoleInvitationInput!): RoleInvitation
 
   """Added in UNRELEASED. Cancel a pending role invitation (admin only)."""
-  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation!
+  adminCancelRoleInvitation(input: CancelRoleInvitationInput!): RoleInvitation
 
   """Added in 26.4.2. Create a new keypair resource policy (admin only)."""
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL!
+  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL
 
   """
   Added in 26.4.2. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL!
+  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL!
+  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL!
+  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL
 
   """
   Added in 26.4.2. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL!
+  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL!
+  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Create a new project resource policy (admin only)."""
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL!
+  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL
 
   """
   Added in 26.4.2. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL!
+  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL!
+  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL
 
   """Added in 26.4.2. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL!
+  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL
 
   """Added in 26.4.2. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL!
+  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL
 
   """Added in 26.4.2. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL!
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL
 
   """Added in 26.4.2. Create a new login client type (super admin only)."""
-  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload!
+  adminCreateLoginClientType(input: CreateLoginClientTypeInput!): CreateLoginClientTypePayload
 
   """Added in 26.4.2. Update a login client type (super admin only)."""
-  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload!
+  adminUpdateLoginClientType(id: UUID!, input: UpdateLoginClientTypeInput!): UpdateLoginClientTypePayload
 
   """Added in 26.4.2. Delete a login client type (super admin only)."""
-  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload!
+  adminDeleteLoginClientType(id: UUID!): DeleteLoginClientTypePayload
 
   """Added in 26.4.2. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL!
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL
 
   """Added in 26.4.2. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL!
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL
 
   """Added in 26.4.2. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL!
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
-  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL!
+  adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayloadGQL
 
   """Added in 26.4.2. Create a runtime variant preset (superadmin only)."""
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL!
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL
 
   """Added in 26.4.2. Update a runtime variant preset (superadmin only)."""
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL!
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL
 
   """Added in 26.4.2. Delete a runtime variant preset (superadmin only)."""
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL!
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL
 
   """Added in 26.4.2. Create a deployment revision preset (admin only)."""
-  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL!
+  adminCreateDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL
 
   """Added in 26.4.2. Update a deployment revision preset (admin only)."""
-  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL!
+  adminUpdateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL
 
   """Added in 26.4.2. Delete a deployment revision preset (admin only)."""
-  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL!
+  adminDeleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL
 
   """Added in 26.4.2. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL!
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL
 
   """Added in 26.4.2. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL!
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL
 
   """Added in 26.4.2. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL!
+  adminDeleteModelCardV2(id: UUID!, options: DeleteModelCardV2Options = null): DeleteModelCardPayloadGQL
 
   """
   Added in UNRELEASED. Bulk-delete model cards (admin only) with per-card partial-failure reporting.
@@ -7272,67 +7272,67 @@ type Mutation {
   """
   Added in 26.4.2. Scan a MODEL_STORE project and upsert model cards from vfolder model-definition.yaml files.
   """
-  scanProjectModelCardsV2(projectId: UUID!): ScanProjectModelCardsV2Payload!
+  scanProjectModelCardsV2(projectId: UUID!): ScanProjectModelCardsV2Payload
 
   """
   Added in 26.4.2. Deploy a model card by creating a deployment with a revision preset.
   """
-  deployModelCardV2(cardId: UUID!, input: DeployModelCardV2Input!): DeployModelCardV2Payload!
+  deployModelCardV2(cardId: UUID!, input: DeployModelCardV2Input!): DeployModelCardV2Payload
 
   """Added in 26.4.2. Create a new virtual folder."""
-  createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload!
+  createVfolderV2(input: CreateVFolderV2Input!): CreateVFolderV2Payload
 
   """
   Added in UNRELEASED. Create a virtual folder owned by the specified project. Requires project-scoped CREATE permission.
   """
-  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload!
+  createVFolderInProject(projectId: UUID!, input: CreateVFolderInScopeInput!): CreateVFolderV2Payload
 
   """Added in 26.4.2. Soft-delete a virtual folder (move to trash)."""
-  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload!
+  deleteVfolderV2(vfolderId: UUID!): DeleteVFolderV2Payload
 
   """Added in 26.4.2. Permanently purge a virtual folder."""
-  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload!
+  purgeVfolderV2(vfolderId: UUID!, options: PurgeVFolderOptionsInput = null): PurgeVFolderV2Payload
 
   """
   Added in UNRELEASED. Restore a trashed virtual folder. RBAC enforced via scope chain.
   """
-  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload!
+  restoreVFolder(vfolderId: UUID!): RestoreVFolderPayload
 
   """Added in 26.4.2. Deploy a deployment directly from a model VFolder."""
-  deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload!
+  deployVfolderV2(vfolderId: UUID!, input: DeployVFolderV2Input!): DeployVFolderV2Payload
 
   """Added in 26.4.2. Soft-delete multiple virtual folders."""
-  bulkDeleteVfoldersV2(input: BulkDeleteVFoldersV2Input!): BulkDeleteVFoldersV2Payload!
+  bulkDeleteVfoldersV2(input: BulkDeleteVFoldersV2Input!): BulkDeleteVFoldersV2Payload
 
   """Added in 26.4.2. Permanently purge multiple virtual folders."""
-  bulkPurgeVfoldersV2(input: BulkPurgeVFoldersV2Input!): BulkPurgeVFoldersV2Payload!
+  bulkPurgeVfoldersV2(input: BulkPurgeVFoldersV2Input!): BulkPurgeVFoldersV2Payload
 
   """Added in 26.4.2. Clone a virtual folder."""
-  cloneVfolderV2(vfolderId: UUID!, input: CloneVFolderV2Input!): CloneVFolderV2Payload!
+  cloneVfolderV2(vfolderId: UUID!, input: CloneVFolderV2Input!): CloneVFolderV2Payload
 
   """Added in 26.4.2. List files in a virtual folder."""
-  vfolderListFilesV2(vfolderId: UUID!, input: ListFilesV2Input!): ListFilesV2Payload!
+  vfolderListFilesV2(vfolderId: UUID!, input: ListFilesV2Input!): ListFilesV2Payload
 
   """Added in 26.4.2. Create directories inside a virtual folder."""
-  vfolderMkdirV2(vfolderId: UUID!, input: MkdirV2Input!): MkdirV2Payload!
+  vfolderMkdirV2(vfolderId: UUID!, input: MkdirV2Input!): MkdirV2Payload
 
   """Added in 26.4.2. Move a file within a virtual folder."""
-  vfolderMoveFileV2(vfolderId: UUID!, input: MoveFileV2Input!): MoveFileV2Payload!
+  vfolderMoveFileV2(vfolderId: UUID!, input: MoveFileV2Input!): MoveFileV2Payload
 
   """Added in 26.4.2. Delete files inside a virtual folder."""
-  vfolderDeleteFilesV2(vfolderId: UUID!, input: DeleteFilesV2Input!): DeleteFilesV2Payload!
+  vfolderDeleteFilesV2(vfolderId: UUID!, input: DeleteFilesV2Input!): DeleteFilesV2Payload
 
   """Added in 26.4.2. Create an upload session for a virtual folder."""
-  vfolderCreateUploadSessionV2(vfolderId: UUID!, input: CreateUploadSessionV2Input!): CreateUploadSessionV2Payload!
+  vfolderCreateUploadSessionV2(vfolderId: UUID!, input: CreateUploadSessionV2Input!): CreateUploadSessionV2Payload
 
   """Added in 26.4.2. Create a download session for a virtual folder."""
-  vfolderCreateDownloadSessionV2(vfolderId: UUID!, input: CreateDownloadSessionV2Input!): CreateDownloadSessionV2Payload!
+  vfolderCreateDownloadSessionV2(vfolderId: UUID!, input: CreateDownloadSessionV2Input!): CreateDownloadSessionV2Payload
 
   """Added in 26.4.2. Enqueue a new compute session."""
-  enqueueSession(input: EnqueueSessionInput!): EnqueueSessionPayload!
+  enqueueSession(input: EnqueueSessionInput!): EnqueueSessionPayload
 
   """Added in 26.4.2. Terminate sessions within a project scope."""
-  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload!
+  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload
 }
 
 """
@@ -7568,7 +7568,7 @@ type ObjectStorage implements Node {
   region: String!
 
   """The namespaces of this entity."""
-  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): StorageNamespaceConnection!
+  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): StorageNamespaceConnection
 }
 
 """
@@ -7582,7 +7582,7 @@ type ObjectStorageConnection {
   edges: [ObjectStorageEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -8326,17 +8326,17 @@ type ProjectUsageBucket implements Node {
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 
   """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
-  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection
 }
 
 """
@@ -8470,23 +8470,23 @@ type ProjectV2 implements Node @key(fields: "id") {
   """
   Fair share record for this project in the specified resource group. Returns the scheduling priority configuration for this project. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: ProjectFairShareScope!): ProjectFairShare!
+  fairShare(scope: ProjectFairShareScope!): ProjectFairShare
 
   """
   Added in 26.4.0. Active resource usage overview for this project. Returns the currently occupied resource slots and the number of active sessions.
   """
-  activeResourceOverview: ActiveResourceOverview!
+  activeResourceOverview: ActiveResourceOverview
 
   """
   Usage buckets for this project, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: ProjectUsageScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  usageBuckets(scope: ProjectUsageScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection
 
   """The domain this project belongs to."""
-  domain: DomainV2!
+  domain: DomainV2
 
   """Users who are members of this project."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection
 }
 
 """
@@ -8675,7 +8675,7 @@ type Query {
   """
   Added in 25.16.0. Retrieve merged app configuration for the current user. The result combines domain-level and user-level configurations, where user settings override domain settings for the same keys. This query should be used when working with user app configurations to get the actual configuration values that will be applied.
   """
-  mergedAppConfig: AppConfig!
+  mergedAppConfig: AppConfig
 
   """Added in 25.16.0. Get a specific deployment by ID."""
   deployment(id: ID!): ModelDeployment
@@ -8702,7 +8702,7 @@ type Query {
   """
   Added in 26.4.2. Get JSON schema for a notification rule type's message format
   """
-  notificationRuleTypeSchema(ruleType: NotificationRuleType!): JSON!
+  notificationRuleTypeSchema(ruleType: NotificationRuleType!): JSON
 
   """Added in 25.14.0. Get an object storage by ID"""
   objectStorage(id: ID!): ObjectStorage
@@ -8750,30 +8750,30 @@ type Query {
   """
   Added in UNRELEASED. List all registered deployment scheduling handlers (superadmin only). The returned ``name`` values are valid keys for ``DeploymentOptions.timeouts.by_handler``.
   """
-  schedulingHandlers: [SchedulingHandlerNode!]!
+  schedulingHandlers: [SchedulingHandlerNode!]
 
   """
   Added in 26.4.2. Get allowed resource groups for a domain (admin only).
   """
-  adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload!
+  adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload
 
   """
   Added in 26.4.2. Get allowed resource groups for a project (admin only).
   """
-  adminAllowedResourceGroupsForProjectV2(projectId: UUID!): AllowedResourceGroupsPayload!
+  adminAllowedResourceGroupsForProjectV2(projectId: UUID!): AllowedResourceGroupsPayload
 
   """
   Added in 26.4.2. Get allowed domains for a resource group (admin only).
   """
-  adminAllowedDomainsForResourceGroupV2(resourceGroupName: String!): AllowedDomainsPayload!
+  adminAllowedDomainsForResourceGroupV2(resourceGroupName: String!): AllowedDomainsPayload
 
   """
   Added in 26.4.2. Get allowed projects for a resource group (admin only).
   """
-  adminAllowedProjectsForResourceGroupV2(resourceGroupName: String!): AllowedProjectsPayload!
+  adminAllowedProjectsForResourceGroupV2(resourceGroupName: String!): AllowedProjectsPayload
 
   """Added in 26.3.0. Query service catalog entries. Admin only."""
-  adminServiceCatalogs(filter: ServiceCatalogFilter = null, orderBy: [ServiceCatalogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): [ServiceCatalog!]!
+  adminServiceCatalogs(filter: ServiceCatalogFilter = null, orderBy: [ServiceCatalogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): [ServiceCatalog!]
 
   """Added in 26.4.2. List session scheduling history (admin only)"""
   adminSessionSchedulingHistories(filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection
@@ -8844,7 +8844,7 @@ type Query {
   """
   Added in 26.3.0. Query audit logs with pagination and filtering. (admin only)
   """
-  adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection!
+  adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -8854,22 +8854,22 @@ type Query {
   """
   Added in 26.4.2. Query login sessions with pagination and filtering. (admin only)
   """
-  adminLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection!
+  adminLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection
 
   """
   Added in 26.4.2. Query login history with pagination and filtering. (admin only)
   """
-  adminLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection!
+  adminLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection
 
   """
   Added in 26.3.0. Query sessions with pagination and filtering. (admin only)
   """
-  adminSessionsV2(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection!
+  adminSessionsV2(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection
 
   """
   Added in 26.4.2. List sessions within a specific project. Requires project membership or higher privileges.
   """
-  projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection!
+  projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection
 
   """
   Added in 26.4.3. Query a single session by ID. Returns an error if not found.
@@ -8890,7 +8890,7 @@ type Query {
   """
   Added in 26.3.0. Returns resource slot types with pagination and filtering.
   """
-  resourceSlotTypes(filter: ResourceSlotTypeFilter = null, orderBy: [ResourceSlotTypeOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceSlotTypeConnection!
+  resourceSlotTypes(filter: ResourceSlotTypeFilter = null, orderBy: [ResourceSlotTypeOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceSlotTypeConnection
 
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
@@ -8910,7 +8910,7 @@ type Query {
   """
   Added in 26.4.2. Execute a prometheus query preset by ID and return the result. Available to any authenticated user; the underlying preset query is the same regardless of who runs it.
   """
-  prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult!
+  prometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult
 
   """
   Added in UNRELEASED. Preview a prometheus query template before saving it as a preset (admin only).
@@ -8925,7 +8925,7 @@ type Query {
   """
   Added in 26.4.2. List query preset categories with filtering and pagination. Available to any authenticated user.
   """
-  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]!
+  prometheusQueryPresetCategories(filter: CategoryFilter = null, orderBy: [CategoryOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): [QueryPresetCategory!]
 
   """Added in 26.3.0. Get a single role by ID (admin only)."""
   adminRole(id: UUID!): Role
@@ -8933,27 +8933,27 @@ type Query {
   """
   Added in 26.3.0. List roles with filtering and pagination (admin only).
   """
-  adminRoles(filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
+  adminRoles(filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection
 
   """
   Added in 26.3.0. List scoped permissions with filtering and pagination (admin only).
   """
-  adminPermissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection!
+  adminPermissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
   """
   Added in 26.3.0. List role assignments with filtering and pagination (admin only).
   """
-  adminRoleAssignments(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
+  adminRoleAssignments(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection
 
   """
   Added in 26.3.0. Search entity associations (admin only). Optionally filter by entity_type and entity_id.
   """
-  adminEntities(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection!
+  adminEntities(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection
 
   """
   Added in 26.4.2. List keypairs owned by the current authenticated user. Supports filtering, ordering, and both cursor-based and offset-based pagination.
   """
-  myKeypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection!
+  myKeypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection
 
   """
   Added in 26.4.2. Get a single keypair by access key (admin only). Requires superadmin privileges.
@@ -8963,55 +8963,55 @@ type Query {
   """
   Added in 26.4.2. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminKeypairsV2(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection!
+  adminKeypairsV2(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection
 
   """
   Added in 26.4.2. Get a user's SSH public key (admin only). The private key is never returned.
   """
-  adminSshKeypairV2(accessKey: String!): AdminGetSSHKeypairPayload!
+  adminSshKeypairV2(accessKey: String!): AdminGetSSHKeypairPayload
 
   """
   Added in 26.4.2. Query login sessions of the current user with pagination and filtering.
   """
-  myLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection!
+  myLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection
 
   """
   Added in 26.4.2. Query login history of the current user with pagination and filtering.
   """
-  myLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection!
+  myLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection
 
   """
   Added in 26.3.0. List roles assigned to the current authenticated user.
   """
-  myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
+  myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection
 
   """Added in UNRELEASED. List the current user's role invitations."""
-  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  myRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection
 
   """Added in UNRELEASED. List role invitations sent by the current user."""
-  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  mySentRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection
 
   """
   Added in UNRELEASED. List all role invitations across the system (superadmin only).
   """
-  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  adminRoleInvitations(filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection
 
   """Added in 26.4.2. List roles registered in a project scope."""
-  projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection!
+  projectRoles(projectId: UUID!, filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection
 
   """Added in UNRELEASED. List invitations for a specific role."""
-  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection!
+  roleScopedRoleInvitations(roleId: UUID!, filter: RoleInvitationFilter = null, orderBy: [RoleInvitationOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleInvitationConnection
 
   """Added in 26.3.0. List valid RBAC scope-entity type combinations."""
-  rbacScopeEntityCombinations: [ScopeEntityCombination!]!
+  rbacScopeEntityCombinations: [ScopeEntityCombination!]
 
   """Added in 26.4.2. List valid RBAC entity-operation combinations."""
-  rbacEntityOperationCombinations: [EntityOperationCombination!]!
+  rbacEntityOperationCombinations: [EntityOperationCombination!]
 
   """
   Added in 26.4.2. List complete RBAC scope-entity-operation combinations (permission matrix).
   """
-  rbacPermissionMatrix: [ScopeEntityOperationCombination!]!
+  rbacPermissionMatrix: [ScopeEntityOperationCombination!]
 
   """Added in 26.2.0. Query kernels within a specific session."""
   sessionKernelsV2(scope: SessionScope!, filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection
@@ -9112,10 +9112,10 @@ type Query {
   """
   Added in 25.16.0. Get configuration JSON Schemas for all inference runtimes.
   """
-  inferenceRuntimeConfigs: JSON!
+  inferenceRuntimeConfigs: JSON
 
   """Added in 25.16.0. Get JSON Schema for inference runtime configuration"""
-  inferenceRuntimeConfig(name: String!): JSON!
+  inferenceRuntimeConfig(name: String!): JSON
 
   """Added in 25.19.0. Get a specific route by ID."""
   route(id: ID!): Route
@@ -9150,7 +9150,7 @@ type Query {
   """
   Added in 26.4.2. Get the current client's IP address as seen by the server. Useful for configuring IP allowlists.
   """
-  myClientIp: MyClientIp!
+  myClientIp: MyClientIp
 
   """
   Added in 26.2.0. Get the current authenticated user's information. Returns the user associated with the current session. Returns an error if not authenticated.
@@ -9234,7 +9234,7 @@ type Query {
   """
   Added in 26.4.2. List storage hosts the current user is allowed to mount, with the union of permissions inherited from domain, project, and keypair resource policies.
   """
-  myStorageHostPermissions: MyStorageHostPermissionsPayload!
+  myStorageHostPermissions: MyStorageHostPermissionsPayload
 
   """Added in 26.4.2. List resource presets (admin only)."""
   adminResourcePresetsV2(filter: ResourcePresetFilter = null, orderBy: [ResourcePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourcePresetConnection
@@ -9283,45 +9283,45 @@ type Query {
   modelCardAvailablePresets(scope: ModelCardAvailablePresetsScope!, filter: DeploymentRevisionPresetFilter = null, orderBy: [DeploymentRevisionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentRevisionPresetConnection
 
   """Added in 26.4.2. Get my keypair resource allocation (current user)."""
-  myKeypairResourceAllocationV2: KeypairResourceAllocationV2!
+  myKeypairResourceAllocationV2: KeypairResourceAllocationV2
 
   """Added in 26.4.2. Get project resource allocation (project usage)."""
-  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2!
+  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2
 
   """Added in 26.4.2. Get domain resource allocation (admin only)."""
-  adminDomainResourceAllocationV2(domainName: String!): DomainResourceAllocationV2!
+  adminDomainResourceAllocationV2(domainName: String!): DomainResourceAllocationV2
 
   """Added in 26.4.2. Get resource group resource allocation."""
-  resourceGroupResourceAllocationV2(resourceGroupName: String!): ResourceGroupResourceAllocationV2!
+  resourceGroupResourceAllocationV2(resourceGroupName: String!): ResourceGroupResourceAllocationV2
 
   """
   Added in 26.4.2. Get effective resource allocation for the current user.
   """
-  effectiveResourceAllocationV2(input: EffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2!
+  effectiveResourceAllocationV2(input: EffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2
 
   """
   Added in 26.4.2. Get effective resource allocation for a specific user (admin only).
   """
-  adminEffectiveResourceAllocationV2(input: AdminEffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2!
+  adminEffectiveResourceAllocationV2(input: AdminEffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2
 
   """
   Added in 26.4.2. Check which resource presets are available for session creation.
   """
-  checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2!
+  checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2
 
   """Added in 26.4.2. Search all virtual folders (superadmin only)."""
-  adminVfoldersV2(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection!
+  adminVfoldersV2(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection
 
   """Added in 26.4.2. Get a single virtual folder by ID."""
   vfolderV2(vfolderId: UUID!): VFolder
 
   """Added in 26.4.2. List virtual folders within a specific project."""
-  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection!
+  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection
 
   """
   Added in 26.4.2. Search virtual folders accessible to the current user with pagination and filtering.
   """
-  myVfolders(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection!
+  myVfolders(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection
 }
 
 """
@@ -9846,7 +9846,7 @@ type ReservoirRegistry implements Node {
   apiVersion: String!
 
   """The remote artifact registries of this entity."""
-  remoteArtifactRegistries: ArtifactRegistryMetaConnection!
+  remoteArtifactRegistries: ArtifactRegistryMetaConnection
 }
 
 """
@@ -9860,7 +9860,7 @@ type ReservoirRegistryConnection {
   edges: [ReservoirRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -9902,7 +9902,7 @@ Added in 25.19.0. Compute resource configuration for the deployment. Specifies C
 """
 type ResourceConfig {
   """The resource group of this entity."""
-  resourceGroup: ScalingGroupNode!
+  resourceGroup: ScalingGroupNode
   resourceGroupName: String!
   resourceOpts: ResourceOpts
 }
@@ -9959,12 +9959,12 @@ type ResourceGroup implements Node {
   """
   Added in 26.1.0. Fair share calculation configuration for this resource group. Defines decay parameters and resource weights for fair share factor computation. Resource weights are merged with capacity and include default indicators.
   """
-  fairShareSpec: FairShareScalingGroupSpec!
+  fairShareSpec: FairShareScalingGroupSpec
 
   """
   Added in 26.1.0. Resource usage information for this resource group. Provides aggregated metrics for capacity, used, and free resources. This is a lazy-loaded field that queries agent and kernel data on demand.
   """
-  resourceInfo: ResourceInfo!
+  resourceInfo: ResourceInfo
 }
 
 """Added in 26.2.0. Resource group connection"""
@@ -10464,13 +10464,13 @@ type Role implements Node {
   deletedAt: DateTime
 
   """Added in 26.3.0. Permissions associated with this role."""
-  permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection!
+  permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection
 
   """Added in 26.3.0. Users assigned to this role."""
-  users(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
+  users(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection
 
   """Added in 26.4.2. Scopes this role is registered in."""
-  scopes(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection!
+  scopes(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection
 }
 
 """Added in 26.3.0. RBAC role assignment (user-role association)."""
@@ -10797,7 +10797,7 @@ type Route implements Node {
   errorData: JSON
 
   """The deployment this route belongs to."""
-  deployment: ModelDeployment!
+  deployment: ModelDeployment
 
   """
   The session associated with the route. Can be null if the route is still provisioning.
@@ -11225,7 +11225,7 @@ type SchedulingBroadcastEventPayload {
   """
   The session ID associated with the replica. This can be null right after replica creation.
   """
-  session: ComputeSessionNode!
+  session: ComputeSessionNode
 
   """UUID of the session being scheduled."""
   sessionId: ID!
@@ -11674,10 +11674,10 @@ type SessionV2 implements Node {
   """
   Added in 26.4.3. The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.
   """
-  images: ImageV2Connection!
+  images: ImageV2Connection
 
   """Added in 26.3.0. The kernels belonging to this session."""
-  kernels: KernelV2Connection!
+  kernels: KernelV2Connection
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""
@@ -11923,7 +11923,7 @@ type StorageNamespaceConnection {
   edges: [StorageNamespaceEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""
@@ -13503,12 +13503,12 @@ type UserUsageBucket implements Node {
   """
   Added in 26.2.0. Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
-  averageDailyUsage: ResourceSlot!
+  averageDailyUsage: ResourceSlot
 
   """
   Added in 26.2.0. Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.
   """
-  usageCapacityRatio: ResourceSlot!
+  usageCapacityRatio: ResourceSlot
 }
 
 """
@@ -13630,18 +13630,18 @@ type UserV2 implements Node @key(fields: "id") {
   """
   Fair share record for this user in the specified resource group and project. Returns the scheduling priority configuration for this user. Always returns an object, even if no explicit configuration exists (in which case default values are used).
   """
-  fairShare(scope: UserFairShareScope!): UserFairShare!
+  fairShare(scope: UserFairShareScope!): UserFairShare
 
   """
   Usage buckets for this user, filtered by resource group and project. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: UserUsageScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  usageBuckets(scope: UserUsageScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection
 
   """The domain this user belongs to."""
   domain: DomainV2
 
   """Projects this user is a member of."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection
 }
 
 """
@@ -13842,7 +13842,7 @@ type VFSStorageConnection {
   edges: [VFSStorageEdge!]!
 
   """The count of this entity."""
-  count: Int!
+  count: Int
 }
 
 """An edge in a connection."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -4588,7 +4588,7 @@ type HuggingFaceRegistryConnection {
   edges: [HuggingFaceRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -7582,7 +7582,7 @@ type ObjectStorageConnection {
   edges: [ObjectStorageEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -9860,7 +9860,7 @@ type ReservoirRegistryConnection {
   edges: [ReservoirRegistryEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -11923,7 +11923,7 @@ type StorageNamespaceConnection {
   edges: [StorageNamespaceEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""
@@ -13842,7 +13842,7 @@ type VFSStorageConnection {
   edges: [VFSStorageEdge!]!
 
   """The count of this entity."""
-  count: Int
+  count: Int!
 }
 
 """An edge in a connection."""

--- a/src/ai/backend/manager/api/gql/README.md
+++ b/src/ai/backend/manager/api/gql/README.md
@@ -176,6 +176,75 @@ DomainStatusGQL = gql_enum(
 )
 ```
 
+### Nullable Return Types
+
+Any field that runs through a **resolver** MUST be declared nullable (`T | None`). This
+covers root `Query` / `Mutation` fields and any computed nested field on a Node /
+Connection / Payload type — anything decorated with `@gql_root_field`, `@gql_mutation`,
+`@gql_field`, or `@gql_added_field`. This follows GraphQL's nullable-by-default best
+practice.
+
+**Why**
+
+- **Partial failure isolation.** When a resolver raises, GraphQL propagates `null` up to
+  the nearest nullable ancestor. A non-null computed field turns a single nested
+  resolver failure into a whole-parent failure, wiping sibling fields the client could
+  otherwise have used.
+- **Permission / scope denial.** Fields that are visible only to some users naturally
+  express "denied" as `null` instead of an error that aborts the query.
+- **Forward compatibility.** `nullable → non-null` is a breaking change; `non-null →
+  nullable` is not. Starting nullable is the safe default.
+
+**The rule (in Python resolvers)**
+
+```python
+# Root Query — single object
+@gql_root_field(BackendAIGQLMeta(...))
+async def admin_search_domains(...) -> AdminSearchDomainsPayloadGQL | None: ...
+
+# Root Mutation — payload
+@gql_mutation(BackendAIGQLMeta(...))
+async def admin_create_domain(...) -> CreateDomainPayloadGQL | None: ...
+
+# Root Connection
+@gql_root_field(BackendAIGQLMeta(...))
+async def admin_audit_logs_v2(...) -> AuditLogV2ConnectionGQL | None: ...
+
+# Computed nested field — cross-entity DataLoader resolver
+class DomainV2GQL(PydanticNodeMixin[DomainNode]):
+    @gql_field(description="Projects belonging to this domain.")
+    async def projects(self, info: Info[StrawberryGQLContext]) -> ProjectV2ConnectionGQL | None: ...
+
+# Computed nested field — derived scalar
+class FooConnection(Connection[Foo]):
+    @gql_field(description="Total count.")
+    def count(self) -> int | None: ...
+
+# List — only the outer list is nullable; element non-null is fine
+@gql_root_field(BackendAIGQLMeta(...))
+async def scheduling_handlers(...) -> list[SchedulingHandlerNodeGQL] | None: ...
+```
+
+This emits the return type without `!` in the SDL — e.g. `AdminSearchDomainsPayload`,
+`AuditLogV2Connection`, `[SchedulingHandlerNode!]`, `ProjectV2Connection`.
+
+**Resolver implementation note**
+
+Returning `None` is allowed and recommended for "not found" / "denied" cases. Do NOT
+catch domain exceptions inside fetchers just to swallow them as `None` — let
+`BackendAIError` propagate so the failure surfaces in the GraphQL `errors` array.
+
+**Exceptions**
+
+- **Statically projected DTO fields** — class-level attributes that map directly from
+  the backing Pydantic DTO (e.g. via `@gql_pydantic_type(all_fields=True)` or scalar
+  declarations like `name: str`) follow the DTO contract and may stay non-null. The
+  rule applies to fields that run through a Python resolver, not to fields whose value
+  is guaranteed by the DTO.
+- **Apollo Federation entry points** — `_service: _Service!` and
+  `_entities([_Any!]!): [_Entity]!` are mandated by the spec and remain non-null.
+- **Subscriptions** — streaming-event return types are governed separately.
+
 ## Fetcher Pattern
 
 ```python
@@ -213,7 +282,7 @@ async def admin_search_domains(
     order_by: list[DomainV2OrderByGQL] | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> AdminSearchDomainsPayloadGQL:
+) -> AdminSearchDomainsPayloadGQL | None:
     check_admin_only(info)
     return await fetch_admin_search_domains(
         info=info, filter=filter, order_by=order_by, limit=limit, offset=offset
@@ -227,7 +296,7 @@ async def admin_search_domains(
 async def admin_create_domain(
     input: CreateDomainInputGQL,
     info: Info[StrawberryGQLContext],
-) -> CreateDomainPayloadGQL:
+) -> CreateDomainPayloadGQL | None:
     check_admin_only(info)
     payload_dto = await info.context.adapters.domain.create(input.to_pydantic())
     return CreateDomainPayloadGQL.from_pydantic(payload_dto)

--- a/src/ai/backend/manager/api/gql/README.md
+++ b/src/ai/backend/manager/api/gql/README.md
@@ -215,10 +215,10 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
     @gql_field(description="Projects belonging to this domain.")
     async def projects(self, info: Info[StrawberryGQLContext]) -> ProjectV2ConnectionGQL | None: ...
 
-# Computed nested field — derived scalar
+# Trivially derived scalar — exempt, see Exceptions below
 class FooConnection(Connection[Foo]):
     @gql_field(description="Total count.")
-    def count(self) -> int | None: ...
+    def count(self) -> int: ...
 
 # List — only the outer list is nullable; element non-null is fine
 @gql_root_field(BackendAIGQLMeta(...))
@@ -237,12 +237,12 @@ catch domain exceptions inside fetchers just to swallow them as `None` — let
 **Exceptions**
 
 - **Statically projected DTO fields** — class-level attributes that map directly from
-  the backing Pydantic DTO (e.g. via `@gql_pydantic_type(all_fields=True)` or scalar
-  declarations like `name: str`) follow the DTO contract and may stay non-null. The
-  rule applies to fields that run through a Python resolver, not to fields whose value
-  is guaranteed by the DTO.
-- **Apollo Federation entry points** — `_service: _Service!` and
-  `_entities([_Any!]!): [_Entity]!` are mandated by the spec and remain non-null.
+  the backing Pydantic DTO (e.g. `name: str`) may stay non-null.
+- **Trivially derived scalars** — resolver-decorated fields whose value is computed
+  synchronously from non-null parent state with no I/O, permission check, or external
+  call. Example: a Connection `count` returning `len(self.edges)` stays non-null.
+- **Apollo Federation entry points** — `_service` and `_entities` are mandated by the
+  spec and remain non-null.
 - **Subscriptions** — streaming-event return types are governed separately.
 
 ## Fetcher Pattern

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -289,7 +289,7 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
     async def container_count(
         self,
         info: Info[StrawberryGQLContext],
-    ) -> int:
+    ) -> int | None:
         """
         Get the container count for a specific agent.
         """
@@ -320,9 +320,10 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        KernelV2ConnectionGQL, strawberry.lazy("ai.backend.manager.api.gql.kernel.types")
-    ]:
+    ) -> (
+        Annotated[KernelV2ConnectionGQL, strawberry.lazy("ai.backend.manager.api.gql.kernel.types")]
+        | None
+    ):
         """Fetch kernels associated with this agent."""
         from ai.backend.common.dto.manager.v2.kernel.request import AdminSearchKernelsInput
         from ai.backend.manager.api.gql.base import encode_cursor
@@ -381,9 +382,12 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        SessionV2ConnectionGQL, strawberry.lazy("ai.backend.manager.api.gql.session.types")
-    ]:
+    ) -> (
+        Annotated[
+            SessionV2ConnectionGQL, strawberry.lazy("ai.backend.manager.api.gql.session.types")
+        ]
+        | None
+    ):
         """Fetch sessions associated with this agent."""
         from ai.backend.common.dto.manager.v2.session.request import AdminSearchSessionsInput
         from ai.backend.manager.api.gql.base import encode_cursor
@@ -446,10 +450,13 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
         before: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        AgentResourceConnectionGQL,
-        strawberry.lazy("ai.backend.manager.api.gql.resource_slot.types"),
-    ]:
+    ) -> (
+        Annotated[
+            AgentResourceConnectionGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.resource_slot.types"),
+        ]
+        | None
+    ):
         """Fetch per-slot resource capacity and usage for this agent."""
         from decimal import Decimal
 

--- a/src/ai/backend/manager/api/gql/app_config.py
+++ b/src/ai/backend/manager/api/gql/app_config.py
@@ -249,7 +249,7 @@ async def user_app_config(
 )  # type: ignore[misc]
 async def merged_app_config(
     info: Info[StrawberryGQLContext],
-) -> AppConfig:
+) -> AppConfig | None:
     """Get merged app configuration for the current user."""
     me = current_user()
     if me is None:
@@ -269,7 +269,7 @@ async def merged_app_config(
 async def admin_upsert_domain_app_config(
     input: UpsertDomainConfigInput,
     info: Info[StrawberryGQLContext],
-) -> UpsertDomainConfigPayload:
+) -> UpsertDomainConfigPayload | None:
     """Create or update domain-level app configuration (admin only)."""
     check_admin_only()
     result = await info.context.adapters.app_config.upsert_domain_config(
@@ -289,7 +289,7 @@ async def admin_upsert_domain_app_config(
 async def upsert_domain_app_config(
     input: UpsertDomainConfigInput,
     info: Info[StrawberryGQLContext],
-) -> UpsertDomainConfigPayload:
+) -> UpsertDomainConfigPayload | None:
     """Create or update domain-level app configuration."""
     me = current_user()
     if me is None or not (me.is_admin or me.is_superadmin):
@@ -311,7 +311,7 @@ async def upsert_domain_app_config(
 async def upsert_user_app_config(
     input: UpsertUserConfigInput,
     info: Info[StrawberryGQLContext],
-) -> UpsertUserConfigPayload:
+) -> UpsertUserConfigPayload | None:
     """Create or update user-level app configuration."""
     me = current_user()
     if me is None:
@@ -339,7 +339,7 @@ async def upsert_user_app_config(
 async def admin_delete_domain_app_config(
     input: DeleteDomainConfigInput,
     info: Info[StrawberryGQLContext],
-) -> DeleteDomainConfigPayload:
+) -> DeleteDomainConfigPayload | None:
     """Delete domain-level app configuration (admin only)."""
     check_admin_only()
     result = await info.context.adapters.app_config.delete_domain_config(input.domain_name)
@@ -357,7 +357,7 @@ async def admin_delete_domain_app_config(
 async def delete_domain_app_config(
     input: DeleteDomainConfigInput,
     info: Info[StrawberryGQLContext],
-) -> DeleteDomainConfigPayload:
+) -> DeleteDomainConfigPayload | None:
     """Delete domain-level app configuration."""
     me = current_user()
     if me is None or not (me.is_admin or me.is_superadmin):
@@ -377,7 +377,7 @@ async def delete_domain_app_config(
 async def delete_user_app_config(
     input: DeleteUserConfigInput,
     info: Info[StrawberryGQLContext],
-) -> DeleteUserConfigPayload:
+) -> DeleteUserConfigPayload | None:
     """Delete user-level app configuration."""
     me = current_user()
     if me is None:

--- a/src/ai/backend/manager/api/gql/artifact/resolver.py
+++ b/src/ai/backend/manager/api/gql/artifact/resolver.py
@@ -232,7 +232,7 @@ async def artifact_revision(id: ID, info: Info[StrawberryGQLContext]) -> Artifac
 )
 async def scan_artifacts(
     input: ScanArtifactsInput, info: Info[StrawberryGQLContext]
-) -> ScanArtifactsPayload:
+) -> ScanArtifactsPayload | None:
     if input.limit > ARTIFACT_MAX_SCAN_LIMIT:
         raise ArtifactScanLimitExceededError(f"Limit cannot exceed {ARTIFACT_MAX_SCAN_LIMIT}")
 
@@ -268,7 +268,7 @@ async def scan_artifacts(
 )
 async def import_artifacts(
     input: ImportArtifactsInput, info: Info[StrawberryGQLContext]
-) -> ImportArtifactsPayload:
+) -> ImportArtifactsPayload | None:
     imported_artifacts = []
     tasks = []
     vfolder_id = UUID(input.vfolder_id) if input.vfolder_id else None
@@ -319,7 +319,7 @@ async def import_artifacts(
 )
 async def delegate_scan_artifacts(
     input: DelegateScanArtifactsInput, info: Info[StrawberryGQLContext]
-) -> DelegateScanArtifactsPayload:
+) -> DelegateScanArtifactsPayload | None:
     if input.limit > ARTIFACT_MAX_SCAN_LIMIT:
         raise ArtifactScanLimitExceededError(f"Limit cannot exceed {ARTIFACT_MAX_SCAN_LIMIT}")
 
@@ -358,7 +358,7 @@ async def delegate_scan_artifacts(
 )
 async def delegate_import_artifacts(
     input: DelegateImportArtifactsInput, info: Info[StrawberryGQLContext]
-) -> DelegateImportArtifactsPayload:
+) -> DelegateImportArtifactsPayload | None:
     tasks = []
 
     options = input.options or ImportArtifactsOptionsGQL()
@@ -416,7 +416,7 @@ async def delegate_import_artifacts(
 )
 async def update_artifact(
     input: UpdateArtifactInput, info: Info[StrawberryGQLContext]
-) -> UpdateArtifactPayload:
+) -> UpdateArtifactPayload | None:
     pydantic_input = UpdateArtifactInputDTO(
         readonly=input.readonly if input.readonly is not UNSET else None,
         description=input.description if input.description is not UNSET else SENTINEL,
@@ -448,7 +448,7 @@ async def update_artifact(
 )
 async def cleanup_artifact_revisions(
     input: CleanupArtifactRevisionsInput, info: Info[StrawberryGQLContext]
-) -> CleanupArtifactRevisionsPayload:
+) -> CleanupArtifactRevisionsPayload | None:
     cleaned_artifact_revisions: list[ArtifactRevision] = []
     # TODO: Refactor with asyncio.gather()
     pydantic_input = input.to_pydantic()
@@ -483,7 +483,7 @@ async def cleanup_artifact_revisions(
 )
 async def delete_artifacts(
     input: DeleteArtifactsInput, info: Info[StrawberryGQLContext]
-) -> DeleteArtifactsPayload:
+) -> DeleteArtifactsPayload | None:
     pydantic_input = input.to_pydantic()
     payload = await info.context.adapters.artifact.delete(pydantic_input)
 
@@ -510,7 +510,7 @@ async def delete_artifacts(
 )
 async def restore_artifacts(
     input: RestoreArtifactsInput, info: Info[StrawberryGQLContext]
-) -> RestoreArtifactsPayload:
+) -> RestoreArtifactsPayload | None:
     artifact_node_list = await info.context.adapters.artifact.restore(
         artifact_ids=[UUID(id) for id in input.artifact_ids],
     )
@@ -538,7 +538,7 @@ async def restore_artifacts(
 )
 async def cancel_import_artifact(
     input: CancelArtifactInput, info: Info[StrawberryGQLContext]
-) -> CancelImportArtifactPayload:
+) -> CancelImportArtifactPayload | None:
     # TODO: Cancel actual import bgtask
     pydantic_input = input.to_pydantic()
     revision_node = await info.context.adapters.artifact.cancel_import(
@@ -558,7 +558,7 @@ async def cancel_import_artifact(
 )
 async def approve_artifact_revision(
     input: ApproveArtifactInput, info: Info[StrawberryGQLContext]
-) -> ApproveArtifactPayload:
+) -> ApproveArtifactPayload | None:
     revision_node = await info.context.adapters.artifact.approve_revision(
         UUID(input.artifact_revision_id)
     )
@@ -573,7 +573,7 @@ async def approve_artifact_revision(
 )
 async def reject_artifact_revision(
     input: RejectArtifactInput, info: Info[StrawberryGQLContext]
-) -> RejectArtifactPayload:
+) -> RejectArtifactPayload | None:
     revision_node = await info.context.adapters.artifact.reject_revision(
         UUID(input.artifact_revision_id)
     )
@@ -588,7 +588,7 @@ async def reject_artifact_revision(
 )
 async def scan_artifact_models(
     input: ScanArtifactModelsInput, info: Info[StrawberryGQLContext]
-) -> ScanArtifactModelsPayload:
+) -> ScanArtifactModelsPayload | None:
     results = await info.context.adapters.artifact.retrieve_models(
         models=[m.to_pydantic() for m in input.models],
         registry_id=input.registry_id,

--- a/src/ai/backend/manager/api/gql/artifact/types.py
+++ b/src/ai/backend/manager/api/gql/artifact/types.py
@@ -658,7 +658,7 @@ class Artifact(PydanticNodeMixin[ArtifactGQLNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> ArtifactRevisionConnection:
+    ) -> ArtifactRevisionConnection | None:
         pydantic_filter = filter.to_pydantic() if filter is not None else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by is not None else None
 
@@ -762,7 +762,7 @@ class ArtifactRevision(PydanticNodeMixin[ArtifactRevisionNode]):
         return cast(list[Self | None], results)
 
     @gql_field(description="The artifact of this entity.")  # type: ignore[misc]
-    async def artifact(self, info: Info[StrawberryGQLContext]) -> Artifact:
+    async def artifact(self, info: Info[StrawberryGQLContext]) -> Artifact | None:
         revision_node = await info.context.adapters.artifact.get_revision(uuid.UUID(self.id))
         artifact_node = await info.context.adapters.artifact.get(revision_node.artifact_id)
 

--- a/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/audit_log/resolver/query.py
@@ -36,7 +36,7 @@ async def admin_audit_logs_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> AuditLogV2ConnectionGQL:
+) -> AuditLogV2ConnectionGQL | None:
     check_admin_only()
     result = await info.context.adapters.audit_log.admin_search(
         AdminSearchAuditLogsInput(

--- a/src/ai/backend/manager/api/gql/container_registry/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/container_registry/resolver/mutation.py
@@ -31,7 +31,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def admin_create_container_registry_v2(
     info: Info[StrawberryGQLContext],
     input: CreateContainerRegistryInputGQL,
-) -> CreateContainerRegistryPayloadGQL:
+) -> CreateContainerRegistryPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.container_registry.admin_create(input.to_pydantic())
     return CreateContainerRegistryPayloadGQL.from_pydantic(payload)
@@ -46,7 +46,7 @@ async def admin_create_container_registry_v2(
 async def admin_update_container_registry_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateContainerRegistryInputGQL,
-) -> UpdateContainerRegistryPayloadGQL:
+) -> UpdateContainerRegistryPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.container_registry.admin_update(input.to_pydantic())
     return UpdateContainerRegistryPayloadGQL.from_pydantic(payload)
@@ -61,7 +61,7 @@ async def admin_update_container_registry_v2(
 async def admin_delete_container_registry_v2(
     info: Info[StrawberryGQLContext],
     id: str,
-) -> DeleteContainerRegistryPayloadGQL:
+) -> DeleteContainerRegistryPayloadGQL | None:
     check_admin_only()
     from uuid import UUID
 

--- a/src/ai/backend/manager/api/gql/deployment/resolver/access_token.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/access_token.py
@@ -24,7 +24,7 @@ from ai.backend.manager.api.gql.types import StrawberryGQLContext
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Create access token."))
 async def create_access_token(
     input: CreateAccessTokenInput, info: Info[StrawberryGQLContext]
-) -> CreateAccessTokenPayload:
+) -> CreateAccessTokenPayload | None:
     """Create a new access token for a deployment."""
     payload = await info.context.adapters.deployment.create_access_token(input.to_pydantic())
     return CreateAccessTokenPayload(access_token=AccessToken.from_pydantic(payload.access_token))
@@ -35,7 +35,7 @@ async def create_access_token(
 )
 async def delete_access_token(
     input: DeleteAccessTokenInput, info: Info[StrawberryGQLContext]
-) -> DeleteAccessTokenPayload:
+) -> DeleteAccessTokenPayload | None:
     """Delete an access token."""
     payload = await info.context.adapters.deployment.delete_access_token(input.to_pydantic())
     return DeleteAccessTokenPayload(id=payload.id)

--- a/src/ai/backend/manager/api/gql/deployment/resolver/auto_scaling.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/auto_scaling.py
@@ -25,7 +25,7 @@ from ai.backend.manager.api.gql.types import StrawberryGQLContext
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Create auto scaling rule."))
 async def create_auto_scaling_rule(
     input: CreateAutoScalingRuleInput, info: Info[StrawberryGQLContext]
-) -> CreateAutoScalingRulePayload:
+) -> CreateAutoScalingRulePayload | None:
     """Create a new auto-scaling rule for a deployment."""
     payload = await info.context.adapters.deployment.create_rule(input.to_pydantic())
     return CreateAutoScalingRulePayload(rule=AutoScalingRule.from_pydantic(payload.rule))
@@ -34,7 +34,7 @@ async def create_auto_scaling_rule(
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Update auto scaling rule."))
 async def update_auto_scaling_rule(
     input: UpdateAutoScalingRuleInput, info: Info[StrawberryGQLContext]
-) -> UpdateAutoScalingRulePayload:
+) -> UpdateAutoScalingRulePayload | None:
     """Update an existing auto-scaling rule."""
     payload = await info.context.adapters.deployment.update_rule(input.to_pydantic())
     return UpdateAutoScalingRulePayload(rule=AutoScalingRule.from_pydantic(payload.rule))
@@ -43,7 +43,7 @@ async def update_auto_scaling_rule(
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Delete auto scaling rule."))
 async def delete_auto_scaling_rule(
     input: DeleteAutoScalingRuleInput, info: Info[StrawberryGQLContext]
-) -> DeleteAutoScalingRulePayload:
+) -> DeleteAutoScalingRulePayload | None:
     """Delete an auto-scaling rule."""
     payload = await info.context.adapters.deployment.delete_rule(input.to_pydantic())
     return DeleteAutoScalingRulePayload(id=ID(str(payload.id)))

--- a/src/ai/backend/manager/api/gql/deployment/resolver/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/deployment.py
@@ -206,7 +206,7 @@ async def deployment(id: ID, info: Info[StrawberryGQLContext]) -> ModelDeploymen
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Create model deployment."))
 async def create_model_deployment(
     input: CreateDeploymentInput, info: Info[StrawberryGQLContext]
-) -> CreateDeploymentPayload:
+) -> CreateDeploymentPayload | None:
     """Create a new model deployment."""
     user_data = current_user()
     if user_data is None:
@@ -218,7 +218,7 @@ async def create_model_deployment(
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Update model deployment."))
 async def update_model_deployment(
     input: UpdateDeploymentInput, info: Info[StrawberryGQLContext]
-) -> UpdateDeploymentPayload:
+) -> UpdateDeploymentPayload | None:
     """Update an existing model deployment."""
     payload = await info.context.adapters.deployment.update(input.to_pydantic(), UUID(input.id))
     return UpdateDeploymentPayload(deployment=ModelDeployment.from_pydantic(payload.deployment))
@@ -227,7 +227,7 @@ async def update_model_deployment(
 @gql_mutation(BackendAIGQLMeta(added_version="25.16.0", description="Delete model deployment."))
 async def delete_model_deployment(
     input: DeleteDeploymentInput, info: Info[StrawberryGQLContext]
-) -> DeleteDeploymentPayload:
+) -> DeleteDeploymentPayload | None:
     """Delete a model deployment."""
     await info.context.adapters.deployment.delete(input.to_pydantic())
     return DeleteDeploymentPayload(id=input.id)
@@ -244,7 +244,7 @@ async def delete_model_deployment(
 )
 async def replace_deployment_options(
     input: ReplaceDeploymentOptionsInputGQL, info: Info[StrawberryGQLContext]
-) -> ReplaceDeploymentOptionsPayload:
+) -> ReplaceDeploymentOptionsPayload | None:
     """Replace the options surface of a deployment.
 
     GQL input carries the target ``deployment_id`` and the full ``options``
@@ -270,7 +270,7 @@ async def replace_deployment_options(
 )
 async def sync_replicas(
     input: SyncReplicaInput, info: Info[StrawberryGQLContext]
-) -> SyncReplicaPayload:
+) -> SyncReplicaPayload | None:
     payload = await info.context.adapters.deployment.sync_replicas(input.to_pydantic())
     return SyncReplicaPayload(success=payload.success)
 
@@ -287,7 +287,7 @@ async def sync_replicas(
 )
 async def admin_refresh_deployment_revisions(
     info: Info[StrawberryGQLContext],
-) -> AdminRefreshDeploymentRevisionsPayload:
+) -> AdminRefreshDeploymentRevisionsPayload | None:
     check_admin_only()
     payload = await info.context.adapters.deployment.admin_refresh_deployment_revisions()
     return AdminRefreshDeploymentRevisionsPayload(

--- a/src/ai/backend/manager/api/gql/deployment/resolver/policy.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/policy.py
@@ -26,7 +26,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def update_deployment_policy(
     input: UpdateDeploymentPolicyInputGQL,
     info: Info[StrawberryGQLContext],
-) -> UpdateDeploymentPolicyPayloadGQL:
+) -> UpdateDeploymentPolicyPayloadGQL | None:
     """Update (upsert) a deployment policy for a deployment."""
     check_admin_only()
     payload = await info.context.adapters.deployment.upsert_policy(input.to_pydantic())

--- a/src/ai/backend/manager/api/gql/deployment/resolver/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/revision.py
@@ -106,7 +106,7 @@ async def revision(id: ID, info: Info[StrawberryGQLContext]) -> ModelRevision | 
         added_version="25.16.0", description="Get JSON Schema for inference runtime configuration"
     )
 )  # type: ignore[misc]
-async def inference_runtime_config(name: str) -> JSON:
+async def inference_runtime_config(name: str) -> JSON | None:
     match name.lower():
         case "vllm":
             return cast(JSON, VLLMRuntimeConfig.to_json_schema())
@@ -131,7 +131,7 @@ async def inference_runtime_config(name: str) -> JSON:
         description="Get configuration JSON Schemas for all inference runtimes.",
     )
 )  # type: ignore[misc]
-async def inference_runtime_configs(info: Info[StrawberryGQLContext]) -> JSON:
+async def inference_runtime_configs(info: Info[StrawberryGQLContext]) -> JSON | None:
     return cast(
         JSON,
         {
@@ -150,7 +150,7 @@ async def inference_runtime_configs(info: Info[StrawberryGQLContext]) -> JSON:
 async def add_model_revision(
     input: AddRevisionInput,
     info: Info[StrawberryGQLContext],
-) -> AddRevisionPayload:
+) -> AddRevisionPayload | None:
     """Add a model revision to a deployment."""
     input_dto = input.to_pydantic()
     payload = await info.context.adapters.deployment.add_revision(
@@ -169,7 +169,7 @@ async def add_model_revision(
 async def activate_deployment_revision(
     input: ActivateRevisionInputGQL,
     info: Info[StrawberryGQLContext, None],
-) -> ActivateRevisionPayloadGQL:
+) -> ActivateRevisionPayloadGQL | None:
     """Activate a revision to be the current revision for a deployment."""
     payload = await info.context.adapters.deployment.activate_revision(input.to_pydantic())
     return ActivateRevisionPayloadGQL(

--- a/src/ai/backend/manager/api/gql/deployment/resolver/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/revision_preset.py
@@ -113,7 +113,7 @@ async def deployment_revision_preset(
 async def admin_create_deployment_revision_preset(
     info: Info[StrawberryGQLContext],
     input: CreateDeploymentRevisionPresetInputGQL,
-) -> CreateDeploymentRevisionPresetPayloadGQL:
+) -> CreateDeploymentRevisionPresetPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.deployment_revision_preset.create(dto)
@@ -129,7 +129,7 @@ async def admin_create_deployment_revision_preset(
 async def admin_update_deployment_revision_preset(
     info: Info[StrawberryGQLContext],
     input: UpdateDeploymentRevisionPresetInputGQL,
-) -> UpdateDeploymentRevisionPresetPayloadGQL:
+) -> UpdateDeploymentRevisionPresetPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.deployment_revision_preset.update(dto)
@@ -145,7 +145,7 @@ async def admin_update_deployment_revision_preset(
 async def admin_delete_deployment_revision_preset(
     info: Info[StrawberryGQLContext],
     id: UUID,
-) -> DeleteDeploymentRevisionPresetPayloadGQL:
+) -> DeleteDeploymentRevisionPresetPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.deployment_revision_preset.delete(id)
     return DeleteDeploymentRevisionPresetPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/deployment/resolver/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/resolver/route.py
@@ -102,7 +102,7 @@ async def route(id: ID, info: Info[StrawberryGQLContext]) -> Route | None:
 async def update_route_traffic_status(
     input: UpdateRouteTrafficStatusInputGQL,
     info: Info[StrawberryGQLContext],
-) -> UpdateRouteTrafficStatusPayloadGQL:
+) -> UpdateRouteTrafficStatusPayloadGQL | None:
     """Update route traffic status (ACTIVE/INACTIVE)."""
     _, route_id = resolve_global_id(input.route_id)
     route_node = await info.context.adapters.deployment.update_route_traffic(

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -236,7 +236,7 @@ class ModelDeploymentMetadata:
         description="The project of this entity.",
         deprecation_reason="Use project_v2 instead.",
     )  # type: ignore[misc]
-    async def project(self, info: Info[StrawberryGQLContext]) -> Project:
+    async def project(self, info: Info[StrawberryGQLContext]) -> Project | None:
         project_global_id = to_global_id(
             GroupNode, UUID(str(self.project_id)), is_target_graphene_object=True
         )
@@ -263,7 +263,7 @@ class ModelDeploymentMetadata:
         description="The domain of this entity.",
         deprecation_reason="Use domain_v2 instead.",
     )  # type: ignore[misc]
-    async def domain(self, info: Info[StrawberryGQLContext]) -> Domain:
+    async def domain(self, info: Info[StrawberryGQLContext]) -> Domain | None:
         domain_global_id = to_global_id(
             DomainNode, self.domain_name, is_target_graphene_object=True
         )
@@ -397,7 +397,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> ModelRevisionConnection:
+    ) -> ModelRevisionConnection | None:
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment.search_revisions(
@@ -438,7 +438,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> ModelReplicaConnection:
+    ) -> ModelReplicaConnection | None:
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment.search_replicas(
@@ -479,7 +479,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> AutoScalingRuleConnection:
+    ) -> AutoScalingRuleConnection | None:
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment.search_rules(
@@ -522,7 +522,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> AccessTokenConnection:
+    ) -> AccessTokenConnection | None:
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
         payload = await info.context.adapters.deployment.search_access_tokens(

--- a/src/ai/backend/manager/api/gql/deployment/types/replica.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/replica.py
@@ -228,7 +228,7 @@ class ModelReplica(PydanticNodeMixin[ReplicaNodeDTO]):
         )
 
     @gql_field(description="The revision of this entity.")  # type: ignore[misc]
-    async def revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision:
+    async def revision(self, info: Info[StrawberryGQLContext]) -> ModelRevision | None:
         """Resolve revision by ID using DataLoader."""
         result = await info.context.data_loaders.revision_loader.load(UUID(str(self.revision_id)))
         if result is None:

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -221,7 +221,7 @@ class ResourceConfig:
     )
 
     @gql_field(description="The resource group of this entity.")  # type: ignore[misc]
-    def resource_group(self) -> ResourceGroup:
+    def resource_group(self) -> ResourceGroup | None:
         """Resolves the federated ResourceGroup."""
         global_id = to_global_id(
             ScalingGroupNode, self.resource_group_name, is_target_graphene_object=True
@@ -284,7 +284,7 @@ class ModelMountConfig:
     )
 
     @gql_field(description="The vfolder of this entity.")  # type: ignore[misc]
-    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder:
+    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder | None:
         vfolder_global_id = to_global_id(
             VirtualFolderNode, UUID(str(self.vfolder_id)), is_target_graphene_object=True
         )
@@ -314,7 +314,7 @@ class ExtraVFolderMountInfoGQL:
     )
 
     @gql_field(description="The vfolder of this entity.")  # type: ignore[misc]
-    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder:
+    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder | None:
         vfolder_global_id = to_global_id(
             VirtualFolderNode, UUID(str(self.vfolder_id)), is_target_graphene_object=True
         )
@@ -491,7 +491,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         description="The image of this entity.",
         deprecation_reason="Use image_v2 instead.",
     )  # type: ignore[misc]
-    async def image(self, info: Info[StrawberryGQLContext]) -> Image:
+    async def image(self, info: Info[StrawberryGQLContext]) -> Image | None:
         image_global_id = to_global_id(
             ImageNode, UUID(str(self.image_id)), is_target_graphene_object=True
         )
@@ -552,7 +552,7 @@ class ModelRevision(PydanticNodeMixin[RevisionNodeDTO]):
         info: Info[StrawberryGQLContext],
         filter: AllocatedResourceSlotFilterGQL | None = None,
         order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
-    ) -> list[AllocatedResourceSlotGQL]:
+    ) -> list[AllocatedResourceSlotGQL] | None:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
         )

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -310,7 +310,7 @@ class DeploymentRevisionPresetGQL(PydanticNodeMixin[NodeDTO]):
         info: Info[StrawberryGQLContext],
         filter: AllocatedResourceSlotFilterGQL | None = None,
         order_by: list[AllocatedResourceSlotOrderByGQL] | None = None,
-    ) -> list[AllocatedResourceSlotGQL]:
+    ) -> list[AllocatedResourceSlotGQL] | None:
         from ai.backend.common.dto.manager.v2.resource_slot.request import (
             SearchAllocatedResourceSlotsInput,
         )

--- a/src/ai/backend/manager/api/gql/deployment/types/route.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/route.py
@@ -121,7 +121,7 @@ class Route(PydanticNodeMixin[RouteNodeDTO]):
     @gql_field(description="The deployment this route belongs to.")  # type: ignore[misc]
     async def deployment(
         self, info: Info[StrawberryGQLContext]
-    ) -> Annotated[ModelDeployment, strawberry.lazy(".deployment")]:
+    ) -> Annotated[ModelDeployment, strawberry.lazy(".deployment")] | None:
         """Resolve deployment using dataloader."""
         deployment_id = UUID(str(self.deployment_id))
         deployment_data = await info.context.data_loaders.deployment_loader.load(deployment_id)

--- a/src/ai/backend/manager/api/gql/domain_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/domain_v2/resolver/mutation.py
@@ -43,7 +43,7 @@ def _get_user_info() -> UserInfo:
 async def admin_create_domain_v2(
     info: Info[StrawberryGQLContext],
     input: CreateDomainInputGQL,
-) -> DomainPayloadGQL:
+) -> DomainPayloadGQL | None:
     """Create a new domain."""
     check_admin_only()
     ctx = info.context
@@ -61,7 +61,7 @@ async def admin_update_domain_v2(
     info: Info[StrawberryGQLContext],
     domain_name: str,
     input: UpdateDomainInputGQL,
-) -> DomainPayloadGQL:
+) -> DomainPayloadGQL | None:
     """Update a domain."""
     check_admin_only()
     ctx = info.context
@@ -80,7 +80,7 @@ async def admin_update_domain_v2(
 async def admin_delete_domain_v2(
     info: Info[StrawberryGQLContext],
     domain_name: str,
-) -> DeleteDomainPayloadGQL:
+) -> DeleteDomainPayloadGQL | None:
     """Soft-delete a domain."""
     check_admin_only()
     ctx = info.context
@@ -99,7 +99,7 @@ async def admin_delete_domain_v2(
 async def admin_purge_domain_v2(
     info: Info[StrawberryGQLContext],
     domain_name: str,
-) -> PurgeDomainPayloadGQL:
+) -> PurgeDomainPayloadGQL | None:
     """Permanently purge a domain."""
     check_admin_only()
     ctx = info.context

--- a/src/ai/backend/manager/api/gql/domain_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/domain_v2/types/node.py
@@ -102,7 +102,7 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
         self,
         info: Info,
         scope: DomainFairShareScopeGQL,
-    ) -> DomainFairShareGQL:
+    ) -> DomainFairShareGQL | None:
         from ai.backend.common.dto.manager.v2.fair_share.request import GetDomainFairShareInput
 
         payload = await info.context.adapters.fair_share.get_domain(
@@ -123,7 +123,7 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
     async def active_resource_overview(
         self,
         info: Info,
-    ) -> ActiveResourceOverviewGQL:
+    ) -> ActiveResourceOverviewGQL | None:
         dto = await info.context.adapters.resource_slot.get_domain_resource_overview(str(self.id))
         return ActiveResourceOverviewGQL.from_pydantic(dto)
 
@@ -142,7 +142,7 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> DomainUsageBucketConnection:
+    ) -> DomainUsageBucketConnection | None:
         from strawberry.relay import PageInfo
 
         from ai.backend.manager.api.gql.base import encode_cursor
@@ -208,10 +208,13 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        ProjectV2Connection,
-        strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
-    ]:
+    ) -> (
+        Annotated[
+            ProjectV2Connection,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
         from strawberry.relay import PageInfo
 
         from ai.backend.common.dto.manager.v2.group.request import AdminSearchProjectsInput
@@ -271,10 +274,13 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        UserV2Connection,
-        strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
-    ]:
+    ) -> (
+        Annotated[
+            UserV2Connection,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
         from strawberry.relay import PageInfo
 
         from ai.backend.common.dto.manager.v2.user.request import AdminSearchUsersInput

--- a/src/ai/backend/manager/api/gql/fair_share/resolver/domain.py
+++ b/src/ai/backend/manager/api/gql/fair_share/resolver/domain.py
@@ -261,7 +261,7 @@ async def domain_fair_shares(
 async def admin_upsert_domain_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertDomainFairShareWeightInput,
-) -> UpsertDomainFairShareWeightPayload:
+) -> UpsertDomainFairShareWeightPayload | None:
     """Upsert domain fair share weight (admin only)."""
     check_admin_only()
 
@@ -280,7 +280,7 @@ async def admin_upsert_domain_fair_share_weight(
 async def admin_bulk_upsert_domain_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertDomainFairShareWeightInput,
-) -> BulkUpsertDomainFairShareWeightPayload:
+) -> BulkUpsertDomainFairShareWeightPayload | None:
     """Bulk upsert domain fair share weights (admin only)."""
     check_admin_only()
 
@@ -301,7 +301,7 @@ async def admin_bulk_upsert_domain_fair_share_weight(
 async def upsert_domain_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertDomainFairShareWeightInput,
-) -> UpsertDomainFairShareWeightPayload:
+) -> UpsertDomainFairShareWeightPayload | None:
     """Upsert domain fair share weight."""
     me = current_user()
     if me is None or not me.is_superadmin:
@@ -323,7 +323,7 @@ async def upsert_domain_fair_share_weight(
 async def bulk_upsert_domain_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertDomainFairShareWeightInput,
-) -> BulkUpsertDomainFairShareWeightPayload:
+) -> BulkUpsertDomainFairShareWeightPayload | None:
     """Bulk upsert domain fair share weights."""
     me = current_user()
     if me is None or not me.is_superadmin:

--- a/src/ai/backend/manager/api/gql/fair_share/resolver/project.py
+++ b/src/ai/backend/manager/api/gql/fair_share/resolver/project.py
@@ -266,7 +266,7 @@ async def project_fair_shares(
 async def admin_upsert_project_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertProjectFairShareWeightInput,
-) -> UpsertProjectFairShareWeightPayload:
+) -> UpsertProjectFairShareWeightPayload | None:
     """Upsert project fair share weight (admin only)."""
     check_admin_only()
 
@@ -285,7 +285,7 @@ async def admin_upsert_project_fair_share_weight(
 async def admin_bulk_upsert_project_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertProjectFairShareWeightInput,
-) -> BulkUpsertProjectFairShareWeightPayload:
+) -> BulkUpsertProjectFairShareWeightPayload | None:
     """Bulk upsert project fair share weights (admin only)."""
     check_admin_only()
 
@@ -306,7 +306,7 @@ async def admin_bulk_upsert_project_fair_share_weight(
 async def upsert_project_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertProjectFairShareWeightInput,
-) -> UpsertProjectFairShareWeightPayload:
+) -> UpsertProjectFairShareWeightPayload | None:
     """Upsert project fair share weight."""
     me = current_user()
     if me is None or not me.is_superadmin:
@@ -328,7 +328,7 @@ async def upsert_project_fair_share_weight(
 async def bulk_upsert_project_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertProjectFairShareWeightInput,
-) -> BulkUpsertProjectFairShareWeightPayload:
+) -> BulkUpsertProjectFairShareWeightPayload | None:
     """Bulk upsert project fair share weights."""
     me = current_user()
     if me is None or not me.is_superadmin:

--- a/src/ai/backend/manager/api/gql/fair_share/resolver/user.py
+++ b/src/ai/backend/manager/api/gql/fair_share/resolver/user.py
@@ -278,7 +278,7 @@ async def user_fair_shares(
 async def admin_upsert_user_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertUserFairShareWeightInput,
-) -> UpsertUserFairShareWeightPayload:
+) -> UpsertUserFairShareWeightPayload | None:
     """Upsert user fair share weight (admin only)."""
     check_admin_only()
 
@@ -297,7 +297,7 @@ async def admin_upsert_user_fair_share_weight(
 async def admin_bulk_upsert_user_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertUserFairShareWeightInput,
-) -> BulkUpsertUserFairShareWeightPayload:
+) -> BulkUpsertUserFairShareWeightPayload | None:
     """Bulk upsert user fair share weights (admin only)."""
     check_admin_only()
 
@@ -318,7 +318,7 @@ async def admin_bulk_upsert_user_fair_share_weight(
 async def upsert_user_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: UpsertUserFairShareWeightInput,
-) -> UpsertUserFairShareWeightPayload:
+) -> UpsertUserFairShareWeightPayload | None:
     """Upsert user fair share weight."""
     me = current_user()
     if me is None or not me.is_superadmin:
@@ -340,7 +340,7 @@ async def upsert_user_fair_share_weight(
 async def bulk_upsert_user_fair_share_weight(
     info: Info[StrawberryGQLContext],
     input: BulkUpsertUserFairShareWeightInput,
-) -> BulkUpsertUserFairShareWeightPayload:
+) -> BulkUpsertUserFairShareWeightPayload | None:
     """Bulk upsert user fair share weights."""
     me = current_user()
     if me is None or not me.is_superadmin:

--- a/src/ai/backend/manager/api/gql/fair_share/types/common.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/common.py
@@ -158,7 +158,7 @@ class FairShareCalculationSnapshotGQL(PydanticOutputMixin[FairShareCalculationSn
             description="Average daily decayed resource usage during the lookback period. Calculated as total_decayed_usage divided by lookback duration in days. For each resource type, this represents the average decayed amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).",
         )
     )  # type: ignore[misc]
-    def average_daily_decayed_usage(self) -> ResourceSlotGQL:
+    def average_daily_decayed_usage(self) -> ResourceSlotGQL | None:
         from ai.backend.manager.api.gql.resource_usage.types.common_calculations import (
             calculate_average_daily_usage,
         )

--- a/src/ai/backend/manager/api/gql/huggingface_registry.py
+++ b/src/ai/backend/manager/api/gql/huggingface_registry.py
@@ -93,7 +93,7 @@ HuggingFaceRegistryEdge = Edge[HuggingFaceRegistry]
 )
 class HuggingFaceRegistryConnection(Connection[HuggingFaceRegistry]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int:
+    def count(self) -> int | None:
         return len(self.edges)
 
 
@@ -205,7 +205,7 @@ class DeleteHuggingFaceRegistryPayload(PydanticOutputMixin[DeleteHuggingFaceRegi
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Create huggingface registry."))
 async def create_huggingface_registry(
     input: CreateHuggingFaceRegistryInput, info: Info[StrawberryGQLContext]
-) -> CreateHuggingFaceRegistryPayload:
+) -> CreateHuggingFaceRegistryPayload | None:
     result = await info.context.adapters.huggingface_registry.create(input.to_pydantic())
     return CreateHuggingFaceRegistryPayload(
         huggingface_registry=HuggingFaceRegistry.from_pydantic(result.huggingface_registry)
@@ -215,7 +215,7 @@ async def create_huggingface_registry(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Update huggingface registry."))
 async def update_huggingface_registry(
     input: UpdateHuggingFaceRegistryInput, info: Info[StrawberryGQLContext]
-) -> UpdateHuggingFaceRegistryPayload:
+) -> UpdateHuggingFaceRegistryPayload | None:
     result = await info.context.adapters.huggingface_registry.update(input.to_pydantic())
     return UpdateHuggingFaceRegistryPayload(
         huggingface_registry=HuggingFaceRegistry.from_pydantic(result.huggingface_registry)
@@ -225,7 +225,7 @@ async def update_huggingface_registry(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Delete huggingface registry."))
 async def delete_huggingface_registry(
     input: DeleteHuggingFaceRegistryInput, info: Info[StrawberryGQLContext]
-) -> DeleteHuggingFaceRegistryPayload:
+) -> DeleteHuggingFaceRegistryPayload | None:
     pydantic_input = input.to_pydantic()
     result = await info.context.adapters.huggingface_registry.delete(pydantic_input)
     return DeleteHuggingFaceRegistryPayload(id=result.id)

--- a/src/ai/backend/manager/api/gql/huggingface_registry.py
+++ b/src/ai/backend/manager/api/gql/huggingface_registry.py
@@ -93,7 +93,7 @@ HuggingFaceRegistryEdge = Edge[HuggingFaceRegistry]
 )
 class HuggingFaceRegistryConnection(Connection[HuggingFaceRegistry]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int | None:
+    def count(self) -> int:
         return len(self.edges)
 
 

--- a/src/ai/backend/manager/api/gql/image/types.py
+++ b/src/ai/backend/manager/api/gql/image/types.py
@@ -302,7 +302,7 @@ class ImageV2GQL(PydanticNodeMixin[ImageNode]):
         after: str | None = None,
         first: int | None = None,
         last: int | None = None,
-    ) -> ImageV2AliasConnectionGQL:
+    ) -> ImageV2AliasConnectionGQL | None:
         """Get the aliases for this image with pagination, filtering, and ordering."""
         pydantic_filter = filter.to_pydantic() if filter else None
         pydantic_orders = [o.to_pydantic() for o in order_by] if order_by else None

--- a/src/ai/backend/manager/api/gql/kernel/types.py
+++ b/src/ai/backend/manager/api/gql/kernel/types.py
@@ -442,10 +442,13 @@ class KernelV2GQL(PydanticNodeMixin[KernelNode]):
         before: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        ResourceAllocationConnectionGQL,
-        strawberry.lazy("ai.backend.manager.api.gql.resource_slot.types"),
-    ]:
+    ) -> (
+        Annotated[
+            ResourceAllocationConnectionGQL,
+            strawberry.lazy("ai.backend.manager.api.gql.resource_slot.types"),
+        ]
+        | None
+    ):
         """Fetch per-slot resource allocation for this kernel."""
         import uuid as _uuid
         from decimal import Decimal

--- a/src/ai/backend/manager/api/gql/keypair/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/keypair/resolver/mutation.py
@@ -48,7 +48,7 @@ def _get_current_user_id() -> UUID:
 )
 async def issue_my_keypair(
     info: Info[StrawberryGQLContext],
-) -> IssueMyKeypairPayloadGQL:
+) -> IssueMyKeypairPayloadGQL | None:
     user_id = _get_current_user_id()
     payload = await info.context.adapters.user.issue_my_keypair(user_id)
     return IssueMyKeypairPayloadGQL.from_pydantic(payload)
@@ -63,7 +63,7 @@ async def issue_my_keypair(
 async def revoke_my_keypair(
     info: Info[StrawberryGQLContext],
     input: RevokeMyKeypairInputGQL,
-) -> RevokeMyKeypairPayloadGQL:
+) -> RevokeMyKeypairPayloadGQL | None:
     user_id = _get_current_user_id()
     payload = await info.context.adapters.user.revoke_my_keypair(user_id, input.access_key)
     return RevokeMyKeypairPayloadGQL.from_pydantic(payload)
@@ -78,7 +78,7 @@ async def revoke_my_keypair(
 async def update_my_keypair(
     info: Info[StrawberryGQLContext],
     input: UpdateMyKeypairInputGQL,
-) -> UpdateMyKeypairPayloadGQL:
+) -> UpdateMyKeypairPayloadGQL | None:
     user_id = _get_current_user_id()
     payload = await info.context.adapters.user.update_my_keypair(
         user_id, input.access_key, input.is_active
@@ -95,7 +95,7 @@ async def update_my_keypair(
 async def switch_my_main_access_key(
     info: Info[StrawberryGQLContext],
     input: SwitchMyMainAccessKeyInputGQL,
-) -> SwitchMyMainAccessKeyPayloadGQL:
+) -> SwitchMyMainAccessKeyPayloadGQL | None:
     user_id = _get_current_user_id()
     payload = await info.context.adapters.user.switch_my_main_access_key(user_id, input.access_key)
     return SwitchMyMainAccessKeyPayloadGQL.from_pydantic(payload)
@@ -113,7 +113,7 @@ async def switch_my_main_access_key(
 async def admin_create_keypair_v2(
     info: Info[StrawberryGQLContext],
     input: AdminCreateKeypairInputGQL,
-) -> AdminCreateKeypairPayloadGQL:
+) -> AdminCreateKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_create_keypair(input.to_pydantic())
     return AdminCreateKeypairPayloadGQL.from_pydantic(payload)
@@ -128,7 +128,7 @@ async def admin_create_keypair_v2(
 async def admin_update_keypair_v2(
     info: Info[StrawberryGQLContext],
     input: AdminUpdateKeypairInputGQL,
-) -> AdminUpdateKeypairPayloadGQL:
+) -> AdminUpdateKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_update_keypair(input.to_pydantic())
     return AdminUpdateKeypairPayloadGQL.from_pydantic(payload)
@@ -143,7 +143,7 @@ async def admin_update_keypair_v2(
 async def admin_delete_keypair_v2(
     info: Info[StrawberryGQLContext],
     access_key: str,
-) -> AdminDeleteKeypairPayloadGQL:
+) -> AdminDeleteKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_delete_keypair(access_key)
     return AdminDeleteKeypairPayloadGQL.from_pydantic(payload)
@@ -161,7 +161,7 @@ async def admin_delete_keypair_v2(
 async def admin_register_ssh_keypair_v2(
     info: Info[StrawberryGQLContext],
     input: AdminRegisterSSHKeypairInputGQL,
-) -> AdminRegisterSSHKeypairPayloadGQL:
+) -> AdminRegisterSSHKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_register_ssh_keypair(input.to_pydantic())
     return AdminRegisterSSHKeypairPayloadGQL.from_pydantic(payload)
@@ -176,7 +176,7 @@ async def admin_register_ssh_keypair_v2(
 async def admin_delete_ssh_keypair_v2(
     info: Info[StrawberryGQLContext],
     access_key: str,
-) -> AdminDeleteSSHKeypairPayloadGQL:
+) -> AdminDeleteSSHKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_delete_ssh_keypair(access_key)
     return AdminDeleteSSHKeypairPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/keypair/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/keypair/resolver/query.py
@@ -37,7 +37,7 @@ async def my_keypairs(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> KeyPairConnection:
+) -> KeyPairConnection | None:
     result = await info.context.adapters.user.search_my_keypairs(
         SearchMyKeypairsRequest(
             filter=filter.to_pydantic() if filter is not None else None,
@@ -80,7 +80,7 @@ async def admin_keypairs_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> KeyPairConnection:
+) -> KeyPairConnection | None:
     check_admin_only()
     result = await info.context.adapters.user.gql_admin_search_keypairs(
         AdminSearchKeypairsInput(
@@ -132,7 +132,7 @@ async def admin_keypair_v2(
 async def admin_ssh_keypair_v2(
     info: Info[StrawberryGQLContext],
     access_key: str,
-) -> AdminGetSSHKeypairPayloadGQL:
+) -> AdminGetSSHKeypairPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.user.admin_get_ssh_keypair(access_key)
     return AdminGetSSHKeypairPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/login_client_type/resolver.py
+++ b/src/ai/backend/manager/api/gql/login_client_type/resolver.py
@@ -96,7 +96,7 @@ async def login_client_types(
 async def admin_create_login_client_type(
     info: Info[StrawberryGQLContext],
     input: CreateLoginClientTypeInputGQL,
-) -> CreateLoginClientTypePayloadGQL:
+) -> CreateLoginClientTypePayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.login_client_type.admin_create(input.to_pydantic())
     return CreateLoginClientTypePayloadGQL.from_pydantic(payload)
@@ -112,7 +112,7 @@ async def admin_update_login_client_type(
     info: Info[StrawberryGQLContext],
     id: UUID,
     input: UpdateLoginClientTypeInputGQL,
-) -> UpdateLoginClientTypePayloadGQL:
+) -> UpdateLoginClientTypePayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.login_client_type.admin_update(id, input.to_pydantic())
     return UpdateLoginClientTypePayloadGQL.from_pydantic(payload)
@@ -127,7 +127,7 @@ async def admin_update_login_client_type(
 async def admin_delete_login_client_type(
     info: Info[StrawberryGQLContext],
     id: UUID,
-) -> DeleteLoginClientTypePayloadGQL:
+) -> DeleteLoginClientTypePayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.login_client_type.admin_delete(id)
     return DeleteLoginClientTypePayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/login_history/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/login_history/resolver/query.py
@@ -41,7 +41,7 @@ async def admin_login_history_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> LoginHistoryV2ConnectionGQL:
+) -> LoginHistoryV2ConnectionGQL | None:
     check_admin_only()
     result = await info.context.adapters.login_history.admin_search(
         AdminSearchLoginHistoryInput(
@@ -85,7 +85,7 @@ async def my_login_history_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> LoginHistoryV2ConnectionGQL:
+) -> LoginHistoryV2ConnectionGQL | None:
     result = await info.context.adapters.login_history.my_search(
         MySearchLoginHistoryInput(
             filter=filter.to_pydantic() if filter else None,

--- a/src/ai/backend/manager/api/gql/login_session/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/login_session/resolver/query.py
@@ -49,7 +49,7 @@ async def admin_login_sessions_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> LoginSessionV2ConnectionGQL:
+) -> LoginSessionV2ConnectionGQL | None:
     check_admin_only()
     result = await info.context.adapters.login_session.admin_search(
         AdminSearchLoginSessionsInput(
@@ -93,7 +93,7 @@ async def my_login_sessions_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> LoginSessionV2ConnectionGQL:
+) -> LoginSessionV2ConnectionGQL | None:
     result = await info.context.adapters.login_session.my_search(
         MySearchLoginSessionsInput(
             filter=filter.to_pydantic() if filter else None,
@@ -129,7 +129,7 @@ async def my_login_sessions_v2(
 async def admin_revoke_login_session(
     info: Info[StrawberryGQLContext],
     session_id: UUID,
-) -> RevokeLoginSessionPayloadGQL:
+) -> RevokeLoginSessionPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.login_session.admin_revoke(
         AdminRevokeLoginSessionInput(session_id=session_id)
@@ -146,7 +146,7 @@ async def admin_revoke_login_session(
 async def my_revoke_login_session(
     info: Info[StrawberryGQLContext],
     session_id: UUID,
-) -> RevokeLoginSessionPayloadGQL:
+) -> RevokeLoginSessionPayloadGQL | None:
     payload = await info.context.adapters.login_session.my_revoke(
         MyRevokeLoginSessionInput(session_id=session_id)
     )
@@ -162,7 +162,7 @@ async def my_revoke_login_session(
 async def admin_unblock_user(
     info: Info[StrawberryGQLContext],
     username: str,
-) -> UnblockUserPayloadGQL:
+) -> UnblockUserPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.login_session.admin_unblock_user(
         AdminUnblockUserInput(username=username)

--- a/src/ai/backend/manager/api/gql/model_card/resolver.py
+++ b/src/ai/backend/manager/api/gql/model_card/resolver.py
@@ -124,7 +124,7 @@ async def model_card_v2(
 async def admin_create_model_card_v2(
     info: Info[StrawberryGQLContext],
     input: CreateModelCardInputGQL,
-) -> CreateModelCardPayloadGQL:
+) -> CreateModelCardPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.model_card.create(dto)
@@ -140,7 +140,7 @@ async def admin_create_model_card_v2(
 async def admin_update_model_card_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateModelCardInputGQL,
-) -> UpdateModelCardPayloadGQL:
+) -> UpdateModelCardPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.model_card.update(dto)
@@ -157,7 +157,7 @@ async def admin_delete_model_card_v2(
     info: Info[StrawberryGQLContext],
     id: UUID,
     options: DeleteModelCardOptionsGQL | None = None,
-) -> DeleteModelCardPayloadGQL:
+) -> DeleteModelCardPayloadGQL | None:
     check_admin_only()
     options_dto = options.to_pydantic() if options is not None else DeleteModelCardOptions()
     payload = await info.context.adapters.model_card.delete(id, options=options_dto)
@@ -198,7 +198,7 @@ async def admin_bulk_delete_model_cards_v2(
 async def scan_project_model_cards_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-) -> ScanProjectModelCardsPayloadGQL:
+) -> ScanProjectModelCardsPayloadGQL | None:
     payload = await info.context.adapters.model_card.scan_project(project_id)
     return ScanProjectModelCardsPayloadGQL.from_pydantic(payload)
 
@@ -213,7 +213,7 @@ async def deploy_model_card_v2(
     info: Info[StrawberryGQLContext],
     card_id: UUID,
     input: DeployModelCardInputGQL,
-) -> DeployModelCardPayloadGQL:
+) -> DeployModelCardPayloadGQL | None:
     payload = await info.context.adapters.model_card.deploy(card_id, input.to_pydantic())
     return DeployModelCardPayloadGQL.from_pydantic(payload)
 

--- a/src/ai/backend/manager/api/gql/notification/resolver.py
+++ b/src/ai/backend/manager/api/gql/notification/resolver.py
@@ -334,7 +334,7 @@ async def notification_rule_types() -> list[NotificationRuleTypeGQL] | None:
 )  # type: ignore[misc]
 async def notification_rule_type_schema(
     rule_type: NotificationRuleTypeGQL,
-) -> strawberry.scalars.JSON:
+) -> strawberry.scalars.JSON | None:
     """Return the JSON schema for a given notification rule type."""
     from ai.backend.common.data.notification import NotifiableMessage, NotificationRuleType
 
@@ -353,7 +353,7 @@ async def notification_rule_type_schema(
 )
 async def admin_create_notification_channel(
     input: CreateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> CreateNotificationChannelPayload:
+) -> CreateNotificationChannelPayload | None:
     check_admin_only()
     me = current_user()
     if me is None:
@@ -370,7 +370,7 @@ async def admin_create_notification_channel(
 )
 async def create_notification_channel(
     input: CreateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> CreateNotificationChannelPayload:
+) -> CreateNotificationChannelPayload | None:
     me = current_user()
     if me is None:
         raise InvalidAuthParameters("User authentication is required")
@@ -387,7 +387,7 @@ async def create_notification_channel(
 )
 async def admin_update_notification_channel(
     input: UpdateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> UpdateNotificationChannelPayload:
+) -> UpdateNotificationChannelPayload | None:
     check_admin_only()
     channel_id = uuid.UUID(input.id)
     result = await info.context.adapters.notification.update_channel(
@@ -402,7 +402,7 @@ async def admin_update_notification_channel(
 )
 async def update_notification_channel(
     input: UpdateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> UpdateNotificationChannelPayload:
+) -> UpdateNotificationChannelPayload | None:
     channel_id = uuid.UUID(input.id)
     result = await info.context.adapters.notification.update_channel(
         channel_id, input.to_pydantic()
@@ -417,7 +417,7 @@ async def update_notification_channel(
 )
 async def admin_delete_notification_channel(
     input: DeleteNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> DeleteNotificationChannelPayload:
+) -> DeleteNotificationChannelPayload | None:
     check_admin_only()
     result = await info.context.adapters.notification.delete_channel(input.to_pydantic())
     return DeleteNotificationChannelPayload.from_pydantic(result)
@@ -429,7 +429,7 @@ async def admin_delete_notification_channel(
 )
 async def delete_notification_channel(
     input: DeleteNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> DeleteNotificationChannelPayload:
+) -> DeleteNotificationChannelPayload | None:
     result = await info.context.adapters.notification.delete_channel(input.to_pydantic())
     return DeleteNotificationChannelPayload.from_pydantic(result)
 
@@ -442,7 +442,7 @@ async def delete_notification_channel(
 )
 async def admin_create_notification_rule(
     input: CreateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> CreateNotificationRulePayload:
+) -> CreateNotificationRulePayload | None:
     check_admin_only()
     me = current_user()
     if me is None:
@@ -457,7 +457,7 @@ async def admin_create_notification_rule(
 )
 async def create_notification_rule(
     input: CreateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> CreateNotificationRulePayload:
+) -> CreateNotificationRulePayload | None:
     me = current_user()
     if me is None:
         raise InvalidAuthParameters("User authentication is required")
@@ -470,7 +470,7 @@ async def create_notification_rule(
 )
 async def admin_update_notification_rule(
     input: UpdateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> UpdateNotificationRulePayload:
+) -> UpdateNotificationRulePayload | None:
     check_admin_only()
     rule_id = uuid.UUID(input.id)
     result = await info.context.adapters.notification.update_rule(rule_id, input.to_pydantic())
@@ -483,7 +483,7 @@ async def admin_update_notification_rule(
 )
 async def update_notification_rule(
     input: UpdateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> UpdateNotificationRulePayload:
+) -> UpdateNotificationRulePayload | None:
     rule_id = uuid.UUID(input.id)
     result = await info.context.adapters.notification.update_rule(rule_id, input.to_pydantic())
     return UpdateNotificationRulePayload.from_pydantic(result)
@@ -494,7 +494,7 @@ async def update_notification_rule(
 )
 async def admin_delete_notification_rule(
     input: DeleteNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> DeleteNotificationRulePayload:
+) -> DeleteNotificationRulePayload | None:
     check_admin_only()
     result = await info.context.adapters.notification.delete_rule(input.to_pydantic())
     return DeleteNotificationRulePayload.from_pydantic(result)
@@ -506,7 +506,7 @@ async def admin_delete_notification_rule(
 )
 async def delete_notification_rule(
     input: DeleteNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> DeleteNotificationRulePayload:
+) -> DeleteNotificationRulePayload | None:
     result = await info.context.adapters.notification.delete_rule(input.to_pydantic())
     return DeleteNotificationRulePayload.from_pydantic(result)
 
@@ -519,7 +519,7 @@ async def delete_notification_rule(
 )
 async def admin_validate_notification_channel(
     input: ValidateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> ValidateNotificationChannelPayload:
+) -> ValidateNotificationChannelPayload | None:
     check_admin_only()
     result = await info.context.adapters.notification.validate_channel(input.to_pydantic())
     return ValidateNotificationChannelPayload.from_pydantic(result)
@@ -531,7 +531,7 @@ async def admin_validate_notification_channel(
 )
 async def validate_notification_channel(
     input: ValidateNotificationChannelInput, info: Info[StrawberryGQLContext]
-) -> ValidateNotificationChannelPayload:
+) -> ValidateNotificationChannelPayload | None:
     result = await info.context.adapters.notification.validate_channel(input.to_pydantic())
     return ValidateNotificationChannelPayload.from_pydantic(result)
 
@@ -543,7 +543,7 @@ async def validate_notification_channel(
 )
 async def admin_validate_notification_rule(
     input: ValidateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> ValidateNotificationRulePayload:
+) -> ValidateNotificationRulePayload | None:
     check_admin_only()
     result = await info.context.adapters.notification.validate_rule(input.to_pydantic())
     return ValidateNotificationRulePayload.from_pydantic(result)
@@ -555,6 +555,6 @@ async def admin_validate_notification_rule(
 )
 async def validate_notification_rule(
     input: ValidateNotificationRuleInput, info: Info[StrawberryGQLContext]
-) -> ValidateNotificationRulePayload:
+) -> ValidateNotificationRulePayload | None:
     result = await info.context.adapters.notification.validate_rule(input.to_pydantic())
     return ValidateNotificationRulePayload.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/object_storage.py
+++ b/src/ai/backend/manager/api/gql/object_storage.py
@@ -131,7 +131,7 @@ ObjectStorageEdge = Edge[ObjectStorage]
 )
 class ObjectStorageConnection(Connection[ObjectStorage]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int | None:
+    def count(self) -> int:
         return len(self.edges)
 
 

--- a/src/ai/backend/manager/api/gql/object_storage.py
+++ b/src/ai/backend/manager/api/gql/object_storage.py
@@ -103,7 +103,7 @@ class ObjectStorage(PydanticNodeMixin[ObjectStorageNode]):
         last: int | None,
         limit: int | None,
         offset: int | None,
-    ) -> StorageNamespaceConnection:
+    ) -> StorageNamespaceConnection | None:
         # TODO: Support pagination
         items = await info.context.adapters.storage_namespace.get_namespaces(UUID(self.id))
         nodes = [StorageNamespace.from_pydantic(item) for item in items]
@@ -131,7 +131,7 @@ ObjectStorageEdge = Edge[ObjectStorage]
 )
 class ObjectStorageConnection(Connection[ObjectStorage]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int:
+    def count(self) -> int | None:
         return len(self.edges)
 
 
@@ -295,7 +295,7 @@ class GetPresignedUploadURLPayload:
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Create an object storage."))
 async def create_object_storage(
     input: CreateObjectStorageInput, info: Info[StrawberryGQLContext]
-) -> CreateObjectStoragePayload:
+) -> CreateObjectStoragePayload | None:
     result = await info.context.adapters.object_storage.create(input.to_pydantic())
     return CreateObjectStoragePayload(
         object_storage=ObjectStorage.from_pydantic(
@@ -307,7 +307,7 @@ async def create_object_storage(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Update an object storage."))
 async def update_object_storage(
     input: UpdateObjectStorageInput, info: Info[StrawberryGQLContext]
-) -> UpdateObjectStoragePayload:
+) -> UpdateObjectStoragePayload | None:
     result = await info.context.adapters.object_storage.update(input.to_pydantic())
     return UpdateObjectStoragePayload(
         object_storage=ObjectStorage.from_pydantic(
@@ -319,7 +319,7 @@ async def update_object_storage(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Delete an object storage."))
 async def delete_object_storage(
     input: DeleteObjectStorageInput, info: Info[StrawberryGQLContext]
-) -> DeleteObjectStoragePayload:
+) -> DeleteObjectStoragePayload | None:
     pydantic_input = input.to_pydantic()
     result = await info.context.adapters.object_storage.delete(pydantic_input)
     return DeleteObjectStoragePayload.from_pydantic(result)
@@ -330,7 +330,7 @@ async def delete_object_storage(
 )
 async def get_presigned_download_url(
     input: GetPresignedDownloadURLInput, info: Info[StrawberryGQLContext]
-) -> GetPresignedDownloadURLPayload:
+) -> GetPresignedDownloadURLPayload | None:
     dto = input.to_pydantic()
     result = await info.context.adapters.object_storage.get_presigned_download_url(
         artifact_revision_id=dto.artifact_revision_id,
@@ -343,7 +343,7 @@ async def get_presigned_download_url(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Get a presigned upload URL."))
 async def get_presigned_upload_url(
     input: GetPresignedUploadURLInput, info: Info[StrawberryGQLContext]
-) -> GetPresignedUploadURLPayload:
+) -> GetPresignedUploadURLPayload | None:
     dto = input.to_pydantic()
     result = await info.context.adapters.object_storage.get_presigned_upload_url(
         artifact_revision_id=dto.artifact_revision_id,

--- a/src/ai/backend/manager/api/gql/project_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/project_v2/resolver/mutation.py
@@ -33,7 +33,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def admin_create_project_v2(
     info: Info[StrawberryGQLContext],
     input: CreateProjectInputGQL,
-) -> ProjectPayloadGQL:
+) -> ProjectPayloadGQL | None:
     """Create a new project."""
     check_admin_only()
     ctx = info.context
@@ -51,7 +51,7 @@ async def admin_update_project_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
     input: UpdateProjectInputGQL,
-) -> ProjectPayloadGQL:
+) -> ProjectPayloadGQL | None:
     """Update a project."""
     check_admin_only()
     ctx = info.context
@@ -68,7 +68,7 @@ async def admin_update_project_v2(
 async def admin_delete_project_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-) -> DeleteProjectPayloadGQL:
+) -> DeleteProjectPayloadGQL | None:
     """Soft-delete a project."""
     check_admin_only()
     ctx = info.context
@@ -85,7 +85,7 @@ async def admin_delete_project_v2(
 async def admin_purge_project_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-) -> PurgeProjectPayloadGQL:
+) -> PurgeProjectPayloadGQL | None:
     """Permanently purge a project."""
     check_admin_only()
     ctx = info.context
@@ -103,7 +103,7 @@ async def unassign_users_from_project_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
     input: UnassignUsersFromProjectInputGQL,
-) -> UnassignUsersFromProjectPayloadGQL:
+) -> UnassignUsersFromProjectPayloadGQL | None:
     """Unassign users from a project."""
     ctx = info.context
     payload = await ctx.adapters.project.unassign_users(project_id, input.to_pydantic())

--- a/src/ai/backend/manager/api/gql/project_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/project_v2/types/node.py
@@ -109,7 +109,7 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
         self,
         info: Info,
         scope: ProjectFairShareScopeGQL,
-    ) -> ProjectFairShareGQL:
+    ) -> ProjectFairShareGQL | None:
         from ai.backend.common.dto.manager.v2.fair_share.request import GetProjectFairShareInput
 
         payload = await info.context.adapters.fair_share.get_project(
@@ -130,7 +130,7 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
     async def active_resource_overview(
         self,
         info: Info,
-    ) -> ActiveResourceOverviewGQL:
+    ) -> ActiveResourceOverviewGQL | None:
         dto = await info.context.adapters.resource_slot.get_project_resource_overview(
             UUID(str(self.id))
         )
@@ -151,7 +151,7 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> ProjectUsageBucketConnection:
+    ) -> ProjectUsageBucketConnection | None:
         from strawberry.relay import PageInfo
 
         from ai.backend.manager.api.gql.base import encode_cursor
@@ -198,10 +198,13 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
     async def domain(
         self,
         info: Info,
-    ) -> Annotated[
-        DomainV2GQL,
-        strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
-    ]:
+    ) -> (
+        Annotated[
+            DomainV2GQL,
+            strawberry.lazy("ai.backend.manager.api.gql.domain_v2.types.node"),
+        ]
+        | None
+    ):
         from ai.backend.manager.errors.resource import DomainNotFound
 
         domain: DomainV2GQL | None = await info.context.data_loaders.domain_loader.load(
@@ -232,10 +235,13 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        UserV2Connection,
-        strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
-    ]:
+    ) -> (
+        Annotated[
+            UserV2Connection,
+            strawberry.lazy("ai.backend.manager.api.gql.user.types.node"),
+        ]
+        | None
+    ):
         from strawberry.relay import PageInfo
 
         from ai.backend.common.dto.manager.v2.user.request import AdminSearchUsersInput

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_mutation.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_mutation.py
@@ -34,7 +34,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def admin_create_prometheus_query_preset_category(
     info: Info[StrawberryGQLContext],
     input: CreateCategoryInputGQL,
-) -> CreateCategoryPayloadGQL:
+) -> CreateCategoryPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.prometheus_query_preset_category.create(
         input.to_pydantic()
@@ -51,7 +51,7 @@ async def admin_create_prometheus_query_preset_category(
 async def admin_delete_prometheus_query_preset_category(
     info: Info[StrawberryGQLContext],
     id: ID,
-) -> DeleteCategoryPayloadGQL:
+) -> DeleteCategoryPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.prometheus_query_preset_category.delete(
         DeleteCategoryInputDTO(id=UUID(id))

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/category_query.py
@@ -53,7 +53,7 @@ async def prometheus_query_preset_categories(
     before: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> list[CategoryGQL]:
+) -> list[CategoryGQL] | None:
     pydantic_filter = filter.to_pydantic() if filter else None
     pydantic_order = [o.to_pydantic() for o in order_by] if order_by else None
 

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/mutation.py
@@ -38,7 +38,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def admin_create_prometheus_query_preset(
     info: Info[StrawberryGQLContext],
     input: CreateQueryDefinitionInput,
-) -> CreateQueryDefinitionPayload:
+) -> CreateQueryDefinitionPayload | None:
     check_admin_only()
     result = await info.context.adapters.prometheus_query_preset.create(input.to_pydantic())
     return CreateQueryDefinitionPayload.from_pydantic(
@@ -55,7 +55,7 @@ async def admin_modify_prometheus_query_preset(
     info: Info[StrawberryGQLContext],
     id: ID,
     input: ModifyQueryDefinitionInput,
-) -> ModifyQueryDefinitionPayload:
+) -> ModifyQueryDefinitionPayload | None:
     check_admin_only()
     result = await info.context.adapters.prometheus_query_preset.update(
         UUID(id), input.to_pydantic()
@@ -71,7 +71,7 @@ async def admin_modify_prometheus_query_preset(
 async def admin_delete_prometheus_query_preset(
     info: Info[StrawberryGQLContext],
     id: ID,
-) -> DeleteQueryDefinitionPayload:
+) -> DeleteQueryDefinitionPayload | None:
     check_admin_only()
     result = await info.context.adapters.prometheus_query_preset.delete(
         DeleteQueryDefinitionInputDTO(id=UUID(id))

--- a/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/prometheus_query_preset/resolver/query.py
@@ -99,7 +99,7 @@ async def prometheus_query_preset_result(
     time_range: QueryTimeRangeInput | None = None,
     options: ExecuteQueryDefinitionOptionsInput | None = None,
     time_window: str | None = None,
-) -> QueryDefinitionResultGQL:
+) -> QueryDefinitionResultGQL | None:
     dto = await info.context.adapters.prometheus_query_preset.execute_preset(
         preset_id=UUID(id),
         options=options.to_pydantic() if options is not None else None,

--- a/src/ai/backend/manager/api/gql/rbac/resolver/entity.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/entity.py
@@ -37,7 +37,7 @@ async def admin_entities(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> EntityConnection:
+) -> EntityConnection | None:
     """Search entity associations with filtering, ordering, and pagination."""
     check_admin_only()
     result = await info.context.adapters.rbac.admin_search_entities_gql(

--- a/src/ai/backend/manager/api/gql/rbac/resolver/permission.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/permission.py
@@ -63,7 +63,7 @@ async def admin_permissions(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> PermissionConnection:
+) -> PermissionConnection | None:
     check_admin_only()
     result = await info.context.adapters.rbac.admin_search_permissions_gql(
         AdminSearchPermissionsGQLInput(
@@ -103,7 +103,7 @@ async def admin_permissions(
 )  # type: ignore[misc]
 async def rbac_scope_entity_combinations(
     info: Info[StrawberryGQLContext],
-) -> list[ScopeEntityCombinationGQL]:
+) -> list[ScopeEntityCombinationGQL] | None:
     return [
         ScopeEntityCombinationGQL(
             scope_type=RBACElementTypeGQL(scope.value),
@@ -124,7 +124,7 @@ async def rbac_scope_entity_combinations(
 )  # type: ignore[misc]
 async def rbac_entity_operation_combinations(
     info: Info[StrawberryGQLContext],
-) -> list[EntityOperationCombinationGQL]:
+) -> list[EntityOperationCombinationGQL] | None:
     entity_ops: dict[RBACElementType, list[OperationInfoGQL]] = {}
     for action_cls in RBAC_ACTION_REGISTRY:
         perm = action_cls.required_permission()
@@ -154,7 +154,7 @@ async def rbac_entity_operation_combinations(
 )  # type: ignore[misc]
 async def rbac_permission_matrix(
     info: Info[StrawberryGQLContext],
-) -> list[ScopeEntityOperationCombinationGQL]:
+) -> list[ScopeEntityOperationCombinationGQL] | None:
     dto_items = await info.context.adapters.rbac.get_permission_matrix()
     return [ScopeEntityOperationCombinationGQL.from_pydantic(item) for item in dto_items]
 
@@ -168,7 +168,7 @@ async def rbac_permission_matrix(
 async def admin_create_permission(
     info: Info[StrawberryGQLContext],
     input: CreatePermissionInput,
-) -> PermissionGQL:
+) -> PermissionGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.create_permission(input.to_pydantic())
     return PermissionGQL.from_pydantic(result)
@@ -180,7 +180,7 @@ async def admin_create_permission(
 async def admin_update_permission(
     info: Info[StrawberryGQLContext],
     input: UpdatePermissionInput,
-) -> PermissionGQL:
+) -> PermissionGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.update_permission(input.to_pydantic())
     return PermissionGQL.from_pydantic(result)
@@ -192,7 +192,7 @@ async def admin_update_permission(
 async def admin_delete_permission(
     info: Info[StrawberryGQLContext],
     input: DeletePermissionInput,
-) -> DeletePermissionPayload:
+) -> DeletePermissionPayload | None:
     check_admin_only()
     result = await info.context.adapters.rbac.delete_permission(input.id)
     return DeletePermissionPayload.from_pydantic(result)
@@ -207,7 +207,7 @@ async def admin_delete_permission(
 async def admin_bulk_add_role_permissions(
     info: Info[StrawberryGQLContext],
     input: BulkAddRolePermissionsInputGQL,
-) -> BulkAddRolePermissionsPayloadGQL:
+) -> BulkAddRolePermissionsPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.bulk_add_role_permissions(input.to_pydantic())
     return BulkAddRolePermissionsPayloadGQL.from_pydantic(result)
@@ -222,7 +222,7 @@ async def admin_bulk_add_role_permissions(
 async def admin_bulk_remove_role_permissions(
     info: Info[StrawberryGQLContext],
     input: BulkRemoveRolePermissionsInputGQL,
-) -> BulkRemoveRolePermissionsPayloadGQL:
+) -> BulkRemoveRolePermissionsPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.bulk_remove_role_permissions(input.to_pydantic())
     return BulkRemoveRolePermissionsPayloadGQL.from_pydantic(result)
@@ -237,7 +237,7 @@ async def admin_bulk_remove_role_permissions(
 async def admin_replace_role_permissions(
     info: Info[StrawberryGQLContext],
     input: ReplaceRolePermissionsInputGQL,
-) -> ReplaceRolePermissionsPayloadGQL:
+) -> ReplaceRolePermissionsPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.replace_role_permissions(input.to_pydantic())
     return ReplaceRolePermissionsPayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role.py
@@ -77,7 +77,7 @@ async def admin_roles(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleConnection:
+) -> RoleConnection | None:
     check_admin_only()
     result = await info.context.adapters.rbac.admin_search_roles_gql(
         SearchRolesInput(
@@ -123,7 +123,7 @@ async def admin_role_assignments(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleAssignmentConnection:
+) -> RoleAssignmentConnection | None:
     check_admin_only()
     result = await info.context.adapters.rbac.admin_search_role_assignments(
         SearchRoleAssignmentsInput(
@@ -171,7 +171,7 @@ async def my_roles(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleAssignmentConnection:
+) -> RoleAssignmentConnection | None:
     me = current_user()
     if me is None:
         from ai.backend.manager.errors.auth import InsufficientPrivilege
@@ -227,7 +227,7 @@ async def project_roles(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleConnection:
+) -> RoleConnection | None:
     result = await info.context.adapters.rbac.search_roles_in_scope(
         ScopedRoleSearchScope(element_type=RBACElementType.PROJECT, scope_id=str(project_id)),
         SearchRolesInput(
@@ -266,7 +266,7 @@ async def project_roles(
 async def admin_create_role(
     info: Info[StrawberryGQLContext],
     input: CreateRoleInput,
-) -> RoleGQL:
+) -> RoleGQL | None:
     check_admin_only()
     payload = await info.context.adapters.rbac.create(input.to_pydantic())
     return RoleGQL.from_pydantic(payload.role)
@@ -278,7 +278,7 @@ async def admin_create_role(
 async def admin_update_role(
     info: Info[StrawberryGQLContext],
     input: UpdateRoleInput,
-) -> RoleGQL:
+) -> RoleGQL | None:
     check_admin_only()
     payload = await info.context.adapters.rbac.update(input.id, input.to_pydantic())
     return RoleGQL.from_pydantic(payload.role)
@@ -290,7 +290,7 @@ async def admin_update_role(
 async def admin_delete_role(
     info: Info[StrawberryGQLContext],
     input: DeleteRoleInput,
-) -> DeleteRolePayload:
+) -> DeleteRolePayload | None:
     check_admin_only()
     result = await info.context.adapters.rbac.delete(input.id)
     return DeleteRolePayload.from_pydantic(result)
@@ -302,7 +302,7 @@ async def admin_delete_role(
 async def admin_purge_role(
     info: Info[StrawberryGQLContext],
     input: PurgeRoleInput,
-) -> PurgeRolePayload:
+) -> PurgeRolePayload | None:
     check_admin_only()
     result = await info.context.adapters.rbac.purge(input.id)
     return PurgeRolePayload.from_pydantic(result)
@@ -314,7 +314,7 @@ async def admin_purge_role(
 async def admin_assign_role(
     info: Info[StrawberryGQLContext],
     input: AssignRoleInput,
-) -> RoleAssignmentGQL:
+) -> RoleAssignmentGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.assign_role(input.to_pydantic())
     return RoleAssignmentGQL.from_pydantic(result)
@@ -326,7 +326,7 @@ async def admin_assign_role(
 async def admin_revoke_role(
     info: Info[StrawberryGQLContext],
     input: RevokeRoleInput,
-) -> RoleAssignmentGQL:
+) -> RoleAssignmentGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.revoke_role(input.to_pydantic())
     return RoleAssignmentGQL.from_pydantic(result)
@@ -340,7 +340,7 @@ async def admin_revoke_role(
 async def admin_bulk_assign_role(
     info: Info[StrawberryGQLContext],
     input: BulkAssignRoleInputGQL,
-) -> BulkAssignRolePayloadGQL:
+) -> BulkAssignRolePayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.bulk_assign_role(input.to_pydantic())
     return BulkAssignRolePayloadGQL.from_pydantic(result)
@@ -354,7 +354,7 @@ async def admin_bulk_assign_role(
 async def admin_bulk_revoke_role(
     info: Info[StrawberryGQLContext],
     input: BulkRevokeRoleInputGQL,
-) -> BulkRevokeRolePayloadGQL:
+) -> BulkRevokeRolePayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.rbac.bulk_revoke_role(input.to_pydantic())
     return BulkRevokeRolePayloadGQL.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
+++ b/src/ai/backend/manager/api/gql/rbac/resolver/role_invitation.py
@@ -51,7 +51,7 @@ async def my_role_invitations(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleInvitationConnection:
+) -> RoleInvitationConnection | None:
     result = await info.context.adapters.rbac.my_search_role_invitations(
         SearchRoleInvitationsInput(
             filter=filter.to_pydantic() if filter is not None else None,
@@ -99,7 +99,7 @@ async def my_sent_role_invitations(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleInvitationConnection:
+) -> RoleInvitationConnection | None:
     result = await info.context.adapters.rbac.my_sent_search_role_invitations(
         SearchRoleInvitationsInput(
             filter=filter.to_pydantic() if filter is not None else None,
@@ -148,7 +148,7 @@ async def role_scoped_role_invitations(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleInvitationConnection:
+) -> RoleInvitationConnection | None:
     result = await info.context.adapters.rbac.role_search_invitations(
         role_id,
         SearchRoleInvitationsInput(
@@ -197,7 +197,7 @@ async def admin_role_invitations(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> RoleInvitationConnection:
+) -> RoleInvitationConnection | None:
     check_admin_only()
     result = await info.context.adapters.rbac.admin_search_role_invitations(
         SearchRoleInvitationsInput(
@@ -242,7 +242,7 @@ async def admin_role_invitations(
 async def create_role_invitation(
     info: Info[StrawberryGQLContext],
     input: CreateRoleInvitationInputGQL,
-) -> CreateRoleInvitationPayload:
+) -> CreateRoleInvitationPayload | None:
     result = await info.context.adapters.rbac.create_role_invitation(input.to_pydantic())
     return CreateRoleInvitationPayload.from_pydantic(result)
 
@@ -256,7 +256,7 @@ async def create_role_invitation(
 async def accept_role_invitation(
     info: Info[StrawberryGQLContext],
     input: AcceptRoleInvitationInputGQL,
-) -> RoleInvitationGQL:
+) -> RoleInvitationGQL | None:
     dto = input.to_pydantic()
     result = await info.context.adapters.rbac.accept_role_invitation(dto.invitation_id)
     return RoleInvitationGQL.from_pydantic(result)
@@ -271,7 +271,7 @@ async def accept_role_invitation(
 async def reject_role_invitation(
     info: Info[StrawberryGQLContext],
     input: RejectRoleInvitationInputGQL,
-) -> RoleInvitationGQL:
+) -> RoleInvitationGQL | None:
     dto = input.to_pydantic()
     result = await info.context.adapters.rbac.reject_role_invitation(dto.invitation_id)
     return RoleInvitationGQL.from_pydantic(result)
@@ -286,7 +286,7 @@ async def reject_role_invitation(
 async def admin_cancel_role_invitation(
     info: Info[StrawberryGQLContext],
     input: CancelRoleInvitationInputGQL,
-) -> RoleInvitationGQL:
+) -> RoleInvitationGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     result = await info.context.adapters.rbac.cancel_role_invitation(dto.invitation_id)

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -194,10 +194,13 @@ class RoleGQL(PydanticNodeMixin[Any]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        PermissionConnection,
-        strawberry.lazy("ai.backend.manager.api.gql.rbac.types.permission"),
-    ]:
+    ) -> (
+        Annotated[
+            PermissionConnection,
+            strawberry.lazy("ai.backend.manager.api.gql.rbac.types.permission"),
+        ]
+        | None
+    ):
         from ai.backend.manager.api.gql.rbac.types.permission import (
             PermissionConnection,
             PermissionEdge,
@@ -264,7 +267,7 @@ class RoleGQL(PydanticNodeMixin[Any]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> RoleAssignmentConnection:
+    ) -> RoleAssignmentConnection | None:
         # Add role_id filter to scope assignments to this role
         role_filter = RoleAssignmentFilter(role_id=UUIDFilter(equals=UUID(self.id)))
         if filter is not None:
@@ -338,10 +341,13 @@ class RoleGQL(PydanticNodeMixin[Any]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        EntityConnection,
-        strawberry.lazy("ai.backend.manager.api.gql.rbac.types.entity"),
-    ]:
+    ) -> (
+        Annotated[
+            EntityConnection,
+            strawberry.lazy("ai.backend.manager.api.gql.rbac.types.entity"),
+        ]
+        | None
+    ):
         from ai.backend.manager.api.gql.rbac.types.entity import (
             EntityConnection,
             EntityEdge,

--- a/src/ai/backend/manager/api/gql/reservoir_registry.py
+++ b/src/ai/backend/manager/api/gql/reservoir_registry.py
@@ -100,7 +100,7 @@ ReservoirRegistryEdge = Edge[ReservoirRegistry]
 )
 class ReservoirRegistryConnection(Connection[ReservoirRegistry]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int | None:
+    def count(self) -> int:
         return len(self.edges)
 
 

--- a/src/ai/backend/manager/api/gql/reservoir_registry.py
+++ b/src/ai/backend/manager/api/gql/reservoir_registry.py
@@ -85,7 +85,7 @@ class ReservoirRegistry(PydanticNodeMixin[ReservoirRegistryNode]):
     @classmethod
     async def remote_artifact_registries(
         cls, ctx: strawberry.Info[StrawberryGQLContext]
-    ) -> ArtifactRegistryMetaConnection:
+    ) -> ArtifactRegistryMetaConnection | None:
         raise NotImplementedAPI("This API is not implemented.")
 
 
@@ -100,7 +100,7 @@ ReservoirRegistryEdge = Edge[ReservoirRegistry]
 )
 class ReservoirRegistryConnection(Connection[ReservoirRegistry]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int:
+    def count(self) -> int | None:
         return len(self.edges)
 
 
@@ -214,7 +214,7 @@ class DeleteReservoirRegistryPayload(PydanticOutputMixin[DeleteReservoirRegistry
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Create reservoir registry."))
 async def create_reservoir_registry(
     input: CreateReservoirRegistryInput, info: Info[StrawberryGQLContext]
-) -> CreateReservoirRegistryPayload:
+) -> CreateReservoirRegistryPayload | None:
     result = await info.context.adapters.reservoir_registry.create(input.to_pydantic())
     return CreateReservoirRegistryPayload(
         reservoir=ReservoirRegistry.from_pydantic(result.reservoir)
@@ -224,7 +224,7 @@ async def create_reservoir_registry(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Update reservoir registry."))
 async def update_reservoir_registry(
     input: UpdateReservoirRegistryInput, info: Info[StrawberryGQLContext]
-) -> UpdateReservoirRegistryPayload:
+) -> UpdateReservoirRegistryPayload | None:
     result = await info.context.adapters.reservoir_registry.update(input.to_pydantic())
     return UpdateReservoirRegistryPayload(
         reservoir=ReservoirRegistry.from_pydantic(result.reservoir)
@@ -234,7 +234,7 @@ async def update_reservoir_registry(
 @gql_mutation(BackendAIGQLMeta(added_version="25.14.0", description="Delete reservoir registry."))
 async def delete_reservoir_registry(
     input: DeleteReservoirRegistryInput, info: Info[StrawberryGQLContext]
-) -> DeleteReservoirRegistryPayload:
+) -> DeleteReservoirRegistryPayload | None:
     pydantic_input = input.to_pydantic()
     result = await info.context.adapters.reservoir_registry.delete(pydantic_input)
     return DeleteReservoirRegistryPayload(id=result.id)

--- a/src/ai/backend/manager/api/gql/resource_allocation/resolver.py
+++ b/src/ai/backend/manager/api/gql/resource_allocation/resolver.py
@@ -34,7 +34,7 @@ from .types import (
 )  # type: ignore[misc]
 async def my_keypair_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
-) -> KeypairResourceAllocationPayloadGQL:
+) -> KeypairResourceAllocationPayloadGQL | None:
     payload = await info.context.adapters.resource_allocation.my_keypair_usage_for_current_user()
     return KeypairResourceAllocationPayloadGQL.from_pydantic(payload)
 
@@ -48,7 +48,7 @@ async def my_keypair_resource_allocation_v2(
 async def project_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-) -> ProjectResourceAllocationPayloadGQL:
+) -> ProjectResourceAllocationPayloadGQL | None:
     payload = await info.context.adapters.resource_allocation.project_usage(
         project_id=project_id,
     )
@@ -64,7 +64,7 @@ async def project_resource_allocation_v2(
 async def admin_domain_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
     domain_name: str,
-) -> DomainResourceAllocationPayloadGQL:
+) -> DomainResourceAllocationPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_allocation.admin_domain_usage(
         domain_name=domain_name,
@@ -81,7 +81,7 @@ async def admin_domain_resource_allocation_v2(
 async def resource_group_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
     resource_group_name: str,
-) -> ResourceGroupResourceAllocationPayloadGQL:
+) -> ResourceGroupResourceAllocationPayloadGQL | None:
     payload = await info.context.adapters.resource_allocation.resource_group_usage(
         rg_name=resource_group_name,
     )
@@ -97,7 +97,7 @@ async def resource_group_resource_allocation_v2(
 async def effective_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
     input: EffectiveResourceAllocationInputGQL,
-) -> EffectiveResourceAllocationPayloadGQL:
+) -> EffectiveResourceAllocationPayloadGQL | None:
     payload = await info.context.adapters.resource_allocation.effective_allocation_for_current_user(
         input=input.to_pydantic(),
     )
@@ -113,7 +113,7 @@ async def effective_resource_allocation_v2(
 async def admin_effective_resource_allocation_v2(
     info: Info[StrawberryGQLContext],
     input: AdminEffectiveResourceAllocationInputGQL,
-) -> EffectiveResourceAllocationPayloadGQL:
+) -> EffectiveResourceAllocationPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_allocation.admin_effective_allocation_resolved(
         input=input.to_pydantic(),
@@ -130,7 +130,7 @@ async def admin_effective_resource_allocation_v2(
 async def check_preset_availability_v2(
     info: Info[StrawberryGQLContext],
     input: CheckPresetAvailabilityInputGQL,
-) -> CheckPresetAvailabilityPayloadGQL:
+) -> CheckPresetAvailabilityPayloadGQL | None:
     payload = (
         await info.context.adapters.resource_allocation.check_preset_availability_for_current_user(
             input=input.to_pydantic(),

--- a/src/ai/backend/manager/api/gql/resource_group/resolver.py
+++ b/src/ai/backend/manager/api/gql/resource_group/resolver.py
@@ -176,7 +176,7 @@ async def resource_groups(
 async def admin_update_resource_group_fair_share_spec(
     info: Info[StrawberryGQLContext],
     input: UpdateResourceGroupFairShareSpecInput,
-) -> UpdateResourceGroupFairShareSpecPayload:
+) -> UpdateResourceGroupFairShareSpecPayload | None:
     """Update fair share spec with partial update and validation."""
     check_admin_only()
 
@@ -199,7 +199,7 @@ async def admin_update_resource_group_fair_share_spec(
 async def update_resource_group_fair_share_spec(
     info: Info[StrawberryGQLContext],
     input: UpdateResourceGroupFairShareSpecInput,
-) -> UpdateResourceGroupFairShareSpecPayload:
+) -> UpdateResourceGroupFairShareSpecPayload | None:
     """Update fair share spec with partial update and validation."""
     dto = input.to_pydantic()
     payload_dto = await info.context.adapters.resource_group.update_fair_share_spec(dto)
@@ -216,7 +216,7 @@ async def update_resource_group_fair_share_spec(
 async def admin_update_resource_group(
     info: Info[StrawberryGQLContext],
     input: UpdateResourceGroupInput,
-) -> UpdateResourceGroupPayload:
+) -> UpdateResourceGroupPayload | None:
     """Update resource group configuration with partial update."""
     check_admin_only()
 
@@ -240,7 +240,7 @@ async def admin_update_resource_group(
 async def replace_resource_group_default_deployment_options(
     info: Info[StrawberryGQLContext],
     input: ReplaceResourceGroupDefaultDeploymentOptionsInputGQL,
-) -> ReplaceResourceGroupDefaultDeploymentOptionsPayloadGQL:
+) -> ReplaceResourceGroupDefaultDeploymentOptionsPayloadGQL | None:
     """Admin-only replacement of the resource group default deployment options.
 
     Only the refreshed ``default_deployment_options`` surface is returned
@@ -276,7 +276,7 @@ async def replace_resource_group_default_deployment_options(
 async def replace_resource_group_default_session_options(
     info: Info[StrawberryGQLContext],
     input: ReplaceResourceGroupDefaultSessionOptionsInputGQL,
-) -> ReplaceResourceGroupDefaultSessionOptionsPayloadGQL:
+) -> ReplaceResourceGroupDefaultSessionOptionsPayloadGQL | None:
     """Admin-only replacement of the resource group default session options.
 
     Only the refreshed ``default_session_options`` surface is returned
@@ -319,7 +319,7 @@ async def admin_resource_group_v2(
 async def admin_create_resource_group_v2(
     info: Info[StrawberryGQLContext],
     input: CreateResourceGroupInputGQL,
-) -> CreateResourceGroupPayloadGQL:
+) -> CreateResourceGroupPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.create(input.to_pydantic())
     return CreateResourceGroupPayloadGQL.from_pydantic(payload)
@@ -334,7 +334,7 @@ async def admin_create_resource_group_v2(
 async def admin_delete_resource_group_v2(
     info: Info[StrawberryGQLContext],
     name: str,
-) -> DeleteResourceGroupPayloadGQL:
+) -> DeleteResourceGroupPayloadGQL | None:
     check_admin_only()
     result = await info.context.adapters.resource_group.purge(name)
     payload = DeleteResourceGroupPayload(id=result.id)
@@ -353,7 +353,7 @@ async def admin_delete_resource_group_v2(
 async def admin_allowed_resource_groups_for_domain_v2(
     info: Info[StrawberryGQLContext],
     domain_name: str,
-) -> AllowedResourceGroupsPayloadGQL:
+) -> AllowedResourceGroupsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.get_allowed_resource_groups_for_domain(
         domain_name
@@ -370,7 +370,7 @@ async def admin_allowed_resource_groups_for_domain_v2(
 async def admin_allowed_resource_groups_for_project_v2(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
-) -> AllowedResourceGroupsPayloadGQL:
+) -> AllowedResourceGroupsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.get_allowed_resource_groups_for_project(
         project_id
@@ -387,7 +387,7 @@ async def admin_allowed_resource_groups_for_project_v2(
 async def admin_allowed_domains_for_resource_group_v2(
     info: Info[StrawberryGQLContext],
     resource_group_name: str,
-) -> AllowedDomainsPayloadGQL:
+) -> AllowedDomainsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.get_allowed_domains_for_resource_group(
         resource_group_name
@@ -404,7 +404,7 @@ async def admin_allowed_domains_for_resource_group_v2(
 async def admin_allowed_projects_for_resource_group_v2(
     info: Info[StrawberryGQLContext],
     resource_group_name: str,
-) -> AllowedProjectsPayloadGQL:
+) -> AllowedProjectsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.get_allowed_projects_for_resource_group(
         resource_group_name
@@ -424,7 +424,7 @@ async def admin_allowed_projects_for_resource_group_v2(
 async def admin_update_allowed_resource_groups_for_domain_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateAllowedResourceGroupsForDomainInputGQL,
-) -> AllowedResourceGroupsPayloadGQL:
+) -> AllowedResourceGroupsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.update_allowed_resource_groups_for_domain(
         input.to_pydantic()
@@ -441,7 +441,7 @@ async def admin_update_allowed_resource_groups_for_domain_v2(
 async def admin_update_allowed_resource_groups_for_project_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateAllowedResourceGroupsForProjectInputGQL,
-) -> AllowedResourceGroupsPayloadGQL:
+) -> AllowedResourceGroupsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.update_allowed_resource_groups_for_project(
         input.to_pydantic()
@@ -458,7 +458,7 @@ async def admin_update_allowed_resource_groups_for_project_v2(
 async def admin_update_allowed_domains_for_resource_group_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateAllowedDomainsForResourceGroupInputGQL,
-) -> AllowedDomainsPayloadGQL:
+) -> AllowedDomainsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.update_allowed_domains_for_resource_group(
         input.to_pydantic()
@@ -475,7 +475,7 @@ async def admin_update_allowed_domains_for_resource_group_v2(
 async def admin_update_allowed_projects_for_resource_group_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateAllowedProjectsForResourceGroupInputGQL,
-) -> AllowedProjectsPayloadGQL:
+) -> AllowedProjectsPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_group.update_allowed_projects_for_resource_group(
         input.to_pydantic()

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -382,7 +382,7 @@ class ResourceGroupGQL(PydanticNodeMixin[ResourceGroupDetailNode]):
     )  # type: ignore[misc]
     async def fair_share_spec(
         self, info: Info[StrawberryGQLContext, None]
-    ) -> FairShareScalingGroupSpecGQL:
+    ) -> FairShareScalingGroupSpecGQL | None:
         """Get fair share spec with merged resource weights from capacity."""
         ctx = info.context
         dto = await ctx.adapters.resource_group.get_fair_share_spec(self.name)
@@ -394,7 +394,7 @@ class ResourceGroupGQL(PydanticNodeMixin[ResourceGroupDetailNode]):
             description="Resource usage information for this resource group. Provides aggregated metrics for capacity, used, and free resources. This is a lazy-loaded field that queries agent and kernel data on demand.",
         )
     )  # type: ignore[misc]
-    async def resource_info(self, info: Info[StrawberryGQLContext, None]) -> ResourceInfoGQL:
+    async def resource_info(self, info: Info[StrawberryGQLContext, None]) -> ResourceInfoGQL | None:
         """Get resource information for this resource group."""
         ctx = info.context
         resource_info_dto = await ctx.adapters.resource_group.get_resource_info(self.name)

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/resolver/mutation.py
@@ -45,7 +45,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 async def admin_create_keypair_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     input: CreateKeypairResourcePolicyInputGQL,
-) -> CreateKeypairResourcePolicyPayloadGQL:
+) -> CreateKeypairResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_create_keypair_resource_policy(
         input.to_pydantic()
@@ -63,7 +63,7 @@ async def admin_update_keypair_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
     input: UpdateKeypairResourcePolicyInputGQL,
-) -> UpdateKeypairResourcePolicyPayloadGQL:
+) -> UpdateKeypairResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_update_keypair_resource_policy(
         name, input.to_pydantic()
@@ -80,7 +80,7 @@ async def admin_update_keypair_resource_policy_v2(
 async def admin_delete_keypair_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
-) -> DeleteKeypairResourcePolicyPayloadGQL:
+) -> DeleteKeypairResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_delete_keypair_resource_policy(
         DeleteKeypairResourcePolicyInput(name=name)
@@ -100,7 +100,7 @@ async def admin_delete_keypair_resource_policy_v2(
 async def admin_create_user_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     input: CreateUserResourcePolicyInputGQL,
-) -> CreateUserResourcePolicyPayloadGQL:
+) -> CreateUserResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_create_user_resource_policy(
         input.to_pydantic()
@@ -118,7 +118,7 @@ async def admin_update_user_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
     input: UpdateUserResourcePolicyInputGQL,
-) -> UpdateUserResourcePolicyPayloadGQL:
+) -> UpdateUserResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_update_user_resource_policy(
         name, input.to_pydantic()
@@ -135,7 +135,7 @@ async def admin_update_user_resource_policy_v2(
 async def admin_delete_user_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
-) -> DeleteUserResourcePolicyPayloadGQL:
+) -> DeleteUserResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_delete_user_resource_policy(
         DeleteUserResourcePolicyInput(name=name)
@@ -155,7 +155,7 @@ async def admin_delete_user_resource_policy_v2(
 async def admin_create_project_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     input: CreateProjectResourcePolicyInputGQL,
-) -> CreateProjectResourcePolicyPayloadGQL:
+) -> CreateProjectResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_create_project_resource_policy(
         input.to_pydantic()
@@ -173,7 +173,7 @@ async def admin_update_project_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
     input: UpdateProjectResourcePolicyInputGQL,
-) -> UpdateProjectResourcePolicyPayloadGQL:
+) -> UpdateProjectResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_update_project_resource_policy(
         name, input.to_pydantic()
@@ -190,7 +190,7 @@ async def admin_update_project_resource_policy_v2(
 async def admin_delete_project_resource_policy_v2(
     info: Info[StrawberryGQLContext],
     name: str,
-) -> DeleteProjectResourcePolicyPayloadGQL:
+) -> DeleteProjectResourcePolicyPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_policy.admin_delete_project_resource_policy(
         DeleteProjectResourcePolicyInput(name=name)

--- a/src/ai/backend/manager/api/gql/resource_preset/resolver.py
+++ b/src/ai/backend/manager/api/gql/resource_preset/resolver.py
@@ -114,7 +114,7 @@ async def admin_resource_preset_v2(
 async def admin_create_resource_preset_v2(
     info: Info[StrawberryGQLContext],
     input: CreateResourcePresetInputGQL,
-) -> CreateResourcePresetPayloadGQL:
+) -> CreateResourcePresetPayloadGQL | None:
     check_admin_only()
 
     dto = input.to_pydantic()
@@ -139,7 +139,7 @@ async def admin_create_resource_preset_v2(
 async def admin_update_resource_preset_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateResourcePresetInputGQL,
-) -> UpdateResourcePresetPayloadGQL:
+) -> UpdateResourcePresetPayloadGQL | None:
     check_admin_only()
 
     dto = input.to_pydantic()
@@ -156,7 +156,7 @@ async def admin_update_resource_preset_v2(
 async def admin_delete_resource_preset_v2(
     info: Info[StrawberryGQLContext],
     id: UUID,
-) -> DeleteResourcePresetPayloadGQL:
+) -> DeleteResourcePresetPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.resource_preset.delete(id)
     return DeleteResourcePresetPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/resource_slot/resolver.py
+++ b/src/ai/backend/manager/api/gql/resource_slot/resolver.py
@@ -54,7 +54,7 @@ async def resource_slot_types(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> ResourceSlotTypeConnectionGQL:
+) -> ResourceSlotTypeConnectionGQL | None:
     search_input = AdminSearchResourceSlotTypesInput(
         filter=filter.to_pydantic() if filter is not None else None,
         order=[o.to_pydantic() for o in order_by] if order_by is not None else None,

--- a/src/ai/backend/manager/api/gql/resource_usage/types/domain_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/domain_usage.py
@@ -85,7 +85,7 @@ class DomainUsageBucketGQL(PydanticNodeMixin[DomainUsageBucketNode]):
             description="Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).",
         )
     )  # type: ignore[misc]
-    def average_daily_usage(self) -> ResourceSlotGQL:
+    def average_daily_usage(self) -> ResourceSlotGQL | None:
         return calculate_average_daily_usage(
             self.resource_usage,
             self.metadata.period_start,
@@ -98,7 +98,7 @@ class DomainUsageBucketGQL(PydanticNodeMixin[DomainUsageBucketNode]):
             description="Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.",
         )
     )  # type: ignore[misc]
-    def usage_capacity_ratio(self) -> ResourceSlotGQL:
+    def usage_capacity_ratio(self) -> ResourceSlotGQL | None:
         return calculate_usage_capacity_ratio(
             self.resource_usage,
             self.capacity_snapshot,
@@ -121,7 +121,7 @@ class DomainUsageBucketGQL(PydanticNodeMixin[DomainUsageBucketNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> ProjectUsageBucketConnection:
+    ) -> ProjectUsageBucketConnection | None:
         from strawberry.relay import PageInfo
 
         from ai.backend.manager.api.gql.base import encode_cursor

--- a/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/project_usage.py
@@ -89,7 +89,7 @@ class ProjectUsageBucketGQL(PydanticNodeMixin[ProjectUsageBucketNode]):
             description="Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).",
         )
     )  # type: ignore[misc]
-    def average_daily_usage(self) -> ResourceSlotGQL:
+    def average_daily_usage(self) -> ResourceSlotGQL | None:
         return calculate_average_daily_usage(
             self.resource_usage,
             self.metadata.period_start,
@@ -102,7 +102,7 @@ class ProjectUsageBucketGQL(PydanticNodeMixin[ProjectUsageBucketNode]):
             description="Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.",
         )
     )  # type: ignore[misc]
-    def usage_capacity_ratio(self) -> ResourceSlotGQL:
+    def usage_capacity_ratio(self) -> ResourceSlotGQL | None:
         return calculate_usage_capacity_ratio(
             self.resource_usage,
             self.capacity_snapshot,
@@ -125,7 +125,7 @@ class ProjectUsageBucketGQL(PydanticNodeMixin[ProjectUsageBucketNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> UserUsageBucketConnection:
+    ) -> UserUsageBucketConnection | None:
         from strawberry.relay import PageInfo
 
         from ai.backend.manager.api.gql.base import encode_cursor

--- a/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
+++ b/src/ai/backend/manager/api/gql/resource_usage/types/user_usage.py
@@ -77,7 +77,7 @@ class UserUsageBucketGQL(PydanticNodeMixin[UserUsageBucketNode]):
             description="Average daily resource usage during this period. Calculated as resource_usage divided by bucket duration in days. For each resource type, this represents the average amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).",
         )
     )  # type: ignore[misc]
-    def average_daily_usage(self) -> ResourceSlotGQL:
+    def average_daily_usage(self) -> ResourceSlotGQL | None:
         return calculate_average_daily_usage(
             self.resource_usage,
             self.metadata.period_start,
@@ -90,7 +90,7 @@ class UserUsageBucketGQL(PydanticNodeMixin[UserUsageBucketNode]):
             description="Usage ratio against total available capacity for each resource. Calculated as resource_usage divided by capacity_snapshot. Represents the fraction of total capacity consumed (resource-seconds / resource). The result is in seconds, where 86400 means full utilization for one day. Values can exceed this if usage exceeds capacity.",
         )
     )  # type: ignore[misc]
-    def usage_capacity_ratio(self) -> ResourceSlotGQL:
+    def usage_capacity_ratio(self) -> ResourceSlotGQL | None:
         return calculate_usage_capacity_ratio(
             self.resource_usage,
             self.capacity_snapshot,

--- a/src/ai/backend/manager/api/gql/runtime_variant/resolver.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant/resolver.py
@@ -113,7 +113,7 @@ async def runtime_variant(
 async def admin_create_runtime_variant(
     info: Info[StrawberryGQLContext],
     input: CreateRuntimeVariantInputGQL,
-) -> CreateRuntimeVariantPayloadGQL:
+) -> CreateRuntimeVariantPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.runtime_variant.create(dto)
@@ -129,7 +129,7 @@ async def admin_create_runtime_variant(
 async def admin_update_runtime_variant(
     info: Info[StrawberryGQLContext],
     input: UpdateRuntimeVariantInputGQL,
-) -> UpdateRuntimeVariantPayloadGQL:
+) -> UpdateRuntimeVariantPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.runtime_variant.update(dto)
@@ -145,7 +145,7 @@ async def admin_update_runtime_variant(
 async def admin_delete_runtime_variant(
     info: Info[StrawberryGQLContext],
     id: UUID,
-) -> DeleteRuntimeVariantPayloadGQL:
+) -> DeleteRuntimeVariantPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.runtime_variant.delete(id)
     return DeleteRuntimeVariantPayloadGQL.from_pydantic(payload)
@@ -160,7 +160,7 @@ async def admin_delete_runtime_variant(
 async def admin_delete_runtime_variants(
     info: Info[StrawberryGQLContext],
     input: DeleteRuntimeVariantsInputGQL,
-) -> DeleteRuntimeVariantsPayloadGQL:
+) -> DeleteRuntimeVariantsPayloadGQL | None:
     """Delete multiple runtime variants.
 
     Args:

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/resolver.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/resolver.py
@@ -113,7 +113,7 @@ async def runtime_variant_preset(
 async def admin_create_runtime_variant_preset(
     info: Info[StrawberryGQLContext],
     input: CreateRuntimeVariantPresetInputGQL,
-) -> CreateRuntimeVariantPresetPayloadGQL:
+) -> CreateRuntimeVariantPresetPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.runtime_variant_preset.create(dto)
@@ -129,7 +129,7 @@ async def admin_create_runtime_variant_preset(
 async def admin_update_runtime_variant_preset(
     info: Info[StrawberryGQLContext],
     input: UpdateRuntimeVariantPresetInputGQL,
-) -> UpdateRuntimeVariantPresetPayloadGQL:
+) -> UpdateRuntimeVariantPresetPayloadGQL | None:
     check_admin_only()
     dto = input.to_pydantic()
     payload = await info.context.adapters.runtime_variant_preset.update(dto)
@@ -145,7 +145,7 @@ async def admin_update_runtime_variant_preset(
 async def admin_delete_runtime_variant_preset(
     info: Info[StrawberryGQLContext],
     id: UUID,
-) -> DeleteRuntimeVariantPresetPayloadGQL:
+) -> DeleteRuntimeVariantPresetPayloadGQL | None:
     check_admin_only()
     payload = await info.context.adapters.runtime_variant_preset.delete(id)
     return DeleteRuntimeVariantPresetPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/scheduler.py
+++ b/src/ai/backend/manager/api/gql/scheduler.py
@@ -77,7 +77,7 @@ class SchedulingBroadcastEventPayloadGQL:
     @gql_field(
         description="The session ID associated with the replica. This can be null right after replica creation."
     )  # type: ignore[misc]
-    async def session(self, info: Info[StrawberryGQLContext]) -> Session:
+    async def session(self, info: Info[StrawberryGQLContext]) -> Session | None:
         session_global_id = to_global_id(
             ComputeSessionNode, self.session_id, is_target_graphene_object=True
         )

--- a/src/ai/backend/manager/api/gql/scheduling_handler/resolver.py
+++ b/src/ai/backend/manager/api/gql/scheduling_handler/resolver.py
@@ -23,7 +23,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
 )  # type: ignore[misc]
 async def scheduling_handlers(
     info: Info[StrawberryGQLContext],
-) -> list[SchedulingHandlerNodeGQL]:
+) -> list[SchedulingHandlerNodeGQL] | None:
     """Return every registered deployment scheduling handler."""
     check_admin_only()
     payload = await info.context.adapters.scheduling_handler.list_scheduling_handlers()

--- a/src/ai/backend/manager/api/gql/service_catalog/resolver.py
+++ b/src/ai/backend/manager/api/gql/service_catalog/resolver.py
@@ -34,7 +34,7 @@ async def admin_service_catalogs(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> list[ServiceCatalogGQL]:
+) -> list[ServiceCatalogGQL] | None:
     check_admin_only()
     ctx = info.context
 

--- a/src/ai/backend/manager/api/gql/session/resolver/session.py
+++ b/src/ai/backend/manager/api/gql/session/resolver/session.py
@@ -63,7 +63,7 @@ async def admin_sessions_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> SessionV2ConnectionGQL:
+) -> SessionV2ConnectionGQL | None:
     check_admin_only()
     payload = await info.context.adapters.session.admin_search(
         AdminSearchSessionsInput(
@@ -108,7 +108,7 @@ async def project_sessions_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> SessionV2ConnectionGQL:
+) -> SessionV2ConnectionGQL | None:
     from ai.backend.manager.repositories.session.types import ProjectSessionSearchScope
 
     payload = await info.context.adapters.session.gql_search_by_project(
@@ -147,7 +147,7 @@ async def project_sessions_v2(
 async def enqueue_session(
     input: EnqueueSessionInputGQL,
     info: Info[StrawberryGQLContext],
-) -> EnqueueSessionPayloadGQL:
+) -> EnqueueSessionPayloadGQL | None:
     """Enqueue a new compute session (interactive or batch)."""
     user_data = current_user()
     if user_data is None:
@@ -177,7 +177,7 @@ async def terminate_project_sessions_v2(
     scope: ProjectSessionScopeGQL,
     session_ids: list[ID],
     forced: bool = False,
-) -> TerminateSessionsPayloadGQL:
+) -> TerminateSessionsPayloadGQL | None:
     """Terminate one or more sessions scoped to a project."""
     payload = await info.context.adapters.session.terminate_in_project(
         TerminateSessionsInProjectInput(

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -376,7 +376,7 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
             description="The images used by this session. Multiple images are possible in multi-kernel (cluster) sessions.",
         )
     )  # type: ignore[misc]
-    async def images(self, info: Info[StrawberryGQLContext]) -> ImageV2ConnectionGQL:
+    async def images(self, info: Info[StrawberryGQLContext]) -> ImageV2ConnectionGQL | None:
         from ai.backend.manager.api.gql.image.types import ImageV2EdgeGQL
 
         if not self.image_ids:
@@ -411,7 +411,7 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
             added_version="26.3.0", description="The kernels belonging to this session."
         )
     )  # type: ignore[misc]
-    async def kernels(self, info: Info[StrawberryGQLContext]) -> KernelV2ConnectionGQL:
+    async def kernels(self, info: Info[StrawberryGQLContext]) -> KernelV2ConnectionGQL | None:
         user = current_user()
         if user is None:
             raise UserNotFound("User not found in context")

--- a/src/ai/backend/manager/api/gql/storage_host.py
+++ b/src/ai/backend/manager/api/gql/storage_host.py
@@ -63,6 +63,6 @@ class MyStorageHostPermissionsPayloadGQL(PydanticOutputMixin[MyStorageHostPermis
 )  # type: ignore[misc]
 async def my_storage_host_permissions(
     info: Info[StrawberryGQLContext],
-) -> MyStorageHostPermissionsPayloadGQL:
+) -> MyStorageHostPermissionsPayloadGQL | None:
     payload = await info.context.adapters.storage_host.my_storage_host_permissions()
     return MyStorageHostPermissionsPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/storage_namespace.py
+++ b/src/ai/backend/manager/api/gql/storage_namespace.py
@@ -78,7 +78,7 @@ StorageNamespaceEdge = Edge[StorageNamespace]
 )
 class StorageNamespaceConnection(Connection[StorageNamespace]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int | None:
+    def count(self) -> int:
         return len(self.edges)
 
 

--- a/src/ai/backend/manager/api/gql/storage_namespace.py
+++ b/src/ai/backend/manager/api/gql/storage_namespace.py
@@ -78,7 +78,7 @@ StorageNamespaceEdge = Edge[StorageNamespace]
 )
 class StorageNamespaceConnection(Connection[StorageNamespace]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int:
+    def count(self) -> int | None:
         return len(self.edges)
 
 
@@ -135,7 +135,7 @@ class UnregisterStorageNamespacePayload:
 )
 async def register_storage_namespace(
     input: RegisterStorageNamespaceInput, info: Info[StrawberryGQLContext]
-) -> RegisterStorageNamespacePayload:
+) -> RegisterStorageNamespacePayload | None:
     payload = await info.context.adapters.storage_namespace.register(input.to_pydantic())
     return RegisterStorageNamespacePayload(id=payload.namespace.storage_id)
 
@@ -147,7 +147,7 @@ async def register_storage_namespace(
 )
 async def unregister_storage_namespace(
     input: UnregisterStorageNamespaceInput, info: Info[StrawberryGQLContext]
-) -> UnregisterStorageNamespacePayload:
+) -> UnregisterStorageNamespacePayload | None:
     pydantic_input = input.to_pydantic()
     payload = await info.context.adapters.storage_namespace.unregister(pydantic_input)
     return UnregisterStorageNamespacePayload(id=payload.id)

--- a/src/ai/backend/manager/api/gql/user/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/user/resolver/mutation.py
@@ -71,7 +71,7 @@ from ai.backend.manager.types import OptionalState, TriState
 async def admin_create_user_v2(
     info: Info[StrawberryGQLContext],
     input: CreateUserInputGQL,
-) -> CreateUserPayloadGQL:
+) -> CreateUserPayloadGQL | None:
     """Create a new user.
 
     Args:
@@ -98,7 +98,7 @@ async def admin_create_user_v2(
 async def admin_bulk_create_users_v2(
     info: Info[StrawberryGQLContext],
     input: BulkCreateUserV2InputGQL,
-) -> BulkCreateUsersV2PayloadGQL:
+) -> BulkCreateUsersV2PayloadGQL | None:
     """Create multiple users in bulk with individual specifications.
 
     Args:
@@ -164,7 +164,7 @@ async def admin_update_user_v2(
     info: Info[StrawberryGQLContext],
     user_id: UUID,
     input: UpdateUserV2InputGQL,
-) -> UpdateUserPayloadGQL:
+) -> UpdateUserPayloadGQL | None:
     """Update a user's information.
 
     Args:
@@ -192,7 +192,7 @@ async def admin_update_user_v2(
 async def admin_bulk_update_users_v2(
     info: Info[StrawberryGQLContext],
     input: BulkUpdateUserV2InputGQL,
-) -> BulkUpdateUsersV2PayloadGQL:
+) -> BulkUpdateUsersV2PayloadGQL | None:
     """Update multiple users in bulk with individual specifications.
 
     Args:
@@ -321,7 +321,7 @@ async def admin_bulk_update_users_v2(
 async def update_user_v2(
     info: Info[StrawberryGQLContext],
     input: UpdateUserV2InputGQL,
-) -> UpdateUserPayloadGQL:
+) -> UpdateUserPayloadGQL | None:
     """Update the current user's own information.
 
     Args:
@@ -353,7 +353,7 @@ async def update_user_v2(
 async def admin_delete_user_v2(
     info: Info[StrawberryGQLContext],
     user_id: UUID,
-) -> DeleteUserPayloadGQL:
+) -> DeleteUserPayloadGQL | None:
     """Soft-delete a single user.
 
     Args:
@@ -380,7 +380,7 @@ async def admin_delete_user_v2(
 async def admin_delete_users_v2(
     info: Info[StrawberryGQLContext],
     input: DeleteUsersInputGQL,
-) -> DeleteUsersPayloadGQL:
+) -> DeleteUsersPayloadGQL | None:
     """Soft-delete multiple users.
 
     Args:
@@ -412,7 +412,7 @@ async def admin_delete_users_v2(
 async def admin_purge_user_v2(
     info: Info[StrawberryGQLContext],
     input: PurgeUserInputGQL,
-) -> PurgeUserPayloadGQL:
+) -> PurgeUserPayloadGQL | None:
     """Permanently delete a single user.
 
     Args:
@@ -451,7 +451,7 @@ async def admin_purge_user_v2(
 async def admin_bulk_purge_users_v2(
     info: Info[StrawberryGQLContext],
     input: BulkPurgeUsersV2InputGQL,
-) -> BulkPurgeUsersV2PayloadGQL:
+) -> BulkPurgeUsersV2PayloadGQL | None:
     """Permanently delete multiple users in bulk.
 
     Args:
@@ -511,7 +511,7 @@ async def admin_bulk_purge_users_v2(
 async def update_my_allowed_client_ip(
     info: Info[StrawberryGQLContext],
     input: UpdateMyAllowedClientIPInputGQL,
-) -> UpdateMyAllowedClientIPPayloadGQL:
+) -> UpdateMyAllowedClientIPPayloadGQL | None:
     """Update the current user's allowed client IP addresses."""
     me = current_user()
     if me is None:

--- a/src/ai/backend/manager/api/gql/user/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/user/resolver/query.py
@@ -209,6 +209,6 @@ async def my_user_v2(
 )  # type: ignore[misc]
 async def my_client_ip(
     info: Info[StrawberryGQLContext],
-) -> MyClientIpGQL:
+) -> MyClientIpGQL | None:
     ip = current_client_ip() or ""
     return MyClientIpGQL(client_ip=ip)

--- a/src/ai/backend/manager/api/gql/user/types/node.py
+++ b/src/ai/backend/manager/api/gql/user/types/node.py
@@ -116,7 +116,7 @@ class UserV2GQL(PydanticNodeMixin[UserNode]):
         self,
         info: Info,
         scope: UserFairShareScopeGQL,
-    ) -> UserFairShareGQL:
+    ) -> UserFairShareGQL | None:
         from ai.backend.common.dto.manager.v2.fair_share.request import GetUserFairShareInput
 
         if self.organization.domain_name is None:
@@ -147,7 +147,7 @@ class UserV2GQL(PydanticNodeMixin[UserNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> UserUsageBucketConnection:
+    ) -> UserUsageBucketConnection | None:
         from strawberry.relay import PageInfo
 
         from ai.backend.manager.api.gql.base import encode_cursor
@@ -233,10 +233,13 @@ class UserV2GQL(PydanticNodeMixin[UserNode]):
         last: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> Annotated[
-        ProjectV2Connection,
-        strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
-    ]:
+    ) -> (
+        Annotated[
+            ProjectV2Connection,
+            strawberry.lazy("ai.backend.manager.api.gql.project_v2.types.node"),
+        ]
+        | None
+    ):
         from strawberry.relay import PageInfo
 
         from ai.backend.common.dto.manager.v2.group.request import AdminSearchProjectsInput

--- a/src/ai/backend/manager/api/gql/vfolder.py
+++ b/src/ai/backend/manager/api/gql/vfolder.py
@@ -45,7 +45,7 @@ class ExtraVFolderMount(PydanticNodeMixin[Any]):
     vfolder_id: ID
 
     @gql_field(description="The vfolder of this entity.")  # type: ignore[misc]
-    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder:
+    async def vfolder(self, info: Info[StrawberryGQLContext]) -> VFolder | None:
         vfolder_global_id = AsyncNode.to_global_id("VirtualFolderNode", str(self.vfolder_id))
         return VFolder(id=ID(vfolder_global_id))
 

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/mutation.py
@@ -53,7 +53,7 @@ from ai.backend.manager.api.gql.vfolder_v2.types.mutations import (
 async def create_vfolder_v2(
     info: Info[StrawberryGQLContext],
     input: CreateVFolderInputGQL,
-) -> CreateVFolderPayloadGQL:
+) -> CreateVFolderPayloadGQL | None:
     payload = await info.context.adapters.vfolder.create(input.to_pydantic())
     return CreateVFolderPayloadGQL.from_pydantic(payload)
 
@@ -67,7 +67,7 @@ async def create_vfolder_v2(
 async def delete_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
-) -> DeleteVFolderPayloadGQL:
+) -> DeleteVFolderPayloadGQL | None:
     payload = await info.context.adapters.vfolder.delete(vfolder_id)
     return DeleteVFolderPayloadGQL.from_pydantic(payload)
 
@@ -82,7 +82,7 @@ async def purge_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     options: PurgeVFolderOptionsInputGQL | None = None,
-) -> PurgeVFolderPayloadGQL:
+) -> PurgeVFolderPayloadGQL | None:
     options_dto = options.to_pydantic() if options is not None else PurgeVFolderOptions()
     payload = await info.context.adapters.vfolder.purge(
         vfolder_id,
@@ -101,7 +101,7 @@ async def purge_vfolder_v2(
 async def restore_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
-) -> RestoreVFolderPayloadGQL:
+) -> RestoreVFolderPayloadGQL | None:
     """Restore a virtual folder from trash."""
     payload = await info.context.adapters.vfolder.restore(vfolder_id)
     return RestoreVFolderPayloadGQL.from_pydantic(payload)
@@ -117,7 +117,7 @@ async def deploy_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: DeployVFolderInputGQL,
-) -> DeployVFolderPayloadGQL:
+) -> DeployVFolderPayloadGQL | None:
     payload = await info.context.adapters.vfolder.deploy(vfolder_id, input.to_pydantic())
     return DeployVFolderPayloadGQL.from_pydantic(payload)
 
@@ -132,7 +132,7 @@ async def clone_vfolder_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: CloneVFolderInputGQL,
-) -> CloneVFolderPayloadGQL:
+) -> CloneVFolderPayloadGQL | None:
     payload = await info.context.adapters.vfolder.clone(vfolder_id, input.to_pydantic())
     return CloneVFolderPayloadGQL.from_pydantic(payload)
 
@@ -147,7 +147,7 @@ async def vfolder_list_files_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: ListFilesInputGQL,
-) -> ListFilesPayloadGQL:
+) -> ListFilesPayloadGQL | None:
     payload = await info.context.adapters.vfolder.list_files(vfolder_id, input.to_pydantic())
     return ListFilesPayloadGQL.from_pydantic(payload)
 
@@ -162,7 +162,7 @@ async def vfolder_mkdir_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: MkdirInputGQL,
-) -> MkdirPayloadGQL:
+) -> MkdirPayloadGQL | None:
     payload = await info.context.adapters.vfolder.mkdir(vfolder_id, input.to_pydantic())
     return MkdirPayloadGQL.from_pydantic(payload)
 
@@ -177,7 +177,7 @@ async def vfolder_move_file_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: MoveFileInputGQL,
-) -> MoveFilePayloadGQL:
+) -> MoveFilePayloadGQL | None:
     payload = await info.context.adapters.vfolder.move_file(vfolder_id, input.to_pydantic())
     return MoveFilePayloadGQL.from_pydantic(payload)
 
@@ -192,7 +192,7 @@ async def vfolder_delete_files_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: DeleteFilesInputGQL,
-) -> DeleteFilesPayloadGQL:
+) -> DeleteFilesPayloadGQL | None:
     payload = await info.context.adapters.vfolder.delete_files(vfolder_id, input.to_pydantic())
     return DeleteFilesPayloadGQL.from_pydantic(payload)
 
@@ -207,7 +207,7 @@ async def vfolder_create_upload_session_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: UploadSessionInputGQL,
-) -> UploadSessionPayloadGQL:
+) -> UploadSessionPayloadGQL | None:
     payload = await info.context.adapters.vfolder.create_upload_session(
         vfolder_id, input.to_pydantic()
     )
@@ -224,7 +224,7 @@ async def vfolder_create_download_session_v2(
     info: Info[StrawberryGQLContext],
     vfolder_id: UUID,
     input: DownloadSessionInputGQL,
-) -> DownloadSessionPayloadGQL:
+) -> DownloadSessionPayloadGQL | None:
     payload = await info.context.adapters.vfolder.create_download_session(
         vfolder_id, input.to_pydantic()
     )
@@ -240,7 +240,7 @@ async def vfolder_create_download_session_v2(
 async def bulk_delete_vfolders_v2(
     info: Info[StrawberryGQLContext],
     input: BulkDeleteVFoldersInputGQL,
-) -> BulkDeleteVFoldersPayloadGQL:
+) -> BulkDeleteVFoldersPayloadGQL | None:
     """Soft-delete multiple virtual folders.
 
     Args:
@@ -270,7 +270,7 @@ async def create_vfolder_in_project(
     info: Info[StrawberryGQLContext],
     project_id: UUID,
     input: CreateVFolderInScopeInputGQL,
-) -> CreateVFolderPayloadGQL:
+) -> CreateVFolderPayloadGQL | None:
     """Create a new virtual folder scoped to a project."""
     payload = await info.context.adapters.vfolder.create_in_project(project_id, input.to_pydantic())
     return CreateVFolderPayloadGQL.from_pydantic(payload)
@@ -285,7 +285,7 @@ async def create_vfolder_in_project(
 async def bulk_purge_vfolders_v2(
     info: Info[StrawberryGQLContext],
     input: BulkPurgeVFoldersInputGQL,
-) -> BulkPurgeVFoldersPayloadGQL:
+) -> BulkPurgeVFoldersPayloadGQL | None:
     """Permanently purge multiple virtual folders, optionally cascading linked model cards."""
     ctx = info.context
     dto = input.to_pydantic()

--- a/src/ai/backend/manager/api/gql/vfolder_v2/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/resolver/query.py
@@ -40,7 +40,7 @@ async def admin_vfolders_v2(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> VFolderConnection:
+) -> VFolderConnection | None:
     """Search all virtual folders (superadmin only)."""
     check_admin_only()
     result = await info.context.adapters.vfolder.admin_search(
@@ -101,7 +101,7 @@ async def project_vfolders(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> VFolderConnection:
+) -> VFolderConnection | None:
     """List virtual folders within a specific project."""
     result = await info.context.adapters.vfolder.project_search(
         project_id,
@@ -146,7 +146,7 @@ async def my_vfolders(
     last: int | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> VFolderConnection:
+) -> VFolderConnection | None:
     """Search virtual folders accessible to the current user."""
     result = await info.context.adapters.vfolder.my_search(
         SearchVFoldersInput(

--- a/src/ai/backend/manager/api/gql/vfs_storage.py
+++ b/src/ai/backend/manager/api/gql/vfs_storage.py
@@ -86,7 +86,7 @@ VFSStorageEdge = Edge[VFSStorage]
 )
 class VFSStorageConnection(Connection[VFSStorage]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int:
+    def count(self) -> int | None:
         return len(self.edges)
 
 
@@ -189,7 +189,7 @@ class DeleteVFSStoragePayload(PydanticOutputMixin[DeleteVFSStoragePayloadDTO]):
 )
 async def create_vfs_storage(
     input: CreateVFSStorageInput, info: Info[StrawberryGQLContext]
-) -> CreateVFSStoragePayload:
+) -> CreateVFSStoragePayload | None:
     result = await info.context.adapters.vfs_storage.create(input.to_pydantic())
     return CreateVFSStoragePayload(vfs_storage=VFSStorage.from_pydantic(result.vfs_storage))
 
@@ -200,7 +200,7 @@ async def create_vfs_storage(
 )
 async def update_vfs_storage(
     input: UpdateVFSStorageInput, info: Info[StrawberryGQLContext]
-) -> UpdateVFSStoragePayload:
+) -> UpdateVFSStoragePayload | None:
     result = await info.context.adapters.vfs_storage.update(input.to_pydantic())
     return UpdateVFSStoragePayload(vfs_storage=VFSStorage.from_pydantic(result.vfs_storage))
 
@@ -211,6 +211,6 @@ async def update_vfs_storage(
 )
 async def delete_vfs_storage(
     input: DeleteVFSStorageInput, info: Info[StrawberryGQLContext]
-) -> DeleteVFSStoragePayload:
+) -> DeleteVFSStoragePayload | None:
     result = await info.context.adapters.vfs_storage.delete(input.to_pydantic())
     return DeleteVFSStoragePayload.from_pydantic(result)

--- a/src/ai/backend/manager/api/gql/vfs_storage.py
+++ b/src/ai/backend/manager/api/gql/vfs_storage.py
@@ -86,7 +86,7 @@ VFSStorageEdge = Edge[VFSStorage]
 )
 class VFSStorageConnection(Connection[VFSStorage]):
     @gql_field(description="The count of this entity.")  # type: ignore[misc]
-    def count(self) -> int | None:
+    def count(self) -> int:
         return len(self.edges)
 
 


### PR DESCRIPTION
## Summary
- Makes every v2 GraphQL field that runs through a Python resolver nullable (`T | None`), aligning with the GraphQL nullable-by-default best practice. Covers `@gql_root_field`, `@gql_mutation`, `@gql_field`, and `@gql_added_field` — root Query/Mutation payloads plus computed nested fields on Node / Connection / Payload types.
- Apollo Federation `_service` / `_entities` entry points and statically projected DTO fields (no resolver) stay non-null.
- Updates `v2-schema.graphql` / `supergraph.graphql` and documents the policy with exceptions in `src/ai/backend/manager/api/gql/README.md` (under `Type Definition Conventions › Nullable Return Types`).

## Test plan
- [x] `pants fmt :: && pants fix :: && pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main` (mypy passes)
- [x] Regenerated SDL via `scripts/generate-graphql-schema.sh` — only Federation entry points retain `!` on Query/Mutation root types

Resolves BA-5956

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11517.org.readthedocs.build/en/11517/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11517.org.readthedocs.build/ko/11517/

<!-- readthedocs-preview sorna-ko end -->