### PR TITLE
fix(BA-5980): accept UUID-shaped strings in the legacy session-create `mounts` field

### DIFF
--- a/changes/11521.fix.md
+++ b/changes/11521.fix.md
@@ -1,1 +1,1 @@
-Accept UUID-shaped strings in the legacy session-create `mounts` field so passing a vfolder UUID no longer raises `VFolderNotFound`.
+Accept UUID-shaped strings in the legacy session-create `mounts` field.

--- a/changes/11521.fix.md
+++ b/changes/11521.fix.md
@@ -1,1 +1,1 @@
-Accept UUID-shaped strings in the legacy session-create `mounts` field so `./backend.ai session create -v <vfolder-uuid>:/dst` no longer raises `VFolderNotFound`.
+Accept UUID-shaped strings in the legacy session-create `mounts` field so passing a vfolder UUID no longer raises `VFolderNotFound`.

--- a/changes/11521.fix.md
+++ b/changes/11521.fix.md
@@ -1,0 +1,1 @@
+Accept UUID-shaped strings in the legacy session-create `mounts` field so `./backend.ai session create -v <vfolder-uuid>:/dst` no longer raises `VFolderNotFound`.

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -233,6 +233,13 @@ def _validate_creation_config(
         ) from e
 
 
+def _try_parse_uuid(s: str) -> UUID | None:
+    try:
+        return UUID(s)
+    except (ValueError, TypeError):
+        return None
+
+
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
     name_to_id: dict[str, UUID],
