### PR TITLE
fix(BA-5981): normalize str start_command in model definition validators

### DIFF
--- a/changes/11525.fix.md
+++ b/changes/11525.fix.md
@@ -1,0 +1,1 @@
+Accept legacy str start_command in model definition by normalizing it to an argv list via shlex.split

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
@@ -14,6 +15,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
 )
 
 from . import validators as tx
@@ -143,6 +145,16 @@ agent_selector_globalconfig_iv = t.Dict({}).allow_extra("*")
 agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 
 
+def _normalize_start_command(value: Any) -> Any:
+    """Coerce legacy ``str`` ``start_command`` into argv list via
+    :func:`shlex.split`. Lists, ``None``, and other types pass through so
+    the schema's strict check rejects them.
+    """
+    if isinstance(value, str):
+        return shlex.split(value)
+    return value
+
+
 model_definition_iv = t.Dict({
     t.Key("models"): t.List(
         t.Dict({
@@ -159,7 +171,8 @@ model_definition_iv = t.Dict({
                         t.Key("args"): t.Dict().allow_extra("*"),
                     })
                 ),
-                t.Key("start_command", default=None): t.Null | t.List(t.String),
+                t.Key("start_command", default=None): (t.Null | t.String | t.List(t.String))
+                >> _normalize_start_command,
                 t.Key("shell", default="/bin/bash"): t.String,
                 t.Key("port"): t.ToInt[1:],
                 t.Key("health_check", default=None): t.Null
@@ -269,6 +282,11 @@ class ModelServiceConfig(BaseConfigModel):
         default=None,
         description="Health check configuration for the model service.",
     )
+
+    @field_validator("start_command", mode="before")
+    @classmethod
+    def _coerce_start_command(cls, value: Any) -> Any:
+        return _normalize_start_command(value)
 
 
 class ModelMetadata(BaseConfigModel):
@@ -534,6 +552,11 @@ class ModelServiceConfigDraft(BaseConfigModel):
     shell: str | None = None
     port: int | None = None
     health_check: ModelHealthCheckDraft | None = None
+
+    @field_validator("start_command", mode="before")
+    @classmethod
+    def _coerce_start_command(cls, value: Any) -> Any:
+        return _normalize_start_command(value)
 
     def to_resolved(self) -> ModelServiceConfig:
         if self.port is None:

--- a/tests/unit/common/test_config.py
+++ b/tests/unit/common/test_config.py
@@ -227,21 +227,6 @@ class TestModelConfigs:
         assert service.start_command is None
         assert service.port == 8000
 
-    def test_model_service_config_draft_rejects_string_start_command(self) -> None:
-        with pytest.raises(ValueError):
-            ModelDefinitionDraft.model_validate({
-                "models": [
-                    {
-                        "name": "demo",
-                        "model_path": "/models/demo",
-                        "service": {
-                            "start_command": "python serve.py",
-                            "port": 8000,
-                        },
-                    }
-                ]
-            })
-
     def test_to_resolved_substitutes_model_path_placeholder(self) -> None:
         # The variant baseline keeps ``{model_path}`` so a single fixture
         # entry covers any mount destination; the placeholder is resolved

--- a/tests/unit/manager/data/deployment/test_model_definition_start_command_compat.py
+++ b/tests/unit/manager/data/deployment/test_model_definition_start_command_compat.py
@@ -1,0 +1,147 @@
+"""Unit tests for ``start_command`` input compatibility (str → list[str]) in
+``model_definition`` validators.
+
+PR #11402 narrowed ``ModelServiceConfig.start_command`` from
+``str | list[str]`` to ``list[str] | None``. To preserve backward
+compatibility for users who still author the field as a shell string,
+the validators normalize ``str`` input via :func:`shlex.split`.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+
+import pytest
+from ruamel.yaml import YAML
+from sqlalchemy.engine.default import DefaultDialect
+
+from ai.backend.common.config import (
+    ModelDefinition,
+    ModelServiceConfigDraft,
+    model_definition_iv,
+)
+from ai.backend.manager.models.base import PydanticColumn
+
+START_COMMAND_CASES = [
+    pytest.param(
+        "python service.py",
+        ["python", "service.py"],
+        id="simple-split",
+    ),
+    pytest.param(
+        'python -c "import x; x.run()"',
+        ["python", "-c", "import x; x.run()"],
+        id="shlex-preserves-quoted",
+    ),
+]
+
+
+def _wrap_definition(start_command: str) -> dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "model",
+                "model_path": "/models/x",
+                "service": {
+                    "start_command": start_command,
+                    "port": 8080,
+                },
+            }
+        ]
+    }
+
+
+class TestPydanticInputCompat:
+    """REST/GQL input → ``ModelServiceConfigDraft`` Pydantic validator."""
+
+    @pytest.mark.parametrize(("raw", "expected"), START_COMMAND_CASES)
+    def test_str_input_is_normalized(self, raw: str, expected: list[str]) -> None:
+        draft = ModelServiceConfigDraft.model_validate({
+            "start_command": raw,
+            "port": 8080,
+        })
+        assert draft.start_command == expected
+
+
+class TestTrafaretInputCompat:
+    """vfolder YAML scan → ``model_definition_iv`` trafaret validator."""
+
+    @pytest.mark.parametrize(("raw", "expected"), START_COMMAND_CASES)
+    def test_str_input_is_normalized(self, raw: str, expected: list[str]) -> None:
+        result = model_definition_iv.check(_wrap_definition(raw))
+        assert result["models"][0]["service"]["start_command"] == expected
+
+
+class TestYAMLInputCompat:
+    """End-to-end vfolder scan path: a user-authored ``model-definition.yaml``
+    is parsed by ruamel.yaml and fed to ``model_definition_iv``. Confirms that
+    every YAML notation a user might write — legacy shell string, inline flow
+    sequence, hyphenated block sequence — resolves to the same canonical
+    ``list[str]``.
+    """
+
+    @pytest.mark.parametrize(
+        ("yaml_text", "expected"),
+        [
+            pytest.param(
+                textwrap.dedent("""\
+                    models:
+                    - name: model
+                      model_path: /models/x
+                      service:
+                        start_command: python service.py
+                        port: 8080
+                """),
+                ["python", "service.py"],
+                id="legacy-shell-string",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    models:
+                    - name: model
+                      model_path: /models/x
+                      service:
+                        start_command: ["/bin/bash", "/models/start.sh"]
+                        port: 8080
+                """),
+                ["/bin/bash", "/models/start.sh"],
+                id="flow-sequence",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    models:
+                    - name: model
+                      model_path: /models/x
+                      service:
+                        start_command:
+                        - /bin/bash
+                        - /models/start.sh
+                        port: 8080
+                """),
+                ["/bin/bash", "/models/start.sh"],
+                id="block-sequence",
+            ),
+        ],
+    )
+    def test_yaml_forms_are_normalized(self, yaml_text: str, expected: list[str]) -> None:
+        loaded = YAML().load(yaml_text)
+        result = model_definition_iv.check(loaded)
+        assert result["models"][0]["service"]["start_command"] == expected
+
+
+class TestPydanticColumnReadCompat:
+    """DB read path → ``PydanticColumn(ModelDefinition).process_result_value``.
+
+    Downstream ``Row.to_data`` only forwards ``self.model_definition`` to the
+    output dataclass, so verifying the resolved object here covers the
+    read → to_data flow.
+    """
+
+    @pytest.mark.parametrize(("raw", "expected"), START_COMMAND_CASES)
+    def test_legacy_str_is_normalized(self, raw: str, expected: list[str]) -> None:
+        column = PydanticColumn(ModelDefinition)
+        resolved = column.process_result_value(_wrap_definition(raw), DefaultDialect())
+        assert resolved is not None
+        assert resolved.models[0].service is not None
+        assert resolved.models[0].service.start_command == expected


### PR DESCRIPTION
## Summary

PR #11402 narrowed `ModelServiceConfig.start_command` from `str | list[str]` to `list[str] | None`, but users still author the field as a single shell string in `model-definition.yaml` ("python service.py"). The narrowed schema rejects those inputs at validation, regressing user compatibility.

This change preserves the `list[str] | None` annotation while letting validators coerce legacy `str` input via `shlex.split`:

- Pydantic `ModelServiceConfig` / `ModelServiceConfigDraft`: `@field_validator("start_command", mode="before")`
- trafaret `model_definition_iv`: `(t.Null | t.String | t.List(t.String)) >> _normalize_start_command`

`shlex.split` is chosen over `str.split` so quoted argv tokens (`'python -c "import x; x.run()"'`) keep their boundaries.

The DB read path is automatically covered: `PydanticColumn(ModelDefinition)` / `PydanticColumn(ModelDefinitionDraft)` deserialize JSONB via `model_validate`, which triggers the same `field_validator`. No write-side migration is needed (#11446, #11497 already canonicalized stored data).

## Test plan

New unit tests in `tests/unit/manager/data/deployment/test_model_definition_start_command_compat.py` covering each entry point:

- [x] `TestPydanticInputCompat` — REST/GQL DTO → `ModelServiceConfigDraft.model_validate`
- [x] `TestTrafaretInputCompat` — vfolder dict → `model_definition_iv.check`
- [x] `TestYAMLInputCompat` — end-to-end ruamel.yaml parsing for legacy shell-string / flow sequence / hyphenated block sequence
- [x] `TestPydanticColumnReadCompat` — DB read via `PydanticColumn.process_result_value` (covers `Row.to_data` since `to_data` only forwards `self.model_definition`)

Also drops the now-obsolete `test_model_service_config_draft_rejects_string_start_command` regression test from `tests/unit/common/test_config.py` — it asserted exactly the behavior this PR intentionally reverses.

Resolves BA-5981