### PR TITLE
fix: merge alembic heads c7d58e2a4f93 and 5a139f0e951e

### DIFF
--- a/changes/11518.fix.md
+++ b/changes/11518.fix.md
@@ -1,1 +1,0 @@
-Reconcile diverged Alembic migration heads so `alembic upgrade head` again resolves to a single tip.

--- a/changes/11518.fix.md
+++ b/changes/11518.fix.md
@@ -1,0 +1,1 @@
+Reconcile diverged Alembic migration heads so `alembic upgrade head` again resolves to a single tip.

--- a/src/ai/backend/manager/models/alembic/versions/6b8149885649_merge_c7d58e2a4f93_and_5a139f0e951e.py
+++ b/src/ai/backend/manager/models/alembic/versions/6b8149885649_merge_c7d58e2a4f93_and_5a139f0e951e.py
@@ -1,0 +1,22 @@
+"""merge c7d58e2a4f93 and 5a139f0e951e
+
+Revision ID: 6b8149885649
+Revises: c7d58e2a4f93, 5a139f0e951e
+Create Date: 2026-05-08
+
+"""
+
+# revision identifiers, used by Alembic.
+# Part of: 26.5.0
+revision = "6b8149885649"
+down_revision = ("c7d58e2a4f93", "5a139f0e951e")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/6b8149885649_merge_c7d58e2a4f93_and_5a139f0e951e.py
+++ b/src/ai/backend/manager/models/alembic/versions/6b8149885649_merge_c7d58e2a4f93_and_5a139f0e951e.py
@@ -4,6 +4,8 @@ Revision ID: 6b8149885649
 Revises: c7d58e2a4f93, 5a139f0e951e
 Create Date: 2026-05-08
 
+No-op merge revision; no schema changes.
+
 """
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
## Summary

Two migrations landed on main with the same parent so ``check-multiple-alembic-heads`` is now failing on every PR opened against main:

- ``c7d58e2a4f93`` — drop_endpoint_name_unique_index (#11507, BA-5974)
- ``5a139f0e951e`` — add_updated_at_to_vfolders (#10821, BA-5504)

Add an empty merge revision (``6b8149885649``) pointing at both heads so ``alembic upgrade head`` resolves to a single tip again. No schema changes; ``upgrade()``/``downgrade()`` are intentionally no-ops.

## Test plan

- [x] ``python scripts/check-multiple-alembic-heads.py`` reports a single head (``6b8149885649``) locally
- [x] ``pants lint`` / ``pants check`` clean on the new revision file
- [ ] CI ``check-alembic-migrations`` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)