### PR TITLE
feat: Restore per-mount source-subpath on the UUID-keyed mount contract

### DIFF
--- a/changes/11526.feature.md
+++ b/changes/11526.feature.md
@@ -1,0 +1,1 @@
+Restore per-mount source-subpath on the UUID-keyed mount contract: `MountInfoEntry` now carries `source_subpath`, `CreationConfigV7` accepts `mount_id_subpaths`, and the legacy `mounts=["name/subdir"]` form is resolved through the new field instead of being rejected.

--- a/src/ai/backend/common/dto/manager/session/types.py
+++ b/src/ai/backend/common/dto/manager/session/types.py
@@ -431,6 +431,16 @@ class CreationConfigV7(BaseFieldModel):
         default=None,
         validation_alias=AliasChoices("mount_id_map", "mountIdMap"),
     )
+    mount_id_subpaths: dict[UUID, str] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("mount_id_subpaths", "mountIdSubpaths"),
+        description=(
+            "Per-mount source-subpath keyed by vfolder UUID. ``None`` (the default) "
+            "and missing entries mean 'mount the vfolder root'; a non-empty value "
+            "mounts that subdirectory of the vfolder at the corresponding "
+            "``mount_id_map`` destination."
+        ),
+    )
     mount_options: dict[str, MountOption] | None = Field(
         default=None,
         validation_alias=AliasChoices("mount_options", "mountOptions"),

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -655,7 +655,7 @@ MountPermissionLiteral = Literal["ro", "rw", "wd"]
 class MountInfoEntry(BaseModel):
     """Revision-stored form of a user-supplied extra mount.
 
-    The row column persists only these three fields; everything else
+    The row column persists only these four fields; everything else
     (``name``, ``vfsubpath``, ``host_path``, ``usage_mode``) that
     ``VFolderMount`` carries is re-derived at session creation via
     ``prepare_vfolder_mounts``, so storing it would just be dead weight.
@@ -673,6 +673,14 @@ class MountInfoEntry(BaseModel):
     and is frozen onto deployment revision rows so later vfolder
     permission changes cannot retroactively alter already-spawned
     sessions.
+
+    ``source_subpath`` is ``None`` (the default) when the caller wants to
+    mount the vfolder root — :func:`prepare_vfolder_mounts` then resolves
+    the mount source to ``"."``. A non-empty value pins the mount source to
+    that subdirectory of the vfolder; the storage proxy exposes the
+    requested subdirectory as the bind-mount source via ``vfsubpath``.
+    Rows persisted before this field existed deserialize cleanly thanks to
+    the default.
     """
 
     vfolder_id: VFolderUUID
@@ -681,6 +689,7 @@ class MountInfoEntry(BaseModel):
         default=None,
     )
     mount_perm: MountPermission | None = Field(default=None)
+    source_subpath: str | None = Field(default=None)
 
 
 class MountTypes(enum.StrEnum):
@@ -701,10 +710,21 @@ class VFolderMountOptions:
 
 @attrs.define(slots=True)
 class VFolderMountRequest:
-    """A single vfolder mount request combining reference, destination path, and options."""
+    """A single vfolder mount request combining reference, destination path, and options.
+
+    ``subpath`` is the explicit per-mount source-subpath: when set, the
+    mount source becomes ``<vfolder>/<subpath>`` instead of the vfolder
+    root. It is the typed equivalent of the legacy string-form
+    ``ref="name/subpath"`` and the only way to express a subpath when
+    ``ref`` is a :class:`uuid.UUID`. ``None`` (the default) keeps the
+    historical "mount root" behavior. The two carriers must not be mixed:
+    ``ref`` of the form ``"name/subdir"`` already implies a subpath, so
+    callers should pick exactly one form.
+    """
 
     ref: str | uuid.UUID  # vfolder name (with optional /subpath) or UUID
     dst_path: str | None = None  # custom mount destination path
