### PR TITLE
fix(BA-5986): make ModelMountConfigInput.definition_path nullable

### DIFF
--- a/changes/11537.fix.md
+++ b/changes/11537.fix.md
@@ -1,0 +1,1 @@
+Allow `ModelMountConfigInput.definition_path` to be omitted so the server auto-detects `model-definition.yaml` or `model-definition.yml` in the model vfolder

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9558,7 +9558,7 @@ input ModelMountConfigInput
 {
   vfolderId: ID!
   mountDestination: String!
-  definitionPath: String!
+  definitionPath: String = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -6337,7 +6337,7 @@ type ModelMountConfig {
 input ModelMountConfigInput {
   vfolderId: ID!
   mountDestination: String!
-  definitionPath: String!
+  definitionPath: String = null
 }
 
 """

--- a/src/ai/backend/common/dto/manager/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/deployment/request.py
@@ -238,7 +238,14 @@ class ModelMountConfigInput(BaseRequestModel):
 
     vfolder_id: VFolderUUID = Field(description="Model vfolder ID")
     mount_destination: str = Field(default="/models", description="Mount destination path")
-    definition_path: str = Field(description="Model definition file path within vfolder")
+    definition_path: str | None = Field(
+        default=None,
+        description=(
+            "Optional model definition file path within vfolder. "
+            "When omitted, the server auto-detects `model-definition.yaml` or "
+            "`model-definition.yml`."
+        ),
+    )
 
 
 class ModelRuntimeConfigInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -202,7 +202,14 @@ class ModelMountConfigInput(BaseRequestModel):
 
     vfolder_id: VFolderUUID = Field(description="VFolder ID for the model")
     mount_destination: str = Field(description="Mount destination path inside container")
-    definition_path: str = Field(description="Path to model definition file")
+    definition_path: str | None = Field(
+        default=None,
+        description=(
+            "Optional path to the model definition file within the model vfolder. "
+            "When omitted, the server auto-detects `model-definition.yaml` or "
+            "`model-definition.yml`."
+        ),
+    )
 
 
 class ExtraVFolderMountInput(BaseRequestModel):

--- a/src/ai/backend/manager/api/gql/deployment/types/revision.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision.py
@@ -776,7 +776,7 @@ class ModelRuntimeConfigInput(PydanticInputMixin[ModelRuntimeConfigInputDTO]):
 class ModelMountConfigInput(PydanticInputMixin[ModelMountConfigInputDTO]):
     vfolder_id: ID
     mount_destination: str
-    definition_path: str
+    definition_path: str | None = None
 
 
 @gql_pydantic_input(


### PR DESCRIPTION
## Summary
- `ModelMountConfigInput.definition_path` is now nullable in the GQL input, v2 DTO, and legacy DTO. When omitted, the server falls back to the existing `model-definition.yaml` / `model-definition.yml` auto-detect in `DeploymentRepository.fetch_model_definition()`.
- Previously the non-null boundary forced frontends to send a placeholder; if the actual file used the `.yml` extension, the server tried the placeholder verbatim and failed with `DefinitionFileNotFound`, never reaching the fallback.
- Input-only change. Response DTO `ModelMountConfigInfoDTO.definition_path` stays `str` (service-layer `or ""` coercion preserved) so existing clients keep compiling.

## Test plan
- [x] `pants check` clean on the changed DTO / GQL files
- [x] `pants test --changed-since=HEAD --changed-dependents=transitive` green (incl. `tests/component/deployment/*`, `tests/unit/client_v2/test_deployment.py`)
- [ ] Manual: `addModelRevision` without `model_mount_config.definition_path` against a vfolder that contains only `model-definition.yml`
- [ ] Manual: existing call with explicit `definition_path` still works

Resolves BA-5986

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--11537.org.readthedocs.build/en/11537/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--11537.org.readthedocs.build/ko/11537/

<!-- readthedocs-preview sorna-ko end -->