@@ -240,26 +247,30 @@ def _merge_resolved_legacy_mounts(
     """Merge a ``name → UUID`` resolution into the UUID-keyed buckets of
     ``creation_config`` and drop the now-resolved name-keyed legacy keys.
 
+    Legacy ``mounts`` entries that are already UUID-shaped strings (i.e. the
+    caller passed a vfolder UUID, not a name) bypass the name resolver and
+    are routed directly into ``mount_ids`` here, alongside name-resolved
+    entries. Their ``mount_map`` / ``mount_options`` companions are similarly
+    re-keyed onto the parsed UUID.
+
     The resolved ids are appended to ``mount_ids`` (skipping duplicates),
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
     explicit UUID-keyed entry the caller already supplied.
     """
-    if not name_to_id:
-        return creation_config
+    legacy_mounts: Sequence[Any] = creation_config.get("mounts") or ()
+    legacy_mount_map: Mapping[Any, str] = creation_config.get("mount_map") or {}
+    legacy_mount_options: Mapping[Any, Any] = creation_config.get("mount_options") or {}
 
     merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
     existing_uuid_set: set[UUID] = set()
     for rid in merged_mount_ids:
-        try:
-            existing_uuid_set.add(UUID(str(rid)))
-        except (ValueError, TypeError):
-            continue
+        if (parsed := _try_parse_uuid(str(rid))) is not None:
+            existing_uuid_set.add(parsed)
     merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
-    legacy_mount_map = creation_config.get("mount_map") or {}
-    legacy_mount_options = creation_config.get("mount_options") or {}
 
+    # Pass 1: name-resolved entries.
     for name, vfid in name_to_id.items():
         if vfid not in existing_uuid_set:
             merged_mount_ids.append(vfid)
@@ -268,6 +279,27 @@ def _merge_resolved_legacy_mounts(
             merged_mount_id_map[vfid] = dst
         if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
+
+    # Pass 2: entries that came in already as UUID-shaped strings — route them
+    # through the same UUID-keyed buckets without going via the name resolver.
+    seen_uuid_keys: set[str] = set()
+    for raw in (
+        list(legacy_mounts) + list(legacy_mount_map.keys()) + list(legacy_mount_options.keys())
+    ):
+        key = str(raw)
+        if key in seen_uuid_keys:
+            continue
+        seen_uuid_keys.add(key)
+        parsed_vfid = _try_parse_uuid(key)
+        if parsed_vfid is None:
+            continue
+        if parsed_vfid not in existing_uuid_set:
+            merged_mount_ids.append(parsed_vfid)
+            existing_uuid_set.add(parsed_vfid)
+        if (dst := legacy_mount_map.get(key)) and parsed_vfid not in merged_mount_id_map:
+            merged_mount_id_map[parsed_vfid] = dst
+        if (opts := legacy_mount_options.get(key)) and parsed_vfid not in merged_mount_options:
+            merged_mount_options[parsed_vfid] = opts
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
@@ -305,12 +337,12 @@ class SessionHandler:
         """Resolve legacy v1 CLI name-keyed mount surfaces into a unified
         ``name → UUID`` mapping.
 
-        ``mounts`` (list of names), ``mount_map`` (dict keyed by name), and
-        ``mount_options`` (dict keyed by name) are all name-based legacy
-        inputs populated together by ``-v`` on the v1 CLI; they must be
-        re-keyed onto UUIDs together so a name that appears only in
-        ``mount_map`` or ``mount_options`` is not silently dropped
-        downstream.
+        ``mounts`` (list), ``mount_map`` (dict keys), and ``mount_options``
+        (dict keys) hold whatever the v1 CLI's ``-v`` flag forwards — a mix
+        of vfolder names and already-stringified UUIDs. Only the name-shaped
+        entries hit the resolver here; UUID-shaped entries are passed
+        through unchanged and routed directly into ``mount_ids`` by
+        :func:`_merge_resolved_legacy_mounts`.
 
         Subpath syntax (``name/subdir``) is rejected here because
         :class:`MountInfoEntry` carries no subpath field; silently dropping
@@ -324,7 +356,13 @@ class SessionHandler:
         if not mounts and not mount_map and not mount_options:
             return {}
 
-        subpath_entries = [m for m in mounts if "/" in str(m)]
+        # Subpath check applies to name-shaped entries only — a UUID-shaped
+        # source like ``<uuid>`` parses cleanly even when read from the
+        # legacy ``mounts`` list, and may legitimately appear there from
+        # callers that stuff UUIDs into ``-v``.
+        subpath_entries = [
+            m for m in mounts if "/" in str(m) and _try_parse_uuid(str(m).split("/", 1)[0]) is None
+        ]
         if subpath_entries:
             raise InvalidAPIParameters(
                 "Legacy 'mounts' field with subpath syntax "
@@ -335,30 +373,16 @@ class SessionHandler:
         names_to_resolve: list[str] = []
         seen: set[str] = set()
 
-        # ``mounts`` and ``mount_map`` are strictly name-keyed legacy
-        # surfaces — every entry is treated as a vfolder name.
-        for raw in list(mounts) + list(mount_map.keys()):
-            name = str(raw)
-            if name in seen:
+        # Walk every key once; UUID-shaped entries are skipped here and
+        # picked up later by ``_merge_resolved_legacy_mounts``.
+        for raw in list(mounts) + list(mount_map.keys()) + list(mount_options.keys()):
+            key = str(raw)
+            if key in seen:
                 continue
-            seen.add(name)
-            names_to_resolve.append(name)
-
-        # ``mount_options`` is the single polymorphic field shared by
-        # both legacy (name-keyed) and modern (UUID-string-keyed)
-        # callers; skip keys that already parse as UUID strings since
-        # they are not vfolder names to resolve.
-        for raw in mount_options.keys():
-            name = str(raw)
-            if name in seen:
+            seen.add(key)
+            if _try_parse_uuid(key) is not None:
                 continue
-            try:
-                UUID(name)
-                continue
-            except (ValueError, TypeError):
-                pass
-            seen.add(name)
-            names_to_resolve.append(name)
+            names_to_resolve.append(key)
 
         if not names_to_resolve:
             return {}

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -440,13 +440,15 @@ class SessionHandler:
             template=True,
         )
 
-        validated_config = _route_legacy_uuid_mounts(validated_config)
         legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
         legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
         legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}
         if legacy_mounts or legacy_mount_map or legacy_mount_options:
+            validated_config = _route_legacy_uuid_mounts(validated_config)
             name_to_id = await self._resolve_legacy_name_mounts(
-                legacy_mounts, legacy_mount_map, legacy_mount_options
+                validated_config.get("mounts") or (),
+                validated_config.get("mount_map") or {},
+                validated_config.get("mount_options") or {},
             )
             validated_config = _merge_resolved_legacy_mounts(validated_config, name_to_id)
 
@@ -552,13 +554,15 @@ class SessionHandler:
         api_version = request["api_version"]
         validated_config = _validate_creation_config(api_version, params.config)
 
-        validated_config = _route_legacy_uuid_mounts(validated_config)
         legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
         legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
         legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}
         if legacy_mounts or legacy_mount_map or legacy_mount_options:
+            validated_config = _route_legacy_uuid_mounts(validated_config)
             name_to_id = await self._resolve_legacy_name_mounts(
-                legacy_mounts, legacy_mount_map, legacy_mount_options
+                validated_config.get("mounts") or (),
+                validated_config.get("mount_map") or {},
+                validated_config.get("mount_options") or {},
             )
             validated_config = _merge_resolved_legacy_mounts(validated_config, name_to_id)
 

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -234,12 +234,8 @@ def _validate_creation_config(
 
 
 def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]:
-    """Move UUID-shaped strings from the legacy ``mounts`` / ``mount_map`` /
-    ``mount_options`` buckets into the UUID-keyed ``mount_ids`` /
-    ``mount_id_map`` / ``mount_options`` buckets, leaving only name-shaped
-    entries for ``_resolve_legacy_name_mounts``. ``mount_options`` is
-    polymorphic (modern callers key it by UUID, legacy callers by name),
-    so name keys are preserved alongside the routed UUID-keyed entries.
+    """Lift UUID-shaped strings from legacy mount buckets onto the UUID-keyed
+    buckets, leaving only name-shaped entries for the name resolver.
     """
     next_config = dict(creation_config)
     mount_ids: list[Any] = list(next_config.get("mount_ids") or [])

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -233,13 +233,6 @@ def _validate_creation_config(
         ) from e
 
 
-def _try_parse_uuid(s: str) -> UUID | None:
-    try:
-        return UUID(s)
-    except (ValueError, TypeError):
-        return None
-
-
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
     name_to_id: dict[str, UUID],
@@ -247,59 +240,56 @@ def _merge_resolved_legacy_mounts(
     """Merge a ``name → UUID`` resolution into the UUID-keyed buckets of
     ``creation_config`` and drop the now-resolved name-keyed legacy keys.
 
-    Legacy ``mounts`` entries that are already UUID-shaped strings (i.e. the
-    caller passed a vfolder UUID, not a name) bypass the name resolver and
-    are routed directly into ``mount_ids`` here, alongside name-resolved
-    entries. Their ``mount_map`` / ``mount_options`` companions are similarly
-    re-keyed onto the parsed UUID.
-
     The resolved ids are appended to ``mount_ids`` (skipping duplicates),
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
-    explicit UUID-keyed entry the caller already supplied.
+    explicit UUID-keyed entry the caller already supplied. Legacy entries
+    that came in already as UUID-shaped strings are routed onto the
+    UUID-keyed buckets the same way.
     """
-    legacy_mounts: Sequence[Any] = creation_config.get("mounts") or ()
-    legacy_mount_map: Mapping[Any, str] = creation_config.get("mount_map") or {}
-    legacy_mount_options: Mapping[Any, Any] = creation_config.get("mount_options") or {}
+    legacy_mounts = creation_config.get("mounts") or ()
+    legacy_mount_map = creation_config.get("mount_map") or {}
+    legacy_mount_options = creation_config.get("mount_options") or {}
 
-    merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
-    existing_uuid_set: set[UUID] = set()
-    for rid in merged_mount_ids:
-        if (parsed := _try_parse_uuid(str(rid))) is not None:
-            existing_uuid_set.add(parsed)
-    merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
-    merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
-
-    # Pass 1: name-resolved entries.
-    for name, vfid in name_to_id.items():
-        if vfid not in existing_uuid_set:
-            merged_mount_ids.append(vfid)
-            existing_uuid_set.add(vfid)
-        if (dst := legacy_mount_map.get(name)) and vfid not in merged_mount_id_map:
-            merged_mount_id_map[vfid] = dst
-        if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
-            merged_mount_options[vfid] = opts
-
-    # Pass 2: entries that came in already as UUID-shaped strings — route them
-    # through the same UUID-keyed buckets without going via the name resolver.
-    seen_uuid_keys: set[str] = set()
+    # Collect UUIDs that arrived as already-stringified UUIDs in any of the
+    # legacy buckets so name-resolution and pass-through can share one merge.
+    pass_through_uuids: dict[UUID, str] = {}
     for raw in (
         list(legacy_mounts) + list(legacy_mount_map.keys()) + list(legacy_mount_options.keys())
     ):
         key = str(raw)
-        if key in seen_uuid_keys:
+        try:
+            vfid = UUID(key)
+        except (ValueError, TypeError):
             continue
-        seen_uuid_keys.add(key)
-        parsed_vfid = _try_parse_uuid(key)
-        if parsed_vfid is None:
+        pass_through_uuids.setdefault(vfid, key)
+
+    if not name_to_id and not pass_through_uuids:
+        return creation_config
+
+    merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
+    existing_uuid_set: set[UUID] = set()
+    for rid in merged_mount_ids:
+        try:
+            existing_uuid_set.add(UUID(str(rid)))
+        except (ValueError, TypeError):
             continue
-        if parsed_vfid not in existing_uuid_set:
-            merged_mount_ids.append(parsed_vfid)
-            existing_uuid_set.add(parsed_vfid)
-        if (dst := legacy_mount_map.get(key)) and parsed_vfid not in merged_mount_id_map:
-            merged_mount_id_map[parsed_vfid] = dst
-        if (opts := legacy_mount_options.get(key)) and parsed_vfid not in merged_mount_options:
-            merged_mount_options[parsed_vfid] = opts
+    merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
+    merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
+
+    def _route(vfid: UUID, key: str) -> None:
+        if vfid not in existing_uuid_set:
+            merged_mount_ids.append(vfid)
+            existing_uuid_set.add(vfid)
+        if (dst := legacy_mount_map.get(key)) and vfid not in merged_mount_id_map:
+            merged_mount_id_map[vfid] = dst
+        if (opts := legacy_mount_options.get(key)) and vfid not in merged_mount_options:
+            merged_mount_options[vfid] = opts
+
+    for name, vfid in name_to_id.items():
+        _route(vfid, name)
+    for vfid, key in pass_through_uuids.items():
+        _route(vfid, key)
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
@@ -337,11 +327,13 @@ class SessionHandler:
         """Resolve legacy v1 CLI name-keyed mount surfaces into a unified
         ``name → UUID`` mapping.
 
-        ``mounts`` (list), ``mount_map`` (dict keys), and ``mount_options``
-        (dict keys) hold whatever the v1 CLI's ``-v`` flag forwards — a mix
-        of vfolder names and already-stringified UUIDs. Only the name-shaped
-        entries hit the resolver here; UUID-shaped entries are passed
-        through unchanged and routed directly into ``mount_ids`` by
+        ``mounts`` (list of names), ``mount_map`` (dict keyed by name), and
+        ``mount_options`` (dict keyed by name) are all name-based legacy
+        inputs populated together by ``-v`` on the v1 CLI; they must be
+        re-keyed onto UUIDs together so a name that appears only in
+        ``mount_map`` or ``mount_options`` is not silently dropped
+        downstream. Entries that are already UUID-shaped strings are
+        skipped here and routed directly to ``mount_ids`` by
         :func:`_merge_resolved_legacy_mounts`.
 
         Subpath syntax (``name/subdir``) is rejected here because
@@ -356,13 +348,7 @@ class SessionHandler:
         if not mounts and not mount_map and not mount_options:
             return {}
 
-        # Subpath check applies to name-shaped entries only — a UUID-shaped
-        # source like ``<uuid>`` parses cleanly even when read from the
-        # legacy ``mounts`` list, and may legitimately appear there from
-        # callers that stuff UUIDs into ``-v``.
-        subpath_entries = [
-            m for m in mounts if "/" in str(m) and _try_parse_uuid(str(m).split("/", 1)[0]) is None
-        ]
+        subpath_entries = [m for m in mounts if "/" in str(m)]
         if subpath_entries:
             raise InvalidAPIParameters(
                 "Legacy 'mounts' field with subpath syntax "
@@ -370,19 +356,27 @@ class SessionHandler:
                 "Use UUID-keyed 'mount_ids' / 'mount_id_map' instead."
             )
 
+        def _is_uuid(s: str) -> bool:
+            try:
+                UUID(s)
+            except (ValueError, TypeError):
+                return False
+            return True
+
         names_to_resolve: list[str] = []
         seen: set[str] = set()
 
-        # Walk every key once; UUID-shaped entries are skipped here and
-        # picked up later by ``_merge_resolved_legacy_mounts``.
+        # All three buckets may carry UUID-shaped strings — those are passed
+        # through to ``_merge_resolved_legacy_mounts`` and only real names
+        # reach the resolver.
         for raw in list(mounts) + list(mount_map.keys()) + list(mount_options.keys()):
-            key = str(raw)
-            if key in seen:
+            name = str(raw)
+            if name in seen:
                 continue
-            seen.add(key)
-            if _try_parse_uuid(key) is not None:
+            seen.add(name)
+            if _is_uuid(name):
                 continue
-            names_to_resolve.append(key)
+            names_to_resolve.append(name)
 
         if not names_to_resolve:
             return {}

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -345,9 +345,7 @@ class SessionHandler:
         self._vfolder = vfolder
         self._config_provider = config_provider
 
-    async def _normalize_legacy_mounts(
-        self, validated_config: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _normalize_legacy_mounts(self, validated_config: dict[str, Any]) -> dict[str, Any]:
         """One-stop processor for the legacy ``mounts`` / ``mount_map`` /
         ``mount_options`` surfaces: route UUID-shaped entries onto the
         UUID-keyed buckets, then resolve any remaining names to UUIDs and

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -233,6 +233,56 @@ def _validate_creation_config(
         ) from e
 
 
+def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]:
+    """Move UUID-shaped strings from the legacy ``mounts`` / ``mount_map`` /
+    ``mount_options`` buckets into the UUID-keyed ``mount_ids`` /
+    ``mount_id_map`` / ``mount_options`` buckets, leaving only name-shaped
+    entries for ``_resolve_legacy_name_mounts``. ``mount_options`` is
+    polymorphic (modern callers key it by UUID, legacy callers by name),
+    so name keys are preserved alongside the routed UUID-keyed entries.
+    """
+    next_config = dict(creation_config)
+    mount_ids: list[Any] = list(next_config.get("mount_ids") or [])
+    mount_id_map: dict[Any, str] = dict(next_config.get("mount_id_map") or {})
+    mount_options: dict[Any, Any] = {}
+    name_mounts: list[Any] = []
+    name_mount_map: dict[str, str] = {}
+
+    for raw in next_config.get("mounts") or ():
+        try:
+            vfid = UUID(str(raw))
+        except (ValueError, TypeError):
+            name_mounts.append(raw)
+            continue
+        if vfid not in mount_ids:
+            mount_ids.append(vfid)
+    for raw, dst in (next_config.get("mount_map") or {}).items():
+        try:
+            vfid = UUID(str(raw))
+        except (ValueError, TypeError):
+            name_mount_map[raw] = dst
+            continue
+        if vfid not in mount_ids:
+            mount_ids.append(vfid)
+        mount_id_map.setdefault(vfid, dst)
+    for raw, opts in (next_config.get("mount_options") or {}).items():
+        try:
+            vfid = UUID(str(raw))
+        except (ValueError, TypeError):
+            mount_options[raw] = opts
+            continue
+        if vfid not in mount_ids:
+            mount_ids.append(vfid)
+        mount_options.setdefault(vfid, opts)
+
+    next_config["mounts"] = name_mounts
+    next_config["mount_map"] = name_mount_map
+    next_config["mount_options"] = mount_options
+    next_config["mount_ids"] = mount_ids
+    next_config["mount_id_map"] = mount_id_map
+    return next_config
+
+
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
     name_to_id: dict[str, UUID],
@@ -245,20 +295,7 @@ def _merge_resolved_legacy_mounts(
     dicts are re-keyed onto the resolved UUIDs without overwriting an
     explicit UUID-keyed entry the caller already supplied.
     """
-    legacy_mount_map = creation_config.get("mount_map") or {}
-    legacy_mount_options = creation_config.get("mount_options") or {}
-    legacy_mounts = creation_config.get("mounts") or ()
-    pass_through_uuids: dict[UUID, str] = {}
-    for raw in (
-        list(legacy_mounts) + list(legacy_mount_map.keys()) + list(legacy_mount_options.keys())
-    ):
-        key = str(raw)
-        try:
-            pass_through_uuids.setdefault(UUID(key), key)
-        except (ValueError, TypeError):
-            continue
-
-    if not name_to_id and not pass_through_uuids:
+    if not name_to_id:
         return creation_config
 
     merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
@@ -270,6 +307,8 @@ def _merge_resolved_legacy_mounts(
             continue
     merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
+    legacy_mount_map = creation_config.get("mount_map") or {}
+    legacy_mount_options = creation_config.get("mount_options") or {}
 
     for name, vfid in name_to_id.items():
         if vfid not in existing_uuid_set:
@@ -278,15 +317,6 @@ def _merge_resolved_legacy_mounts(
         if (dst := legacy_mount_map.get(name)) and vfid not in merged_mount_id_map:
             merged_mount_id_map[vfid] = dst
         if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
-            merged_mount_options[vfid] = opts
-
-    for vfid, key in pass_through_uuids.items():
-        if vfid not in existing_uuid_set:
-            merged_mount_ids.append(vfid)
-            existing_uuid_set.add(vfid)
-        if (dst := legacy_mount_map.get(key)) and vfid not in merged_mount_id_map:
-            merged_mount_id_map[vfid] = dst
-        if (opts := legacy_mount_options.get(key)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
 
     next_config = dict(creation_config)
@@ -362,11 +392,6 @@ class SessionHandler:
             if name in seen:
                 continue
             seen.add(name)
-            try:
-                UUID(name)
-                continue
-            except (ValueError, TypeError):
-                pass
             names_to_resolve.append(name)
 
         # ``mount_options`` is the single polymorphic field shared by
@@ -415,6 +440,7 @@ class SessionHandler:
             template=True,
         )
 
+        validated_config = _route_legacy_uuid_mounts(validated_config)
         legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
         legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
         legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}
@@ -526,6 +552,7 @@ class SessionHandler:
         api_version = request["api_version"]
         validated_config = _validate_creation_config(api_version, params.config)
 
+        validated_config = _route_legacy_uuid_mounts(validated_config)
         legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
         legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
         legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -243,26 +243,20 @@ def _merge_resolved_legacy_mounts(
     The resolved ids are appended to ``mount_ids`` (skipping duplicates),
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
-    explicit UUID-keyed entry the caller already supplied. Legacy entries
-    that came in already as UUID-shaped strings are routed onto the
-    UUID-keyed buckets the same way.
+    explicit UUID-keyed entry the caller already supplied.
     """
-    legacy_mounts = creation_config.get("mounts") or ()
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
-
-    # Collect UUIDs that arrived as already-stringified UUIDs in any of the
-    # legacy buckets so name-resolution and pass-through can share one merge.
+    legacy_mounts = creation_config.get("mounts") or ()
     pass_through_uuids: dict[UUID, str] = {}
     for raw in (
         list(legacy_mounts) + list(legacy_mount_map.keys()) + list(legacy_mount_options.keys())
     ):
         key = str(raw)
         try:
-            vfid = UUID(key)
+            pass_through_uuids.setdefault(UUID(key), key)
         except (ValueError, TypeError):
             continue
-        pass_through_uuids.setdefault(vfid, key)
 
     if not name_to_id and not pass_through_uuids:
         return creation_config
@@ -277,7 +271,16 @@ def _merge_resolved_legacy_mounts(
     merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
 
-    def _route(vfid: UUID, key: str) -> None:
+    for name, vfid in name_to_id.items():
+        if vfid not in existing_uuid_set:
+            merged_mount_ids.append(vfid)
+            existing_uuid_set.add(vfid)
+        if (dst := legacy_mount_map.get(name)) and vfid not in merged_mount_id_map:
+            merged_mount_id_map[vfid] = dst
+        if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
+            merged_mount_options[vfid] = opts
+
+    for vfid, key in pass_through_uuids.items():
         if vfid not in existing_uuid_set:
             merged_mount_ids.append(vfid)
             existing_uuid_set.add(vfid)
@@ -285,11 +288,6 @@ def _merge_resolved_legacy_mounts(
             merged_mount_id_map[vfid] = dst
         if (opts := legacy_mount_options.get(key)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
-
-    for name, vfid in name_to_id.items():
-        _route(vfid, name)
-    for vfid, key in pass_through_uuids.items():
-        _route(vfid, key)
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
@@ -332,9 +330,7 @@ class SessionHandler:
         inputs populated together by ``-v`` on the v1 CLI; they must be
         re-keyed onto UUIDs together so a name that appears only in
         ``mount_map`` or ``mount_options`` is not silently dropped
-        downstream. Entries that are already UUID-shaped strings are
-        skipped here and routed directly to ``mount_ids`` by
-        :func:`_merge_resolved_legacy_mounts`.
+        downstream.
 
         Subpath syntax (``name/subdir``) is rejected here because
         :class:`MountInfoEntry` carries no subpath field; silently dropping
@@ -356,26 +352,37 @@ class SessionHandler:
                 "Use UUID-keyed 'mount_ids' / 'mount_id_map' instead."
             )
 
-        def _is_uuid(s: str) -> bool:
-            try:
-                UUID(s)
-            except (ValueError, TypeError):
-                return False
-            return True
-
         names_to_resolve: list[str] = []
         seen: set[str] = set()
 
-        # All three buckets may carry UUID-shaped strings — those are passed
-        # through to ``_merge_resolved_legacy_mounts`` and only real names
-        # reach the resolver.
-        for raw in list(mounts) + list(mount_map.keys()) + list(mount_options.keys()):
+        # ``mounts`` and ``mount_map`` are strictly name-keyed legacy
+        # surfaces — every entry is treated as a vfolder name.
+        for raw in list(mounts) + list(mount_map.keys()):
             name = str(raw)
             if name in seen:
                 continue
             seen.add(name)
-            if _is_uuid(name):
+            try:
+                UUID(name)
                 continue
+            except (ValueError, TypeError):
+                pass
+            names_to_resolve.append(name)
+
+        # ``mount_options`` is the single polymorphic field shared by
+        # both legacy (name-keyed) and modern (UUID-string-keyed)
+        # callers; skip keys that already parse as UUID strings since
+        # they are not vfolder names to resolve.
+        for raw in mount_options.keys():
+            name = str(raw)
+            if name in seen:
+                continue
+            try:
+                UUID(name)
+                continue
+            except (ValueError, TypeError):
+                pass
+            seen.add(name)
             names_to_resolve.append(name)
 
         if not names_to_resolve:

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -237,40 +237,43 @@ def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]
     """Lift UUID-shaped strings from legacy mount buckets onto the UUID-keyed
     buckets, leaving only name-shaped entries for the name resolver.
     """
-    next_config = dict(creation_config)
-    mount_ids: list[Any] = list(next_config.get("mount_ids") or [])
-    mount_id_map: dict[Any, str] = dict(next_config.get("mount_id_map") or {})
+    legacy_mounts = creation_config.get("mounts") or ()
+    legacy_mount_map = creation_config.get("mount_map") or {}
+    legacy_mount_options = creation_config.get("mount_options") or {}
+
+    mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
+    mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
     mount_options: dict[Any, Any] = {}
     name_mounts: list[Any] = []
     name_mount_map: dict[str, str] = {}
 
-    for raw in next_config.get("mounts") or ():
+    legacy_mounts_keys = {str(m) for m in legacy_mounts}
+    seen: set[str] = set()
+    for raw in list(legacy_mounts) + list(legacy_mount_map) + list(legacy_mount_options):
+        key = str(raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        dst = legacy_mount_map.get(key)
+        opts = legacy_mount_options.get(key)
         try:
-            vfid = UUID(str(raw))
+            vfid = UUID(key)
         except (ValueError, TypeError):
-            name_mounts.append(raw)
+            if key in legacy_mounts_keys:
+                name_mounts.append(raw)
+            if dst is not None:
+                name_mount_map[key] = dst
+            if opts is not None:
+                mount_options[key] = opts
             continue
         if vfid not in mount_ids:
             mount_ids.append(vfid)
-    for raw, dst in (next_config.get("mount_map") or {}).items():
-        try:
-            vfid = UUID(str(raw))
-        except (ValueError, TypeError):
-            name_mount_map[raw] = dst
-            continue
-        if vfid not in mount_ids:
-            mount_ids.append(vfid)
-        mount_id_map.setdefault(vfid, dst)
-    for raw, opts in (next_config.get("mount_options") or {}).items():
-        try:
-            vfid = UUID(str(raw))
-        except (ValueError, TypeError):
-            mount_options[raw] = opts
-            continue
-        if vfid not in mount_ids:
-            mount_ids.append(vfid)
-        mount_options.setdefault(vfid, opts)
+        if dst is not None:
+            mount_id_map.setdefault(vfid, dst)
+        if opts is not None:
+            mount_options.setdefault(vfid, opts)
 
+    next_config = dict(creation_config)
     next_config["mounts"] = name_mounts
     next_config["mount_map"] = name_mount_map
     next_config["mount_options"] = mount_options

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -345,6 +345,27 @@ class SessionHandler:
         self._vfolder = vfolder
         self._config_provider = config_provider
 
+    async def _normalize_legacy_mounts(
+        self, validated_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        """One-stop processor for the legacy ``mounts`` / ``mount_map`` /
+        ``mount_options`` surfaces: route UUID-shaped entries onto the
+        UUID-keyed buckets, then resolve any remaining names to UUIDs and
+        merge the resolution back in.
+        """
+        legacy_mounts = validated_config.get("mounts") or ()
+        legacy_mount_map = validated_config.get("mount_map") or {}
+        legacy_mount_options = validated_config.get("mount_options") or {}
+        if not (legacy_mounts or legacy_mount_map or legacy_mount_options):
+            return validated_config
+        validated_config = _route_legacy_uuid_mounts(validated_config)
+        name_to_id = await self._resolve_legacy_name_mounts(
+            validated_config.get("mounts") or (),
+            validated_config.get("mount_map") or {},
+            validated_config.get("mount_options") or {},
+        )
+        return _merge_resolved_legacy_mounts(validated_config, name_to_id)
+
     async def _resolve_legacy_name_mounts(
         self,
         mounts: Sequence[str],
@@ -439,17 +460,7 @@ class SessionHandler:
             template=True,
         )
 
-        legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
-        legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
-        legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}
-        if legacy_mounts or legacy_mount_map or legacy_mount_options:
-            validated_config = _route_legacy_uuid_mounts(validated_config)
-            name_to_id = await self._resolve_legacy_name_mounts(
-                validated_config.get("mounts") or (),
-                validated_config.get("mount_map") or {},
-                validated_config.get("mount_options") or {},
-            )
-            validated_config = _merge_resolved_legacy_mounts(validated_config, name_to_id)
+        validated_config = await self._normalize_legacy_mounts(validated_config)
 
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
@@ -553,17 +564,7 @@ class SessionHandler:
         api_version = request["api_version"]
         validated_config = _validate_creation_config(api_version, params.config)
 
-        legacy_mounts: Sequence[str] = validated_config.get("mounts") or ()
-        legacy_mount_map: dict[str, str] = validated_config.get("mount_map") or {}
-        legacy_mount_options: dict[str, Any] = validated_config.get("mount_options") or {}
-        if legacy_mounts or legacy_mount_map or legacy_mount_options:
-            validated_config = _route_legacy_uuid_mounts(validated_config)
-            name_to_id = await self._resolve_legacy_name_mounts(
-                validated_config.get("mounts") or (),
-                validated_config.get("mount_map") or {},
-                validated_config.get("mount_options") or {},
-            )
-            validated_config = _merge_resolved_legacy_mounts(validated_config, name_to_id)
+        validated_config = await self._normalize_legacy_mounts(validated_config)
 
         agent_list = cast(list[str] | None, validated_config.get("agent_list"))
         if agent_list is not None:

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -1138,26 +1138,35 @@ class TestCreateFromParams:
         assert "mounts" not in passed_config
         assert "mount_map" not in passed_config
 
-    async def test_route_legacy_uuid_mounts(self) -> None:
-        """``_route_legacy_uuid_mounts`` lifts UUID-shaped strings out of the
-        legacy ``mounts`` / ``mount_map`` / ``mount_options`` buckets into the
-        UUID-keyed ``mount_ids`` / ``mount_id_map`` / ``mount_options``.
-        """
-        vfid = UUID("22222222-2222-2222-2222-222222222222")
-        vfid_str = str(vfid)
-        legacy_config: dict[str, Any] = {
+    @pytest.fixture
+    def legacy_uuid_mount_vfid(self) -> UUID:
+        return UUID("22222222-2222-2222-2222-222222222222")
+
+    @pytest.fixture
+    def legacy_uuid_mount_config(self, legacy_uuid_mount_vfid: UUID) -> dict[str, Any]:
+        vfid_str = str(legacy_uuid_mount_vfid)
+        return {
             "mounts": [vfid_str, "vf-named"],
             "mount_map": {vfid_str: "/data"},
             "mount_options": {vfid_str: {"permission": "ro"}},
         }
 
-        routed = _route_legacy_uuid_mounts(legacy_config)
+    async def test_route_legacy_uuid_mounts(
+        self,
+        legacy_uuid_mount_vfid: UUID,
+        legacy_uuid_mount_config: dict[str, Any],
+    ) -> None:
+        """``_route_legacy_uuid_mounts`` lifts UUID-shaped strings out of the
+        legacy ``mounts`` / ``mount_map`` / ``mount_options`` buckets into the
+        UUID-keyed ``mount_ids`` / ``mount_id_map`` / ``mount_options``.
+        """
+        routed = _route_legacy_uuid_mounts(legacy_uuid_mount_config)
 
         assert routed["mounts"] == ["vf-named"]
         assert routed["mount_map"] == {}
-        assert routed["mount_options"] == {vfid: {"permission": "ro"}}
-        assert routed["mount_ids"] == [vfid]
-        assert routed["mount_id_map"] == {vfid: "/data"}
+        assert routed["mount_options"] == {legacy_uuid_mount_vfid: {"permission": "ro"}}
+        assert routed["mount_ids"] == [legacy_uuid_mount_vfid]
+        assert routed["mount_id_map"] == {legacy_uuid_mount_vfid: "/data"}
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -33,9 +33,6 @@ from ai.backend.manager.api.rest.session.handler import (
 from ai.backend.manager.api.utils import undefined
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.data.user.types import SessionOwnerContext
-from ai.backend.manager.errors.api import (
-    InvalidAPIParameters as ManagerInvalidAPIParameters,
-)
 from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.image import UnknownImageReferenceError
 from ai.backend.manager.errors.kernel import (
@@ -1175,62 +1172,6 @@ class TestCreateFromParams:
         assert merged["mount_options"][vfid] == {"permission": "ro"}
         assert "mounts" not in merged
         assert "mount_map" not in merged
-
-    async def test_legacy_mounts_mixed_name_and_uuid(self) -> None:
-        """Names and UUID-strings can coexist in the legacy ``mounts`` list —
-        names go through the resolver, UUIDs bypass it.
-        """
-        name_vfid = UUID("33333333-3333-3333-3333-333333333333")
-        uuid_only_vfid = UUID("44444444-4444-4444-4444-444444444444")
-
-        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
-            assert list(action.vfolder_names) == ["vf-named"], (
-                "Only the name entry should reach the resolver"
-            )
-            return ResolveIdsByNamesActionResult(name_to_id={"vf-named": name_vfid})
-
-        resolver = MagicMock()
-        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
-        vfolder_pkg = MagicMock()
-        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
-        handler = SessionHandler.__new__(SessionHandler)
-        handler._vfolder = vfolder_pkg
-
-        legacy_config: dict[str, Any] = {
-            "mounts": ["vf-named", str(uuid_only_vfid)],
-            "mount_map": {"vf-named": "/named-dst", str(uuid_only_vfid): "/uuid-dst"},
-            "mount_options": {},
-        }
-        name_to_id = await handler._resolve_legacy_name_mounts(
-            legacy_config["mounts"],
-            legacy_config["mount_map"],
-            legacy_config["mount_options"],
-        )
-        merged = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
-
-        assert sorted(merged["mount_ids"], key=str) == sorted([name_vfid, uuid_only_vfid], key=str)
-        assert merged["mount_id_map"] == {
-            name_vfid: "/named-dst",
-            uuid_only_vfid: "/uuid-dst",
-        }
-
-    async def test_legacy_mounts_name_with_subpath_still_rejected(self) -> None:
-        """``name/subpath`` syntax stays rejected — name-shaped subpath inputs
-        cannot fit into the UUID-keyed buckets without losing the subpath.
-        """
-        resolver = MagicMock()
-        resolver.wait_for_complete = AsyncMock()
-        vfolder_pkg = MagicMock()
-        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
-        handler = SessionHandler.__new__(SessionHandler)
-        handler._vfolder = vfolder_pkg
-
-        with pytest.raises(ManagerInvalidAPIParameters, match="subpath syntax"):
-            await handler._resolve_legacy_name_mounts(
-                ["vf-a/.subdir"],
-                {},
-                {},
-            )
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -29,6 +29,7 @@ from ai.backend.common.types import (
 from ai.backend.manager.api.rest.session.handler import (
     SessionHandler,
     _merge_resolved_legacy_mounts,
+    _route_legacy_uuid_mounts,
 )
 from ai.backend.manager.api.utils import undefined
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
@@ -1137,41 +1138,26 @@ class TestCreateFromParams:
         assert "mounts" not in passed_config
         assert "mount_map" not in passed_config
 
-    async def test_legacy_mounts_uuid_string_routes_to_mount_ids(self) -> None:
-        """A UUID-shaped string in legacy ``mounts`` bypasses the name resolver
-        and lands in ``mount_ids`` / ``mount_id_map`` / ``mount_options`` keyed
-        by the parsed UUID.
+    async def test_route_legacy_uuid_mounts(self) -> None:
+        """``_route_legacy_uuid_mounts`` lifts UUID-shaped strings out of the
+        legacy ``mounts`` / ``mount_map`` / ``mount_options`` buckets into the
+        UUID-keyed ``mount_ids`` / ``mount_id_map`` / ``mount_options``.
         """
         vfid = UUID("22222222-2222-2222-2222-222222222222")
         vfid_str = str(vfid)
-
-        resolver = MagicMock()
-        resolver.wait_for_complete = AsyncMock(
-            side_effect=AssertionError("name resolver must not be called for UUIDs")
-        )
-        vfolder_pkg = MagicMock()
-        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
-        handler = SessionHandler.__new__(SessionHandler)
-        handler._vfolder = vfolder_pkg
-
         legacy_config: dict[str, Any] = {
-            "mounts": [vfid_str],
+            "mounts": [vfid_str, "vf-named"],
             "mount_map": {vfid_str: "/data"},
             "mount_options": {vfid_str: {"permission": "ro"}},
         }
-        name_to_id = await handler._resolve_legacy_name_mounts(
-            legacy_config["mounts"],
-            legacy_config["mount_map"],
-            legacy_config["mount_options"],
-        )
-        merged = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
 
-        assert name_to_id == {}
-        assert merged["mount_ids"] == [vfid]
-        assert merged["mount_id_map"] == {vfid: "/data"}
-        assert merged["mount_options"][vfid] == {"permission": "ro"}
-        assert "mounts" not in merged
-        assert "mount_map" not in merged
+        routed = _route_legacy_uuid_mounts(legacy_config)
+
+        assert routed["mounts"] == ["vf-named"]
+        assert routed["mount_map"] == {}
+        assert routed["mount_options"] == {vfid: {"permission": "ro"}}
+        assert routed["mount_ids"] == [vfid]
+        assert routed["mount_id_map"] == {vfid: "/data"}
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -33,6 +33,9 @@ from ai.backend.manager.api.rest.session.handler import (
 from ai.backend.manager.api.utils import undefined
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.data.user.types import SessionOwnerContext
+from ai.backend.manager.errors.api import (
+    InvalidAPIParameters as ManagerInvalidAPIParameters,
+)
 from ai.backend.manager.errors.common import ServiceUnavailable
 from ai.backend.manager.errors.image import UnknownImageReferenceError
 from ai.backend.manager.errors.kernel import (
@@ -1136,6 +1139,98 @@ class TestCreateFromParams:
         }
         assert "mounts" not in passed_config
         assert "mount_map" not in passed_config
+
+    async def test_legacy_mounts_uuid_string_routes_to_mount_ids(self) -> None:
+        """A UUID-shaped string in legacy ``mounts`` bypasses the name resolver
+        and lands in ``mount_ids`` / ``mount_id_map`` / ``mount_options`` keyed
+        by the parsed UUID.
+        """
+        vfid = UUID("22222222-2222-2222-2222-222222222222")
+        vfid_str = str(vfid)
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(
+            side_effect=AssertionError("name resolver must not be called for UUIDs")
+        )
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        legacy_config: dict[str, Any] = {
+            "mounts": [vfid_str],
+            "mount_map": {vfid_str: "/data"},
+            "mount_options": {vfid_str: {"permission": "ro"}},
+        }
+        name_to_id = await handler._resolve_legacy_name_mounts(
+            legacy_config["mounts"],
+            legacy_config["mount_map"],
+            legacy_config["mount_options"],
+        )
+        merged = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
+
+        assert name_to_id == {}
+        assert merged["mount_ids"] == [vfid]
+        assert merged["mount_id_map"] == {vfid: "/data"}
+        assert merged["mount_options"][vfid] == {"permission": "ro"}
+        assert "mounts" not in merged
+        assert "mount_map" not in merged
+
+    async def test_legacy_mounts_mixed_name_and_uuid(self) -> None:
+        """Names and UUID-strings can coexist in the legacy ``mounts`` list —
+        names go through the resolver, UUIDs bypass it.
+        """
+        name_vfid = UUID("33333333-3333-3333-3333-333333333333")
+        uuid_only_vfid = UUID("44444444-4444-4444-4444-444444444444")
+
+        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
+            assert list(action.vfolder_names) == ["vf-named"], (
+                "Only the name entry should reach the resolver"
+            )
+            return ResolveIdsByNamesActionResult(name_to_id={"vf-named": name_vfid})
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        legacy_config: dict[str, Any] = {
+            "mounts": ["vf-named", str(uuid_only_vfid)],
+            "mount_map": {"vf-named": "/named-dst", str(uuid_only_vfid): "/uuid-dst"},
+            "mount_options": {},
+        }
+        name_to_id = await handler._resolve_legacy_name_mounts(
+            legacy_config["mounts"],
+            legacy_config["mount_map"],
+            legacy_config["mount_options"],
+        )
+        merged = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
+
+        assert sorted(merged["mount_ids"], key=str) == sorted([name_vfid, uuid_only_vfid], key=str)
+        assert merged["mount_id_map"] == {
+            name_vfid: "/named-dst",
+            uuid_only_vfid: "/uuid-dst",
+        }
+
+    async def test_legacy_mounts_name_with_subpath_still_rejected(self) -> None:
+        """``name/subpath`` syntax stays rejected — name-shaped subpath inputs
+        cannot fit into the UUID-keyed buckets without losing the subpath.
+        """
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock()
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        with pytest.raises(ManagerInvalidAPIParameters, match="subpath syntax"):
+            await handler._resolve_legacy_name_mounts(
+                ["vf-a/.subdir"],
+                {},
+                {},
+            )
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,


### PR DESCRIPTION
## Summary
- Restores pre-sokovan behaviour where the deprecated `creation_config["mounts"]` field on REST v1 `POST /session/_/create` and `/_/create-from-template` accepted both vfolder names and UUID-shaped strings.
- After the sokovan refactor (8321c79aa) `_resolve_legacy_name_mounts` routed every entry through the name resolver, so a UUID-string input — including any `-v <vfolder-uuid>:/dst` from the v1 CLI, which forwards every `-v` source through this field without a UUID/name split — raised `VFolderNotFound`.
- `_resolve_legacy_name_mounts` now skips UUID-shaped keys, and `_merge_resolved_legacy_mounts` gains a second pass that routes those UUID-shaped entries from `mounts` / `mount_map` / `mount_options` into the UUID-keyed `mount_ids` / `mount_id_map` / `mount_options` buckets without overwriting explicit caller-supplied values.
- Subpath syntax (`name/subdir`, `<uuid>/subpath`) stays rejected — end-to-end subpath support needs a separate change that plumbs `vfsubpath` through `MountInfoEntry` / `VFolderMountRequest`.

Resolves BA-5980.