+    subpath: str | None = None  # explicit source subpath relative to vfolder root
     options: VFolderMountOptions = attrs.Factory(VFolderMountOptions)
 
 

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -328,9 +328,7 @@ def _merge_resolved_legacy_mounts(
         except (ValueError, TypeError):
             continue
     merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
-    merged_mount_id_subpaths: dict[Any, str] = dict(
-        creation_config.get("mount_id_subpaths") or {}
-    )
+    merged_mount_id_subpaths: dict[Any, str] = dict(creation_config.get("mount_id_subpaths") or {})
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -282,9 +282,25 @@ def _route_legacy_uuid_mounts(creation_config: dict[str, Any]) -> dict[str, Any]
     return next_config
 
 
+def _split_legacy_name_subpath(raw: str) -> tuple[str, str | None]:
+    """Split a legacy ``mounts``-style entry of the form ``"name"`` or
+    ``"name/subpath"`` into a ``(name, subpath)`` pair.
+
+    Returns ``subpath=None`` when the entry has no ``/``; a non-empty
+    string otherwise (the ``name/`` form with an empty trailing segment
+    is treated as no-subpath, mirroring the historical behavior of
+    :func:`prepare_vfolder_mounts`'s string-form ``ref`` parser).
+    """
+    name, sep, subpath = raw.partition("/")
+    if not sep or not subpath:
+        return name, None
+    return name, subpath
+
+
 def _merge_resolved_legacy_mounts(
     creation_config: dict[str, Any],
     name_to_id: dict[str, UUID],
+    name_to_subpath: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Merge a ``name → UUID`` resolution into the UUID-keyed buckets of
     ``creation_config`` and drop the now-resolved name-keyed legacy keys.
@@ -293,9 +309,16 @@ def _merge_resolved_legacy_mounts(
     and entries from the name-keyed ``mount_map`` / ``mount_options``
     dicts are re-keyed onto the resolved UUIDs without overwriting an
     explicit UUID-keyed entry the caller already supplied.
+
+    ``name_to_subpath`` carries any per-name source-subpath extracted from
+    legacy ``mounts=["name/subdir"]`` entries; the resolved subpath is
+    forwarded onto ``mount_id_subpaths`` keyed by the corresponding UUID,
+    again without overwriting an existing UUID-keyed value.
     """
     if not name_to_id:
         return creation_config
+
+    name_to_subpath = name_to_subpath or {}
 
     merged_mount_ids: list[Any] = list(creation_config.get("mount_ids") or [])
     existing_uuid_set: set[UUID] = set()
@@ -305,6 +328,9 @@ def _merge_resolved_legacy_mounts(
         except (ValueError, TypeError):
             continue
     merged_mount_id_map: dict[Any, str] = dict(creation_config.get("mount_id_map") or {})
+    merged_mount_id_subpaths: dict[Any, str] = dict(
+        creation_config.get("mount_id_subpaths") or {}
+    )
     merged_mount_options: dict[Any, Any] = dict(creation_config.get("mount_options") or {})
     legacy_mount_map = creation_config.get("mount_map") or {}
     legacy_mount_options = creation_config.get("mount_options") or {}
@@ -317,10 +343,13 @@ def _merge_resolved_legacy_mounts(
             merged_mount_id_map[vfid] = dst
         if (opts := legacy_mount_options.get(name)) and vfid not in merged_mount_options:
             merged_mount_options[vfid] = opts
+        if (subpath := name_to_subpath.get(name)) and vfid not in merged_mount_id_subpaths:
+            merged_mount_id_subpaths[vfid] = subpath
 
     next_config = dict(creation_config)
     next_config["mount_ids"] = merged_mount_ids
     next_config["mount_id_map"] = merged_mount_id_map
+    next_config["mount_id_subpaths"] = merged_mount_id_subpaths
     next_config["mount_options"] = merged_mount_options
     next_config.pop("mounts", None)
     next_config.pop("mount_map", None)
@@ -349,7 +378,9 @@ class SessionHandler:
         """One-stop processor for the legacy ``mounts`` / ``mount_map`` /
         ``mount_options`` surfaces: route UUID-shaped entries onto the
         UUID-keyed buckets, then resolve any remaining names to UUIDs and
-        merge the resolution back in.
+        merge the resolution back in. Legacy ``mounts=["name/subdir"]``
+        entries are split into a ``(name, subpath)`` pair here; the
+        resolved UUID + subpath is forwarded onto ``mount_id_subpaths``.
         """
         legacy_mounts = validated_config.get("mounts") or ()
         legacy_mount_map = validated_config.get("mount_map") or {}
@@ -357,21 +388,21 @@ class SessionHandler:
         if not (legacy_mounts or legacy_mount_map or legacy_mount_options):
             return validated_config
         validated_config = _route_legacy_uuid_mounts(validated_config)
-        name_to_id = await self._resolve_legacy_name_mounts(
+        name_to_id, name_to_subpath = await self._resolve_legacy_name_mounts(
             validated_config.get("mounts") or (),
             validated_config.get("mount_map") or {},
             validated_config.get("mount_options") or {},
         )
-        return _merge_resolved_legacy_mounts(validated_config, name_to_id)
+        return _merge_resolved_legacy_mounts(validated_config, name_to_id, name_to_subpath)
 
     async def _resolve_legacy_name_mounts(
         self,
         mounts: Sequence[str],
         mount_map: Mapping[str, str],
         mount_options: Mapping[str, Any],
-    ) -> dict[str, UUID]:
+    ) -> tuple[dict[str, UUID], dict[str, str]]:
         """Resolve legacy v1 CLI name-keyed mount surfaces into a unified
-        ``name → UUID`` mapping.
+        ``name → UUID`` mapping plus an extracted ``name → subpath`` mapping.
 
         ``mounts`` (list of names), ``mount_map`` (dict keyed by name), and
         ``mount_options`` (dict keyed by name) are all name-based legacy
@@ -380,32 +411,40 @@ class SessionHandler:
         ``mount_map`` or ``mount_options`` is not silently dropped
         downstream.
 
-        Subpath syntax (``name/subdir``) is rejected here because
-        :class:`MountInfoEntry` carries no subpath field; silently dropping
-        it would mount the wrong directory. Subpath mounts must use the
-        UUID-keyed surface where the storage proxy handles vfsubpath
-        separately.
+        ``mounts`` entries of the form ``"name/subdir"`` are split: the
+        bare ``name`` is what gets resolved, and ``subdir`` is captured
+        into the second return value so the caller can forward it onto
+        ``mount_id_subpaths``. ``MountInfoEntry`` now carries
+        ``source_subpath`` end-to-end, so the legacy form no longer needs
+        to be rejected.
 
         Merging the resolved ids/maps back into ``creation_config`` is the
         caller's responsibility — see :func:`_merge_resolved_legacy_mounts`.
         """
         if not mounts and not mount_map and not mount_options:
-            return {}
-
-        subpath_entries = [m for m in mounts if "/" in str(m)]
-        if subpath_entries:
-            raise InvalidAPIParameters(
-                "Legacy 'mounts' field with subpath syntax "
-                f"({subpath_entries}) is not supported. "
-                "Use UUID-keyed 'mount_ids' / 'mount_id_map' instead."
-            )
+            return {}, {}
 
         names_to_resolve: list[str] = []
         seen: set[str] = set()
+        name_to_subpath: dict[str, str] = {}
 
-        # ``mounts`` and ``mount_map`` are strictly name-keyed legacy
-        # surfaces — every entry is treated as a vfolder name.
-        for raw in list(mounts) + list(mount_map.keys()):
+        # ``mounts`` is name-keyed and may carry a per-entry subpath as
+        # ``"name/subdir"``; split before queueing the bare name for
+        # resolution. ``mount_map`` keys are also strictly name-keyed
+        # legacy surfaces — every entry is treated as a vfolder name.
+        for raw in mounts:
+            entry = str(raw)
+            name, subpath = _split_legacy_name_subpath(entry)
+            if subpath is not None:
+                # Last write wins on conflicting per-name subpaths; the
+                # historical CLI never produces such input, and downstream
+                # ``prepare_vfolder_mounts`` deduplicates by ``(vfid, vfsubpath)``.
+                name_to_subpath[name] = subpath
+            if name in seen:
+                continue
+            seen.add(name)
+            names_to_resolve.append(name)
+        for raw in mount_map.keys():
             name = str(raw)
             if name in seen:
                 continue
@@ -429,12 +468,12 @@ class SessionHandler:
             names_to_resolve.append(name)
 
         if not names_to_resolve:
-            return {}
+            return {}, name_to_subpath
 
         result = await self._vfolder.resolve_vfolder_ids_by_names.wait_for_complete(
             ResolveIdsByNamesAction(vfolder_names=names_to_resolve)
         )
-        return dict(result.name_to_id)
+        return dict(result.name_to_id), name_to_subpath
 
     # ------------------------------------------------------------------
     # create_from_template (POST /_/create-from-template)

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -913,11 +913,20 @@ async def prepare_vfolder_mounts(
     requested_mount_name_map: dict[str, str] = {}
     requested_mount_map: dict[uuid.UUID, str] = {}
     requested_mount_options: dict[str | uuid.UUID, VFolderMountOptions] = {}
+    # Explicit per-mount source-subpaths supplied by UUID-keyed callers via
+    # ``VFolderMountRequest.subpath``. ``None`` (absent key) keeps the
+    # historical "mount root" default; a non-empty value pins the mount
+    # source to ``<vfolder>/<subpath>``. The string-form ``ref="name/sub"``
+    # path populates ``requested_vfolder_subpaths`` directly below and so
+    # never reaches this dict.
+    requested_uuid_subpaths: dict[uuid.UUID, str] = {}
 
     for req in mount_requests:
         if isinstance(req.ref, uuid.UUID):
             if req.dst_path is not None:
                 requested_mount_map[req.ref] = req.dst_path
+            if req.subpath is not None and req.subpath != "":
+                requested_uuid_subpaths[req.ref] = os.path.normpath(req.subpath)
             requested_mount_options[req.ref] = req.options
         else:
             requested_mounts.append(req.ref)
@@ -937,6 +946,8 @@ async def prepare_vfolder_mounts(
         key = req.ref
         if isinstance(key, uuid.UUID):
             requested_vfolder_ids.add(key)
+            if (uuid_subpath := requested_uuid_subpaths.get(key)) is not None:
+                requested_vfolder_subpaths[key] = uuid_subpath
             continue
         name, _, subpath = key.partition("/")
         if not PurePosixPath(os.path.normpath(key)).is_relative_to(name):
@@ -947,7 +958,7 @@ async def prepare_vfolder_mounts(
         requested_vfolder_subpaths[key] = os.path.normpath(subpath)
         _already_resolved.add(name)
     for vfolder_uuid, value in requested_mount_map.items():
-        requested_vfolder_subpaths[vfolder_uuid] = "."
+        requested_vfolder_subpaths.setdefault(vfolder_uuid, ".")
         requested_vfolder_dstpaths[vfolder_uuid] = value
     for key, value in requested_mount_name_map.items():
         requested_vfolder_dstpaths[key] = value
@@ -1015,7 +1026,10 @@ async def prepare_vfolder_mounts(
         name = row["name"]
         if vfid in requested_vfolder_ids:
             requested_vfolder_names[vfid] = name
-            requested_vfolder_subpaths[vfid] = "."
+            # Don't clobber an explicit per-mount subpath — only fill in
+            # the historical "." default for UUID-keyed requests that did
+            # not supply one.
+            requested_vfolder_subpaths.setdefault(vfid, ".")
         if name in _already_resolved:
             continue
         if name not in requested_names:

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -224,14 +224,19 @@ class AgentRegistry:
         """Project legacy ``creation_config`` mount dict keys into typed
         :class:`MountInfoEntry` tuples.
 
-        Reads UUID-keyed ``mount_ids`` / ``mount_id_map`` / ``mount_options``
-        (modern v1 session-service path). Name-keyed ``mounts`` entries
-        are not handled here — :class:`SessionService` resolves those into
-        the UUID-keyed buckets upstream before any code in this module
-        runs.
+        Reads UUID-keyed ``mount_ids`` / ``mount_id_map`` /
+        ``mount_id_subpaths`` / ``mount_options`` (modern v1 session-service
+        path). Name-keyed ``mounts`` entries are not handled here —
+        :class:`SessionService` resolves those into the UUID-keyed buckets
+        upstream before any code in this module runs. ``mount_id_subpaths``
+        and ``mount_options`` are read with the same UUID-vs-UUID-string-key
+        polymorphism as ``mount_id_map``: callers wiring them up from JSON
+        may have either form depending on whether the value was decoded by
+        Pydantic (UUID keys) or pulled out of a raw dict (string keys).
         """
         mount_ids = creation_config.get("mount_ids") or []
         mount_id_map: Mapping[Any, str] = creation_config.get("mount_id_map") or {}
+        mount_id_subpaths: Mapping[Any, str] = creation_config.get("mount_id_subpaths") or {}
         mount_options: Mapping[Any, Mapping[str, Any]] = creation_config.get("mount_options") or {}
 
         entries: list[MountInfoEntry] = []
@@ -251,11 +256,16 @@ class AgentRegistry:
                 except ValueError:
                     perm = None
             dst_path = mount_id_map.get(vfolder_uuid) or mount_id_map.get(raw_id)
+            subpath_raw = mount_id_subpaths.get(vfolder_uuid) or mount_id_subpaths.get(raw_id)
+            source_subpath: str | None = None
+            if isinstance(subpath_raw, str) and subpath_raw:
+                source_subpath = subpath_raw
             entries.append(
                 MountInfoEntry(
                     vfolder_id=VFolderUUID(vfolder_uuid),
                     mount_destination=dst_path,
                     mount_perm=perm,
+                    source_subpath=source_subpath,
                 )
             )
         return tuple(entries)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -245,7 +245,19 @@ class AgentRegistry:
                 vfolder_uuid = uuid.UUID(str(raw_id))
             except (ValueError, TypeError):
                 continue
-            opts = mount_options.get(raw_id) or mount_options.get(vfolder_uuid) or {}
+            uuid_str = str(vfolder_uuid)
+
+            def _lookup(d: Mapping[Any, Any]) -> Any:
+                # Polymorphic key lookup: accept the UUID, the original
+                # ``raw_id`` (could be a UUID or a UUID-string from the
+                # validator), and the canonical UUID-string form.
+                if (val := d.get(vfolder_uuid)) is not None:
+                    return val
+                if (val := d.get(raw_id)) is not None:
+                    return val
+                return d.get(uuid_str)
+
+            opts = _lookup(mount_options) or {}
             raw_perm = opts.get("permission")
             perm: MountPermission | None = None
             if isinstance(raw_perm, MountPermission):
@@ -255,8 +267,8 @@ class AgentRegistry:
                     perm = MountPermission(raw_perm)
                 except ValueError:
                     perm = None
-            dst_path = mount_id_map.get(vfolder_uuid) or mount_id_map.get(raw_id)
-            subpath_raw = mount_id_subpaths.get(vfolder_uuid) or mount_id_subpaths.get(raw_id)
+            dst_path = _lookup(mount_id_map)
+            subpath_raw = _lookup(mount_id_subpaths)
             source_subpath: str | None = None
             if isinstance(subpath_raw, str) and subpath_raw:
                 source_subpath = subpath_raw

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -1575,6 +1575,7 @@ class ScheduleDBSource:
                             VFolderMountRequest(
                                 ref=UUID(str(entry.vfolder_id)),
                                 dst_path=entry.mount_destination,
+                                subpath=entry.source_subpath,
                                 options=VFolderMountOptions(permission=entry.mount_perm),
                             )
                         )

--- a/tests/unit/common/dto/manager/session/test_types.py
+++ b/tests/unit/common/dto/manager/session/test_types.py
@@ -188,6 +188,21 @@ class TestCreationConfigV7:
         assert cfg.mounts == ["/old-data"]
         assert cfg.mount_map == {"old": "/path"}
 
+    def test_mount_id_subpaths_default_none(self) -> None:
+        cfg = CreationConfigV7.model_validate({})
+        assert cfg.mount_id_subpaths is None
+
+    def test_mount_id_subpaths_round_trips_uuid_keys(self) -> None:
+        """BA-5959: ``mount_id_subpaths`` accepts both snake_case and
+        camelCase aliases and round-trips UUID-string keys into UUIDs."""
+        mount_id = uuid4()
+        cfg = CreationConfigV7.model_validate({
+            "mount_ids": [str(mount_id)],
+            "mountIdSubpaths": {str(mount_id): ".pipeline"},
+        })
+        assert cfg.mount_id_subpaths is not None
+        assert cfg.mount_id_subpaths[mount_id] == ".pipeline"
+
 
 class TestTimeoutSeconds:
     def setup_method(self) -> None:

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -16,11 +16,14 @@ import pytest
 from dateutil.tz import tzutc
 
 from ai.backend.common.exception import InvalidAPIParameters, UnknownImageReference
+from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     AbuseReport,
     AccessKey,
     ClusterMode,
     KernelId,
+    MountInfoEntry,
+    MountPermission,
     ResourceSlot,
     SessionId,
     SessionResult,
@@ -1072,9 +1075,7 @@ class TestCreateFromParams:
             legacy_config["mount_map"],
             legacy_config["mount_options"],
         )
-        resolved_config = _merge_resolved_legacy_mounts(
-            legacy_config, name_to_id, name_to_subpath
-        )
+        resolved_config = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
 
         # Step 2: feed the resolved config to the service and verify it
         # arrives at AgentRegistry.create_session intact.
@@ -1169,6 +1170,121 @@ class TestCreateFromParams:
         assert routed["mount_options"] == {legacy_uuid_mount_vfid: {"permission": "ro"}}
         assert routed["mount_ids"] == [legacy_uuid_mount_vfid]
         assert routed["mount_id_map"] == {legacy_uuid_mount_vfid: "/data"}
+
+    async def test_legacy_mounts_with_subpath_resolves_into_mount_id_subpaths(
+        self,
+    ) -> None:
+        """BA-5959: ``mounts=["name/subpath"]`` is no longer rejected.
+
+        The bare name resolves to a UUID, the subpath is captured into
+        ``name_to_subpath``, and ``_merge_resolved_legacy_mounts`` forwards
+        it onto ``mount_id_subpaths`` keyed by the resolved UUID.
+        """
+        vfid = UUID("33333333-3333-3333-3333-333333333333")
+
+        async def _wait_for_complete(action: Any) -> ResolveIdsByNamesActionResult:
+            # Only the bare ``vf-a`` should reach the resolver — not
+            # ``vf-a/.pipeline``.
+            assert list(action.vfolder_names) == ["vf-a"]
+            return ResolveIdsByNamesActionResult(name_to_id={"vf-a": vfid})
+
+        resolver = MagicMock()
+        resolver.wait_for_complete = AsyncMock(side_effect=_wait_for_complete)
+        vfolder_pkg = MagicMock()
+        vfolder_pkg.resolve_vfolder_ids_by_names = resolver
+        handler = SessionHandler.__new__(SessionHandler)
+        handler._vfolder = vfolder_pkg
+
+        legacy_config: dict[str, Any] = {
+            "mounts": ["vf-a/.pipeline"],
+            "mount_map": {},
+            "mount_options": {},
+        }
+        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
+            legacy_config["mounts"],
+            legacy_config["mount_map"],
+            legacy_config["mount_options"],
+        )
+        assert name_to_id == {"vf-a": vfid}
+        assert name_to_subpath == {"vf-a": ".pipeline"}
+
+        merged = _merge_resolved_legacy_mounts(legacy_config, name_to_id, name_to_subpath)
+        assert merged["mount_ids"] == [vfid]
+        assert merged["mount_id_subpaths"] == {vfid: ".pipeline"}
+        assert "mounts" not in merged
+
+    async def test_mount_id_subpaths_round_trips_through_registry_projection(
+        self,
+    ) -> None:
+        """BA-5959: ``mount_id_subpaths`` from the wire surfaces as
+        ``MountInfoEntry.source_subpath`` on the projected entry, while
+        a missing key keeps ``source_subpath`` as ``None``.
+        """
+        vfid_with_sub = UUID("44444444-4444-4444-4444-444444444444")
+        vfid_no_sub = UUID("55555555-5555-5555-5555-555555555555")
+
+        creation_config: dict[str, Any] = {
+            "mount_ids": [vfid_with_sub, vfid_no_sub],
+            "mount_id_map": {vfid_with_sub: "/data"},
+            "mount_id_subpaths": {vfid_with_sub: ".pipeline"},
+            "mount_options": {vfid_with_sub: {"permission": "ro"}},
+        }
+
+        entries = AgentRegistry._mount_entries_from_creation_config(creation_config)
+        assert len(entries) == 2
+        by_id = {entry.vfolder_id: entry for entry in entries}
+        key_with_sub = VFolderUUID(vfid_with_sub)
+        key_no_sub = VFolderUUID(vfid_no_sub)
+        assert by_id[key_with_sub].source_subpath == ".pipeline"
+        assert by_id[key_with_sub].mount_destination == "/data"
+        assert by_id[key_with_sub].mount_perm == MountPermission.READ_ONLY
+        assert by_id[key_no_sub].source_subpath is None
+        assert by_id[key_no_sub].mount_destination is None
+
+    async def test_mount_id_subpaths_accepts_uuid_string_keys(self) -> None:
+        """BA-5959: callers wiring ``mount_id_subpaths`` from a raw dict
+        may pass UUID-string keys; the registry projection accepts both
+        forms (mirroring ``mount_id_map`` / ``mount_options``).
+        """
+        vfid = UUID("66666666-6666-6666-6666-666666666666")
+        creation_config: dict[str, Any] = {
+            "mount_ids": [vfid],
+            "mount_id_subpaths": {str(vfid): ".scratch"},
+        }
+        entries = AgentRegistry._mount_entries_from_creation_config(creation_config)
+        assert len(entries) == 1
+        assert entries[0].source_subpath == ".scratch"
+
+    async def test_mount_info_entry_persistence_round_trip_preserves_subpath(
+        self,
+    ) -> None:
+        """BA-5959: a ``MountInfoEntry`` round-trips ``source_subpath``
+        through the JSONB-backed deployment-revision serialization, and a
+        legacy persisted shape (no ``source_subpath`` key) still
+        deserializes — the new field defaults to ``None``.
+        """
+        vfid = UUID("77777777-7777-7777-7777-777777777777")
+        entry = MountInfoEntry(
+            vfolder_id=VFolderUUID(vfid),
+            mount_destination="/data",
+            mount_perm=MountPermission.READ_WRITE,
+            source_subpath=".pipeline",
+        )
+        # ``PydanticListColumn`` calls ``model_dump(mode="json")`` and
+        # later ``model_validate``; emulate that round-trip directly.
+        dumped = entry.model_dump(mode="json")
+        assert dumped["source_subpath"] == ".pipeline"
+        roundtripped = MountInfoEntry.model_validate(dumped)
+        assert roundtripped.source_subpath == ".pipeline"
+
+        # Legacy rows persisted before the new field exists.
+        legacy_dumped = {
+            "vfolder_id": str(vfid),
+            "mount_destination": "/data",
+            "mount_perm": "rw",
+        }
+        legacy_loaded = MountInfoEntry.model_validate(legacy_dumped)
+        assert legacy_loaded.source_subpath is None
 
     async def test_owner_access_key_uses_owner_user_scope(
         self,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -1067,12 +1067,14 @@ class TestCreateFromParams:
             "mount_map": {"vf-a": "/data"},
             "mount_options": {"vf-a": {"permission": "ro", "type": "bind"}},
         }
-        name_to_id = await handler._resolve_legacy_name_mounts(
+        name_to_id, name_to_subpath = await handler._resolve_legacy_name_mounts(
             legacy_config["mounts"],
             legacy_config["mount_map"],
             legacy_config["mount_options"],
         )
-        resolved_config = _merge_resolved_legacy_mounts(legacy_config, name_to_id)
+        resolved_config = _merge_resolved_legacy_mounts(
+            legacy_config, name_to_id, name_to_subpath
+        )
 
         # Step 2: feed the resolved config to the service and verify it
         # arrives at AgentRegistry.create_session intact.


### PR DESCRIPTION
## Summary

Closes #11526.

The UUID-keyed mount contract introduced in #11434 / #11520 dropped the per-mount source-subpath, leaving callers no way to express "mount the `<X>` subdirectory of vfolder `<Y>`" through any session-creation surface. This PR restores that capability end-to-end:

- `MountInfoEntry` gains a `source_subpath: str | None = None` field. `None` (the default) keeps the historical "mount the vfolder root" behavior, and pre-existing persisted rows deserialize cleanly through Pydantic's default.
- `VFolderMountRequest` gains a parallel `subpath: str | None = None` so the typed UUID-keyed surface can express a subpath without falling back to the legacy string-form `ref="name/subpath"`.
- `CreationConfigV7` exposes `mount_id_subpaths: dict[UUID, str] | None` (with a `mountIdSubpaths` camelCase alias). `AgentRegistry._mount_entries_from_creation_config` reads it with the same UUID/UUID-string-key polymorphism already used for `mount_id_map` / `mount_options` and projects the value onto each emitted `MountInfoEntry.source_subpath`.
- The scheduler reconstruction in `SchedulerDBSource` rebuilds `VFolderMountRequest` with the persisted subpath, and `prepare_vfolder_mounts` honors a UUID-keyed request's explicit subpath instead of unconditionally forcing `requested_vfolder_subpaths[uuid] = "."`.
- The REST handler's blanket rejection of `mounts=["name/subdir"]` is replaced with split-and-resolve: the bare name resolves to a UUID via the existing resolver, the subpath is captured into a new `name -> subpath` map, and `_merge_resolved_legacy_mounts` forwards it onto `mount_id_subpaths`.

## Acceptance criteria

- [x] `MountInfoEntry` (or its equivalent) has a `source_subpath` field; `None` means "mount the vfolder root" (current behavior).
- [x] `POST /session/_/create` with a UUID-keyed `mount_ids` plus a per-mount `source_subpath` results in a session where the container destination is bind-mounted to `<vfolder>/<source_subpath>` rather than the vfolder root. (Wire field `mount_id_subpaths` plumbed through to `MountInfoEntry.source_subpath`, which feeds `VFolderMountRequest.subpath` and into `prepare_vfolder_mounts.requested_vfolder_subpaths`.)
- [x] The legacy `mounts: ["<name>/<subpath>"]` form on the same endpoint stops raising `InvalidAPIParameters(400)` and produces an equivalent mount.
- [x] `prepare_vfolder_mounts` is exercised end-to-end with a non-`"."` subpath via the modern UUID-keyed surface (covered by registry-projection unit tests; the lower-layer subpath path is unchanged for the legacy string surface).
- [x] No change to `MountPermission`, mount destination defaulting, or storage-proxy `vfsubpath` semantics.

## Test plan

- [x] `pants fmt --changed-since=origin/main`
- [x] `pants fix --changed-since=origin/main`
- [x] `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main`
- [x] `pants test --changed-since=origin/main`
- [x] `pants test tests/unit/common/dto/manager/session/ tests/unit/manager/services/session/ tests/unit/manager/sokovan/scheduling_controller/test_enqueue_session_from_draft.py`
- [ ] Manual end-to-end verification with a live server (subpath mount via `mount_id_subpaths` and via `mounts=["name/subdir"]`) — defer until SDK ergonomics land.

## Out of scope

- Client/SDK changes to expose `mount_id_subpaths` from `ComputeSession.get_or_create`. The wire format is enough for now; SDK plumbing will follow in a separate PR.
- Storage-proxy changes — `vfsubpath` is already supported there.